### PR TITLE
工作流打磨：版本副本 / 队列并行 / 表单校验 / 图片格式统一

### DIFF
--- a/anima_train.py
+++ b/anima_train.py
@@ -981,7 +981,9 @@ class ImageDataset(Dataset):
     1. JSON 文件（优先）- 支持分类 shuffle
     2. TXT 文件（回退）- 传统 shuffle
     """
-    EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp"}
+    # 保持与 studio/datasets.py:IMAGE_EXTS 同步（anima_train.py 是独立 CLI 脚本，
+    # 不强制 import studio package；改一处时另一处也要跟着改）。
+    EXTS = {".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif"}
 
     def __init__(self, data_dir, resolution=1024, bucket_mgr=None,
                  shuffle_caption=False, keep_tokens=0, flip_augment=False,

--- a/docs/studio-pipeline/pp10-workflow-polish.md
+++ b/docs/studio-pipeline/pp10-workflow-polish.md
@@ -223,68 +223,50 @@ function commit() {
 
 ---
 
-## PP10.4 — 项目控制字段「解锁」按钮
+## PP10.4 — 项目控制字段直接放开编辑
 
 ### 问题
-Train 页里 `data_dir / reg_data_dir / output_dir / output_name / resume_lora / resume_state` + 全局 model 路径都是 disabled 状态。用户偶尔需要改：比如 `resume_lora` 想接续训练（spec 里写「除非用户显式 PUT 改写」但 UI 没给入口），或者 `output_name` 想改 LoRA 文件名。需要每条字段一个解锁按钮，点击后变成可编辑。
+Train 页里 `data_dir / reg_data_dir / output_dir / output_name / resume_lora / resume_state` 都是 disabled。用户偶尔需要改（最常见：`resume_lora` 接续训练，自定义 `output_name`），但没有入口。
 
 ### 现状
 
-**前端**
-- `studio/web/src/components/SchemaForm.tsx` 透传 `disabledFields: string[]` 给 Field。
-- `studio/web/src/components/Field.tsx:38` 渲染「自动 · 项目控制」徽章；input 全禁。
-- `studio/web/src/pages/project/steps/Train.tsx:62-68`：`disabledFields = [...project_specific_fields, ...GLOBAL_MODEL_FIELDS]`。
+- 前端：`Train.tsx` 把 `configResp.project_specific_fields + GLOBAL_MODEL_FIELDS` 都列到 `disabledFields`。Field 组件按 `disabled` 全禁。
+- 后端：`PUT /api/projects/{pid}/versions/{vid}/config` 调 `write_version_config(force_project_overrides=True)`，会用 `project_specific_overrides` 强制覆盖 `PROJECT_SPECIFIC_FIELDS`。**前端就算解禁，存盘也会被服务器盖掉。**
 
-**后端**
-- `studio/services/version_config.py` 的 `write_version_config(force_project_overrides=True)`（行 113-138）会用 `project_specific_overrides(p, v)` 强制覆盖 `PROJECT_SPECIFIC_FIELDS`。**这意味着前端就算把字段改了，存盘时也会被服务器盖掉。**所以解锁不只是前端事，得有一份「该 version 用户已解锁的字段」状态。
+### 定稿方案：直接放开编辑（不引入 unlock 状态）
 
-### 改造方案
+讨论时识别出这是**过度工程化**：所谓「锁」的本质就两层（前端 disabled + 后端 force-override），把两层都关掉，字段就回到普通可编辑状态；fork preset 时仍走 `force=True` 路径预填项目路径，所以「自动填」语义没变。
 
-#### 推荐方案：version 级 `unlocked_fields` 数组，前端 + 后端共同尊重
+**前端 `Train.tsx`**
+- `disabledFields` 只保留 `GLOBAL_MODEL_FIELDS`（来自 Settings.models 的全局值，version 维度改它没意义）。
+- 去掉 `project_specific_fields` 那一段。
 
-**数据**
-- 在 version 私有 config.yaml 里加一个 meta key（不进入 TrainingConfig schema 校验）。最简：在 yaml 顶部加一段注释或单独的旁路文件 `versions/{label}/.unlocked.json`。
-  - **更干净的选择**：旁路文件 `versions/{label}/.unlocked.json`，内容是 `{"fields": ["resume_lora", "output_name"]}`。schema 不动，pydantic `extra=forbid` 不破。
-- API：`GET /api/projects/{pid}/versions/{vid}/config` 返回 `{has_config, config, project_specific_fields, unlocked_fields}`。
-- 新端点：`POST /api/projects/{pid}/versions/{vid}/config/unlock` body `{field: "resume_lora"}`；`POST /.../lock` 反向。
+**后端 `PUT /api/projects/{pid}/versions/{vid}/config`**
+- `write_version_config(..., force_project_overrides=False)`。
 
-**后端 `write_version_config` 逻辑**
-- `force_project_overrides=True` 时：用 `project_specific_overrides` 但跳过 `unlocked_fields` 列表里那几个，让用户值生效。
-- pseudo：
-  ```python
-  overrides = project_specific_overrides(p, v)
-  for f in unlocked_fields(p, v):
-      overrides.pop(f, None)
-  payload.update(overrides)
-  ```
+**保留不变**
+- `write_version_config` 函数默认仍是 `force_project_overrides=True`。
+- `fork_preset_for_version`（services/presets.py）仍显式 `force=True` —— 换预设时项目特定字段被预填成 `versions/{label}/train` 等。
+- PP10.1 `versions.create_version` 在 fork 时也仍 `force=True` 重写一次刷新路径。
+- 这样「换预设 / 复制版本」的预填行为完全不变；只有用户在 Train 页**手动 PUT** 时才尊重用户值。
 
-**前端**
-- Field 组件已经接收 `disabled` + `disabledHint`。新增 prop `onUnlock?: () => void`。
-- 当 `disabled=true` 且 `onUnlock` 给了，徽章右边加一个小按钮「🔓 解锁」。点击 → 调 `api.unlockField(pid, vid, name)` → setUnlockedFields → 重新计算 disabledFields（从 disabledFields 里去掉这个 name）。
-- 解锁的字段右上角换成「⚠️ 已解锁」徽章，提示「保存时不会用项目路径覆盖」；旁边给「🔒 重新锁定」按钮。
-- 全局 model 字段（`transformer_path` 等）**不**走解锁路径——那些是用户在 Settings 里改的源头，Train 页解锁了存到 version config 也没有意义（且新建 version 后又会被覆盖回去）。所以解锁只对 `PROJECT_SPECIFIC_FIELDS` 开放。
-
-#### 候选 B：全局解锁开关（一个按钮把六个字段全打开）
-
-**优点**：UI 简单。
-
-**缺点**：用户大多数场景只想改 1 个字段（比如 `resume_lora`），全开后下次保存把所有字段都按用户值落盘，路径错位风险高。**不推荐**。
-
-#### 候选 C：在 yaml 里加 `# unlock: resume_lora` 注释行
-
-**优点**：零端点改动。
-
-**缺点**：注释靠 yaml round-trip 保留；pydantic 走 dict 之后注释丢失。**不推荐**。
+**得到的语义**
+- 进 Train 页：项目特定字段都已经预填好（fork preset 的产物）。
+- 用户可以直接改任意字段（`resume_lora` 接续 / `output_name` 改名 / 极端情况下改 `data_dir`）。
+- 保存 → yaml 落用户值。
+- 想恢复默认值？再换一次预设。
 
 ### 风险 / 边界
-- **解锁后的字段不再被项目重命名跟随**：比如解锁了 `output_dir` 后，用户改 project slug（PP1 决定 slug 不可改，所以这个风险其实不存在），路径也不会自动跟。OK。
-- **`resume_lora` 解锁是常见用法**：用户接续训练时填上一次的 `_final.safetensors` 路径。让这条 work 起来很有价值。
-- **fork preset 后 unlocked 状态怎么办**：换预设时 `.unlocked.json` 应该被清掉（重置成默认锁住所有项目字段）。fork_preset_for_version 那条路径加一行 unlink。
-- **从老 version 复制（PP10.1）后 unlocked 状态怎么办**：建议**不**复制 `.unlocked.json`，新 version 默认全锁；用户自己再开。
-- **测试**：新增 2-3 个测试：unlock + write 后字段保留用户值；lock 后字段被重新覆盖；fork preset 清空 unlocked。
+- 用户改坏 `data_dir` → 训练读错路径。但 Curation / Stepper / Tagging 等页面都不读 `data_dir`，按 `versions/{label}/train` 操作，影响范围限定在「真去训练时数据从哪读」。
+- 现有测试 `test_write_forces_project_overrides` 测的是函数默认值（仍 True），不需要改。
+- 现有测试 `test_fork_preset_for_version_applies_overrides` 测 fork preset 路径强制覆盖，仍 True，不变。
+- 新增测试：PUT 端点不强制覆盖 —— 用户传错的 `data_dir` 会被保留。
 
 ### 切片
-单一 commit：旁路文件 + 2 个端点 + Field 加按钮 + Train 页传 onUnlock + 几个测试。比 PP10.1/10.3 略大但仍单 PR。
+单一 commit：
+- 后端 `server.py` PUT 端点参数改 `force=False`。
+- 前端 `Train.tsx` `disabledFields` 去掉 `project_specific_fields`。
+- pytest 加 1 个 case：PUT 端点尊重用户值。
 
 ---
 

--- a/docs/studio-pipeline/pp10-workflow-polish.md
+++ b/docs/studio-pipeline/pp10-workflow-polish.md
@@ -1,0 +1,305 @@
+# PP10 — 工作流打磨：副本 / 并行 / 校验 / 解锁
+
+**状态**：📝 plan 待讨论
+**前置依赖**：PP6 已合（version 私有 config、project_jobs、Train 页）
+**范围**：4 个独立的 UX/调度优化，互相不耦合，可分别切片单独 commit
+
+| 子片 | 范围 | 难度 |
+|---|---|---|
+| PP10.1 | 新建 version 时从老 version 做副本（前端 UI + 全量复制 train/reg/config/解锁状态）| 小 |
+| PP10.2 | 队列并行：训练任务与数据准备任务可同时跑 | 中 |
+| PP10.3 | SchemaForm 数字字段 onBlur 校验（修「0.05 第二个 0 卡住」）| 小 |
+| PP10.4 | 项目控制字段「解锁」按钮（per-field unlock，把强制覆盖关掉）| 小 |
+
+---
+
+## PP10.1 — 新版本从老版本做副本
+
+### 问题
+建新 version 时只能从空开始；用户做完一次「下载 → 筛选 → 打标 → 正则集」之后想试不同训练参数，每个 version 都要重做一遍。reg 是整个流水线最耗时的阶段（booru 拉几百张图 + auto_tag），最该被复用。
+
+### 现状
+- 后端 `versions.create_version(...)` 已经有 `fork_from_version_id` 参数（`studio/versions.py:106`），用 `_copytree_train` 递归 copy `train/`，并把 `config_name` 字段继承到新 version 行。
+- API `POST /api/projects/{pid}/versions` 已经把这个参数透传（`studio/server.py:331-340, 471-477`，`VersionCreate.fork_from_version_id`）。
+- **前端没用上**：`NewVersionDialog`（`studio/web/src/pages/project/Layout.tsx:219`）只收 `label` 一个字段，调 `api.createVersion(pid, { label })`。
+- 后端复制目前只覆盖 `train/` 和 `config_name` 字段；`config.yaml` / `reg/` / `samples/` / `output/` / `monitor_state.json` / `.unlocked.json` 都不复制。
+
+### 定稿方案：全量复制（除训练产物外的所有用户产物）
+
+**复制对象**
+
+| 目录 / 文件 | 是否复制 | 说明 |
+|---|---|---|
+| `train/`（图片+caption）| ✅ | 已有逻辑 |
+| `reg/`（含 meta.json）| ✅ **新增** | 最耗时的阶段，全量复制；用户想重做可在正则页点「清理」 |
+| `config.yaml`（PP6.2 version 私有训练配置）| ✅ **新增** | 复制后强制刷新项目特定路径 |
+| `.unlocked.json`（PP10.4 解锁状态）| ✅ **新增** | 跟随复制（同 project 内字段语义不变，安全）|
+| `samples/` | ❌ | 训练产物，无意义 |
+| `output/` | ❌ | 训练产物 |
+| `monitor_state.json` | ❌ | 训练运行时状态 |
+| `config_name`（DB 字段）| ✅ | 已有逻辑 |
+
+**stage 推进**：fork 时新 version 的 `stage` 跟随源 version。源 stage ∈ `{done, training}` 时新 version 落 `ready`（重新进入待训练态）；其他 stage 直接拷过来。
+
+**前端**
+- `NewVersionDialog` 加一个 `<select>`：「从空白开始 / 从 {label1} 复制 / 从 {label2} 复制 / …」，默认空白。
+- 当前项目至少有 1 个 version 时下拉才显示选项；首个 version 不显示下拉。
+- 选中源 version 时下方一行 hint：「将复制 train/、reg/、训练配置和解锁状态（output/、samples/ 不复制）。」
+- 调 `api.createVersion(pid, { label, fork_from_version_id })`。
+
+**后端 `versions.create_version` 扩展**
+- 现有 `_copytree_train` 通用化为 `_copytree`（递归 copy；Win 不用硬链接，沿用 `shutil.copy2`）。
+- 复制顺序：`train/` → `reg/`（存在才复制）→ `config.yaml`（存在才复制）→ `.unlocked.json`（存在才复制）。
+- 复制完 `config.yaml` 后**立即调一次** `version_config.write_version_config(p, new_v, cfg, force_project_overrides=True)` 重写，把 `data_dir / reg_data_dir / output_dir / output_name` 刷成新 version 的路径。`reg_data_dir` 由 `project_specific_overrides` 自动算（它检查新 version 的 `reg/meta.json` 是否存在 → 复制后存在 → 自动指向新路径）。
+- stage：源 stage ∈ `{done, training}` → 新 version 落 `ready`；其他 stage 直接 copy。
+
+### 风险 / 边界
+- 复制 `train/` + `reg/` 在大数据集上慢（合计可能 2-4 GB）；PP1 已决定 Win 不用硬链接，统一 `shutil.copy2`，可接受。
+- 复制 config 后 `data_dir / reg_data_dir / output_dir / output_name` 必须强制覆盖到新 version 路径，否则训练会跑去旧 version 的 train/，污染对照实验。落到 `write_version_config(..., force_project_overrides=True)`。
+- `.unlocked.json` 列里的字段是项目特定字段（`resume_lora` 等），跟具体 version 无关，复制是安全的。
+- 源 version 和新 version 必须同 project（已有约束 `versions.create_version` 行 132-135）。
+- stage 跟随源时新 version 的 `created_at` 仍然是新的 → version tabs 排序正确。
+
+### 切片
+单一 commit：
+- 后端 `versions.create_version`：全量复制 + stage 跟随 + config 路径强制覆盖。
+- 前端 NewVersionDialog 加下拉。
+- 测试 case：(1) fork 后 train/ 、reg/ 、config.yaml 、.unlocked.json 都存在；(2) config.yaml 里 data_dir / reg_data_dir / output_dir 指向新 version 路径；(3) 源 stage=done → 新 stage=ready，源 stage=tagging → 新 stage=tagging。
+
+---
+
+## PP10.2 — 队列并行：训练 ∥ 数据准备
+
+### 问题
+现在所有任务（download / tag / reg_build / training）都在 supervisor 单进程串行跑。训练一个 LoRA 要几小时，期间下一个项目的下载、打标都堵在队列里。用户希望「炼第一个的时候同时给第二个项目下载、打标」。
+
+### 现状
+- `studio/supervisor.py` 单 `_current_proc` / `_current_kind` / `_current_id`（行 153-160），同一时刻只有一个子进程在跑。
+- `_tick()` 调度顺序：先 `project_jobs.next_pending`（download/tag/reg_build），再 `db.next_pending`（training tasks）—— 数据准备**优先**，但仍然是串行（行 280-298）。
+- 取消逻辑围绕单 `_current_proc` / `_current_kind`（`cancel`、`cancel_job`、`_signal_terminate_async`）。
+- 进程结束后 `_finish_current` 清掉 4 块状态字段（proc/kind/id/log_fp/tailer）。
+
+### 改造方案
+
+核心思路：把 supervisor 改成「多槽位调度器」。每个槽位独立：自己的 `_current_proc` / 状态字段 / log tailer / cancel 路径。
+
+#### 推荐方案：双槽位（training 槽 + data 槽）
+
+**槽位定义**
+| 槽位 | 接的活 | 资源画像 |
+|---|---|---|
+| TRAIN | `tasks` 表（训练）| 长任务、占满 GPU |
+| DATA  | `project_jobs` 表（download / tag / reg_build）| 短任务、CPU+IO 为主，tag/reg_build 也吃 GPU |
+
+**调度策略**
+- TRAIN 槽空 → 拉一条 pending task。
+- DATA 槽空 → 拉一条 pending job；但**如果 TRAIN 槽正在跑且新 job 是 GPU-bound（tag、reg_build）**，先看 settings 里的开关 `allow_gpu_during_train`：默认 **off**（保守，避免抢显存 OOM），用户在 Settings 里勾上才并行。download job 不受这个限制（IO-only）。
+- 「GPU-bound」判定：job.kind ∈ `{tag, reg_build}` 当作 GPU；download 当作 CPU。reg_build 实际 90% 时间在 booru 拉图（IO），但末尾的 auto_tag 阶段才吃 GPU——粒度不够细，先按整 job 标 GPU-bound 处理。如果之后觉得太保守，再拆 reg_build 的 phase。
+
+**取消 / 终止改造**
+- `cancel(task_id)` 只看 TRAIN 槽。
+- `cancel_job(job_id)` 只看 DATA 槽。
+- `Supervisor.stop()` 同时终止两个槽。
+- `_signal_terminate_async` 改成参数化：`_signal_terminate_async(slot)`。
+
+**SSE / event 不变**
+- 前端 Queue 页和 project_jobs 那条 SSE 消息已经是 per-task / per-job 区分的，多槽位不影响订阅契约。
+
+**字段重构（实现层）**
+当前 `_current_*` 5 个字段抽成一个 `_Slot` 内部类：
+```
+class _Slot:
+    proc / kind / id / log_fp / tailer / state_poller / cancel_pending
+```
+然后 `Supervisor` 拥有 `self._train_slot` 和 `self._data_slot`。每个 `_tick` 轮询两个槽各自的 `proc.poll()`，独立结束。
+
+#### 候选 B：通用 N 槽位 + 资源标签
+
+**做法**：每个 worker 声明所需资源（`gpu`、`cpu`、`io`）；槽位池按资源画像匹配。
+
+**优点**：以后加 sample preview / 第二张 GPU 都能复用。
+
+**缺点**：第一版过度抽象。当前只有「GPU 训练」「IO 下载」「GPU 打标」三类，明确双槽足够。
+
+**结论**：先双槽（推荐方案），架构上把 `_Slot` 抽成可扩展的列表（一个 `list[_Slot]`），以后想加第三槽（比如 sample preview 槽）只是 append 一个槽 + 调度规则。
+
+#### 候选 C：完全独立的两个 supervisor 线程
+
+**做法**：起两个 `Supervisor` 实例，一个只看 tasks 一个只看 project_jobs。
+
+**优点**：代码改动最少。
+
+**缺点**：两份 `_loop` / `_reconcile_orphans` 重复；两个线程读同一 SQLite 的并发锁需要小心；`stop()` 协调要写两遍。**不推荐**。
+
+### 风险 / 边界
+- **GPU 显存抢占**：训练 anima 一般占 14-22 GB（4090 24G），WD14 onnxruntime-gpu 占 1-2 GB；同时跑可能 OOM 或大幅降速。**默认 off** 是关键防线。Settings 页加一行开关 + 风险提示。
+- **磁盘 IO 抢占**：训练读 train/ 是顺序读 + 缓存住，下载是写 `download/`，互不冲突。可忽略。
+- **日志文件互不冲突**：每个 task / job 自己一份 log，已经分开（`logs/{task_id}.log` / `jobs/{job_id}.log`），没问题。
+- **重启恢复**：`_reconcile_orphans` 已分别清 tasks 和 project_jobs（行 257-278），双槽不影响这套逻辑。
+- **测试**：现有 `test_supervisor.py` 注入 `cmd_builder` 模拟，需要新增 1-2 个并发 case（同时 spawn 一个 task 和一个 download job）。
+
+### 切片
+- **PP10.2.a**：把 supervisor 单槽位重构成 `_Slot` + `_slots: list[_Slot]`，先不开并行（仍只有一个槽）。验证测试不挂。
+- **PP10.2.b**：加第二槽 + 调度策略（download 总并行、tag/reg_build 看 settings 开关）。Settings 页加开关 UI。新增 2 个测试。
+
+两个 commit。10.2.a 是纯重构、风险低；10.2.b 是行为改动。
+
+---
+
+## PP10.3 — SchemaForm 数字字段 onBlur 校验
+
+### 问题
+表单里输入 `0.05`，敲到第二个 `0`（即输入框内容是 `0.0`）时，`parseFloat("0.0") === 0`，state 重置成 `0`，受控 `<input>` 重新渲染显示 `"0"`，用户键入的小数点被吞掉，再也输不进 `0.05`。用户描述「强制到 1」对应的可能是 `min={prop.minimum}` HTML5 约束的视觉表现。
+
+### 现状
+`studio/web/src/components/Field.tsx:144-172` int / float 分支：
+```tsx
+<input
+  type="number"
+  step={kind === 'int' ? 1 : 'any'}
+  value={value === null || value === undefined ? '' : String(value)}
+  min={prop.minimum} max={prop.maximum}
+  onChange={(e) => {
+    const raw = e.target.value
+    if (raw === '') { onChange(prop.default); return }
+    const num = kind === 'int' ? parseInt(raw, 10) : parseFloat(raw)
+    if (!Number.isNaN(num)) onChange(num)   // 每次按键都立即父 onChange
+  }}
+/>
+```
+父 `SchemaForm.onChange → setConfig(...)` 每次都会触发整树重渲染，受控组件的 value 永远来自数字 → 字符串，丢了「输入中状态」。
+
+### 改造方案
+
+#### 推荐方案：Field 内部维护 raw 字符串缓冲，blur/Enter 时提交
+
+```tsx
+const [raw, setRaw] = useState<string>(() => formatNum(value))
+useEffect(() => {
+  // 外部 value 变化（比如 reset / fork preset）时同步缓冲
+  setRaw(formatNum(value))
+}, [value])
+
+<input
+  type="text"            // 改成 text 或 number 都可；text 更宽容
+  inputMode="decimal"    // 移动端键盘
+  value={raw}
+  onChange={(e) => setRaw(e.target.value)}      // 只更新本地
+  onBlur={() => commit()}
+  onKeyDown={(e) => { if (e.key === 'Enter') commit() }}
+/>
+
+function commit() {
+  if (raw === '') { onChange(prop.default); setRaw(formatNum(prop.default)); return }
+  const num = kind === 'int' ? parseInt(raw, 10) : parseFloat(raw)
+  if (!Number.isNaN(num)) onChange(num)
+  // 失败：丢回 raw=''→default，或者保留红边显示「不合法」。先简单：丢回原值。
+  else setRaw(formatNum(value))
+}
+```
+
+注意点：
+- **type 改成 `text` + `inputMode="decimal"`**：避免浏览器 `type=number` 的内置规整（Firefox 会阻止用户输 `0.0`，Chrome 不会但 valueAsNumber 行为不同）。也避开 HTML5 `min/max` 自动 clamp。
+- **min / max 改成手动校验**：commit 时若超出范围，blur 后 onChange(clamp(num)) + 提示。或者只在 SaveBar 提交时整体校验。第一刀**先不 clamp**，让用户填什么就填什么；schema 校验由后端 `TrainingConfig` 兜底（`write_version_config` 已经走 pydantic）。前端只做转换。
+- **空字符串行为**：用户清空想用 default。当前是立即写 default，新方案改成 blur 时才写。提示更平滑。
+
+#### 候选 B：保留 onChange 但加防抖（debounce 300ms）
+
+**做法**：`onChange` 用 `useDeferredValue` 或 lodash debounce。
+
+**缺点**：仍然受 value 字符串化截断（debounce 不解决根因，只是把闪回延迟）。**不推荐**。
+
+#### 候选 C：用三方表单库（react-hook-form / formik）
+
+**远超本次范围**，整套 SchemaForm 重写。**不考虑**。
+
+### 风险 / 边界
+- 同一个 Field 既有 path 字符串又有 number；`PathStringField` 不受影响（已经是 text）。
+- string-list（textarea）也是 onChange 立即更新；用户没抱怨过——保持不变。
+- 单元测试：`Field.test.tsx` 还没有，可以新增 1 个测试覆盖「输入 0.05 不被截断」。
+
+### 切片
+单一 commit。改 `Field.tsx` 的 int/float 分支 + 加 1-2 个 vitest case。
+
+---
+
+## PP10.4 — 项目控制字段「解锁」按钮
+
+### 问题
+Train 页里 `data_dir / reg_data_dir / output_dir / output_name / resume_lora / resume_state` + 全局 model 路径都是 disabled 状态。用户偶尔需要改：比如 `resume_lora` 想接续训练（spec 里写「除非用户显式 PUT 改写」但 UI 没给入口），或者 `output_name` 想改 LoRA 文件名。需要每条字段一个解锁按钮，点击后变成可编辑。
+
+### 现状
+
+**前端**
+- `studio/web/src/components/SchemaForm.tsx` 透传 `disabledFields: string[]` 给 Field。
+- `studio/web/src/components/Field.tsx:38` 渲染「自动 · 项目控制」徽章；input 全禁。
+- `studio/web/src/pages/project/steps/Train.tsx:62-68`：`disabledFields = [...project_specific_fields, ...GLOBAL_MODEL_FIELDS]`。
+
+**后端**
+- `studio/services/version_config.py` 的 `write_version_config(force_project_overrides=True)`（行 113-138）会用 `project_specific_overrides(p, v)` 强制覆盖 `PROJECT_SPECIFIC_FIELDS`。**这意味着前端就算把字段改了，存盘时也会被服务器盖掉。**所以解锁不只是前端事，得有一份「该 version 用户已解锁的字段」状态。
+
+### 改造方案
+
+#### 推荐方案：version 级 `unlocked_fields` 数组，前端 + 后端共同尊重
+
+**数据**
+- 在 version 私有 config.yaml 里加一个 meta key（不进入 TrainingConfig schema 校验）。最简：在 yaml 顶部加一段注释或单独的旁路文件 `versions/{label}/.unlocked.json`。
+  - **更干净的选择**：旁路文件 `versions/{label}/.unlocked.json`，内容是 `{"fields": ["resume_lora", "output_name"]}`。schema 不动，pydantic `extra=forbid` 不破。
+- API：`GET /api/projects/{pid}/versions/{vid}/config` 返回 `{has_config, config, project_specific_fields, unlocked_fields}`。
+- 新端点：`POST /api/projects/{pid}/versions/{vid}/config/unlock` body `{field: "resume_lora"}`；`POST /.../lock` 反向。
+
+**后端 `write_version_config` 逻辑**
+- `force_project_overrides=True` 时：用 `project_specific_overrides` 但跳过 `unlocked_fields` 列表里那几个，让用户值生效。
+- pseudo：
+  ```python
+  overrides = project_specific_overrides(p, v)
+  for f in unlocked_fields(p, v):
+      overrides.pop(f, None)
+  payload.update(overrides)
+  ```
+
+**前端**
+- Field 组件已经接收 `disabled` + `disabledHint`。新增 prop `onUnlock?: () => void`。
+- 当 `disabled=true` 且 `onUnlock` 给了，徽章右边加一个小按钮「🔓 解锁」。点击 → 调 `api.unlockField(pid, vid, name)` → setUnlockedFields → 重新计算 disabledFields（从 disabledFields 里去掉这个 name）。
+- 解锁的字段右上角换成「⚠️ 已解锁」徽章，提示「保存时不会用项目路径覆盖」；旁边给「🔒 重新锁定」按钮。
+- 全局 model 字段（`transformer_path` 等）**不**走解锁路径——那些是用户在 Settings 里改的源头，Train 页解锁了存到 version config 也没有意义（且新建 version 后又会被覆盖回去）。所以解锁只对 `PROJECT_SPECIFIC_FIELDS` 开放。
+
+#### 候选 B：全局解锁开关（一个按钮把六个字段全打开）
+
+**优点**：UI 简单。
+
+**缺点**：用户大多数场景只想改 1 个字段（比如 `resume_lora`），全开后下次保存把所有字段都按用户值落盘，路径错位风险高。**不推荐**。
+
+#### 候选 C：在 yaml 里加 `# unlock: resume_lora` 注释行
+
+**优点**：零端点改动。
+
+**缺点**：注释靠 yaml round-trip 保留；pydantic 走 dict 之后注释丢失。**不推荐**。
+
+### 风险 / 边界
+- **解锁后的字段不再被项目重命名跟随**：比如解锁了 `output_dir` 后，用户改 project slug（PP1 决定 slug 不可改，所以这个风险其实不存在），路径也不会自动跟。OK。
+- **`resume_lora` 解锁是常见用法**：用户接续训练时填上一次的 `_final.safetensors` 路径。让这条 work 起来很有价值。
+- **fork preset 后 unlocked 状态怎么办**：换预设时 `.unlocked.json` 应该被清掉（重置成默认锁住所有项目字段）。fork_preset_for_version 那条路径加一行 unlink。
+- **从老 version 复制（PP10.1）后 unlocked 状态怎么办**：建议**不**复制 `.unlocked.json`，新 version 默认全锁；用户自己再开。
+- **测试**：新增 2-3 个测试：unlock + write 后字段保留用户值；lock 后字段被重新覆盖；fork preset 清空 unlocked。
+
+### 切片
+单一 commit：旁路文件 + 2 个端点 + Field 加按钮 + Train 页传 onUnlock + 几个测试。比 PP10.1/10.3 略大但仍单 PR。
+
+---
+
+## 实施顺序建议
+
+1. **PP10.3 数字 onBlur**（小、独立、立即受益）
+2. **PP10.1 副本 version**（小、独立、与 10.3 不耦合）
+3. **PP10.4 解锁按钮**（小、改动后端但隔离在 version_config）
+4. **PP10.2 队列并行**（中、唯一动 supervisor 的、放最后）
+
+每片单独 commit + 手测，按 [workflow.md](../../C:/Users/Mei/.claude/projects/G--AnimaLoraToolkit/memory/workflow.md) 里「PP 之间不混 commit」的约定走。
+
+## 不做的事
+
+- **训练中实时调参**（PP6 已经决定不支持，入队即锁定 config 副本）。
+- **多 GPU 并行训练**（不在本次范围；只是单 GPU 上「训练 + 数据准备」并行）。
+- **跨 version 共享 reg/**（spec 决定 reg 跟 train 走，不复用；PP10.1 候选 B 也不做）。
+- **解锁全局 model 路径**（值的源头在 Settings，不在 version 维度暴露解锁）。

--- a/docs/studio-pipeline/pp10-workflow-polish.md
+++ b/docs/studio-pipeline/pp10-workflow-polish.md
@@ -71,78 +71,44 @@
 ## PP10.2 — 队列并行：训练 ∥ 数据准备
 
 ### 问题
-现在所有任务（download / tag / reg_build / training）都在 supervisor 单进程串行跑。训练一个 LoRA 要几小时，期间下一个项目的下载、打标都堵在队列里。用户希望「炼第一个的时候同时给第二个项目下载、打标」。
+原本所有任务（download / tag / reg_build / training）在 supervisor 单进程串行。训练一个 LoRA 要几小时，期间下一个项目的下载 / 打标都堵在队列里。
 
-### 现状
-- `studio/supervisor.py` 单 `_current_proc` / `_current_kind` / `_current_id`（行 153-160），同一时刻只有一个子进程在跑。
-- `_tick()` 调度顺序：先 `project_jobs.next_pending`（download/tag/reg_build），再 `db.next_pending`（training tasks）—— 数据准备**优先**，但仍然是串行（行 280-298）。
-- 取消逻辑围绕单 `_current_proc` / `_current_kind`（`cancel`、`cancel_job`、`_signal_terminate_async`）。
-- 进程结束后 `_finish_current` 清掉 4 块状态字段（proc/kind/id/log_fp/tailer）。
+### 定稿方案：双槽位调度器
 
-### 改造方案
+**槽位**
 
-核心思路：把 supervisor 改成「多槽位调度器」。每个槽位独立：自己的 `_current_proc` / 状态字段 / log tailer / cancel 路径。
-
-#### 推荐方案：双槽位（training 槽 + data 槽）
-
-**槽位定义**
 | 槽位 | 接的活 | 资源画像 |
 |---|---|---|
 | TRAIN | `tasks` 表（训练）| 长任务、占满 GPU |
-| DATA  | `project_jobs` 表（download / tag / reg_build）| 短任务、CPU+IO 为主，tag/reg_build 也吃 GPU |
+| DATA  | `project_jobs` 表（download / tag / reg_build）| download IO-only；tag / reg_build 吃 GPU |
 
-**调度策略**
-- TRAIN 槽空 → 拉一条 pending task。
-- DATA 槽空 → 拉一条 pending job；但**如果 TRAIN 槽正在跑且新 job 是 GPU-bound（tag、reg_build）**，先看 settings 里的开关 `allow_gpu_during_train`：默认 **off**（保守，避免抢显存 OOM），用户在 Settings 里勾上才并行。download job 不受这个限制（IO-only）。
-- 「GPU-bound」判定：job.kind ∈ `{tag, reg_build}` 当作 GPU；download 当作 CPU。reg_build 实际 90% 时间在 booru 拉图（IO），但末尾的 auto_tag 阶段才吃 GPU——粒度不够细，先按整 job 标 GPU-bound 处理。如果之后觉得太保守，再拆 reg_build 的 phase。
+**调度策略（`_dispatch_train` / `_dispatch_data`）**
+- TRAIN 槽空 → 取 `db.next_pending(tasks)` 派活。
+- DATA 槽空 → 扫 `project_jobs.list_jobs(status='pending')`（按 id ASC），找第一条**可跑**的：若是 GPU-bound (`{tag, reg_build}`) 且 TRAIN 槽 busy 且 `secrets.queue.allow_gpu_during_train=False` → 跳过。download 永远直接跑。
+- 训练结束 → 下一 tick 自动把推迟的 GPU job 拉起来。
 
-**取消 / 终止改造**
-- `cancel(task_id)` 只看 TRAIN 槽。
-- `cancel_job(job_id)` 只看 DATA 槽。
-- `Supervisor.stop()` 同时终止两个槽。
-- `_signal_terminate_async` 改成参数化：`_signal_terminate_async(slot)`。
+**实现层（PP10.2.a 重构 + PP10.2.b 行为）**
+- `@dataclass _Slot`：`name / proc / kind / id / log_fp / tailer / state_poller / cancel_pending` + `busy` / `reset()`。
+- `Supervisor._slots: list[_Slot] = [_Slot(SLOT_TRAIN), _Slot(SLOT_DATA)]`。
+- `_tick`：先 poll 所有 busy 槽收尸，再给空槽派活（按槽位 name 分流）。
+- `cancel(task_id)` / `cancel_job(job_id)` 用 `_find_slot(kind, id)` 定位槽位发信号。
+- `Supervisor.stop()` 遍历所有 busy 槽 `_terminate_slot`。
+- `_signal_terminate_async(slot)` / `_finish_slot(slot, rc)` 都接 slot 参数。
 
-**SSE / event 不变**
-- 前端 Queue 页和 project_jobs 那条 SSE 消息已经是 per-task / per-job 区分的，多槽位不影响订阅契约。
-
-**字段重构（实现层）**
-当前 `_current_*` 5 个字段抽成一个 `_Slot` 内部类：
-```
-class _Slot:
-    proc / kind / id / log_fp / tailer / state_poller / cancel_pending
-```
-然后 `Supervisor` 拥有 `self._train_slot` 和 `self._data_slot`。每个 `_tick` 轮询两个槽各自的 `proc.poll()`，独立结束。
-
-#### 候选 B：通用 N 槽位 + 资源标签
-
-**做法**：每个 worker 声明所需资源（`gpu`、`cpu`、`io`）；槽位池按资源画像匹配。
-
-**优点**：以后加 sample preview / 第二张 GPU 都能复用。
-
-**缺点**：第一版过度抽象。当前只有「GPU 训练」「IO 下载」「GPU 打标」三类，明确双槽足够。
-
-**结论**：先双槽（推荐方案），架构上把 `_Slot` 抽成可扩展的列表（一个 `list[_Slot]`），以后想加第三槽（比如 sample preview 槽）只是 append 一个槽 + 调度规则。
-
-#### 候选 C：完全独立的两个 supervisor 线程
-
-**做法**：起两个 `Supervisor` 实例，一个只看 tasks 一个只看 project_jobs。
-
-**优点**：代码改动最少。
-
-**缺点**：两份 `_loop` / `_reconcile_orphans` 重复；两个线程读同一 SQLite 的并发锁需要小心；`stop()` 协调要写两遍。**不推荐**。
+**Settings**
+- `secrets.QueueConfig.allow_gpu_during_train: bool = False`。
+- Settings 页加「队列调度」section + 风险提示。
 
 ### 风险 / 边界
-- **GPU 显存抢占**：训练 anima 一般占 14-22 GB（4090 24G），WD14 onnxruntime-gpu 占 1-2 GB；同时跑可能 OOM 或大幅降速。**默认 off** 是关键防线。Settings 页加一行开关 + 风险提示。
-- **磁盘 IO 抢占**：训练读 train/ 是顺序读 + 缓存住，下载是写 `download/`，互不冲突。可忽略。
-- **日志文件互不冲突**：每个 task / job 自己一份 log，已经分开（`logs/{task_id}.log` / `jobs/{job_id}.log`），没问题。
-- **重启恢复**：`_reconcile_orphans` 已分别清 tasks 和 project_jobs（行 257-278），双槽不影响这套逻辑。
-- **测试**：现有 `test_supervisor.py` 注入 `cmd_builder` 模拟，需要新增 1-2 个并发 case（同时 spawn 一个 task 和一个 download job）。
+- **GPU 显存抢占**：训练占 14-22 GB（4090 24G），WD14 onnxruntime-gpu 占 1-2 GB；同时跑可能 OOM。**默认 off** 是关键防线。
+- **磁盘 IO 抢占**：训练读 train/ 顺序读 + 缓存，下载写 `download/`，互不冲突。
+- **日志文件**：每个 task / job 自己一份 log，已分开。
+- **重启恢复**：`_reconcile_orphans` 已分别清 tasks 和 project_jobs，双槽不影响。
+- **reg_build 粒度**：整 job 标 GPU-bound（实际 90% 时间是 booru 拉图 IO，末尾才 auto_tag 吃 GPU）—— 第一刀保守。觉得太保守再拆 phase。
 
 ### 切片
-- **PP10.2.a**：把 supervisor 单槽位重构成 `_Slot` + `_slots: list[_Slot]`，先不开并行（仍只有一个槽）。验证测试不挂。
-- **PP10.2.b**：加第二槽 + 调度策略（download 总并行、tag/reg_build 看 settings 开关）。Settings 页加开关 UI。新增 2 个测试。
-
-两个 commit。10.2.a 是纯重构、风险低；10.2.b 是行为改动。
+- **PP10.2.a** (`a6fbf20`)：把 `_current_*` 字段抽到 `_Slot` 数据类 + `self._slots: list[_Slot]`（暂留单槽 main）；行为完全不变；pytest 525 全过。
+- **PP10.2.b** (本片)：拆 TRAIN + DATA 双槽 + 调度策略 + Settings 开关 + 3 个新 supervisor case；pytest 527 / vitest 57。
 
 ---
 

--- a/studio/datasets.py
+++ b/studio/datasets.py
@@ -8,7 +8,10 @@ import re
 from pathlib import Path
 from typing import Any
 
-IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif", ".jxl"}
+# 全链路图片格式白名单 —— 上传 / 下载 / curation / tag / reg / 训练都引用这个集合。
+# 保持与 anima_train.py:EXTS 同步（trainer 是独立脚本，不 import studio）。
+# 删了 .jxl：PIL 12 没注册 .jxl，需要 pillow-jxl-plugin 才能解，booru 生态见不到。
+IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif"}
 KOHYA_PREFIX = re.compile(r"^(\d+)_(.+)$")
 
 

--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -97,6 +97,18 @@ class WD14Config(BaseModel):
         return self
 
 
+class QueueConfig(BaseModel):
+    """队列调度策略（PP10.2）。
+
+    Studio supervisor 使用双槽位调度：TRAIN 槽跑训练 task，DATA 槽跑
+    数据准备 job（download / tag / reg_build）。download 永远与训练并行
+    （IO-only，不抢 GPU）；tag / reg_build 走 GPU，默认在训练时**推迟执行**
+    避免 OOM。把 `allow_gpu_during_train` 打开后才允许并行（用户自己确认
+    显存够）。
+    """
+    allow_gpu_during_train: bool = False
+
+
 class ModelsConfig(BaseModel):
     """全局模型配置（PP7）。
 
@@ -119,6 +131,7 @@ class Secrets(BaseModel):
     joycaption: JoyCaptionConfig = Field(default_factory=JoyCaptionConfig)
     wd14: WD14Config = Field(default_factory=WD14Config)
     models: ModelsConfig = Field(default_factory=ModelsConfig)
+    queue: QueueConfig = Field(default_factory=QueueConfig)
 
 
 # ---------------------------------------------------------------------------

--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -27,7 +27,9 @@ class GelbooruConfig(BaseModel):
     api_key: str = ""
     save_tags: bool = False
     convert_to_png: bool = True
-    remove_alpha_channel: bool = False
+    # 新装默认 true：训练里 4-channel PNG 会让 VAE 把透明区域当噪声学进去，
+    # 多数情况下用户都需要去掉 alpha。已存在 secrets.json 里显式 false 不受影响。
+    remove_alpha_channel: bool = True
 
 
 class DanbooruConfig(BaseModel):

--- a/studio/server.py
+++ b/studio/server.py
@@ -1589,13 +1589,15 @@ def put_version_config_endpoint(
 ) -> dict[str, Any]:
     """直接写 version 私有 config（全量替换）。
 
-    项目特定字段（data_dir / output_dir / output_name 等）由服务端强制覆盖，
-    防止用户绕过前端 disabled 改路径。
+    PP10.4：项目特定字段（data_dir / output_dir / output_name 等）**不**强制
+    覆盖。fork_preset 时已经预填好；用户在 Train 页可以自由改（例如
+    `resume_lora` 接续训练、自定义 output_name）。改坏了再换一次预设回到
+    默认。
     """
     project, ver = _project_and_version_or_404(pid, vid)
     try:
         version_config.write_version_config(
-            project, ver, body, force_project_overrides=True
+            project, ver, body, force_project_overrides=False
         )
         cfg = version_config.read_version_config(project, ver)
     except version_config.VersionConfigError as exc:

--- a/studio/services/uploads.py
+++ b/studio/services/uploads.py
@@ -1,10 +1,11 @@
-"""本地上传：单图（jpg/png）或 zip 压缩包（自动解压拍平），落盘到 download/。
+"""本地上传：单图或 zip 压缩包（自动解压拍平），落盘到 download/。
 
 用户通过浏览器 file picker / 拖拽上传文件 → server 端解析 → 写入项目的
 `download/` 目录，与 booru 下载共享同一份「全量备份」。
 
 约束：
-- 仅接受 .jpg / .jpeg / .png 单图；zip 包内同样仅提取 jpg/png。
+- 接受 IMAGE_EXTS 里所有格式的单图（png / jpg / jpeg / webp / bmp / gif）；
+  zip 包内同样按这套白名单提取，原样落盘（不做格式转换）。
 - zip 内的子目录结构会被拍平（取 basename）。
 - 文件名冲突保守跳过，不覆盖、不自动重命名 —— 让用户知道哪里跳过了。
 - zip 损坏时整包跳过并报告，不影响其它文件。
@@ -17,7 +18,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import BinaryIO, Iterable
 
-ALLOWED_IMAGE_EXTS = {".jpg", ".jpeg", ".png"}
+from ..datasets import IMAGE_EXTS
+
+# PP10 起复用全链路白名单：上传 / 下载 / curation / 训练共用一份。
+ALLOWED_IMAGE_EXTS = IMAGE_EXTS
 ZIP_EXT = ".zip"
 
 
@@ -50,8 +54,8 @@ def accept_one(
 ) -> UploadResult:
     """处理单个上传文件。
 
-    - jpg/jpeg/png → 直接拷到 dest_dir
-    - zip → 解压所有 jpg/png（拍平）
+    - IMAGE_EXTS 内任一格式 → 直接拷到 dest_dir（不做格式转换）
+    - zip → 解压所有图片格式（拍平）
     - 其他 / 没扩展名 → 拒绝
     """
     base = _safe_basename(src_name or "")
@@ -101,8 +105,9 @@ def accept_one(
             result.skipped.append({"name": base, "reason": "zip 损坏"})
         return result
 
+    allowed = ", ".join(sorted(ALLOWED_IMAGE_EXTS)) + ", .zip"
     result.skipped.append(
-        {"name": base, "reason": "格式不支持（仅 .jpg / .png / .zip）"}
+        {"name": base, "reason": f"格式不支持（仅 {allowed}）"}
     )
     return result
 

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -26,19 +26,30 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Optional
 
-from . import db, project_jobs
+from . import db, project_jobs, secrets as _secrets
 from .log_tail import LogTailer, MonitorStatePoller
 from .paths import LOGS_DIR, REPO_ROOT, STUDIO_DATA, STUDIO_DB, USER_PRESETS_DIR
 
 logger = logging.getLogger(__name__)
+
+# PP10.2.b：哪些 job kind 吃 GPU。这些 kind 在训练运行中默认会被推迟，
+# 除非 secrets.queue.allow_gpu_during_train=True 显式允许并行。
+GPU_BOUND_JOB_KINDS: frozenset[str] = frozenset({"tag", "reg_build"})
+
+# 槽位名常量
+SLOT_TRAIN = "train"
+SLOT_DATA = "data"
 
 
 @dataclass
 class _Slot:
     """Supervisor 内的一个执行槽位。每个槽位最多跑 1 个子进程。
 
-    PP10.2.a 起从「单 _current_* 字段」改成「list[_Slot]」。10.2.a 仍是单槽位
-    （行为不变），10.2.b 会拆成 TRAIN + DATA 两槽位让训练与数据准备并行。
+    PP10.2.a 起从「单 _current_* 字段」改成「list[_Slot]」；10.2.b 拆成
+    两个槽位：
+      - TRAIN 槽：只跑 training tasks（db.tasks 表）
+      - DATA  槽：只跑 project_jobs（download / tag / reg_build）
+    download 永远跟训练并行；tag / reg_build 看 settings 开关。
     """
     name: str = "main"
     proc: Optional[subprocess.Popen] = None
@@ -181,9 +192,12 @@ class Supervisor:
 
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
-        # PP10.2.a：执行槽位列表。10.2.a 单槽位（行为不变），10.2.b 拆成
-        # TRAIN + DATA 让训练与数据准备并行。
-        self._slots: list[_Slot] = [_Slot(name="main")]
+        # PP10.2.b：双槽位。TRAIN 槽只跑 tasks，DATA 槽只跑 project_jobs。
+        # download 永远跟训练并行；tag / reg_build 默认在训练时推迟。
+        self._slots: list[_Slot] = [
+            _Slot(name=SLOT_TRAIN),
+            _Slot(name=SLOT_DATA),
+        ]
         self._log_seq = itertools.count()
 
     # ------------------------------------------------------------------ 控制
@@ -322,32 +336,58 @@ class Supervisor:
             if rc is not None:
                 self._finish_slot(slot, rc)
 
-        # 2) 给空闲槽位派活
+        # 2) 给空闲槽位派活（按槽位职责分工）
         for slot in self._slots:
             if slot.busy:
                 continue
-            if self._dispatch(slot):
-                # 派出去就停 — 同一 tick 不再给同槽派第二个活
-                continue
+            if slot.name == SLOT_TRAIN:
+                self._dispatch_train(slot)
+            elif slot.name == SLOT_DATA:
+                self._dispatch_data(slot)
 
-    def _dispatch(self, slot: _Slot) -> bool:
-        """给空闲 slot 找一个 pending 单元跑。返回 True 表示已派活。
-
-        10.2.a：单槽位，沿用 jobs > tasks 的旧优先级，行为不变。
-        10.2.b 起会重写为按槽位职责（TRAIN 槽只看 tasks，DATA 槽按 GPU 策略
-        筛 jobs）。
-        """
-        with db.connection_for(self._db_path) as conn:
-            job = project_jobs.next_pending(conn)
-        if job:
-            self._spawn_job(slot, job)
-            return True
+    def _dispatch_train(self, slot: _Slot) -> None:
+        """TRAIN 槽：只跑 db.tasks 表里的训练 task。"""
         with db.connection_for(self._db_path) as conn:
             task = db.next_pending(conn)
         if task:
             self._spawn_task(slot, task)
-            return True
+
+    def _dispatch_data(self, slot: _Slot) -> None:
+        """DATA 槽：跑 project_jobs（download / tag / reg_build）。
+
+        - download 永远 OK（IO-only，不抢 GPU）
+        - tag / reg_build 是 GPU-bound：训练正在跑且未开
+          `secrets.queue.allow_gpu_during_train` → 跳过这条 job，等训练结束
+          再拉。下一条非 GPU job 仍可派。
+        """
+        train_busy = self._train_busy()
+        allow_gpu = self._allow_gpu_during_train()
+        # 简单实现：取 next_pending 那一条；若 GPU-bound 且训练在跑，留着不动
+        # （让它仍然 pending），其他 IO-only job 会在下一次 tick 通过 next_pending
+        # 重新被取到（next_pending 按 id ASC，下一次同样会指向这条；所以需要
+        # 跳过）。这里用 list_jobs 选第一条**可跑**的。
+        with db.connection_for(self._db_path) as conn:
+            pending = project_jobs.list_jobs(conn, status="pending")
+        # list_jobs 默认 ORDER BY id DESC；按入队顺序应该 ASC
+        pending.sort(key=lambda j: j["id"])
+        for job in pending:
+            kind = job["kind"]
+            if kind in GPU_BOUND_JOB_KINDS and train_busy and not allow_gpu:
+                continue  # 训练中暂缓 GPU job
+            self._spawn_job(slot, job)
+            return
+
+    def _train_busy(self) -> bool:
+        for slot in self._slots:
+            if slot.name == SLOT_TRAIN and slot.busy:
+                return True
         return False
+
+    def _allow_gpu_during_train(self) -> bool:
+        try:
+            return bool(_secrets.load().queue.allow_gpu_during_train)
+        except Exception:
+            return False
 
     # -------------------------------------------------------------- 子进程
     def _spawn_task(self, slot: _Slot, task: dict[str, Any]) -> None:

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import threading
 import time
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Optional
 
@@ -30,6 +31,36 @@ from .log_tail import LogTailer, MonitorStatePoller
 from .paths import LOGS_DIR, REPO_ROOT, STUDIO_DATA, STUDIO_DB, USER_PRESETS_DIR
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _Slot:
+    """Supervisor 内的一个执行槽位。每个槽位最多跑 1 个子进程。
+
+    PP10.2.a 起从「单 _current_* 字段」改成「list[_Slot]」。10.2.a 仍是单槽位
+    （行为不变），10.2.b 会拆成 TRAIN + DATA 两槽位让训练与数据准备并行。
+    """
+    name: str = "main"
+    proc: Optional[subprocess.Popen] = None
+    kind: Optional[str] = None  # "task" | "job"
+    id: Optional[int] = None
+    log_fp: Optional[Any] = None
+    tailer: Optional[LogTailer] = None
+    state_poller: Optional[MonitorStatePoller] = None
+    cancel_pending: bool = False
+
+    @property
+    def busy(self) -> bool:
+        return self.proc is not None
+
+    def reset(self) -> None:
+        self.proc = None
+        self.kind = None
+        self.id = None
+        self.log_fp = None
+        self.tailer = None
+        self.state_poller = None
+        self.cancel_pending = False
 
 EventCallback = Callable[[dict[str, Any]], None]
 CmdBuilder = Callable[[dict[str, Any], Path], list[str]]
@@ -150,14 +181,9 @@ class Supervisor:
 
         self._stop = threading.Event()
         self._thread: Optional[threading.Thread] = None
-        # 当前活跃单元（task 或 job 二选一）
-        self._current_proc: Optional[subprocess.Popen] = None
-        self._current_kind: Optional[str] = None  # "task" | "job"
-        self._current_id: Optional[int] = None
-        self._current_log_fp: Optional[Any] = None
-        self._current_tailer: Optional[LogTailer] = None
-        self._current_state_poller: Optional[MonitorStatePoller] = None
-        self._cancel_pending = False
+        # PP10.2.a：执行槽位列表。10.2.a 单槽位（行为不变），10.2.b 拆成
+        # TRAIN + DATA 让训练与数据准备并行。
+        self._slots: list[_Slot] = [_Slot(name="main")]
         self._log_seq = itertools.count()
 
     # ------------------------------------------------------------------ 控制
@@ -172,16 +198,23 @@ class Supervisor:
 
     def stop(self, timeout: float = 5.0) -> None:
         self._stop.set()
-        if self._current_proc:
-            self._terminate_current()
+        for slot in self._slots:
+            if slot.busy:
+                self._terminate_slot(slot)
         if self._thread:
             self._thread.join(timeout=timeout)
+
+    def _find_slot(self, *, kind: str, id: int) -> Optional[_Slot]:
+        for slot in self._slots:
+            if slot.kind == kind and slot.id == id:
+                return slot
+        return None
 
     def cancel(self, task_id: int) -> bool:
         """取消 task：pending → status=canceled；running → 异步发信号立即返回。
 
         异步路径关键：**不阻塞 web 请求线程**。supervisor 主循环会自然 poll
-        proc.poll() 拿到退出码并走 `_finish_current` 流程，把 status 写为
+        proc.poll() 拿到退出码并走 `_finish_slot` 流程，把 status 写为
         canceled。后台 grace timer 在 30s 后还没退就强杀整棵进程树。
         """
         with db.connection_for(self._db_path) as conn:
@@ -196,13 +229,11 @@ class Supervisor:
                     {"type": "task_state_changed", "task_id": task_id, "status": "canceled"}
                 )
                 return True
-        if (
-            task["status"] == "running"
-            and self._current_kind == "task"
-            and self._current_id == task_id
-        ):
-            self._signal_terminate_async()
-            return True
+        if task["status"] == "running":
+            slot = self._find_slot(kind="task", id=task_id)
+            if slot is not None:
+                self._signal_terminate_async(slot)
+                return True
         return False
 
     def cancel_job(self, job_id: int) -> bool:
@@ -224,22 +255,26 @@ class Supervisor:
                     }
                 )
                 return True
-        if (
-            job["status"] == "running"
-            and self._current_kind == "job"
-            and self._current_id == job_id
-        ):
-            self._signal_terminate_async()
-            return True
+        if job["status"] == "running":
+            slot = self._find_slot(kind="job", id=job_id)
+            if slot is not None:
+                self._signal_terminate_async(slot)
+                return True
         return False
 
     @property
     def current_task_id(self) -> Optional[int]:
-        return self._current_id if self._current_kind == "task" else None
+        for slot in self._slots:
+            if slot.kind == "task":
+                return slot.id
+        return None
 
     @property
     def current_job_id(self) -> Optional[int]:
-        return self._current_id if self._current_kind == "job" else None
+        for slot in self._slots:
+            if slot.kind == "job":
+                return slot.id
+        return None
 
     # -------------------------------------------------------------- 主循环
     def _loop(self) -> None:
@@ -278,27 +313,44 @@ class Supervisor:
                 logger.info("orphan running jobs → failed: %d", n)
 
     def _tick(self) -> None:
-        if self._current_proc:
-            rc = self._current_proc.poll()
-            if rc is None:
-                return
-            self._finish_current(rc)
-            return
+        # 1) 先收尸：所有 busy 槽位 poll 一遍，退出的走 _finish_slot
+        for slot in self._slots:
+            if not slot.busy:
+                continue
+            assert slot.proc is not None
+            rc = slot.proc.poll()
+            if rc is not None:
+                self._finish_slot(slot, rc)
 
-        # 优先调度 project_jobs（数据准备）
+        # 2) 给空闲槽位派活
+        for slot in self._slots:
+            if slot.busy:
+                continue
+            if self._dispatch(slot):
+                # 派出去就停 — 同一 tick 不再给同槽派第二个活
+                continue
+
+    def _dispatch(self, slot: _Slot) -> bool:
+        """给空闲 slot 找一个 pending 单元跑。返回 True 表示已派活。
+
+        10.2.a：单槽位，沿用 jobs > tasks 的旧优先级，行为不变。
+        10.2.b 起会重写为按槽位职责（TRAIN 槽只看 tasks，DATA 槽按 GPU 策略
+        筛 jobs）。
+        """
         with db.connection_for(self._db_path) as conn:
             job = project_jobs.next_pending(conn)
         if job:
-            self._spawn_job(job)
-            return
-
+            self._spawn_job(slot, job)
+            return True
         with db.connection_for(self._db_path) as conn:
             task = db.next_pending(conn)
         if task:
-            self._spawn_task(task)
+            self._spawn_task(slot, task)
+            return True
+        return False
 
     # -------------------------------------------------------------- 子进程
-    def _spawn_task(self, task: dict[str, Any]) -> None:
+    def _spawn_task(self, slot: _Slot, task: dict[str, Any]) -> None:
         # PP6.3：优先用 task.config_path（version 私有 config 绝对路径）；
         # 没有时降级到老路径 _configs_dir / {config_name}.yaml。
         explicit_cfg = task.get("config_path")
@@ -345,11 +397,11 @@ class Supervisor:
         cmd = self._cmd_builder(task, cfg_path)
         proc = self._popen(cmd, log_fp)
 
-        self._current_proc = proc
-        self._current_kind = "task"
-        self._current_id = task["id"]
-        self._current_log_fp = log_fp
-        self._cancel_pending = False
+        slot.proc = proc
+        slot.kind = "task"
+        slot.id = task["id"]
+        slot.log_fp = log_fp
+        slot.cancel_pending = False
 
         # PP6.4 — log tail → SSE（取代前端 2s 轮询 /api/logs/{id}）
         tid = task["id"]
@@ -362,8 +414,8 @@ class Supervisor:
                 "seq": next(self._log_seq),
             })
 
-        self._current_tailer = LogTailer(log_path, _on_task_log)
-        self._current_tailer.start()
+        slot.tailer = LogTailer(log_path, _on_task_log)
+        slot.tailer.start()
 
         # PP6.4 — monitor_state.json 变化 → SSE（取代前端 1Hz 轮询 /api/state）
         def _on_state(state: dict[str, Any]) -> None:
@@ -373,10 +425,8 @@ class Supervisor:
                 "state": state,
             })
 
-        self._current_state_poller = MonitorStatePoller(
-            monitor_state_path, _on_state
-        )
-        self._current_state_poller.start()
+        slot.state_poller = MonitorStatePoller(monitor_state_path, _on_state)
+        slot.state_poller.start()
 
         with db.connection_for(self._db_path) as conn:
             db.update_task(
@@ -394,9 +444,11 @@ class Supervisor:
                 "status": "running",
             }
         )
-        logger.info("started task %d (pid=%d)", task["id"], proc.pid)
+        logger.info(
+            "started task %d on slot=%s (pid=%d)", task["id"], slot.name, proc.pid
+        )
 
-    def _spawn_job(self, job: dict[str, Any]) -> None:
+    def _spawn_job(self, slot: _Slot, job: dict[str, Any]) -> None:
         log_path = Path(job.get("log_path") or project_jobs.log_path_for(job["id"]))
         log_path.parent.mkdir(parents=True, exist_ok=True)
         # worker 自己 append 模式开 log，supervisor 这里只挂个 stdout 转发到同一文件
@@ -408,11 +460,11 @@ class Supervisor:
         with db.connection_for(self._db_path) as conn:
             project_jobs.mark_running(conn, job["id"], pid=proc.pid)
 
-        self._current_proc = proc
-        self._current_kind = "job"
-        self._current_id = job["id"]
-        self._current_log_fp = log_fp
-        self._cancel_pending = False
+        slot.proc = proc
+        slot.kind = "job"
+        slot.id = job["id"]
+        slot.log_fp = log_fp
+        slot.cancel_pending = False
 
         # tail 增量 → SSE
         jid = job["id"]
@@ -431,8 +483,8 @@ class Supervisor:
                 "seq": next(self._log_seq),
             })
 
-        self._current_tailer = LogTailer(log_path, _on_line)
-        self._current_tailer.start()
+        slot.tailer = LogTailer(log_path, _on_line)
+        slot.tailer.start()
 
         self._on_event({
             "type": "job_state_changed",
@@ -442,7 +494,10 @@ class Supervisor:
             "kind": kind,
             "status": "running",
         })
-        logger.info("started job %d (kind=%s, pid=%d)", jid, kind, proc.pid)
+        logger.info(
+            "started job %d on slot=%s (kind=%s, pid=%d)",
+            jid, slot.name, kind, proc.pid,
+        )
 
     def _popen(self, cmd: list[str], log_fp: Any) -> subprocess.Popen:
         creationflags = 0
@@ -471,27 +526,27 @@ class Supervisor:
             env=env,
         )
 
-    def _finish_current(self, rc: int) -> None:
-        kind = self._current_kind
-        cid = self._current_id
+    def _finish_slot(self, slot: _Slot, rc: int) -> None:
+        kind = slot.kind
+        cid = slot.id
         assert cid is not None and kind is not None
-        if self._current_log_fp:
+        if slot.log_fp:
             try:
-                self._current_log_fp.close()
+                slot.log_fp.close()
             except Exception:
                 pass
-        if self._current_tailer:
+        if slot.tailer:
             try:
-                self._current_tailer.stop()
+                slot.tailer.stop()
             except Exception:
                 pass
-        if self._current_state_poller:
+        if slot.state_poller:
             try:
-                self._current_state_poller.stop()
+                slot.state_poller.stop()
             except Exception:
                 pass
 
-        if self._cancel_pending:
+        if slot.cancel_pending:
             status = "canceled"
         elif rc == 0:
             status = "done"
@@ -535,33 +590,25 @@ class Supervisor:
             })
             logger.info("job %d finished: %s (rc=%d)", cid, status, rc)
 
-        self._current_proc = None
-        self._current_kind = None
-        self._current_id = None
-        self._current_log_fp = None
-        self._current_tailer = None
-        self._current_state_poller = None
-        self._cancel_pending = False
+        slot.reset()
 
-    def _terminate_current(self) -> None:
-        """同步终止当前子进程（仅 supervisor.stop() 用 —— 进程退出时走这里）。
+    def _terminate_slot(self, slot: _Slot) -> None:
+        """同步终止指定槽位的子进程（仅 supervisor.stop() 用）。
 
         web 请求路径下的 cancel 请用 `_signal_terminate_async`，避免阻塞
         请求线程 30 秒。
         """
-        if not self._current_proc:
+        if not slot.proc:
             return
-        self._cancel_pending = True
-        proc = self._current_proc
+        slot.cancel_pending = True
+        proc = slot.proc
         self._send_terminate_signal(proc)
         try:
             proc.wait(timeout=self._grace)
         except subprocess.TimeoutExpired:
             logger.warning(
-                "%s %s did not exit in %.0fs, killing process tree",
-                self._current_kind,
-                self._current_id,
-                self._grace,
+                "%s %s on slot=%s did not exit in %.0fs, killing process tree",
+                slot.kind, slot.id, slot.name, self._grace,
             )
             _kill_process_tree(proc.pid)
             try:
@@ -569,17 +616,17 @@ class Supervisor:
             except subprocess.TimeoutExpired:
                 pass
 
-    def _signal_terminate_async(self) -> None:
+    def _signal_terminate_async(self, slot: _Slot) -> None:
         """非阻塞：发软终止信号，启动后台 grace timer 强杀进程树。
 
         web 请求线程立刻返回，让 reload() 不被取消请求阻塞 30 秒。supervisor
         主循环每 POLL_INTERVAL 秒 poll proc.poll()，进程一旦退出就走
-        `_finish_current` 把 status 改成 canceled 并 publish 事件。
+        `_finish_slot` 把 status 改成 canceled 并 publish 事件。
         """
-        if not self._current_proc:
+        if not slot.proc:
             return
-        self._cancel_pending = True
-        proc = self._current_proc
+        slot.cancel_pending = True
+        proc = slot.proc
         self._send_terminate_signal(proc)
 
         grace = self._grace

--- a/studio/versions.py
+++ b/studio/versions.py
@@ -98,6 +98,13 @@ def list_versions(
     ]
 
 
+# PP10.1 — fork 时源 stage 落到新 version 的映射。
+# done / training 的 version 已经训完或在训，新 version 重新进入待训练态；
+# 其他 stage（curating / tagging / regularizing / ready）原样跟随，让用户从
+# 副本所处的同一 step 接着干。
+_FORK_STAGE_RESET: frozenset[str] = frozenset({"done", "training"})
+
+
 def create_version(
     conn: sqlite3.Connection,
     *,
@@ -108,9 +115,12 @@ def create_version(
 ) -> dict[str, Any]:
     """label 校验：仅 [A-Za-z0-9_.-]+；同 project 内唯一。
 
-    fork_from_version_id 给了：复制源 version 的 train/ 目录树（递归 copy）。
-    config_name 也一起拷过来 —— 注意 PP6 才会真用 config_name；这里只是字段层
-    继承，避免后续切预设时漏 fork。
+    fork_from_version_id 给了 → 全量复制源 version 的用户产物：
+        train/、reg/、config.yaml、.unlocked.json（PP10.4）
+    输出类（output/、samples/、monitor_state.json）一律不复制。
+    复制 config.yaml 后立即重写一次，把 data_dir / reg_data_dir / output_dir /
+    output_name 强制刷成新 version 的路径。
+    stage 跟随源（done/training → ready；其他原样）。
     """
     p = projects.get_project(conn, project_id)
     if not p:
@@ -127,6 +137,7 @@ def create_version(
         raise VersionError(f"label 已存在: {label!r}")
 
     src_config_name: Optional[str] = None
+    src_stage: str = "curating"
     if fork_from_version_id is not None:
         src = get_version(conn, fork_from_version_id)
         if not src or src["project_id"] != project_id:
@@ -134,12 +145,13 @@ def create_version(
                 f"fork 源不存在或不属于当前项目: id={fork_from_version_id}"
             )
         src_config_name = src["config_name"]
+        src_stage = "ready" if src["stage"] in _FORK_STAGE_RESET else src["stage"]
 
     now = time.time()
     cur = conn.execute(
         "INSERT INTO versions(project_id, label, config_name, stage, created_at, note) "
-        "VALUES (?, ?, ?, 'curating', ?, ?)",
-        (project_id, label, src_config_name, now, note),
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (project_id, label, src_config_name, src_stage, now, note),
     )
     conn.commit()
     vid = int(cur.lastrowid)
@@ -149,9 +161,33 @@ def create_version(
 
     if fork_from_version_id is not None:
         src = _must_get(conn, fork_from_version_id)
-        src_train = version_dir(project_id, p["slug"], src["label"]) / "train"
-        if src_train.exists():
-            _copytree_train(src_train, vdir / "train")
+        src_vdir = version_dir(project_id, p["slug"], src["label"])
+        # train / reg：递归复制目录（存在才复制）
+        for sub in ("train", "reg"):
+            src_sub = src_vdir / sub
+            if src_sub.exists():
+                _copytree(src_sub, vdir / sub)
+        # config.yaml + .unlocked.json：单文件复制
+        for fname in ("config.yaml", ".unlocked.json"):
+            src_file = src_vdir / fname
+            if src_file.exists():
+                shutil.copy2(src_file, vdir / fname)
+        # config.yaml 复制过来后，data_dir / reg_data_dir / output_dir /
+        # output_name 还指向源 version；用 force_project_overrides=True 重写
+        # 一次刷成新 version 的路径。reg_data_dir 由 project_specific_overrides
+        # 自动检测新 version 的 reg/meta.json 是否存在 → 跟随复制结果。
+        v_for_rewrite = _must_get(conn, vid)
+        new_cfg_path = vdir / "config.yaml"
+        if new_cfg_path.exists():
+            from .services import version_config as _vc  # 延迟避免循环
+            try:
+                cfg = _vc.read_version_config(p, v_for_rewrite)
+                _vc.write_version_config(
+                    p, v_for_rewrite, cfg, force_project_overrides=True
+                )
+            except _vc.VersionConfigError:
+                # 源 config 损坏不阻断新建；用户去 Train 页换预设
+                pass
 
     v = _must_get(conn, vid)
     _write_version_json(v, vdir)
@@ -163,16 +199,17 @@ def create_version(
     return v
 
 
-def _copytree_train(src: Path, dst: Path) -> None:
-    """复制训练树（含子文件夹与 .txt/.json 同名 metadata）。
+def _copytree(src: Path, dst: Path) -> None:
+    """递归复制目录（含子文件夹与同名 metadata 文件）。
 
     Win 上硬链接受限较多，统一走 copy（PP1 说明这点）。
+    PP10.1 起从 _copytree_train 通用化 — train / reg 都用这个。
     """
     dst.mkdir(parents=True, exist_ok=True)
     for sub in src.iterdir():
         target = dst / sub.name
         if sub.is_dir():
-            _copytree_train(sub, target)
+            _copytree(sub, target)
         else:
             shutil.copy2(sub, target)
 

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -150,6 +150,12 @@ export interface ModelsConfig {
   selected_anima: string
 }
 
+export interface QueueConfig {
+  /** PP10.2：默认 false，训练时推迟 tag/reg_build job 避免 GPU OOM。
+   * 用户开后允许 GPU job 与训练并行（自己确认显存够）。 */
+  allow_gpu_during_train: boolean
+}
+
 export interface Secrets {
   gelbooru: GelbooruConfig
   danbooru: DanbooruConfig
@@ -158,6 +164,7 @@ export interface Secrets {
   joycaption: JoyCaptionConfig
   wd14: WD14Config
   models: ModelsConfig
+  queue: QueueConfig
 }
 
 /** PUT /api/secrets 的 body：嵌套的 partial dict；MASK ("***") 表示「保持不变」。 */

--- a/studio/web/src/components/BulkActionBar.tsx
+++ b/studio/web/src/components/BulkActionBar.tsx
@@ -32,7 +32,7 @@ export default function BulkActionBar({
   const [tagsInput, setTagsInput] = useState('')
   const [oldTag, setOldTag] = useState('')
   const [newTag, setNewTag] = useState('')
-  const [position, setPosition] = useState<'front' | 'back'>('back')
+  const [position, setPosition] = useState<'front' | 'back'>('front')
 
   const closePopover = () => {
     setOpenOp(null)
@@ -177,8 +177,8 @@ export default function BulkActionBar({
               onChange={(e) => setPosition(e.target.value as 'front' | 'back')}
               className="px-2 py-1 rounded bg-slate-950 border border-slate-700 text-xs"
             >
-              <option value="back">追加到末尾</option>
               <option value="front">插到开头</option>
+              <option value="back">追加到末尾</option>
             </select>
           )}
           {openOp === 'replace' && (

--- a/studio/web/src/components/Field.test.tsx
+++ b/studio/web/src/components/Field.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import type { SchemaProperty } from '../api/client'
+import Field from './Field'
+
+const floatProp: SchemaProperty = {
+  type: 'number',
+  default: 0.5,
+  group: 'misc',
+  control: 'auto',
+  description: '',
+}
+
+const intProp: SchemaProperty = {
+  type: 'integer',
+  default: 1,
+  group: 'misc',
+  control: 'auto',
+  description: '',
+}
+
+describe('Field number input (PP10.3)', () => {
+  it('does not commit on each keystroke — typing 0.05 stays intact', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Field name="lr" prop={floatProp} value={0.5} onChange={onChange} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, '0.05')
+    // 输入过程中父 onChange 不应被调用
+    expect(onChange).not.toHaveBeenCalled()
+    // raw 缓冲保留完整输入
+    expect(input.value).toBe('0.05')
+  })
+
+  it('commits parsed number on blur', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Field name="lr" prop={floatProp} value={0.5} onChange={onChange} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, '0.05')
+    await user.tab() // 触发 blur
+    expect(onChange).toHaveBeenCalledWith(0.05)
+  })
+
+  it('commits parsed number on Enter', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Field name="lr" prop={floatProp} value={0.5} onChange={onChange} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, '0.05{Enter}')
+    expect(onChange).toHaveBeenCalledWith(0.05)
+  })
+
+  it('blur with empty input writes back default', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Field name="lr" prop={floatProp} value={0.5} onChange={onChange} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    await user.clear(input)
+    await user.tab()
+    expect(onChange).toHaveBeenCalledWith(0.5) // floatProp.default
+    expect(input.value).toBe('0.5')
+  })
+
+  it('blur with invalid input rolls back to current value', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Field name="lr" prop={floatProp} value={0.5} onChange={onChange} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, 'abc')
+    await user.tab()
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input.value).toBe('0.5') // 回滚
+  })
+
+  it('int field also uses raw buffer', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<Field name="batch" prop={intProp} value={4} onChange={onChange} />)
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, '16')
+    expect(onChange).not.toHaveBeenCalled()
+    await user.tab()
+    expect(onChange).toHaveBeenCalledWith(16)
+  })
+
+  it('external value change syncs raw only when input is not focused', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <Field name="lr" prop={floatProp} value={0.5} onChange={onChange} />,
+    )
+    const input = screen.getByRole('textbox') as HTMLInputElement
+
+    // 用户 focus 进去开始输入
+    await user.click(input)
+    await user.clear(input)
+    await user.type(input, '0.0')
+    expect(input.value).toBe('0.0')
+
+    // 此时外部 value 变化（如 SSE / 别的字段触发的 reset）—— 不应覆盖用户半截输入
+    rerender(<Field name="lr" prop={floatProp} value={0.999} onChange={onChange} />)
+    expect(input.value).toBe('0.0')
+
+    // blur 后再改外部 value → 这次同步
+    await user.tab()
+    rerender(<Field name="lr" prop={floatProp} value={0.123} onChange={onChange} />)
+    expect(input.value).toBe('0.123')
+  })
+
+  it('does not clamp values outside min/max — backend pydantic decides', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    const propWithRange: SchemaProperty = {
+      ...floatProp,
+      minimum: 0,
+      maximum: 1,
+    }
+    render(
+      <Field name="lr" prop={propWithRange} value={0.5} onChange={onChange} />,
+    )
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, '5')
+    await user.tab()
+    expect(onChange).toHaveBeenCalledWith(5) // 不 clamp
+  })
+
+  it('disabled input cannot be typed into', () => {
+    render(
+      <Field
+        name="lr"
+        prop={floatProp}
+        value={0.5}
+        onChange={() => {}}
+        disabled
+      />,
+    )
+    expect(screen.getByRole('textbox')).toBeDisabled()
+  })
+})

--- a/studio/web/src/components/Field.test.tsx
+++ b/studio/web/src/components/Field.test.tsx
@@ -120,7 +120,27 @@ describe('Field number input (PP10.3)', () => {
     expect(input.value).toBe('0.123')
   })
 
-  it('does not clamp values outside min/max — backend pydantic decides', async () => {
+  it('rolls back values below schema minimum (恢复 type=number min 校验)', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    const propWithRange: SchemaProperty = {
+      ...floatProp,
+      minimum: 0,
+      maximum: 1,
+    }
+    render(
+      <Field name="lr" prop={propWithRange} value={0.5} onChange={onChange} />,
+    )
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, '-0.1')
+    await user.tab()
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input.value).toBe('0.5')
+  })
+
+  it('rolls back values above schema maximum', async () => {
     const onChange = vi.fn()
     const user = userEvent.setup()
     const propWithRange: SchemaProperty = {
@@ -136,7 +156,32 @@ describe('Field number input (PP10.3)', () => {
     await user.clear(input)
     await user.type(input, '5')
     await user.tab()
-    expect(onChange).toHaveBeenCalledWith(5) // 不 clamp
+    expect(onChange).not.toHaveBeenCalled()
+    expect(input.value).toBe('0.5')
+  })
+
+  it('accepts values exactly at min / max boundaries', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    const propWithRange: SchemaProperty = {
+      ...floatProp,
+      minimum: 0,
+      maximum: 1,
+    }
+    render(
+      <Field name="lr" prop={propWithRange} value={0.5} onChange={onChange} />,
+    )
+
+    const input = screen.getByRole('textbox') as HTMLInputElement
+    await user.clear(input)
+    await user.type(input, '0')
+    await user.tab()
+    expect(onChange).toHaveBeenLastCalledWith(0)
+
+    await user.clear(input)
+    await user.type(input, '1')
+    await user.tab()
+    expect(onChange).toHaveBeenLastCalledWith(1)
   })
 
   it('disabled input cannot be typed into', () => {

--- a/studio/web/src/components/Field.tsx
+++ b/studio/web/src/components/Field.tsx
@@ -149,6 +149,8 @@ export default function Field({
         help={help}
         value={value}
         defaultValue={prop.default}
+        minimum={prop.minimum}
+        maximum={prop.maximum}
         onChange={onChange}
         disabled={disabled}
         hintNode={hintNode}
@@ -176,6 +178,8 @@ interface NumberFieldProps {
   help: string | undefined
   value: unknown
   defaultValue: unknown
+  minimum?: number
+  maximum?: number
   onChange: (v: unknown) => void
   disabled?: boolean
   hintNode?: React.ReactNode
@@ -187,9 +191,15 @@ interface NumberFieldProps {
  * 之前 onChange 立即 parseFloat → 父 setConfig 立即重渲染 → 受控 value 字符串
  * 化把「0.0」截成「0」，用户没法输 0.05。改用 raw 缓冲后输入中状态保留，
  * 仅在 blur 时把合法值上报；外部 value 变化只在 input 不 focus 时同步。
+ *
+ * min/max：blur 时若解析出的数超出 schema 声明的 minimum/maximum，
+ * 回滚到上次合法 value（跟 NaN 同处理）。这是为了恢复 PP10.3 之前
+ * `<input type="number" min max>` 自带的 HTML5 校验—— text 模式下浏览器
+ * 不再阻止超界输入，要前端自己挡。
  */
 function NumberField({
-  label, kind, help, value, defaultValue, onChange, disabled = false, hintNode,
+  label, kind, help, value, defaultValue, minimum, maximum,
+  onChange, disabled = false, hintNode,
 }: NumberFieldProps) {
   const formatNum = (v: unknown) =>
     v === null || v === undefined ? '' : String(v)
@@ -213,6 +223,14 @@ function NumberField({
     const num = kind === 'int' ? parseInt(raw, 10) : parseFloat(raw)
     if (Number.isNaN(num)) {
       // 输入非法 → 回滚到上次合法 value
+      setRaw(formatNum(value))
+      return
+    }
+    if (
+      (minimum !== undefined && num < minimum) ||
+      (maximum !== undefined && num > maximum)
+    ) {
+      // 超出 schema 范围 → 回滚（避免「先存进去再 PUT 时被 400」的滞后反馈）
       setRaw(formatNum(value))
       return
     }

--- a/studio/web/src/components/Field.tsx
+++ b/studio/web/src/components/Field.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { SchemaProperty } from '../api/client'
 import { controlKind, fieldLabel } from '../lib/schema'
 import PathPicker from './PathPicker'
@@ -143,31 +143,16 @@ export default function Field({
   // int / float ---------------------------------------------------------
   if (kind === 'int' || kind === 'float') {
     return (
-      <div className="py-1.5">
-        <div className={labelCls}>
-          {label}
-          {hintNode}
-        </div>
-        <input
-          type="number"
-          step={kind === 'int' ? 1 : 'any'}
-          value={value === null || value === undefined ? '' : String(value)}
-          min={prop.minimum}
-          max={prop.maximum}
-          onChange={(e) => {
-            const raw = e.target.value
-            if (raw === '') {
-              onChange(prop.default)
-              return
-            }
-            const num = kind === 'int' ? parseInt(raw, 10) : parseFloat(raw)
-            if (!Number.isNaN(num)) onChange(num)
-          }}
-          disabled={disabled}
-          className={inputCls}
-        />
-        {help && <div className={helpCls}>{help}</div>}
-      </div>
+      <NumberField
+        label={label}
+        kind={kind}
+        help={help}
+        value={value}
+        defaultValue={prop.default}
+        onChange={onChange}
+        disabled={disabled}
+        hintNode={hintNode}
+      />
     )
   }
 
@@ -182,6 +167,84 @@ export default function Field({
       disabled={disabled}
       hintNode={hintNode}
     />
+  )
+}
+
+interface NumberFieldProps {
+  label: string
+  kind: 'int' | 'float'
+  help: string | undefined
+  value: unknown
+  defaultValue: unknown
+  onChange: (v: unknown) => void
+  disabled?: boolean
+  hintNode?: React.ReactNode
+}
+
+/**
+ * 数字输入：内部维护 raw 字符串，blur / Enter 时才解析并提交父 onChange。
+ *
+ * 之前 onChange 立即 parseFloat → 父 setConfig 立即重渲染 → 受控 value 字符串
+ * 化把「0.0」截成「0」，用户没法输 0.05。改用 raw 缓冲后输入中状态保留，
+ * 仅在 blur 时把合法值上报；外部 value 变化只在 input 不 focus 时同步。
+ */
+function NumberField({
+  label, kind, help, value, defaultValue, onChange, disabled = false, hintNode,
+}: NumberFieldProps) {
+  const formatNum = (v: unknown) =>
+    v === null || v === undefined ? '' : String(v)
+  const [raw, setRaw] = useState<string>(() => formatNum(value))
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  // 外部 value 变化（reset / fork preset）→ 只在用户没在输入时才覆盖 raw，
+  // 否则会把用户半截输入吞掉。
+  useEffect(() => {
+    if (document.activeElement !== inputRef.current) {
+      setRaw(formatNum(value))
+    }
+  }, [value])
+
+  const commit = () => {
+    if (raw === '') {
+      onChange(defaultValue)
+      setRaw(formatNum(defaultValue))
+      return
+    }
+    const num = kind === 'int' ? parseInt(raw, 10) : parseFloat(raw)
+    if (Number.isNaN(num)) {
+      // 输入非法 → 回滚到上次合法 value
+      setRaw(formatNum(value))
+      return
+    }
+    onChange(num)
+    // 规范化显示：用户输 "0.050" / "+1" → 提交后显示 "0.05" / "1"
+    setRaw(formatNum(num))
+  }
+
+  return (
+    <div className="py-1.5">
+      <div className={labelCls}>
+        {label}
+        {hintNode}
+      </div>
+      <input
+        ref={inputRef}
+        type="text"
+        inputMode={kind === 'int' ? 'numeric' : 'decimal'}
+        value={raw}
+        onChange={(e) => setRaw(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault()
+            commit()
+          }
+        }}
+        disabled={disabled}
+        className={inputCls}
+      />
+      {help && <div className={helpCls}>{help}</div>}
+    </div>
   )
 }
 

--- a/studio/web/src/components/TagEditor.test.tsx
+++ b/studio/web/src/components/TagEditor.test.tsx
@@ -10,13 +10,13 @@ describe('TagEditor (PP4 chip mode)', () => {
     expect(screen.getByText('b')).toBeInTheDocument()
   })
 
-  it('Enter adds a tag', async () => {
+  it('Enter adds a tag at the front (default position)', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
     render(<TagEditor tags={['a']} onChange={onChange} />)
     const input = screen.getByPlaceholderText(/添加标签/)
     await user.type(input, 'new{Enter}')
-    expect(onChange).toHaveBeenCalledWith(['a', 'new'])
+    expect(onChange).toHaveBeenCalledWith(['new', 'a'])
   })
 
   it('comma also adds a tag', async () => {

--- a/studio/web/src/components/TagEditor.tsx
+++ b/studio/web/src/components/TagEditor.tsx
@@ -50,7 +50,8 @@ export default function TagEditor({
       setDraft('')
       return
     }
-    onChange([...tags, t])
+    // 新 tag 默认插到开头（用户偏好：训练时主标签更靠前）
+    onChange([t, ...tags])
     setDraft('')
   }
 

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -80,6 +80,7 @@ function fmtDuration(start: number | null, end: number | null): string {
 export default function QueuePage() {
   const [tasks, setTasks] = useState<Task[]>([])
   const [configs, setConfigs] = useState<ConfigSummary[]>([])
+  const [loaded, setLoaded] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const reloadTimer = useRef<number | null>(null)
@@ -96,6 +97,8 @@ export default function QueuePage() {
       setConfigs(cfgList)
     } catch (e) {
       setError(String(e))
+    } finally {
+      setLoaded(true)
     }
   }, [])
 
@@ -237,7 +240,26 @@ export default function QueuePage() {
           </div>
         </header>
 
-        {tasks.length === 0 ? (
+        {!loaded ? (
+          <ul
+            className="divide-y divide-slate-800"
+            role="status"
+            aria-label="加载队列中"
+          >
+            {Array.from({ length: 3 }).map((_, i) => (
+              <li key={i} className="px-3 py-3 animate-pulse flex items-center gap-3">
+                <div className="h-3 w-6 bg-slate-700 rounded" />
+                <div className="flex-1 space-y-1">
+                  <div className="h-3 w-40 bg-slate-700 rounded" />
+                  <div className="h-2.5 w-28 bg-slate-800 rounded" />
+                </div>
+                <div className="h-5 w-14 bg-slate-700/70 rounded" />
+                <div className="h-3 w-24 bg-slate-700/60 rounded" />
+              </li>
+            ))}
+            <span className="sr-only">加载队列中...</span>
+          </ul>
+        ) : tasks.length === 0 ? (
           <p className="px-4 py-8 text-center text-slate-500 text-sm">
             队列为空
           </p>

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -232,7 +232,9 @@ export default function QueueDetailPage() {
           <LogTab taskId={taskId} status={status ?? null} />
         )}
         {tab === 'monitor' && <MonitorTab taskId={taskId} />}
-        {tab === 'outputs' && <OutputsTab taskId={taskId} />}
+        {tab === 'outputs' && (
+          <OutputsTab taskId={taskId} taskName={task?.name ?? ''} />
+        )}
       </div>
 
       {/* Footer actions — 危险操作集中在这里，跟内容区视觉隔开 */}
@@ -514,7 +516,7 @@ function MonitorTab({ taskId }: { taskId: number }) {
 // Outputs tab — 之前 OutputsModal 的逻辑搬过来
 // ---------------------------------------------------------------------------
 
-function OutputsTab({ taskId }: { taskId: number }) {
+function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) {
   const { toast } = useToast()
   const [data, setData] = useState<TaskOutputs | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -557,7 +559,11 @@ function OutputsTab({ taskId }: { taskId: number }) {
     if (zipping) return
     setZipping(true)
     try {
-      await downloadBlob(api.taskOutputsZipUrl(taskId), `task_${taskId}_outputs.zip`)
+      // task.name 在 PP6.3 起就是 `{slug}_{label}`，与 LoRA ckpt 命名一致；
+      // 老任务（PP1 之前）name 不规范时回落到 task_{id}。
+      const safe = taskName && /^[A-Za-z0-9_.-]+$/.test(taskName)
+      const zipName = safe ? `${taskName}_outputs.zip` : `task_${taskId}_outputs.zip`
+      await downloadBlob(api.taskOutputsZipUrl(taskId), zipName)
     } catch (e) {
       toast(`下载失败: ${e}`, 'error')
     } finally {

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -81,14 +81,24 @@ export default function ProjectLayout() {
     }
   }
 
-  const handleCreateVersion = async (label: string) => {
+  const handleCreateVersion = async (
+    label: string,
+    forkFromVersionId: number | null,
+  ) => {
     if (!project) return
     try {
-      const v = await api.createVersion(project.id, { label })
+      const body: { label: string; fork_from_version_id?: number } = { label }
+      if (forkFromVersionId !== null) body.fork_from_version_id = forkFromVersionId
+      const v = await api.createVersion(project.id, body)
       await api.activateVersion(project.id, v.id)
       await reload()
       setCreating(false)
-      toast(`已创建版本 ${label}`, 'success')
+      toast(
+        forkFromVersionId !== null
+          ? `已从副本创建版本 ${label}`
+          : `已创建版本 ${label}`,
+        'success',
+      )
     } catch (e) {
       toast(String(e), 'error')
     }
@@ -208,6 +218,7 @@ export default function ProjectLayout() {
       {creating && (
         <NewVersionDialog
           existingLabels={project.versions.map((v) => v.label)}
+          existingVersions={project.versions.map((v) => ({ id: v.id, label: v.label }))}
           onCancel={() => setCreating(false)}
           onSubmit={handleCreateVersion}
         />
@@ -216,16 +227,20 @@ export default function ProjectLayout() {
   )
 }
 
-function NewVersionDialog({
+export function NewVersionDialog({
   existingLabels,
+  existingVersions,
   onCancel,
   onSubmit,
 }: {
   existingLabels: string[]
+  existingVersions: { id: number; label: string }[]
   onCancel: () => void
-  onSubmit: (label: string) => void
+  onSubmit: (label: string, forkFromVersionId: number | null) => void
 }) {
   const [label, setLabel] = useState('')
+  // '' = 从空白开始；其他值 = string 化的 version id
+  const [forkFrom, setForkFrom] = useState<string>('')
   const [err, setErr] = useState<string | null>(null)
 
   const submit = (e: React.FormEvent) => {
@@ -235,7 +250,8 @@ function NewVersionDialog({
     if (!/^[A-Za-z0-9_.-]+$/.test(l))
       return setErr('label 只允许字母 / 数字 / 下划线 / 连字符 / 点')
     if (existingLabels.includes(l)) return setErr('label 已存在')
-    onSubmit(l)
+    const fid = forkFrom === '' ? null : Number(forkFrom)
+    onSubmit(l, fid)
   }
 
   return (
@@ -262,6 +278,28 @@ function NewVersionDialog({
             placeholder="例：baseline / high-lr"
           />
         </label>
+        {existingVersions.length > 0 && (
+          <label className="block">
+            <span className="text-xs text-slate-400 font-mono">从…创建</span>
+            <select
+              value={forkFrom}
+              onChange={(e) => setForkFrom(e.target.value)}
+              className="mt-1 w-full px-2 py-1.5 rounded bg-slate-950 border border-slate-700 text-sm focus:outline-none focus:border-cyan-500"
+            >
+              <option value="">从空白开始</option>
+              {existingVersions.map((v) => (
+                <option key={v.id} value={String(v.id)}>
+                  从 {v.label} 复制
+                </option>
+              ))}
+            </select>
+            {forkFrom !== '' && (
+              <p className="text-[10px] text-slate-500 mt-1">
+                将复制 train/、reg/、训练配置、解锁状态（output/、samples/ 不复制）
+              </p>
+            )}
+          </label>
+        )}
         {err && <p className="text-xs text-red-400">{err}</p>}
         <div className="flex gap-2 justify-end">
           <button

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -16,6 +16,7 @@ export default function ProjectLayout() {
   const [project, setProject] = useState<ProjectDetail | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
+  const [creatingBusy, setCreatingBusy] = useState(false)
   const [exporting, setExporting] = useState(false)
   const [collapsed, setCollapsed] = useState<boolean>(() => {
     try {
@@ -85,7 +86,8 @@ export default function ProjectLayout() {
     label: string,
     forkFromVersionId: number | null,
   ) => {
-    if (!project) return
+    if (!project || creatingBusy) return
+    setCreatingBusy(true)
     try {
       const body: { label: string; fork_from_version_id?: number } = { label }
       if (forkFromVersionId !== null) body.fork_from_version_id = forkFromVersionId
@@ -101,6 +103,8 @@ export default function ProjectLayout() {
       )
     } catch (e) {
       toast(String(e), 'error')
+    } finally {
+      setCreatingBusy(false)
     }
   }
 
@@ -219,7 +223,11 @@ export default function ProjectLayout() {
         <NewVersionDialog
           existingLabels={project.versions.map((v) => v.label)}
           existingVersions={project.versions.map((v) => ({ id: v.id, label: v.label }))}
-          onCancel={() => setCreating(false)}
+          busy={creatingBusy}
+          onCancel={() => {
+            if (creatingBusy) return
+            setCreating(false)
+          }}
           onSubmit={handleCreateVersion}
         />
       )}
@@ -230,11 +238,13 @@ export default function ProjectLayout() {
 export function NewVersionDialog({
   existingLabels,
   existingVersions,
+  busy = false,
   onCancel,
   onSubmit,
 }: {
   existingLabels: string[]
   existingVersions: { id: number; label: string }[]
+  busy?: boolean
   onCancel: () => void
   onSubmit: (label: string, forkFromVersionId: number | null) => void
 }) {
@@ -245,6 +255,7 @@ export function NewVersionDialog({
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault()
+    if (busy) return
     const l = label.trim()
     if (!l) return setErr('label 不能为空')
     if (!/^[A-Za-z0-9_.-]+$/.test(l))
@@ -305,15 +316,17 @@ export function NewVersionDialog({
           <button
             type="button"
             onClick={onCancel}
-            className="px-3 py-1.5 rounded text-sm bg-slate-700 hover:bg-slate-600"
+            disabled={busy}
+            className="px-3 py-1.5 rounded text-sm bg-slate-700 hover:bg-slate-600 disabled:opacity-40 disabled:cursor-not-allowed"
           >
             取消
           </button>
           <button
             type="submit"
-            className="px-3 py-1.5 rounded text-sm bg-cyan-600 hover:bg-cyan-500"
+            disabled={busy}
+            className="px-3 py-1.5 rounded text-sm bg-cyan-600 hover:bg-cyan-500 disabled:bg-slate-700 disabled:text-slate-500"
           >
-            创建
+            {busy ? '创建中...' : '创建'}
           </button>
         </div>
       </form>

--- a/studio/web/src/pages/project/NewVersionDialog.test.tsx
+++ b/studio/web/src/pages/project/NewVersionDialog.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { NewVersionDialog } from './Layout'
+
+describe('NewVersionDialog (PP10.1)', () => {
+  it('hides 从…创建 dropdown when no existing versions', () => {
+    render(
+      <NewVersionDialog
+        existingLabels={[]}
+        existingVersions={[]}
+        onCancel={() => {}}
+        onSubmit={() => {}}
+      />,
+    )
+    expect(screen.queryByText(/从…创建/)).toBeNull()
+  })
+
+  it('shows dropdown with existing versions and submits with null forkFrom by default', async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <NewVersionDialog
+        existingLabels={['baseline']}
+        existingVersions={[{ id: 7, label: 'baseline' }]}
+        onCancel={() => {}}
+        onSubmit={onSubmit}
+      />,
+    )
+    expect(screen.getByText(/从…创建/)).toBeInTheDocument()
+    expect(screen.getByRole('option', { name: '从空白开始' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('option', { name: /从 baseline 复制/ }),
+    ).toBeInTheDocument()
+
+    await user.type(screen.getByPlaceholderText(/baseline/), 'high-lr')
+    await user.click(screen.getByRole('button', { name: '创建' }))
+    expect(onSubmit).toHaveBeenCalledWith('high-lr', null)
+  })
+
+  it('passes fork_from_version_id when user picks a source version', async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <NewVersionDialog
+        existingLabels={['baseline']}
+        existingVersions={[{ id: 7, label: 'baseline' }]}
+        onCancel={() => {}}
+        onSubmit={onSubmit}
+      />,
+    )
+    await user.type(screen.getByPlaceholderText(/baseline/), 'forked')
+    await user.selectOptions(screen.getByRole('combobox'), '7')
+    // 选了源 version 后应该出现 hint
+    expect(screen.getByText(/将复制 train\/、reg\//)).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: '创建' }))
+    expect(onSubmit).toHaveBeenCalledWith('forked', 7)
+  })
+
+  it('rejects duplicate label', async () => {
+    const onSubmit = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <NewVersionDialog
+        existingLabels={['baseline']}
+        existingVersions={[{ id: 7, label: 'baseline' }]}
+        onCancel={() => {}}
+        onSubmit={onSubmit}
+      />,
+    )
+    await user.type(screen.getByPlaceholderText(/baseline/), 'baseline')
+    await user.click(screen.getByRole('button', { name: '创建' }))
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(screen.getByText(/label 已存在/)).toBeInTheDocument()
+  })
+})

--- a/studio/web/src/pages/project/steps/Download.tsx
+++ b/studio/web/src/pages/project/steps/Download.tsx
@@ -12,8 +12,9 @@ import ImageGrid, { applySelection } from '../../../components/ImageGrid'
 import { useToast } from '../../../components/Toast'
 import { useEventStream } from '../../../lib/useEventStream'
 
+// 跟 studio/datasets.py:IMAGE_EXTS 对齐 — 上传白名单 = 全链路图片白名单 + .zip。
 const UPLOAD_ACCEPT =
-  '.jpg,.jpeg,.png,.zip,image/jpeg,image/png,application/zip'
+  '.png,.jpg,.jpeg,.webp,.bmp,.gif,.zip,image/png,image/jpeg,image/webp,image/bmp,image/gif,application/zip'
 
 interface Ctx {
   project: ProjectDetail
@@ -567,7 +568,7 @@ function UploadPanel({
         />
         <span className="font-medium">点击选择 / 拖入</span>
         <span className="text-slate-500">
-          · .jpg / .png / .zip(自动解压)
+          · png / jpg / webp / bmp / gif / .zip(自动解压)
         </span>
         <span className="flex-1" />
         {picked.length > 0 && (

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -239,8 +239,39 @@ export default function TrainPage() {
           />
         </section>
       ) : (
-        <p className="text-slate-500 text-sm">加载中...</p>
+        <ConfigSkeleton />
       )}
     </div>
+  )
+}
+
+/** 训练配置加载中的 skeleton — 模拟 SchemaForm 的分组卡片结构。 */
+function ConfigSkeleton() {
+  // 一个分组卡片：标题条 + 4-6 行字段（label + input 灰条）
+  const groups = [5, 6, 4, 5]
+  return (
+    <section
+      className="flex-1 min-h-0 overflow-y-auto pr-1 space-y-3"
+      role="status"
+      aria-label="加载训练配置中"
+    >
+      {groups.map((rows, gi) => (
+        <div
+          key={gi}
+          className="border border-slate-700 rounded-lg bg-slate-800/40 p-4 animate-pulse"
+        >
+          <div className="h-4 w-32 bg-slate-700 rounded mb-3" />
+          <div className="space-y-2">
+            {Array.from({ length: rows }).map((_, ri) => (
+              <div key={ri} className="space-y-1">
+                <div className="h-3 w-24 bg-slate-700/70 rounded" />
+                <div className="h-7 bg-slate-800 border border-slate-700 rounded" />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+      <span className="sr-only">加载训练配置中...</span>
+    </section>
   )
 }

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -224,11 +224,14 @@ export default function TrainPage() {
         </button>
       </section>
 
-      {!configResp?.has_config ? (
+      {configResp === null || !schema ? (
+        // 初次加载（configResp 还没 fetch 回来 / schema 还没拉到）→ skeleton
+        <ConfigSkeleton />
+      ) : !configResp.has_config ? (
         <div className="flex-1 flex items-center justify-center text-slate-500 text-sm">
           请先从下拉「换一个预设」选一个，复制进当前 version 后即可编辑配置。
         </div>
-      ) : config && schema ? (
+      ) : config ? (
         <section className="flex-1 min-h-0 overflow-y-auto pr-1">
           <SchemaForm
             schema={schema}

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -51,21 +51,16 @@ export default function TrainPage() {
     void refreshConfig()
   }, [refreshConfig])
 
-  // 项目特定字段（data_dir 等）+ 全局模型路径都灰显 readonly。前者来自后端
-  // project_specific_fields；后者前端 hardcode（统一来自 settings.models 配置）。
+  // 全局模型路径仍然灰显 readonly（值来自 Settings.models 配置；version 维度
+  // 改了没意义）。PP10.4 起项目特定字段（data_dir 等）改成可编辑：fork preset
+  // 时仍然预填项目路径，但用户后续可以自由改（接续训练填 resume_lora 之类）。
   const GLOBAL_MODEL_FIELDS = [
     'transformer_path',
     'vae_path',
     'text_encoder_path',
     't5_tokenizer_path',
   ]
-  const disabledFields = useMemo(
-    () => [
-      ...(configResp?.project_specific_fields ?? []),
-      ...GLOBAL_MODEL_FIELDS,
-    ],
-    [configResp]
-  )
+  const disabledFields = useMemo(() => GLOBAL_MODEL_FIELDS, [])
   const disabledHints = useMemo(() => {
     const h: Record<string, string> = {}
     for (const f of GLOBAL_MODEL_FIELDS) h[f] = '自动 · 全局设置'

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -40,6 +40,7 @@ const initialServerState = {
     batch_size: 8,
   },
   models: { root: null, selected_anima: 'preview3-base' },
+  queue: { allow_gpu_during_train: false },
 }
 
 const emptyModelsCatalog = {

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -29,7 +29,7 @@ const EMPTY: Secrets = {
     api_key: '',
     save_tags: false,
     convert_to_png: true,
-    remove_alpha_channel: false,
+    remove_alpha_channel: true,
   },
   danbooru: { username: '', api_key: '', account_type: 'free' },
   download: {

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -425,7 +425,7 @@ export default function SettingsPage() {
               onChange={(v) => update('queue', 'allow_gpu_during_train', v)}
             />
             <span className="text-[10px] text-amber-300">
-              ⚠ 仅在显存充裕（≥ 24GB 且训练用量 ≤ 18GB）时打开；否则可能 OOM
+              ⚠ WD14 打标推理 onnxruntime-gpu 大约占 ~2 GB；确认训练之外的剩余显存够再打开，否则 OOM
             </span>
           </div>
         </Field>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -21,6 +21,7 @@ type Section =
   | 'joycaption'
   | 'wd14'
   | 'models'
+  | 'queue'
 
 const EMPTY: Secrets = {
   gelbooru: {
@@ -53,6 +54,7 @@ const EMPTY: Secrets = {
     batch_size: 8,
   },
   models: { root: null, selected_anima: 'preview3-base' },
+  queue: { allow_gpu_during_train: false },
 }
 
 export default function SettingsPage() {
@@ -408,6 +410,25 @@ export default function SettingsPage() {
           />
         </Field>
         <WD14RuntimePanel />
+      </Section>
+
+      <Section title="队列调度">
+        <p className="text-[11px] text-slate-500 px-1">
+          训练任务（占满 GPU）跟数据准备任务（下载 / 打标 / 正则集）
+          走两个独立槽位。下载（IO-only）始终跟训练并行；打标 / 正则集吃
+          GPU，默认在训练时推迟，避免抢显存 OOM。
+        </p>
+        <Field label="允许 GPU 任务与训练并行">
+          <div className="flex items-center gap-3">
+            <Bool
+              value={draft.queue.allow_gpu_during_train}
+              onChange={(v) => update('queue', 'allow_gpu_during_train', v)}
+            />
+            <span className="text-[10px] text-amber-300">
+              ⚠ 仅在显存充裕（≥ 24GB 且训练用量 ≤ 18GB）时打开；否则可能 OOM
+            </span>
+          </div>
+        </Field>
       </Section>
 
       <ModelsSection />

--- a/tests/test_supervisor_jobs.py
+++ b/tests/test_supervisor_jobs.py
@@ -36,47 +36,158 @@ def _setup_project(isolated) -> dict:
         return projects.create_project(conn, title="P")
 
 
-def test_jobs_take_priority_over_tasks(isolated) -> None:
-    """同时入队 task 与 job：job 先跑。"""
+def test_download_job_runs_in_parallel_with_training_task(isolated, tmp_path) -> None:
+    """PP10.2.b：download job (IO-only) 应该跟训练 task 并行跑，不互相堵塞。"""
     p = _setup_project(isolated)
     events: list[dict] = []
-    job_cmd = lambda j: [sys.executable, "-c", "print('hi')"]
-    task_cmd = lambda t, _cfg: [sys.executable, "-c", "print('task')"]
+    # task 走慢 sleep，download job 走慢 sleep；如果是串行，两者 running 不会重叠
+    task_sleep = lambda t, _cfg: [
+        sys.executable, "-c", "import time; time.sleep(0.5)"
+    ]
+    job_sleep = lambda j: [sys.executable, "-c", "import time; time.sleep(0.5)"]
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    (configs / "fake.yaml").write_text("epochs: 1\n", encoding="utf-8")
+
     sup = Supervisor(
         on_event=events.append,
-        cmd_builder=task_cmd,
-        job_cmd_builder=job_cmd,
+        cmd_builder=task_sleep,
+        job_cmd_builder=job_sleep,
         db_path=isolated["db"],
         logs_dir=isolated["logs"],
+        configs_dir=configs,
         poll_interval=0.05,
         terminate_grace=2.0,
     )
     with db.connection_for(isolated["db"]) as conn:
-        # 任意 task（preset 路径不存在 → 标 failed，但不会先于 job 跑）
-        db.create_task(conn, name="t1", config_name="not_exist")
+        tid = db.create_task(conn, name="t1", config_name="fake")
         job = project_jobs.create_job(
             conn, project_id=p["id"], kind="download", params={}
         )
     sup.start()
     try:
+        # 等到两边都进入 running
         assert _wait_until(
             lambda: any(
-                e.get("type") == "job_state_changed" and e.get("status") == "running"
+                e.get("type") == "task_state_changed" and e.get("status") == "running"
                 for e in events
             )
+            and any(
+                e.get("type") == "job_state_changed" and e.get("status") == "running"
+                for e in events
+            ),
+            timeout=5.0,
+        ), "task 和 download job 没能同时进入 running（疑似仍串行）"
+    finally:
+        sup.stop(timeout=10.0)
+
+
+def test_gpu_job_deferred_during_training_by_default(isolated, tmp_path) -> None:
+    """PP10.2.b：训练 task 在跑时，tag / reg_build job 默认推迟（避免抢 GPU）。"""
+    p = _setup_project(isolated)
+    events: list[dict] = []
+    task_sleep = lambda t, _cfg: [
+        sys.executable, "-c", "import time; time.sleep(0.6)"
+    ]
+    job_quick = lambda j: [sys.executable, "-c", "print('tag done')"]
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    (configs / "fake.yaml").write_text("epochs: 1\n", encoding="utf-8")
+
+    sup = Supervisor(
+        on_event=events.append,
+        cmd_builder=task_sleep,
+        job_cmd_builder=job_quick,
+        db_path=isolated["db"],
+        logs_dir=isolated["logs"],
+        configs_dir=configs,
+        poll_interval=0.05,
+        terminate_grace=2.0,
+    )
+    with db.connection_for(isolated["db"]) as conn:
+        tid = db.create_task(conn, name="t1", config_name="fake")
+        job = project_jobs.create_job(
+            conn, project_id=p["id"], kind="tag", params={}
+        )
+    sup.start()
+    try:
+        # 等到训练 task running
+        assert _wait_until(
+            lambda: any(
+                e.get("type") == "task_state_changed" and e.get("status") == "running"
+                for e in events
+            ),
+            timeout=5.0,
+        )
+        # 给 tag job 一点时间被错误调度起来 — 它**不应**跑
+        time.sleep(0.3)
+        with db.connection_for(isolated["db"]) as conn:
+            job_now = project_jobs.get_job(conn, job["id"])
+        assert job_now["status"] == "pending", \
+            f"tag job 不应在训练中起跑，当前状态={job_now['status']}"
+        # 等训练结束 → tag job 应该自动跑起来
+        assert _wait_until(
+            lambda: project_jobs.get_job(
+                db.connect(isolated["db"]), job["id"]
+            )["status"] == "done",
+            timeout=10.0,
         )
     finally:
-        sup.stop(timeout=5.0)
-    # job_running 事件出现的位置应该早于 task 的任何事件出现
-    job_run_idx = next(
-        i for i, e in enumerate(events)
-        if e.get("type") == "job_state_changed" and e.get("status") == "running"
-    )
-    task_evt_indices = [
-        i for i, e in enumerate(events) if e.get("type") == "task_state_changed"
+        sup.stop(timeout=10.0)
+
+
+def test_gpu_job_runs_during_training_when_allowed(isolated, tmp_path, monkeypatch) -> None:
+    """PP10.2.b：开 secrets.queue.allow_gpu_during_train=True 后，tag job
+    可以跟训练 task 并行（用户自己确认显存够）。"""
+    from studio import secrets as _sec
+    # 写一份 secrets 进 tmp，monkeypatch 切到这里
+    secrets_file = tmp_path / "secrets.json"
+    monkeypatch.setattr(_sec, "SECRETS_FILE", secrets_file)
+    sec = _sec.Secrets()
+    sec.queue.allow_gpu_during_train = True
+    _sec.save(sec)
+
+    p = _setup_project(isolated)
+    events: list[dict] = []
+    task_sleep = lambda t, _cfg: [
+        sys.executable, "-c", "import time; time.sleep(0.5)"
     ]
-    if task_evt_indices:
-        assert job_run_idx < min(task_evt_indices)
+    job_sleep = lambda j: [sys.executable, "-c", "import time; time.sleep(0.5)"]
+    configs = tmp_path / "configs"
+    configs.mkdir()
+    (configs / "fake.yaml").write_text("epochs: 1\n", encoding="utf-8")
+
+    sup = Supervisor(
+        on_event=events.append,
+        cmd_builder=task_sleep,
+        job_cmd_builder=job_sleep,
+        db_path=isolated["db"],
+        logs_dir=isolated["logs"],
+        configs_dir=configs,
+        poll_interval=0.05,
+        terminate_grace=2.0,
+    )
+    with db.connection_for(isolated["db"]) as conn:
+        tid = db.create_task(conn, name="t1", config_name="fake")
+        job = project_jobs.create_job(
+            conn, project_id=p["id"], kind="tag", params={}
+        )
+    sup.start()
+    try:
+        # 应该两边都跑起来
+        assert _wait_until(
+            lambda: any(
+                e.get("type") == "task_state_changed" and e.get("status") == "running"
+                for e in events
+            )
+            and any(
+                e.get("type") == "job_state_changed" and e.get("status") == "running"
+                for e in events
+            ),
+            timeout=5.0,
+        ), "开关打开后 tag job 仍被推迟"
+    finally:
+        sup.stop(timeout=10.0)
 
 
 def test_job_lifecycle_done(isolated) -> None:

--- a/tests/test_train_endpoints.py
+++ b/tests/test_train_endpoints.py
@@ -103,7 +103,9 @@ def test_fork_preset_unknown_404(client: TestClient) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_put_config_forces_project_overrides(client: TestClient, env) -> None:
+def test_put_config_keeps_user_values(client: TestClient, env) -> None:
+    """PP10.4：PUT 端点不强制覆盖项目特定字段，让用户改 resume_lora /
+    output_name 等。fork preset 时仍预填项目路径（在 from_preset 端点测覆盖）。"""
     pid, vid = _make(client)
     _seed_preset(env, "tpl")
     client.post(
@@ -111,18 +113,34 @@ def test_put_config_forces_project_overrides(client: TestClient, env) -> None:
         json={"name": "tpl"},
     )
     cfg = client.get(f"/api/projects/{pid}/versions/{vid}/config").json()["config"]
-    cfg["data_dir"] = "/etc/passwd"
-    cfg["output_name"] = "hacked"
+    cfg["output_name"] = "custom_lora"
+    cfg["resume_lora"] = "/tmp/some/lora.safetensors"
     cfg["lora_rank"] = 96
     r = client.put(f"/api/projects/{pid}/versions/{vid}/config", json=cfg)
     assert r.status_code == 200
     body = r.json()
-    # data_dir 被服务端覆盖回 train
-    assert body["config"]["data_dir"].endswith("train")
-    # output_name 也被覆盖
-    assert body["config"]["output_name"] != "hacked"
-    # 用户改的非项目字段保留
+    # 用户改的项目特定字段被保留（PP10.4）
+    assert body["config"]["output_name"] == "custom_lora"
+    assert body["config"]["resume_lora"] == "/tmp/some/lora.safetensors"
+    # 用户改的非项目字段也保留
     assert body["config"]["lora_rank"] == 96
+
+
+def test_fork_preset_still_forces_project_overrides(
+    client: TestClient, env
+) -> None:
+    """PP10.4：换预设时项目特定字段仍然被预填成项目路径（force=True 路径未动）。"""
+    pid, vid = _make(client)
+    # preset 故意带错误路径
+    _seed_preset(env, "tpl", data_dir="/wrong/path", output_name="wrong_name")
+    r = client.post(
+        f"/api/projects/{pid}/versions/{vid}/config/from_preset",
+        json={"name": "tpl"},
+    )
+    assert r.status_code == 200
+    cfg = client.get(f"/api/projects/{pid}/versions/{vid}/config").json()["config"]
+    assert cfg["data_dir"].endswith("train")
+    assert cfg["output_name"] != "wrong_name"
 
 
 def test_put_config_invalid_data_400(client: TestClient, env) -> None:

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -39,6 +39,18 @@ def test_reject_unsupported_format(tmp_path: Path) -> None:
     assert "格式不支持" in out.skipped[0]["reason"]
 
 
+def test_accepts_extended_image_formats(tmp_path: Path) -> None:
+    """PP10：上传白名单与全链路 IMAGE_EXTS 对齐，webp/bmp/gif 也接受。"""
+    for fname, payload in [
+        ("a.webp", b"WEBP"),
+        ("b.bmp", b"BMP"),
+        ("c.gif", b"GIF"),
+    ]:
+        out = uploads.accept_one(fname, io.BytesIO(payload), tmp_path)
+        assert out.added == [fname], f"{fname} 应被接受"
+        assert (tmp_path / fname).read_bytes() == payload
+
+
 def test_skip_existing_does_not_overwrite(tmp_path: Path) -> None:
     (tmp_path / "p.png").write_bytes(b"old")
     out = uploads.accept_one("p.png", io.BytesIO(b"new"), tmp_path)

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -92,6 +92,111 @@ def test_fork_copies_train_tree(isolated) -> None:
     assert v2["config_name"] == src["config_name"]
 
 
+def test_fork_full_copy_includes_reg_config_unlocked(isolated, monkeypatch) -> None:
+    """PP10.1：fork 时 train/、reg/、config.yaml、.unlocked.json 全量复制；
+    config.yaml 里 data_dir / reg_data_dir / output_dir / output_name 强制刷成新 version 路径。"""
+    from studio.services import version_config
+    from studio.schema import TrainingConfig
+
+    p = _new_project(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        src = versions.create_version(conn, project_id=p["id"], label="baseline")
+    src_vdir = versions.version_dir(p["id"], p["slug"], "baseline")
+
+    # train 内放图
+    (src_vdir / "train" / "5_concept").mkdir()
+    (src_vdir / "train" / "5_concept" / "001.png").write_bytes(b"trainpng")
+
+    # reg/ 含 meta.json 和图
+    (src_vdir / "reg" / "1_data").mkdir(parents=True)
+    (src_vdir / "reg" / "meta.json").write_text(
+        '{"target": 100}', encoding="utf-8"
+    )
+    (src_vdir / "reg" / "1_data" / "r.png").write_bytes(b"regpng")
+
+    # 写一份 source config.yaml（路径故意指向 src 自己；fork 后应被刷掉）
+    src_cfg = TrainingConfig().model_dump()
+    version_config.write_version_config(p, src, src_cfg)
+
+    # .unlocked.json 旁路文件（PP10.4 预留）
+    (src_vdir / ".unlocked.json").write_text(
+        '{"fields": ["resume_lora"]}', encoding="utf-8"
+    )
+
+    with db.connection_for(isolated["db"]) as conn:
+        v2 = versions.create_version(
+            conn,
+            project_id=p["id"],
+            label="forked",
+            fork_from_version_id=src["id"],
+        )
+    new_vdir = versions.version_dir(p["id"], p["slug"], "forked")
+
+    # train 复制
+    assert (new_vdir / "train" / "5_concept" / "001.png").read_bytes() == b"trainpng"
+    # reg 复制
+    assert (new_vdir / "reg" / "meta.json").exists()
+    assert (new_vdir / "reg" / "1_data" / "r.png").read_bytes() == b"regpng"
+    # config.yaml 复制
+    assert (new_vdir / "config.yaml").exists()
+    # .unlocked.json 复制
+    assert (new_vdir / ".unlocked.json").read_text(encoding="utf-8") == (
+        '{"fields": ["resume_lora"]}'
+    )
+
+    # config.yaml 里项目特定字段已重写到新 version 路径
+    new_cfg = version_config.read_version_config(p, v2)
+    assert new_cfg["data_dir"] == str(new_vdir / "train")
+    assert new_cfg["reg_data_dir"] == str(new_vdir / "reg")
+    assert new_cfg["output_dir"] == str(new_vdir / "output")
+    assert new_cfg["output_name"] == f"{p['slug']}_forked"
+
+
+def test_fork_stage_done_resets_to_ready(isolated) -> None:
+    """源 stage=done → 新 version 落 ready（重新进入待训练态）。"""
+    p = _new_project(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        src = versions.create_version(conn, project_id=p["id"], label="baseline")
+        versions.update_version(conn, src["id"], stage="done")
+        v2 = versions.create_version(
+            conn,
+            project_id=p["id"],
+            label="forked",
+            fork_from_version_id=src["id"],
+        )
+    assert v2["stage"] == "ready"
+
+
+def test_fork_stage_training_resets_to_ready(isolated) -> None:
+    """源 stage=training → 新 version 也落 ready。"""
+    p = _new_project(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        src = versions.create_version(conn, project_id=p["id"], label="baseline")
+        versions.update_version(conn, src["id"], stage="training")
+        v2 = versions.create_version(
+            conn,
+            project_id=p["id"],
+            label="forked",
+            fork_from_version_id=src["id"],
+        )
+    assert v2["stage"] == "ready"
+
+
+def test_fork_stage_intermediate_passthrough(isolated) -> None:
+    """源 stage 是中间态（tagging）→ 新 version 直接 copy。"""
+    p = _new_project(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        src = versions.create_version(conn, project_id=p["id"], label="baseline")
+        versions.update_version(conn, src["id"], stage="tagging")
+        v2 = versions.create_version(
+            conn,
+            project_id=p["id"],
+            label="forked",
+            fork_from_version_id=src["id"],
+        )
+    assert v2["stage"] == "tagging"
+
+
 def test_fork_rejects_alien_source(isolated) -> None:
     a = _new_project(isolated, title="A")
     b = _new_project(isolated, title="B")


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   4 个核心改动 + 一连串小修：                                                                                                                                                                                                                                           
  
  - **PP10.1** 新建 version 时可从老 version 全量复制（train/、reg/、config.yaml、解锁状态）；reg 重建最耗时，全量复制最受益。
  - **PP10.2** Supervisor 拆 TRAIN + DATA 双槽位：下载（IO-only）始终跟训练并行；打标 / 正则集（GPU-bound）默认在训练期间推迟，避免 OOM。Settings 加 `allow_gpu_during_train` 开关用户自己拍板。
  - **PP10.3** SchemaForm 数字字段 onBlur 提交，修「输 0.05 第二个 0 被截断成 0」的卡顿；blur 时尊重 schema `min/max` 回滚（恢复 PP10.3 重写前 type=number 自带的 HTML5 校验）。
  - **PP10.4** 项目特定字段（data_dir / output_name / resume_lora 等）直接放开编辑：fork preset 仍预填项目路径，PUT 端点不再强制覆盖；用户接续训练 / 自定义 LoRA 名字现在能直接改。

  UX 小修：
  - NewVersionDialog 防双提交（API ~1s 重复点导致「label 已存在」）
  - Train 页 / Queue 页加 skeleton（初始 state 误判修正）
  - 加 tag 默认插到开头（chip + bulk 一致）
  - `remove_alpha_channel` 默认 true（4-channel PNG 训练时 VAE 把透明区当噪声学，多数情况要去掉）
  - outputs zip 文件名改用 `{slug}_{label}_outputs.zip`，与 LoRA `_final.safetensors` 命名一致
  - 队列调度风险提示改成「剩余显存 / WD14 ~2GB 占用」
  - 全链路图片格式统一：`{png, jpg, jpeg, webp, bmp, gif}`，删 `.jxl`（PIL 无支持）；上传 / 下载 / curation / 训练共用同一份白名单

  ## Pipeline 文档
  `docs/studio-pipeline/pp10-workflow-polish.md` 详细方案。

  ## 测试
  - pytest **528** / vitest **57** / vite build clean
  - 主要新增 case：版本 fork 全量复制 + 路径重写 + stage 跟随、双槽位并行 + GPU 推迟、Field min/max 回滚 + 边界值、上传扩展格式
  - 用户在云端手测过整条流水线

  ## Test plan
  - [x] PP10.1 fork 老 version → train/reg/config 都过去 + 路径已刷
  - [x] PP10.2 训练运行中起下载 → 并行；起 tag → 默认推迟，开关打开后并行
  - [x] PP10.3 输入 `0.05` 不再卡；超 min/max 自动回滚
  - [x] PP10.4 项目特定字段可改、保存生效；fork preset 仍预填
  - [x] NewVersionDialog 期间重复点击不再报「label 已存在」
  - [x] Train / Queue 页首次进入显示 skeleton
  - [x] 上传 webp / gif → 落盘原格式 → 训练能读