### PR TITLE
feat(redesign/pr1): tokens + new chrome (Sidebar + Topbar)

### DIFF
--- a/studio/web/src/App.tsx
+++ b/studio/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom'
 import Sidebar from './components/Sidebar'
+import Topbar from './components/Topbar'
 import ProjectsPage from './pages/Projects'
 import QueuePage from './pages/Queue'
 import QueueDetailPage from './pages/QueueDetail'
@@ -31,9 +32,11 @@ function QueueDetailRedirect({ tab }: { tab: 'log' | 'monitor' }) {
 export default function App() {
   return (
     <BrowserRouter basename="/studio">
-      <div className="min-h-screen flex">
-        <Sidebar />
-        <main className="flex-1 px-4 py-4 overflow-auto h-screen min-w-0">
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+        <Topbar />
+        <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+          <Sidebar />
+          <main style={{ flex: 1, padding: '16px', overflowY: 'auto' }} className="overflow-auto">
           <Routes>
             <Route path="/" element={<ProjectsPage />} />
             <Route path="/queue" element={<QueuePage />} />
@@ -76,8 +79,9 @@ export default function App() {
               element={<Navigate to="/tools/monitor" replace />}
             />
             <Route path="/datasets" element={<Navigate to="/" replace />} />
-          </Routes>
-        </main>
+            </Routes>
+          </main>
+        </div>
       </div>
     </BrowserRouter>
   )

--- a/studio/web/src/components/Sidebar.tsx
+++ b/studio/web/src/components/Sidebar.tsx
@@ -1,47 +1,190 @@
-import { useEffect, useState } from 'react'
-import { NavLink, useLocation } from 'react-router-dom'
+import { useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
 
-interface Link {
-  to: string
-  label: string
-  icon: string
+// ── icons ──────────────────────────────────────────────────────────────────
+const I = {
+  folder:  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>,
+  queue:   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M4 6h16M4 12h10M4 18h16"/><circle cx="18" cy="12" r="2" fill="currentColor"/></svg>,
+  preset:  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><line x1="6" y1="4" x2="6" y2="20"/><line x1="12" y1="4" x2="12" y2="20"/><line x1="18" y1="4" x2="18" y2="20"/><circle cx="6" cy="9" r="2" fill="var(--bg-sunken)"/><circle cx="12" cy="15" r="2" fill="var(--bg-sunken)"/><circle cx="18" cy="7" r="2" fill="var(--bg-sunken)"/></svg>,
+  monitor: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M3 17l4-6 4 3 5-9 5 7"/></svg>,
+  cog:     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>,
+  check:   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"><path d="m4 12 5 5 11-12"/></svg>,
+  chevL:   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M15 6l-6 6 6 6"/></svg>,
+  chevR:   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M9 6l6 6-6 6"/></svg>,
+  download:<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M12 4v12m0 0-4-4m4 4 4-4M4 20h16"/></svg>,
+  filter:  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M3 5h18l-7 9v6l-4-2v-4z"/></svg>,
+  tag:     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M20 12 12 20l-9-9V3h8z"/><circle cx="7" cy="7" r="1.5" fill="currentColor"/></svg>,
+  edit:    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M3 21h4l11-11-4-4L3 17z"/><path d="m14 5 4 4"/></svg>,
+  reg:     <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><circle cx="17.5" cy="17.5" r="3.5"/></svg>,
+  train:   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><path d="M3 18 9 12l4 4 8-9"/><path d="M15 7h6v6"/></svg>,
 }
 
-const main: Link[] = [
-  { to: '/', label: '项目', icon: '📁' },
-  { to: '/queue', label: '队列', icon: '🚦' },
+// ── logo ───────────────────────────────────────────────────────────────────
+function Logo({ collapsed }: { collapsed: boolean }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+      <svg width="26" height="26" viewBox="0 0 26 26" aria-hidden>
+        <rect x="2" y="2" width="22" height="22" rx="5" fill="var(--accent)" />
+        <path d="M8 18 L13 7 L18 18" stroke="var(--accent-fg)" strokeWidth="2" fill="none" strokeLinejoin="round" strokeLinecap="round" />
+        <line x1="10.5" y1="14" x2="15.5" y2="14" stroke="var(--accent-fg)" strokeWidth="2" strokeLinecap="round" />
+      </svg>
+      {!collapsed && (
+        <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.1 }}>
+          <span style={{ fontWeight: 600, fontSize: 'var(--t-md)', letterSpacing: '-0.01em' }}>Anima</span>
+          <span style={{ fontSize: 'var(--t-xs)', color: 'var(--fg-tertiary)', fontFamily: 'var(--font-mono)' }}>lora studio · 0.4</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── nav item ───────────────────────────────────────────────────────────────
+interface NavItemProps {
+  to: string
+  label: string
+  icon: React.ReactNode
+  active: boolean
+  collapsed: boolean
+  end?: boolean
+}
+
+function NavItem({ to, label, icon, active, collapsed }: NavItemProps) {
+  return (
+    <Link
+      to={to}
+      title={collapsed ? label : undefined}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: collapsed ? '9px 0' : '8px 12px',
+        justifyContent: collapsed ? 'center' : 'flex-start',
+        borderRadius: 'var(--r-md)',
+        background: active ? 'var(--bg-surface)' : 'transparent',
+        color: active ? 'var(--fg-primary)' : 'var(--fg-secondary)',
+        fontSize: 'var(--t-sm)',
+        fontWeight: active ? 600 : 500,
+        boxShadow: active ? 'var(--sh-sm)' : 'none',
+        position: 'relative',
+        textDecoration: 'none',
+        transition: 'background 100ms ease, color 100ms ease',
+      }}
+      onMouseEnter={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'var(--bg-overlay)' }}
+      onMouseLeave={(e) => { if (!active) (e.currentTarget as HTMLElement).style.background = 'transparent' }}
+    >
+      {active && !collapsed && (
+        <span style={{ position: 'absolute', left: 0, top: 8, bottom: 8, width: 3, background: 'var(--accent)', borderRadius: 2 }} />
+      )}
+      {icon}
+      {!collapsed && <span style={{ flex: 1 }}>{label}</span>}
+    </Link>
+  )
+}
+
+// ── project stepper nav ────────────────────────────────────────────────────
+interface StepperProps {
+  pid: string
+  vid: string | null
+  currentStep: string | null
+  collapsed: boolean
+}
+
+const STEPS = [
+  { key: 'download', label: '下载',     idx: '1', icon: I.download },
+  { key: 'curate',   label: '筛选',     idx: '2', icon: I.filter },
+  { key: 'tag',      label: '打标',     idx: '3', icon: I.tag },
+  { key: 'edit',     label: '标签编辑', idx: '4', icon: I.edit },
+  { key: 'reg',      label: '正则集',   idx: '5', icon: I.reg },
+  { key: 'train',    label: '训练',     idx: '6', icon: I.train },
 ]
 
-const tools: Link[] = [
-  { to: '/tools/presets', label: '预设', icon: '🎚' },
-  { to: '/tools/monitor', label: '监控', icon: '📊' },
-  { to: '/tools/settings', label: '设置', icon: '⚙️' },
-]
+function ProjectStepperNav({ pid, vid, currentStep, collapsed }: StepperProps) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 1, padding: '0 4px' }}>
+      {STEPS.map((s) => {
+        const isActive = s.key === currentStep
+        // derive href — download has no vid
+        const href = s.key === 'download'
+          ? `/projects/${pid}/download`
+          : vid ? `/projects/${pid}/v/${vid}/${s.key}` : null
 
-const SIDEBAR_OVERRIDE_KEY = 'studio.globalSidebar.expanded'
+        const status: 'active' | 'pending' = isActive ? 'active' : 'pending'
+        const dotBg = status === 'active' ? 'var(--accent-soft)' : 'var(--bg-overlay)'
+        const dotColor = status === 'active' ? 'var(--accent)' : 'var(--fg-tertiary)'
+
+        const inner = (
+          <>
+            <span style={{
+              width: 20, height: 20, borderRadius: '50%',
+              background: dotBg, color: dotColor,
+              display: 'grid', placeItems: 'center',
+              fontSize: 10, fontWeight: 700, fontFamily: 'var(--font-mono)',
+              flexShrink: 0,
+            }}>
+              {s.idx}
+            </span>
+            {!collapsed && <span style={{ flex: 1, textAlign: 'left' }}>{s.label}</span>}
+            {!collapsed && isActive && <span className="dot dot-running" />}
+          </>
+        )
+
+        const commonStyle: React.CSSProperties = {
+          display: 'flex', alignItems: 'center', gap: 10,
+          padding: collapsed ? '7px 0' : '7px 10px',
+          justifyContent: collapsed ? 'center' : 'flex-start',
+          borderRadius: 'var(--r-md)',
+          background: isActive ? 'var(--bg-surface)' : 'transparent',
+          color: isActive ? 'var(--fg-primary)' : 'var(--fg-secondary)',
+          fontSize: 'var(--t-sm)', fontWeight: isActive ? 600 : 400,
+          boxShadow: isActive ? 'var(--sh-sm)' : 'none',
+          transition: 'background 100ms ease',
+          textDecoration: 'none',
+        }
+
+        if (!href) {
+          return (
+            <span key={s.key} title={collapsed ? `${s.idx}. ${s.label}` : undefined} style={{ ...commonStyle, opacity: 0.4, cursor: 'default' }}>
+              {inner}
+            </span>
+          )
+        }
+
+        return (
+          <Link
+            key={s.key}
+            to={href}
+            title={collapsed ? `${s.idx}. ${s.label}` : undefined}
+            style={commonStyle}
+            onMouseEnter={(e) => { if (!isActive) (e.currentTarget as HTMLElement).style.background = 'var(--bg-overlay)' }}
+            onMouseLeave={(e) => { if (!isActive) (e.currentTarget as HTMLElement).style.background = 'transparent' }}
+          >
+            {inner}
+          </Link>
+        )
+      })}
+    </div>
+  )
+}
+
+// ── sidebar ────────────────────────────────────────────────────────────────
+const SIDEBAR_KEY = 'studio.sidebar.expanded'
 
 export default function Sidebar() {
-  const loc = useLocation()
-  const inProject =
-    loc.pathname.startsWith('/projects/') && loc.pathname !== '/projects/'
+  const location = useLocation()
 
-  // 默认：进项目页自动折叠成图标条；其它页展开。
-  // 用户手动点切换会写一个 session 级 override，刷新就清。
-  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(
-    () => {
-      try {
-        const v = sessionStorage.getItem(SIDEBAR_OVERRIDE_KEY)
-        return v === '1' ? true : v === '0' ? false : null
-      } catch {
-        return null
-      }
-    }
-  )
+  const pid = location.pathname.match(/^\/projects\/([^/]+)/)?.[1] ?? null
+  const vid = location.pathname.match(/\/v\/([^/]+)/)?.[1] ?? null
+  const stepMatch = location.pathname.match(/\/v\/[^/]+\/([^/]+)$/)
+  const currentStep = stepMatch?.[1] ?? (location.pathname.endsWith('/download') ? 'download' : null)
 
-  // 路由切换且没有 override 时，默认行为接管
-  useEffect(() => {
-    // intentionally not resetting override on every nav — let user keep it
-  }, [inProject])
+  const inProject = pid !== null
+
+  const [expandedOverride, setExpandedOverride] = useState<boolean | null>(() => {
+    try {
+      const v = sessionStorage.getItem(SIDEBAR_KEY)
+      return v === '1' ? true : v === '0' ? false : null
+    } catch { return null }
+  })
 
   const expanded = expandedOverride ?? !inProject
   const collapsed = !expanded
@@ -49,91 +192,83 @@ export default function Sidebar() {
   const toggle = () => {
     const next = !expanded
     setExpandedOverride(next)
-    try {
-      sessionStorage.setItem(SIDEBAR_OVERRIDE_KEY, next ? '1' : '0')
-    } catch {
-      /* ignore */
-    }
+    try { sessionStorage.setItem(SIDEBAR_KEY, next ? '1' : '0') } catch { /* ignore */ }
   }
 
-  const linkClass = ({ isActive }: { isActive: boolean }): string =>
-    (collapsed
-      ? 'flex items-center justify-center w-9 h-9 mx-auto my-1 rounded text-base transition-colors '
-      : 'flex items-center gap-2 px-3 py-2 rounded text-sm transition-colors ') +
-    (isActive
-      ? 'bg-cyan-600/20 text-cyan-300'
-      : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800/60')
+  const isMain = (path: string) => {
+    if (path === '/') return location.pathname === '/'
+    return location.pathname.startsWith(path)
+  }
 
   return (
-    <aside
-      className={
-        'shrink-0 flex flex-col border-r border-slate-800 transition-[width] duration-150 ' +
-        (collapsed ? 'w-12 py-2 px-0' : 'w-44 py-4 px-2')
-      }
-    >
-      {!collapsed ? (
-        <div className="px-3 mb-4 flex items-start">
-          <div className="flex-1 min-w-0">
-            <div className="text-base font-bold bg-gradient-to-r from-cyan-400 to-violet-400 bg-clip-text text-transparent truncate">
-              AnimaStudio
-            </div>
-            <div className="text-[10px] text-slate-500 mt-0.5">v0.2</div>
-          </div>
+    <aside style={{
+      width: collapsed ? 'var(--sidebar-collapsed-w)' : 'var(--sidebar-w)',
+      flexShrink: 0,
+      background: 'var(--bg-sunken)',
+      borderRight: '1px solid var(--border-subtle)',
+      display: 'flex', flexDirection: 'column',
+      transition: 'width 160ms ease',
+      overflow: 'hidden',
+    }}>
+      {/* header / logo */}
+      <div style={{
+        height: 'var(--topbar-h)', padding: '0 14px',
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        borderBottom: '1px solid var(--border-subtle)',
+        flexShrink: 0,
+      }}>
+        <Logo collapsed={collapsed} />
+        {!collapsed && (
           <button
             onClick={toggle}
-            title="折叠侧栏"
-            className="text-slate-500 hover:text-slate-200 text-xs px-1"
+            title="折叠"
+            style={{ padding: 4, color: 'var(--fg-tertiary)', background: 'transparent', border: 'none', borderRadius: 4, cursor: 'pointer', display: 'flex' }}
           >
-            ‹
+            {I.chevL}
           </button>
-        </div>
-      ) : (
-        <button
-          onClick={toggle}
-          title="展开侧栏"
-          className="text-slate-500 hover:text-slate-200 text-xs h-6 mb-2"
-        >
-          ›
-        </button>
-      )}
-
-      <nav className="flex-1" aria-label="primary">
-        {main.map((l) => (
-          <NavLink
-            key={l.to}
-            to={l.to}
-            end
-            className={linkClass}
-            title={collapsed ? l.label : undefined}
-          >
-            <span aria-hidden>{l.icon}</span>
-            {!collapsed && <span>{l.label}</span>}
-          </NavLink>
-        ))}
-
-        {!collapsed ? (
-          <>
-            <div className="mt-3 mb-1 px-3 text-[10px] uppercase tracking-wider text-slate-600 font-semibold">
-              工具
-            </div>
-            <div className="border-t border-slate-800 mb-1" />
-          </>
-        ) : (
-          <div className="mx-2 my-2 border-t border-slate-800" />
         )}
-        {tools.map((l) => (
-          <NavLink
-            key={l.to}
-            to={l.to}
-            end
-            className={linkClass}
-            title={collapsed ? l.label : undefined}
-          >
-            <span aria-hidden>{l.icon}</span>
-            {!collapsed && <span>{l.label}</span>}
-          </NavLink>
-        ))}
+      </div>
+
+      {/* main nav */}
+      <nav style={{ flex: 1, padding: collapsed ? '10px 6px' : '14px 10px', display: 'flex', flexDirection: 'column', gap: 2, overflowY: 'auto' }}>
+        <NavItem to="/" label="项目" icon={I.folder} active={!inProject && location.pathname === '/'} collapsed={collapsed} />
+        <NavItem to="/queue" label="队列" icon={I.queue} active={isMain('/queue')} collapsed={collapsed} />
+
+        {inProject && pid && (
+          <div style={{ marginTop: 10 }}>
+            {!collapsed && (
+              <div style={{ padding: '8px 10px 6px', display: 'flex', alignItems: 'center', gap: 6 }}>
+                <span style={{ fontSize: 'var(--t-xs)', color: 'var(--fg-tertiary)', fontFamily: 'var(--font-mono)', textTransform: 'uppercase', letterSpacing: '0.06em' }}>项目</span>
+                <span style={{ flex: 1, height: 1, background: 'var(--border-subtle)' }} />
+              </div>
+            )}
+            {!collapsed && (
+              <div style={{ padding: '6px 10px 8px', margin: '0 4px 6px', borderRadius: 'var(--r-md)', background: 'var(--bg-overlay)', fontSize: 'var(--t-sm)' }}>
+                <div style={{ fontFamily: 'var(--font-mono)', fontSize: 'var(--t-xs)', color: 'var(--fg-tertiary)' }}>
+                  {pid}{vid ? ` · v${vid}` : ''}
+                </div>
+              </div>
+            )}
+            <ProjectStepperNav pid={pid} vid={vid} currentStep={currentStep} collapsed={collapsed} />
+          </div>
+        )}
       </nav>
+
+      {/* tools + collapse toggle */}
+      <div style={{ padding: collapsed ? '8px 6px' : '10px', borderTop: '1px solid var(--border-subtle)', display: 'flex', flexDirection: 'column', gap: 2, flexShrink: 0 }}>
+        <NavItem to="/tools/presets" label="预设" icon={I.preset} active={isMain('/tools/presets')} collapsed={collapsed} />
+        <NavItem to="/tools/monitor" label="监控" icon={I.monitor} active={isMain('/tools/monitor')} collapsed={collapsed} />
+        <NavItem to="/tools/settings" label="设置" icon={I.cog} active={isMain('/tools/settings')} collapsed={collapsed} />
+        {collapsed && (
+          <button
+            onClick={toggle}
+            title="展开"
+            style={{ padding: 8, marginTop: 4, color: 'var(--fg-tertiary)', background: 'transparent', border: 'none', borderRadius: 4, cursor: 'pointer', display: 'flex', justifyContent: 'center' }}
+          >
+            {I.chevR}
+          </button>
+        )}
+      </div>
     </aside>
   )
 }

--- a/studio/web/src/components/Topbar.tsx
+++ b/studio/web/src/components/Topbar.tsx
@@ -1,0 +1,90 @@
+import { useLocation } from 'react-router-dom'
+
+const SearchIcon = (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+    <circle cx="11" cy="11" r="7" /><path d="m21 21-4.3-4.3" />
+  </svg>
+)
+
+interface Crumb { label: string; mono?: boolean }
+
+function useBreadcrumbs(): Crumb[] {
+  const { pathname } = useLocation()
+  const parts = pathname.split('/').filter(Boolean)
+
+  if (parts.length === 0) return [{ label: '项目' }]
+
+  if (parts[0] === 'queue') {
+    if (parts.length === 1) return [{ label: '队列' }]
+    return [{ label: '队列' }, { label: `#${parts[1]}`, mono: true }]
+  }
+
+  if (parts[0] === 'tools') {
+    const labels: Record<string, string> = { presets: '预设', monitor: '监控', settings: '设置' }
+    return [{ label: labels[parts[1]] ?? parts[1] }]
+  }
+
+  if (parts[0] === 'projects') {
+    const crumbs: Crumb[] = [{ label: '项目' }]
+    if (parts[1]) crumbs.push({ label: parts[1], mono: true })
+    const vIdx = parts.indexOf('v')
+    if (vIdx !== -1 && parts[vIdx + 1]) {
+      crumbs.push({ label: `v${parts[vIdx + 1]}`, mono: true })
+      const stepLabels: Record<string, string> = {
+        curate: '筛选', tag: '打标', edit: '标签编辑', reg: '正则集', train: '训练',
+      }
+      const step = parts[vIdx + 2]
+      if (step && stepLabels[step]) crumbs.push({ label: stepLabels[step] })
+    } else if (parts[2] === 'download') {
+      crumbs.push({ label: '下载' })
+    }
+    return crumbs
+  }
+
+  return [{ label: pathname }]
+}
+
+export default function Topbar() {
+  const crumbs = useBreadcrumbs()
+
+  return (
+    <header style={{
+      height: 'var(--topbar-h)',
+      padding: '0 20px',
+      display: 'flex', alignItems: 'center', gap: 16,
+      borderBottom: '1px solid var(--border-subtle)',
+      background: 'var(--bg-canvas)',
+      flexShrink: 0,
+    }}>
+      {/* breadcrumb */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flex: 1, minWidth: 0 }}>
+        {crumbs.map((b, i) => (
+          <span key={i} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            {i > 0 && <span style={{ color: 'var(--fg-tertiary)', userSelect: 'none' }}>/</span>}
+            <span style={{
+              fontSize: 'var(--t-sm)',
+              fontFamily: b.mono ? 'var(--font-mono)' : 'var(--font-sans)',
+              color: i === crumbs.length - 1 ? 'var(--fg-primary)' : 'var(--fg-secondary)',
+              fontWeight: i === crumbs.length - 1 ? 600 : 400,
+            }}>
+              {b.label}
+            </span>
+          </span>
+        ))}
+      </div>
+
+      {/* search placeholder */}
+      <button style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '5px 10px 5px 12px',
+        background: 'var(--bg-surface)', border: '1px solid var(--border-default)',
+        borderRadius: 'var(--r-md)', color: 'var(--fg-tertiary)',
+        fontSize: 'var(--t-sm)', minWidth: 200, cursor: 'default',
+      }}>
+        {SearchIcon}
+        <span style={{ flex: 1, textAlign: 'left' }}>跳转 / 搜索…</span>
+        <span className="kbd">⌘K</span>
+      </button>
+    </header>
+  )
+}

--- a/studio/web/src/index.css
+++ b/studio/web/src/index.css
@@ -1,42 +1,9 @@
+@import './styles/tokens.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-html,
-body {
-  margin: 0;
-  background: #0b1120;
-  color: #e2e8f0;
-  font-family:
-    'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Roboto',
-    sans-serif;
-}
-
-/* —— 自定义滚动条 —— 全局细滚动条 + 悬停加深 ——
- * `scrollbar-gutter: stable` 给容器永远预留滚动条空间，避免内容因为出现 / 消失
- * 滚动条而横向跳动。Firefox 用 `scrollbar-width`，Chromium 走 ::-webkit。 */
-* {
-  scrollbar-width: thin;
-  scrollbar-color: rgba(148, 163, 184, 0.35) transparent;
-}
-
-*::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-*::-webkit-scrollbar-track {
-  background: transparent;
-}
-*::-webkit-scrollbar-thumb {
-  background-color: rgba(148, 163, 184, 0.25);
-  border-radius: 4px;
-}
-*::-webkit-scrollbar-thumb:hover {
-  background-color: rgba(148, 163, 184, 0.55);
-}
-
-/* 给所有 overflow-auto / overflow-y-auto 默认预留滚动槽，杜绝抖动。
- * 想关掉的特定容器加 `[scrollbar-gutter:auto]`。 */
+/* 给所有 overflow-auto / overflow-y-auto 默认预留滚动槽，杜绝抖动 */
 .overflow-auto,
 .overflow-y-auto {
   scrollbar-gutter: stable;

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -1,0 +1,244 @@
+/* AnimaLoraStudio — redesigned design tokens
+ * Light + dark, comfortable density, responsive 1280→2560
+ * Inspired by warm-ivory studio aesthetic, adapted for a heavy workbench
+ */
+
+:root {
+  /* — palette: warm ivory (light) — */
+  --bg-canvas:   #f6f5f1;   /* page bg */
+  --bg-surface:  #ffffff;   /* card */
+  --bg-sunken:   #efeee8;   /* nav, code wells */
+  --bg-overlay:  #e6e5dd;   /* hover */
+  --bg-elevated: #fcfbf7;   /* tooltip / modal */
+
+  --fg-primary:   #1a1812;
+  --fg-secondary: #4a4740;
+  --fg-tertiary:  #7a7770;
+  --fg-disabled:  #b8b5ac;
+  --fg-inverse:   #f6f5f1;
+
+  --border-subtle:  #e0ded4;
+  --border-default: #cdcbc0;
+  --border-strong:  #a8a59a;
+
+  /* accents */
+  --accent:        #d8541d;     /* orange — primary action */
+  --accent-hover:  #b9441a;
+  --accent-soft:   #fbe8de;
+  --accent-fg:     #ffffff;
+
+  --ok:    #2d7a4f;
+  --ok-soft: #d6ebde;
+  --warn:  #b97a16;
+  --warn-soft: #f4e4c3;
+  --err:   #c2371b;
+  --err-soft: #f6dad1;
+  --info:  #2a6597;
+  --info-soft: #d4e3ef;
+
+  /* type */
+  --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, "PingFang SC", "Microsoft YaHei", sans-serif;
+  --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --font-serif: "EB Garamond", ui-serif, Georgia, serif;
+
+  /* sizes — bumped up vs current 12-13px baseline */
+  --t-xs: 11px;
+  --t-sm: 13px;
+  --t-base: 14px;
+  --t-md: 15px;
+  --t-lg: 17px;
+  --t-xl: 20px;
+  --t-2xl: 26px;
+  --t-3xl: 34px;
+  --t-4xl: 44px;
+  --t-display: 56px;
+
+  /* spacing — comfortable */
+  --s-1: 4px;
+  --s-2: 8px;
+  --s-3: 12px;
+  --s-4: 16px;
+  --s-5: 20px;
+  --s-6: 24px;
+  --s-8: 32px;
+  --s-10: 40px;
+  --s-12: 48px;
+  --s-16: 64px;
+
+  /* radius */
+  --r-sm: 4px;
+  --r-md: 6px;
+  --r-lg: 10px;
+  --r-xl: 14px;
+  --r-pill: 999px;
+
+  /* shadows — layered */
+  --sh-sm: 0 1px 2px rgba(20, 18, 12, 0.05), 0 0 0 1px rgba(20, 18, 12, 0.04);
+  --sh-md: 0 4px 8px -2px rgba(20, 18, 12, 0.08), 0 2px 4px rgba(20, 18, 12, 0.04), 0 0 0 1px rgba(20, 18, 12, 0.05);
+  --sh-lg: 0 14px 32px rgba(20, 18, 12, 0.10), 0 4px 12px rgba(20, 18, 12, 0.06), 0 0 0 1px rgba(20, 18, 12, 0.05);
+  --sh-xl: 0 28px 60px rgba(20, 18, 12, 0.14), 0 12px 28px rgba(20, 18, 12, 0.08), 0 0 0 1px rgba(20, 18, 12, 0.05);
+
+  /* layout */
+  --sidebar-w: 232px;
+  --sidebar-collapsed-w: 56px;
+  --topbar-h: 52px;
+}
+
+/* — dark mode — */
+.theme-dark {
+  --bg-canvas:   #15140f;
+  --bg-surface:  #1d1c16;
+  --bg-sunken:   #110f0b;
+  --bg-overlay:  #2a2820;
+  --bg-elevated: #25231c;
+
+  --fg-primary:   #f0eee5;
+  --fg-secondary: #b8b5ac;
+  --fg-tertiary:  #807d74;
+  --fg-disabled:  #4f4d45;
+  --fg-inverse:   #15140f;
+
+  --border-subtle:  #2a2820;
+  --border-default: #3a3830;
+  --border-strong:  #5a5750;
+
+  --accent:        #ed6b3a;
+  --accent-hover:  #f78a5e;
+  --accent-soft:   #3a1f12;
+  --accent-fg:     #15140f;
+
+  --ok: #5fc78c;       --ok-soft: #1a3328;
+  --warn: #e0a23a;     --warn-soft: #3a2a10;
+  --err: #e8765c;      --err-soft: #3a1a14;
+  --info: #6db1d9;     --info-soft: #18293a;
+
+  --sh-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.04);
+  --sh-md: 0 4px 8px -2px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  --sh-lg: 0 14px 32px rgba(0, 0, 0, 0.5), 0 4px 12px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.05);
+  --sh-xl: 0 28px 60px rgba(0, 0, 0, 0.6), 0 12px 28px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.06);
+}
+
+/* — density modifiers — */
+.density-tight { --s-3: 8px; --s-4: 12px; --s-5: 14px; --s-6: 18px; --s-8: 24px; --t-base: 13px; --t-md: 14px; --t-lg: 16px; }
+.density-loose { --s-3: 16px; --s-4: 22px; --s-5: 28px; --s-6: 32px; --s-8: 44px; --t-base: 15px; --t-md: 16px; --t-lg: 18px; }
+
+/* — radius modifiers — */
+.radius-sharp { --r-sm: 0; --r-md: 2px; --r-lg: 4px; --r-xl: 6px; }
+.radius-soft  { --r-sm: 8px; --r-md: 10px; --r-lg: 14px; --r-xl: 20px; }
+
+* { box-sizing: border-box; }
+
+html, body, #app {
+  margin: 0; padding: 0;
+  height: 100%;
+  background: var(--bg-canvas);
+  color: var(--fg-primary);
+  font-family: var(--font-sans);
+  font-size: var(--t-base);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  font-feature-settings: "cv11", "ss01", "tnum";
+}
+
+button { font-family: inherit; cursor: pointer; }
+a { color: inherit; text-decoration: none; }
+input, select, textarea { font-family: inherit; color: inherit; }
+
+::selection { background: var(--accent); color: var(--accent-fg); }
+
+/* scrollbars */
+* { scrollbar-width: thin; scrollbar-color: var(--border-default) transparent; }
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+*::-webkit-scrollbar-track { background: transparent; }
+*::-webkit-scrollbar-thumb { background: var(--border-default); border-radius: 6px; border: 2px solid transparent; background-clip: padding-box; }
+*::-webkit-scrollbar-thumb:hover { background-color: var(--border-strong); }
+
+/* — primitives — */
+.mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.tnum { font-variant-numeric: tabular-nums; }
+.serif { font-family: var(--font-serif); }
+.caption {
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  color: var(--fg-tertiary);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 14px;
+  border-radius: var(--r-md);
+  border: 1px solid transparent;
+  font-size: var(--t-base); font-weight: 500;
+  transition: all 120ms ease;
+  white-space: nowrap;
+}
+.btn-primary { background: var(--accent); color: var(--accent-fg); }
+.btn-primary:hover { background: var(--accent-hover); }
+.btn-secondary { background: var(--bg-surface); color: var(--fg-primary); border-color: var(--border-default); }
+.btn-secondary:hover { background: var(--bg-overlay); border-color: var(--border-strong); }
+.btn-ghost { background: transparent; color: var(--fg-secondary); }
+.btn-ghost:hover { background: var(--bg-overlay); color: var(--fg-primary); }
+.btn-sm { padding: 4px 10px; font-size: var(--t-sm); }
+
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-lg);
+}
+.card-hover { transition: all 120ms ease; }
+.card-hover:hover { box-shadow: var(--sh-md); border-color: var(--border-default); transform: translateY(-1px); }
+
+.kbd {
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  padding: 2px 6px;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border-subtle);
+  border-bottom-width: 2px;
+  border-radius: var(--r-sm);
+  color: var(--fg-secondary);
+}
+
+.badge {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  padding: 2px 8px;
+  border-radius: var(--r-pill);
+  letter-spacing: 0.02em;
+}
+.badge-ok   { background: var(--ok-soft);   color: var(--ok); }
+.badge-warn { background: var(--warn-soft); color: var(--warn); }
+.badge-err  { background: var(--err-soft);  color: var(--err); }
+.badge-info { background: var(--info-soft); color: var(--info); }
+.badge-neutral { background: var(--bg-overlay); color: var(--fg-secondary); }
+.badge-accent { background: var(--accent-soft); color: var(--accent); }
+
+.dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
+.dot-ok { background: var(--ok); }
+.dot-warn { background: var(--warn); }
+.dot-err { background: var(--err); }
+.dot-running { background: var(--accent); animation: pulse 1.6s infinite; }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+.input {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--r-md);
+  padding: 7px 12px;
+  font-size: var(--t-base);
+  color: var(--fg-primary);
+  outline: none;
+  transition: border-color 100ms ease, box-shadow 100ms ease;
+  width: 100%;
+}
+.input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.input-mono { font-family: var(--font-mono); font-size: var(--t-sm); }
+
+.divider { height: 1px; background: var(--border-subtle); }
+
+/* page transitions */
+.fade-in { animation: fade-in 200ms ease; }
+@keyframes fade-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }


### PR DESCRIPTION
- add studio/web/src/styles/tokens.css: warm-ivory design tokens (CSS vars for color, type, spacing, radius, shadow, layout dims) light + dark variants, density modifiers, primitive utility classes
- rewrite Sidebar: warm-ivory palette, CSS-var styling, collapse/expand with sessionStorage persist, ProjectStepperNav shows steps when inside a project (derived from URL), SVG icon set
- add Topbar: breadcrumb from URL, ⌘K search placeholder
- App.tsx: column layout (Topbar / Sidebar + main), import Topbar
- index.css: import tokens.css, remove hardcoded dark theme

All existing pages are untouched (business logic unchanged). Verification: 0 lint errors, 0 TS errors, vite build succeeds.