### PR TITLE
Feat/cltagger support

### DIFF
--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -99,6 +99,20 @@ class WD14Config(BaseModel):
         return self
 
 
+class CLTaggerConfig(BaseModel):
+    model_id: str = "cella110n/cl_tagger"
+    model_path: str = "cl_tagger_1_02/model.onnx"
+    tag_mapping_path: str = "cl_tagger_1_02/tag_mapping.json"
+    local_dir: Optional[str] = None
+    threshold_general: float = 0.35
+    threshold_character: float = 0.6
+    add_rating_tag: bool = False
+    add_model_tag: bool = False
+    blacklist_tags: list[str] = Field(default_factory=list)
+    # 与 WD14 一致：只有 CUDA EP 时才真正 batch，CPU 自动降到 1。
+    batch_size: int = 8
+
+
 class QueueConfig(BaseModel):
     """队列调度策略（PP10.2）。
 
@@ -132,6 +146,7 @@ class Secrets(BaseModel):
     huggingface: HuggingFaceConfig = Field(default_factory=HuggingFaceConfig)
     joycaption: JoyCaptionConfig = Field(default_factory=JoyCaptionConfig)
     wd14: WD14Config = Field(default_factory=WD14Config)
+    cltagger: CLTaggerConfig = Field(default_factory=CLTaggerConfig)
     models: ModelsConfig = Field(default_factory=ModelsConfig)
     queue: QueueConfig = Field(default_factory=QueueConfig)
 

--- a/studio/server.py
+++ b/studio/server.py
@@ -1100,10 +1100,24 @@ class Wd14Overrides(BaseModel):
     blacklist_tags: Optional[list[str]] = None
 
 
+class CLTaggerOverrides(BaseModel):
+    """打标页对 CLTagger 设置的「本次任务覆盖」—— 仅在 worker 进程内生效。"""
+    threshold_general: Optional[float] = None
+    threshold_character: Optional[float] = None
+    model_id: Optional[str] = None
+    model_path: Optional[str] = None
+    tag_mapping_path: Optional[str] = None
+    local_dir: Optional[str] = None
+    add_rating_tag: Optional[bool] = None
+    add_model_tag: Optional[bool] = None
+    blacklist_tags: Optional[list[str]] = None
+
+
 class TagJobRequest(BaseModel):
     tagger: str = "wd14"
     output_format: str = "txt"                # "txt" | "json"
     wd14_overrides: Optional[Wd14Overrides] = None
+    cltagger_overrides: Optional[CLTaggerOverrides] = None
 
 
 class CaptionEdit(BaseModel):
@@ -1216,6 +1230,10 @@ def start_tag(pid: int, vid: int, body: TagJobRequest) -> dict[str, Any]:
         ov = body.wd14_overrides.model_dump(exclude_none=True)
         if ov:
             params["wd14_overrides"] = ov
+    if body.tagger == "cltagger" and body.cltagger_overrides is not None:
+        ov = body.cltagger_overrides.model_dump(exclude_none=True)
+        if ov:
+            params["cltagger_overrides"] = ov
 
     with db.connection_for() as conn:
         job = project_jobs.create_job(

--- a/studio/services/cltagger_tagger.py
+++ b/studio/services/cltagger_tagger.py
@@ -49,7 +49,7 @@ class CLTagger:
                 base[k] = v
         return secrets.CLTaggerConfig(**base)
 
-    def _resolve_model_files(self) -> tuple[Path, Path]:
+    def _local_model_files_status(self) -> tuple[Path, Path, bool]:
         cfg = self._cfg()
         base = (
             Path(cfg.local_dir)
@@ -59,17 +59,25 @@ class CLTagger:
         model_path = base / cfg.model_path
         mapping_path = base / cfg.tag_mapping_path
         if model_path.exists() and mapping_path.exists():
-            return model_path, mapping_path
+            return model_path, mapping_path, True
         if cfg.local_dir:
-            # 兼容用户把 local_dir 直接指到 cl_tagger_1_02/ 子目录。
             flat_model = base / Path(cfg.model_path).name
             flat_mapping = base / Path(cfg.tag_mapping_path).name
             if flat_model.exists() and flat_mapping.exists():
-                return flat_model, flat_mapping
+                return flat_model, flat_mapping, True
+        return model_path, mapping_path, False
+
+    def _resolve_model_files(self) -> tuple[Path, Path]:
+        cfg = self._cfg()
+        model_path, mapping_path, ok = self._local_model_files_status()
+        if ok:
+            return model_path, mapping_path
+        if cfg.local_dir:
             raise FileNotFoundError(
                 "local_dir 缺少 CLTagger 模型文件或 tag_mapping.json: "
                 f"{model_path} / {mapping_path}"
             )
+        base = model_path.parents[len(Path(cfg.model_path).parts) - 1]
         model_downloader.download_cltagger(base, cfg, on_log=logger.info)
         if not model_path.exists() or not mapping_path.exists():
             raise FileNotFoundError(
@@ -80,9 +88,16 @@ class CLTagger:
 
     def is_available(self) -> tuple[bool, str]:
         try:
-            model_path, _ = self._resolve_model_files()
+            model_path, mapping_path, ok = self._local_model_files_status()
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
+        if not ok:
+            if self._cfg().local_dir:
+                return False, (
+                    "local_dir 缺少 CLTagger 模型文件或 tag_mapping.json: "
+                    f"{model_path} / {mapping_path}"
+                )
+            return False, f"需下载模型: {model_path.parent.name}"
         return True, f"模型: {model_path.parent.name}"
 
     def prepare(self) -> None:

--- a/studio/services/cltagger_tagger.py
+++ b/studio/services/cltagger_tagger.py
@@ -1,0 +1,272 @@
+"""CLTagger ONNX 打标。
+
+CLTagger 与 WD14 都走本地 onnxruntime，但模型资产和后处理不同：
+CLTagger 使用 `tag_mapping.json`，输出 logits 需 sigmoid，角色标签有单独阈值。
+"""
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, Optional
+
+import numpy as np
+from PIL import Image, ImageOps
+
+from .. import secrets
+from . import model_downloader, onnxruntime_setup
+from .tagger import ProgressFn, TagResult
+from .wd14_tagger import _safe_dir_name, _silenced_fd_stderr
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _LabelData:
+    names: list[str | None]
+    categories: list[str]
+
+
+class CLTagger:
+    name = "cltagger"
+    requires_service = False
+
+    def __init__(self, overrides: dict | None = None) -> None:
+        self._overrides = {k: v for k, v in (overrides or {}).items() if v is not None}
+        self._session = None
+        self._labels: _LabelData | None = None
+        self._input_name: str | None = None
+        self._output_names: list[str] | None = None
+        self._input_size: int = 448
+
+    def _cfg(self) -> "secrets.CLTaggerConfig":
+        base = secrets.load().cltagger.model_dump()
+        for k, v in self._overrides.items():
+            if k in base:
+                base[k] = v
+        return secrets.CLTaggerConfig(**base)
+
+    def _resolve_model_files(self) -> tuple[Path, Path]:
+        cfg = self._cfg()
+        base = (
+            Path(cfg.local_dir)
+            if cfg.local_dir
+            else model_downloader.models_root() / "cltagger" / _safe_dir_name(cfg.model_id)
+        )
+        model_path = base / cfg.model_path
+        mapping_path = base / cfg.tag_mapping_path
+        if model_path.exists() and mapping_path.exists():
+            return model_path, mapping_path
+        if cfg.local_dir:
+            # 兼容用户把 local_dir 直接指到 cl_tagger_1_02/ 子目录。
+            flat_model = base / Path(cfg.model_path).name
+            flat_mapping = base / Path(cfg.tag_mapping_path).name
+            if flat_model.exists() and flat_mapping.exists():
+                return flat_model, flat_mapping
+            raise FileNotFoundError(
+                "local_dir 缺少 CLTagger 模型文件或 tag_mapping.json: "
+                f"{model_path} / {mapping_path}"
+            )
+        model_downloader.download_cltagger(base, cfg, on_log=logger.info)
+        if not model_path.exists() or not mapping_path.exists():
+            raise FileNotFoundError(
+                "CLTagger 下载后仍缺少模型文件或 tag_mapping.json: "
+                f"{model_path} / {mapping_path}"
+            )
+        return model_path, mapping_path
+
+    def is_available(self) -> tuple[bool, str]:
+        try:
+            model_path, _ = self._resolve_model_files()
+        except Exception as exc:  # noqa: BLE001
+            return False, str(exc)
+        return True, f"模型: {model_path.parent.name}"
+
+    def prepare(self) -> None:
+        if self._session is not None:
+            return
+        try:
+            import onnxruntime as ort
+        except ImportError as exc:  # pragma: no cover - install hint
+            raise RuntimeError(
+                "未安装 onnxruntime；请安装 onnxruntime 或 onnxruntime-gpu"
+            ) from exc
+
+        model_path, mapping_path = self._resolve_model_files()
+        providers = ["CPUExecutionProvider"]
+        avail = ort.get_available_providers()
+        if "CUDAExecutionProvider" in avail:
+            providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+        cuda_attempt = "CUDAExecutionProvider" in providers
+        ctx = _silenced_fd_stderr() if cuda_attempt else contextlib.nullcontext()
+        try:
+            with ctx:
+                self._session = ort.InferenceSession(str(model_path), providers=providers)
+        except Exception as exc:  # noqa: BLE001
+            if not cuda_attempt:
+                raise
+            err = str(exc)
+            logger.warning("CLTagger CUDA session 创建失败，降级 CPU 重试: %s", err)
+            onnxruntime_setup.record_cuda_load_error(err)
+            self._session = ort.InferenceSession(
+                str(model_path), providers=["CPUExecutionProvider"]
+            )
+        self._input_name = self._session.get_inputs()[0].name
+        self._output_names = [o.name for o in self._session.get_outputs()]
+        self._input_size = self._infer_input_size(self._session.get_inputs()[0].shape)
+        self._labels = self._load_tag_mapping(mapping_path)
+
+    @staticmethod
+    def _infer_input_size(shape: list[object]) -> int:
+        for dim in reversed(shape):
+            if isinstance(dim, int) and dim > 0:
+                return dim
+        return 448
+
+    @staticmethod
+    def _load_tag_mapping(mapping_path: Path) -> _LabelData:
+        raw = json.loads(mapping_path.read_text(encoding="utf-8"))
+        if isinstance(raw, dict) and "idx_to_tag" in raw:
+            idx_to_tag = {int(k): str(v) for k, v in raw["idx_to_tag"].items()}
+            tag_to_category = {str(k): str(v) for k, v in raw.get("tag_to_category", {}).items()}
+        elif isinstance(raw, dict):
+            idx_to_tag = {}
+            tag_to_category = {}
+            for k, v in raw.items():
+                if not isinstance(v, dict):
+                    raise ValueError("Unsupported CLTagger tag_mapping.json format")
+                tag = str(v["tag"])
+                idx_to_tag[int(k)] = tag
+                tag_to_category[tag] = str(v.get("category", "General"))
+        else:
+            raise ValueError("Unsupported CLTagger tag_mapping.json format")
+
+        size = max(idx_to_tag.keys(), default=-1) + 1
+        names: list[str | None] = [None] * size
+        categories = ["General"] * size
+        for idx, tag in idx_to_tag.items():
+            names[idx] = tag
+            categories[idx] = tag_to_category.get(tag, "General")
+        return _LabelData(names=names, categories=categories)
+
+    def _preprocess(self, img: Image.Image) -> np.ndarray:
+        size = self._input_size
+        img = ImageOps.exif_transpose(img) or img
+        if img.mode not in ("RGB", "RGBA"):
+            img = img.convert("RGBA") if "transparency" in img.info else img.convert("RGB")
+        if img.mode == "RGBA":
+            canvas = Image.new("RGB", img.size, (255, 255, 255))
+            canvas.paste(img, mask=img.split()[3])
+            img = canvas
+        if img.width != img.height:
+            side = max(img.width, img.height)
+            canvas = Image.new("RGB", (side, side), (255, 255, 255))
+            canvas.paste(img, ((side - img.width) // 2, (side - img.height) // 2))
+            img = canvas
+        img = img.resize((size, size), Image.Resampling.BICUBIC)
+        arr = np.asarray(img, dtype=np.float32) / 255.0
+        arr = arr.transpose(2, 0, 1)[::-1, :, :]
+        mean = np.array([0.5, 0.5, 0.5], dtype=np.float32).reshape(3, 1, 1)
+        std = np.array([0.5, 0.5, 0.5], dtype=np.float32).reshape(3, 1, 1)
+        return (arr - mean) / std
+
+    @staticmethod
+    def _sigmoid(x: np.ndarray) -> np.ndarray:
+        return 1.0 / (1.0 + np.exp(-np.clip(x, -30, 30)))
+
+    def _postprocess_one(
+        self, logits: np.ndarray
+    ) -> tuple[list[str], dict[str, float]]:
+        cfg = self._cfg()
+        assert self._labels is not None
+        scores = self._sigmoid(logits)
+        out: list[tuple[str, float]] = []
+        blacklist = set(cfg.blacklist_tags)
+        for i, p in enumerate(scores):
+            if i >= len(self._labels.names):
+                break
+            tag = self._labels.names[i]
+            if not tag or tag in blacklist:
+                continue
+            cat = self._labels.categories[i]
+            if cat == "Rating" and not cfg.add_rating_tag:
+                continue
+            if cat == "Model" and not cfg.add_model_tag:
+                continue
+            thr = cfg.threshold_character if cat == "Character" else cfg.threshold_general
+            p_f = float(p)
+            if p_f >= thr:
+                out.append((tag.replace("_", " "), p_f))
+        out.sort(key=lambda x: -x[1])
+        return [t for t, _ in out], dict(out)
+
+    def _effective_batch_size(self) -> int:
+        cfg = self._cfg()
+        n = max(1, int(cfg.batch_size or 1))
+        if self._session is not None:
+            providers = list(self._session.get_providers())
+            if "CUDAExecutionProvider" not in providers:
+                return 1
+        return n
+
+    def _preprocess_one_safe(
+        self, indexed: tuple[int, Path]
+    ) -> tuple[int, Optional[np.ndarray], Optional[str]]:
+        j, p = indexed
+        try:
+            with Image.open(p) as raw:
+                return j, self._preprocess(raw), None
+        except Exception as exc:  # noqa: BLE001
+            return j, None, str(exc)
+
+    def tag(
+        self,
+        image_paths: list[Path],
+        on_progress: ProgressFn = lambda d, t: None,
+    ) -> Iterator[TagResult]:
+        if self._session is None:
+            self.prepare()
+        assert self._session is not None
+        assert self._input_name is not None
+        total = len(image_paths)
+        batch_n = self._effective_batch_size()
+        done = 0
+        i = 0
+        while i < total:
+            chunk = image_paths[i : i + batch_n]
+            arrs: list[np.ndarray] = []
+            ok_idx: list[int] = []
+            errs: dict[int, str] = {}
+            for j, p in enumerate(chunk):
+                j, arr, err = self._preprocess_one_safe((j, p))
+                if err is None and arr is not None:
+                    arrs.append(arr)
+                    ok_idx.append(j)
+                else:
+                    errs[j] = err or "preprocess failed"
+            logits_batch: Optional[np.ndarray] = None
+            if arrs:
+                try:
+                    batch = np.stack(arrs, axis=0).copy()
+                    outputs = self._session.run(self._output_names, {self._input_name: batch})
+                    logits_batch = np.nan_to_num(
+                        outputs[0], nan=0.0, posinf=1.0, neginf=0.0
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    for j in ok_idx:
+                        errs[j] = f"inference failed: {exc}"
+            ok_pos = 0
+            for j, p in enumerate(chunk):
+                if j in errs:
+                    yield {"image": p, "tags": [], "error": errs[j]}
+                elif logits_batch is not None and ok_pos < logits_batch.shape[0]:
+                    tags, raw_scores = self._postprocess_one(logits_batch[ok_pos])
+                    ok_pos += 1
+                    yield {"image": p, "tags": tags, "raw_scores": raw_scores}
+                else:
+                    yield {"image": p, "tags": [], "error": "no logits"}
+                done += 1
+                on_progress(done, total)
+            i += batch_n

--- a/studio/services/cltagger_tagger.py
+++ b/studio/services/cltagger_tagger.py
@@ -40,6 +40,7 @@ class CLTagger:
         self._input_name: str | None = None
         self._output_names: list[str] | None = None
         self._input_size: int = 448
+        self._input_layout: str = "nchw"
 
     def _cfg(self) -> "secrets.CLTaggerConfig":
         base = secrets.load().cltagger.model_dump()
@@ -113,15 +114,36 @@ class CLTagger:
             self._session = ort.InferenceSession(
                 str(model_path), providers=["CPUExecutionProvider"]
             )
-        self._input_name = self._session.get_inputs()[0].name
+        input_meta = self._session.get_inputs()[0]
+        self._input_name = input_meta.name
         self._output_names = [o.name for o in self._session.get_outputs()]
-        self._input_size = self._infer_input_size(self._session.get_inputs()[0].shape)
+        self._input_layout = self._infer_input_layout(input_meta.shape)
+        self._input_size = self._infer_input_size(input_meta.shape, self._input_layout)
         self._labels = self._load_tag_mapping(mapping_path)
 
     @staticmethod
-    def _infer_input_size(shape: list[object]) -> int:
-        for dim in reversed(shape):
-            if isinstance(dim, int) and dim > 0:
+    def _infer_input_layout(shape: list[object]) -> str:
+        if len(shape) >= 4:
+            if shape[1] == 3:
+                return "nchw"
+            if shape[-1] == 3:
+                return "nhwc"
+        return "nchw"
+
+    @staticmethod
+    def _infer_input_size(shape: list[object], layout: str) -> int:
+        dims = list(shape)
+        if len(dims) >= 4:
+            if layout == "nchw":
+                for dim in (dims[2], dims[3]):
+                    if isinstance(dim, int) and dim > 0:
+                        return dim
+            else:
+                for dim in (dims[1], dims[2]):
+                    if isinstance(dim, int) and dim > 0:
+                        return dim
+        for dim in reversed(dims):
+            if isinstance(dim, int) and dim > 0 and dim != 3:
                 return dim
         return 448
 
@@ -167,9 +189,14 @@ class CLTagger:
             img = canvas
         img = img.resize((size, size), Image.Resampling.BICUBIC)
         arr = np.asarray(img, dtype=np.float32) / 255.0
-        arr = arr.transpose(2, 0, 1)[::-1, :, :]
-        mean = np.array([0.5, 0.5, 0.5], dtype=np.float32).reshape(3, 1, 1)
-        std = np.array([0.5, 0.5, 0.5], dtype=np.float32).reshape(3, 1, 1)
+        arr = arr[..., ::-1]  # RGB -> BGR
+        if self._input_layout == "nchw":
+            arr = arr.transpose(2, 0, 1)
+            mean = np.array([0.5, 0.5, 0.5], dtype=np.float32).reshape(3, 1, 1)
+            std = np.array([0.5, 0.5, 0.5], dtype=np.float32).reshape(3, 1, 1)
+        else:
+            mean = np.array([0.5, 0.5, 0.5], dtype=np.float32).reshape(1, 1, 3)
+            std = np.array([0.5, 0.5, 0.5], dtype=np.float32).reshape(1, 1, 3)
         return (arr - mean) / std
 
     @staticmethod

--- a/studio/services/model_downloader.py
+++ b/studio/services/model_downloader.py
@@ -61,7 +61,6 @@ T5_FILES = [
     "special_tokens_map.json",
 ]
 
-
 # ---------------------------------------------------------------------------
 # paths
 # ---------------------------------------------------------------------------
@@ -257,6 +256,22 @@ def download_t5_tokenizer(
     return ok
 
 
+def download_cltagger(
+    target_root: Path,
+    cfg: Optional["secrets.CLTaggerConfig"] = None,
+    *,
+    on_log: Callable[[str], None] = print,
+) -> bool:
+    cfg = cfg or secrets.load().cltagger
+    on_log(f"\n📥 CLTagger → {target_root}")
+    target_root.mkdir(parents=True, exist_ok=True)
+    ok = True
+    for f in (cfg.model_path, cfg.tag_mapping_path):
+        if not download_flat(cfg.model_id, f, target_root / f, on_log=on_log):
+            ok = False
+    return ok
+
+
 # ---------------------------------------------------------------------------
 # catalog
 # ---------------------------------------------------------------------------
@@ -293,6 +308,8 @@ def build_catalog(root: Optional[Path] = None) -> dict[str, Any]:
     vae_target = anima_vae_target(r)
     qwen_d = qwen_dir(r)
     t5_d = t5_tokenizer_dir(r)
+    cl_cfg = secrets.load().cltagger
+    cl_root = r / "cltagger" / cl_cfg.model_id.replace("/", "_").replace("\\", "_")
 
     return {
         "models_root": str(r),
@@ -330,6 +347,17 @@ def build_catalog(root: Optional[Path] = None) -> dict[str, Any]:
             "target_dir": str(t5_d),
             "files": [
                 {"name": f, **_file_status(t5_d / f)} for f in T5_FILES
+            ],
+        },
+        "cltagger": {
+            "id": "cltagger",
+            "name": "CLTagger",
+            "description": "cella110n CLTagger ONNX",
+            "repo": cl_cfg.model_id,
+            "target_dir": str(cl_root),
+            "files": [
+                {"name": f, **_file_status(cl_root / f)}
+                for f in (cl_cfg.model_path, cl_cfg.tag_mapping_path)
             ],
         },
         "downloads": get_status_snapshot(),
@@ -464,6 +492,14 @@ def trigger(model_id: str, variant: Optional[str] = None) -> str:
         key = "t5_tokenizer"
         start_download_async(
             key, lambda log: download_t5_tokenizer(root, on_log=log)
+        )
+        return key
+    if model_id == "cltagger":
+        cfg = secrets.load().cltagger
+        key = "cltagger"
+        target = root / "cltagger" / cfg.model_id.replace("/", "_").replace("\\", "_")
+        start_download_async(
+            key, lambda log: download_cltagger(target, cfg, on_log=log)
         )
         return key
     raise ValueError(f"unknown model_id {model_id!r}")

--- a/studio/services/tagger.py
+++ b/studio/services/tagger.py
@@ -43,18 +43,21 @@ class Tagger(Protocol):
 
 
 def get_tagger(name: str, overrides: dict | None = None) -> Tagger:
-    """工厂：name = 'wd14' | 'joycaption'。
+    """工厂：name = 'wd14' | 'cltagger' | 'joycaption'。
 
-    `overrides` 仅 wd14 当前消费 —— 本次打标参数覆盖（threshold / model_id /
-    blacklist_tags 等）；不影响全局 secrets.json。joycaption 暂时忽略。
+    `overrides` 仅本地 ONNX tagger 当前消费 —— 本次打标参数覆盖；
+    不影响全局 secrets.json。joycaption 暂时忽略。
     """
     if name == "wd14":
         from .wd14_tagger import WD14Tagger
         return WD14Tagger(overrides=overrides)
+    if name == "cltagger":
+        from .cltagger_tagger import CLTagger
+        return CLTagger(overrides=overrides)
     if name == "joycaption":
         from .joycaption_tagger import JoyCaptionTagger
         return JoyCaptionTagger()
     raise ValueError(f"unknown tagger: {name!r}")
 
 
-VALID_TAGGER_NAMES: tuple[str, ...] = ("wd14", "joycaption")
+VALID_TAGGER_NAMES: tuple[str, ...] = ("wd14", "cltagger", "joycaption")

--- a/studio/services/wd14_tagger.py
+++ b/studio/services/wd14_tagger.py
@@ -88,6 +88,16 @@ class WD14Tagger:
 
     # -------------------- model resolution --------------------
 
+    def _local_model_dir_status(self) -> tuple[Path, bool]:
+        cfg = self._cfg()
+        if cfg.local_dir:
+            d = Path(cfg.local_dir)
+            ok = (d / "model.onnx").exists() and (d / "selected_tags.csv").exists()
+            return d, ok
+        d = REPO_ROOT / "models" / "wd14" / _safe_dir_name(cfg.model_id)
+        ok = (d / "model.onnx").exists() and (d / "selected_tags.csv").exists()
+        return d, ok
+
     def _resolve_model_dir(self) -> Path:
         cfg = self._cfg()
         if cfg.local_dir:
@@ -118,10 +128,14 @@ class WD14Tagger:
 
     def is_available(self) -> tuple[bool, str]:
         try:
-            d = self._resolve_model_dir()
+            d, ok = self._local_model_dir_status()
         except Exception as exc:  # noqa: BLE001
             return False, str(exc)
-        return True, f"模型: {d.name}"
+        if ok:
+            return True, f"模型: {d.name}"
+        if self._cfg().local_dir:
+            return False, f"local_dir 缺少 model.onnx 或 selected_tags.csv: {d}"
+        return False, f"需下载模型: {d.name}"
 
     def prepare(self) -> None:
         if self._session is not None:

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -92,6 +92,19 @@ export interface WD14Config {
   batch_size: number
 }
 
+export interface CLTaggerConfig {
+  model_id: string
+  model_path: string
+  tag_mapping_path: string
+  local_dir: string | null
+  threshold_general: number
+  threshold_character: number
+  add_rating_tag: boolean
+  add_model_tag: boolean
+  blacklist_tags: string[]
+  batch_size: number
+}
+
 /** PP8 — onnxruntime 装包状态 + nvidia-smi 检测结果。 */
 export interface WD14Runtime {
   installed: 'onnxruntime' | 'onnxruntime-gpu' | null
@@ -163,6 +176,7 @@ export interface Secrets {
   huggingface: HuggingFaceConfig
   joycaption: JoyCaptionConfig
   wd14: WD14Config
+  cltagger: CLTaggerConfig
   models: ModelsConfig
   queue: QueueConfig
 }
@@ -204,7 +218,7 @@ export interface AnimaVaeCatalog extends ModelFileStatus {
 }
 
 export interface ModelDirCatalog {
-  id: 'qwen3' | 't5_tokenizer'
+  id: 'qwen3' | 't5_tokenizer' | 'cltagger'
   name: string
   description: string
   repo: string
@@ -227,6 +241,7 @@ export interface ModelsCatalog {
   anima_vae: AnimaVaeCatalog
   qwen3: ModelDirCatalog
   t5_tokenizer: ModelDirCatalog
+  cltagger: ModelDirCatalog
   downloads: Record<string, ModelDownloadStatus>
 }
 
@@ -347,7 +362,7 @@ export interface CopyResult {
 
 // ---- tagging (PP4) --------------------------------------------------------
 
-export type TaggerName = 'wd14' | 'joycaption'
+export type TaggerName = 'wd14' | 'cltagger' | 'joycaption'
 
 export interface TaggerStatus {
   name: TaggerName
@@ -862,6 +877,17 @@ export const api = {
         threshold_character?: number | null
         model_id?: string | null
         local_dir?: string | null
+        blacklist_tags?: string[] | null
+      }
+      cltagger_overrides?: {
+        threshold_general?: number | null
+        threshold_character?: number | null
+        model_id?: string | null
+        model_path?: string | null
+        tag_mapping_path?: string | null
+        local_dir?: string | null
+        add_rating_tag?: boolean | null
+        add_model_tag?: boolean | null
         blacklist_tags?: string[] | null
       }
     }

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -3,6 +3,7 @@ import { Link, useOutletContext } from 'react-router-dom'
 import {
   api,
   type Job,
+  type CLTaggerConfig,
   type ProjectDetail,
   type TaggerName,
   type TaggerStatus,
@@ -32,12 +33,38 @@ type Wd14Form = {
   blacklist_tags: string[]
 }
 
+type CLTaggerForm = {
+  threshold_general: number
+  threshold_character: number
+  model_id: string
+  model_path: string
+  tag_mapping_path: string
+  local_dir: string
+  add_rating_tag: boolean
+  add_model_tag: boolean
+  blacklist_tags: string[]
+}
+
 function fromConfig(cfg: WD14Config): Wd14Form {
   return {
     threshold_general: cfg.threshold_general,
     threshold_character: cfg.threshold_character,
     model_id: cfg.model_id,
     local_dir: cfg.local_dir ?? '',
+    blacklist_tags: cfg.blacklist_tags,
+  }
+}
+
+function fromCLTaggerConfig(cfg: CLTaggerConfig): CLTaggerForm {
+  return {
+    threshold_general: cfg.threshold_general,
+    threshold_character: cfg.threshold_character,
+    model_id: cfg.model_id,
+    model_path: cfg.model_path,
+    tag_mapping_path: cfg.tag_mapping_path,
+    local_dir: cfg.local_dir ?? '',
+    add_rating_tag: cfg.add_rating_tag,
+    add_model_tag: cfg.add_model_tag,
     blacklist_tags: cfg.blacklist_tags,
   }
 }
@@ -52,6 +79,8 @@ export default function TaggingPage() {
 
   const [wd14Defaults, setWd14Defaults] = useState<WD14Config | null>(null)
   const [wd14Form, setWd14Form] = useState<Wd14Form | null>(null)
+  const [cltaggerDefaults, setCltaggerDefaults] = useState<CLTaggerConfig | null>(null)
+  const [cltaggerForm, setCltaggerForm] = useState<CLTaggerForm | null>(null)
   const [advOpen, setAdvOpen] = useState(false)
 
   const [job, setJob] = useState<Job | null>(null)
@@ -66,6 +95,8 @@ export default function TaggingPage() {
       .then((s) => {
         setWd14Defaults(s.wd14)
         setWd14Form(fromConfig(s.wd14))
+        setCltaggerDefaults(s.cltagger)
+        setCltaggerForm(fromCLTaggerConfig(s.cltagger))
       })
       .catch((e) => toast(`读取 wd14 默认配置失败：${e}`, 'error'))
     // toast 函数引用稳定；只在 mount 时跑一次
@@ -140,6 +171,34 @@ export default function TaggingPage() {
     return Object.keys(out).length ? out : undefined
   }
 
+  const buildCLTaggerOverrides = (): Record<string, unknown> | undefined => {
+    if (!cltaggerForm || !cltaggerDefaults) return undefined
+    const out: Record<string, unknown> = {}
+    if (cltaggerForm.threshold_general !== cltaggerDefaults.threshold_general)
+      out.threshold_general = cltaggerForm.threshold_general
+    if (cltaggerForm.threshold_character !== cltaggerDefaults.threshold_character)
+      out.threshold_character = cltaggerForm.threshold_character
+    if (cltaggerForm.model_id !== cltaggerDefaults.model_id)
+      out.model_id = cltaggerForm.model_id
+    if (cltaggerForm.model_path !== cltaggerDefaults.model_path)
+      out.model_path = cltaggerForm.model_path
+    if (cltaggerForm.tag_mapping_path !== cltaggerDefaults.tag_mapping_path)
+      out.tag_mapping_path = cltaggerForm.tag_mapping_path
+    const localDirChanged =
+      (cltaggerForm.local_dir || null) !== (cltaggerDefaults.local_dir ?? null)
+    if (localDirChanged) out.local_dir = cltaggerForm.local_dir || null
+    if (cltaggerForm.add_rating_tag !== cltaggerDefaults.add_rating_tag)
+      out.add_rating_tag = cltaggerForm.add_rating_tag
+    if (cltaggerForm.add_model_tag !== cltaggerDefaults.add_model_tag)
+      out.add_model_tag = cltaggerForm.add_model_tag
+    if (
+      JSON.stringify(cltaggerForm.blacklist_tags) !==
+      JSON.stringify(cltaggerDefaults.blacklist_tags)
+    )
+      out.blacklist_tags = cltaggerForm.blacklist_tags
+    return Object.keys(out).length ? out : undefined
+  }
+
   const startTagging = async () => {
     if (!taggerStatus?.ok) {
       toast(`${tagger} 不可用：${taggerStatus?.msg ?? '未知'}`, 'error')
@@ -147,11 +206,14 @@ export default function TaggingPage() {
     }
     try {
       const overrides =
-        tagger === 'wd14' ? buildWd14Overrides() : undefined
+        tagger === 'wd14' ? buildWd14Overrides()
+          : tagger === 'cltagger' ? buildCLTaggerOverrides()
+            : undefined
       const j = await api.startTag(project.id, activeVersion.id, {
         tagger,
         output_format: outputFormat,
-        wd14_overrides: overrides,
+        wd14_overrides: tagger === 'wd14' ? overrides : undefined,
+        cltagger_overrides: tagger === 'cltagger' ? overrides : undefined,
       })
       setJob(j)
       setLogs([])
@@ -201,6 +263,7 @@ export default function TaggingPage() {
               style={{ padding: '3px 8px' }}
             >
               <option value="wd14">WD14（本地 ONNX）</option>
+              <option value="cltagger">CLTagger（本地 ONNX）</option>
               <option value="joycaption">JoyCaption（远程 vLLM）</option>
             </select>
             <span
@@ -237,6 +300,17 @@ export default function TaggingPage() {
               form={wd14Form}
               defaults={wd14Defaults}
               onChange={setWd14Form}
+              advOpen={advOpen}
+              setAdvOpen={setAdvOpen}
+              disabled={isLive}
+            />
+          )}
+
+          {tagger === 'cltagger' && (
+            <CLTaggerPanel
+              form={cltaggerForm}
+              defaults={cltaggerDefaults}
+              onChange={setCltaggerForm}
               advOpen={advOpen}
               setAdvOpen={setAdvOpen}
               disabled={isLive}
@@ -386,6 +460,170 @@ function Wd14Panel({
             label="blacklist_tags（逗号分隔）"
             value={form.blacklist_tags.join(', ')}
             placeholder="如 monochrome, comic"
+            disabled={disabled}
+            onChange={(v) =>
+              onChange({
+                ...form,
+                blacklist_tags: v
+                  .split(',')
+                  .map((t) => t.trim())
+                  .filter(Boolean),
+              })
+            }
+            modified={
+              JSON.stringify(form.blacklist_tags) !==
+              JSON.stringify(defaults.blacklist_tags)
+            }
+          />
+        </div>
+      )}
+    </section>
+  )
+}
+
+function CLTaggerPanel({
+  form,
+  defaults,
+  onChange,
+  advOpen,
+  setAdvOpen,
+  disabled,
+}: {
+  form: CLTaggerForm | null
+  defaults: CLTaggerConfig | null
+  onChange: (f: CLTaggerForm) => void
+  advOpen: boolean
+  setAdvOpen: (b: boolean) => void
+  disabled: boolean
+}) {
+  if (!form || !defaults) {
+    return (
+      <section className="rounded-md border border-subtle bg-surface px-3 py-2 text-xs text-fg-tertiary shrink-0">
+        加载 CLTagger 默认参数...
+      </section>
+    )
+  }
+
+  const dirty =
+    form.threshold_general !== defaults.threshold_general ||
+    form.threshold_character !== defaults.threshold_character ||
+    form.model_id !== defaults.model_id ||
+    form.model_path !== defaults.model_path ||
+    form.tag_mapping_path !== defaults.tag_mapping_path ||
+    (form.local_dir || null) !== (defaults.local_dir ?? null) ||
+    form.add_rating_tag !== defaults.add_rating_tag ||
+    form.add_model_tag !== defaults.add_model_tag ||
+    JSON.stringify(form.blacklist_tags) !==
+      JSON.stringify(defaults.blacklist_tags)
+
+  const restore = () => onChange(fromCLTaggerConfig(defaults))
+
+  return (
+    <section className="rounded-md border border-subtle bg-surface px-3.5 py-2.5 flex flex-col gap-2 shrink-0 text-sm">
+      <div className="flex items-center gap-2 flex-wrap">
+        <PanelDot />
+        <span className="caption">CLTagger 参数</span>
+        <span className="text-xs text-fg-tertiary">
+          预填{' '}
+          <Link to="/tools/settings" className="text-accent" title="去设置页编辑全局默认">
+            全局设置
+          </Link>{' '}
+          · 本次有效，不写回
+        </span>
+        <span className="flex-1" />
+        {dirty && (
+          <>
+            <span className="badge badge-warn">已改</span>
+            <button
+              onClick={restore}
+              disabled={disabled}
+              className="btn btn-ghost btn-sm"
+              title="还原为全局设置"
+            >
+              ↻ 还原
+            </button>
+          </>
+        )}
+      </div>
+
+      <div className="flex items-center gap-3 flex-wrap">
+        <ThresholdInput
+          label="general"
+          value={form.threshold_general}
+          base={defaults.threshold_general}
+          disabled={disabled}
+          onChange={(v) => onChange({ ...form, threshold_general: v })}
+        />
+        <ThresholdInput
+          label="character"
+          value={form.threshold_character}
+          base={defaults.threshold_character}
+          disabled={disabled}
+          onChange={(v) => onChange({ ...form, threshold_character: v })}
+        />
+        <label className="flex items-center gap-1.5 text-xs text-fg-tertiary">
+          <input
+            type="checkbox"
+            checked={form.add_rating_tag}
+            disabled={disabled}
+            onChange={(e) => onChange({ ...form, add_rating_tag: e.target.checked })}
+          />
+          rating
+        </label>
+        <label className="flex items-center gap-1.5 text-xs text-fg-tertiary">
+          <input
+            type="checkbox"
+            checked={form.add_model_tag}
+            disabled={disabled}
+            onChange={(e) => onChange({ ...form, add_model_tag: e.target.checked })}
+          />
+          model
+        </label>
+        <button
+          type="button"
+          onClick={() => setAdvOpen(!advOpen)}
+          className="btn btn-ghost btn-sm text-xs text-fg-tertiary"
+        >
+          {advOpen ? '▾' : '▸'} 高级
+        </button>
+      </div>
+
+      {advOpen && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-2 pt-1">
+          <LabeledInput
+            label="model_id"
+            value={form.model_id}
+            disabled={disabled}
+            onChange={(v) => onChange({ ...form, model_id: v })}
+            modified={form.model_id !== defaults.model_id}
+          />
+          <LabeledInput
+            label="local_dir"
+            value={form.local_dir}
+            placeholder="留空 = 自动 HF 下载"
+            disabled={disabled}
+            onChange={(v) => onChange({ ...form, local_dir: v })}
+            modified={(form.local_dir || null) !== (defaults.local_dir ?? null)}
+          />
+          <LabeledInput
+            label="model_path"
+            value={form.model_path}
+            disabled={disabled}
+            onChange={(v) => onChange({ ...form, model_path: v })}
+            modified={form.model_path !== defaults.model_path}
+          />
+          <LabeledInput
+            label="tag_mapping_path"
+            value={form.tag_mapping_path}
+            disabled={disabled}
+            onChange={(v) => onChange({ ...form, tag_mapping_path: v })}
+            modified={form.tag_mapping_path !== defaults.tag_mapping_path}
+          />
+          <LabeledInput
+            className="md:col-span-2"
+            label="blacklist_tags（逗号分隔）"
+            value={form.blacklist_tags.join(', ')}
+            placeholder="如 low quality, signature"
             disabled={disabled}
             onChange={(v) =>
               onChange({
@@ -565,7 +803,9 @@ function TagPreviewPanel({
         <div className="text-xs text-fg-secondary leading-relaxed">
           {tagger === 'wd14'
             ? 'WD14 ONNX 本地推理，无需网络'
-            : 'JoyCaption 远程 vLLM，自然语言描述'}
+            : tagger === 'cltagger'
+              ? 'CLTagger ONNX 本地推理，支持角色阈值'
+              : 'JoyCaption 远程 vLLM，自然语言描述'}
         </div>
       </div>
 

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -22,6 +22,7 @@ type Section =
   | 'huggingface'
   | 'joycaption'
   | 'wd14'
+  | 'cltagger'
   | 'models'
   | 'queue'
 
@@ -52,6 +53,18 @@ const EMPTY: Secrets = {
     local_dir: null,
     threshold_general: 0.35,
     threshold_character: 0.85,
+    blacklist_tags: [],
+    batch_size: 8,
+  },
+  cltagger: {
+    model_id: 'cella110n/cl_tagger',
+    model_path: 'cl_tagger_1_02/model.onnx',
+    tag_mapping_path: 'cl_tagger_1_02/tag_mapping.json',
+    local_dir: null,
+    threshold_general: 0.35,
+    threshold_character: 0.6,
+    add_rating_tag: false,
+    add_model_tag: false,
     blacklist_tags: [],
     batch_size: 8,
   },
@@ -331,6 +344,73 @@ export default function SettingsPage() {
             className={textInputClass}                                  />
         </SettingsField>
         <WD14RuntimePanel />
+      </SettingsSection>
+
+      <SettingsSection title="CLTagger">
+        <SettingsField label="model_id">
+          <input
+            type="text"
+            value={draft.cltagger.model_id}
+            onChange={(e) => update('cltagger', 'model_id', e.target.value)}
+            className={textInputClass}                                  />
+        </SettingsField>
+        <SettingsField label="model_path">
+          <input
+            type="text"
+            value={draft.cltagger.model_path}
+            onChange={(e) => update('cltagger', 'model_path', e.target.value)}
+            className={textInputClass}                                  />
+        </SettingsField>
+        <SettingsField label="tag_mapping_path">
+          <input
+            type="text"
+            value={draft.cltagger.tag_mapping_path}
+            onChange={(e) => update('cltagger', 'tag_mapping_path', e.target.value)}
+            className={textInputClass}                                  />
+        </SettingsField>
+        <SettingsField label="local_dir (留空 = 自动 HF 下载)">
+          <input
+            type="text"
+            value={draft.cltagger.local_dir ?? ''}
+            onChange={(e) => update('cltagger', 'local_dir', e.target.value || null)}
+            className={textInputClass}                                  />
+        </SettingsField>
+        <div className="grid grid-cols-2 gap-2">
+          <SettingsField label="threshold_general">
+            <input
+              type="number" step="0.01" min={0} max={1}
+              value={draft.cltagger.threshold_general}
+              onChange={(e) => update('cltagger', 'threshold_general', Number(e.target.value))}
+              className={textInputClass}                                          />
+          </SettingsField>
+          <SettingsField label="threshold_character">
+            <input
+              type="number" step="0.01" min={0} max={1}
+              value={draft.cltagger.threshold_character}
+              onChange={(e) => update('cltagger', 'threshold_character', Number(e.target.value))}
+              className={textInputClass}                                          />
+          </SettingsField>
+        </div>
+        <SettingsField label="add_rating_tag">
+          <Bool value={draft.cltagger.add_rating_tag} onChange={(v) => update('cltagger', 'add_rating_tag', v)} />
+        </SettingsField>
+        <SettingsField label="add_model_tag">
+          <Bool value={draft.cltagger.add_model_tag} onChange={(v) => update('cltagger', 'add_model_tag', v)} />
+        </SettingsField>
+        <SettingsField label="blacklist_tags (逗号分隔)">
+          <input
+            type="text"
+            value={draft.cltagger.blacklist_tags.join(', ')}
+            onChange={(e) => update('cltagger', 'blacklist_tags', e.target.value.split(',').map((t) => t.trim()).filter(Boolean))}
+            className={textInputClass}                                  />
+        </SettingsField>
+        <SettingsField label="batch_size (GPU 推理一批塞几张；CPU 自动降到 1)">
+          <input
+            type="number" min={1} max={64}
+            value={draft.cltagger.batch_size}
+            onChange={(e) => update('cltagger', 'batch_size', Math.max(1, Number(e.target.value) || 1))}
+            className={textInputClass}                                  />
+        </SettingsField>
       </SettingsSection>
 
       <SettingsSection title="队列调度">
@@ -620,7 +700,7 @@ function ModelsSection() {
           </ModelGroupCard>
 
           {/* Qwen3 + T5 */}
-          {(['qwen3', 't5_tokenizer'] as const).map((id) => {
+          {(['qwen3', 't5_tokenizer', 'cltagger'] as const).map((id) => {
             const m = catalog[id]
             const dl = catalog.downloads[id]
             const allExist = m.files.every((f) => f.exists)

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -2,7 +2,7 @@
 
 `python -m studio.workers.tag_worker --job-id N`。读 `project_jobs.params`：
     {
-      "tagger": "wd14" | "joycaption",
+      "tagger": "wd14" | "cltagger" | "joycaption",
       "version_id": int,
       "output_format": "txt"|"json"  # 默认 "txt"，已存在的 .json 仍按 .json 写
     }
@@ -68,6 +68,7 @@ def run(job_id: int) -> int:
         version_id = int(params["version_id"])
         fmt = str(params.get("output_format", "txt"))
         wd14_overrides = params.get("wd14_overrides") or None
+        cltagger_overrides = params.get("cltagger_overrides") or None
 
         with db.connection_for() as conn:
             v = versions.get_version(conn, version_id)
@@ -88,11 +89,12 @@ def run(job_id: int) -> int:
             f"images={len(images)} format={fmt}"
         )
 
-        tagger = get_tagger(tagger_name, overrides=wd14_overrides)
+        overrides = cltagger_overrides if tagger_name == "cltagger" else wd14_overrides
+        tagger = get_tagger(tagger_name, overrides=overrides)
         tagger.prepare()
-        if wd14_overrides:
+        if overrides:
             progress(
-                f"[overrides] {', '.join(f'{k}={v}' for k, v in wd14_overrides.items())}"
+                f"[overrides] {', '.join(f'{k}={v}' for k, v in overrides.items())}"
             )
         progress(f"[ready] {tagger_name} 已就绪")
 

--- a/tests/test_cltagger_tagger.py
+++ b/tests/test_cltagger_tagger.py
@@ -1,0 +1,101 @@
+"""CLTagger tagger：mock onnx + mapping 解析、阈值过滤。"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from studio import secrets
+from studio.services import cltagger_tagger
+
+
+@pytest.fixture
+def isolated_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    sf = tmp_path / "secrets.json"
+    monkeypatch.setattr(secrets, "SECRETS_FILE", sf)
+    return tmp_path
+
+
+def _make_local_model(model_dir: Path) -> None:
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "model.onnx").write_bytes(b"fake-onnx")
+    (model_dir / "tag_mapping.json").write_text(
+        json.dumps({
+            "idx_to_tag": {
+                "0": "general_tag",
+                "1": "hero_name",
+                "2": "explicit",
+                "3": "model_tag",
+            },
+            "tag_to_category": {
+                "general_tag": "General",
+                "hero_name": "Character",
+                "explicit": "Rating",
+                "model_tag": "Model",
+            },
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_resolve_local_dir_flat_files(isolated_secrets: Path) -> None:
+    model_dir = isolated_secrets / "cl"
+    _make_local_model(model_dir)
+    secrets.update({"cltagger": {"local_dir": str(model_dir)}})
+    t = cltagger_tagger.CLTagger()
+    model_path, mapping_path = t._resolve_model_files()
+    assert model_path == model_dir / "model.onnx"
+    assert mapping_path == model_dir / "tag_mapping.json"
+
+
+def test_postprocess_uses_character_threshold_and_optional_categories(
+    isolated_secrets: Path,
+) -> None:
+    secrets.update({
+        "cltagger": {
+            "threshold_general": 0.5,
+            "threshold_character": 0.7,
+            "add_rating_tag": False,
+            "add_model_tag": False,
+        }
+    })
+    t = cltagger_tagger.CLTagger()
+    t._labels = cltagger_tagger._LabelData(
+        names=["general_tag", "hero_name", "explicit", "model_tag"],
+        categories=["General", "Character", "Rating", "Model"],
+    )
+    logits = np.array([2.0, 0.0, 4.0, 4.0], dtype=np.float32)
+    tags, raw = t._postprocess_one(logits)
+    assert tags == ["general tag"]
+    assert raw["general tag"] > 0.5
+
+    secrets.update({"cltagger": {"add_rating_tag": True, "add_model_tag": True}})
+    tags, _ = t._postprocess_one(logits)
+    assert tags[:2] == ["explicit", "model tag"]
+
+
+def test_tag_iterator_runs_onnx_batch(isolated_secrets: Path, tmp_path: Path) -> None:
+    secrets.update({"cltagger": {"threshold_general": 0.1, "batch_size": 2}})
+    t = cltagger_tagger.CLTagger()
+    t._session = MagicMock()
+    t._session.get_providers.return_value = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    t._session.run.return_value = (np.array([[2.0], [3.0]], dtype=np.float32),)
+    t._input_name = "input"
+    t._output_names = ["output"]
+    t._input_size = 4
+    t._labels = cltagger_tagger._LabelData(names=["x"], categories=["General"])
+
+    paths = []
+    for i in range(2):
+        p = tmp_path / f"img{i}.png"
+        Image.new("RGB", (8, 8)).save(p)
+        paths.append(p)
+
+    results = list(t.tag(paths))
+    assert [r["tags"] for r in results] == [["x"], ["x"]]
+    fed = t._session.run.call_args[0][1]["input"]
+    assert fed.shape == (2, 3, 4, 4)

--- a/tests/test_cltagger_tagger.py
+++ b/tests/test_cltagger_tagger.py
@@ -99,3 +99,13 @@ def test_tag_iterator_runs_onnx_batch(isolated_secrets: Path, tmp_path: Path) ->
     assert [r["tags"] for r in results] == [["x"], ["x"]]
     fed = t._session.run.call_args[0][1]["input"]
     assert fed.shape == (2, 3, 4, 4)
+
+
+def test_preprocess_supports_nhwc_layout(isolated_secrets: Path) -> None:
+    t = cltagger_tagger.CLTagger()
+    t._input_size = 4
+    t._input_layout = "nhwc"
+    arr = t._preprocess(Image.new("RGB", (8, 8), (255, 0, 0)))
+    assert arr.shape == (4, 4, 3)
+    assert arr[0, 0, 0] == pytest.approx(-1.0, abs=1e-4)  # B
+    assert arr[0, 0, 2] == pytest.approx(1.0, abs=1e-4)   # R

--- a/tests/test_cltagger_tagger.py
+++ b/tests/test_cltagger_tagger.py
@@ -52,6 +52,23 @@ def test_resolve_local_dir_flat_files(isolated_secrets: Path) -> None:
     assert mapping_path == model_dir / "tag_mapping.json"
 
 
+def test_is_available_does_not_download_when_model_missing(
+    isolated_secrets: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    called = {"download": False}
+
+    def _boom(*args, **kwargs):
+        called["download"] = True
+        raise AssertionError("download should not run in is_available")
+
+    monkeypatch.setattr(cltagger_tagger.model_downloader, "download_cltagger", _boom)
+    t = cltagger_tagger.CLTagger()
+    ok, msg = t.is_available()
+    assert ok is False
+    assert "需下载模型" in msg
+    assert called["download"] is False
+
+
 def test_postprocess_uses_character_threshold_and_optional_categories(
     isolated_secrets: Path,
 ) -> None:

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -50,6 +50,14 @@ def test_wd14_defaults_include_candidate_list(secrets_file: Path) -> None:
     assert set(secrets.DEFAULT_WD14_MODELS).issubset(set(s.wd14.model_ids))
 
 
+def test_cltagger_defaults_use_1_02(secrets_file: Path) -> None:
+    s = secrets.load()
+    assert s.cltagger.model_id == "cella110n/cl_tagger"
+    assert s.cltagger.model_path == "cl_tagger_1_02/model.onnx"
+    assert s.cltagger.tag_mapping_path == "cl_tagger_1_02/tag_mapping.json"
+    assert s.cltagger.threshold_character == pytest.approx(0.6)
+
+
 def test_wd14_legacy_file_without_model_ids_gets_defaults(
     secrets_file: Path,
 ) -> None:

--- a/tests/test_tag_endpoints.py
+++ b/tests/test_tag_endpoints.py
@@ -134,6 +134,33 @@ def test_start_tag_with_wd14_overrides(client: TestClient) -> None:
     }
 
 
+def test_start_tag_with_cltagger_overrides(client: TestClient) -> None:
+    """传 cltagger_overrides 时，端点应把它落进 params。"""
+    import json as _json
+    pid, vid = _make(client)
+    r = client.post(
+        f"/api/projects/{pid}/versions/{vid}/tag",
+        json={
+            "tagger": "cltagger",
+            "output_format": "txt",
+            "cltagger_overrides": {
+                "threshold_general": 0.25,
+                "threshold_character": 0.55,
+                "add_rating_tag": True,
+                "blacklist_tags": ["signature"],
+            },
+        },
+    )
+    assert r.status_code == 200, r.text
+    params = _json.loads(r.json()["params"])
+    assert params["cltagger_overrides"] == {
+        "threshold_general": 0.25,
+        "threshold_character": 0.55,
+        "add_rating_tag": True,
+        "blacklist_tags": ["signature"],
+    }
+
+
 def test_start_tag_drops_empty_wd14_overrides(client: TestClient) -> None:
     """全部字段都是 None 时不要写空 dict 进 params。"""
     import json as _json

--- a/tests/test_tag_worker.py
+++ b/tests/test_tag_worker.py
@@ -113,5 +113,31 @@ def test_run_passes_wd14_overrides_through(env, monkeypatch) -> None:
     assert captured["overrides"] == {"threshold_general": 0.2}
 
 
+def test_run_passes_cltagger_overrides_through(env, monkeypatch) -> None:
+    """worker 应把 params['cltagger_overrides'] 透传到 get_tagger(overrides=...)。"""
+    captured: dict = {}
+
+    def _factory(name: str, overrides=None):
+        captured["name"] = name
+        captured["overrides"] = overrides
+        return _FakeTagger()
+
+    monkeypatch.setattr("studio.workers.tag_worker.get_tagger", _factory)
+
+    with db.connection_for(env["db"]) as conn:
+        conn.execute(
+            "UPDATE project_jobs SET params = json_set(params, "
+            "'$.tagger', 'cltagger', "
+            "'$.cltagger_overrides', json(?)) WHERE id = ?",
+            (json.dumps({"threshold_character": 0.55}), env["job_id"]),
+        )
+        conn.commit()
+
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    assert captured["name"] == "cltagger"
+    assert captured["overrides"] == {"threshold_character": 0.55}
+
+
 def test_run_unknown_job(env) -> None:
     assert tag_worker.run(99999) == 1


### PR DESCRIPTION
## Summary

Targeting `dev`.

Add CLTagger support alongside WD14 and JoyCaption.

## Changes

- add backend CLTagger ONNX tagger with `cl_tagger_1_02` defaults
- add CLTagger settings for model download and configuration
- add CLTagger option in the tagging page dropdown
- add per-job CLTagger overrides passed through API to worker
- add model downloader and catalog entry for CLTagger
- fix CLTagger ONNX input layout by detecting `NCHW` vs `NHWC` from the model input shape
- speed up tagger availability checks so the UI no longer blocks on model download/path resolution during page load
- add tests covering config defaults, endpoint overrides, worker passthrough, postprocess behavior, and non-blocking availability checks

## Notes

- keep runtime environment selection unchanged and do not force CPU/GPU-specific packages into the project venv
- local frontend production build passed
- cloud test verified the CLTagger integration path and exposed the ONNX input layout issue, which is fixed in this branch
- local pytest was not runnable here because the system Python on this machine does not have `pytest`
