### PR TITLE
feat(web+server): 先验生成 + 测试页面（PR #17 part 2）

### DIFF
--- a/scripts/anima_train.py
+++ b/scripts/anima_train.py
@@ -285,10 +285,21 @@ def enable_xformers(model):
 # ============================================================================
 
 def find_diffusion_pipe_root():
-    """查找 diffusion-pipe 模型代码路径"""
+    """查找 diffusion-pipe 模型代码路径。
+
+    候选顺序（首个命中即返回）：
+      1. 脚本同目录 `diffusion_models/` / `models/`（CLI 直接 cd 进 scripts/ 跑）
+      2. 仓库根 `models/` / `diffusion_models/`（训练脚本搬到 scripts/ 后的 repo
+         layout：repo_root/scripts/anima_train.py → ../models/anima_modeling.py）
+      3. 环境变量 `DIFFUSION_PIPE_ROOT`（覆盖路径用）
+    """
+    script_dir = Path(__file__).parent
+    repo_root = script_dir.parent
     candidates = [
-        Path(__file__).parent / "diffusion_models",
-        Path(__file__).parent / "models",
+        script_dir / "diffusion_models",
+        script_dir / "models",
+        repo_root / "models",
+        repo_root / "diffusion_models",
         Path(os.environ.get("DIFFUSION_PIPE_ROOT", "")) if os.environ.get("DIFFUSION_PIPE_ROOT") else None,
     ]
     for candidate in candidates:

--- a/studio/migrations/__init__.py
+++ b/studio/migrations/__init__.py
@@ -17,6 +17,7 @@ from typing import Callable
 from ._v2_projects import migrate as _migrate_v2
 from ._v3_monitor_state import migrate as _migrate_v3
 from ._v4_task_config_path import migrate as _migrate_v4
+from ._v5_task_type import migrate as _migrate_v5
 
 Migration = Callable[[sqlite3.Connection], None]
 
@@ -25,6 +26,7 @@ MIGRATIONS: list[Migration] = [
     _migrate_v2,  # v2: projects / versions / project_jobs + tasks 扩字段
     _migrate_v3,  # v3: tasks.monitor_state_path（PP6.1 per-version monitor）
     _migrate_v4,  # v4: tasks.config_path（PP6.3 私有 config 路径）
+    _migrate_v5,  # v5: tasks.task_type（PR-9 区分 train / reg_ai / generate）
 ]
 
 

--- a/studio/migrations/_v5_task_type.py
+++ b/studio/migrations/_v5_task_type.py
@@ -1,0 +1,22 @@
+"""v4 → v5: tasks 表加 task_type 列（区分 train / reg_ai / generate）。
+
+- train (默认): 现有训练任务，跑 scripts/anima_train.py。所有老 task 都 fallback 这个。
+- reg_ai: 先验生成（base 模型对每张训练图反向出对照图作正则集），
+  跑 tools/anima_reg_ai.py。PR-9 commit 3 引入。
+- generate: 测试出图（用户手动跑 prompt 看效果），跑 tools/anima_generate.py。
+  PR-9 commit 5 引入。
+
+DEFAULT 'train' 让旧库升级时所有现有 task 自动归类训练，无需 backfill。
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from ._v2_projects import _add_column_if_missing
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    _add_column_if_missing(
+        conn, "tasks", "task_type",
+        "task_type TEXT NOT NULL DEFAULT 'train'",
+    )

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -407,6 +407,54 @@ class TrainingConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# 测试出图（独立工具页，多 LoRA + multi-prompt）—— 对应 tools/anima_generate.py
+# ---------------------------------------------------------------------------
+
+
+class GenerateConfig(BaseModel):
+    """测试出图任务参数。对应 tools/anima_generate.py 的 JSON 配置。
+
+    LoRA 加载走 inference_core.apply_loras —— 每份 LoRA 独立 inject，
+    rank/alpha 从 ss_network_args 读，正确合并多 LoRA。
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # 模型路径（服务端从 secrets 填充）
+    transformer_path: str = Field("models/diffusion_models/anima-preview3-base.safetensors")
+    vae_path: str = Field("models/vae/qwen_image_vae.safetensors")
+    text_encoder_path: str = Field("models/text_encoders")
+    t5_tokenizer_path: str = Field("models/t5_tokenizer")
+
+    # 生成参数
+    prompts: list[str] = Field(
+        default_factory=lambda: ["newest, safe, 1girl, masterpiece, best quality"],
+        description="正向提示词列表（每条 prompt 生成 count 张）",
+    )
+    negative_prompt: str = Field("")
+    width: int = Field(1024, ge=256, le=4096)
+    height: int = Field(1024, ge=256, le=4096)
+    steps: int = Field(25, ge=1, le=150)
+    cfg_scale: float = Field(4.0, ge=0.0, le=20.0)
+    sampler_name: str = Field("er_sde")
+    scheduler: str = Field("simple")
+    count: int = Field(1, ge=1, le=32, description="每个 prompt 生成张数")
+    seed: int = Field(0, description="随机种子（0=随机）")
+
+    # LoRA（多 LoRA 独立 inject + multiplier=scale 控贡献权重）
+    lora_configs: list[dict] = Field(
+        default_factory=list,
+        description="LoRA 列表，每项 {path: str, scale: float}",
+    )
+
+    # 运行时
+    output_dir: str = Field("", description="输出目录（服务端填 tempdir，task 结束清）")
+    mixed_precision: str = Field("bf16")
+    xformers: bool = Field(False)
+    flash_attn: bool = Field(True)
+
+
+# ---------------------------------------------------------------------------
 # 先验生成（base 模型对每张训练图反向出对照图作正则集）—— 对应 tools/anima_reg_ai.py
 # ---------------------------------------------------------------------------
 

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -411,6 +411,14 @@ class TrainingConfig(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class LoraEntry(BaseModel):
+    """单个 LoRA 的加载参数。Generate / API 共享，避免 server.py 私有定义。"""
+
+    model_config = ConfigDict(extra="forbid")
+    path: str = Field(..., description="LoRA safetensors 绝对路径")
+    scale: float = Field(1.0, description="贡献权重（multiplier），多 LoRA 各自独立")
+
+
 class GenerateConfig(BaseModel):
     """测试出图任务参数。对应 tools/anima_generate.py 的 JSON 配置。
 
@@ -442,9 +450,9 @@ class GenerateConfig(BaseModel):
     seed: int = Field(0, description="随机种子（0=随机）")
 
     # LoRA（多 LoRA 独立 inject + multiplier=scale 控贡献权重）
-    lora_configs: list[dict] = Field(
+    lora_configs: list[LoraEntry] = Field(
         default_factory=list,
-        description="LoRA 列表，每项 {path: str, scale: float}",
+        description="LoRA 列表（每份独立 inject，multiplier=scale）",
     )
 
     # 运行时

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -407,6 +407,53 @@ class TrainingConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# 先验生成（base 模型对每张训练图反向出对照图作正则集）—— 对应 tools/anima_reg_ai.py
+# ---------------------------------------------------------------------------
+
+
+class RegAiConfig(BaseModel):
+    """先验生成的 JSON 配置（对应 tools/anima_reg_ai.py）。
+
+    设计来自 DreamBooth prior preservation：训练损失同时见到「LoRA 学到的样子」和
+    「base 模型本来的样子」，让 LoRA 只学差异。**不带 LoRA** —— 出现 LoRA
+    反而会把要保留的 prior 给覆盖了。
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # 模型路径（服务端从 secrets 填充）
+    transformer_path: str = Field("")
+    vae_path: str = Field("")
+    text_encoder_path: str = Field("")
+    t5_tokenizer_path: str = Field("")
+
+    # 数据目录（服务端填充）
+    train_dir: str = Field("")
+    reg_dir: str = Field("")
+
+    # 生成控制
+    excluded_tags: list[str] = Field(
+        default_factory=list,
+        description="排除的 tag（不参与 prompt 拼接）",
+    )
+    negative_prompt: str = Field("")
+    width: int = Field(1024, ge=256, le=4096)
+    height: int = Field(1024, ge=256, le=4096)
+    steps: int = Field(25, ge=1, le=150)
+    cfg_scale: float = Field(4.0, ge=0.0, le=20.0)
+    sampler_name: str = Field("er_sde")
+    scheduler: str = Field("simple")
+    seed: int = Field(0, description="随机种子（0=随机）")
+    incremental: bool = Field(
+        False,
+        description="补足模式：跳过 reg 子文件夹中已有以 train_stem 开头的图（重启续跑用）",
+    )
+    mixed_precision: str = Field("bf16")
+    xformers: bool = Field(False)
+    flash_attn: bool = Field(True)
+
+
+# ---------------------------------------------------------------------------
 # 分组顺序（前端按这个顺序渲染区块）
 # ---------------------------------------------------------------------------
 

--- a/studio/server.py
+++ b/studio/server.py
@@ -78,7 +78,7 @@ from .paths import (
     WEB_DIST,
     ensure_dirs,
 )
-from .schema import GROUP_ORDER, RegAiConfig, TrainingConfig
+from .schema import GROUP_ORDER, GenerateConfig, RegAiConfig, TrainingConfig
 from .supervisor import Supervisor
 
 ensure_dirs()
@@ -90,6 +90,10 @@ logger = logging.getLogger(__name__)
 @asynccontextmanager
 async def _lifespan(app_: FastAPI) -> AsyncIterator[None]:
     """启动绑定 event bus 到当前 loop 并起 supervisor；关闭时停 supervisor。"""
+    # 测试出图 tempdir 遗留清扫（防 supervisor crash 泄漏 anima_gen_* 目录）
+    from .services.inference_core import cleanup_stale_generate_tempdirs
+    cleanup_stale_generate_tempdirs()
+
     bus.attach_loop(asyncio.get_running_loop())
     sup = Supervisor(on_event=bus.publish)
     sup.start()
@@ -1704,6 +1708,106 @@ def get_reg_prior_task(pid: int, vid: int, task_id: int) -> dict[str, Any]:
     if not task or task.get("task_type") != "reg_ai":
         raise HTTPException(404)
     return task
+
+
+# ---------------------------------------------------------------------------
+# /api/generate — 测试出图（独立工具页，多 LoRA + multi-prompt）
+# ---------------------------------------------------------------------------
+#
+# 用户决策："测试" 出图不保存：图写到 tempfile.gettempdir() / anima_gen_{task_id}/，
+# task 结束 supervisor 自动清；启动时扫清遗留。前端没有 history 列表 —— 看完即丢。
+
+
+class LoraEntry(BaseModel):
+    """Generate 端点的 LoRA 项（path + scale）。"""
+    path: str
+    scale: float = 1.0
+
+
+class GenerateRequest(BaseModel):
+    prompts: list[str] = ["newest, safe, 1girl, masterpiece, best quality"]
+    negative_prompt: str = ""
+    width: int = 1024
+    height: int = 1024
+    steps: int = 25
+    cfg_scale: float = 4.0
+    sampler_name: str = "er_sde"
+    scheduler: str = "simple"
+    count: int = 1
+    seed: int = 0
+    lora_configs: list[LoraEntry] = []
+    mixed_precision: str = "bf16"
+    xformers: bool = False
+    flash_attn: bool = True
+
+
+@app.post("/api/generate")
+def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
+    """启动测试出图 task。"""
+    from .services.inference_core import generate_tempdir
+
+    model_paths = _resolve_anima_model_paths()
+
+    with db.connection_for() as conn:
+        task_id = db.create_task(
+            conn, name="generate", config_name="generate", priority=0,
+        )
+        db.update_task(conn, task_id, task_type="generate")
+
+    tempdir = generate_tempdir(task_id)
+    tempdir.mkdir(parents=True, exist_ok=True)
+
+    cfg = GenerateConfig(
+        **model_paths,
+        output_dir=str(tempdir),
+        prompts=body.prompts,
+        negative_prompt=body.negative_prompt,
+        width=body.width,
+        height=body.height,
+        steps=body.steps,
+        cfg_scale=body.cfg_scale,
+        sampler_name=body.sampler_name,
+        scheduler=body.scheduler,
+        count=body.count,
+        seed=body.seed,
+        lora_configs=[lc.model_dump() for lc in body.lora_configs],
+        mixed_precision=body.mixed_precision,
+        xformers=body.xformers,
+        flash_attn=body.flash_attn,
+    )
+
+    cfg_path = tempdir / "config.json"
+    cfg_path.write_text(cfg.model_dump_json(indent=2), encoding="utf-8")
+
+    with db.connection_for() as conn:
+        db.update_task(conn, task_id, config_path=str(cfg_path))
+        task = db.get_task(conn, task_id)
+
+    bus.publish({"type": "task_state_changed", "task_id": task_id, "status": "pending"})
+    return task or {"id": task_id}
+
+
+@app.get("/api/generate/{task_id}")
+def get_generate_task(task_id: int) -> dict[str, Any]:
+    """查询测试 task 状态。"""
+    with db.connection_for() as conn:
+        task = db.get_task(conn, task_id)
+    if not task or task.get("task_type") != "generate":
+        raise HTTPException(404)
+    return task
+
+
+@app.get("/api/generate/{task_id}/sample/{filename}")
+def get_generate_sample(task_id: int, filename: str) -> Any:
+    """读 generate task 的输出图（task 还在跑或刚结束时；清理后 404）。"""
+    if "/" in filename or "\\" in filename or ".." in filename:
+        raise HTTPException(400, "invalid filename")
+    from fastapi.responses import FileResponse
+    from .services.inference_core import generate_tempdir
+    img = generate_tempdir(task_id) / filename
+    if not img.exists() or img.suffix.lower() not in datasets.IMAGE_EXTS:
+        raise HTTPException(404)
+    return FileResponse(str(img))
 
 
 @app.delete("/api/projects/{pid}/versions/{vid}/reg")

--- a/studio/server.py
+++ b/studio/server.py
@@ -78,7 +78,7 @@ from .paths import (
     WEB_DIST,
     ensure_dirs,
 )
-from .schema import GROUP_ORDER, GenerateConfig, RegAiConfig, TrainingConfig
+from .schema import GROUP_ORDER, GenerateConfig, LoraEntry, RegAiConfig, TrainingConfig
 from .supervisor import Supervisor
 
 ensure_dirs()
@@ -1716,12 +1716,6 @@ def get_reg_prior_task(pid: int, vid: int, task_id: int) -> dict[str, Any]:
 #
 # 用户决策："测试" 出图不保存：图写到 tempfile.gettempdir() / anima_gen_{task_id}/，
 # task 结束 supervisor 自动清；启动时扫清遗留。前端没有 history 列表 —— 看完即丢。
-
-
-class LoraEntry(BaseModel):
-    """Generate 端点的 LoRA 项（path + scale）。"""
-    path: str
-    scale: float = 1.0
 
 
 class GenerateRequest(BaseModel):

--- a/studio/server.py
+++ b/studio/server.py
@@ -78,7 +78,7 @@ from .paths import (
     WEB_DIST,
     ensure_dirs,
 )
-from .schema import GROUP_ORDER, TrainingConfig
+from .schema import GROUP_ORDER, RegAiConfig, TrainingConfig
 from .supervisor import Supervisor
 
 ensure_dirs()
@@ -1605,6 +1605,105 @@ def get_reg_caption(pid: int, vid: int, path: str) -> dict[str, Any]:
     if not img.exists() or img.suffix.lower() not in datasets.IMAGE_EXTS:
         raise HTTPException(404, "image not found")
     return {"path": path, "tags": tagedit.read_tags(img)}
+
+
+def _resolve_anima_model_paths() -> dict[str, str]:
+    """解析 base 模型默认路径（先验生成 / 测试出图共用）。
+
+    与 version_config 的 model 字段对齐。用户用别的 base 模型时，
+    在 Settings → 模型 里改 selected_anima 影响这里的 anima 主权重路径。
+    """
+    from .services.model_downloader import models_root
+    root = models_root()
+    return {
+        "transformer_path": str(root / "diffusion_models" / "anima-preview3-base.safetensors"),
+        "vae_path": str(root / "vae" / "qwen_image_vae.safetensors"),
+        "text_encoder_path": str(root / "text_encoders"),
+        "t5_tokenizer_path": str(root / "t5_tokenizer"),
+    }
+
+
+class RegAiRequest(BaseModel):
+    """先验生成请求 —— 不含 lora_configs，先验生成不带 LoRA。"""
+    excluded_tags: list[str] = []
+    negative_prompt: str = ""
+    width: int = 1024
+    height: int = 1024
+    steps: int = 25
+    cfg_scale: float = 4.0
+    sampler_name: str = "er_sde"
+    scheduler: str = "simple"
+    seed: int = 0
+    incremental: bool = False
+    mixed_precision: str = "bf16"
+    xformers: bool = False
+    flash_attn: bool = True
+
+
+@app.post("/api/projects/{pid}/versions/{vid}/reg/generate-prior")
+def reg_generate_prior(pid: int, vid: int, body: RegAiRequest) -> dict[str, Any]:
+    """启动先验生成 task —— base 模型给每张 train 图的 tag 反向出对照图。"""
+    model_paths = _resolve_anima_model_paths()
+    _, _, vdir = _version_dir_or_404(pid, vid)
+    train = vdir / "train"
+    has_image = train.exists() and any(
+        f.is_file() and f.suffix.lower() in datasets.IMAGE_EXTS
+        for f in train.rglob("*")
+    )
+    if not has_image:
+        raise HTTPException(400, "train 还没有图片，请先完成 Step 1（下载）或 Step 2（筛选）")
+
+    rdir = _reg_dir(vdir)
+    rdir.mkdir(parents=True, exist_ok=True)
+
+    cfg = RegAiConfig(
+        **model_paths,
+        train_dir=str(train),
+        reg_dir=str(rdir),
+        excluded_tags=list(body.excluded_tags),
+        negative_prompt=body.negative_prompt,
+        width=body.width,
+        height=body.height,
+        steps=body.steps,
+        cfg_scale=body.cfg_scale,
+        sampler_name=body.sampler_name,
+        scheduler=body.scheduler,
+        seed=body.seed,
+        incremental=body.incremental,
+        mixed_precision=body.mixed_precision,
+        xformers=body.xformers,
+        flash_attn=body.flash_attn,
+    )
+
+    cfg_dir = STUDIO_DATA / "reg_ai_configs"
+    cfg_dir.mkdir(parents=True, exist_ok=True)
+
+    with db.connection_for() as conn:
+        task_id = db.create_task(
+            conn, name=f"reg-prior p{pid}v{vid}", config_name="reg_ai", priority=0,
+        )
+        db.update_task(
+            conn, task_id, task_type="reg_ai", project_id=pid, version_id=vid,
+        )
+
+    cfg_path = cfg_dir / f"reg_ai_{task_id}.json"
+    cfg_path.write_text(cfg.model_dump_json(indent=2), encoding="utf-8")
+
+    with db.connection_for() as conn:
+        db.update_task(conn, task_id, config_path=str(cfg_path))
+        task = db.get_task(conn, task_id)
+
+    bus.publish({"type": "task_state_changed", "task_id": task_id, "status": "pending"})
+    return task or {"id": task_id}
+
+
+@app.get("/api/projects/{pid}/versions/{vid}/reg/generate-prior/{task_id}")
+def get_reg_prior_task(pid: int, vid: int, task_id: int) -> dict[str, Any]:
+    with db.connection_for() as conn:
+        task = db.get_task(conn, task_id)
+    if not task or task.get("task_type") != "reg_ai":
+        raise HTTPException(404)
+    return task
 
 
 @app.delete("/api/projects/{pid}/versions/{vid}/reg")

--- a/studio/services/inference_core.py
+++ b/studio/services/inference_core.py
@@ -23,11 +23,18 @@ from __future__ import annotations
 
 import json
 import logging
+import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
 
 logger = logging.getLogger(__name__)
+
+# 测试出图 task 的临时输出目录前缀。每个 task 一个 anima_gen_{task_id}/。
+# 用户决策：测试页面出图不保存，task 结束 supervisor 清掉整个目录；
+# studio 启动时扫一遍清遗留（防 supervisor crash 时 leak）。
+GENERATE_TEMP_PREFIX = "anima_gen_"
 
 
 # 缺 metadata 时的回退值。与 AnimaLycorisAdapter 默认对齐。
@@ -162,3 +169,43 @@ def apply_loras(
         adapters.append(adapter)
 
     return adapters
+
+
+# ---------------------------------------------------------------------------
+# Generate 测试出图：临时目录管理
+# ---------------------------------------------------------------------------
+
+
+def generate_tempdir(task_id: int) -> Path:
+    """单个 generate task 的临时输出目录路径。
+
+    位于系统 tempdir 下（与 studio_data 隔离），task 完成清掉。
+    """
+    return Path(tempfile.gettempdir()) / f"{GENERATE_TEMP_PREFIX}{task_id}"
+
+
+def cleanup_generate_tempdir(task_id: int) -> None:
+    """task 结束时清单个 tempdir。目录不存在视为 noop（非 generate task 也安全调）。"""
+    d = generate_tempdir(task_id)
+    if not d.exists():
+        return
+    try:
+        shutil.rmtree(d)
+        logger.info(f"cleaned generate tempdir: {d}")
+    except OSError as e:
+        logger.warning(f"failed to clean {d}: {e}")
+
+
+def cleanup_stale_generate_tempdirs() -> None:
+    """启动时扫清所有 anima_gen_* 遗留目录（防 supervisor crash 泄漏）。"""
+    parent = Path(tempfile.gettempdir())
+    if not parent.exists():
+        return
+    for d in parent.glob(f"{GENERATE_TEMP_PREFIX}*"):
+        if not d.is_dir():
+            continue
+        try:
+            shutil.rmtree(d)
+            logger.info(f"cleaned stale generate tempdir: {d}")
+        except OSError as e:
+            logger.warning(f"failed to clean stale {d}: {e}")

--- a/studio/services/inference_core.py
+++ b/studio/services/inference_core.py
@@ -1,0 +1,164 @@
+"""推理核心 — 多 LoRA 加载 / 合并的统一实现。
+
+服务对象：
+  - tools/anima_generate.py（独立测试出图，多 LoRA 叠加）
+  - scripts/anima_train.py 训练期 sample（PR-9 commit 7 切过来）
+  - tools/anima_reg_ai.py（先验生成 — 不调 apply_loras，base 模型直出）
+
+PR #17 作者在 anima_generate.py / anima_reg_ai.py 各 copy 了一份 LoRA 加载，
+有两个 P0 bug：
+  1. rank/alpha 硬编码 32/32，不从顶层 ss_network_dim/ss_network_alpha 读 ——
+     训练 dim≠32 的 LoRA 会 shape 错或 alpha 缩放错。
+  2. 多 LoRA 把不同 LoRA 的 tensor 直接 add 到一份 state_dict 然后灌进
+     一个 LycorisNetwork —— LoKr 的 lokr_w1/lokr_w2 是子矩阵，
+     子矩阵相加 ≠ 权重 delta 相加，出图错。
+
+本模块统一修这两条：
+  - read_lora_meta()：从顶层 metadata 读 rank/alpha，从 ss_network_args 读 algo/factor
+  - apply_loras()：每份 LoRA 单独 inject 一份 AnimaLycorisAdapter，靠
+    LycorisNetwork.multiplier=scale 控制贡献权重；forward 时多份 hook
+    自然累加 delta，等价于权重 delta 加和。
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+# 缺 metadata 时的回退值。与 AnimaLycorisAdapter 默认对齐。
+_DEFAULT_RANK = 32
+_DEFAULT_ALPHA = 16.0
+_DEFAULT_ALGO = "lokr"
+_DEFAULT_FACTOR = 8
+
+
+@dataclass
+class LoRASpec:
+    """单个 LoRA 的加载参数。"""
+    path: str
+    scale: float = 1.0
+
+
+@dataclass
+class LoRAMeta:
+    """从 safetensors metadata 解析出来的 LoRA 训练参数。"""
+    rank: int
+    alpha: float
+    algo: str
+    factor: int
+
+
+def read_lora_meta(path: str) -> LoRAMeta:
+    """从 safetensors 顶层 metadata 读 LoRA 训练参数。
+
+    AnimaLycorisAdapter.save() 写入约定（utils/lycoris_adapter.py:178）：
+      - 顶层 metadata: ss_network_dim (rank), ss_network_alpha (alpha)
+      - ss_network_args JSON 内: algo, factor, dropout, ...
+
+    缺字段或解析失败时回退到默认值（rank=32, alpha=rank, algo=lokr, factor=8）。
+    """
+    from safetensors import safe_open
+
+    try:
+        with safe_open(str(path), framework="pt", device="cpu") as f:
+            meta = f.metadata() or {}
+    except Exception as e:
+        logger.warning(f"读 LoRA metadata 失败 {path}: {e}; 用默认参数")
+        return LoRAMeta(_DEFAULT_RANK, _DEFAULT_ALPHA, _DEFAULT_ALGO, _DEFAULT_FACTOR)
+
+    try:
+        ss_args = json.loads(meta.get("ss_network_args", "{}"))
+        if not isinstance(ss_args, dict):
+            ss_args = {}
+    except (ValueError, TypeError):
+        ss_args = {}
+
+    rank = _DEFAULT_RANK
+    if "ss_network_dim" in meta:
+        try:
+            rank = int(meta["ss_network_dim"])
+        except (ValueError, TypeError):
+            pass
+
+    # 没显式 alpha 时常见约定是 alpha=rank（保留 1.0 倍率）
+    alpha = float(rank)
+    if "ss_network_alpha" in meta:
+        try:
+            alpha = float(meta["ss_network_alpha"])
+        except (ValueError, TypeError):
+            pass
+
+    algo = str(ss_args.get("algo", _DEFAULT_ALGO))
+    factor = _DEFAULT_FACTOR
+    if "factor" in ss_args:
+        try:
+            factor = int(ss_args["factor"])
+        except (ValueError, TypeError):
+            pass
+
+    return LoRAMeta(rank=rank, alpha=alpha, algo=algo, factor=factor)
+
+
+def apply_loras(
+    model: Any,
+    specs: Sequence[LoRASpec],
+    device: str,
+    dtype: Any,
+) -> list[Any]:
+    """对每个 LoRA 单独 inject 一份 AnimaLycorisAdapter；forward 时 hook 累加 delta。
+
+    multiplier 字段控制每份 LoRA 贡献权重（用户传的 scale）：
+      - LycorisNetwork.multiplier 是 forward 内取的全局倍率
+      - per-lora module 也设一份兜底（lycoris 不同版本取值路径有差异）
+
+    返回 adapter 列表 — caller **必须保持引用**，否则 Python GC 触发后
+    AnimaLycorisAdapter 内的 LycorisNetwork 也会被 GC，model 上的 forward
+    hook 跟着失效（lycoris 通过 closure 持有 network）。
+    """
+    from safetensors import safe_open
+
+    from utils.lycoris_adapter import AnimaLycorisAdapter
+
+    adapters: list[Any] = []
+    for spec in specs:
+        path = spec.path or ""
+        if not path or not Path(path).exists():
+            logger.warning(f"LoRA 路径不存在，跳过: {path!r}")
+            continue
+
+        meta = read_lora_meta(path)
+        adapter = AnimaLycorisAdapter(
+            algo=meta.algo,
+            rank=meta.rank,
+            alpha=meta.alpha,
+            factor=meta.factor,
+        )
+        adapter.inject(model)
+
+        if adapter.network is not None:
+            adapter.network.multiplier = float(spec.scale)
+            for lora in getattr(adapter.network, "loras", []):
+                if hasattr(lora, "multiplier"):
+                    lora.multiplier = float(spec.scale)
+
+        sd: dict = {}
+        with safe_open(str(path), framework="pt", device="cpu") as f:
+            for k in f.keys():
+                sd[k] = f.get_tensor(k).to(device=device, dtype=dtype)
+
+        result = adapter.load_state_dict(sd, strict=False)
+        missing = len(getattr(result, "missing_keys", []) or [])
+        unexpected = len(getattr(result, "unexpected_keys", []) or [])
+        logger.info(
+            f"已加载 LoRA: {Path(path).name} "
+            f"(algo={meta.algo}, rank={meta.rank}, alpha={meta.alpha}, "
+            f"scale={spec.scale}; missing={missing}, unexpected={unexpected})"
+        )
+        adapters.append(adapter)
+
+    return adapters

--- a/studio/services/reg_builder.py
+++ b/studio/services/reg_builder.py
@@ -110,6 +110,12 @@ class RegMeta:
     postprocess_clusters: Optional[int] = None
     postprocess_method: Optional[str] = None
     postprocess_max_crop_ratio: Optional[float] = None
+    # 生成方式："scrape" = booru 拉取（默认，兼容旧 meta），
+    # "ai_base" = base 模型对 train tag 反向出对照图作正则集（先验生成）。
+    # 引入此字段是为了让 api_source 字段不被 "ai_generated" 这种伪 source 污染：
+    # generation_method="scrape" 时 api_source 才是 "gelbooru"|"danbooru"；
+    # generation_method="ai_base" 时 api_source 留空（语义上无来源）。
+    generation_method: str = "scrape"
 
 
 # ---------------------------------------------------------------------------

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -619,6 +619,13 @@ class Supervisor:
                 # PP6.3：训练成功时回填 version.output_lora_path + 推 stage=done
                 if status == "done":
                     _maybe_finalize_version(conn, cid)
+            # 测试出图 tempdir 清理：generate task 结束（任意状态）都清掉。
+            # 函数内部 if d.exists() 兜底，非 generate task 调进来也安全。
+            try:
+                from .services.inference_core import cleanup_generate_tempdir
+                cleanup_generate_tempdir(cid)
+            except Exception as e:
+                logger.warning("cleanup generate tempdir failed: %s", e)
             self._on_event(
                 {"type": "task_state_changed", "task_id": cid, "status": status}
             )

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -79,10 +79,22 @@ JobCmdBuilder = Callable[[dict[str, Any]], list[str]]
 
 
 def _default_cmd_builder(task: dict[str, Any], config_path: Path) -> list[str]:
-    """默认调用 scripts/anima_train.py --config <path> --monitor-state-file <state>。"""
+    """根据 task_type 路由到对应脚本。
+
+    train (默认 / 老 task): scripts/anima_train.py
+    reg_ai: tools/anima_reg_ai.py（先验生成）
+    generate: tools/anima_generate.py（测试出图）
+    """
+    task_type = task.get("task_type") or "train"
+    if task_type == "reg_ai":
+        script = REPO_ROOT / "tools" / "anima_reg_ai.py"
+    elif task_type == "generate":
+        script = REPO_ROOT / "tools" / "anima_generate.py"
+    else:
+        script = REPO_ROOT / "scripts" / "anima_train.py"
     cmd = [
         sys.executable,
-        str(REPO_ROOT / "scripts" / "anima_train.py"),
+        str(script),
         "--config",
         str(config_path),
     ]

--- a/studio/web/src/App.tsx
+++ b/studio/web/src/App.tsx
@@ -14,6 +14,7 @@ import RegularizationPage from './pages/project/steps/Regularization'
 import TagEditPage from './pages/project/steps/TagEdit'
 import TaggingPage from './pages/project/steps/Tagging'
 import TrainPage from './pages/project/steps/Train'
+import GeneratePage from './pages/tools/Generate'
 import MonitorPage from './pages/tools/Monitor'
 import PresetsPage from './pages/tools/Presets'
 import SettingsPage from './pages/tools/Settings'
@@ -74,6 +75,7 @@ export default function App() {
             <Route path="/tools/presets" element={<PresetsPage />} />
             <Route path="/tools/monitor" element={<MonitorPage />} />
             <Route path="/tools/settings" element={<SettingsPage />} />
+            <Route path="/tools/generate" element={<GeneratePage />} />
 
             {/* 旧 → 新 路由兼容（PP0 重构）。下个 minor 版本删除。 */}
             <Route

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -557,6 +557,8 @@ export interface RegMeta {
   postprocess_clusters: number | null
   postprocess_method: string | null
   postprocess_max_crop_ratio: number | null
+  // "scrape" = booru 拉取，"ai_base" = base 模型先验生成；缺省按 "scrape" 处理（旧 meta 兼容）
+  generation_method?: 'scrape' | 'ai_base'
 }
 
 export interface RegStatus {

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -612,6 +612,29 @@ export interface RegAiRequest {
   flash_attn?: boolean
 }
 
+/** PR-9 — 测试出图（独立工具页，多 LoRA + multi-prompt）。 */
+export interface LoraEntry {
+  path: string
+  scale: number
+}
+
+export interface GenerateRequest {
+  prompts: string[]
+  negative_prompt?: string
+  width?: number
+  height?: number
+  steps?: number
+  cfg_scale?: number
+  sampler_name?: string
+  scheduler?: string
+  count?: number
+  seed?: number
+  lora_configs?: LoraEntry[]
+  mixed_precision?: string
+  xformers?: boolean
+  flash_attn?: boolean
+}
+
 export type TaskStatus = 'pending' | 'running' | 'done' | 'failed' | 'canceled'
 
 export interface Task {
@@ -1106,6 +1129,15 @@ export const api = {
   /** 查询先验生成 task 状态。 */
   getRegPriorTask: (pid: number, vid: number, taskId: number) =>
     req<Task>(`/api/projects/${pid}/versions/${vid}/reg/generate-prior/${taskId}`),
+
+  /** PR-9 — 启动测试出图 task。图写到 tempdir，task 结束清掉（不保存）。 */
+  enqueueGenerate: (body: GenerateRequest) =>
+    req<Task>('/api/generate', { method: 'POST', body: JSON.stringify(body) }),
+  /** 查询测试 task 状态。 */
+  getGenerateTask: (id: number) => req<Task>(`/api/generate/${id}`),
+  /** 测试出图单张 URL（task 跑中或刚完成时拉；清理后 404）。 */
+  generateSampleUrl: (taskId: number, filename: string) =>
+    `/api/generate/${taskId}/sample/${encodeURIComponent(filename)}`,
 
   // Train config (PP6.2) -------------------------------------------------
   getVersionConfig: (pid: number, vid: number) =>

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -595,6 +595,23 @@ export interface RegBuildRequest {
   postprocess_max_crop_ratio?: number
 }
 
+/** PR-9 — 先验生成（base 模型反向出 reg 集，无 LoRA）。 */
+export interface RegAiRequest {
+  excluded_tags?: string[]
+  negative_prompt?: string
+  width?: number
+  height?: number
+  steps?: number
+  cfg_scale?: number
+  sampler_name?: string
+  scheduler?: string
+  seed?: number
+  incremental?: boolean
+  mixed_precision?: string
+  xformers?: boolean
+  flash_attn?: boolean
+}
+
 export type TaskStatus = 'pending' | 'running' | 'done' | 'failed' | 'canceled'
 
 export interface Task {
@@ -1080,6 +1097,15 @@ export const api = {
     req<{ path: string; tags: string[] }>(
       `/api/projects/${pid}/versions/${vid}/reg/caption?path=${encodeURIComponent(path)}`
     ),
+  /** PR-9 — 启动先验生成 task（base 模型对每张 train 图反向出对照图）。 */
+  enqueueRegPrior: (pid: number, vid: number, body: RegAiRequest) =>
+    req<Task>(`/api/projects/${pid}/versions/${vid}/reg/generate-prior`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }),
+  /** 查询先验生成 task 状态。 */
+  getRegPriorTask: (pid: number, vid: number, taskId: number) =>
+    req<Task>(`/api/projects/${pid}/versions/${vid}/reg/generate-prior/${taskId}`),
 
   // Train config (PP6.2) -------------------------------------------------
   getVersionConfig: (pid: number, vid: number) =>

--- a/studio/web/src/components/Sidebar.tsx
+++ b/studio/web/src/components/Sidebar.tsx
@@ -27,6 +27,7 @@ const I = {
   preset:  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><line x1="6" y1="4" x2="6" y2="20"/><line x1="12" y1="4" x2="12" y2="20"/><line x1="18" y1="4" x2="18" y2="20"/><circle cx="6" cy="9" r="2" fill="var(--bg-sunken)"/><circle cx="12" cy="15" r="2" fill="var(--bg-sunken)"/><circle cx="18" cy="7" r="2" fill="var(--bg-sunken)"/></svg>,
   monitor: <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><path d="M3 17l4-6 4 3 5-9 5 7"/></svg>,
   cog:     <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h0a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v0a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>,
+  image:   <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.7" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="1.6" fill="currentColor"/><path d="m21 15-5-5L5 21"/></svg>,
   check:   <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round"><path d="m4 12 5 5 11-12"/></svg>,
   chevL:   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M15 6l-6 6 6 6"/></svg>,
   chevR:   <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M9 6l6 6-6 6"/></svg>,
@@ -365,6 +366,7 @@ export default function Sidebar() {
       <nav className={`flex-1 flex flex-col gap-0.5 overflow-y-auto ${collapsed ? 'px-1.5 py-2.5' : 'px-2.5 py-3.5'}`}>
         <NavItem to="/" label="项目" icon={I.folder} active={!inProject && location.pathname === '/'} collapsed={collapsed} />
         <NavItem to="/queue" label="队列" icon={I.queue} active={isMain('/queue')} collapsed={collapsed} />
+        <NavItem to="/tools/generate" label="测试" icon={I.image} active={isMain('/tools/generate')} collapsed={collapsed} />
 
         {inProject && pid && (
           <div className="mt-2.5 flex flex-col gap-1">

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -471,7 +471,9 @@ function RegStatusBar({
               target {m.actual_count}/{m.target_count}
             </span>
             <span className="text-fg-tertiary">·</span>
-            <span className="text-fg-tertiary">{m.api_source}</span>
+            <span className="text-fg-tertiary">
+              {m.generation_method === 'ai_base' ? '先验生成' : m.api_source}
+            </span>
             <span className="text-fg-tertiary">·</span>
             <span className="text-fg-tertiary">
               auto-tag:{' '}

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -4,9 +4,11 @@ import {
   api,
   type Job,
   type ProjectDetail,
+  type RegAiRequest,
   type RegBuildRequest,
   type RegStatus,
   type RegTagCount,
+  type Task,
   type Version,
 } from '../../../api/client'
 import ImageGrid from '../../../components/ImageGrid'
@@ -62,8 +64,25 @@ export default function RegularizationPage() {
   const jobIdRef = useRef<number | null>(null)
   jobIdRef.current = job?.id ?? null
 
-  // Tab：设置&日志 / 图片预览。job done 时自动切到图片，让用户看成果。
-  const [activeTab, setActiveTab] = useState<'config' | 'images'>('config')
+  // Tab：设置&日志 / 图片预览 / 先验生成。job done 时自动切到图片，让用户看成果。
+  const [activeTab, setActiveTab] = useState<'config' | 'images' | 'ai'>('config')
+
+  // 先验生成 — base 模型对每张 train 图反向出对照图，无 LoRA 参数（DreamBooth prior preservation）。
+  // excluded tag 复用主组件 `excluded` Set，与 booru tab 双向同步。
+  const [aiNeg, setAiNeg] = useState(
+    'worst quality, low quality, score_1, score_2, score_3, blurry, jpeg artifacts, bad anatomy, bad hands, bad feet'
+  )
+  const [aiWidth, setAiWidth] = useState(1024)
+  const [aiHeight, setAiHeight] = useState(1024)
+  const [aiSteps, setAiSteps] = useState(25)
+  const [aiCfg, setAiCfg] = useState(4.0)
+  const [aiSeed, setAiSeed] = useState(0)
+  const [aiIncremental, setAiIncremental] = useState(false)
+  const [aiFlashAttn, setAiFlashAttn] = useState(true)
+  const [aiTask, setAiTask] = useState<Task | null>(null)
+  const [aiBusy, setAiBusy] = useState(false)
+  const aiTaskIdRef = useRef<number | null>(null)
+  aiTaskIdRef.current = aiTask?.id ?? null
 
   // 预览 modal
   const [previewIdx, setPreviewIdx] = useState<number | null>(null)
@@ -141,6 +160,7 @@ export default function RegularizationPage() {
 
   useEventStream((evt) => {
     const jid = jobIdRef.current
+    const tid = aiTaskIdRef.current
     if (evt.type === 'job_log_appended' && jid && evt.job_id === jid) {
       setLogs((prev) => [...prev, String(evt.text ?? '')])
     } else if (evt.type === 'job_state_changed' && jid && evt.job_id === jid) {
@@ -151,11 +171,21 @@ export default function RegularizationPage() {
         // job 成功完成 → 自动切到图片 tab，让用户看成果
         if (evt.status === 'done') setActiveTab('images')
       }
+    } else if (evt.type === 'task_state_changed' && tid && evt.task_id === tid) {
+      void api.getRegPriorTask(project.id, vid!, tid).then((t) => {
+        setAiTask(t)
+        if (t.status === 'done' || t.status === 'failed' || t.status === 'canceled') {
+          setAiBusy(false)
+          void refreshReg()
+          if (t.status === 'done') setActiveTab('images')
+        }
+      }).catch(() => {})
     }
   })
 
   const trainImageCount = activeVersion?.stats?.train_image_count ?? 0
-  const isLive = job?.status === 'running' || job?.status === 'pending'
+  // 任意一种生成跑着都视为 live —— 防止 booru / AI 并发同时写 reg/。
+  const isLive = job?.status === 'running' || job?.status === 'pending' || aiBusy
 
   const toggleTag = (tag: string) => {
     setExcluded((prev) => {
@@ -164,6 +194,35 @@ export default function RegularizationPage() {
       else next.add(tag)
       return next
     })
+  }
+
+  const handleAiGenerate = async () => {
+    if (!vid) return
+    if (trainImageCount <= 0) {
+      toast('train 还没有图片，请先完成 Step 1（下载）或 Step 2（筛选）', 'error')
+      return
+    }
+    setAiBusy(true)
+    setAiTask(null)
+    try {
+      const body: RegAiRequest = {
+        excluded_tags: Array.from(excluded),
+        negative_prompt: aiNeg,
+        width: aiWidth,
+        height: aiHeight,
+        steps: aiSteps,
+        cfg_scale: aiCfg,
+        seed: aiSeed,
+        incremental: aiIncremental,
+        flash_attn: aiFlashAttn,
+      }
+      const t = await api.enqueueRegPrior(project.id, vid, body)
+      setAiTask(t)
+      toast(`先验生成任务 #${t.id} 已入队`, 'success')
+    } catch (e) {
+      toast(String(e), 'error')
+      setAiBusy(false)
+    }
   }
 
   const startBuild = async (incremental = false) => {
@@ -230,13 +289,23 @@ export default function RegularizationPage() {
       title="正则集"
       subtitle="基于 train tag 拉正则图，镜像结构到 reg/"
       actions={
-        <button
-          onClick={() => void startBuild(false)}
-          disabled={isLive || trainImageCount <= 0}
-          className="btn btn-primary"
-        >
-          {isLive ? '生成中…' : '开始生成'}
-        </button>
+        activeTab === 'ai' ? (
+          <button
+            onClick={() => void handleAiGenerate()}
+            disabled={isLive || trainImageCount <= 0}
+            className="btn btn-primary"
+          >
+            {isLive ? '生成中…' : '先验生成'}
+          </button>
+        ) : (
+          <button
+            onClick={() => void startBuild(false)}
+            disabled={isLive || trainImageCount <= 0}
+            className="btn btn-primary"
+          >
+            {isLive ? '生成中…' : '开始生成'}
+          </button>
+        )
       }
     >
     <div className="flex flex-col h-full gap-3 min-h-0">
@@ -264,10 +333,31 @@ export default function RegularizationPage() {
           label="图片"
           badge={reg && reg.image_count > 0 ? String(reg.image_count) : undefined}
         />
+        <TabButton
+          active={activeTab === 'ai'}
+          onClick={() => setActiveTab('ai')}
+          label="先验生成"
+          badge={aiBusy ? 'live' : aiTask?.status === 'done' ? '✓' : undefined}
+        />
       </div>
 
       {/* tab 内容（占满剩余高度，全宽） */}
-      {activeTab === 'config' ? (
+      {activeTab === 'ai' ? (
+        <AiGenPanel
+          trainTags={trainTags}
+          excluded={excluded} onToggle={toggleTag}
+          neg={aiNeg} onNegChange={setAiNeg}
+          width={aiWidth} onWidthChange={setAiWidth}
+          height={aiHeight} onHeightChange={setAiHeight}
+          steps={aiSteps} onStepsChange={setAiSteps}
+          cfg={aiCfg} onCfgChange={setAiCfg}
+          seed={aiSeed} onSeedChange={setAiSeed}
+          incremental={aiIncremental} onIncrementalChange={setAiIncremental}
+          flashAttn={aiFlashAttn} onFlashAttnChange={setAiFlashAttn}
+          task={aiTask}
+          trainImageCount={trainImageCount}
+        />
+      ) : activeTab === 'config' ? (
         <div className="flex flex-col gap-3 min-h-0 flex-1 overflow-y-auto">
           <section className="rounded-md border border-subtle bg-surface px-3.5 py-2.5 flex flex-col gap-2.5 shrink-0">
             <div className="flex flex-wrap items-center gap-2.5 text-xs">
@@ -681,6 +771,144 @@ function Group({
         {label}
       </span>
       <div className="flex flex-wrap items-center gap-2.5 flex-1">{children}</div>
+    </div>
+  )
+}
+
+// ── AiGenPanel ──────────────────────────────────────────────────────────────
+//
+// 先验生成（DreamBooth prior preservation）：base 模型对每张 train 图的 tag
+// 反向出对照图作正则集。**无 LoRA UI** —— LoRA 加进来反而把要保留的 prior
+// 给覆盖了。
+
+function AiNumField({
+  label, value, onChange, min, max, step,
+}: {
+  label: string; value: number
+  onChange: (v: number) => void
+  min?: number; max?: number; step?: number
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="caption">{label}</label>
+      <input
+        type="number" className="input"
+        min={min} max={max} step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+    </div>
+  )
+}
+
+function AiTaskStatus({ task }: { task: Task | null }) {
+  if (!task) return null
+  const label =
+    task.status === 'done' ? '已完成' :
+    task.status === 'running' ? '生成中' :
+    task.status === 'failed' ? '失败' :
+    task.status === 'pending' ? '排队中' :
+    task.status === 'canceled' ? '已取消' : task.status
+  const cls =
+    task.status === 'done' ? 'badge badge-ok' :
+    task.status === 'running' ? 'badge badge-info' :
+    task.status === 'failed' ? 'badge badge-err' : 'badge'
+  return (
+    <div className="flex items-center gap-2 text-sm">
+      <span className={cls}>{label}</span>
+      <span className="caption font-mono">#{task.id}</span>
+      {task.status === 'done' && (
+        <span className="text-xs text-fg-tertiary">已写入 reg 对应子目录</span>
+      )}
+      {task.status === 'failed' && task.error_msg && (
+        <span className="text-xs text-err">{task.error_msg}</span>
+      )}
+    </div>
+  )
+}
+
+function AiGenPanel({
+  trainTags,
+  excluded, onToggle,
+  neg, onNegChange,
+  width, onWidthChange,
+  height, onHeightChange,
+  steps, onStepsChange,
+  cfg, onCfgChange,
+  seed, onSeedChange,
+  incremental, onIncrementalChange,
+  flashAttn, onFlashAttnChange,
+  task,
+  trainImageCount,
+}: {
+  trainTags: RegTagCount[]
+  excluded: Set<string>; onToggle: (tag: string) => void
+  neg: string; onNegChange: (v: string) => void
+  width: number; onWidthChange: (v: number) => void
+  height: number; onHeightChange: (v: number) => void
+  steps: number; onStepsChange: (v: number) => void
+  cfg: number; onCfgChange: (v: number) => void
+  seed: number; onSeedChange: (v: number) => void
+  incremental: boolean; onIncrementalChange: (v: boolean) => void
+  flashAttn: boolean; onFlashAttnChange: (v: boolean) => void
+  task: Task | null
+  trainImageCount: number
+}) {
+  return (
+    <div className="flex flex-col gap-3 min-h-0 flex-1 overflow-y-auto">
+      <section className="rounded-md border border-subtle bg-surface px-3.5 py-3 flex flex-col gap-3 shrink-0 text-sm">
+        <p className="text-2xs text-fg-tertiary m-0 leading-relaxed">
+          用 base 模型对每张训练图的 tag 反向出对照图作为正则集。让训练损失同时见到
+          base 分布，把不该学的概念推回去。每张训练图（共{' '}
+          <span className="font-mono text-fg-primary">{trainImageCount}</span>
+          {' '}张）对应生成 1 张正则图，写入{' '}
+          <span className="font-mono">reg/{'{subfolder}'}/</span>。
+          排除 tag 与左侧「Booru」共用，修改后两边同步。
+        </p>
+
+        <ExcludeTagsPicker trainTags={trainTags} excluded={excluded} onToggle={onToggle} />
+
+        <div className="flex flex-col gap-1">
+          <label className="caption">负面提示词</label>
+          <textarea
+            className="input font-mono text-sm resize-y"
+            rows={2}
+            value={neg}
+            onChange={(e) => onNegChange(e.target.value)}
+          />
+        </div>
+
+        <div className="flex gap-2">
+          <AiNumField label="宽度" value={width} onChange={onWidthChange} min={256} max={4096} step={64} />
+          <AiNumField label="高度" value={height} onChange={onHeightChange} min={256} max={4096} step={64} />
+        </div>
+        <div className="flex gap-2">
+          <AiNumField label="步数" value={steps} onChange={onStepsChange} min={1} max={150} />
+          <AiNumField label="CFG Scale" value={cfg} onChange={onCfgChange} min={0} max={20} step={0.5} />
+        </div>
+        <AiNumField label="种子（0=随机）" value={seed} onChange={onSeedChange} min={0} />
+
+        <div className="flex flex-wrap gap-3">
+          <label className="flex items-center gap-1.5 cursor-pointer text-xs">
+            <input
+              type="checkbox"
+              checked={incremental}
+              onChange={(e) => onIncrementalChange(e.target.checked)}
+            />
+            <span className="text-fg-secondary">补足模式（跳过 reg 子目录中已有对应文件名前缀的图）</span>
+          </label>
+          <label className="flex items-center gap-1.5 cursor-pointer text-xs">
+            <input
+              type="checkbox"
+              checked={flashAttn}
+              onChange={(e) => onFlashAttnChange(e.target.checked)}
+            />
+            <span className="text-fg-secondary">Flash Attention</span>
+          </label>
+        </div>
+
+        <AiTaskStatus task={task} />
+      </section>
     </div>
   )
 }

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -1,0 +1,470 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  api,
+  type GenerateRequest,
+  type LoraEntry,
+  type MonitorState,
+  type Task,
+} from '../../api/client'
+import PageHeader from '../../components/PageHeader'
+import PathPicker from '../../components/PathPicker'
+import { useToast } from '../../components/Toast'
+import { useEventStream } from '../../lib/useEventStream'
+
+interface RecentLora {
+  label: string
+  path: string
+  createdAt: number
+}
+
+// ── SampleGallery ─────────────────────────────────────────────────────────────
+
+function SampleGallery({ samples, taskId }: {
+  samples: Array<{ path: string; step?: number }>
+  taskId: number
+}) {
+  const [active, setActive] = useState(0)
+  const prevLen = useRef(0)
+
+  useEffect(() => {
+    if (samples.length > prevLen.current) setActive(samples.length - 1)
+    prevLen.current = samples.length
+  }, [samples.length])
+
+  if (!samples.length) {
+    return (
+      <div className="grid place-items-center rounded-md border border-subtle bg-sunken text-fg-tertiary text-sm" style={{ minHeight: 220 }}>
+        等待生成图…
+      </div>
+    )
+  }
+
+  const cur = samples[active]
+  const filename = cur.path.split(/[\\/]/).pop() ?? cur.path
+  const fullUrl = api.generateSampleUrl(taskId, filename)
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex gap-1.5 overflow-x-auto pb-0.5" style={{ scrollbarWidth: 'thin' }}>
+        {samples.map((s, i) => {
+          const fn = s.path.split(/[\\/]/).pop() ?? s.path
+          return (
+            <button
+              key={i}
+              onClick={() => setActive(i)}
+              className={`shrink-0 w-14 h-14 rounded overflow-hidden border-2 p-0 cursor-pointer bg-transparent transition-colors ${
+                i === active ? 'border-accent' : 'border-transparent hover:border-dim'
+              }`}
+            >
+              <img src={api.generateSampleUrl(taskId, fn)} className="w-full h-full object-cover" alt="" />
+            </button>
+          )
+        })}
+      </div>
+      <a href={fullUrl} target="_blank" rel="noreferrer">
+        <img
+          src={fullUrl}
+          className="w-full rounded-md border border-subtle object-contain"
+          style={{ maxHeight: 480 }}
+          alt={filename}
+        />
+      </a>
+      <div className="text-xs text-fg-tertiary font-mono truncate">{filename}</div>
+    </div>
+  )
+}
+
+// ── LoraList ──────────────────────────────────────────────────────────────────
+
+function LoraList({ loras, onChange, recent }: {
+  loras: LoraEntry[]
+  onChange: (l: LoraEntry[]) => void
+  recent: RecentLora[]
+}) {
+  const [pickerIdx, setPickerIdx] = useState<number | null>(null)
+  const [recentOpenIdx, setRecentOpenIdx] = useState<number | null>(null)
+
+  const add = () => onChange([...loras, { path: '', scale: 1.0 }])
+  const del = (i: number) => onChange(loras.filter((_, idx) => idx !== i))
+  const setPath = (i: number, path: string) =>
+    onChange(loras.map((l, idx) => idx === i ? { ...l, path } : l))
+  const setScale = (i: number, scale: number) =>
+    onChange(loras.map((l, idx) => idx === i ? { ...l, scale } : l))
+
+  return (
+    <div className="flex flex-col gap-2">
+      {loras.map((l, i) => (
+        <div key={i} className="flex gap-1.5 items-center">
+          <div className="flex-1 flex gap-1 items-center bg-sunken border border-dim rounded-md px-2 py-1.5">
+            <span className="text-xs text-fg-tertiary shrink-0 w-4 text-center font-mono">{i + 1}</span>
+            <input
+              type="text"
+              className="input input-mono flex-1 border-0 bg-transparent p-0 text-xs"
+              style={{ outline: 'none', boxShadow: 'none' }}
+              placeholder="LoRA 路径…"
+              value={l.path}
+              onChange={(e) => setPath(i, e.target.value)}
+            />
+            {recent.length > 0 && (
+              <button
+                onClick={() => setRecentOpenIdx(recentOpenIdx === i ? null : i)}
+                className="btn btn-ghost btn-sm text-xs shrink-0 px-1.5 text-fg-tertiary"
+                title="最近训出的 LoRA"
+              >
+                最近
+              </button>
+            )}
+            <button
+              onClick={() => setPickerIdx(i)}
+              className="btn btn-ghost btn-sm text-xs shrink-0 px-1.5"
+              title="浏览文件"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/></svg>
+            </button>
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            <span className="text-xs text-fg-tertiary">×</span>
+            <input
+              type="number"
+              className="input text-center text-sm"
+              style={{ width: 60, padding: '5px 6px' }}
+              min={0} max={2} step={0.05}
+              value={l.scale}
+              onChange={(e) => setScale(i, Number(e.target.value))}
+              title="权重倍率"
+            />
+          </div>
+          <button onClick={() => del(i)} className="btn btn-ghost btn-sm text-fg-tertiary hover:text-err shrink-0 px-1.5">×</button>
+        </div>
+      ))}
+      <button onClick={add} className="btn btn-ghost btn-sm self-start text-xs text-fg-tertiary">
+        + 添加 LoRA
+      </button>
+
+      {/* 最近 LoRA 浮层（按行下方展开） */}
+      {recentOpenIdx !== null && recent.length > 0 && (
+        <div className="rounded-md border border-subtle bg-overlay px-2 py-1.5 flex flex-col gap-px text-sm">
+          <div className="caption pb-1">最近训出的 LoRA</div>
+          {recent.slice(0, 12).map((r) => (
+            <button
+              key={r.path}
+              onClick={() => {
+                setPath(recentOpenIdx, r.path)
+                setRecentOpenIdx(null)
+              }}
+              className="flex items-center gap-2 text-left px-2 py-1 rounded text-xs cursor-pointer border-none bg-transparent text-fg-secondary hover:bg-surface"
+            >
+              <span className="flex-1 truncate">{r.label}</span>
+              <span className="font-mono text-fg-tertiary text-2xs truncate" style={{ maxWidth: 280 }}>
+                {r.path}
+              </span>
+            </button>
+          ))}
+          <button
+            onClick={() => setRecentOpenIdx(null)}
+            className="btn btn-ghost btn-sm self-end text-2xs text-fg-tertiary mt-1"
+          >
+            关闭
+          </button>
+        </div>
+      )}
+
+      {pickerIdx !== null && (
+        <PathPicker
+          dirOnly={false}
+          onPick={(p) => { setPath(pickerIdx, p); setPickerIdx(null) }}
+          onClose={() => setPickerIdx(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+// ── PromptList ────────────────────────────────────────────────────────────────
+
+function PromptList({ prompts, onChange }: {
+  prompts: string[]
+  onChange: (p: string[]) => void
+}) {
+  const add = () => onChange([...prompts, ''])
+  const del = (i: number) => onChange(prompts.filter((_, idx) => idx !== i))
+  const set = (i: number, v: string) => onChange(prompts.map((p, idx) => idx === i ? v : p))
+
+  return (
+    <div className="flex flex-col gap-2">
+      {prompts.map((p, i) => (
+        <div key={i} className="flex gap-1.5">
+          {prompts.length > 1 && (
+            <span className="caption mt-2.5 w-4 text-center shrink-0">{i + 1}</span>
+          )}
+          <textarea
+            className="input flex-1 font-mono text-sm resize-y"
+            rows={3}
+            value={p}
+            onChange={(e) => set(i, e.target.value)}
+            placeholder="输入正向提示词…"
+          />
+          {prompts.length > 1 && (
+            <button onClick={() => del(i)} className="btn btn-ghost btn-sm text-fg-tertiary hover:text-err self-start px-1.5">×</button>
+          )}
+        </div>
+      ))}
+      <button onClick={add} className="btn btn-ghost btn-sm self-start text-xs text-fg-secondary">
+        + 添加 prompt（轮换生成）
+      </button>
+    </div>
+  )
+}
+
+// ── NumField ──────────────────────────────────────────────────────────────────
+
+function NumField({ label, value, onChange, min, max, step }: {
+  label: string; value: number
+  onChange: (v: number) => void
+  min?: number; max?: number; step?: number
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="caption">{label}</label>
+      <input
+        type="number"
+        className="input"
+        min={min} max={max} step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+    </div>
+  )
+}
+
+// ── StatusBadge ───────────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: string }) {
+  const cls =
+    status === 'done'    ? 'badge badge-ok'
+    : status === 'running'  ? 'badge badge-info'
+    : status === 'failed'   ? 'badge badge-err'
+    : status === 'canceled' ? 'badge'
+    : 'badge'
+  const label =
+    status === 'done'    ? '已完成'
+    : status === 'running'  ? '生成中'
+    : status === 'failed'   ? '失败'
+    : status === 'pending'  ? '排队中'
+    : status === 'canceled' ? '已取消'
+    : status
+  return <span className={cls}>{label}</span>
+}
+
+// ── GeneratePage ──────────────────────────────────────────────────────────────
+
+const DEFAULT_NEG = 'worst quality, low quality, score_1, score_2, score_3, blurry, jpeg artifacts, bad anatomy, bad hands, bad feet, missing fingers, extra fingers, text, watermark, logo, signature'
+
+export default function GeneratePage() {
+  const { toast } = useToast()
+
+  const [prompts, setPrompts] = useState<string[]>(['newest, safe, 1girl, masterpiece, best quality'])
+  const [negPrompt, setNegPrompt] = useState(DEFAULT_NEG)
+  const [width, setWidth] = useState(1024)
+  const [height, setHeight] = useState(1024)
+  const [steps, setSteps] = useState(25)
+  const [cfgScale, setCfgScale] = useState(4.0)
+  const [count, setCount] = useState(1)
+  const [seed, setSeed] = useState(0)
+  const [loras, setLoras] = useState<LoraEntry[]>([])
+  const [flashAttn, setFlashAttn] = useState(true)
+
+  const [busy, setBusy] = useState(false)
+  const [currentTask, setCurrentTask] = useState<Task | null>(null)
+  const [monitorState, setMonitorState] = useState<MonitorState | null>(null)
+  const taskIdRef = useRef<number | null>(null)
+  taskIdRef.current = currentTask?.id ?? null
+
+  // 最近训出的 LoRA：listProjects → 并行 getProject → 收集 output_lora_path。
+  // 用户场景下 project 数 < 20，N+1 调用可接受；不在乎实时性，启动加载一次即可。
+  const [recentLoras, setRecentLoras] = useState<RecentLora[]>([])
+  useEffect(() => {
+    void (async () => {
+      try {
+        const projects = await api.listProjects()
+        const details = await Promise.all(
+          projects.map((p) => api.getProject(p.id).catch(() => null))
+        )
+        const items: RecentLora[] = []
+        for (const d of details) {
+          if (!d) continue
+          for (const v of d.versions) {
+            if (v.output_lora_path) {
+              items.push({
+                label: `${d.title} / ${v.label}`,
+                path: v.output_lora_path,
+                createdAt: v.created_at,
+              })
+            }
+          }
+        }
+        items.sort((a, b) => b.createdAt - a.createdAt)
+        setRecentLoras(items)
+      } catch {
+        /* 启动失败不阻塞 — 用户仍可手敲 / PathPicker */
+      }
+    })()
+  }, [])
+
+  const samples = monitorState?.samples ?? []
+
+  // SSE：task_state_changed 触发 task refresh；monitor_state_updated 推 sample 列表。
+  // 不用 setInterval（与 dev 4e31c44 全 SSE 原则一致）。
+  useEventStream((evt) => {
+    const tid = taskIdRef.current
+    if (tid == null) return
+    if (evt.type === 'task_state_changed' && evt.task_id === tid) {
+      void api.getGenerateTask(tid).then((t) => {
+        setCurrentTask(t)
+        if (t.status === 'done' || t.status === 'failed' || t.status === 'canceled') {
+          setBusy(false)
+        }
+      }).catch(() => { /* task 已清也走这里 */ })
+    } else if (
+      evt.type === 'monitor_state_updated'
+      && String(evt.task_id) === String(tid)
+      && evt.state
+    ) {
+      setMonitorState(evt.state as MonitorState)
+    }
+  })
+
+  const handleGenerate = async () => {
+    if (!prompts.some((p) => p.trim())) {
+      toast('请输入至少一条提示词', 'error')
+      return
+    }
+    setBusy(true)
+    setCurrentTask(null)
+    setMonitorState(null)
+    try {
+      const body: GenerateRequest = {
+        prompts: prompts.filter((p) => p.trim()),
+        negative_prompt: negPrompt,
+        width, height, steps, count, seed,
+        cfg_scale: cfgScale,
+        lora_configs: loras.filter((l) => l.path.trim()),
+        flash_attn: flashAttn,
+      }
+      const t = await api.enqueueGenerate(body)
+      setCurrentTask(t)
+      toast(`测试任务 #${t.id} 已入队`, 'success')
+    } catch (e) {
+      toast(String(e), 'error')
+      setBusy(false)
+    }
+  }
+
+  const handleCancel = async () => {
+    if (!currentTask) return
+    try {
+      await api.cancelTask(currentTask.id)
+      toast(`已请求取消 #${currentTask.id}`, 'info')
+    } catch (e) {
+      toast(String(e), 'error')
+    }
+  }
+
+  const cancelable = currentTask
+    && (currentTask.status === 'pending' || currentTask.status === 'running')
+
+  return (
+    <div className="fade-in">
+      <PageHeader eyebrow="工具" title="测试" subtitle="独立运行推理，复用训练采样逻辑（出图不保存，关页面即丢）" />
+
+      <div className="p-6 flex flex-col gap-4">
+
+        {/* ── 提示词（全宽） ── */}
+        <div className="card" style={{ padding: 18 }}>
+          <div className="text-md font-semibold mb-3">正向提示词</div>
+          <PromptList prompts={prompts} onChange={setPrompts} />
+          <div className="mt-4">
+            <label className="caption block mb-1.5">负面提示词</label>
+            <textarea
+              className="input w-full font-mono text-sm resize-y"
+              rows={3}
+              value={negPrompt}
+              onChange={(e) => setNegPrompt(e.target.value)}
+            />
+          </div>
+        </div>
+
+        {/* ── 主体：参数 + 结果 ── */}
+        <div className="flex gap-4 items-start flex-wrap xl:flex-nowrap">
+
+          {/* 左：参数 */}
+          <div className="flex flex-col gap-4 w-full xl:w-[320px] shrink-0">
+
+            <div className="card" style={{ padding: 18 }}>
+              <div className="text-md font-semibold mb-3">生成参数</div>
+              <div className="flex flex-col gap-3">
+                <div className="flex gap-2">
+                  <NumField label="宽度" value={width} onChange={setWidth} min={256} max={4096} step={64} />
+                  <NumField label="高度" value={height} onChange={setHeight} min={256} max={4096} step={64} />
+                </div>
+                <div className="flex gap-2">
+                  <NumField label="步数" value={steps} onChange={setSteps} min={1} max={150} />
+                  <NumField label="CFG Scale" value={cfgScale} onChange={setCfgScale} min={0} max={20} step={0.5} />
+                </div>
+                <div className="flex gap-2">
+                  <NumField label="每 prompt 张数" value={count} onChange={setCount} min={1} max={32} />
+                  <NumField label="种子（0=随机）" value={seed} onChange={setSeed} min={0} />
+                </div>
+              </div>
+            </div>
+
+            <div className="card" style={{ padding: 18 }}>
+              <div className="text-md font-semibold mb-3">LoRA</div>
+              <LoraList loras={loras} onChange={setLoras} recent={recentLoras} />
+            </div>
+
+            <label className="flex items-center gap-2 text-sm cursor-pointer">
+              <input type="checkbox" checked={flashAttn} onChange={(e) => setFlashAttn(e.target.checked)} />
+              <span className="text-fg-secondary">Flash Attention</span>
+            </label>
+
+            <div className="flex gap-2">
+              <button className="btn btn-primary flex-1" onClick={handleGenerate} disabled={busy}>
+                {busy ? '生成中…' : '开始生成'}
+              </button>
+              {cancelable && (
+                <button className="btn btn-ghost" onClick={handleCancel} title="取消当前任务">
+                  取消
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* 右：结果 */}
+          <div className="flex-1 min-w-0">
+            {currentTask ? (
+              <div className="card" style={{ padding: 18 }}>
+                <div className="flex items-center gap-2 mb-4">
+                  <span className="text-md font-semibold">生成结果</span>
+                  <span className="caption">#{currentTask.id}</span>
+                  <StatusBadge status={currentTask.status} />
+                  {currentTask.error_msg && (
+                    <span className="text-xs text-err ml-1">{currentTask.error_msg}</span>
+                  )}
+                </div>
+                <SampleGallery samples={samples} taskId={currentTask.id} />
+              </div>
+            ) : (
+              <div
+                className="grid place-items-center rounded-md border border-subtle bg-sunken text-fg-tertiary text-sm"
+                style={{ minHeight: 260 }}
+              >
+                填写参数后点击「开始生成」
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/tests/test_find_diffusion_pipe_root.py
+++ b/tests/test_find_diffusion_pipe_root.py
@@ -1,0 +1,102 @@
+"""find_diffusion_pipe_root 路径解析回归 —— PR-1 搬目录漏修。
+
+anima_train.py 从 repo root 搬到 scripts/ 后，`Path(__file__).parent` 变成
+scripts/，原候选 `Path(__file__).parent / "models"` 找不到 repo_root/models/。
+线上首次跑训练立即 RuntimeError。
+
+本测试用 AST 抽函数源码独立执行，避免 import 整个 anima_train（torch +
+anima 依赖太重），保持单测轻量稳定。
+"""
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+
+import pytest
+
+
+def _exec_fn() -> tuple[object, dict]:
+    """从 scripts/anima_train.py 抽 find_diffusion_pipe_root，独立编译。"""
+    src_path = Path(__file__).resolve().parent.parent / "scripts" / "anima_train.py"
+    tree = ast.parse(src_path.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "find_diffusion_pipe_root":
+            mod = ast.Module(body=[node], type_ignores=[])
+            ns: dict = {"Path": Path, "os": os}
+            return mod, ns
+    raise RuntimeError("find_diffusion_pipe_root not found in anima_train.py")
+
+
+def _run(file_loc: Path, env_root: str | None = None) -> Path:
+    """在 ns 里执行函数，返回 find_diffusion_pipe_root() 的结果。"""
+    mod, ns = _exec_fn()
+    ns["__file__"] = str(file_loc)
+    if env_root is None:
+        # 隔离 env：忽略实际机器上的 DIFFUSION_PIPE_ROOT
+        os_env_backup = os.environ.pop("DIFFUSION_PIPE_ROOT", None)
+        try:
+            exec(compile(mod, "<test>", "exec"), ns)
+            return ns["find_diffusion_pipe_root"]()
+        finally:
+            if os_env_backup is not None:
+                os.environ["DIFFUSION_PIPE_ROOT"] = os_env_backup
+    else:
+        os.environ["DIFFUSION_PIPE_ROOT"] = env_root
+        try:
+            exec(compile(mod, "<test>", "exec"), ns)
+            return ns["find_diffusion_pipe_root"]()
+        finally:
+            os.environ.pop("DIFFUSION_PIPE_ROOT", None)
+
+
+def test_finds_repo_root_models_after_scripts_move(tmp_path: Path) -> None:
+    """PR-1 搬目录后的标准 layout：repo_root/scripts/anima_train.py + repo_root/models/anima_modeling.py。"""
+    scripts_dir = tmp_path / "scripts"
+    scripts_dir.mkdir()
+    fake_train = scripts_dir / "anima_train.py"
+    fake_train.write_text("# placeholder")
+
+    models = tmp_path / "models"
+    models.mkdir()
+    (models / "anima_modeling.py").write_text("")
+
+    found = _run(fake_train)
+    assert found == models, f"expected {models}, got {found}"
+
+
+def test_finds_script_sibling_models_directory(tmp_path: Path) -> None:
+    """脚本同目录的 models/（CLI 用户把脚本和模型代码放一起，候选 1）。"""
+    fake_train = tmp_path / "anima_train.py"
+    fake_train.write_text("# placeholder")
+
+    sibling_models = tmp_path / "models"
+    sibling_models.mkdir()
+    (sibling_models / "anima_modeling.py").write_text("")
+
+    found = _run(fake_train)
+    assert found == sibling_models
+
+
+def test_env_var_override_when_no_layout_match(tmp_path: Path) -> None:
+    """DIFFUSION_PIPE_ROOT 直接指向 anima_modeling.py 所在目录。"""
+    fake_train = tmp_path / "scripts" / "anima_train.py"
+    fake_train.parent.mkdir()
+    fake_train.write_text("# placeholder")
+
+    custom = tmp_path / "custom_pipe"
+    custom.mkdir()
+    (custom / "anima_modeling.py").write_text("")
+
+    found = _run(fake_train, env_root=str(custom))
+    assert found == custom
+
+
+def test_raises_when_nothing_found(tmp_path: Path) -> None:
+    """所有候选都没命中 → RuntimeError。"""
+    fake_train = tmp_path / "scripts" / "anima_train.py"
+    fake_train.parent.mkdir()
+    fake_train.write_text("# placeholder")
+
+    with pytest.raises(RuntimeError, match="anima_modeling.py"):
+        _run(fake_train)

--- a/tests/test_inference_core.py
+++ b/tests/test_inference_core.py
@@ -177,3 +177,74 @@ def test_apply_loras_skips_missing_path(tmp_path: Path) -> None:
 def test_apply_loras_empty_specs() -> None:
     model = MagicMock()
     assert apply_loras(model, [], device="cpu", dtype=torch.float32) == []
+
+
+# ---------------------------------------------------------------------------
+# generate tempdir helpers
+# ---------------------------------------------------------------------------
+
+
+def test_generate_tempdir_path() -> None:
+    """tempdir 路径基于 task_id，落在系统 tempdir 下。"""
+    import tempfile
+    from studio.services.inference_core import (
+        GENERATE_TEMP_PREFIX,
+        generate_tempdir,
+    )
+    d = generate_tempdir(42)
+    assert d.parent == Path(tempfile.gettempdir())
+    assert d.name == f"{GENERATE_TEMP_PREFIX}42"
+
+
+def test_cleanup_generate_tempdir_removes_dir() -> None:
+    """cleanup_generate_tempdir 清掉对应 task 的目录。"""
+    from studio.services.inference_core import (
+        cleanup_generate_tempdir,
+        generate_tempdir,
+    )
+    d = generate_tempdir(99999)
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "img.png").write_bytes(b"\x89PNG")
+    assert d.exists()
+
+    cleanup_generate_tempdir(99999)
+    assert not d.exists()
+
+
+def test_cleanup_generate_tempdir_noop_when_missing() -> None:
+    """目录不存在时调 cleanup 是 noop（非 generate task 也安全）。"""
+    from studio.services.inference_core import (
+        cleanup_generate_tempdir,
+        generate_tempdir,
+    )
+    d = generate_tempdir(88888)
+    if d.exists():
+        import shutil
+        shutil.rmtree(d)
+    cleanup_generate_tempdir(88888)
+
+
+def test_cleanup_stale_generate_tempdirs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """启动扫清：把所有 anima_gen_* 目录全清。"""
+    import tempfile
+    monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+    from studio.services.inference_core import (
+        GENERATE_TEMP_PREFIX,
+        cleanup_stale_generate_tempdirs,
+    )
+
+    leak1 = tmp_path / f"{GENERATE_TEMP_PREFIX}111"
+    leak2 = tmp_path / f"{GENERATE_TEMP_PREFIX}222"
+    keep = tmp_path / "unrelated_dir"
+    leak1.mkdir()
+    (leak1 / "x.png").write_bytes(b"\x89")
+    leak2.mkdir()
+    keep.mkdir()
+    (keep / "important.txt").write_text("dont touch")
+
+    cleanup_stale_generate_tempdirs()
+
+    assert not leak1.exists()
+    assert not leak2.exists()
+    assert keep.exists()  # 不带前缀的不动
+    assert (keep / "important.txt").exists()

--- a/tests/test_inference_core.py
+++ b/tests/test_inference_core.py
@@ -1,0 +1,179 @@
+"""inference_core 单测：rank/alpha 从 metadata 读 + 多 LoRA 各自 inject。
+
+回归 PR #17 作者在 anima_generate.py / anima_reg_ai.py 引入的两个 P0 bug：
+  1. rank/alpha 硬编码 32/32（应该从顶层 ss_network_dim / ss_network_alpha 读）
+  2. 多 LoRA 张量直加合到一个 LycorisNetwork（应该每份独立 inject）
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+torch = pytest.importorskip("torch")
+pytest.importorskip("safetensors")
+
+from safetensors.torch import save_file
+
+from studio.services.inference_core import LoRASpec, apply_loras, read_lora_meta
+
+
+@contextmanager
+def _patched_adapter(factory: object) -> Iterator[None]:
+    """注入 fake AnimaLycorisAdapter 到 utils.lycoris_adapter（绕开 lycoris-lora 真依赖）。
+
+    inference_core.apply_loras 内部 `from utils.lycoris_adapter import
+    AnimaLycorisAdapter` 是函数局部 lazy import，不能直接 patch
+    inference_core 的 module attr。用 sys.modules 替换整个
+    utils.lycoris_adapter 模块。
+    """
+    fake_mod = types.ModuleType("utils.lycoris_adapter")
+    fake_mod.AnimaLycorisAdapter = factory  # type: ignore[attr-defined]
+    with patch.dict(sys.modules, {"utils.lycoris_adapter": fake_mod}):
+        yield
+
+
+def _write_lora_safetensors(
+    path: Path, *, rank: int, alpha: float, algo: str, factor: int,
+) -> None:
+    """写一个伪 LoRA safetensors，带 ss_* metadata；tensor 内容空。"""
+    sd = {"lora_unet_dummy.lokr_w1": torch.zeros(2, 2)}
+    meta = {
+        "ss_network_dim": str(rank),
+        "ss_network_alpha": str(alpha),
+        "ss_network_module": "lycoris.kohya",
+        "ss_network_args": json.dumps({
+            "algo": algo,
+            "factor": factor,
+            "preset": "anima_full",
+        }),
+    }
+    save_file(sd, str(path), metadata=meta)
+
+
+def test_read_lora_meta_from_ss_network_dim_alpha(tmp_path: Path) -> None:
+    p = tmp_path / "lora.safetensors"
+    _write_lora_safetensors(p, rank=64, alpha=32.0, algo="lokr", factor=16)
+
+    meta = read_lora_meta(str(p))
+    assert meta.rank == 64
+    assert meta.alpha == 32.0
+    assert meta.algo == "lokr"
+    assert meta.factor == 16
+
+
+def test_read_lora_meta_unusual_dim(tmp_path: Path) -> None:
+    """rank=8 训练的 LoRA 必须读到 8，不能 fallback 到 32（旧 bug 核心场景）。"""
+    p = tmp_path / "lora_dim8.safetensors"
+    _write_lora_safetensors(p, rank=8, alpha=4.0, algo="lokr", factor=8)
+
+    meta = read_lora_meta(str(p))
+    assert meta.rank == 8
+    assert meta.alpha == 4.0
+
+
+def test_read_lora_meta_missing_metadata(tmp_path: Path) -> None:
+    """metadata 完全缺失时回退默认。"""
+    p = tmp_path / "no_meta.safetensors"
+    save_file({"x": torch.zeros(1)}, str(p))
+
+    meta = read_lora_meta(str(p))
+    assert meta.rank == 32
+    assert meta.algo == "lokr"
+    assert meta.factor == 8
+
+
+def test_read_lora_meta_invalid_fields(tmp_path: Path) -> None:
+    """字段是非法字符串时不崩、回退默认。"""
+    p = tmp_path / "bad.safetensors"
+    save_file({"x": torch.zeros(1)}, str(p), metadata={
+        "ss_network_dim": "not_a_number",
+        "ss_network_alpha": "also_bad",
+        "ss_network_args": "not_json{",
+    })
+    meta = read_lora_meta(str(p))
+    assert meta.rank == 32
+    assert meta.alpha == 32.0  # alpha fallback to rank
+    assert meta.algo == "lokr"
+
+
+def test_apply_loras_each_lora_injects_separately(tmp_path: Path) -> None:
+    """多 LoRA 必须每个独立 inject —— PR #17 旧 bug 回归测试。
+
+    旧 bug：把多个 LoRA 的 tensor 直接 add 到一份 dict 然后灌进
+    一个 AnimaLycorisAdapter，LoKr 的 lokr_w1/lokr_w2 子矩阵相加
+    ≠ 权重 delta 相加，出图错。
+    """
+    p1 = tmp_path / "a.safetensors"
+    p2 = tmp_path / "b.safetensors"
+    _write_lora_safetensors(p1, rank=16, alpha=8.0, algo="lokr", factor=8)
+    _write_lora_safetensors(p2, rank=8, alpha=4.0, algo="lokr", factor=8)
+
+    created: list[MagicMock] = []
+
+    def _fake_adapter(*args: object, **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        m.init_kwargs = dict(kwargs)
+        m.network = MagicMock()
+        m.network.loras = []
+        m.load_state_dict.return_value = MagicMock(missing_keys=[], unexpected_keys=[])
+        created.append(m)
+        return m
+
+    model = MagicMock()
+
+    with _patched_adapter(_fake_adapter):
+        adapters = apply_loras(
+            model,
+            [LoRASpec(path=str(p1), scale=1.0), LoRASpec(path=str(p2), scale=0.5)],
+            device="cpu",
+            dtype=torch.float32,
+        )
+
+    assert len(adapters) == 2
+    # 每个 adapter 各 inject(model) 一次（不是合并到一个）
+    for a in adapters:
+        a.inject.assert_called_once_with(model)
+    # rank/alpha 从 metadata 读，不是硬编码 32/32
+    assert created[0].init_kwargs["rank"] == 16
+    assert created[0].init_kwargs["alpha"] == 8.0
+    assert created[1].init_kwargs["rank"] == 8
+    assert created[1].init_kwargs["alpha"] == 4.0
+    # multiplier 设为 spec.scale
+    assert created[0].network.multiplier == 1.0
+    assert created[1].network.multiplier == 0.5
+
+
+def test_apply_loras_skips_missing_path(tmp_path: Path) -> None:
+    p_real = tmp_path / "real.safetensors"
+    _write_lora_safetensors(p_real, rank=16, alpha=8.0, algo="lokr", factor=8)
+    p_fake = tmp_path / "nonexistent.safetensors"
+
+    def _fake_adapter(*args: object, **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        m.network = MagicMock()
+        m.network.loras = []
+        m.load_state_dict.return_value = MagicMock(missing_keys=[], unexpected_keys=[])
+        return m
+
+    model = MagicMock()
+    with _patched_adapter(_fake_adapter):
+        adapters = apply_loras(
+            model,
+            [LoRASpec(path=str(p_fake)), LoRASpec(path=str(p_real))],
+            device="cpu",
+            dtype=torch.float32,
+        )
+
+    assert len(adapters) == 1
+
+
+def test_apply_loras_empty_specs() -> None:
+    model = MagicMock()
+    assert apply_loras(model, [], device="cpu", dtype=torch.float32) == []

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -40,6 +40,24 @@ def test_v2_creates_tables_and_extends_tasks(tmp_path: Path) -> None:
         assert {"project_id", "version_id"} <= cols
 
 
+def test_v5_adds_task_type_column(tmp_path: Path) -> None:
+    """v5: tasks 加 task_type 列，旧 task 自动 fallback 到 'train'。"""
+    dbfile = tmp_path / "fresh.db"
+    db.init_db(dbfile)
+    with _open(dbfile) as c:
+        cols = {r["name"] for r in c.execute("PRAGMA table_info(tasks)")}
+        assert "task_type" in cols
+        # 新建一个 task，default 应该是 'train'
+        c.execute(
+            "INSERT INTO tasks(name, config_name, status, priority, created_at) "
+            "VALUES (?, ?, 'pending', 0, ?)",
+            ("legacy_task", "cfg", time.time()),
+        )
+        c.commit()
+        row = c.execute("SELECT task_type FROM tasks").fetchone()
+        assert row["task_type"] == "train"
+
+
 def test_v1_db_upgrades_in_place_preserving_tasks(tmp_path: Path) -> None:
     """模拟 PP0 之前留下来的 v1 库（只有 tasks 表）：执行 init_db 应升到 v2 且数据不丢。"""
     dbfile = tmp_path / "legacy.db"

--- a/tests/test_reg_builder.py
+++ b/tests/test_reg_builder.py
@@ -504,7 +504,50 @@ def test_meta_roundtrip(tmp_path: Path) -> None:
     assert m2 is not None
     assert m2.actual_count == 8
     assert m2.train_tag_distribution == {"a": 5}
+    # 默认 generation_method = "scrape"（兼容旧 meta）
+    assert m2.generation_method == "scrape"
 
     reg_builder.update_meta_auto_tagged(out, True)
     m3 = reg_builder.read_meta(out)
     assert m3.auto_tagged is True
+
+
+def test_meta_legacy_without_generation_method(tmp_path: Path) -> None:
+    """旧 meta.json（无 generation_method 字段）反序列化必须不崩，落到默认 "scrape"。"""
+    import json
+    out = tmp_path / "reg"
+    out.mkdir()
+    legacy = {
+        "generated_at": 1.0, "based_on_version": "x", "api_source": "gelbooru",
+        "target_count": 5, "actual_count": 5,
+        "source_tags": [], "excluded_tags": [], "blacklist_tags": [],
+        "failed_tags": [], "train_tag_distribution": {}, "auto_tagged": False,
+        "incremental_runs": 0,
+        "postprocessed_at": None, "postprocess_clusters": None,
+        "postprocess_method": None, "postprocess_max_crop_ratio": None,
+        # 故意不带 generation_method
+    }
+    (out / "meta.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+    m = reg_builder.read_meta(out)
+    assert m is not None
+    assert m.generation_method == "scrape"
+    assert m.api_source == "gelbooru"
+
+
+def test_meta_ai_base_roundtrip(tmp_path: Path) -> None:
+    """先验生成写出的 meta：generation_method='ai_base' + api_source 留空。"""
+    out = tmp_path / "reg"
+    out.mkdir()
+    m = reg_builder.RegMeta(
+        generated_at=2.0, based_on_version="", api_source="",
+        target_count=10, actual_count=10, source_tags=[],
+        excluded_tags=["face_focus"], blacklist_tags=[], failed_tags=[],
+        train_tag_distribution={"1girl": 5}, auto_tagged=False,
+        generation_method="ai_base",
+    )
+    reg_builder.write_meta(out, m)
+    m2 = reg_builder.read_meta(out)
+    assert m2 is not None
+    assert m2.generation_method == "ai_base"
+    assert m2.api_source == ""

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -71,6 +71,29 @@ def test_pending_task_runs_to_completion(env) -> None:
     assert "done" in statuses
 
 
+def test_default_cmd_builder_routes_by_task_type() -> None:
+    """_default_cmd_builder 按 task_type 选择脚本（PR-9 commit 3）。"""
+    from studio.paths import REPO_ROOT
+    from studio.supervisor import _default_cmd_builder
+
+    cfg = Path("/tmp/fake.json")
+
+    cmd_train = _default_cmd_builder({"task_type": "train"}, cfg)
+    assert str(REPO_ROOT / "scripts" / "anima_train.py") in cmd_train
+
+    cmd_reg = _default_cmd_builder({"task_type": "reg_ai"}, cfg)
+    assert str(REPO_ROOT / "tools" / "anima_reg_ai.py") in cmd_reg
+
+    cmd_gen = _default_cmd_builder({"task_type": "generate"}, cfg)
+    assert str(REPO_ROOT / "tools" / "anima_generate.py") in cmd_gen
+
+    # 缺字段 / None / 未知 → 默认 train（兼容老 task）
+    cmd_legacy = _default_cmd_builder({}, cfg)
+    assert str(REPO_ROOT / "scripts" / "anima_train.py") in cmd_legacy
+    cmd_none = _default_cmd_builder({"task_type": None}, cfg)
+    assert str(REPO_ROOT / "scripts" / "anima_train.py") in cmd_none
+
+
 def test_failed_task_marked_failed(env) -> None:
     events, on_event = _events_collector()
 

--- a/tools/anima_generate.py
+++ b/tools/anima_generate.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""测试出图 — 独立运行推理，复用 anima_train.sample_image 推理链路 + inference_core 多 LoRA。
+
+用法：
+    python tools/anima_generate.py --config generate_config.json [--monitor-state-file state.json]
+
+JSON 配置字段见 studio.schema.GenerateConfig。
+
+关键：
+  - 多 LoRA 加载走 studio.services.inference_core.apply_loras —— 每份 LoRA 独立
+    inject 一份 AnimaLycorisAdapter，rank/alpha 从 ss_network_args 读，用
+    multiplier=scale 控制贡献权重。**修复 PR #17 作者的 P0 bug**：硬编码
+    rank=32 + tensor 直加 LoKr 子矩阵会出错图。
+  - 输出图写到 cfg.output_dir（Studio 模式由 server 填 tempfile.gettempdir() /
+    anima_gen_{task_id}，task 结束清掉 —— 用户视角"不保存"）。
+  - 进度通过 train_monitor 推 SSE，前端按 sample_path 拉单图显示。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import random
+import sys
+from pathlib import Path
+
+import torch
+
+# anima_train 在 scripts/，train_monitor 在同一 tools/ 目录
+_THIS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _THIS_DIR.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+for _p in (_THIS_DIR, _SCRIPTS_DIR, _REPO_ROOT):
+    s = str(_p)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+
+import anima_train as _T  # noqa: E402
+
+from studio.services.inference_core import LoRASpec, apply_loras  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("anima_generate")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Anima 测试出图")
+    p.add_argument("--config", required=True, help="JSON 配置文件路径")
+    p.add_argument("--monitor-state-file", default="", help="进度状态文件路径")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    cfg_path = Path(args.config)
+    if not cfg_path.exists():
+        logger.error(f"配置文件不存在: {cfg_path}")
+        sys.exit(1)
+
+    with open(cfg_path, encoding="utf-8") as f:
+        cfg = json.load(f)
+
+    output_dir = Path(cfg.get("output_dir", "./generate_output"))
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    prompts: list[str] = cfg.get("prompts") or ["newest, safe, 1girl, masterpiece, best quality"]
+    negative_prompt: str = cfg.get("negative_prompt", "")
+    width: int = int(cfg.get("width", 1024))
+    height: int = int(cfg.get("height", 1024))
+    steps: int = int(cfg.get("steps", 25))
+    cfg_scale: float = float(cfg.get("cfg_scale", 4.0))
+    sampler_name: str = cfg.get("sampler_name", "er_sde")
+    scheduler: str = cfg.get("scheduler", "simple")
+    count: int = max(1, int(cfg.get("count", 1)))
+    base_seed: int = int(cfg.get("seed", 0))
+    lora_configs: list[dict] = cfg.get("lora_configs", [])
+    mixed_precision: str = cfg.get("mixed_precision", "bf16")
+    xformers: bool = bool(cfg.get("xformers", False))
+    flash_attn: bool = bool(cfg.get("flash_attn", True))
+
+    transformer_path: str = cfg["transformer_path"]
+    vae_path: str = cfg["vae_path"]
+    text_encoder_path: str = cfg["text_encoder_path"]
+    t5_tokenizer_path: str = cfg.get("t5_tokenizer_path", "")
+
+    # monitor
+    state_file = args.monitor_state_file or str(output_dir / "monitor_state.json")
+    _update_monitor = None
+    try:
+        from train_monitor import set_state_file, update_monitor
+        set_state_file(state_file)
+        update_monitor(config={
+            "type": "generate",
+            "prompts": len(prompts),
+            "count": count,
+            "steps": steps,
+            "cfg_scale": cfg_scale,
+        })
+        _update_monitor = update_monitor
+    except Exception as e:
+        logger.warning(f"monitor 初始化失败: {e}")
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.bfloat16 if mixed_precision == "bf16" else torch.float32
+
+    # 路径解析
+    repo_root = _T.find_diffusion_pipe_root()
+    bases = [Path.cwd(), _THIS_DIR, repo_root]
+    transformer_path = _T.resolve_path_best_effort(transformer_path, bases)
+    vae_path = _T.resolve_path_best_effort(vae_path, bases)
+    text_encoder_path = _T.resolve_path_best_effort(text_encoder_path, bases)
+    if t5_tokenizer_path:
+        t5_tokenizer_path = _T.resolve_path_best_effort(t5_tokenizer_path, bases)
+
+    use_flash = flash_attn and not xformers
+
+    logger.info("加载 Transformer...")
+    model = _T.load_anima_model(transformer_path, device, dtype, repo_root, flash_attn=use_flash)
+    if xformers:
+        _T.enable_xformers(model)
+
+    logger.info("加载 VAE...")
+    vae = _T.load_vae(vae_path, device, dtype, repo_root)
+
+    logger.info("加载文本编码器...")
+    qwen_model, qwen_tok, t5_tok = _T.load_text_encoders(
+        text_encoder_path, t5_tokenizer_path or None, device, dtype,
+    )
+
+    # 多 LoRA：每份独立 inject + multiplier=scale。adapters 必须保持引用，否则
+    # 被 GC 后 forward hook 失效（lycoris 通过 closure 持有 network）。
+    specs = [
+        LoRASpec(path=str(lc.get("path", "")), scale=float(lc.get("scale", 1.0)))
+        for lc in lora_configs
+    ]
+    _adapters = apply_loras(model, specs, device, dtype)  # noqa: F841 — 保持引用
+
+    model.eval()
+
+    # 生成循环
+    total = count * len(prompts)
+    logger.info(f"开始生成：{len(prompts)} 个 prompt × {count} 次 = {total} 张")
+
+    img_idx = 0
+    for pi, prompt in enumerate(prompts):
+        for ci in range(count):
+            seed = (base_seed + img_idx) if base_seed != 0 else random.randint(0, 2**31 - 1)
+            torch.manual_seed(seed)
+            random.seed(seed)
+
+            logger.info(f"[{img_idx + 1}/{total}] seed={seed}  prompt={prompt[:60]}...")
+            try:
+                img = _T.sample_image(
+                    model, vae, qwen_model, qwen_tok, t5_tok,
+                    prompt=prompt,
+                    height=height,
+                    width=width,
+                    steps=steps,
+                    cfg_scale=cfg_scale,
+                    negative_prompt=negative_prompt or None,
+                    sampler_name=sampler_name,
+                    scheduler=scheduler,
+                    device=device,
+                    dtype=dtype,
+                )
+                fname = f"gen_{img_idx:04d}_p{pi}_c{ci}_s{seed}.png"
+                out_path = output_dir / fname
+                img.save(out_path)
+                logger.info(f"已保存: {out_path}")
+                if _update_monitor:
+                    _update_monitor(sample_path=str(out_path), step=img_idx + 1)
+            except Exception as e:
+                logger.error(f"生成失败 [{img_idx + 1}/{total}]: {e}")
+
+            img_idx += 1
+
+    logger.info("生成完成")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/anima_reg_ai.py
+++ b/tools/anima_reg_ai.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""先验生成 — base 模型对每张训练图的 tag 反向出对照图作正则集。
+
+设计来自 DreamBooth prior preservation：训练损失同时见到「LoRA 学到的样子」和
+「base 模型本来的样子」，让 LoRA 只学差异、不污染 base 概念。
+
+**不带 LoRA** —— 出现 LoRA 反而把要保留的 prior 给覆盖了。
+
+用法：
+    python tools/anima_reg_ai.py --config reg_ai_config.json [--monitor-state-file state.json]
+
+逻辑：
+  1. 扫 train 目录所有图 + caption
+  2. 每张图 → tag 去除 excluded → ", " 拼成 prompt → 生成 1 张正则图
+  3. 输出到 reg/{对应子文件夹}/{stem}_ai_{seed}.png（镜像 train 子目录结构）
+  4. 同名 .txt 写入用过的 prompt
+  5. reg/meta.json 写 generation_method="ai_base", api_source=""
+     （与 booru 拉取共用 reg_builder.RegMeta schema，不再撞名重写）
+
+incremental=True：跳过 reg 子文件夹中已有以 train_stem 开头的图（重启续跑用）。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import random
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+import torch
+
+# anima_train 在 scripts/，train_monitor 在同一 tools/ 目录
+_THIS_DIR = Path(__file__).resolve().parent
+_REPO_ROOT = _THIS_DIR.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+for _p in (_THIS_DIR, _SCRIPTS_DIR, _REPO_ROOT):
+    s = str(_p)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+
+import anima_train as _T  # noqa: E402
+
+# 复用 reg_builder.RegMeta（PR-9 commit 2 加了 generation_method 字段）
+from studio.services.reg_builder import RegMeta, read_meta, write_meta  # noqa: E402
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    datefmt="%H:%M:%S",
+)
+logger = logging.getLogger("anima_reg_ai")
+
+IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif"}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Anima 先验生成（base 模型反向出 reg 集）")
+    p.add_argument("--config", required=True)
+    p.add_argument("--monitor-state-file", default="")
+    return p.parse_args()
+
+
+def _read_tags(img_path: Path) -> list[str]:
+    """读图片旁边的 .txt caption，返回 raw tag 列表（不归一化）。"""
+    txt = img_path.with_suffix(".txt")
+    if not txt.exists():
+        return []
+    raw = txt.read_text(encoding="utf-8", errors="ignore").strip()
+    return [t.strip() for t in raw.split(",") if t.strip()]
+
+
+def _normalize(tag: str) -> str:
+    return tag.lower().strip().replace(" ", "_")
+
+
+def _scan_train(train_dir: Path) -> list[dict]:
+    """扫 train 目录，返回每张图的信息列表。
+
+    元素: {"subfolder": str, "stem": str, "img": Path, "tags": list[str]}
+    subfolder="" 表示 train 根目录。
+    """
+    entries: list[dict] = []
+    train_dir = train_dir.resolve()
+
+    def _scan(folder: Path, sub: str) -> None:
+        for f in sorted(folder.iterdir()):
+            if f.is_file() and f.suffix.lower() in IMAGE_EXTS:
+                entries.append({
+                    "subfolder": sub,
+                    "stem": f.stem,
+                    "img": f,
+                    "tags": _read_tags(f),
+                })
+            elif f.is_dir():
+                child = f.name if not sub else f"{sub}/{f.name}"
+                _scan(f, child)
+
+    _scan(train_dir, "")
+    return entries
+
+
+def _already_has_reg(reg_sub: Path, train_stem: str) -> bool:
+    """incremental: reg 子目录里已有以 train_stem 开头的图就跳过。"""
+    if not reg_sub.exists():
+        return False
+    for f in reg_sub.iterdir():
+        if (
+            f.is_file()
+            and f.stem.startswith(train_stem)
+            and f.suffix.lower() in IMAGE_EXTS
+        ):
+            return True
+    return False
+
+
+def _write_meta_final(
+    reg_dir: Path,
+    entries: list[dict],
+    excluded_tags: set,
+    incremental: bool,
+    actual_count: int,
+) -> None:
+    """写 reg/meta.json 用 reg_builder.RegMeta（generation_method='ai_base'）。
+
+    与 booru 拉取共享 schema；api_source 留空（先验生成无 booru 来源）。
+    incremental_runs 在已有 meta 基础上 +1（与 PP5.1 booru 行为一致）。
+    """
+    prior = read_meta(reg_dir)
+    runs = (prior.incremental_runs + 1) if (incremental and prior) else 0
+
+    tag_dist: Counter = Counter()
+    for e in entries:
+        tag_dist.update(e["tags"])
+
+    meta = RegMeta(
+        generated_at=time.time(),
+        based_on_version="",
+        api_source="",  # 先验生成无 booru 来源
+        target_count=len(entries),
+        actual_count=actual_count + (prior.actual_count if (incremental and prior) else 0),
+        source_tags=[],
+        excluded_tags=sorted(excluded_tags),
+        blacklist_tags=[],
+        failed_tags=[],
+        train_tag_distribution=dict(tag_dist.most_common(50)),
+        auto_tagged=False,
+        incremental_runs=runs,
+        generation_method="ai_base",
+    )
+    write_meta(reg_dir, meta)
+
+
+def main() -> None:
+    args = parse_args()
+    cfg_path = Path(args.config)
+    if not cfg_path.exists():
+        logger.error(f"配置文件不存在: {cfg_path}")
+        sys.exit(1)
+
+    cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
+
+    train_dir = Path(cfg["train_dir"])
+    reg_dir = Path(cfg["reg_dir"])
+    excluded_tags: set = {_normalize(t) for t in cfg.get("excluded_tags", [])}
+    negative_prompt: str = cfg.get("negative_prompt", "")
+    width: int = int(cfg.get("width", 1024))
+    height: int = int(cfg.get("height", 1024))
+    steps: int = int(cfg.get("steps", 25))
+    cfg_scale: float = float(cfg.get("cfg_scale", 4.0))
+    sampler_name: str = cfg.get("sampler_name", "er_sde")
+    scheduler: str = cfg.get("scheduler", "simple")
+    base_seed: int = int(cfg.get("seed", 0))
+    incremental: bool = bool(cfg.get("incremental", False))
+    mixed_precision: str = cfg.get("mixed_precision", "bf16")
+    xformers: bool = bool(cfg.get("xformers", False))
+    flash_attn: bool = bool(cfg.get("flash_attn", True))
+
+    transformer_path: str = cfg["transformer_path"]
+    vae_path: str = cfg["vae_path"]
+    text_encoder_path: str = cfg["text_encoder_path"]
+    t5_tokenizer_path: str = cfg.get("t5_tokenizer_path", "")
+
+    # monitor (fallback 到 reg/.monitor_state.json，与 anima_generate 行为对齐)
+    state_file = args.monitor_state_file or str(reg_dir / "monitor_state.json")
+    _update_monitor = None
+    try:
+        from train_monitor import set_state_file, update_monitor
+        set_state_file(state_file)
+        update_monitor(config={"type": "reg_ai"})
+        _update_monitor = update_monitor
+    except Exception as e:
+        logger.warning(f"monitor 初始化失败: {e}")
+
+    if not train_dir.exists():
+        logger.error(f"train 目录不存在: {train_dir}")
+        sys.exit(1)
+
+    entries = _scan_train(train_dir)
+    if not entries:
+        logger.error("train 目录没有任何图片")
+        sys.exit(1)
+
+    logger.info(f"train 共 {len(entries)} 张图")
+
+    if incremental:
+        to_generate = [
+            e for e in entries
+            if not _already_has_reg(
+                reg_dir / e["subfolder"] if e["subfolder"] else reg_dir,
+                e["stem"],
+            )
+        ]
+        logger.info(f"incremental 模式：需生成 {len(to_generate)}/{len(entries)} 张")
+    else:
+        to_generate = entries
+
+    if not to_generate:
+        logger.info("所有图片已有对应正则图，无需生成")
+        _write_meta_final(reg_dir, entries, excluded_tags, incremental, 0)
+        return
+
+    # 加载 base 模型（不带 LoRA）
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    dtype = torch.bfloat16 if mixed_precision == "bf16" else torch.float32
+
+    repo_root = _T.find_diffusion_pipe_root()
+    bases = [Path.cwd(), _THIS_DIR, repo_root]
+    transformer_path = _T.resolve_path_best_effort(transformer_path, bases)
+    vae_path = _T.resolve_path_best_effort(vae_path, bases)
+    text_encoder_path = _T.resolve_path_best_effort(text_encoder_path, bases)
+    if t5_tokenizer_path:
+        t5_tokenizer_path = _T.resolve_path_best_effort(t5_tokenizer_path, bases)
+
+    use_flash = flash_attn and not xformers
+
+    logger.info("加载 Transformer...")
+    model = _T.load_anima_model(transformer_path, device, dtype, repo_root, flash_attn=use_flash)
+    if xformers:
+        _T.enable_xformers(model)
+
+    logger.info("加载 VAE...")
+    vae = _T.load_vae(vae_path, device, dtype, repo_root)
+
+    logger.info("加载文本编码器...")
+    qwen_model, qwen_tok, t5_tok = _T.load_text_encoders(
+        text_encoder_path, t5_tokenizer_path or None, device, dtype,
+    )
+
+    model.eval()
+
+    # 生成循环
+    total = len(to_generate)
+    actual_count = 0
+
+    for idx, entry in enumerate(to_generate):
+        tags = [_normalize(t) for t in entry["tags"]]
+        tags = [t for t in tags if t and t not in excluded_tags]
+
+        if not tags:
+            logger.warning(f"[{idx + 1}/{total}] {entry['img'].name} 过滤后无 tag，跳过")
+            continue
+
+        prompt = ", ".join(tags)
+        seed = (base_seed + idx) if base_seed != 0 else random.randint(0, 2**31 - 1)
+        torch.manual_seed(seed)
+        random.seed(seed)
+
+        subfolder = entry["subfolder"]
+        reg_sub = (reg_dir / subfolder) if subfolder else reg_dir
+        reg_sub.mkdir(parents=True, exist_ok=True)
+
+        out_name = f"{entry['stem']}_ai_{seed}.png"
+        out_path = reg_sub / out_name
+
+        logger.info(f"[{idx + 1}/{total}] {entry['img'].name} -> {out_name}")
+        logger.info(f"  prompt: {prompt[:80]}")
+
+        try:
+            img = _T.sample_image(
+                model, vae, qwen_model, qwen_tok, t5_tok,
+                prompt=prompt,
+                height=height,
+                width=width,
+                steps=steps,
+                cfg_scale=cfg_scale,
+                negative_prompt=negative_prompt or None,
+                sampler_name=sampler_name,
+                scheduler=scheduler,
+                device=device,
+                dtype=dtype,
+            )
+            img.save(out_path)
+            out_path.with_suffix(".txt").write_text(prompt, encoding="utf-8")
+            actual_count += 1
+            logger.info(f"  已保存: {out_path}")
+            if _update_monitor:
+                _update_monitor(sample_path=str(out_path), step=idx + 1)
+        except Exception as e:
+            logger.error(f"  生成失败: {e}")
+
+    _write_meta_final(reg_dir, entries, excluded_tags, incremental, actual_count)
+    logger.info(f"完成: {actual_count}/{total} 张")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
PR #17 Generate 工具页 + Reg AI tab 两块功能。本 PR 把两块功能拆出来，修掉所有阻塞项。

  PR-1 ~ PR-S3（基础设施 / Flash Attention / ModelScope）已合并到 master。本 PR 是 part 2，专做 Generate / Reg AI。

  ## 新增功能

  ### 1. Step 4「先验生成」tab（DreamBooth prior preservation）

  用 base 模型对每张训练图的 tag 反向出对照图作为正则集，让训练损失同时见到 base 分布、把不该学的概念推回去。

  **关键语义修正**：原 PR 把它实现成「用现有 LoRA 反向出图」并加了 LoRA UI —— 这与 prior preservation 语义相反（LoRA 加进来反而把要保留的 prior 给覆盖了）。本 PR 删除所有 LoRA UI，纯 base + per-image tag →    
  reg/{subfolder}/。

  - `POST /api/projects/{pid}/versions/{vid}/reg/generate-prior`
  - `tools/anima_reg_ai.py`：base 模型 + train tag 反向出图，镜像 train 子文件夹
  - 复用 `reg_builder.RegMeta`（不再撞名重写），`generation_method="ai_base"` + `api_source` 留空
  - SSE 进度 + 与 booru tab 共享 `excluded_tags` Set
  - 保留 incremental 补足模式（500+ 张大数据集挂掉后续跑救命）

  ### 2.「测试」页（独立工具页 / 旧 Generate 改名）

  侧栏「项目 / 队列 / **测试**」（图片框 icon），路由 `/tools/generate` 不动（老书签兼容）。

  **用户决策：出图不保存（规避部分云的 tos）** —— 写到 `tempfile.gettempdir() / anima_gen_{task_id}/`，task 结束 supervisor 自动清；启动扫遗留；前端无 history 列表，关页面即丢。

  - `POST /api/generate` + `GET /api/generate/{task_id}/sample/{filename}`
  - 多 LoRA + multi-prompt + cancel 按钮
  - 「最近训出 LoRA」下拉（`listProjects` + 并行 `getProject` 收集 `output_lora_path`，按 `created_at` 倒序）—— 把「刚训完→验证」高频路径从 5 步降到 3 步
  - SSE：`task_state_changed` + `monitor_state_updated`（删 PR #17 那版的 `setInterval(2s)`，与 dev `4e31c44` 全 SSE 原则对齐）

  ## P0 修复

  | 项 | 出处 | 修法 |
  |---|---|---|
  | 多 LoRA 合并方式错（出图错） | `anima_generate.py` + `anima_reg_ai.py` 各 copy 80+ 行 | 抽 `studio/services/inference_core.py`：`apply_loras` 每份独立 inject + `multiplier=scale`；rank/alpha 从
  `ss_network_dim/ss_network_alpha` 读（不再硬编码 32/32） |
  | RegMeta 撞名 + `api_source` 字段语义双关 | `tools/anima_reg_ai.py:79` vs `studio/services/reg_builder.py:94` | 合并到 `reg_builder.RegMeta` + 加 `generation_method:
  "scrape"\|"ai_base"`，前端徽标按字段分支渲染 |
  | `setInterval(2s)` 与 SSE 原则冲突 | `Generate.tsx:3244` | `useEventStream` 监 `task_state_changed` + `monitor_state_updated` |
  | `find_diffusion_pipe_root` PR-1 漏改 | `scripts/anima_train.py:287` | 加 `repo_root/models` + `repo_root/diffusion_models` 候选（影响 train + reg_ai + generate 三脚本，修一处全好） |

  ## 架构变动

  - v5 migration: `tasks` 表加 `task_type` 列，default `'train'`，老 task 自动 fallback
  - `supervisor._default_cmd_builder` 按 `task_type` 路由：`train → scripts/anima_train.py` / `reg_ai → tools/anima_reg_ai.py` / `generate → tools/anima_generate.py`
  - supervisor task 结束 finally 调 `cleanup_generate_tempdir`
  - server lifespan startup 调 `cleanup_stale_generate_tempdirs`

  ## 8 commits（边界清晰，可独立 review / revert）

  0652863 fix(scripts): find_diffusion_pipe_root 加 repo root 候选（PR-1 漏修）
  00b56e8 refactor(schema): LoraEntry 抽到 schema.py 收尾 PR-9
  6561f6f feat(web): 测试页面（旧 PR #17 Generate）+ 侧栏入口
  9f1b4ab feat(server): /api/generate 测试出图端点 + anima_generate.py（用 inference_core）
  d300326 feat(web): Step 4 加先验生成 tab（无 LoRA UI + explainer）
  2fe5969 feat(server): /api/projects/.../reg/generate-prior 端点 + anima_reg_ai.py（无 LoRA）
  b5a142e feat(reg): RegMeta 加 generation_method 字段为先验生成做准备
  cee4d82 feat(services): 抽 inference_core 修多 LoRA 加载 P0 bug

  ## Test plan

  - [x] `tests/test_inference_core.py` — 11 passed（rank/alpha 从 metadata 读 / 多 LoRA 各自 inject / tempdir helpers）
  - [x] `tests/test_supervisor.py::test_default_cmd_builder_routes_by_task_type` — train / reg_ai / generate / None / 缺字段 5 种路由
  - [x] `tests/test_migrations.py::test_v5_adds_task_type_column` — 加列 + 默认 train fallback
  - [x] `tests/test_reg_builder.py` — 24 passed（含 generation_method 兼容性 + ai_base round-trip + 旧 meta.json 读取）
  - [x] `tests/test_find_diffusion_pipe_root.py` — 4 passed（PR-1 后 layout / 同目录 layout / env var / 全 miss）
  - [x] 前端 `tsc --noEmit` 0 errors
  - [ ] **线上手动验证**（需要 GPU 环境）：
    - [ ] Step 4 先验生成 tab：勾排除 tag → 点「先验生成」→ task 跑通 → reg/{subfolder}/{stem}_ai_*.png 写入 + meta.json `generation_method=ai_base`
    - [ ] 测试页面：单 LoRA + 多 LoRA + multi-prompt 出图正常（多 LoRA 出图视觉上对得上各自 LoRA 风格的合成）
    - [ ] 测试出图 task done 后 tempdir 被清掉
    - [ ] cancel 按钮在 pending/running 状态下能终止 task