### PR TITLE
feat: attention backend 三选一（替代 xformers/flash_attn 双 bool）+ Settings xformers 卡片

### DIFF
--- a/scripts/anima_train.py
+++ b/scripts/anima_train.py
@@ -131,10 +131,15 @@ def apply_yaml_config(args, config):
     实现走 studio.argparse_bridge.merge_yaml_into_namespace —— 字段名 / 默认值
     都从 studio.schema.TrainingConfig 这一份单一权威源派生，避免与 parse_args
     脱节。未在 schema 中的 YAML 键会被忽略（拼写错误一目了然）。
+
+    在 merge 前调用 migrate_legacy_attention 兜底老 yaml 的 xformers/flash_attn
+    双 bool —— argparse_bridge 不走 pydantic validator，schema 层的迁移逻辑
+    无法生效，所以这里显式做一次。
     """
     from studio.argparse_bridge import merge_yaml_into_namespace
-    from studio.schema import TrainingConfig
-    return merge_yaml_into_namespace(args, config or {}, TrainingConfig)
+    from studio.schema import TrainingConfig, migrate_legacy_attention
+    config = migrate_legacy_attention(dict(config or {}))
+    return merge_yaml_into_namespace(args, config, TrainingConfig)
 
 
 # Lazy imports after dependency check
@@ -473,8 +478,13 @@ def ensure_models_namespace(repo_root):
         sys.path.insert(0, str(repo_root.parent))
 
 
-def load_anima_model(transformer_path, device, dtype, repo_root):
-    """加载 Anima transformer 模型"""
+def load_anima_model(transformer_path, device, dtype, repo_root, *, flash_attn: bool = True):
+    """加载 Anima transformer 模型。
+
+    `flash_attn=False` 显式禁用 flash_attn fast path（attention_backend=xformers/none
+    时由 caller 传入），让 caller 完全决定 attention 实现 —— PR #17 那版默认
+    fn(True) 强制开 flash_attn 不让用户关，与 cfg.attention_backend 解耦不彻底。
+    """
     from safetensors import safe_open
 
     ensure_models_namespace(repo_root)
@@ -490,13 +500,17 @@ def load_anima_model(transformer_path, device, dtype, repo_root):
     )
     Anima = anima_modeling.Anima
 
-    # flash_attn 加速：模型类加载完后 try-enable。set_flash_attn_enabled 内部
-    # 检查 _FLASH_ATTN_AVAILABLE，未装时返回 False 不抛错，安全 idempotent。
+    # flash_attn 全局开关：set_flash_attn_enabled 内部检查 _FLASH_ATTN_AVAILABLE，
+    # 未装时返回 False 不抛错（idempotent）。用 caller 传入的 flash_attn 而不是
+    # 强制 True，让 attention_backend=none/xformers 时显式关掉。
     fn = getattr(cosmos_modeling, "set_flash_attn_enabled", None)
     if fn is not None:
         try:
-            if fn(True):
+            if fn(flash_attn):
                 logger.info("flash_attn 启用（训练 + sample 走 fast path）")
+            else:
+                logger.info("flash_attn 关闭（attention_backend=%s 或包未安装）",
+                            "flash_attn" if flash_attn else "non-flash")
         except Exception as exc:  # noqa: BLE001
             logger.warning("flash_attn 启用失败，继续走 SDPA fallback: %s", exc)
 
@@ -1906,13 +1920,22 @@ def main():
     if reg_data_dir:
         args.reg_data_dir = resolve_path_best_effort(reg_data_dir, bases)
 
+    # 按 attention_backend 决策：xformers / flash_attn / none。
+    # load_anima_model 内部按 flash_attn 参数设 flash_attn 全局开关；
+    # xformers 是 model 层面的额外注入（与 flash_attn 互斥）。
+    backend = getattr(args, "attention_backend", "flash_attn")
+    use_flash = (backend == "flash_attn")
+
     # 加载模型
     logger.info("加载 Transformer...")
-    model = load_anima_model(args.transformer_path, device, dtype, repo_root)
+    model = load_anima_model(
+        args.transformer_path, device, dtype, repo_root, flash_attn=use_flash,
+    )
 
-    # 启用 xformers
-    if args.xformers:
+    if backend == "xformers":
         enable_xformers(model)
+    elif backend == "none":
+        logger.info("attention_backend=none，flash_attn / xformers 都不启用，走 PyTorch SDPA")
 
     logger.info("加载 VAE...")
     vae = load_vae(args.vae_path, device, dtype, repo_root)

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -13,11 +13,56 @@
 """
 from typing import Any, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 def _meta(group: str, control: str = "auto", **extra: Any) -> dict[str, Any]:
     return {"group": group, "control": control, **extra}
+
+
+# ---------------------------------------------------------------------------
+# attention backend 字段：xformers / flash_attn / 无 三选一（替代原本两个 bool）
+# ---------------------------------------------------------------------------
+
+AttentionBackend = Literal["none", "xformers", "flash_attn"]
+
+
+def migrate_legacy_attention(data: Any) -> Any:
+    """把老 cfg 的 `xformers` / `flash_attn` 双 bool 映射成 `attention_backend`。
+
+    Idempotent：已有 attention_backend 就剥掉老字段；只有老字段时按下面规则映射；
+    都没有则保持空（让 schema default 生效）。
+
+    映射规则（与原代码 `use_flash = flash_attn and not xformers` 一致 — xformers 优先）：
+        xformers=true  → "xformers"
+        xformers=false, flash_attn=true → "flash_attn"
+        xformers=false, flash_attn=false → "none"
+
+    在两个地方调用：
+      1. schema model_validator(mode='before')（pydantic 校验前先洗）—— server
+         构造 cfg / 前端送老字段都兼容
+      2. scripts/anima_train.py apply_yaml_config 之前显式调一次 —— 子进程读老
+         yaml 时 argparse_bridge.merge_yaml_into_namespace 不走 pydantic validator,
+         需要这层兜底
+    """
+    if not isinstance(data, dict):
+        return data
+    if "attention_backend" in data:
+        data.pop("xformers", None)
+        data.pop("flash_attn", None)
+        return data
+    has_legacy = "xformers" in data or "flash_attn" in data
+    if not has_legacy:
+        return data
+    xf = bool(data.pop("xformers", False))
+    fa = bool(data.pop("flash_attn", True))
+    if xf:
+        data["attention_backend"] = "xformers"
+    elif fa:
+        data["attention_backend"] = "flash_attn"
+    else:
+        data["attention_backend"] = "none"
+    return data
 
 
 class TrainingConfig(BaseModel):
@@ -242,9 +287,9 @@ class TrainingConfig(BaseModel):
         description="梯度检查点（省显存）",
         json_schema_extra=_meta("training"),
     )
-    xformers: bool = Field(
-        False,
-        description="xformers attention（5090 推荐 false）",
+    attention_backend: AttentionBackend = Field(
+        "flash_attn",
+        description="Attention backend：none（PyTorch SDPA）/ xformers / Flash Attention（5090 推荐 flash_attn）",
         json_schema_extra=_meta("training"),
     )
     num_workers: int = Field(
@@ -252,6 +297,11 @@ class TrainingConfig(BaseModel):
         description="数据加载线程（Windows 必须 0）",
         json_schema_extra=_meta("training"),
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_attention(cls, data: Any) -> Any:
+        return migrate_legacy_attention(data)
 
     # ---------------------------------------------------------------- 输出/保存
     output_dir: str = Field(
@@ -458,8 +508,15 @@ class GenerateConfig(BaseModel):
     # 运行时
     output_dir: str = Field("", description="输出目录（服务端填 tempdir，task 结束清）")
     mixed_precision: str = Field("bf16")
-    xformers: bool = Field(False)
-    flash_attn: bool = Field(True)
+    attention_backend: AttentionBackend = Field(
+        "flash_attn",
+        description="Attention backend：none（SDPA）/ xformers / flash_attn",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_attention(cls, data: Any) -> Any:
+        return migrate_legacy_attention(data)
 
 
 # ---------------------------------------------------------------------------
@@ -505,8 +562,15 @@ class RegAiConfig(BaseModel):
         description="补足模式：跳过 reg 子文件夹中已有以 train_stem 开头的图（重启续跑用）",
     )
     mixed_precision: str = Field("bf16")
-    xformers: bool = Field(False)
-    flash_attn: bool = Field(True)
+    attention_backend: AttentionBackend = Field(
+        "flash_attn",
+        description="Attention backend：none（SDPA）/ xformers / flash_attn",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_attention(cls, data: Any) -> Any:
+        return migrate_legacy_attention(data)
 
 
 # ---------------------------------------------------------------------------

--- a/studio/server.py
+++ b/studio/server.py
@@ -37,7 +37,7 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from . import (
     browse,
@@ -78,7 +78,15 @@ from .paths import (
     WEB_DIST,
     ensure_dirs,
 )
-from .schema import GROUP_ORDER, GenerateConfig, LoraEntry, RegAiConfig, TrainingConfig
+from .schema import (
+    GROUP_ORDER,
+    AttentionBackend,
+    GenerateConfig,
+    LoraEntry,
+    RegAiConfig,
+    TrainingConfig,
+    migrate_legacy_attention,
+)
 from .supervisor import Supervisor
 
 ensure_dirs()
@@ -1640,8 +1648,13 @@ class RegAiRequest(BaseModel):
     seed: int = 0
     incremental: bool = False
     mixed_precision: str = "bf16"
-    xformers: bool = False
-    flash_attn: bool = True
+    attention_backend: AttentionBackend = "flash_attn"
+
+    # 兼容老前端送 xformers / flash_attn 双 bool（自动映射成 attention_backend）
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_attention(cls, data: Any) -> Any:
+        return migrate_legacy_attention(data)
 
 
 @app.post("/api/projects/{pid}/versions/{vid}/reg/generate-prior")
@@ -1675,8 +1688,7 @@ def reg_generate_prior(pid: int, vid: int, body: RegAiRequest) -> dict[str, Any]
         seed=body.seed,
         incremental=body.incremental,
         mixed_precision=body.mixed_precision,
-        xformers=body.xformers,
-        flash_attn=body.flash_attn,
+        attention_backend=body.attention_backend,
     )
 
     cfg_dir = STUDIO_DATA / "reg_ai_configs"
@@ -1731,8 +1743,13 @@ class GenerateRequest(BaseModel):
     seed: int = 0
     lora_configs: list[LoraEntry] = []
     mixed_precision: str = "bf16"
-    xformers: bool = False
-    flash_attn: bool = True
+    attention_backend: AttentionBackend = "flash_attn"
+
+    # 兼容老前端送 xformers / flash_attn 双 bool（自动映射成 attention_backend）
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_attention(cls, data: Any) -> Any:
+        return migrate_legacy_attention(data)
 
 
 @app.post("/api/generate")
@@ -1766,8 +1783,7 @@ def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
         seed=body.seed,
         lora_configs=[lc.model_dump() for lc in body.lora_configs],
         mixed_precision=body.mixed_precision,
-        xformers=body.xformers,
-        flash_attn=body.flash_attn,
+        attention_backend=body.attention_backend,
     )
 
     cfg_path = tempdir / "config.json"

--- a/studio/server.py
+++ b/studio/server.py
@@ -67,6 +67,7 @@ from .services import (
     train_io,
     uploads as uploads_svc,
     version_config,
+    xformers_setup,
 )
 from .services.tagger import VALID_TAGGER_NAMES, get_tagger
 from .paths import (
@@ -1275,6 +1276,34 @@ def flash_attn_install(body: FlashAttnInstallRequest) -> dict[str, Any]:
     """
     try:
         return flash_attention_setup.install(body.url)
+    except RuntimeError as exc:
+        raise HTTPException(500, str(exc)) from exc
+
+
+# xformers runtime ------------------------------------------------------
+
+
+@app.get("/api/xformers/status")
+def xformers_status() -> dict[str, Any]:
+    """返回 xformers 安装状态。
+
+    比 flash_attention/status 简洁很多 —— xformers 走 PyPI 直装，不需要 GitHub
+    候选 wheel 列表 / 环境检测细节（status 里 installed/version 已经够用）。
+    """
+    return xformers_setup.current_status()
+
+
+@app.post("/api/xformers/install")
+def xformers_install() -> dict[str, Any]:
+    """pip install xformers --index-url <torch-cu-index>。
+
+    同步执行；远端 wheel 通常几十到几百 MB，几分钟级。装失败抛 500，message
+    含 stderr 末尾（多数失败 = 上游 wheel 没覆盖当前 torch+cu 组合）。
+
+    xformers 是 C extension，装完返回 restart_required=True 让 UI 提示重启。
+    """
+    try:
+        return xformers_setup.install()
     except RuntimeError as exc:
         raise HTTPException(500, str(exc)) from exc
 

--- a/studio/services/xformers_setup.py
+++ b/studio/services/xformers_setup.py
@@ -1,0 +1,91 @@
+"""xformers 安装服务（简化版，类比 flash_attention_setup）。
+
+xformers 与 flash_attn 同为 attention 加速 C extension，但安装路径**显著简单**：
+  - flash_attn：依赖 dao-AILab + mjun0812 prebuild 的 GitHub Releases，
+    每个 torch+cuda+python 组合一个 wheel，需要解析 wheel 名 + 评分匹配
+  - xformers：facebook 官方 PyPI 直接发 wheel，与 torch+cuda 强绑定但
+    PyTorch 官方 wheel index (download.pytorch.org/whl/cuXXX) 已经
+    把对应 cu_tag 的 wheel 集中起来。
+
+所以本服务只暴露：
+  - current_status() → {installed, version}
+  - install() → pip install xformers --index-url <torch-cuda-index>
+
+不复刻 flash_attention_setup 的 GitHub Releases 解析 / 候选列表 UI。
+装失败时把 stderr 透传，让用户自己看（多数失败 = 上游没出对应 torch+cu
+组合的 wheel，需要换 torch 版本或等上游覆盖）。
+"""
+from __future__ import annotations
+
+import importlib.metadata
+import re
+import subprocess
+import sys
+from typing import Any, Optional
+
+
+def current_status() -> dict[str, Any]:
+    """xformers 当前安装状态：{installed: bool, version: str|None}。"""
+    try:
+        version = importlib.metadata.version("xformers")
+        return {"installed": True, "version": version}
+    except importlib.metadata.PackageNotFoundError:
+        return {"installed": False, "version": None}
+
+
+def _torch_cuda_index() -> Optional[str]:
+    """从 `torch.__version__` 的 `+cuXXX` 后缀推 PyTorch CUDA index URL。
+
+    xformers wheel 与 torch ABI 强绑定（每个 xformers 版本锁定特定 torch+cuda），
+    必须装与当前 torch 同 CUDA 的 wheel。PyTorch 官方 index 按 cu_tag 分组：
+        https://download.pytorch.org/whl/cu128
+        https://download.pytorch.org/whl/cu130
+        ...
+
+    ABI 检测原则与 flash_attention_setup.detect_env() 一致：从 torch 拿，
+    不从 nvidia-smi 拿（nvidia-smi 是 driver 支持的 CUDA，不是 PyTorch 编译的）。
+    """
+    try:
+        import torch  # noqa: PLC0415
+    except ImportError:
+        return None
+    m = re.search(r"\+cu(\d+)", torch.__version__)
+    if m:
+        return f"https://download.pytorch.org/whl/cu{m.group(1)}"
+    return None
+
+
+def install() -> dict[str, Any]:
+    """pip install xformers，自动按当前 torch 的 CUDA index 选 wheel。
+
+    返回 {installed, version, stdout_tail, restart_required}。
+    安装失败抛 RuntimeError，message 含 stderr 末尾（多数 wheel 找不到时
+    pip 会打印「No matching distribution found for xformers」）。
+
+    `restart_required=True` 因为 xformers 是 C extension —— 装好后必须重启
+    Studio 进程才能 import（与 flash_attn 同）。
+    """
+    cmd = [sys.executable, "-m", "pip", "install", "xformers"]
+    index = _torch_cuda_index()
+    if index:
+        cmd += ["--index-url", index]
+
+    try:
+        r = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=600,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError("pip install xformers 超时（10 分钟）") from exc
+
+    if r.returncode != 0:
+        tail = (r.stderr or r.stdout or "")[-1500:]
+        raise RuntimeError(
+            f"pip install xformers 失败 (exit {r.returncode}):\n{tail}"
+        )
+
+    status = current_status()
+    return {
+        **status,
+        "stdout_tail": (r.stdout or "")[-1500:],
+        "restart_required": True,
+    }

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -598,6 +598,9 @@ export interface RegBuildRequest {
   postprocess_max_crop_ratio?: number
 }
 
+/** Attention backend 三选一 — 替代原 xformers/flash_attn 双 bool。 */
+export type AttentionBackend = 'none' | 'xformers' | 'flash_attn'
+
 /** PR-9 — 先验生成（base 模型反向出 reg 集，无 LoRA）。 */
 export interface RegAiRequest {
   excluded_tags?: string[]
@@ -611,8 +614,7 @@ export interface RegAiRequest {
   seed?: number
   incremental?: boolean
   mixed_precision?: string
-  xformers?: boolean
-  flash_attn?: boolean
+  attention_backend?: AttentionBackend
 }
 
 /** PR-9 — 测试出图（独立工具页，多 LoRA + multi-prompt）。 */
@@ -634,8 +636,20 @@ export interface GenerateRequest {
   seed?: number
   lora_configs?: LoraEntry[]
   mixed_precision?: string
-  xformers?: boolean
-  flash_attn?: boolean
+  attention_backend?: AttentionBackend
+}
+
+/** xformers 安装状态 / 安装结果（简化版，对照 FlashAttnStatus）。 */
+export interface XformersStatus {
+  installed: boolean
+  version: string | null
+}
+
+export interface XformersInstallResult {
+  installed: boolean
+  version: string | null
+  stdout_tail: string
+  restart_required: boolean
 }
 
 export type TaskStatus = 'pending' | 'running' | 'done' | 'failed' | 'canceled'
@@ -1277,6 +1291,16 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ url }),
     }),
+
+  // xformers 运行时（attention_backend=xformers 用） -----------------------
+  /** xformers 安装状态。比 flash_attn 简洁：xformers 走 PyPI 直装，
+   *  没有 GitHub 候选 wheel 列表的复杂选择逻辑。 */
+  getXformersStatus: () => req<XformersStatus>('/api/xformers/status'),
+  /** pip install xformers --index-url <torch-cu-index>。同步 pip，几分钟级。
+   *  装失败时后端把 stderr 末尾透传到 message，多数失败 = 上游 wheel 没覆盖
+   *  当前 torch+cu 组合。装完必须重启 Studio（C extension 不能热替换）。 */
+  installXformers: () =>
+    req<XformersInstallResult>('/api/xformers/install', { method: 'POST' }),
 
   // PP7 — 训练集导出 / 导入 -----------------------------------------------
   /** 当前 version 的 train/ 打包 zip 直链。用 downloadBlob() 调它显示 loading。 */

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useOutletContext } from 'react-router-dom'
 import {
   api,
+  type AttentionBackend,
   type Job,
   type ProjectDetail,
   type RegAiRequest,
@@ -78,7 +79,7 @@ export default function RegularizationPage() {
   const [aiCfg, setAiCfg] = useState(4.0)
   const [aiSeed, setAiSeed] = useState(0)
   const [aiIncremental, setAiIncremental] = useState(false)
-  const [aiFlashAttn, setAiFlashAttn] = useState(true)
+  const [aiBackend, setAiBackend] = useState<AttentionBackend>('flash_attn')
   const [aiTask, setAiTask] = useState<Task | null>(null)
   const [aiBusy, setAiBusy] = useState(false)
   const aiTaskIdRef = useRef<number | null>(null)
@@ -214,7 +215,7 @@ export default function RegularizationPage() {
         cfg_scale: aiCfg,
         seed: aiSeed,
         incremental: aiIncremental,
-        flash_attn: aiFlashAttn,
+        attention_backend: aiBackend,
       }
       const t = await api.enqueueRegPrior(project.id, vid, body)
       setAiTask(t)
@@ -353,7 +354,7 @@ export default function RegularizationPage() {
           cfg={aiCfg} onCfgChange={setAiCfg}
           seed={aiSeed} onSeedChange={setAiSeed}
           incremental={aiIncremental} onIncrementalChange={setAiIncremental}
-          flashAttn={aiFlashAttn} onFlashAttnChange={setAiFlashAttn}
+          backend={aiBackend} onBackendChange={setAiBackend}
           task={aiTask}
           trainImageCount={trainImageCount}
         />
@@ -837,7 +838,7 @@ function AiGenPanel({
   cfg, onCfgChange,
   seed, onSeedChange,
   incremental, onIncrementalChange,
-  flashAttn, onFlashAttnChange,
+  backend, onBackendChange,
   task,
   trainImageCount,
 }: {
@@ -850,7 +851,7 @@ function AiGenPanel({
   cfg: number; onCfgChange: (v: number) => void
   seed: number; onSeedChange: (v: number) => void
   incremental: boolean; onIncrementalChange: (v: boolean) => void
-  flashAttn: boolean; onFlashAttnChange: (v: boolean) => void
+  backend: AttentionBackend; onBackendChange: (v: AttentionBackend) => void
   task: Task | null
   trainImageCount: number
 }) {
@@ -888,7 +889,7 @@ function AiGenPanel({
         </div>
         <AiNumField label="种子（0=随机）" value={seed} onChange={onSeedChange} min={0} />
 
-        <div className="flex flex-wrap gap-3">
+        <div className="flex flex-wrap gap-3 items-end">
           <label className="flex items-center gap-1.5 cursor-pointer text-xs">
             <input
               type="checkbox"
@@ -897,14 +898,18 @@ function AiGenPanel({
             />
             <span className="text-fg-secondary">补足模式（跳过 reg 子目录中已有对应文件名前缀的图）</span>
           </label>
-          <label className="flex items-center gap-1.5 cursor-pointer text-xs">
-            <input
-              type="checkbox"
-              checked={flashAttn}
-              onChange={(e) => onFlashAttnChange(e.target.checked)}
-            />
-            <span className="text-fg-secondary">Flash Attention</span>
-          </label>
+          <div className="flex flex-col gap-1">
+            <label className="caption text-2xs">加速</label>
+            <select
+              className="input text-xs py-1"
+              value={backend}
+              onChange={(e) => onBackendChange(e.target.value as AttentionBackend)}
+            >
+              <option value="flash_attn">Flash Attention</option>
+              <option value="xformers">xformers</option>
+              <option value="none">无（SDPA）</option>
+            </select>
+          </div>
         </div>
 
         <AiTaskStatus task={task} />

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import {
   api,
+  type AttentionBackend,
   type GenerateRequest,
   type LoraEntry,
   type MonitorState,
@@ -272,7 +273,7 @@ export default function GeneratePage() {
   const [count, setCount] = useState(1)
   const [seed, setSeed] = useState(0)
   const [loras, setLoras] = useState<LoraEntry[]>([])
-  const [flashAttn, setFlashAttn] = useState(true)
+  const [attentionBackend, setAttentionBackend] = useState<AttentionBackend>('flash_attn')
 
   const [busy, setBusy] = useState(false)
   const [currentTask, setCurrentTask] = useState<Task | null>(null)
@@ -349,7 +350,7 @@ export default function GeneratePage() {
         width, height, steps, count, seed,
         cfg_scale: cfgScale,
         lora_configs: loras.filter((l) => l.path.trim()),
-        flash_attn: flashAttn,
+        attention_backend: attentionBackend,
       }
       const t = await api.enqueueGenerate(body)
       setCurrentTask(t)
@@ -423,10 +424,18 @@ export default function GeneratePage() {
               <LoraList loras={loras} onChange={setLoras} recent={recentLoras} />
             </div>
 
-            <label className="flex items-center gap-2 text-sm cursor-pointer">
-              <input type="checkbox" checked={flashAttn} onChange={(e) => setFlashAttn(e.target.checked)} />
-              <span className="text-fg-secondary">Flash Attention</span>
-            </label>
+            <div className="flex flex-col gap-1">
+              <label className="caption">加速</label>
+              <select
+                className="input"
+                value={attentionBackend}
+                onChange={(e) => setAttentionBackend(e.target.value as AttentionBackend)}
+              >
+                <option value="flash_attn">Flash Attention</option>
+                <option value="xformers">xformers</option>
+                <option value="none">无（PyTorch SDPA）</option>
+              </select>
+            </div>
 
             <div className="flex gap-2">
               <button className="btn btn-primary flex-1" onClick={handleGenerate} disabled={busy}>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -4,6 +4,7 @@ import {
   DEFAULT_WD14_MODELS,
   type CLTaggerVariantInfo,
   type FlashAttnStatus,
+  type XformersStatus,
   type ModelDownloadStatus,
   type ModelsCatalog,
   type Secrets,
@@ -522,6 +523,8 @@ export default function SettingsPage() {
       <PyTorchSection />
 
       <FlashAttentionSection />
+
+      <XformersSection />
 
       <ModelsSection
         catalog={catalog}
@@ -1585,6 +1588,116 @@ function FlashAttentionSection() {
               </div>
             </div>
           )}
+        </>)}
+      </div>
+    </details>
+  )
+}
+
+// ── xformers Section（训练 tab）─────────────────────────────────────────────
+//
+// 简化版 attention 加速（替代 flash_attn 的另一选项）。xformers 走 PyPI 直装，
+// 不需要 flash_attn 那种 GitHub 候选 wheel 列表。失败时给 stderr 让用户排错。
+
+function XformersSection() {
+  const [status, setStatus] = useState<XformersStatus | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const { toast } = useToast()
+
+  const refresh = useCallback(async () => {
+    try {
+      const s = await api.getXformersStatus()
+      setStatus(s)
+      setError(null)
+    } catch (e) {
+      setError(String(e))
+    }
+  }, [])
+
+  useEffect(() => { void refresh() }, [refresh])
+
+  const install = async () => {
+    if (!confirm(
+      '将 pip install xformers，按当前 torch+cu 选 PyTorch index URL。\n' +
+      '装包几分钟到十几分钟，装完后必须重启 Studio。继续？'
+    )) return
+    setBusy(true)
+    try {
+      const r = await api.installXformers()
+      toast(`xformers==${r.version ?? '?'} 安装成功，请重启 Studio`, 'success')
+      await refresh()
+    } catch (e) {
+      toast(`安装失败: ${e}`, 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const statusLabel = error
+    ? '加载失败'
+    : !status
+      ? '加载中...'
+      : status.installed
+        ? `已安装 v${status.version ?? '?'}`
+        : '未安装'
+  const statusOk = status?.installed && !error
+  const hasIssue = !!error
+
+  return (
+    <details open={!!hasIssue} className="rounded-md border border-subtle bg-surface group">
+      <summary className="cursor-pointer p-4 list-none flex items-center gap-2">
+        <span className="text-fg-tertiary text-xs transition-transform group-open:rotate-90 inline-block w-3">▸</span>
+        <h2 className="text-sm font-semibold text-fg-primary m-0">xformers</h2>
+        <span className="text-xs text-fg-tertiary">attention 加速（与 Flash Attention 二选一）</span>
+        <span className={`ml-auto text-xs font-mono ${statusOk ? 'text-ok' : 'text-warn'}`}>{statusLabel}</span>
+      </summary>
+
+      <div className="px-4 pb-4 flex flex-col gap-3">
+        {error && <div className="text-err text-xs font-mono">{error}</div>}
+        {!error && !status && <div className="text-xs text-fg-tertiary">加载状态...</div>}
+
+        {status && (<>
+          <div className="rounded-sm border border-subtle bg-sunken p-2 flex items-center gap-2 text-xs">
+            <span className="text-fg-tertiary shrink-0">xformers:</span>
+            <code className="font-mono text-fg-primary">
+              {status.installed ? `v${status.version ?? '?'}` : '（未安装）'}
+            </code>
+            {status.installed && <StatusLabel bg="bg-ok-soft" fg="text-ok" text="已安装" />}
+          </div>
+
+          <p className="text-2xs text-fg-tertiary m-0 leading-relaxed">
+            xformers 与 Flash Attention <strong>互斥</strong>，每个训练/出图任务的{' '}
+            <code className="font-mono">attention_backend</code>{' '}
+            字段三选一（无 / xformers / flash_attn）。xformers 泛用性更广（支持
+            sm_70+），flash_attn 性能更高（sm_80+ Ampere 起）。
+          </p>
+
+          <div className="flex gap-2">
+            <button
+              onClick={() => void install()}
+              disabled={busy}
+              className="btn btn-primary btn-sm"
+            >
+              {busy
+                ? '安装中...'
+                : status.installed
+                  ? '重装（自动匹配）'
+                  : '安装（自动匹配）'}
+            </button>
+            <button
+              onClick={() => void refresh()}
+              disabled={busy}
+              className="btn btn-ghost btn-sm"
+              title="刷新状态"
+            >↻</button>
+          </div>
+
+          <p className="text-2xs text-fg-tertiary m-0">
+            装失败多数是上游 PyPI / PyTorch index 没出对应 torch+cu 组合的 wheel
+            （5090 / 新 GPU 常见）。失败时按钮 toast 会显示 stderr 末尾，可
+            根据提示降 torch 版本或等上游覆盖。
+          </p>
         </>)}
       </div>
     </details>

--- a/tests/test_attention_backend_schema.py
+++ b/tests/test_attention_backend_schema.py
@@ -1,0 +1,140 @@
+"""schema.attention_backend 字段 + migrate_legacy_attention 兼容性回归。
+
+覆盖 schema layer + scripts cfg 加载层共用的 migration helper：
+  - 老 cfg（xformers/flash_attn 双 bool）能映射成 attention_backend
+  - 新 cfg（attention_backend）直接通过
+  - 同时存在 → 优先 attention_backend，剥老字段
+"""
+from __future__ import annotations
+
+import pytest
+
+from studio.schema import (
+    AttentionBackend,  # noqa: F401  re-export 烟雾测试
+    GenerateConfig,
+    RegAiConfig,
+    TrainingConfig,
+    migrate_legacy_attention,
+)
+
+
+# ---------------------------------------------------------------------------
+# migrate_legacy_attention（dict 层 helper）
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_legacy_xformers_true() -> None:
+    """xformers=True 映射成 attention_backend="xformers"，剥老字段。"""
+    out = migrate_legacy_attention({"xformers": True, "flash_attn": False})
+    assert out == {"attention_backend": "xformers"}
+
+
+def test_migrate_legacy_xformers_overrides_flash_attn() -> None:
+    """xformers=True 优先于 flash_attn=True（与原 use_flash 优先级一致）。"""
+    out = migrate_legacy_attention({"xformers": True, "flash_attn": True})
+    assert out["attention_backend"] == "xformers"
+
+
+def test_migrate_legacy_flash_attn_only() -> None:
+    out = migrate_legacy_attention({"xformers": False, "flash_attn": True})
+    assert out["attention_backend"] == "flash_attn"
+
+
+def test_migrate_legacy_both_false() -> None:
+    """xformers=False, flash_attn=False → "none"（用户主动关掉所有加速）。"""
+    out = migrate_legacy_attention({"xformers": False, "flash_attn": False})
+    assert out["attention_backend"] == "none"
+
+
+def test_migrate_legacy_only_xformers_field() -> None:
+    """只有 xformers 字段时 flash_attn 默认 True，xformers=False → "flash_attn"。"""
+    out = migrate_legacy_attention({"xformers": False})
+    assert out["attention_backend"] == "flash_attn"
+
+
+def test_migrate_no_legacy_no_change() -> None:
+    """没有任何 attention 字段时不增加 attention_backend（让 schema default 起作用）。"""
+    out = migrate_legacy_attention({"width": 1024})
+    assert "attention_backend" not in out
+
+
+def test_migrate_new_field_strips_legacy() -> None:
+    """attention_backend 已设 → 剥老字段，新字段优先（兼容期混发场景）。"""
+    out = migrate_legacy_attention({
+        "attention_backend": "none",
+        "xformers": True,  # 应该被忽略 + 删
+        "flash_attn": True,
+    })
+    assert out == {"attention_backend": "none"}
+
+
+def test_migrate_non_dict_passthrough() -> None:
+    """非 dict 直接 return 不动（pydantic model_validator(mode='before') 兼容）。"""
+    assert migrate_legacy_attention(None) is None
+    assert migrate_legacy_attention("notadict") == "notadict"
+    assert migrate_legacy_attention(42) == 42
+
+
+def test_migrate_idempotent() -> None:
+    """重复调用结果不变。"""
+    once = migrate_legacy_attention({"xformers": True})
+    twice = migrate_legacy_attention(dict(once))
+    assert once == twice == {"attention_backend": "xformers"}
+
+
+# ---------------------------------------------------------------------------
+# pydantic model_validator —— schema 层走 migrate 后能正确构造
+# ---------------------------------------------------------------------------
+
+
+def test_generate_config_legacy_xformers() -> None:
+    """老 yaml { xformers: true } → GenerateConfig.attention_backend = "xformers"。"""
+    g = GenerateConfig(transformer_path="", vae_path="", text_encoder_path="",
+                       xformers=True, flash_attn=False)  # type: ignore[call-arg]
+    assert g.attention_backend == "xformers"
+
+
+def test_generate_config_legacy_double_false() -> None:
+    g = GenerateConfig(transformer_path="", vae_path="", text_encoder_path="",
+                       xformers=False, flash_attn=False)  # type: ignore[call-arg]
+    assert g.attention_backend == "none"
+
+
+def test_generate_config_default_is_flash_attn() -> None:
+    """无字段 → 默认 flash_attn（与历史 flash_attn=True 默认一致）。"""
+    g = GenerateConfig(transformer_path="", vae_path="", text_encoder_path="")
+    assert g.attention_backend == "flash_attn"
+
+
+def test_generate_config_new_field() -> None:
+    g = GenerateConfig(transformer_path="", vae_path="", text_encoder_path="",
+                       attention_backend="xformers")
+    assert g.attention_backend == "xformers"
+
+
+def test_reg_ai_config_legacy_compatibility() -> None:
+    """RegAiConfig 同样支持老字段。"""
+    r = RegAiConfig(xformers=True)  # type: ignore[call-arg]
+    assert r.attention_backend == "xformers"
+
+
+def test_training_config_legacy_compatibility() -> None:
+    """TrainingConfig 同样兼容（schema 是单一权威源）。"""
+    t = TrainingConfig(xformers=True)  # type: ignore[call-arg]
+    assert t.attention_backend == "xformers"
+
+
+@pytest.mark.parametrize("backend", ["none", "xformers", "flash_attn"])
+def test_all_backends_validate(backend: str) -> None:
+    """三个枚举值都能 validate。"""
+    g = GenerateConfig(transformer_path="", vae_path="", text_encoder_path="",
+                       attention_backend=backend)  # type: ignore[arg-type]
+    assert g.attention_backend == backend
+
+
+def test_invalid_backend_rejected() -> None:
+    """无效 backend → ValidationError。"""
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        GenerateConfig(transformer_path="", vae_path="", text_encoder_path="",
+                       attention_backend="sdpa")  # type: ignore[arg-type]

--- a/tests/test_xformers_setup.py
+++ b/tests/test_xformers_setup.py
@@ -1,0 +1,137 @@
+"""xformers_setup 单测 —— current_status / install / _torch_cuda_index 路径覆盖。
+
+参考 test_flash_attention_setup.py 的风格但更简洁（xformers service 比
+flash_attention 简单很多）。
+"""
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from studio.services import xformers_setup as xs
+
+
+# ---------------------------------------------------------------------------
+# current_status
+# ---------------------------------------------------------------------------
+
+
+def test_current_status_not_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """importlib.metadata 找不到 xformers → installed=False。"""
+    import importlib.metadata as md
+    def boom(name: str) -> str:
+        raise md.PackageNotFoundError(name)
+    monkeypatch.setattr(xs.importlib.metadata, "version", boom)
+    s = xs.current_status()
+    assert s == {"installed": False, "version": None}
+
+
+def test_current_status_installed(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(xs.importlib.metadata, "version", lambda _: "0.0.28")
+    s = xs.current_status()
+    assert s == {"installed": True, "version": "0.0.28"}
+
+
+# ---------------------------------------------------------------------------
+# _torch_cuda_index — 与 flash_attention_setup.detect_env 同样从 torch 拿 ABI tag
+# ---------------------------------------------------------------------------
+
+
+def _patch_torch(monkeypatch: pytest.MonkeyPatch, version: str | None) -> None:
+    """注入 / 移除 fake torch 模块（version=None 模拟未装 torch）。"""
+    if version is None:
+        monkeypatch.setitem(sys.modules, "torch", None)  # type: ignore[arg-type]
+        return
+    fake = types.ModuleType("torch")
+    fake.__version__ = version  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "torch", fake)
+
+
+def test_torch_cuda_index_from_torch_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    """torch.__version__='2.11.0+cu128' → cu128 index URL。"""
+    _patch_torch(monkeypatch, "2.11.0+cu128")
+    assert xs._torch_cuda_index() == "https://download.pytorch.org/whl/cu128"
+
+
+def test_torch_cuda_index_no_cu_suffix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CPU-only torch（无 +cu）→ None；caller 走 PyPI default。"""
+    _patch_torch(monkeypatch, "2.11.0")
+    assert xs._torch_cuda_index() is None
+
+
+def test_torch_cuda_index_no_torch(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_torch(monkeypatch, None)
+    assert xs._torch_cuda_index() is None
+
+
+# ---------------------------------------------------------------------------
+# install
+# ---------------------------------------------------------------------------
+
+
+def _make_pip_result(returncode: int, stdout: str = "", stderr: str = "") -> Any:
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+def test_install_success_with_torch_cu(monkeypatch: pytest.MonkeyPatch) -> None:
+    """成功路径：cmd 含 --index-url cu_tag；返回 status + restart_required。"""
+    _patch_torch(monkeypatch, "2.11.0+cu128")
+    captured: list[list[str]] = []
+    def fake_run(cmd, **_kw):
+        captured.append(cmd)
+        return _make_pip_result(0, stdout="Successfully installed xformers-0.0.28")
+    monkeypatch.setattr(xs.subprocess, "run", fake_run)
+    monkeypatch.setattr(xs.importlib.metadata, "version", lambda _: "0.0.28")
+
+    result = xs.install()
+
+    assert result["installed"] is True
+    assert result["version"] == "0.0.28"
+    assert result["restart_required"] is True
+    assert "Successfully installed" in result["stdout_tail"]
+    # cmd 含 --index-url cu128
+    assert "--index-url" in captured[0]
+    idx = captured[0].index("--index-url")
+    assert captured[0][idx + 1] == "https://download.pytorch.org/whl/cu128"
+
+
+def test_install_no_torch_falls_back_to_pypi(monkeypatch: pytest.MonkeyPatch) -> None:
+    """无 torch / 无 cu 后缀 → 不传 --index-url，走 PyPI default。"""
+    _patch_torch(monkeypatch, None)
+    captured: list[list[str]] = []
+    def fake_run(cmd, **_kw):
+        captured.append(cmd)
+        return _make_pip_result(0, stdout="Successfully installed xformers-0.0.27")
+    monkeypatch.setattr(xs.subprocess, "run", fake_run)
+    monkeypatch.setattr(xs.importlib.metadata, "version", lambda _: "0.0.27")
+
+    result = xs.install()
+
+    assert result["installed"] is True
+    assert "--index-url" not in captured[0]
+
+
+def test_install_pip_failure_raises_with_stderr(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pip exit != 0 → RuntimeError 含 stderr 末尾。"""
+    _patch_torch(monkeypatch, "2.11.0+cu128")
+    monkeypatch.setattr(
+        xs.subprocess, "run",
+        lambda *a, **k: _make_pip_result(1, stderr="ERROR: No matching distribution found"),
+    )
+    with pytest.raises(RuntimeError) as exc_info:
+        xs.install()
+    assert "No matching distribution found" in str(exc_info.value)
+    assert "exit 1" in str(exc_info.value)
+
+
+def test_install_timeout_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_torch(monkeypatch, "2.11.0+cu128")
+    def boom(*_a, **_k):
+        raise xs.subprocess.TimeoutExpired(cmd="pip", timeout=600)
+    monkeypatch.setattr(xs.subprocess, "run", boom)
+    with pytest.raises(RuntimeError, match="超时"):
+        xs.install()

--- a/tools/anima_generate.py
+++ b/tools/anima_generate.py
@@ -80,8 +80,13 @@ def main() -> None:
     base_seed: int = int(cfg.get("seed", 0))
     lora_configs: list[dict] = cfg.get("lora_configs", [])
     mixed_precision: str = cfg.get("mixed_precision", "bf16")
-    xformers: bool = bool(cfg.get("xformers", False))
-    flash_attn: bool = bool(cfg.get("flash_attn", True))
+    # 兼容老 cfg 的 xformers/flash_attn 双 bool（migrate_legacy_attention 默认值与
+    # schema.GenerateConfig.attention_backend 默认 "flash_attn" 一致）
+    from studio.schema import migrate_legacy_attention
+    cfg = migrate_legacy_attention(cfg)
+    backend: str = cfg.get("attention_backend", "flash_attn")
+    use_flash = (backend == "flash_attn")
+    use_xformers = (backend == "xformers")
 
     transformer_path: str = cfg["transformer_path"]
     vae_path: str = cfg["vae_path"]
@@ -117,11 +122,9 @@ def main() -> None:
     if t5_tokenizer_path:
         t5_tokenizer_path = _T.resolve_path_best_effort(t5_tokenizer_path, bases)
 
-    use_flash = flash_attn and not xformers
-
     logger.info("加载 Transformer...")
     model = _T.load_anima_model(transformer_path, device, dtype, repo_root, flash_attn=use_flash)
-    if xformers:
+    if use_xformers:
         _T.enable_xformers(model)
 
     logger.info("加载 VAE...")

--- a/tools/anima_reg_ai.py
+++ b/tools/anima_reg_ai.py
@@ -175,8 +175,12 @@ def main() -> None:
     base_seed: int = int(cfg.get("seed", 0))
     incremental: bool = bool(cfg.get("incremental", False))
     mixed_precision: str = cfg.get("mixed_precision", "bf16")
-    xformers: bool = bool(cfg.get("xformers", False))
-    flash_attn: bool = bool(cfg.get("flash_attn", True))
+    # 兼容老 cfg 的 xformers/flash_attn 双 bool（schema.RegAiConfig.attention_backend 默认 flash_attn）
+    from studio.schema import migrate_legacy_attention
+    cfg = migrate_legacy_attention(cfg)
+    backend: str = cfg.get("attention_backend", "flash_attn")
+    use_flash = (backend == "flash_attn")
+    use_xformers = (backend == "xformers")
 
     transformer_path: str = cfg["transformer_path"]
     vae_path: str = cfg["vae_path"]
@@ -234,11 +238,9 @@ def main() -> None:
     if t5_tokenizer_path:
         t5_tokenizer_path = _T.resolve_path_best_effort(t5_tokenizer_path, bases)
 
-    use_flash = flash_attn and not xformers
-
     logger.info("加载 Transformer...")
     model = _T.load_anima_model(transformer_path, device, dtype, repo_root, flash_attn=use_flash)
-    if xformers:
+    if use_xformers:
         _T.enable_xformers(model)
 
     logger.info("加载 VAE...")


### PR DESCRIPTION
把 cfg 的 attention 加速从 `xformers + flash_attn` 双 bool 改成单字段 `attention_backend: "none" | "xformers" | "flash_attn"`，同时给 Settings 加 xformers 安装入口。

  ## 背景：双 bool 为什么需要换

  PR-7（Flash Attention 接入）后 cfg 同时存在两个 bool 字段，但代码里它们**互斥**：

  ```python
  # tools/anima_generate.py / tools/anima_reg_ai.py
  use_flash = flash_attn and not xformers   # xformers 优先级覆盖 flash_attn

  UI 是两个独立 checkbox，用户必须自己记住"xformers 开了 flash_attn 就被覆盖"，schema 上没体现这个互斥关系，容易踩。Train cfg 默认 xformers=true 时还会触发 WARNING - xformers 未安装，跳过启用 警告（xformers   
  不是默认安装的）。

  改动概览

  1. schema 单字段 + 老 cfg 兼容

  # studio/schema.py — 三个 Config (Training/Generate/RegAi) 都加：
  attention_backend: Literal["none", "xformers", "flash_attn"] = "flash_attn"

  @model_validator(mode="before")
  def _migrate(cls, data): return migrate_legacy_attention(data)

  migrate_legacy_attention 把老 yaml 的 xformers/flash_attn 双 bool 自动映射成 attention_backend：

  ┌──────────────────────────────────┬─────────────────────────────────┐
  │              老字段              │             新字段              │
  ├──────────────────────────────────┼─────────────────────────────────┤
  │ xformers=true                    │ "xformers"                      │
  ├──────────────────────────────────┼─────────────────────────────────┤
  │ xformers=false, flash_attn=true  │ "flash_attn"                    │
  ├──────────────────────────────────┼─────────────────────────────────┤
  │ xformers=false, flash_attn=false │ "none"                          │
  ├──────────────────────────────────┼─────────────────────────────────┤
  │ 都不设                           │ 默认 "flash_attn"（与历史一致） │
  └──────────────────────────────────┴─────────────────────────────────┘

  兼容点（用户决策 Q3 = A）：老 yaml 不需要改，cfg 加载层无感转换。schema 层 model_validator(mode='before') 覆盖 server 端构造路径；scripts/anima_train.apply_yaml_config 在 merge_yaml_into_namespace
  前显式调一次 helper 兜底（argparse_bridge 不走 pydantic validator）。

  2. xformers 安装服务

  studio/services/xformers_setup.py（91 行）：

  - current_status() → {installed, version}
  - install() → pip install xformers --index-url <torch-cu-index>
  - 比 flash_attention_setup（245 行）简单很多 —— xformers 走 PyPI 直装，不需要 GitHub Releases wheel 解析

  _torch_cuda_index 与 PR #21 修过的 flash_attention_setup.detect_env 同样的原则：从 torch.__version__ 的 +cuXXX 后缀拿 ABI tag，不从 nvidia-smi 拿（后者是 driver 支持版本，不是 PyTorch 编译版本）。

  3. server 端点

  GET  /api/xformers/status       → {installed, version}
  POST /api/xformers/install      → 同步 pip install，返回 {installed, version, stdout_tail, restart_required}

  4. 三个脚本改读 attention_backend

  - scripts/anima_train.py：load_anima_model 加 flash_attn: bool = True 参数（按 backend 派生）；main 按 backend 分支决策
  - tools/anima_generate.py / tools/anima_reg_ai.py：删 xformers/flash_attn 双 bool 读取，从 attention_backend 派生 use_flash / use_xformers，老 cfg 走 migrate_legacy_attention 兜底

  顺手修一个隐藏 bug：dev 上 anima_generate.py / anima_reg_ai.py 调 _T.load_anima_model(..., flash_attn=use_flash) 但 anima_train.load_anima_model 原签名没 flash_attn 参数 → 待爆的 TypeError，commit 4
  把签名加上。

  5. 前端

  - 测试页面（Generate.tsx）+ 先验生成 tab（AiGenPanel）：双 checkbox → 单 select「Flash Attention / xformers / 无（PyTorch SDPA）」
  - 训练页（Train.tsx）：0 修改 — SchemaForm 看到 schema 字段 Literal[...] 自动渲染下拉（Field.tsx:65 prop.enum 逻辑）
  - Settings：加 XformersSection（~95 行简化版，对照 FlashAttentionSection 的 150 行），状态 + 装/重装按钮 + 失败 stderr toast

  6 commits（边界清晰）

  317cebc test: attention_backend schema 迁移 + xformers_setup 单测覆盖
  7d44f58 feat(web): 加速三选一下拉 + Settings xformers 卡片
  489760d feat(scripts): 三脚本改读 attention_backend + load_anima_model 加 flash_attn 参数
  43b11be feat(server): /api/xformers/{status,install} 端点
  cfdac05 feat(services): xformers_setup 提供 status + install
  92c2d65 feat(schema): attention_backend 单字段替代 xformers/flash_attn 双 bool

  Test plan

  - 114/114 passed：8 个测试套件全过
    - 28 个新单测：test_attention_backend_schema (19) + test_xformers_setup (9)
    - 86 个回归：test_inference_core / test_supervisor / test_migrations / test_reg_builder / test_flash_attention_setup / test_find_diffusion_pipe_root 等
  - 前端 tsc --noEmit 0 errors
  - schema migration 4 个核心场景：legacy xformers / legacy double-false / 默认 / 新字段
  - 线上手动验证（GPU 环境）：
    - Settings → xformers 卡片：pip install xformers 装/重装能跑（成功 / 失败两路径）
    - 测试页面 / 先验生成 tab 下拉切 backend，cfg.json 落盘字段正确
    - Train 页 SchemaForm 渲染 attention_backend 下拉（/api/schema 返回 enum 字段）
    - 老 cfg.yaml（含 xformers: true）的 project 切到新版后，跑训练不挂、attention_backend 正确推断成 xformers

  Refs

  - 用户决策 Q1=A / Q2=flash_attn 默认 / Q3=A schema-level 兼容 / Q4=A 简单 pip：聊天讨论
  - 同时引用相关 PR：#20（PR-9 先验生成 / 测试页面），#21（如已开 — flash_attn detect_env hotfix；本 PR 的 _torch_cuda_index 沿用同样原则）
