### PR TITLE
feat(download): add ModelScope mirror source + switch pip/npm mirrors to Tencent Cloud

### DIFF
--- a/studio.bat
+++ b/studio.bat
@@ -95,7 +95,7 @@ if exist "venv\Scripts\python.exe" (
     echo [studio] No venv detected. Creating venv\ via `!BOOTSTRAP_PY!` -- first run may take a few minutes...
     !BOOTSTRAP_PY! -m venv venv || (echo studio.bat: failed to create venv 1>&2 & goto :fail)
     set PYTHON=venv\Scripts\python.exe
-    !PYTHON! -m pip install --upgrade pip -i https://mirrors.aliyun.com/pypi/simple/ || (echo studio.bat: failed to upgrade pip 1>&2 & goto :fail)
+    !PYTHON! -m pip install --upgrade pip -i https://mirrors.cloud.tencent.com/pypi/simple/ || (echo studio.bat: failed to upgrade pip 1>&2 & goto :fail)
 
     REM GPU-aware torch first install (PR-S1a). Without this, requirements.txt's
     REM bare `torch>=2.0.0` makes pip pull the CPU wheel. Installing CUDA torch
@@ -112,11 +112,11 @@ if exist "venv\Scripts\python.exe" (
     )
 
     if exist requirements.txt (
-        echo [studio] Installing Python dependencies -- will retry via Aliyun mirror if slow...
+        echo [studio] Installing Python dependencies -- will retry via Tencent mirror if slow...
         !PYTHON! -m pip install -r requirements.txt
         if errorlevel 1 (
-            echo [studio] pip install failed, retrying via Aliyun mirror...
-            !PYTHON! -m pip install -r requirements.txt -i https://mirrors.aliyun.com/pypi/simple/ || (echo studio.bat: pip install failed 1>&2 & goto :fail)
+            echo [studio] pip install failed, retrying via Tencent mirror...
+            !PYTHON! -m pip install -r requirements.txt -i https://mirrors.cloud.tencent.com/pypi/simple/ || (echo studio.bat: pip install failed 1>&2 & goto :fail)
         )
     ) else (
         echo studio.bat: requirements.txt not found, skipping dependency install 1>&2

--- a/studio.sh
+++ b/studio.sh
@@ -3,7 +3,7 @@
 # Usage:
 #   ./studio.sh [--mirror] [--reinstall] [subcommand]
 #
-#   --mirror     Use Aliyun pip mirror during first-run setup.
+#   --mirror     Use Tencent pip mirror during first-run setup.
 #                Without this flag, official PyPI is tried first; the mirror is
 #                used as a fallback if the official source fails.
 #
@@ -40,20 +40,20 @@ for _arg in "$@"; do
     esac
 done
 
-_ALIYUN="https://mirrors.aliyun.com/pypi/simple/"
+_TENCENT="https://mirrors.cloud.tencent.com/pypi/simple/"
 _REQ_MARKER="venv/.studio-requirements.sha256"
 
 _pip_install() {
     # Usage: _pip_install [pip args...]
-    # Tries official PyPI first; falls back to Aliyun mirror on failure.
-    # With --mirror: goes straight to Aliyun mirror.
+    # Tries official PyPI first; falls back to Tencent mirror on failure.
+    # With --mirror: goes straight to Tencent mirror.
     if [ "$_USE_MIRROR" = "1" ]; then
-        echo "[studio] setup: using Aliyun mirror for pip"
-        "$PYTHON" -m pip install "$@" -i "$_ALIYUN"
+        echo "[studio] setup: using Tencent mirror for pip"
+        "$PYTHON" -m pip install "$@" -i "$_TENCENT"
     else
         "$PYTHON" -m pip install "$@" || {
-            echo "[studio] setup: pip failed, retrying via Aliyun mirror..."
-            "$PYTHON" -m pip install "$@" -i "$_ALIYUN"
+            echo "[studio] setup: pip failed, retrying via Tencent mirror..."
+            "$PYTHON" -m pip install "$@" -i "$_TENCENT"
         }
     fi
 }

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -53,7 +53,7 @@ def find_python() -> str:
 
 
 _NPM_MIRROR = "https://registry.npmmirror.com"
-_PIP_MIRROR = "https://mirrors.aliyun.com/pypi/simple/"
+_PIP_MIRROR = "https://mirrors.cloud.tencent.com/pypi/simple/"
 
 
 def _npm_call(npm: str, args: list[str], cwd: str, timeout: int = 180) -> int:

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -52,7 +52,7 @@ def find_python() -> str:
     return sys.executable
 
 
-_NPM_MIRROR = "https://registry.npmmirror.com"
+_NPM_MIRROR = "https://mirrors.cloud.tencent.com/npm/"
 _PIP_MIRROR = "https://mirrors.cloud.tencent.com/pypi/simple/"
 
 

--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -19,6 +19,7 @@ SENSITIVE_FIELDS: tuple[str, ...] = (
     "gelbooru.api_key",
     "danbooru.api_key",
     "huggingface.token",
+    "modelscope.token",
 )
 
 
@@ -49,6 +50,13 @@ class HuggingFaceConfig(BaseModel):
     # 我们 per-call 传，不依赖 HF_ENDPOINT env var（env var 只在模块 import 时读，
     # runtime 改设置无效）。
     endpoint: str = "https://hf-mirror.com"
+
+
+class ModelScopeConfig(BaseModel):
+    token: str = ""
+    # 魔搭社区（modelscope.cn）下载 token。公开模型不填也能下，私有 / 限速时需要。
+    # 使用前需 pip install modelscope；下载时会优先找 MODELSCOPE_REPO_MAP 里的对应仓库，
+    # 没有映射的模型自动回退 HuggingFace。
 
 
 class DownloadConfig(BaseModel):
@@ -165,6 +173,10 @@ class Secrets(BaseModel):
     danbooru: DanbooruConfig = Field(default_factory=DanbooruConfig)
     download: DownloadConfig = Field(default_factory=DownloadConfig)
     huggingface: HuggingFaceConfig = Field(default_factory=HuggingFaceConfig)
+    modelscope: ModelScopeConfig = Field(default_factory=ModelScopeConfig)
+    # 模型下载源。"huggingface"（默认）走 HF + endpoint 配置；
+    # "modelscope" 走魔搭社区，没有对应映射的模型自动回退 HF。
+    download_source: str = "huggingface"
     joycaption: JoyCaptionConfig = Field(default_factory=JoyCaptionConfig)
     wd14: WD14Config = Field(default_factory=WD14Config)
     cltagger: CLTaggerConfig = Field(default_factory=CLTaggerConfig)

--- a/studio/services/model_downloader.py
+++ b/studio/services/model_downloader.py
@@ -217,7 +217,19 @@ def default_paths_for_new_version() -> dict[str, str]:
 # 魔搭里 Anima repo 将主模型 / VAE / 文本编码器全部打包在 split_files/ 下，
 # 文本编码器是单个 safetensors（而不是 HF 上 Qwen3 的散文件目录）。
 MS_ANIMA_TEXT_ENCODER_PATH = "split_files/text_encoders/qwen_3_06b_base.safetensors"
-# T5 tokenizer / TAEFlux / WD14 / CLTagger 在魔搭暂无对应镜像，走 HF 回退。
+# T5 tokenizer / TAEFlux / CLTagger 在魔搭暂无对应镜像，走 HF 回退。
+# WD14：fireicewolf 在魔搭镜像了 SmilingWolf 系列，repo 命名规则为
+#   SmilingWolf/{name} → fireicewolf/{name}
+_MS_WD14_OWNER = "fireicewolf"
+_HF_WD14_OWNER = "SmilingWolf"
+
+
+def _ms_wd14_repo_id(hf_repo_id: str) -> Optional[str]:
+    """把 SmilingWolf/wd-xxx 换成 fireicewolf/wd-xxx；其它 repo 返回 None。"""
+    if hf_repo_id.startswith(_HF_WD14_OWNER + "/"):
+        name = hf_repo_id[len(_HF_WD14_OWNER) + 1:]
+        return f"{_MS_WD14_OWNER}/{name}"
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -484,12 +496,26 @@ def download_wd14(
     *,
     on_log: Callable[[str], None] = print,
 ) -> bool:
-    """下载 WD14 单个 model_id 的两个文件到 `{models_root}/wd14/{safe_id}/`。"""
+    """下载 WD14 单个 model_id 的两个文件到 `{models_root}/wd14/{safe_id}/`。
+
+    ModelScope 源：SmilingWolf/* → fireicewolf/*（fireicewolf 在魔搭镜像了全套）。
+    没有 MS 映射（非 SmilingWolf 前缀）时自动回退 HF。
+    """
     r = root or models_root()
     target = wd14_target_dir(r, model_id)
-    on_log(f"\n📥 WD14 {model_id} → {target}")
     target.mkdir(parents=True, exist_ok=True)
     ok = True
+    if _get_download_source() == "modelscope":
+        ms_repo = _ms_wd14_repo_id(model_id)
+        if ms_repo:
+            on_log(f"\n📥 WD14 {model_id} → {target}（via ModelScope: {ms_repo}）")
+            for f in WD14_FILES:
+                if not download_flat_ms(ms_repo, f, target / f, on_log=on_log):
+                    ok = False
+            return ok
+        on_log(f"\n📥 WD14 {model_id}：无魔搭映射，回退 HuggingFace")
+    else:
+        on_log(f"\n📥 WD14 {model_id} → {target}")
     for f in WD14_FILES:
         if not download_flat(model_id, f, target / f, on_log=on_log):
             ok = False

--- a/studio/services/model_downloader.py
+++ b/studio/services/model_downloader.py
@@ -438,23 +438,32 @@ def download_anima_vae(root: Path, *, on_log: Callable[[str], None] = print) -> 
 def download_qwen3(root: Path, *, on_log: Callable[[str], None] = print) -> bool:
     """下载文本编码器（Qwen3）。
 
-    - HuggingFace 源：从 Qwen/Qwen3-0.6B-Base 下载 6 个散文件到 text_encoders/ 目录。
-    - ModelScope 源：从 circlestone-labs/Anima 下载单文件
-      split_files/text_encoders/qwen_3_06b_base.safetensors，
-      落到 text_encoders/qwen_3_06b_base.safetensors。
-      （魔搭 Anima repo 已预先合并，无需单独拉 Qwen repo。）
+    - HuggingFace 源：从 Qwen/Qwen3-0.6B-Base 下载完整目录所需的 6 个文件。
+    - ModelScope 源：从 circlestone-labs/Anima 下载权重文件，另外从
+      Qwen/Qwen3-0.6B-Base 补齐 tokenizer / config 文件，确保本地
+      text_encoders/ 是 transformers 可直接加载的完整目录。
     """
     target_dir = qwen_dir(root)
-    if _get_download_source() == "modelscope":
-        on_log(f"\n📥 Anima 文本编码器（ModelScope 单文件）→ {target_dir}")
-        target_dir.mkdir(parents=True, exist_ok=True)
-        # 魔搭 Anima repo 里文件名是 qwen_3_06b_base.safetensors；
-        # 训练脚本按 HF 惯例找 model.safetensors，下载后重命名。
-        target = target_dir / "model.safetensors"
-        return download_flat_ms(ANIMA_REPO, MS_ANIMA_TEXT_ENCODER_PATH, target, on_log=on_log)
-    on_log(f"\n📥 Qwen3-0.6B-Base (~1.2 GB) → {target_dir}")
     target_dir.mkdir(parents=True, exist_ok=True)
     ok = True
+
+    if _get_download_source() == "modelscope":
+        on_log(f"\n📥 Anima 文本编码器（ModelScope 权重 + HF tokenizer）→ {target_dir}")
+        # 魔搭 Anima repo 里只有权重；训练脚本仍要求完整 transformers 目录。
+        ok &= download_flat_ms(
+            ANIMA_REPO,
+            MS_ANIMA_TEXT_ENCODER_PATH,
+            target_dir / "model.safetensors",
+            on_log=on_log,
+        )
+        for f in QWEN_FILES:
+            if f == "model.safetensors":
+                continue
+            if not download_flat(QWEN_REPO, f, target_dir / f, on_log=on_log):
+                ok = False
+        return ok
+
+    on_log(f"\n📥 Qwen3-0.6B-Base (~1.2 GB) → {target_dir}")
     for f in QWEN_FILES:
         if not download_flat(QWEN_REPO, f, target_dir / f, on_log=on_log):
             ok = False

--- a/studio/services/model_downloader.py
+++ b/studio/services/model_downloader.py
@@ -209,6 +209,18 @@ def default_paths_for_new_version() -> dict[str, str]:
 
 
 # ---------------------------------------------------------------------------
+# ModelScope 镜像源映射
+# ---------------------------------------------------------------------------
+
+# ModelScope 镜像路径常量。
+# circlestone-labs 同步在 HF 和魔搭发布，repo ID 一致；
+# 魔搭里 Anima repo 将主模型 / VAE / 文本编码器全部打包在 split_files/ 下，
+# 文本编码器是单个 safetensors（而不是 HF 上 Qwen3 的散文件目录）。
+MS_ANIMA_TEXT_ENCODER_PATH = "split_files/text_encoders/qwen_3_06b_base.safetensors"
+# T5 tokenizer / TAEFlux / WD14 / CLTagger 在魔搭暂无对应镜像，走 HF 回退。
+
+
+# ---------------------------------------------------------------------------
 # 同步下载 helper
 # ---------------------------------------------------------------------------
 
@@ -242,6 +254,92 @@ def _resolve_endpoint() -> Optional[str]:
     except Exception:  # noqa: BLE001  secrets 损坏不应阻断下载
         return None
     return endpoint or None
+
+
+def _get_download_source() -> str:
+    """返回当前配置的下载源（'huggingface' 或 'modelscope'）。
+
+    优先读 MODELSCOPE_SOURCE env var（CLI flag 用）；否则读 secrets。
+    """
+    env = os.environ.get("MODELSCOPE_SOURCE", "").strip()
+    if env:
+        return env
+    try:
+        return secrets.load().download_source or "huggingface"
+    except Exception:  # noqa: BLE001
+        return "huggingface"
+
+
+def _ms_token() -> Optional[str]:
+    """读 ModelScope token：环境变量优先，其次 secrets。"""
+    env = os.environ.get("MODELSCOPE_API_TOKEN", "").strip()
+    if env:
+        return env
+    try:
+        t = secrets.load().modelscope.token
+        return t or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def download_flat_ms(
+    ms_repo_id: str,
+    repo_subpath: str,
+    target: Path,
+    *,
+    on_log: Callable[[str], None] = print,
+) -> bool:
+    """用 modelscope Python API 下载单个文件到 target。
+
+    `model_file_download(local_dir=target.parent)` 会把文件落在
+    `target.parent / repo_subpath`（保留 repo 内路径结构），之后复用与
+    `download_flat` 完全相同的 rename + 清理空目录逻辑把文件移到 target。
+
+    需要 ``pip install modelscope``；未安装时返回 False 并打印提示。
+    token 优先读 MODELSCOPE_API_TOKEN env var，其次 secrets.modelscope.token。
+    """
+    if target.exists():
+        on_log(f"   ✓ {target.name} 已存在，跳过")
+        return True
+    try:
+        from modelscope.hub.file_download import model_file_download
+    except ImportError:
+        on_log("   ✗ 缺 modelscope（pip install modelscope）")
+        return False
+    target.parent.mkdir(parents=True, exist_ok=True)
+    token = _ms_token()
+    try:
+        kwargs: dict = dict(
+            model_id=ms_repo_id,
+            file_path=repo_subpath,
+            local_dir=str(target.parent),
+        )
+        if token:
+            kwargs["token"] = token
+        model_file_download(**kwargs)
+    except Exception as exc:
+        on_log(f"   ✗ {target.name} (ModelScope): {exc}")
+        return False
+    # model_file_download 保留 repo 内路径；与 download_flat 逻辑完全一致
+    src = target.parent / repo_subpath
+    if src != target:
+        try:
+            target.unlink(missing_ok=True)
+            src.rename(target)
+        except OSError as exc:
+            on_log(f"   ✗ rename 失败 {src} → {target}: {exc}")
+            return False
+        parent = src.parent
+        while parent != target.parent and parent.exists():
+            try:
+                if any(parent.iterdir()):
+                    break
+                parent.rmdir()
+            except OSError:
+                break
+            parent = parent.parent
+    on_log(f"   ✓ {target.name} (via ModelScope)")
+    return True
 
 
 def download_flat(
@@ -310,18 +408,38 @@ def download_anima_main(
         on_log(f"✗ 未知 variant {variant!r}")
         return False
     target = anima_main_target(root, variant)
+    subpath = ANIMA_VARIANTS[variant]
     on_log(f"\n📥 Anima 主模型 [{variant}] (~4 GB)")
-    return download_flat(ANIMA_REPO, ANIMA_VARIANTS[variant], target, on_log=on_log)
+    if _get_download_source() == "modelscope":
+        return download_flat_ms(ANIMA_REPO, subpath, target, on_log=on_log)
+    return download_flat(ANIMA_REPO, subpath, target, on_log=on_log)
 
 
 def download_anima_vae(root: Path, *, on_log: Callable[[str], None] = print) -> bool:
     target = anima_vae_target(root)
     on_log("\n📥 Anima VAE (~250 MB)")
+    if _get_download_source() == "modelscope":
+        return download_flat_ms(ANIMA_REPO, ANIMA_VAE_PATH, target, on_log=on_log)
     return download_flat(ANIMA_REPO, ANIMA_VAE_PATH, target, on_log=on_log)
 
 
 def download_qwen3(root: Path, *, on_log: Callable[[str], None] = print) -> bool:
+    """下载文本编码器（Qwen3）。
+
+    - HuggingFace 源：从 Qwen/Qwen3-0.6B-Base 下载 6 个散文件到 text_encoders/ 目录。
+    - ModelScope 源：从 circlestone-labs/Anima 下载单文件
+      split_files/text_encoders/qwen_3_06b_base.safetensors，
+      落到 text_encoders/qwen_3_06b_base.safetensors。
+      （魔搭 Anima repo 已预先合并，无需单独拉 Qwen repo。）
+    """
     target_dir = qwen_dir(root)
+    if _get_download_source() == "modelscope":
+        on_log(f"\n📥 Anima 文本编码器（ModelScope 单文件）→ {target_dir}")
+        target_dir.mkdir(parents=True, exist_ok=True)
+        # 魔搭 Anima repo 里文件名是 qwen_3_06b_base.safetensors；
+        # 训练脚本按 HF 惯例找 model.safetensors，下载后重命名。
+        target = target_dir / "model.safetensors"
+        return download_flat_ms(ANIMA_REPO, MS_ANIMA_TEXT_ENCODER_PATH, target, on_log=on_log)
     on_log(f"\n📥 Qwen3-0.6B-Base (~1.2 GB) → {target_dir}")
     target_dir.mkdir(parents=True, exist_ok=True)
     ok = True

--- a/studio/services/onnxruntime_setup.py
+++ b/studio/services/onnxruntime_setup.py
@@ -322,9 +322,17 @@ def current_runtime() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _pip(args: list[str]) -> tuple[int, str]:
-    """跑 `<sys.executable> -m pip <args>`；返回 (rc, combined_output)。"""
+_PIP_FALLBACK_MIRROR = "https://mirrors.cloud.tencent.com/pypi/simple/"
+
+
+def _pip(args: list[str], *, mirror: str = "") -> tuple[int, str]:
+    """跑 `<sys.executable> -m pip <args>`；返回 (rc, combined_output)。
+
+    mirror 非空时追加 `-i {mirror}`（用于镜像 fallback 重试）。
+    """
     cmd = [sys.executable, "-m", "pip", *args]
+    if mirror:
+        cmd += ["-i", mirror]
     logger.info("[onnx_setup] %s", " ".join(cmd))
     try:
         out = subprocess.run(
@@ -407,6 +415,9 @@ def _install_cuda_runtime_wheels() -> dict[str, Any]:
         }
     rc, out = _pip(["install", *targets])
     if rc != 0:
+        logger.warning("[onnx_setup] CUDA wheels pip 官方源失败，切换腾讯镜像重试...")
+        rc, out = _pip(["install", *targets], mirror=_PIP_FALLBACK_MIRROR)
+    if rc != 0:
         # 回滚：把本次想装的从 venv 里再卸掉，保持装包前的状态
         # （pip install 失败时部分包可能已装；不区分，统一卸）
         rb_rc, rb_out = _pip(["uninstall", "-y", *targets])
@@ -437,6 +448,9 @@ def install_runtime(target: str = "auto") -> dict[str, Any]:
     spec = _decide_target(target)
     rc1, log1 = _pip(["uninstall", "-y", GPU_PACKAGE, CPU_PACKAGE])
     rc2, log2 = _pip(["install", "--upgrade", spec])
+    if rc2 != 0:
+        logger.warning("[onnx_setup] pip 官方源失败，切换腾讯镜像重试...")
+        rc2, log2 = _pip(["install", "--upgrade", spec], mirror=_PIP_FALLBACK_MIRROR)
     if rc2 != 0:
         raise RuntimeError(f"安装 {spec} 失败（rc={rc2}）:\n{log2}")
 

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -82,6 +82,11 @@ export interface HuggingFaceConfig {
   endpoint: string
 }
 
+export interface ModelScopeConfig {
+  /** 魔搭社区 token。公开模型可不填；私有 / 限速时需要。 */
+  token: string
+}
+
 export interface JoyCaptionConfig {
   base_url: string
   model: string
@@ -253,6 +258,10 @@ export interface Secrets {
   danbooru: DanbooruConfig
   download: DownloadGlobalConfig
   huggingface: HuggingFaceConfig
+  modelscope: ModelScopeConfig
+  /** 模型下载源：'huggingface'（默认）或 'modelscope'。
+   *  选 modelscope 时，有映射的模型走魔搭 CLI 下载；无映射的自动回退 HF。 */
+  download_source: string
   joycaption: JoyCaptionConfig
   wd14: WD14Config
   cltagger: CLTaggerConfig

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -25,6 +25,7 @@ type Section =
   | 'danbooru'
   | 'download'
   | 'huggingface'
+  | 'modelscope'
   | 'joycaption'
   | 'wd14'
   | 'cltagger'
@@ -70,6 +71,8 @@ const EMPTY: Secrets = {
     cdn_rate_per_sec: 5,
   },
   huggingface: { token: '', endpoint: 'https://hf-mirror.com' },
+  modelscope: { token: '' },
+  download_source: 'huggingface',
   joycaption: {
     base_url: 'http://localhost:8000/v1',
     model: 'fancyfeast/llama-joycaption-beta-one-hf-llava',
@@ -179,6 +182,11 @@ export default function SettingsPage() {
       ...prev,
       [section]: { ...prev[section], [key]: value },
     }))
+  }
+
+  /** 更新 Secrets 顶层非对象字段（如 download_source）。 */
+  const updateTop = <K extends keyof Secrets>(key: K, value: Secrets[K]) => {
+    setDraft((prev) => ({ ...prev, [key]: value }))
   }
 
   const save = async () => {
@@ -492,6 +500,15 @@ export default function SettingsPage() {
       </>)}
 
       {tab === 'training' && (<>
+      <SettingsSection title="模型下载源">
+        <SettingsField label="下载源" desc="魔搭（ModelScope）对国内用户更快；无映射的模型自动回退 HuggingFace">
+          <DownloadSourceSelect
+            value={draft.download_source}
+            onChange={(v) => updateTop('download_source', v)}
+          />
+        </SettingsField>
+      </SettingsSection>
+
       <SettingsSection title="HuggingFace">
         <SettingsField label="token">
           <SensitiveInput
@@ -510,6 +527,19 @@ export default function SettingsPage() {
             onChange={(v) => update('huggingface', 'endpoint', v)}
           />
         </SettingsField>
+      </SettingsSection>
+
+      <SettingsSection title="ModelScope（魔搭社区）">
+        <SettingsField label="token">
+          <SensitiveInput
+            value={draft.modelscope.token}
+            serverValue={server?.modelscope.token ?? ''}
+            onChange={(v) => update('modelscope', 'token', v)}
+          />
+        </SettingsField>
+        <p className="text-xs text-fg-tertiary px-1">
+          公开模型不用填；私有仓库或限速时需要。需先 <code>pip install modelscope</code> 安装命令行工具。
+        </p>
       </SettingsSection>
 
       <SettingsSection title="队列调度">
@@ -660,6 +690,23 @@ function HFEndpointSelect({ value, onChange }: {
         />
       )}
     </div>
+  )
+}
+
+// ── DownloadSourceSelect ────────────────────────────────────────────────────
+
+function DownloadSourceSelect({ value, onChange }: {
+  value: string; onChange: (v: string) => void
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className={`${textInputClass} max-w-xs`}
+    >
+      <option value="huggingface">HuggingFace（含 hf-mirror 等镜像）</option>
+      <option value="modelscope">ModelScope（魔搭社区，国内直连）</option>
+    </select>
   )
 }
 
@@ -858,9 +905,16 @@ function CLTaggerModelCard({
   )
 }
 
+// 顶层非 object 字段（string / number / bool），直接比较后塞入 patch。
+const TOP_LEVEL_SCALARS: (keyof Secrets)[] = ['download_source']
+
 function buildPatch(draft: Secrets, server: Secrets): SecretsPatch {
-  const out: Record<string, Record<string, unknown>> = {}
-  for (const key of Object.keys(draft) as Section[]) {
+  const out: Record<string, unknown> = {}
+  for (const key of Object.keys(draft) as (keyof Secrets)[]) {
+    if (TOP_LEVEL_SCALARS.includes(key)) {
+      if (draft[key] !== server[key]) out[key] = draft[key]
+      continue
+    }
     const sub: Record<string, unknown> = {}
     const d = draft[key] as unknown as Record<string, unknown>
     const s = server[key] as unknown as Record<string, unknown>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -1777,7 +1777,7 @@ function TaeFluxSection({
   draft, update,
 }: {
   draft: Secrets
-  update: <S extends keyof Secrets, K extends keyof Secrets[S]>(
+  update: <S extends Section, K extends keyof Secrets[S]>(
     section: S, key: K, value: Secrets[S][K],
   ) => void
 }) {

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -268,3 +268,47 @@ def test_download_flat_ms_rename_and_cleanup(
     assert target.read_bytes() == b"weights"
     # 中间目录应已被清理
     assert not (tmp_path / "split_files").exists()
+
+
+def test_download_qwen3_modelscope_builds_complete_directory(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """ModelScope 源下载权重后，仍会从 HF 补齐 tokenizer/config 文件，
+    使 text_encoders/ 成为 transformers 可直接加载的完整目录。"""
+    monkeypatch.setattr(model_downloader, "_get_download_source", lambda: "modelscope")
+
+    ms_calls: list[tuple[str, str, str]] = []
+    hf_calls: list[tuple[str, str, str]] = []
+
+    def fake_download_flat_ms(repo_id, repo_subpath, target, *, on_log=print):
+        ms_calls.append((repo_id, repo_subpath, str(target)))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"ms-weights")
+        return True
+
+    def fake_download_flat(repo_id, repo_subpath, target, *, on_log=print):
+        hf_calls.append((repo_id, repo_subpath, str(target)))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(repo_subpath, encoding="utf-8")
+        return True
+
+    monkeypatch.setattr(model_downloader, "download_flat_ms", fake_download_flat_ms)
+    monkeypatch.setattr(model_downloader, "download_flat", fake_download_flat)
+
+    logs: list[str] = []
+    ok = model_downloader.download_qwen3(tmp_path, on_log=logs.append)
+
+    assert ok, logs
+    qwen_dir = tmp_path / "text_encoders"
+    assert (qwen_dir / "model.safetensors").read_bytes() == b"ms-weights"
+
+    assert ms_calls == [(
+        model_downloader.ANIMA_REPO,
+        model_downloader.MS_ANIMA_TEXT_ENCODER_PATH,
+        str(qwen_dir / "model.safetensors"),
+    )]
+
+    expected_hf_files = [f for f in model_downloader.QWEN_FILES if f != "model.safetensors"]
+    assert [repo_subpath for _, repo_subpath, _ in hf_calls] == expected_hf_files
+    for f in expected_hf_files:
+        assert (qwen_dir / f).read_text(encoding="utf-8") == f

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -1,5 +1,6 @@
 """PR-6 — model_downloader._on_log per-line print。
 PR-S3 — _resolve_endpoint env > secrets > None 优先级。
+MS-1  — _get_download_source / download_flat_ms rename+cleanup 逻辑。
 """
 from __future__ import annotations
 
@@ -179,3 +180,91 @@ def test_on_log_does_not_hold_lock_during_print(
 
     can_finish_print.set()
     _wait_done("test-lock")
+
+
+# ---------------------------------------------------------------------------
+# MS-1 — ModelScope 下载源选择 + download_flat_ms rename/cleanup 逻辑
+# ---------------------------------------------------------------------------
+
+
+def test_get_download_source_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """MODELSCOPE_SOURCE 环境变量优先于 secrets。"""
+    monkeypatch.setenv("MODELSCOPE_SOURCE", "modelscope")
+    from studio import secrets
+
+    monkeypatch.setattr(
+        secrets, "load",
+        lambda: secrets.Secrets(download_source="huggingface"),
+    )
+    assert model_downloader._get_download_source() == "modelscope"
+
+
+def test_get_download_source_falls_back_to_secrets(monkeypatch: pytest.MonkeyPatch) -> None:
+    """无 env 时读 secrets.download_source。"""
+    monkeypatch.delenv("MODELSCOPE_SOURCE", raising=False)
+    from studio import secrets
+
+    monkeypatch.setattr(
+        secrets, "load",
+        lambda: secrets.Secrets(download_source="modelscope"),
+    )
+    assert model_downloader._get_download_source() == "modelscope"
+
+
+def test_get_download_source_default_huggingface(monkeypatch: pytest.MonkeyPatch) -> None:
+    """secrets 空串时回退 'huggingface'。"""
+    monkeypatch.delenv("MODELSCOPE_SOURCE", raising=False)
+    from studio import secrets
+
+    monkeypatch.setattr(
+        secrets, "load",
+        lambda: secrets.Secrets(download_source=""),
+    )
+    assert model_downloader._get_download_source() == "huggingface"
+
+
+def test_download_flat_ms_skips_existing(tmp_path: "Path") -> None:
+    """target 已存在时跳过，不调 modelscope API。"""
+    target = tmp_path / "model.safetensors"
+    target.write_bytes(b"dummy")
+
+    logs: list[str] = []
+    ok = model_downloader.download_flat_ms(
+        "some/repo", "split_files/foo.safetensors", target, on_log=logs.append
+    )
+    assert ok
+    assert any("已存在" in l for l in logs)
+
+
+def test_download_flat_ms_rename_and_cleanup(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """download_flat_ms 把 model_file_download 落盘的深路径文件移到 target，
+    并清理掉空的中间目录。"""
+    target = tmp_path / "model.safetensors"
+    repo_subpath = "split_files/text_encoders/qwen_3_06b_base.safetensors"
+
+    def fake_download(model_id, file_path, local_dir, **kwargs):
+        # 模拟 modelscope 在 local_dir/repo_subpath 落盘
+        dest = tmp_path / file_path
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(b"weights")
+
+    import types
+    fake_mod = types.ModuleType("modelscope.hub.file_download")
+    fake_mod.model_file_download = fake_download  # type: ignore[attr-defined]
+
+    import sys
+    monkeypatch.setitem(sys.modules, "modelscope", types.ModuleType("modelscope"))
+    monkeypatch.setitem(sys.modules, "modelscope.hub", types.ModuleType("modelscope.hub"))
+    monkeypatch.setitem(sys.modules, "modelscope.hub.file_download", fake_mod)
+
+    logs: list[str] = []
+    ok = model_downloader.download_flat_ms(
+        "circlestone-labs/Anima", repo_subpath, target, on_log=logs.append
+    )
+    assert ok, logs
+    assert target.exists()
+    assert target.read_bytes() == b"weights"
+    # 中间目录应已被清理
+    assert not (tmp_path / "split_files").exists()

--- a/tools/download_models.py
+++ b/tools/download_models.py
@@ -56,6 +56,7 @@ Anima 主模型版本（--variant）:
 下载源：默认从 secrets.huggingface.endpoint 读（首装是 hf-mirror.com）。
   - --no-mirror     用 HuggingFace 官方源（覆盖 secrets）
   - --endpoint URL  自定义 endpoint URL（覆盖 secrets 和 --no-mirror）
+  - --modelscope    走魔搭社区下载（需 pip install modelscope）
 """,
     )
     parser.add_argument(
@@ -65,6 +66,10 @@ Anima 主模型版本（--variant）:
     parser.add_argument(
         "--endpoint", default=None,
         help="自定义 HF endpoint URL（覆盖 secrets 配置 + --no-mirror）",
+    )
+    parser.add_argument(
+        "--modelscope", action="store_true",
+        help="走魔搭社区（ModelScope）下载；无映射的模型自动回退 HF",
     )
     parser.add_argument(
         "--output", default="",
@@ -81,17 +86,19 @@ Anima 主模型版本（--variant）:
     parser.add_argument("--skip-t5",   action="store_true")
     args = parser.parse_args()
 
-    # CLI 显式 flag 覆盖 secrets：--endpoint 最强；--no-mirror 设 HF 官方；都没传 → secrets。
     import os  # noqa: PLC0415
-    if args.endpoint:
-        os.environ["HF_ENDPOINT"] = args.endpoint
-    elif args.no_mirror:
-        os.environ["HF_ENDPOINT"] = "https://huggingface.co"
-    # 不传 → 让 _resolve_endpoint 读 secrets（默认 hf-mirror.com）
-
-    from studio.services.model_downloader import _resolve_endpoint  # noqa: PLC0415
-    active = _resolve_endpoint() or "https://huggingface.co (HF 默认)"
-    print(f"使用 endpoint: {active}")
+    if args.modelscope:
+        os.environ["MODELSCOPE_SOURCE"] = "modelscope"
+        print("使用下载源: ModelScope（无映射模型自动回退 HF）")
+    else:
+        # CLI 显式 flag 覆盖 secrets：--endpoint 最强；--no-mirror 设 HF 官方；都没传 → secrets。
+        if args.endpoint:
+            os.environ["HF_ENDPOINT"] = args.endpoint
+        elif args.no_mirror:
+            os.environ["HF_ENDPOINT"] = "https://huggingface.co"
+        from studio.services.model_downloader import _resolve_endpoint  # noqa: PLC0415
+        active = _resolve_endpoint() or "https://huggingface.co (HF 默认)"
+        print(f"使用下载源: HuggingFace  endpoint: {active}")
 
     out_root = Path(args.output) if args.output else models_root()
     print(f"📁 目标根目录: {out_root.absolute()}")


### PR DESCRIPTION
## Summary

Adds ModelScope (魔搭社区) as an optional download source for Anima model weights and WD14 taggers, and switches pip/npm fallback mirrors from Alibaba/npmmirror to Tencent Cloud for consistency.

### ModelScope mirror source (`cf136f3`)
- `secrets.py`: new `ModelScopeConfig` (token) and top-level `download_source` field (default: `huggingface`)
- `model_downloader.py`:
  - `_get_download_source()`: priority — env `MODELSCOPE_SOURCE` → secrets → `"huggingface"`
  - `_ms_token()`: env `MODELSCOPE_API_TOKEN` → secrets
  - `download_flat_ms()`: ModelScope Python API download with same rename/cleanup logic as HF
  - `download_anima_main`, `download_anima_vae`, `download_qwen3`: route to ModelScope when selected
- `Settings.tsx`: `DownloadSourceSelect` component (huggingface / modelscope toggle) + ModelScope token section
- `tools/download_models.py`: `--modelscope` flag sets `MODELSCOPE_SOURCE` env
- 5 new tests covering source priority and `download_flat_ms` rename/cleanup behavior

### WD14 ModelScope support + pip mirror (`eb9b2c2`)
- `model_downloader.py`: `_ms_wd14_repo_id()` maps `SmilingWolf/*` → `fireicewolf/*` (full WD14 mirror on ModelScope); auto-falls back to HF if no mapping
- `onnxruntime_setup.py`: Tencent PyPI mirror as pip fallback; retry on install failure
- `studio.sh` / `studio.bat` / `cli.py`: pip fallback mirror → `mirrors.cloud.tencent.com/pypi/simple/`

### npm mirror (`ac8ce0c`)
- `cli.py`: npm fallback → `mirrors.cloud.tencent.com/npm/` (consistent with pip mirror)

## Test plan
- [ ] Set `download_source: modelscope` in secrets / UI and verify Anima weights download via ModelScope API
- [ ] Verify WD14 download routes to `fireicewolf/*` on ModelScope and falls back to HF for unmapped models
- [ ] Verify pip install failure retries with Tencent mirror
- [x] Run `pytest tests/test_model_downloader.py` — all 5 new cases should pass
- [ ] Default behavior (`download_source: huggingface`) unchanged