### PR TITLE
Improve curation preview workflow

### DIFF
--- a/studio/web/src/components/ImageGrid.test.tsx
+++ b/studio/web/src/components/ImageGrid.test.tsx
@@ -80,6 +80,45 @@ describe('ImageGrid (PP3)', () => {
     )
   })
 
+  it('activate mode uses plain cell click for activation', async () => {
+    const onSelect = vi.fn()
+    const onActivate = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ImageGrid
+        items={items}
+        selected={new Set()}
+        onSelect={onSelect}
+        onActivate={onActivate}
+        clickMode="activate"
+      />
+    )
+    await user.click(screen.getAllByRole('gridcell')[0])
+    expect(onActivate).toHaveBeenCalledWith('a.png')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('activate mode keeps checkbox selection separate', async () => {
+    const onSelect = vi.fn()
+    const onActivate = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ImageGrid
+        items={items}
+        selected={new Set()}
+        onSelect={onSelect}
+        onActivate={onActivate}
+        clickMode="activate"
+      />
+    )
+    await user.click(screen.getByRole('button', { name: '选择 a.png' }))
+    expect(onSelect).toHaveBeenCalledWith(
+      'a.png',
+      expect.objectContaining({ shiftKey: false })
+    )
+    expect(onActivate).not.toHaveBeenCalled()
+  })
+
   it('shows empty hint', () => {
     render(
       <ImageGrid items={[]} selected={new Set()} onSelect={() => {}} emptyHint="空空" />

--- a/studio/web/src/components/ImageGrid.tsx
+++ b/studio/web/src/components/ImageGrid.tsx
@@ -16,6 +16,9 @@ interface Props {
   onHover?: (name: string) => void
   /** 全屏 modal 预览，由 cell 上的放大镜按钮触发（可选）。 */
   onPreview?: (name: string) => void
+  /** 主点击行为：默认选择；activate 模式下普通点击交给外部打开/激活。 */
+  onActivate?: (name: string) => void
+  clickMode?: 'select' | 'activate'
   /** 渲染上限；超出在末尾显示「显示前 N 张」。 */
   limit?: number
   emptyHint?: string
@@ -44,6 +47,8 @@ export default function ImageGrid({
   onSelect,
   onHover,
   onPreview,
+  onActivate,
+  clickMode = 'select',
   limit = 500,
   emptyHint = '没有图片',
   ariaLabel,
@@ -77,6 +82,8 @@ export default function ImageGrid({
             onSelect={onSelect}
             onHover={onHover}
             onPreview={onPreview}
+            onActivate={onActivate}
+            clickMode={clickMode}
           />
         )
       })}
@@ -103,6 +110,8 @@ const Cell = memo(function Cell({
   onSelect,
   onHover,
   onPreview,
+  onActivate,
+  clickMode,
 }: {
   item: ImageGridItem
   selected: boolean
@@ -110,13 +119,28 @@ const Cell = memo(function Cell({
   onSelect: (name: string, e: React.MouseEvent) => void
   onHover?: (name: string) => void
   onPreview?: (name: string) => void
+  onActivate?: (name: string) => void
+  clickMode: 'select' | 'activate'
 }) {
+  const handleCellClick = (e: React.MouseEvent) => {
+    if (clickMode === 'activate' && onActivate && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
+      onActivate(item.name)
+      return
+    }
+    onSelect(item.name, e)
+  }
+
+  const handleSelectionClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onSelect(item.name, e)
+  }
+
   return (
     <div
       role="gridcell"
       aria-selected={selected}
       onMouseEnter={onHover ? () => onHover(item.name) : undefined}
-      onClick={(e) => onSelect(item.name, e)}
+      onClick={handleCellClick}
       title={item.meta ? `${item.name}\n${item.meta}` : item.name}
       className={
         'group relative aspect-square overflow-hidden rounded border cursor-pointer select-none ' +
@@ -134,9 +158,10 @@ const Cell = memo(function Cell({
         draggable={false}
         className="w-full h-full object-cover pointer-events-none"
       />
-      {/* checkbox 视觉指示：选中显示实心 ✓，未选中悬停时显示空框 */}
-      <span
-        aria-hidden
+      <button
+        type="button"
+        onClick={handleSelectionClick}
+        aria-label={`${selected ? '取消选择' : '选择'} ${item.name}`}
         className={
           'absolute top-1 left-1 w-5 h-5 rounded-sm flex items-center justify-center text-[12px] font-bold transition-opacity ' +
           (selected
@@ -145,7 +170,7 @@ const Cell = memo(function Cell({
         }
       >
         ✓
-      </span>
+      </button>
       {/* 放大镜：悬停时出现，点击触发 modal 全屏预览（不影响选择状态） */}
       {onPreview && (
         <button

--- a/studio/web/src/components/ImagePreviewModal.tsx
+++ b/studio/web/src/components/ImagePreviewModal.tsx
@@ -8,6 +8,9 @@ interface Props {
   onClose: () => void
   onPrev?: () => void
   onNext?: () => void
+  onAccept?: () => void
+  onDelete?: () => void
+  shortcutHint?: string
 }
 
 export default function ImagePreviewModal({
@@ -18,64 +21,85 @@ export default function ImagePreviewModal({
   onClose,
   onPrev,
   onNext,
+  onAccept,
+  onDelete,
+  shortcutHint,
 }: Props) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-      else if (e.key === 'ArrowLeft' && hasPrev && onPrev) onPrev()
-      else if (e.key === 'ArrowRight' && hasNext && onNext) onNext()
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      } else if (e.key === 'ArrowLeft' && hasPrev && onPrev) {
+        e.preventDefault()
+        onPrev()
+      } else if (e.key === 'ArrowRight' && hasNext && onNext) {
+        e.preventDefault()
+        onNext()
+      } else if ((e.key === 'Enter' || e.key === ' ') && onAccept) {
+        e.preventDefault()
+        onAccept()
+      } else if ((e.key === 'Delete' || e.key === 'Backspace') && onDelete) {
+        e.preventDefault()
+        onDelete()
+      }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [hasPrev, hasNext, onPrev, onNext, onClose])
+  }, [hasPrev, hasNext, onPrev, onNext, onClose, onAccept, onDelete])
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/85 flex flex-col items-center justify-center"
+      className="fixed inset-0 z-50 bg-black flex flex-col"
       onClick={onClose}
     >
-      <button
-        onClick={(e) => {
-          e.stopPropagation()
-          onClose()
-        }}
-        className="absolute top-3 right-4 text-slate-300 hover:text-white text-2xl"
-        aria-label="关闭"
-      >
-        ×
-      </button>
-      {hasPrev && onPrev && (
+      <div className="relative flex-1 min-h-0 flex items-center justify-center p-4 sm:p-6">
         <button
           onClick={(e) => {
             e.stopPropagation()
-            onPrev()
+            onClose()
           }}
-          className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 hover:text-white text-3xl px-3 py-2 bg-black/30 rounded"
-          aria-label="上一张"
+          className="absolute top-3 right-4 z-10 rounded bg-black/50 px-3 py-1 text-slate-300 hover:text-white text-2xl"
+          aria-label="关闭"
         >
-          ‹
+          ×
         </button>
-      )}
-      {hasNext && onNext && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onNext()
-          }}
-          className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-300 hover:text-white text-3xl px-3 py-2 bg-black/30 rounded"
-          aria-label="下一张"
-        >
-          ›
-        </button>
-      )}
-      <img
-        src={src}
-        alt={caption ?? 'preview'}
-        onClick={(e) => e.stopPropagation()}
-        className="max-w-[95vw] max-h-[88vh] object-contain"
-      />
-      {caption && (
-        <div className="mt-2 text-xs text-slate-400 font-mono">{caption}</div>
+        {hasPrev && onPrev && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onPrev()
+            }}
+            className="absolute left-4 top-1/2 z-10 -translate-y-1/2 text-slate-300 hover:text-white text-5xl px-4 py-3 bg-black/30 rounded"
+            aria-label="上一张"
+          >
+            ‹
+          </button>
+        )}
+        {hasNext && onNext && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onNext()
+            }}
+            className="absolute right-4 top-1/2 z-10 -translate-y-1/2 text-slate-300 hover:text-white text-5xl px-4 py-3 bg-black/30 rounded"
+            aria-label="下一张"
+          >
+            ›
+          </button>
+        )}
+        <img
+          src={src}
+          alt={caption ?? 'preview'}
+          onClick={(e) => e.stopPropagation()}
+          className="max-w-full max-h-full object-contain"
+        />
+      </div>
+      {(caption || shortcutHint) && (
+        <div className="shrink-0 border-t border-white/10 bg-black px-4 py-2 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-slate-400">
+          {caption && <div className="font-mono text-slate-300">{caption}</div>}
+          {shortcutHint && <div>{shortcutHint}</div>}
+        </div>
       )}
     </div>
   )

--- a/studio/web/src/pages/project/steps/Curation.tsx
+++ b/studio/web/src/pages/project/steps/Curation.tsx
@@ -91,6 +91,9 @@ interface Ctx {
 }
 
 interface Preview {
+  side: 'left' | 'right'
+  name: string
+  folder?: string
   url: string
   caption: string
   list: string[]
@@ -330,15 +333,23 @@ export default function CurationPage() {
   }
 
   // ---------- copy / remove / folder ops ----------
-  const doCopy = async () => {
-    if (!rightFolder) return toast('请先在右侧 Train 选一个文件夹', 'error')
-    if (!FOLDER_PATTERN.test(rightFolder))
-      return toast('文件夹名非法', 'error')
-    if (leftSel.size === 0) return
+  const copyLeftFiles = async (
+    files: string[],
+    options: { clearSelection?: boolean } = {}
+  ) => {
+    if (!rightFolder) {
+      toast('请先在右侧 Train 选一个文件夹', 'error')
+      return false
+    }
+    if (!FOLDER_PATTERN.test(rightFolder)) {
+      toast('文件夹名非法', 'error')
+      return false
+    }
+    if (files.length === 0 || busy) return false
     setBusy(true)
     try {
       const r = await api.copyToTrain(project.id, activeVersion.id, {
-        files: Array.from(leftSel),
+        files,
         dest_folder: rightFolder,
       })
       toast(
@@ -347,34 +358,55 @@ export default function CurationPage() {
         }`,
         'success'
       )
-      setLeftSel(new Set())
+      if (options.clearSelection) setLeftSel(new Set())
       await refresh()
       await reload()
+      return true
     } catch (e) {
       toast(String(e), 'error')
+      return false
     } finally {
       setBusy(false)
     }
   }
 
-  const doRemove = async () => {
-    if (!rightFolder || rightSel.size === 0) return
-    if (!confirm(`从 ${rightFolder}/ 移除 ${rightSel.size} 张?`)) return
+  const removeRightFiles = async (
+    folder: string,
+    files: string[],
+    options: { clearSelection?: boolean; confirm?: boolean } = {}
+  ) => {
+    if (!folder || files.length === 0 || busy) return false
+    if (options.confirm && !confirm(`从 ${folder}/ 移除 ${files.length} 张?`)) {
+      return false
+    }
     setBusy(true)
     try {
       const r = await api.removeFromTrain(project.id, activeVersion.id, {
-        folder: rightFolder,
-        files: Array.from(rightSel),
+        folder,
+        files,
       })
       toast(`已移除 ${r.removed.length} 张`, 'success')
-      setRightSel(new Set())
+      if (options.clearSelection) setRightSel(new Set())
       await refresh()
       await reload()
+      return true
     } catch (e) {
       toast(String(e), 'error')
+      return false
     } finally {
       setBusy(false)
     }
+  }
+
+  const doCopy = async () => {
+    await copyLeftFiles(Array.from(leftSel), { clearSelection: true })
+  }
+
+  const doRemove = async () => {
+    await removeRightFiles(rightFolder, Array.from(rightSel), {
+      clearSelection: true,
+      confirm: true,
+    })
   }
 
   const doCreateFolder = async () => {
@@ -456,28 +488,35 @@ export default function CurationPage() {
   // ---------- modal preview ----------
   const openLeftPreview = (name: string) => {
     setPreview({
-      url: api.projectThumbUrl(project.id, name),
+      side: 'left',
+      name,
+      url: api.projectThumbUrl(project.id, name, 'download', 1600),
       caption: name,
       list: leftSortedNames,
       index: leftSortedNames.indexOf(name),
-      resolve: (n) => api.projectThumbUrl(project.id, n),
+      resolve: (n) => api.projectThumbUrl(project.id, n, 'download', 1600),
     })
   }
   const openRightPreview = (name: string) => {
     if (versionId == null) return
+    const folder = rightFolder
     setPreview({
+      side: 'right',
+      name,
+      folder,
       url: api.versionThumbUrl(
         project.id,
         versionId,
         'train',
         name,
-        rightFolder
+        folder,
+        1600
       ),
-      caption: `${rightFolder}/${name}`,
+      caption: `${folder}/${name}`,
       list: rightSortedNames,
       index: rightSortedNames.indexOf(name),
       resolve: (n) =>
-        api.versionThumbUrl(project.id, versionId, 'train', n, rightFolder),
+        api.versionThumbUrl(project.id, versionId, 'train', n, folder, 1600),
     })
   }
   const stepPreview = (delta: number) => {
@@ -487,10 +526,43 @@ export default function CurationPage() {
     const name = preview.list[idx]
     setPreview({
       ...preview,
+      name,
       url: preview.resolve(name),
-      caption: name,
+      caption: preview.side === 'right' && preview.folder ? `${preview.folder}/${name}` : name,
       index: idx,
     })
+  }
+
+  const advancePreviewAfterAction = (doneName: string) => {
+    if (!preview) return
+    const list = preview.list.filter((name) => name !== doneName)
+    if (list.length === 0) {
+      setPreview(null)
+      return
+    }
+    const index = Math.min(preview.index, list.length - 1)
+    const name = list[index]
+    setPreview({
+      ...preview,
+      name,
+      url: preview.resolve(name),
+      caption: preview.side === 'right' && preview.folder ? `${preview.folder}/${name}` : name,
+      list,
+      index,
+    })
+  }
+
+  const copyPreviewImage = async () => {
+    if (!preview || preview.side !== 'left' || busy) return
+    const name = preview.name
+    if (await copyLeftFiles([name])) advancePreviewAfterAction(name)
+  }
+
+  const removePreviewImage = async () => {
+    if (!preview || preview.side !== 'right' || !preview.folder || busy) return
+    const folder = preview.folder
+    const name = preview.name
+    if (await removeRightFiles(folder, [name])) advancePreviewAfterAction(name)
   }
 
   return (
@@ -554,9 +626,12 @@ export default function CurationPage() {
             <ImageGrid
               items={leftItems}
               selected={leftSel}
+              activeName={preview?.side === 'left' ? preview.name : undefined}
               onSelect={handleLeftClick}
               onHover={onLeftHover}
               onPreview={openLeftPreview}
+              onActivate={openLeftPreview}
+              clickMode="activate"
               ariaLabel="download-grid"
               emptyHint="download/ 已经全部用完，或还没下载"
             />
@@ -648,9 +723,12 @@ export default function CurationPage() {
             <ImageGrid
               items={rightItems}
               selected={rightSel}
+              activeName={preview?.side === 'right' ? preview.name : undefined}
               onSelect={handleRightClick}
               onHover={onRightHover}
               onPreview={openRightPreview}
+              onActivate={openRightPreview}
+              clickMode="activate"
               ariaLabel="train-grid"
               emptyHint={
                 rightFolder
@@ -675,6 +753,13 @@ export default function CurationPage() {
           onClose={() => setPreview(null)}
           onPrev={() => stepPreview(-1)}
           onNext={() => stepPreview(1)}
+          onAccept={preview.side === 'left' ? copyPreviewImage : undefined}
+          onDelete={preview.side === 'right' ? removePreviewImage : undefined}
+          shortcutHint={
+            preview.side === 'left'
+              ? '←/→ 浏览 · Enter/Space 复制到 Train'
+              : '←/→ 浏览 · Delete/Backspace 从 Train 移除'
+          }
         />
       )}
     </div>

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useOutletContext } from 'react-router-dom'
 import {
   api,
+  downloadBlob,
   type CommitItem,
   type ProjectDetail,
   type Version,
@@ -49,6 +50,7 @@ export default function TagEditPage() {
   const [sel, setSel] = useState<Set<string>>(new Set())
   const [anchor, setAnchor] = useState<string | null>(null)
   const [filterTag, setFilterTag] = useState<string>('')
+  const [exporting, setExporting] = useState(false)
 
   const reloadCache = useCallback(async () => {
     if (versionId == null) return
@@ -199,6 +201,22 @@ export default function TagEditPage() {
 
   const onAfterRestore = async () => { await reloadCache(); await reload() }
 
+  const exportForCnb = async () => {
+    if (dirty) {
+      toast('先保存标签，再导出给 CNB', 'error')
+      return
+    }
+    setExporting(true)
+    try {
+      const filename = `${project.slug}-${activeVersion.label}.train.zip`
+      await downloadBlob(api.versionTrainZipUrl(project.id, activeVersion.id), filename)
+    } catch (e) {
+      toast(`导出失败: ${e}`, 'error')
+    } finally {
+      setExporting(false)
+    }
+  }
+
   const stats = activeVersion.stats
   const trainTotal = stats?.train_image_count ?? 0
   const taggedTotal = stats?.tagged_image_count ?? 0
@@ -223,6 +241,14 @@ export default function TagEditPage() {
               {taggedTotal}/{trainTotal} 已打标
             </span>
           )}
+          <button
+            className="btn btn-primary btn-sm"
+            disabled={exporting || dirty || trainTotal === 0}
+            onClick={exportForCnb}
+            title={dirty ? '先保存标签再导出' : '导出当前版本训练集 zip，上传到 CNB 训练'}
+          >
+            {exporting ? '打包中…' : '导出给 CNB'}
+          </button>
           <SaveBar
             pid={project.id}
             vid={activeVersion.id}


### PR DESCRIPTION
## Summary
- Make the curation page open a full-browser preview on image click.
- Add keyboard curation shortcuts for preview navigation, copy-to-train, and train-copy removal.
- Add an explicit CNB export button on the tag editing step once tags are saved.


🤖 Generated with [Claude Code](https://claude.com/claude-code)