### PR TITLE
feat(docker): add Docker support with GHCR image workflow

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -1,0 +1,53 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.ide/Dockerfile'
+      - 'requirements.txt'
+      - 'studio/web/package*.json'
+  workflow_dispatch:
+
+concurrency:
+  group: docker-build
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,prefix=sha-
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: .ide/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.ide/Dockerfile
+++ b/.ide/Dockerfile
@@ -1,0 +1,67 @@
+# AnimaLoraStudio — Docker image
+# Built automatically via .github/workflows/build-docker.yml
+# Published to: ghcr.io/<owner>/<repo>:latest
+
+FROM nvidia/cuda:12.9.0-cudnn-devel-ubuntu24.04
+
+ENV TZ=Asia/Shanghai
+ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_NO_CACHE_DIR=1
+
+EXPOSE 8765
+
+# 1. 系统依赖
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        python3-tk \
+        git-lfs \
+        libgl1 \
+        libglib2.0-0 \
+        libgomp1 \
+        python3-venv \
+        python3 \
+        python-is-python3 \
+        python3-pip \
+        zip \
+        unzip \
+        wget \
+        curl \
+        git \
+        python3-dev \
+        build-essential \
+        ninja-build \
+        ca-certificates \
+        gnupg \
+    && ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# 2. Node.js 20
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# 3. Git LFS
+RUN git lfs install --system
+
+# 4. 预建虚拟环境（studio.sh 启动时优先使用 /opt/venv）
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# 5. PyTorch（cu128 匹配 CUDA 12.9）
+RUN pip install --no-cache-dir \
+        torch \
+        torchvision \
+        --index-url https://download.pytorch.org/whl/cu128
+
+# 6. Python 依赖
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
+
+# 7. 预缓存前端 node_modules（避免容器首次启动时重跑 npm install）
+COPY studio/web/package*.json /opt/studio-web/
+RUN cd /opt/studio-web && npm ci
+
+WORKDIR /workspace

--- a/.ide/setup.sh
+++ b/.ide/setup.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# ==============================================================================
+#  AnimaLoraStudio 容器环境初始化脚本（Docker）
+# ==============================================================================
+
+set -e
+
+echo "============================================"
+echo " AnimaLoraStudio 环境初始化"
+echo "============================================"
+echo ""
+
+# --- 1. Git LFS 拉取 ---
+echo "[1/4] 拉取 Git LFS 文件..."
+if command -v git-lfs &> /dev/null; then
+    git lfs pull
+    echo "  Git LFS pull 完成。"
+else
+    echo "  [警告] git-lfs 未安装，跳过 LFS 拉取。"
+fi
+echo ""
+
+# --- 2. 模型文件检查 ---
+echo "[2/4] 检查模型文件..."
+MISSING_MODELS=0
+
+check_file() {
+    local desc="$1"
+    local path="$2"
+    if [ -f "$path" ]; then
+        local size=$(du -h "$path" | cut -f1)
+        echo "  [OK] $desc ($size)"
+    else
+        echo "  [缺失] $desc -> $path"
+        MISSING_MODELS=1
+    fi
+}
+
+check_dir() {
+    local desc="$1"
+    local path="$2"
+    if [ -d "$path" ] && [ -n "$(ls -A "$path" 2>/dev/null)" ]; then
+        echo "  [OK] $desc (目录存在且非空)"
+    else
+        echo "  [缺失] $desc -> $path"
+        MISSING_MODELS=1
+    fi
+}
+
+check_file "Transformer"  "models/diffusion_models/anima-preview3-base.safetensors"
+check_file "VAE"          "models/vae/qwen_image_vae.safetensors"
+check_dir  "Text Encoder" "models/text_encoders"
+check_dir  "T5 Tokenizer" "models/t5_tokenizer"
+
+if [ "$MISSING_MODELS" -eq 1 ]; then
+    echo ""
+    echo "  [提示] 部分模型文件缺失，请手动放入对应目录。"
+fi
+echo ""
+
+# --- 3. 必要目录 ---
+echo "[3/4] 创建必要目录..."
+mkdir -p output logs
+echo "  output/ logs/ 就绪。"
+echo ""
+
+# --- 4. 前端 node_modules ---
+echo "[4/4] 前端依赖..."
+if [ ! -d "studio/web/node_modules" ]; then
+    if [ -d "/opt/studio-web/node_modules" ]; then
+        echo "  从镜像缓存复制 node_modules..."
+        cp -r /opt/studio-web/node_modules studio/web/
+        echo "  完成。"
+    else
+        echo "  [警告] 镜像中无缓存，首次运行 studio.sh 时会自动安装。"
+    fi
+else
+    echo "  [OK] node_modules 已存在。"
+fi
+echo ""
+
+# --- GPU 检测 ---
+echo "============================================"
+echo " GPU 状态"
+echo "============================================"
+if command -v nvidia-smi &> /dev/null; then
+    nvidia-smi --query-gpu=index,name,memory.total,memory.free --format=csv,noheader 2>/dev/null || echo "  nvidia-smi 运行失败。"
+else
+    echo "  [警告] nvidia-smi 不可用。"
+fi
+echo ""
+
+echo "============================================"
+echo " 初始化完成! 运行: bash studio.sh"
+echo "============================================"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  studio:
+    # 从 GitHub Container Registry 拉取预构建镜像。
+    # 本地构建时注释掉 image 行，取消注释 build 块：
+    #   build:
+    #     context: .
+    #     dockerfile: .ide/Dockerfile
+    image: ghcr.io/${GITHUB_REPOSITORY:-animalorastudio/animalorastudio}:latest
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    volumes:
+      - .:/workspace
+    ports:
+      - "8765:8765"
+    working_dir: /workspace
+    command: bash -c "bash .ide/setup.sh && bash studio.sh"
+    restart: unless-stopped

--- a/studio.sh
+++ b/studio.sh
@@ -81,7 +81,10 @@ _check_venv_python_version() {
     fi
 }
 
-if [ -x "venv/bin/python" ]; then
+if [ -x "/opt/venv/bin/python" ]; then
+    # Docker / CNB 镜像内预建 venv，直接使用，跳过本地 venv 检测。
+    PYTHON="/opt/venv/bin/python"
+elif [ -x "venv/bin/python" ]; then
     PYTHON="venv/bin/python"
     _check_venv_python_version
 elif [ -x ".venv/bin/python" ]; then
@@ -148,10 +151,15 @@ if [ "$_STALE" = "stale" ]; then
 fi
 
 echo "studio.sh: using $PYTHON"
-"$PYTHON" -m studio "${_PASSTHROUGH[@]}"
-EXIT_CODE=$?
-if [ $EXIT_CODE -ne 0 ]; then
-    echo ""
-    echo "[studio] Exit code $EXIT_CODE, see error messages above."
+if [ -f "/.dockerenv" ] && [ "${#_PASSTHROUGH[@]}" -eq 0 ]; then
+    # Docker / CNB 容器环境：监听所有接口，不启动浏览器。
+    exec "$PYTHON" -m studio run --host 0.0.0.0 --no-browser
+else
+    "$PYTHON" -m studio "${_PASSTHROUGH[@]}"
+    EXIT_CODE=$?
+    if [ $EXIT_CODE -ne 0 ]; then
+        echo ""
+        echo "[studio] Exit code $EXIT_CODE, see error messages above."
+    fi
+    exit $EXIT_CODE
 fi
-exit $EXIT_CODE


### PR DESCRIPTION
## Summary

Adds a self-contained Docker setup for running AnimaLoraStudio in containerized environments, with automated image publishing to GitHub Container Registry (no external registry credentials required).

### GitHub Actions workflow (`.github/workflows/build-docker.yml`)
- Builds and pushes to `ghcr.io/<owner>/<repo>` using the built-in `GITHUB_TOKEN` — no Docker Hub account or secrets needed
- Triggers on changes to `Dockerfile`, `requirements.txt`, or `studio/web/package*.json`
- Tags: `latest` (on default branch) + `sha-<short>` for traceability
- Concurrency: new push auto-cancels an in-progress build

### Dockerfile (`.ide/Dockerfile`)
- Base: `nvidia/cuda:12.9.0-cudnn-devel-ubuntu24.04`
- Pre-built `/opt/venv` with PyTorch (cu128) and all `requirements.txt` dependencies
- Pre-cached `/opt/studio-web/node_modules` to avoid npm install on every container start
- `studio.sh` detects `/opt/venv` automatically (see below)

### Container init script (`.ide/setup.sh`)
- Runs once at container start before `studio.sh`
- Checks model files and reports missing ones
- Copies cached `node_modules` from image into the mounted workspace
- GPU status report via `nvidia-smi`

### Docker Compose (`docker-compose.yml`)
- Pulls prebuilt image from GHCR; nvidia GPU passthrough via `device_requests`
- Mounts repo root as `/workspace`; exposes port 8765
- Local build alternative documented in comments

### `studio.sh` changes
- Detects `/opt/venv/bin/python` (pre-built venv in Docker image) and uses it directly, skipping local venv setup
- When running inside a container (`/.dockerenv` present) with no subcommand, automatically adds `--host 0.0.0.0 --no-browser`

## Test plan
- [x] Push a Dockerfile change and verify GitHub Actions builds and pushes to `ghcr.io/<owner>/<repo>:latest`
- [ ] `docker compose up` pulls image, mounts repo, starts studio on port 8765
- [x] `studio.sh` inside container picks up `/opt/venv` without creating a local venv
- [x] Studio UI accessible at `http://localhost:8765` without browser auto-open
- [ ] `nvidia-smi` visible inside container; training can utilize GPU