### PR TITLE
fix(tagger): Windows 上 onnxruntime-gpu 静默降级 CPU

### DIFF
--- a/studio/services/onnx_tagger_base.py
+++ b/studio/services/onnx_tagger_base.py
@@ -131,7 +131,23 @@ class OnnxTaggerBase:
                 str(model_path), providers=["CPUExecutionProvider"]
             )
         else:
-            onnxruntime_setup.record_cuda_load_error(None)
+            # onnxruntime 在 CUDA EP dlopen 失败时**不抛异常** —— 内部 silently
+            # fallback 到下一个 EP（CPU）。光看 try/except 不够，必须比对实际
+            # session.get_providers()；不一致 → 用户实际跑 CPU，但 UI 看不到。
+            if cuda_attempt:
+                actual = list(self._session.get_providers())
+                if "CUDAExecutionProvider" not in actual:
+                    msg = (
+                        f"CUDA EP 静默降级到 CPU（InferenceSession 未抛异常，"
+                        f"但 get_providers={actual}）。常见原因：CUDA 驱动版本不够 / "
+                        f"runtime so/DLL 缺失 / cuDNN ABI 错位。"
+                    )
+                    logger.warning("%s %s", self.name, msg)
+                    onnxruntime_setup.record_cuda_load_error(msg)
+                else:
+                    onnxruntime_setup.record_cuda_load_error(None)
+            else:
+                onnxruntime_setup.record_cuda_load_error(None)
 
         self._input_name = self._session.get_inputs()[0].name
         self._output_names = [o.name for o in self._session.get_outputs()]

--- a/studio/services/onnxruntime_setup.py
+++ b/studio/services/onnxruntime_setup.py
@@ -116,31 +116,84 @@ def _has_system_cuda_libs() -> bool:
     return False
 
 
+def _add_torch_dll_dirs_windows() -> dict[str, Any]:
+    """PR — Windows 上把 torch 自带的 CUDA DLL 目录加入 Python DLL 搜索路径。
+
+    Python 3.8+ Windows 出于安全废除了 PATH 自动 dlopen native DLL —— 必须
+    `os.add_dll_directory()` 主动声明。onnxruntime 在 import 期 dlopen
+    `cublasLt64_12.dll` / `cudnn_*.dll` 时找不到，`get_available_providers()`
+    照样列 CUDAExecutionProvider，但 InferenceSession 内部 silently 降 CPU
+    （onnx_tagger_base._create_session 已经能识别这种降级）。
+
+    torch GPU build wheel 把全套 CUDA DLL 放在 `site-packages/torch/lib/`
+    （cublasLt64_12 / cudnn*_9 / curand64_10 / cufft64_11 / cusparse64_12 /
+    cudart64_12 / nvrtc）。加进 DLL search path，后续 onnxruntime 的 dlopen
+    就能找到。
+
+    返回 `{"added", "errors", "candidates"}`：
+    - `added`：成功 add_dll_directory 的目录列表
+    - `errors`：尝试但失败的 (dir, reason) 列表
+    - `candidates`：发现的候选目录数（=0 表示 venv 没装 torch GPU build）
+    """
+    added: list[str] = []
+    errors: list[tuple[str, str]] = []
+    try:
+        import torch  # noqa: PLC0415
+    except ImportError:
+        return {"added": added, "errors": errors, "candidates": 0}
+    lib = os.path.join(os.path.dirname(torch.__file__), "lib")
+    if not os.path.isdir(lib):
+        return {"added": added, "errors": errors, "candidates": 0}
+    try:
+        # Python 3.8+ Windows API；其他平台没有
+        os.add_dll_directory(lib)  # type: ignore[attr-defined]
+        added.append(lib)
+    except (OSError, AttributeError) as exc:
+        errors.append((lib, str(exc)))
+    return {"added": added, "errors": errors, "candidates": 1}
+
+
 def _preload_torch_cuda_libs() -> dict[str, Any]:
-    """Linux 上 ctypes RTLD_GLOBAL 预加载 torch 自带的 CUDA runtime so。
+    """跨平台预加载 torch 自带的 CUDA 库，让 onnxruntime-gpu dlopen 找得到。
 
     背景：onnxruntime-gpu wheel 不打包 CUDA runtime；用户机器没系统装 CUDA
     时，CUDA EP 在 `get_available_providers()` 里看着可用，但创 session 时
-    dlopen 失败（典型 `libcurand.so.10: cannot open shared object file`）。
-    PyTorch 装 GPU build 会带一组 `nvidia-*-cu12` wheel，把 so 放到
-    `site-packages/nvidia/*/lib/`；提前 RTLD_GLOBAL 加载它们后，onnxruntime
-    后续 dlopen 就能从已加载的全局符号表里解析。
+    dlopen 失败（Linux: `libcurand.so.10`；Windows: `cublasLt64_12.dll`）。
+    onnxruntime 不抛异常，会**静默降级到 CPU**（onnx_tagger_base 已有检测）。
 
-    **注意**：系统已有 CUDA（如 nvidia docker 镜像）时跳过 preload。torch wheel
-    的 CUDA 版本（cu128 = cuBLAS 12.8）与 onnxruntime-gpu 编译目标的 CUDA 子
-    版本不一致时，强行 RTLD_GLOBAL 覆盖会导致推理时 CUBLAS_STATUS_INVALID_VALUE。
+    PyTorch GPU build 自带所有需要的 CUDA 库：
+    - **Linux**：装到 `site-packages/nvidia/*/lib/` —— `ctypes.CDLL(RTLD_GLOBAL)`
+      预加载到全局符号表
+    - **Windows**：装到 `site-packages/torch/lib/` —— `os.add_dll_directory()`
+      加入 DLL 搜索路径（Python 3.8+ 必需）
+
+    **注意**：Linux 上系统已有 CUDA（如 nvidia docker 镜像）时跳过 preload。
+    torch wheel 的 CUDA 版本（cu128 = cuBLAS 12.8）与 onnxruntime-gpu 编译目标
+    的 CUDA 子版本不一致时，强行 RTLD_GLOBAL 覆盖会导致推理时
+    CUBLAS_STATUS_INVALID_VALUE。Windows 上 `add_dll_directory` 只是把目录加进
+    搜索路径，不强行覆盖已加载的符号，所以无此问题。
 
     只对**当前进程**生效；server 子进程必须自己再跑一次（本模块在 import 时
     自动跑）。
 
     返回 `{"applied", "platform_skip", "system_cuda_skip", "preloaded", "errors", "candidates"}`：
-    - `platform_skip=True`：非 Linux，整体跳过（Windows / macOS 走别的路子）
-    - `system_cuda_skip=True`：检测到系统 CUDA，跳过 preload 让 onnxruntime
+    - `platform_skip=True`：非 Linux / 非 Windows（如 macOS），整体跳过
+    - `system_cuda_skip=True`：Linux 系统 CUDA 路径，跳过 preload 让 onnxruntime
       自己 dlopen 系统提供的版本
-    - `preloaded`：成功 dlopen 的绝对路径列表
-    - `errors`：尝试 dlopen 但失败的 (path, reason) 列表
-    - `candidates`：被检视的 nvidia.* 子包数（用来观测 venv 里是否有 torch CUDA）
+    - `preloaded`：成功 dlopen / add_dll_directory 的绝对路径列表
+    - `errors`：尝试但失败的 (path, reason) 列表
+    - `candidates`：检视的候选数（Linux: nvidia.* 子包；Windows: torch/lib 目录）
     """
+    if sys.platform == "win32":
+        wres = _add_torch_dll_dirs_windows()
+        return {
+            "applied": True,
+            "platform_skip": False,
+            "system_cuda_skip": False,
+            "preloaded": wres["added"],
+            "errors": wres["errors"],
+            "candidates": wres["candidates"],
+        }
     if not sys.platform.startswith("linux"):
         return {
             "applied": False,

--- a/tests/test_onnx_tagger_base.py
+++ b/tests/test_onnx_tagger_base.py
@@ -65,6 +65,101 @@ def test_is_cuda_inference_error_ignores_unrelated_failures(msg: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _create_session — CUDA EP 静默降级检测
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_session(providers: list[str]):
+    """构造一个 mock onnxruntime session：input/output name + 指定 providers。"""
+    sess = MagicMock()
+    sess.get_inputs.return_value = [MagicMock()]
+    sess.get_inputs.return_value[0].name = "x"
+    sess.get_outputs.return_value = [MagicMock()]
+    sess.get_outputs.return_value[0].name = "y"
+    sess.get_providers.return_value = list(providers)
+    return sess
+
+
+def test_create_session_records_error_on_silent_cuda_downgrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """onnxruntime 在 CUDA dlopen 失败时不抛而是 silently 降 CPU；
+    `_create_session` 必须比对实际 providers 并 stash 错误，否则 UI 看不到。"""
+    t = _StubTagger()
+
+    fake_session = _make_fake_session(["CPUExecutionProvider"])  # 装的是 GPU，但实际只剩 CPU
+    requested_providers: list[list[str]] = []
+
+    def fake_session_ctor(path, providers):
+        requested_providers.append(list(providers))
+        return fake_session
+
+    fake_ort = MagicMock(InferenceSession=fake_session_ctor)
+    fake_ort.get_available_providers.return_value = [
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+    monkeypatch.setitem(__import__("sys").modules, "onnxruntime", fake_ort)
+    # 起始无旧错记录
+    onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+    try:
+        t._create_session(Path("/fake/model.onnx"))
+        # 用户请求过 CUDA
+        assert requested_providers and "CUDAExecutionProvider" in requested_providers[0]
+        # 但 onnxruntime 内部静默降 CPU → 必须有 cuda_load_error 让 UI 显示
+        err = onnx_tagger_base.onnxruntime_setup.get_cuda_load_error()
+        assert err is not None
+        assert "静默降级" in err or "silently" in err.lower()
+    finally:
+        onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+
+def test_create_session_clears_error_when_cuda_actually_works(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """请求 CUDA 且实际 providers 含 CUDA → 清空旧错（成功路径）。"""
+    t = _StubTagger()
+    fake_session = _make_fake_session(
+        ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    )
+
+    fake_ort = MagicMock(InferenceSession=lambda _p, providers: fake_session)
+    fake_ort.get_available_providers.return_value = [
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+    monkeypatch.setitem(__import__("sys").modules, "onnxruntime", fake_ort)
+    # 预置一个旧错
+    onnx_tagger_base.onnxruntime_setup.record_cuda_load_error("old failure")
+
+    try:
+        t._create_session(Path("/fake/model.onnx"))
+        assert onnx_tagger_base.onnxruntime_setup.get_cuda_load_error() is None
+    finally:
+        onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+
+def test_create_session_no_false_positive_when_cuda_not_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """机器没 GPU → 根本没请求 CUDA → providers 只有 CPU 是正常的，不应记错。"""
+    t = _StubTagger()
+    fake_session = _make_fake_session(["CPUExecutionProvider"])
+
+    fake_ort = MagicMock(InferenceSession=lambda _p, providers: fake_session)
+    fake_ort.get_available_providers.return_value = ["CPUExecutionProvider"]
+    monkeypatch.setitem(__import__("sys").modules, "onnxruntime", fake_ort)
+    onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+    try:
+        t._create_session(Path("/fake/model.onnx"))
+        assert onnx_tagger_base.onnxruntime_setup.get_cuda_load_error() is None
+    finally:
+        onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+
+# ---------------------------------------------------------------------------
 # _fallback_to_cpu_session
 # ---------------------------------------------------------------------------
 

--- a/tests/test_onnxruntime_setup.py
+++ b/tests/test_onnxruntime_setup.py
@@ -293,13 +293,79 @@ def test_bootstrap_install_failure_returns_error(
 # ---------------------------------------------------------------------------
 
 
-def test_preload_skips_on_non_linux(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ors.sys, "platform", "win32")
+def test_preload_skips_on_unsupported_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """非 Linux / 非 Windows（如 macOS）→ 整体跳过。"""
+    monkeypatch.setattr(ors.sys, "platform", "darwin")
     res = ors._preload_torch_cuda_libs()
     assert res["platform_skip"] is True
     assert res["applied"] is False
     assert res["preloaded"] == []
     assert res["candidates"] == 0
+
+
+def test_preload_windows_adds_torch_lib_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Windows + 装了 torch GPU build → os.add_dll_directory(torch/lib) 被调，
+    返回结果 preloaded 含目录路径（onnxruntime dlopen cublasLt 等找得到）。"""
+    monkeypatch.setattr(ors.sys, "platform", "win32")
+
+    # 仿造 torch.__file__ 指向带 lib/ 的目录
+    torch_pkg = tmp_path / "torch"
+    (torch_pkg / "lib").mkdir(parents=True)
+    fake_torch = MagicMock()
+    fake_torch.__file__ = str(torch_pkg / "__init__.py")
+
+    def _import(name: str):
+        if name == "torch":
+            return fake_torch
+        raise ImportError(name)
+
+    monkeypatch.setattr(ors.importlib, "import_module", _import)
+    # 旁路：venv/Scripts/python.exe 下 `import torch` 走 sys.modules，
+    # 但 _add_torch_dll_dirs_windows 用的是 `import torch` 函数局部 —— 用
+    # monkeypatch sys.modules 直接喂
+    monkeypatch.setitem(__import__("sys").modules, "torch", fake_torch)
+
+    called: list[str] = []
+    monkeypatch.setattr(
+        ors.os,
+        "add_dll_directory",
+        lambda d: called.append(d) or MagicMock(),
+        raising=False,
+    )
+
+    res = ors._preload_torch_cuda_libs()
+    assert res["applied"] is True
+    assert res["platform_skip"] is False
+    assert str(torch_pkg / "lib") in res["preloaded"]
+    assert called == [str(torch_pkg / "lib")]
+
+
+def test_preload_windows_noop_without_torch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows 但 venv 没 torch → applied 仍为 True（平台支持），candidates=0。"""
+    monkeypatch.setattr(ors.sys, "platform", "win32")
+    monkeypatch.delitem(__import__("sys").modules, "torch", raising=False)
+
+    # 让 `import torch` 失败：覆盖 importlib.import_module 不够，因为函数内
+    # 用的是字面 import；改 sys.modules 哨兵 + meta_path 不太干净。简单做法：
+    # 把 ors.os.path.isdir 在没 torch 时也走 False 路径 —— 但实际函数体先 import
+    # 失败就提前 return。这里直接构造 import 错误：
+    import builtins
+    real_import = builtins.__import__
+
+    def _fake_import(name, *a, **k):
+        if name == "torch":
+            raise ImportError("not installed")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    res = ors._preload_torch_cuda_libs()
+    assert res["applied"] is True
+    assert res["candidates"] == 0
+    assert res["preloaded"] == []
 
 
 def test_preload_noop_when_no_torch_nvidia_packages(


### PR DESCRIPTION
## 背景

用户反馈：装的是 onnxruntime-gpu，但运行 WD14 打标时 CPU 占用飙升，UI / 日志看不到任何 GPU 失败信号。

排查发现 onnxruntime 在请求的 EP dlopen 失败时**不抛异常**，会内部 silently fallback 到下一个可用 EP（CPU）。`tools/bench_wd14.py:107-123` 的注释里已经写过这个特性，但生产路径 `_create_session` 漏了校验。

根因（Windows + Python 3.8+）：

- Python 3.8+ Windows 出于安全废除了 PATH 自动加载 native DLL，必须 `os.add_dll_directory()` 显式声明
- torch import 时只把 `torch/lib` 加给自己用，onnxruntime 看不到
- 结果：onnxruntime dlopen `cublasLt64_12.dll` / `cudnn_*.dll` 失败 → 静默降级 CPU → `get_available_providers()` 仍报 CUDA 可用 → UI 显示一切正常

本机环境对照（说明版本不是根因）：

| | 版本 |
|---|---|
| torch | 2.11.0+cu128 (cuDNN 9.19) |
| onnxruntime-gpu | 1.26.0 |
| CUDA driver | 596.36 |
| GPU | RTX 5090 |

torch 跑 GPU 完全正常，onnxruntime 也是同套 CUDA / cuDNN 编译目标，**只是找不到 DLL**。

## 改动

### 1. 监控（识别静默降级）

`studio/services/onnx_tagger_base.py::_create_session`

- session 创建成功后比对 `self._session.get_providers()`
- 请求过 CUDA 但实际 providers 不含 CUDA → `record_cuda_load_error` stash 一条「静默降级」消息
- 之前只看 `try/except`，onnxruntime 不抛异常时彻底沉默，UI 拿不到任何信号

### 2. 修复（Windows DLL 搜索路径）

`studio/services/onnxruntime_setup.py`

- 新增 `_add_torch_dll_dirs_windows()`：`os.add_dll_directory(torch/lib)`
- `_preload_torch_cuda_libs` 增加 Windows 分支（之前直接 `platform_skip`）
- 模块顶层 `_ensure_preload()` 在 `import onnxruntime` 之前跑，时机正确
- Linux 路径（PP9.5 `RTLD_GLOBAL` preload）和系统 CUDA 检测保持不动

## 测试

### 自动

- `tests/test_onnx_tagger_base.py` 加 3 个 case：静默降级被记录 / CUDA 真生效时清空旧错 / 纯 CPU 模式不误报
- `tests/test_onnxruntime_setup.py` 把 `test_preload_skips_on_non_linux` 改成 `test_preload_skips_on_unsupported_platform`（macOS），新加 2 个 Windows case
- 全套 pytest：**832 passed, 1 failed**（失败的 `test_build_installs_when_node_modules_missing` 在 dev 上同样 fail，是 npm 环境问题，与本 PR 无关）

### 手测

监控生效（改动前的日志）：

```
[start] tagger=wd14 version=v1 images=5 format=txt
wd14 CUDA EP 静默降级到 CPU（InferenceSession 未抛异常，但 get_providers=['CPUExecutionProvider']）。
常见原因：CUDA 驱动版本不够 / runtime so/DLL 缺失 / cuDNN ABI 错位。
[ready] wd14 已就绪
[progress] 1/5 ... [done] tagged 5/5
```

修复后端到端验证：

```
preload result: {'applied': True, 'preloaded': ['...\venv\Lib\site-packages\torch\lib'], ...}
actual providers: ['CUDAExecutionProvider', 'CPUExecutionProvider']
cuda_load_error: None
```

studio 跑 WD14 打标：无降级 warning、GPU 用上、CPU 占用回到基线。

## 影响范围

- **修法对所有 Windows + onnxruntime-gpu + torch GPU build 的组合都生效**，不只 1.26 / cu128 这组
- Linux / macOS 路径**未改动**
- 无 schema / API / 行为变更（PATCH 性质）

> **Note**：后续在 Linux 云上发现还有两个独立的相关 bug（worker subprocess 顶层漏 preload + 系统部分 CUDA 误判），单独走 PR 修复。

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
