### PR TITLE
fix(tagger): Linux 上 onnxruntime-gpu 静默降级 — worker preload + cuDNN 检测

### DIFF
--- a/studio/services/onnxruntime_setup.py
+++ b/studio/services/onnxruntime_setup.py
@@ -92,28 +92,44 @@ _CUDA_LOAD_ERROR: Optional[str] = None
 
 
 def _has_system_cuda_libs() -> bool:
-    """Linux 系统是否自带 CUDA 运行时（/usr/local/cuda、apt 装的 libcublas、nvidia docker）。
+    """Linux 系统是否自带**完整** CUDA 运行时（cuBLAS + cuDNN 都在 ld 路径）。
 
-    有系统 CUDA 时跳过 PP9.5 preload —— torch wheel 自带的 CUDA so（cu128 →
-    cuBLAS 12.8）与 onnxruntime-gpu wheel 编译目标的 CUDA so（typically 12.x
-    某子版本）ABI 不匹配；RTLD_GLOBAL 把 torch 的强行塞进全局符号表后，
-    onnxruntime 后续 dlopen cuBLAS 解到错位版本 → 推理时 CUBLAS_STATUS_INVALID_VALUE。
-    系统 CUDA 路径下让 onnxruntime 直接 dlopen 系统提供的版本反而是对的。
+    有**完整**系统 CUDA 时跳过 PP9.5 preload —— torch wheel 自带的 CUDA so
+    （cu128 → cuBLAS 12.8）与 onnxruntime-gpu wheel 编译目标的 CUDA so
+    （typically 12.x 某子版本）ABI 不匹配；RTLD_GLOBAL 把 torch 的强行塞进
+    全局符号表后，onnxruntime 后续 dlopen cuBLAS 解到错位版本 → 推理时
+    CUBLAS_STATUS_INVALID_VALUE。系统 CUDA 完整时让 onnxruntime 直接 dlopen
+    系统版本反而是对的。
 
-    检测策略：
-    - CUDA_HOME / CUDA_PATH 环境变量指向带 lib64 的目录
-    - /usr/local/cuda/lib64 存在（标准安装位置）
-    - ctypes.util.find_library("cublas") 命中（apt 装的 libcublas-dev 等会进 ld 路径）
+    **关键**：必须 cuBLAS + cuDNN 都在系统里才算完整。云镜像装 CUDA Toolkit
+    （带 cuBLAS）但**没装** cuDNN 极常见（cuDNN 要 NVIDIA Developer 账号单独
+    下）；只检测 cuBLAS 会误判 → preload 跳过 → onnxruntime dlopen
+    libcudnn.so.9 失败 → 静默降 CPU。这种「部分系统 CUDA」场景必须让 torch
+    wheel preload 兜底补 cuDNN（torch GPU build 自带 cuDNN 9.x 在
+    nvidia.cudnn 子包里）。
+
+    检测分两步，都满足才返回 True：
+    1. CUDA Toolkit：CUDA_HOME / CUDA_PATH 指向带 lib64 / 默认 /usr/local/cuda
+       存在 / ld 路径里有 libcublas —— 任一命中
+    2. cuDNN：ld 路径里有 libcudnn —— 必须命中
     """
     import ctypes.util  # noqa: PLC0415  仅 Linux 路径用，避免顶层 import 副作用
     cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH") or ""
+    has_toolkit = False
     if cuda_home and os.path.isdir(os.path.join(cuda_home, "lib64")):
-        return True
-    if os.path.isdir("/usr/local/cuda/lib64"):
-        return True
-    if ctypes.util.find_library("cublas"):
-        return True
-    return False
+        has_toolkit = True
+    elif os.path.isdir("/usr/local/cuda/lib64"):
+        has_toolkit = True
+    elif ctypes.util.find_library("cublas"):
+        has_toolkit = True
+    if not has_toolkit:
+        return False
+    # 关键：cuDNN 同样必须在系统 ld 路径里。云镜像装 CUDA Toolkit（含 cuBLAS）
+    # 但没装 cuDNN 是非常常见的场景；只检测 cuBLAS 会误判 → preload 被跳过 →
+    # onnxruntime dlopen libcudnn.so.9 失败 → 静默降 CPU。这种部分系统 CUDA
+    # 场景下让 torch wheel preload 兜底补 cuDNN（torch GPU build 在
+    # nvidia.cudnn 子包里自带 cuDNN 9.x）。
+    return bool(ctypes.util.find_library("cudnn"))
 
 
 def _add_torch_dll_dirs_windows() -> dict[str, Any]:

--- a/studio/workers/reg_build_worker.py
+++ b/studio/workers/reg_build_worker.py
@@ -39,6 +39,11 @@ for _stream in (sys.stdout, sys.stderr):
     except (AttributeError, OSError):
         pass
 
+# PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload。
+# auto_tag 路径会内联调 wd14_tagger（line ~105 `get_tagger("wd14")`），worker 是独立
+# subprocess，必须自己 import；否则 CUDA EP 静默降级到 CPU，用户看不到任何信号。
+from studio.services import onnxruntime_setup  # noqa: F401
+
 from studio import db, project_jobs, projects, secrets, versions
 from studio.datasets import IMAGE_EXTS
 from studio.services import reg_builder, reg_postprocess, tagedit

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -29,6 +29,12 @@ for _stream in (sys.stdout, sys.stderr):
     except (AttributeError, OSError):
         pass
 
+# PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload
+# （Linux: RTLD_GLOBAL 加载 torch 自带 CUDA so；Windows: os.add_dll_directory）。
+# cli.py / server.py 已覆盖各自进程；worker 是独立 subprocess，靠 get_tagger
+# 懒加载链触发太晚（懒加载在 main() 里，某些路径下来不及）—— worker 顶层显式 import。
+from studio.services import onnxruntime_setup  # noqa: F401
+
 from studio import db, project_jobs, projects, versions
 from studio.datasets import IMAGE_EXTS
 from studio.services import tagedit

--- a/tests/test_onnxruntime_setup.py
+++ b/tests/test_onnxruntime_setup.py
@@ -597,22 +597,22 @@ def test_current_runtime_exposes_cuda_load_error(
 def test_has_system_cuda_libs_via_cuda_home(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
-    """CUDA_HOME 指向带 lib64 的目录 → True。"""
+    """CUDA_HOME + 系统也有 cuDNN → True。"""
     fake_root = tmp_path / "fake-cuda"
     (fake_root / "lib64").mkdir(parents=True)
     monkeypatch.setenv("CUDA_HOME", str(fake_root))
     monkeypatch.delenv("CUDA_PATH", raising=False)
-    # 确保 /usr/local/cuda/lib64 不存在 + ctypes.find_library 不命中（隔离环境）
     monkeypatch.setattr(ors.os.path, "isdir", lambda p: p.endswith(str(fake_root / "lib64")))
     import ctypes.util as _cu  # noqa: PLC0415
-    monkeypatch.setattr(_cu, "find_library", lambda _name: None)
+    # cuDNN 在系统 ld 里
+    monkeypatch.setattr(_cu, "find_library", lambda name: "libcudnn.so.9" if name == "cudnn" else None)
     assert ors._has_system_cuda_libs() is True
 
 
 def test_has_system_cuda_libs_via_default_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """没设 CUDA_HOME 但 /usr/local/cuda/lib64 存在 → True。"""
+    """/usr/local/cuda/lib64 + 系统 cuDNN → True。"""
     monkeypatch.delenv("CUDA_HOME", raising=False)
     monkeypatch.delenv("CUDA_PATH", raising=False)
     monkeypatch.setattr(
@@ -621,7 +621,7 @@ def test_has_system_cuda_libs_via_default_path(
         lambda p: p == "/usr/local/cuda/lib64",
     )
     import ctypes.util as _cu  # noqa: PLC0415
-    monkeypatch.setattr(_cu, "find_library", lambda _name: None)
+    monkeypatch.setattr(_cu, "find_library", lambda name: "libcudnn.so.9" if name == "cudnn" else None)
     assert ors._has_system_cuda_libs() is True
 
 
@@ -633,6 +633,38 @@ def test_has_system_cuda_libs_returns_false_when_no_signals(
     monkeypatch.setattr(ors.os.path, "isdir", lambda _p: False)
     import ctypes.util as _cu  # noqa: PLC0415
     monkeypatch.setattr(_cu, "find_library", lambda _name: None)
+    assert ors._has_system_cuda_libs() is False
+
+
+def test_has_system_cuda_libs_returns_false_when_cudnn_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """关键修复回归：系统有 CUDA Toolkit（cuBLAS 在 /usr/local/cuda）但**没装 cuDNN** —
+    必须返回 False，让 torch wheel preload 兜底补 cuDNN。否则 onnxruntime
+    dlopen libcudnn.so.9 失败 → 静默降 CPU（用户在云上实测踩到）。"""
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    monkeypatch.setattr(
+        ors.os.path,
+        "isdir",
+        lambda p: p == "/usr/local/cuda/lib64",
+    )
+    import ctypes.util as _cu  # noqa: PLC0415
+    # cuBLAS 在系统里，cuDNN 不在
+    monkeypatch.setattr(_cu, "find_library", lambda name: "libcublas.so.12" if name == "cublas" else None)
+    assert ors._has_system_cuda_libs() is False
+
+
+def test_has_system_cuda_libs_returns_false_when_only_cublas_in_ld(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """没 CUDA_HOME、没 /usr/local/cuda，只有 ld 路径里的 cuBLAS（apt 装的）+
+    没 cuDNN → False（同上：部分系统 CUDA 也算不完整）。"""
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    monkeypatch.setattr(ors.os.path, "isdir", lambda _p: False)
+    import ctypes.util as _cu  # noqa: PLC0415
+    monkeypatch.setattr(_cu, "find_library", lambda name: "libcublas.so.12" if name == "cublas" else None)
     assert ors._has_system_cuda_libs() is False
 
 

--- a/tests/test_reg_build_worker.py
+++ b/tests/test_reg_build_worker.py
@@ -158,3 +158,19 @@ def test_worker_skips_auto_tag_when_disabled(env) -> None:
     # 没 auto_tag → 不写 .txt
     txts = list((rdir / "1_data").glob("*.txt"))
     assert txts == []
+
+
+def test_worker_imports_onnxruntime_setup_at_module_level() -> None:
+    """worker 是独立 subprocess —— auto_tag 路径会 get_tagger("wd14")，必须
+    在任何 onnxruntime import 之前触发 onnxruntime_setup 顶层 preload。
+    """
+    import re
+    import sys
+    src = Path(reg_build_worker.__file__).read_text(encoding="utf-8")
+    assert "from studio.services import onnxruntime_setup" in src, (
+        "reg_build_worker.py 顶层必须 import onnxruntime_setup 触发 preload；"
+        "见 onnxruntime_setup.py 顶部 PP9.5 注释。"
+    )
+    bad = re.findall(r"^\s*(?:import onnxruntime|from onnxruntime\b)", src, re.MULTILINE)
+    assert not bad, f"worker 不应直接 import onnxruntime；命中: {bad}"
+    assert "studio.services.onnxruntime_setup" in sys.modules

--- a/tests/test_tag_worker.py
+++ b/tests/test_tag_worker.py
@@ -141,3 +141,21 @@ def test_run_passes_cltagger_overrides_through(env, monkeypatch) -> None:
 
 def test_run_unknown_job(env) -> None:
     assert tag_worker.run(99999) == 1
+
+
+def test_worker_imports_onnxruntime_setup_at_module_level() -> None:
+    """worker 是独立 subprocess —— 必须在任何 `import onnxruntime` 之前触发
+    onnxruntime_setup 的顶层 preload。回归测试：防止有人删掉那行 import 后
+    Linux 上又出 CUDA EP 静默降级，UI 看不到任何信号。"""
+    import re
+    import sys
+    src = Path(tag_worker.__file__).read_text(encoding="utf-8")
+    assert "from studio.services import onnxruntime_setup" in src, (
+        "tag_worker.py 顶层必须 import onnxruntime_setup 触发 preload；"
+        "见 onnxruntime_setup.py 顶部 PP9.5 注释。"
+    )
+    # worker 文件本身不应出现 `^import onnxruntime` / `^from onnxruntime`（行首真 import）
+    bad = re.findall(r"^\s*(?:import onnxruntime|from onnxruntime\b)", src, re.MULTILINE)
+    assert not bad, f"worker 不应直接 import onnxruntime；命中: {bad}"
+    # 模块加载本身把 onnxruntime_setup 拉进 sys.modules
+    assert "studio.services.onnxruntime_setup" in sys.modules

--- a/tools/diagnose_onnx_gpu.py
+++ b/tools/diagnose_onnx_gpu.py
@@ -1,0 +1,116 @@
+"""onnxruntime-gpu 静默降级 CPU 诊断 — 在跑这个 PR 的分支后，
+跑一次打标遇到「CUDA EP 静默降级到 CPU」warning 后用本脚本定位根因。
+
+用法（在 studio 同一个 venv 里）：
+
+    python tools/diagnose_onnx_gpu.py
+
+把整段 stdout 贴回 PR 评论 / issue。
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def section(title: str) -> None:
+    print()
+    print("=" * 60)
+    print("==", title)
+    print("=" * 60)
+
+
+def main() -> None:
+    section("platform")
+    print("python:", sys.version.split()[0])
+    print("platform:", sys.platform)
+    print("executable:", sys.executable)
+
+    section("onnxruntime_setup.current_runtime()")
+    try:
+        from studio.services import onnxruntime_setup as o
+    except ImportError as exc:
+        print("studio import 失败 — 是不是没在 studio 仓库根目录跑？")
+        print("原因:", exc)
+        return
+    rt = o.current_runtime()
+    print(json.dumps(rt, indent=2, ensure_ascii=False, default=str))
+
+    section("系统 CUDA 检测（决定 preload 是否被 skip）")
+    print("CUDA_HOME:", os.environ.get("CUDA_HOME"))
+    print("CUDA_PATH:", os.environ.get("CUDA_PATH"))
+    print("/usr/local/cuda/lib64 存在:", os.path.isdir("/usr/local/cuda/lib64"))
+    import ctypes.util
+    print("ld 路径里 cublas:", ctypes.util.find_library("cublas"))
+    print("ld 路径里 cudnn:", ctypes.util.find_library("cudnn"))
+    print("_has_system_cuda_libs():", o._has_system_cuda_libs())
+
+    section("torch")
+    try:
+        import torch
+        print("torch:", torch.__version__)
+        print("torch.version.cuda:", torch.version.cuda)
+        print("torch.cuda.is_available():", torch.cuda.is_available())
+        if torch.cuda.is_available():
+            print("device_name:", torch.cuda.get_device_name(0))
+            print("cudnn_version:", torch.backends.cudnn.version())
+    except Exception as exc:  # noqa: BLE001
+        print("torch import 失败:", exc)
+
+    section("nvidia-*-cu12 wheels（torch wheel preload 来源） + onnxruntime")
+    out = subprocess.run(
+        [sys.executable, "-m", "pip", "list"],
+        capture_output=True, text=True,
+    ).stdout
+    keep = ("nvidia", "cudnn", "onnxruntime", "torch")
+    for line in out.splitlines():
+        low = line.lower()
+        if any(k in low for k in keep):
+            print(" ", line)
+
+    section("nvidia-smi")
+    try:
+        nv = subprocess.run(
+            ["nvidia-smi", "--query-gpu=driver_version,name", "--format=csv,noheader"],
+            capture_output=True, text=True, timeout=10,
+        )
+        print("rc:", nv.returncode)
+        print("stdout:", nv.stdout.strip())
+        print("stderr:", nv.stderr.strip())
+    except FileNotFoundError:
+        print("nvidia-smi 不在 PATH（云机器可能在 docker 里没暴露）")
+    except Exception as exc:  # noqa: BLE001
+        print("nvidia-smi 跑失败:", exc)
+
+    section("尝试真创 InferenceSession（用 onnxruntime 内置 test model 或现有 wd14 模型）")
+    try:
+        import onnxruntime as ort
+        print("ort.__version__:", ort.__version__)
+        print("ort.get_available_providers():", ort.get_available_providers())
+        import glob
+        candidates = (
+            glob.glob("models/wd14/**/model.onnx", recursive=True)
+            + glob.glob("models/cltagger/**/*.onnx", recursive=True)
+        )
+        if not candidates:
+            print("没找到本地 onnx 模型，跳过 session 创建测试")
+            return
+        path = candidates[0]
+        print("用模型:", path)
+        sess = ort.InferenceSession(
+            path, providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
+        )
+        actual = sess.get_providers()
+        print("实际 session.get_providers():", actual)
+        if "CUDAExecutionProvider" not in actual:
+            print(">>> 确认静默降级：请求过 CUDA 但 session 用的是", actual)
+        else:
+            print(">>> CUDA EP 真生效")
+    except Exception as exc:  # noqa: BLE001
+        print("session 创建抛异常:", exc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 背景

接 #29 后续 —— Windows 路径修完合并后，在云上 Linux（RTX 5090 + driver 580 + onnxruntime-gpu 1.26 + torch 2.11+cu128）实测，发现 Linux 上同样有 CUDA EP 静默降级（#29 加的监控生效，看得到 warning）。继续排查发现**两个独立**的 Linux 路径 bug，与 Windows 修法无关。

| commit | 根因 |
|---|---|
| `9157319` | Worker subprocess 顶层漏 import `onnxruntime_setup` |
| `3311ab2` | `_has_system_cuda_libs()` 把「装 CUDA Toolkit 但缺 cuDNN」误判为完整系统 CUDA，跳过 preload |

## 改动

### 1. Worker subprocess 顶层显式触发 preload

`studio/workers/tag_worker.py` / `studio/workers/reg_build_worker.py`

Worker 是独立 subprocess（`python -m studio.workers.X`），顶层 import 链没碰 `onnxruntime_setup`。`get_tagger("wd14")` 走 `importlib.import_module` 懒加载，触发 `onnxruntime_setup` 加载的时机晚于 onnxruntime 真正 dlopen 的路径 —— PP9.5 的 `_ensure_preload()` 没在 onnxruntime dlopen 之前跑。

修法同 `server.py` / `cli.py` 做法：worker 顶层最早处显式 `from studio.services import onnxruntime_setup  # noqa: F401`。

回归测试 `test_worker_imports_onnxruntime_setup_at_module_level` 用正则匹配 import 行，防止后续被人删掉。

### 2. 系统部分 CUDA 误判（核心 Linux 修复）

`studio/services/onnxruntime_setup.py::_has_system_cuda_libs`

云上诊断脚本输出关键三行：

```
"system_cuda_skip": true,
"_has_system_cuda_libs()": True,
ld 路径里 cudnn: None     ← !!!
```

云镜像装了 CUDA Toolkit（带 cuBLAS，`/usr/local/cuda` 存在）但**没装 cuDNN** —— cuDNN 要 NVIDIA Developer 账号单独下，云镜像常省略。PP9.5 原本的 `_has_system_cuda_libs()` 只检测 cuBLAS / CUDA_HOME / `/usr/local/cuda` 任一就返回 `True`，跳过 torch wheel preload。这种「部分系统 CUDA」场景下，onnxruntime 后续 dlopen `libcudnn.so.9` 在 ld 路径找不到 → 静默降 CPU。

修法：`_has_system_cuda_libs()` 必须 **cuBLAS + cuDNN 都在系统 ld 路径里**才算完整。缺 cuDNN → 走 torch wheel preload 兜底（torch GPU build 自带 cuDNN 9.x 在 `nvidia.cudnn` 子包里，`RTLD_GLOBAL` 加载后 onnxruntime dlopen 即解析）。

### 3. 配套诊断工具

`tools/diagnose_onnx_gpu.py`：顺序输出 platform / `current_runtime()` / 系统 CUDA / torch / nvidia wheels / nvidia-smi / 真创 InferenceSession。给用户报类似问题时一次性提供诊断数据。

## 关键设计点

**进程级别隔离**：`RTLD_GLOBAL` 只影响当前 Python 进程符号表，进程退出清空。不动用户系统的任何 `.so` / `.conf` / PATH / 注册表 / 别的项目。我们只确保 venv 里 torch 已经装好的 cuDNN，在同一进程里能被 onnxruntime dlopen 到。

**版本兼容性**：onnxruntime-gpu 1.20+ 都用 cuDNN 9.x + cuBLAS 12.x；torch cu121-cu128 也是同一套 —— 主流组合都 work。真正错配的场景（如 torch cu118 + onnxruntime-gpu 1.26）这次修不了，但 #29 加的监控会清楚报错让用户自查。

## 测试

### 自动

- `tests/test_onnxruntime_setup.py` 改造 `test_has_system_cuda_libs_via_*` 加 cuDNN mock；新增 `test_has_system_cuda_libs_returns_false_when_cudnn_missing` 直接覆盖云上场景；新增 `test_has_system_cuda_libs_returns_false_when_only_cublas_in_ld` 覆盖 apt 装部分 CUDA 场景
- `tests/test_tag_worker.py` + `tests/test_reg_build_worker.py` 各加 `test_worker_imports_onnxruntime_setup_at_module_level`
- 全套相关测试 68 passed

### 手测

云上 Linux 三轮迭代（每个 commit 后跑一次 wd14 打标）：

| | 改动前（合 #29 后） | 加 worker fix (9157319) | 加 cuDNN 检测 (3311ab2) |
|---|---|---|---|
| 监控 warning | 出现 | 出现 | **消失** |
| `system_cuda_skip` | true（误判） | true（误判） | false（正确） |
| `preload.preloaded` | `[]` | `[]` | `[libcudnn.so.9, libcurand.so.10, ...]` |
| `session.get_providers()` | `[CPU]` | `[CPU]` | `[CUDA, CPU]` |
| 打标实际跑 | CPU | CPU | **GPU** |

## 影响范围

- 只动 onnxruntime 启动期 dlopen 行为，不动业务逻辑 / 模型权重 / 推理代码 / HTTP API / 前端 / DB schema
- Windows 路径（#29 改的 `_add_torch_dll_dirs_windows`）**未触碰**
- 已有的「完整系统 CUDA + 跳过 preload」路径（如 NVIDIA docker 镜像）行为不变 —— `_has_system_cuda_libs()` 收紧后仍正确返回 True
- 无 schema / API / 行为变更（PATCH 性质）

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
