### PR TITLE
feat: v0.5.1 — UI 改进 + onnxruntime-gpu 跨平台修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@
 
 ---
 
+## [0.5.1] — 2026-05-10
+
+UI 体验小改进 + onnxruntime-gpu 跨平台修复（Windows / Linux 都踩到「装了 GPU 包但实际跑 CPU」）。
+
+### 改进
+
+- **打标 curation 工作流**（#27）
+  - 全屏 preview 取代弹窗预览
+  - 键盘 accept / remove 快捷键，过单张图更快
+  - tag 保存后明确的 CNB export 入口
+
+### 修复
+
+- **onnxruntime-gpu 静默降级 CPU**（#29 Windows / #30 Linux）
+  - 根因：onnxruntime 在 CUDA EP dlopen 失败时**不抛异常**，会内部 silently fallback 到 CPU；`ort.get_available_providers()` 仍报 CUDA 可用，UI 显示一切正常，用户只看到 CPU 占用飙升
+  - 加监控：`_create_session` 比对实际 `session.get_providers()`，请求过 CUDA 但实际不在 → 上报 `cuda_load_error` 让 UI 可见
+  - Windows：Python 3.8+ 废除 PATH 自动加载 DLL，新增 `os.add_dll_directory(torch/lib)` 让 onnxruntime 找得到 torch 自带的 `cublasLt64_12.dll` / `cudnn_*.dll`
+  - Linux：worker subprocess 顶层显式 `import onnxruntime_setup` 触发 preload；修 `_has_system_cuda_libs()` 误判（云镜像装 CUDA Toolkit 但没装 cuDNN → 之前被误判为完整系统 CUDA → 跳过 preload）
+  - 新增 `tools/diagnose_onnx_gpu.py` 诊断脚本
+
+---
+
 ## [0.5.0] — 2026-05-09
 
 累计 49 commits / 132 files (+17k / -1.6k)。集中在 4 块：测试出图、先验生成、Setup 重写、Settings 拆分 + 新 tagger（CLTagger）。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,295 @@
+# 贡献指南
+
+适用对象：
+- **Contributor** — 加新功能 / 修 bug 想 PR 进来
+- **Maintainer** — 决定合并 / 发版
+- **AI agent**（Claude Code / 类似）— 帮上面任一角色干活时
+
+---
+
+## 30 秒概览
+
+```
+contributor 切 feature branch from dev
+    ↓ 提多个 commit（noise OK，开发用）
+PR 到 dev：squash 合并（noise 压成 1 个 PR-title commit）
+    ↓ dev 累积一段时间
+maintainer 攒到一组功能 → bump version → PR dev → master：merge commit（保留每 feature 颗粒度）
+    ↓
+打 git tag v0.X.0 → GitHub Release
+```
+
+**为什么这套**：feature branch 上的 noise commit 没价值；master 上每个 commit = 一个完整 feature；release 边界靠 git tag 标，不靠 squash。
+
+---
+
+## 分支策略
+
+| 分支 | 角色 | 谁能 push |
+|---|---|---|
+| `master` | release 分支，永远 stable | **没人直接 push**，只接 dev 的 release PR |
+| `dev` | integration 分支，长期存在 | 默认只接 contributor PR（squash 合并）；**例外**：maintainer 的小型 chore（docs / typo / 配置 / `.gitignore` 等）可直接 push |
+| `feat/<topic>` `fix/<topic>` `refactor/<topic>` `docs/<topic>` `chore/<topic>` | contributor 的临时分支 | 自己 push，从 `dev` 切出 |
+
+切分支：
+
+```bash
+git checkout dev
+git pull origin dev
+git checkout -b feat/cool-thing
+```
+
+---
+
+## Commit message 约定
+
+格式参考 [Conventional Commits](https://www.conventionalcommits.org/zh-hans/)：
+
+```
+type(scope): subject
+
+可选的多行 body，解释 why（不解释 what — 代码就是 what）。
+
+可选 footer（如 BREAKING CHANGE / Co-Authored-By）。
+```
+
+**type**：`feat` / `fix` / `refactor` / `docs` / `chore` / `test` / `perf` / `style`
+
+**scope**（可选）：模块名，`train` / `ui` / `web` / `tagger` / `setup` / `release` 等
+
+示例：
+
+```
+feat(train): 加 attention_backend 三选一字段
+fix(ui): SchemaForm path 字段渲染错位
+refactor: 仓库目录重组 — runtime/ 收纳 anima_* 运行时核心
+docs: 重构 docs/ 为 user-guide / architecture / adr 三块
+chore(release): v0.5.0 — 版本控制系统 + bump 0.4 → 0.5.0
+```
+
+**PR 标题** = 最终 squash 后落到 dev 的 commit message，所以**写 PR 标题要按上面格式**。
+
+---
+
+## PR 流程（Contributor）
+
+### 1. 开始之前
+
+- 确认 issue / 想做的事跟 maintainer 对齐过（避免做了不收）
+- 跑一遍现有测试通过：`python -m studio test`
+
+### 2. 开发
+
+- 在自己的 `feat/<topic>` 分支上自由提 commit（`再调一下` `lint 修了` 这种 noise 都可以，最后会被 squash 掉）
+- **小步走**：一个 PR = 一个完整 unit of work，别把 3 件不相关的事塞一个 PR
+- 改了功能要补 / 改对应测试
+
+### 3. 提交前自检
+
+```bash
+python -m studio test          # 后端 pytest + 前端 vitest 全过
+cd studio/web
+npm run lint                   # 前端 lint
+npx tsc --noEmit               # 前端 typecheck
+```
+
+### 4. 开 PR
+
+- **Base 分支选 `dev`**（不是 master）
+- **PR 标题用 conventional commits 格式** —— 这就是 squash 后的 commit message
+- **PR 描述**至少含：
+  - 背景 / 动机（为什么做）
+  - 改动概要（做了什么）
+  - 测试方式（手测过 / 自动测试覆盖）
+  - 截图（如果是 UI 改动）
+
+### 5. Review
+
+- Maintainer review，可能让你改
+- 改完不需要重开 PR，在原 branch 继续 push 就行
+- CI 必须全过（如果有）
+
+### 6. 合并
+
+- Maintainer 用 **Squash and merge**（GitHub 默认）
+- 你的 noise commits 被压成 1 个 PR-title commit 进 dev
+- 你的 feature branch 可以删了
+
+---
+
+## Release 流程（Maintainer）
+
+### 1. 决定版本号
+
+dev 攒到一组改动后，**看最重的改动**决定 bump 哪一位：
+
+| dev 上的改动 | bump | 例 |
+|---|---|---|
+| 只有 bug fix / 内部 refactor / docs / 配置 | **PATCH** | v0.5.0 → v0.5.1 |
+| 含**任何**新功能 / schema 改 / API 改 / 行为变更 | **MINOR** | v0.5.0 → v0.6.0 |
+
+> 0.x 阶段把 SemVer 收紧用：MINOR 视作「可能不向后兼容」；PATCH **严格不动**既有 config / API / 行为。
+>
+> 「feature 少」很正常——大多数 release 是 PATCH，攒到一个 feat 时再 bump MINOR。
+
+Pre-release 用 `-rc1` / `-beta1` 后缀（v0.6.0-rc1）。
+
+### 2. 在 `dev` 上准备 release
+
+```bash
+git checkout dev
+git pull origin dev
+```
+
+**bump version 三处必须同步**：
+
+1. `studio/__init__.py` — `__version__ = "0.X.0"`
+2. `studio/web/package.json` — `"version": "0.X.0"`
+3. `CHANGELOG.md` 顶部加新段（参考已有格式）
+
+> 前端 Sidebar 的版本号是从 `/api/health` 拉的，**不要去 Sidebar.tsx 硬编码**。
+
+提一个 commit：
+
+```bash
+git add studio/__init__.py studio/web/package.json CHANGELOG.md
+git commit -m "chore(release): v0.X.0"
+git push origin dev
+```
+
+### 3. 开 Release PR：dev → master
+
+- **Base = master，compare = dev**
+- **标题**：`feat: v0.X.0 — <主题>`
+- **描述**：复制 CHANGELOG 的对应段（让 PR 页面就能看到完整改动）
+
+### 4. 合并
+
+- 选 **Create a merge commit**（**不要 squash**）—— 保留 dev 上每个 feature 的 commit 颗粒度
+- Merge commit message 默认 `Merge pull request #N from .../dev`，extended description 简短写 `Version: v0.X.0 — 主题` 即可
+
+### 5. 打 tag
+
+```bash
+git checkout master
+git pull origin master
+git tag -a v0.X.0 -m "v0.X.0 — <主题>"
+git push origin v0.X.0
+```
+
+### 6. 发 GitHub Release
+
+- 去 `https://github.com/WalkingMeatAxolotl/AnimaLoraStudio/releases`
+- 找到刚 push 的 tag → **Create release from tag**
+- **Title**：`v0.X.0 — <主题>`
+- **Body**：复制 [`CHANGELOG.md`](CHANGELOG.md) 对应段
+- 勾选 **Set as the latest release**
+- Publish
+
+---
+
+---
+
+## Hotfix 加急路径（绕过 dev）
+
+**只在等不了下次 release 时用**——线上炸了 / 安全问题 / dev 上有不该跟着发的功能但 bug 必须立即修。平时的 bug fix 走 dev 正常流程，**不算 hotfix**。
+
+```bash
+# 1. 从 master 切（不是从 dev）
+git checkout master && git pull origin master
+git checkout -b hotfix/<topic>
+
+# 2. 修 + 测 + commit + 开 PR
+#    - Base 选 master（不是 dev）
+#    - 标题：fix(scope): ... 描述紧急 bug
+#    - 描述说清楚为什么不能等下次 release
+
+# 3. Squash and merge 进 master
+
+# 4. 按上面 release 流程的第 2 / 5 / 6 步：
+#    - bump PATCH（__init__.py + package.json + CHANGELOG.md）
+#    - 直接在 master 上 commit version bump（也算 hotfix 例外）
+#    - 打 v0.X.Y tag + 发 GitHub Release
+
+# 5. 必须 sync 回 dev！否则 dev 缺这个修复，下次 release 会回归
+git checkout dev
+git merge master
+git push origin dev
+```
+
+第 5 步是关键——很容易忘。Hotfix 之后 dev 必须包含这个修复，不然下次 release（dev → master）的 PR 会显示「这个 bug 又回来了」。
+
+---
+
+## 版本号规则
+
+按 [SemVer](https://semver.org/lang/zh-CN/)：`MAJOR.MINOR.PATCH`
+
+| 阶段 | 规则 |
+|---|---|
+| **0.x**（当前）| MINOR 视为破坏性升级（schema 改 / API 改 / 大重构都进 MINOR）；PATCH 留给 hotfix |
+| **1.0+** | PATCH = bug fix / 内部重构；MINOR = 向后兼容新功能；MAJOR = 破坏性改动 |
+
+唯一来源：`studio/__init__.py:__version__`。FastAPI app version 从这派生（`/api/health` 暴露），前端 Sidebar fetch `/api/health` 拿。
+
+---
+
+## 文档
+
+| 在哪 | 内容 |
+|---|---|
+| [README.md](README.md) | 项目概览 + 快速开始 + 项目结构 |
+| [CHANGELOG.md](CHANGELOG.md) | 版本变更（Keep a Changelog 格式） |
+| [docs/README.md](docs/README.md) | 文档总入口 |
+| [docs/user-guide/](docs/user-guide/) | 用户向：标签格式 / 训练 tips / 正则集 / caption 格式 |
+| [docs/architecture/](docs/architecture/) | 开发者向：跨模块架构总览 |
+| [docs/adr/](docs/adr/) | 架构决策记录（ADR） |
+
+**改了功能**：同步更新对应文档。
+
+**架构层面的「我们选 X 而不选 Y」决定**：写一份新 ADR（`docs/adr/NNNN-title.md`），模板见 [docs/adr/README.md](docs/adr/README.md)。例：[ADR 0001](docs/adr/0001-lokr-via-lycoris-lora.md) 决定 LoKr 走 lycoris-lora 而不切 sd-scripts。
+
+---
+
+## 仓库目录约定
+
+```
+models/      模型实现 + 权重落点
+utils/       lycoris_adapter / optimizer / 训练共享工具
+runtime/     Anima 运行时核心（独立进程；Studio subprocess 拉起 / 也可单独 CLI）
+studio/      Web 后端 + 前端
+tools/       用户 CLI + setup helper（含 dev bench）
+docs/        三块：user-guide / architecture / adr
+tests/       后端 pytest + 前端 vitest（前端测试在 studio/web/src/**/*.test.ts*）
+```
+
+依赖方向单向：`models → utils → runtime → studio → tools`。不要反向 import。
+
+---
+
+## 给 AI agent 的额外说明
+
+如果你是 Claude Code / Cursor / 类似 agent 在帮 maintainer 或 contributor 干活：
+
+**遵守的**：
+
+- 一个 PR = 一个完整 unit of work，别把不相关的改动塞一起
+- 改 version 时**三处必须同步**：`studio/__init__.py` + `studio/web/package.json` + `CHANGELOG.md` 顶部新段
+- 修 bug 不要顺手 refactor 别的代码（除非 maintainer 明确要求）
+- 测试覆盖：bug fix → 加 regression test；feat → 新功能 test
+- 中文 commit message 和文档没问题（仓库已有惯例），但 conventional commits 的 `type(scope):` 前缀用英文
+- 最终 commit message / PR description 走 maintainer 给你说的格式
+
+**不要的**：
+
+- 不要直接 push `master`（不管什么情况）
+- 不要打 git tag / 创建 GitHub Release（这是 maintainer 决定，授权了再做）
+- 不要 squash / rebase / force-push 已经 push 到 origin 的分支（除非 maintainer 明确要求）
+- 不要绕过测试（`--no-verify` / 跳测试 / disable lint），先修根因
+- 不要为了「漂亮」改无关代码 / 改风格 / 改命名（无关改动会让 review 难做）
+
+**优先 reuse 现存代码**：
+
+- 写新组件前 grep 仓库看有没有现成的（`useProjectCtx` / `Toast` / `PathPicker` / `SchemaForm` 等都已存在）
+- 写新 CLI 前看 `tools/` 有没有重叠
+- 写新测试前看 `tests/conftest.py` 的 fixture

--- a/studio/__init__.py
+++ b/studio/__init__.py
@@ -8,4 +8,4 @@
 
 版本规则：MAJOR.MINOR.PATCH（语义版本，但 0.x 阶段 MINOR 即视为破坏性升级）。
 """
-__version__ = "0.5.0"
+__version__ = "0.5.1"

--- a/studio/services/onnx_tagger_base.py
+++ b/studio/services/onnx_tagger_base.py
@@ -131,7 +131,23 @@ class OnnxTaggerBase:
                 str(model_path), providers=["CPUExecutionProvider"]
             )
         else:
-            onnxruntime_setup.record_cuda_load_error(None)
+            # onnxruntime 在 CUDA EP dlopen 失败时**不抛异常** —— 内部 silently
+            # fallback 到下一个 EP（CPU）。光看 try/except 不够，必须比对实际
+            # session.get_providers()；不一致 → 用户实际跑 CPU，但 UI 看不到。
+            if cuda_attempt:
+                actual = list(self._session.get_providers())
+                if "CUDAExecutionProvider" not in actual:
+                    msg = (
+                        f"CUDA EP 静默降级到 CPU（InferenceSession 未抛异常，"
+                        f"但 get_providers={actual}）。常见原因：CUDA 驱动版本不够 / "
+                        f"runtime so/DLL 缺失 / cuDNN ABI 错位。"
+                    )
+                    logger.warning("%s %s", self.name, msg)
+                    onnxruntime_setup.record_cuda_load_error(msg)
+                else:
+                    onnxruntime_setup.record_cuda_load_error(None)
+            else:
+                onnxruntime_setup.record_cuda_load_error(None)
 
         self._input_name = self._session.get_inputs()[0].name
         self._output_names = [o.name for o in self._session.get_outputs()]

--- a/studio/services/onnxruntime_setup.py
+++ b/studio/services/onnxruntime_setup.py
@@ -92,28 +92,44 @@ _CUDA_LOAD_ERROR: Optional[str] = None
 
 
 def _has_system_cuda_libs() -> bool:
-    """Linux 系统是否自带 CUDA 运行时（/usr/local/cuda、apt 装的 libcublas、nvidia docker）。
+    """Linux 系统是否自带**完整** CUDA 运行时（cuBLAS + cuDNN 都在 ld 路径）。
 
-    有系统 CUDA 时跳过 PP9.5 preload —— torch wheel 自带的 CUDA so（cu128 →
-    cuBLAS 12.8）与 onnxruntime-gpu wheel 编译目标的 CUDA so（typically 12.x
-    某子版本）ABI 不匹配；RTLD_GLOBAL 把 torch 的强行塞进全局符号表后，
-    onnxruntime 后续 dlopen cuBLAS 解到错位版本 → 推理时 CUBLAS_STATUS_INVALID_VALUE。
-    系统 CUDA 路径下让 onnxruntime 直接 dlopen 系统提供的版本反而是对的。
+    有**完整**系统 CUDA 时跳过 PP9.5 preload —— torch wheel 自带的 CUDA so
+    （cu128 → cuBLAS 12.8）与 onnxruntime-gpu wheel 编译目标的 CUDA so
+    （typically 12.x 某子版本）ABI 不匹配；RTLD_GLOBAL 把 torch 的强行塞进
+    全局符号表后，onnxruntime 后续 dlopen cuBLAS 解到错位版本 → 推理时
+    CUBLAS_STATUS_INVALID_VALUE。系统 CUDA 完整时让 onnxruntime 直接 dlopen
+    系统版本反而是对的。
 
-    检测策略：
-    - CUDA_HOME / CUDA_PATH 环境变量指向带 lib64 的目录
-    - /usr/local/cuda/lib64 存在（标准安装位置）
-    - ctypes.util.find_library("cublas") 命中（apt 装的 libcublas-dev 等会进 ld 路径）
+    **关键**：必须 cuBLAS + cuDNN 都在系统里才算完整。云镜像装 CUDA Toolkit
+    （带 cuBLAS）但**没装** cuDNN 极常见（cuDNN 要 NVIDIA Developer 账号单独
+    下）；只检测 cuBLAS 会误判 → preload 跳过 → onnxruntime dlopen
+    libcudnn.so.9 失败 → 静默降 CPU。这种「部分系统 CUDA」场景必须让 torch
+    wheel preload 兜底补 cuDNN（torch GPU build 自带 cuDNN 9.x 在
+    nvidia.cudnn 子包里）。
+
+    检测分两步，都满足才返回 True：
+    1. CUDA Toolkit：CUDA_HOME / CUDA_PATH 指向带 lib64 / 默认 /usr/local/cuda
+       存在 / ld 路径里有 libcublas —— 任一命中
+    2. cuDNN：ld 路径里有 libcudnn —— 必须命中
     """
     import ctypes.util  # noqa: PLC0415  仅 Linux 路径用，避免顶层 import 副作用
     cuda_home = os.environ.get("CUDA_HOME") or os.environ.get("CUDA_PATH") or ""
+    has_toolkit = False
     if cuda_home and os.path.isdir(os.path.join(cuda_home, "lib64")):
-        return True
-    if os.path.isdir("/usr/local/cuda/lib64"):
-        return True
-    if ctypes.util.find_library("cublas"):
-        return True
-    return False
+        has_toolkit = True
+    elif os.path.isdir("/usr/local/cuda/lib64"):
+        has_toolkit = True
+    elif ctypes.util.find_library("cublas"):
+        has_toolkit = True
+    if not has_toolkit:
+        return False
+    # 关键：cuDNN 同样必须在系统 ld 路径里。云镜像装 CUDA Toolkit（含 cuBLAS）
+    # 但没装 cuDNN 是非常常见的场景；只检测 cuBLAS 会误判 → preload 被跳过 →
+    # onnxruntime dlopen libcudnn.so.9 失败 → 静默降 CPU。这种部分系统 CUDA
+    # 场景下让 torch wheel preload 兜底补 cuDNN（torch GPU build 在
+    # nvidia.cudnn 子包里自带 cuDNN 9.x）。
+    return bool(ctypes.util.find_library("cudnn"))
 
 
 def _add_torch_dll_dirs_windows() -> dict[str, Any]:

--- a/studio/services/onnxruntime_setup.py
+++ b/studio/services/onnxruntime_setup.py
@@ -116,31 +116,84 @@ def _has_system_cuda_libs() -> bool:
     return False
 
 
+def _add_torch_dll_dirs_windows() -> dict[str, Any]:
+    """PR — Windows 上把 torch 自带的 CUDA DLL 目录加入 Python DLL 搜索路径。
+
+    Python 3.8+ Windows 出于安全废除了 PATH 自动 dlopen native DLL —— 必须
+    `os.add_dll_directory()` 主动声明。onnxruntime 在 import 期 dlopen
+    `cublasLt64_12.dll` / `cudnn_*.dll` 时找不到，`get_available_providers()`
+    照样列 CUDAExecutionProvider，但 InferenceSession 内部 silently 降 CPU
+    （onnx_tagger_base._create_session 已经能识别这种降级）。
+
+    torch GPU build wheel 把全套 CUDA DLL 放在 `site-packages/torch/lib/`
+    （cublasLt64_12 / cudnn*_9 / curand64_10 / cufft64_11 / cusparse64_12 /
+    cudart64_12 / nvrtc）。加进 DLL search path，后续 onnxruntime 的 dlopen
+    就能找到。
+
+    返回 `{"added", "errors", "candidates"}`：
+    - `added`：成功 add_dll_directory 的目录列表
+    - `errors`：尝试但失败的 (dir, reason) 列表
+    - `candidates`：发现的候选目录数（=0 表示 venv 没装 torch GPU build）
+    """
+    added: list[str] = []
+    errors: list[tuple[str, str]] = []
+    try:
+        import torch  # noqa: PLC0415
+    except ImportError:
+        return {"added": added, "errors": errors, "candidates": 0}
+    lib = os.path.join(os.path.dirname(torch.__file__), "lib")
+    if not os.path.isdir(lib):
+        return {"added": added, "errors": errors, "candidates": 0}
+    try:
+        # Python 3.8+ Windows API；其他平台没有
+        os.add_dll_directory(lib)  # type: ignore[attr-defined]
+        added.append(lib)
+    except (OSError, AttributeError) as exc:
+        errors.append((lib, str(exc)))
+    return {"added": added, "errors": errors, "candidates": 1}
+
+
 def _preload_torch_cuda_libs() -> dict[str, Any]:
-    """Linux 上 ctypes RTLD_GLOBAL 预加载 torch 自带的 CUDA runtime so。
+    """跨平台预加载 torch 自带的 CUDA 库，让 onnxruntime-gpu dlopen 找得到。
 
     背景：onnxruntime-gpu wheel 不打包 CUDA runtime；用户机器没系统装 CUDA
     时，CUDA EP 在 `get_available_providers()` 里看着可用，但创 session 时
-    dlopen 失败（典型 `libcurand.so.10: cannot open shared object file`）。
-    PyTorch 装 GPU build 会带一组 `nvidia-*-cu12` wheel，把 so 放到
-    `site-packages/nvidia/*/lib/`；提前 RTLD_GLOBAL 加载它们后，onnxruntime
-    后续 dlopen 就能从已加载的全局符号表里解析。
+    dlopen 失败（Linux: `libcurand.so.10`；Windows: `cublasLt64_12.dll`）。
+    onnxruntime 不抛异常，会**静默降级到 CPU**（onnx_tagger_base 已有检测）。
 
-    **注意**：系统已有 CUDA（如 nvidia docker 镜像）时跳过 preload。torch wheel
-    的 CUDA 版本（cu128 = cuBLAS 12.8）与 onnxruntime-gpu 编译目标的 CUDA 子
-    版本不一致时，强行 RTLD_GLOBAL 覆盖会导致推理时 CUBLAS_STATUS_INVALID_VALUE。
+    PyTorch GPU build 自带所有需要的 CUDA 库：
+    - **Linux**：装到 `site-packages/nvidia/*/lib/` —— `ctypes.CDLL(RTLD_GLOBAL)`
+      预加载到全局符号表
+    - **Windows**：装到 `site-packages/torch/lib/` —— `os.add_dll_directory()`
+      加入 DLL 搜索路径（Python 3.8+ 必需）
+
+    **注意**：Linux 上系统已有 CUDA（如 nvidia docker 镜像）时跳过 preload。
+    torch wheel 的 CUDA 版本（cu128 = cuBLAS 12.8）与 onnxruntime-gpu 编译目标
+    的 CUDA 子版本不一致时，强行 RTLD_GLOBAL 覆盖会导致推理时
+    CUBLAS_STATUS_INVALID_VALUE。Windows 上 `add_dll_directory` 只是把目录加进
+    搜索路径，不强行覆盖已加载的符号，所以无此问题。
 
     只对**当前进程**生效；server 子进程必须自己再跑一次（本模块在 import 时
     自动跑）。
 
     返回 `{"applied", "platform_skip", "system_cuda_skip", "preloaded", "errors", "candidates"}`：
-    - `platform_skip=True`：非 Linux，整体跳过（Windows / macOS 走别的路子）
-    - `system_cuda_skip=True`：检测到系统 CUDA，跳过 preload 让 onnxruntime
+    - `platform_skip=True`：非 Linux / 非 Windows（如 macOS），整体跳过
+    - `system_cuda_skip=True`：Linux 系统 CUDA 路径，跳过 preload 让 onnxruntime
       自己 dlopen 系统提供的版本
-    - `preloaded`：成功 dlopen 的绝对路径列表
-    - `errors`：尝试 dlopen 但失败的 (path, reason) 列表
-    - `candidates`：被检视的 nvidia.* 子包数（用来观测 venv 里是否有 torch CUDA）
+    - `preloaded`：成功 dlopen / add_dll_directory 的绝对路径列表
+    - `errors`：尝试但失败的 (path, reason) 列表
+    - `candidates`：检视的候选数（Linux: nvidia.* 子包；Windows: torch/lib 目录）
     """
+    if sys.platform == "win32":
+        wres = _add_torch_dll_dirs_windows()
+        return {
+            "applied": True,
+            "platform_skip": False,
+            "system_cuda_skip": False,
+            "preloaded": wres["added"],
+            "errors": wres["errors"],
+            "candidates": wres["candidates"],
+        }
     if not sys.platform.startswith("linux"):
         return {
             "applied": False,

--- a/studio/web/package.json
+++ b/studio/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anima-studio-web",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/studio/web/src/components/ImageGrid.test.tsx
+++ b/studio/web/src/components/ImageGrid.test.tsx
@@ -80,6 +80,45 @@ describe('ImageGrid (PP3)', () => {
     )
   })
 
+  it('activate mode uses plain cell click for activation', async () => {
+    const onSelect = vi.fn()
+    const onActivate = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ImageGrid
+        items={items}
+        selected={new Set()}
+        onSelect={onSelect}
+        onActivate={onActivate}
+        clickMode="activate"
+      />
+    )
+    await user.click(screen.getAllByRole('gridcell')[0])
+    expect(onActivate).toHaveBeenCalledWith('a.png')
+    expect(onSelect).not.toHaveBeenCalled()
+  })
+
+  it('activate mode keeps checkbox selection separate', async () => {
+    const onSelect = vi.fn()
+    const onActivate = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <ImageGrid
+        items={items}
+        selected={new Set()}
+        onSelect={onSelect}
+        onActivate={onActivate}
+        clickMode="activate"
+      />
+    )
+    await user.click(screen.getByRole('button', { name: '选择 a.png' }))
+    expect(onSelect).toHaveBeenCalledWith(
+      'a.png',
+      expect.objectContaining({ shiftKey: false })
+    )
+    expect(onActivate).not.toHaveBeenCalled()
+  })
+
   it('shows empty hint', () => {
     render(
       <ImageGrid items={[]} selected={new Set()} onSelect={() => {}} emptyHint="空空" />

--- a/studio/web/src/components/ImageGrid.tsx
+++ b/studio/web/src/components/ImageGrid.tsx
@@ -16,6 +16,9 @@ interface Props {
   onHover?: (name: string) => void
   /** 全屏 modal 预览，由 cell 上的放大镜按钮触发（可选）。 */
   onPreview?: (name: string) => void
+  /** 主点击行为：默认选择；activate 模式下普通点击交给外部打开/激活。 */
+  onActivate?: (name: string) => void
+  clickMode?: 'select' | 'activate'
   /** 渲染上限；超出在末尾显示「显示前 N 张」。 */
   limit?: number
   emptyHint?: string
@@ -44,6 +47,8 @@ export default function ImageGrid({
   onSelect,
   onHover,
   onPreview,
+  onActivate,
+  clickMode = 'select',
   limit = 500,
   emptyHint = '没有图片',
   ariaLabel,
@@ -77,6 +82,8 @@ export default function ImageGrid({
             onSelect={onSelect}
             onHover={onHover}
             onPreview={onPreview}
+            onActivate={onActivate}
+            clickMode={clickMode}
           />
         )
       })}
@@ -103,6 +110,8 @@ const Cell = memo(function Cell({
   onSelect,
   onHover,
   onPreview,
+  onActivate,
+  clickMode,
 }: {
   item: ImageGridItem
   selected: boolean
@@ -110,13 +119,28 @@ const Cell = memo(function Cell({
   onSelect: (name: string, e: React.MouseEvent) => void
   onHover?: (name: string) => void
   onPreview?: (name: string) => void
+  onActivate?: (name: string) => void
+  clickMode: 'select' | 'activate'
 }) {
+  const handleCellClick = (e: React.MouseEvent) => {
+    if (clickMode === 'activate' && onActivate && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
+      onActivate(item.name)
+      return
+    }
+    onSelect(item.name, e)
+  }
+
+  const handleSelectionClick = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    onSelect(item.name, e)
+  }
+
   return (
     <div
       role="gridcell"
       aria-selected={selected}
       onMouseEnter={onHover ? () => onHover(item.name) : undefined}
-      onClick={(e) => onSelect(item.name, e)}
+      onClick={handleCellClick}
       title={item.meta ? `${item.name}\n${item.meta}` : item.name}
       className={
         'group relative aspect-square overflow-hidden rounded border cursor-pointer select-none ' +
@@ -134,9 +158,10 @@ const Cell = memo(function Cell({
         draggable={false}
         className="w-full h-full object-cover pointer-events-none"
       />
-      {/* checkbox 视觉指示：选中显示实心 ✓，未选中悬停时显示空框 */}
-      <span
-        aria-hidden
+      <button
+        type="button"
+        onClick={handleSelectionClick}
+        aria-label={`${selected ? '取消选择' : '选择'} ${item.name}`}
         className={
           'absolute top-1 left-1 w-5 h-5 rounded-sm flex items-center justify-center text-[12px] font-bold transition-opacity ' +
           (selected
@@ -145,7 +170,7 @@ const Cell = memo(function Cell({
         }
       >
         ✓
-      </span>
+      </button>
       {/* 放大镜：悬停时出现，点击触发 modal 全屏预览（不影响选择状态） */}
       {onPreview && (
         <button

--- a/studio/web/src/components/ImagePreviewModal.tsx
+++ b/studio/web/src/components/ImagePreviewModal.tsx
@@ -8,6 +8,9 @@ interface Props {
   onClose: () => void
   onPrev?: () => void
   onNext?: () => void
+  onAccept?: () => void
+  onDelete?: () => void
+  shortcutHint?: string
 }
 
 export default function ImagePreviewModal({
@@ -18,64 +21,85 @@ export default function ImagePreviewModal({
   onClose,
   onPrev,
   onNext,
+  onAccept,
+  onDelete,
+  shortcutHint,
 }: Props) {
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-      else if (e.key === 'ArrowLeft' && hasPrev && onPrev) onPrev()
-      else if (e.key === 'ArrowRight' && hasNext && onNext) onNext()
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      } else if (e.key === 'ArrowLeft' && hasPrev && onPrev) {
+        e.preventDefault()
+        onPrev()
+      } else if (e.key === 'ArrowRight' && hasNext && onNext) {
+        e.preventDefault()
+        onNext()
+      } else if ((e.key === 'Enter' || e.key === ' ') && onAccept) {
+        e.preventDefault()
+        onAccept()
+      } else if ((e.key === 'Delete' || e.key === 'Backspace') && onDelete) {
+        e.preventDefault()
+        onDelete()
+      }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [hasPrev, hasNext, onPrev, onNext, onClose])
+  }, [hasPrev, hasNext, onPrev, onNext, onClose, onAccept, onDelete])
 
   return (
     <div
-      className="fixed inset-0 z-50 bg-black/85 flex flex-col items-center justify-center"
+      className="fixed inset-0 z-50 bg-black flex flex-col"
       onClick={onClose}
     >
-      <button
-        onClick={(e) => {
-          e.stopPropagation()
-          onClose()
-        }}
-        className="absolute top-3 right-4 text-slate-300 hover:text-white text-2xl"
-        aria-label="关闭"
-      >
-        ×
-      </button>
-      {hasPrev && onPrev && (
+      <div className="relative flex-1 min-h-0 flex items-center justify-center p-4 sm:p-6">
         <button
           onClick={(e) => {
             e.stopPropagation()
-            onPrev()
+            onClose()
           }}
-          className="absolute left-4 top-1/2 -translate-y-1/2 text-slate-300 hover:text-white text-3xl px-3 py-2 bg-black/30 rounded"
-          aria-label="上一张"
+          className="absolute top-3 right-4 z-10 rounded bg-black/50 px-3 py-1 text-slate-300 hover:text-white text-2xl"
+          aria-label="关闭"
         >
-          ‹
+          ×
         </button>
-      )}
-      {hasNext && onNext && (
-        <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onNext()
-          }}
-          className="absolute right-4 top-1/2 -translate-y-1/2 text-slate-300 hover:text-white text-3xl px-3 py-2 bg-black/30 rounded"
-          aria-label="下一张"
-        >
-          ›
-        </button>
-      )}
-      <img
-        src={src}
-        alt={caption ?? 'preview'}
-        onClick={(e) => e.stopPropagation()}
-        className="max-w-[95vw] max-h-[88vh] object-contain"
-      />
-      {caption && (
-        <div className="mt-2 text-xs text-slate-400 font-mono">{caption}</div>
+        {hasPrev && onPrev && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onPrev()
+            }}
+            className="absolute left-4 top-1/2 z-10 -translate-y-1/2 text-slate-300 hover:text-white text-5xl px-4 py-3 bg-black/30 rounded"
+            aria-label="上一张"
+          >
+            ‹
+          </button>
+        )}
+        {hasNext && onNext && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              onNext()
+            }}
+            className="absolute right-4 top-1/2 z-10 -translate-y-1/2 text-slate-300 hover:text-white text-5xl px-4 py-3 bg-black/30 rounded"
+            aria-label="下一张"
+          >
+            ›
+          </button>
+        )}
+        <img
+          src={src}
+          alt={caption ?? 'preview'}
+          onClick={(e) => e.stopPropagation()}
+          className="max-w-full max-h-full object-contain"
+        />
+      </div>
+      {(caption || shortcutHint) && (
+        <div className="shrink-0 border-t border-white/10 bg-black px-4 py-2 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-slate-400">
+          {caption && <div className="font-mono text-slate-300">{caption}</div>}
+          {shortcutHint && <div>{shortcutHint}</div>}
+        </div>
       )}
     </div>
   )

--- a/studio/web/src/pages/project/steps/Curation.tsx
+++ b/studio/web/src/pages/project/steps/Curation.tsx
@@ -91,6 +91,9 @@ interface Ctx {
 }
 
 interface Preview {
+  side: 'left' | 'right'
+  name: string
+  folder?: string
   url: string
   caption: string
   list: string[]
@@ -330,15 +333,23 @@ export default function CurationPage() {
   }
 
   // ---------- copy / remove / folder ops ----------
-  const doCopy = async () => {
-    if (!rightFolder) return toast('请先在右侧 Train 选一个文件夹', 'error')
-    if (!FOLDER_PATTERN.test(rightFolder))
-      return toast('文件夹名非法', 'error')
-    if (leftSel.size === 0) return
+  const copyLeftFiles = async (
+    files: string[],
+    options: { clearSelection?: boolean } = {}
+  ) => {
+    if (!rightFolder) {
+      toast('请先在右侧 Train 选一个文件夹', 'error')
+      return false
+    }
+    if (!FOLDER_PATTERN.test(rightFolder)) {
+      toast('文件夹名非法', 'error')
+      return false
+    }
+    if (files.length === 0 || busy) return false
     setBusy(true)
     try {
       const r = await api.copyToTrain(project.id, activeVersion.id, {
-        files: Array.from(leftSel),
+        files,
         dest_folder: rightFolder,
       })
       toast(
@@ -347,34 +358,55 @@ export default function CurationPage() {
         }`,
         'success'
       )
-      setLeftSel(new Set())
+      if (options.clearSelection) setLeftSel(new Set())
       await refresh()
       await reload()
+      return true
     } catch (e) {
       toast(String(e), 'error')
+      return false
     } finally {
       setBusy(false)
     }
   }
 
-  const doRemove = async () => {
-    if (!rightFolder || rightSel.size === 0) return
-    if (!confirm(`从 ${rightFolder}/ 移除 ${rightSel.size} 张?`)) return
+  const removeRightFiles = async (
+    folder: string,
+    files: string[],
+    options: { clearSelection?: boolean; confirm?: boolean } = {}
+  ) => {
+    if (!folder || files.length === 0 || busy) return false
+    if (options.confirm && !confirm(`从 ${folder}/ 移除 ${files.length} 张?`)) {
+      return false
+    }
     setBusy(true)
     try {
       const r = await api.removeFromTrain(project.id, activeVersion.id, {
-        folder: rightFolder,
-        files: Array.from(rightSel),
+        folder,
+        files,
       })
       toast(`已移除 ${r.removed.length} 张`, 'success')
-      setRightSel(new Set())
+      if (options.clearSelection) setRightSel(new Set())
       await refresh()
       await reload()
+      return true
     } catch (e) {
       toast(String(e), 'error')
+      return false
     } finally {
       setBusy(false)
     }
+  }
+
+  const doCopy = async () => {
+    await copyLeftFiles(Array.from(leftSel), { clearSelection: true })
+  }
+
+  const doRemove = async () => {
+    await removeRightFiles(rightFolder, Array.from(rightSel), {
+      clearSelection: true,
+      confirm: true,
+    })
   }
 
   const doCreateFolder = async () => {
@@ -456,28 +488,35 @@ export default function CurationPage() {
   // ---------- modal preview ----------
   const openLeftPreview = (name: string) => {
     setPreview({
-      url: api.projectThumbUrl(project.id, name),
+      side: 'left',
+      name,
+      url: api.projectThumbUrl(project.id, name, 'download', 1600),
       caption: name,
       list: leftSortedNames,
       index: leftSortedNames.indexOf(name),
-      resolve: (n) => api.projectThumbUrl(project.id, n),
+      resolve: (n) => api.projectThumbUrl(project.id, n, 'download', 1600),
     })
   }
   const openRightPreview = (name: string) => {
     if (versionId == null) return
+    const folder = rightFolder
     setPreview({
+      side: 'right',
+      name,
+      folder,
       url: api.versionThumbUrl(
         project.id,
         versionId,
         'train',
         name,
-        rightFolder
+        folder,
+        1600
       ),
-      caption: `${rightFolder}/${name}`,
+      caption: `${folder}/${name}`,
       list: rightSortedNames,
       index: rightSortedNames.indexOf(name),
       resolve: (n) =>
-        api.versionThumbUrl(project.id, versionId, 'train', n, rightFolder),
+        api.versionThumbUrl(project.id, versionId, 'train', n, folder, 1600),
     })
   }
   const stepPreview = (delta: number) => {
@@ -487,10 +526,43 @@ export default function CurationPage() {
     const name = preview.list[idx]
     setPreview({
       ...preview,
+      name,
       url: preview.resolve(name),
-      caption: name,
+      caption: preview.side === 'right' && preview.folder ? `${preview.folder}/${name}` : name,
       index: idx,
     })
+  }
+
+  const advancePreviewAfterAction = (doneName: string) => {
+    if (!preview) return
+    const list = preview.list.filter((name) => name !== doneName)
+    if (list.length === 0) {
+      setPreview(null)
+      return
+    }
+    const index = Math.min(preview.index, list.length - 1)
+    const name = list[index]
+    setPreview({
+      ...preview,
+      name,
+      url: preview.resolve(name),
+      caption: preview.side === 'right' && preview.folder ? `${preview.folder}/${name}` : name,
+      list,
+      index,
+    })
+  }
+
+  const copyPreviewImage = async () => {
+    if (!preview || preview.side !== 'left' || busy) return
+    const name = preview.name
+    if (await copyLeftFiles([name])) advancePreviewAfterAction(name)
+  }
+
+  const removePreviewImage = async () => {
+    if (!preview || preview.side !== 'right' || !preview.folder || busy) return
+    const folder = preview.folder
+    const name = preview.name
+    if (await removeRightFiles(folder, [name])) advancePreviewAfterAction(name)
   }
 
   return (
@@ -554,9 +626,12 @@ export default function CurationPage() {
             <ImageGrid
               items={leftItems}
               selected={leftSel}
+              activeName={preview?.side === 'left' ? preview.name : undefined}
               onSelect={handleLeftClick}
               onHover={onLeftHover}
               onPreview={openLeftPreview}
+              onActivate={openLeftPreview}
+              clickMode="activate"
               ariaLabel="download-grid"
               emptyHint="download/ 已经全部用完，或还没下载"
             />
@@ -648,9 +723,12 @@ export default function CurationPage() {
             <ImageGrid
               items={rightItems}
               selected={rightSel}
+              activeName={preview?.side === 'right' ? preview.name : undefined}
               onSelect={handleRightClick}
               onHover={onRightHover}
               onPreview={openRightPreview}
+              onActivate={openRightPreview}
+              clickMode="activate"
               ariaLabel="train-grid"
               emptyHint={
                 rightFolder
@@ -675,6 +753,13 @@ export default function CurationPage() {
           onClose={() => setPreview(null)}
           onPrev={() => stepPreview(-1)}
           onNext={() => stepPreview(1)}
+          onAccept={preview.side === 'left' ? copyPreviewImage : undefined}
+          onDelete={preview.side === 'right' ? removePreviewImage : undefined}
+          shortcutHint={
+            preview.side === 'left'
+              ? '←/→ 浏览 · Enter/Space 复制到 Train'
+              : '←/→ 浏览 · Delete/Backspace 从 Train 移除'
+          }
         />
       )}
     </div>

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useOutletContext } from 'react-router-dom'
 import {
   api,
+  downloadBlob,
   type CommitItem,
   type ProjectDetail,
   type Version,
@@ -49,6 +50,7 @@ export default function TagEditPage() {
   const [sel, setSel] = useState<Set<string>>(new Set())
   const [anchor, setAnchor] = useState<string | null>(null)
   const [filterTag, setFilterTag] = useState<string>('')
+  const [exporting, setExporting] = useState(false)
 
   const reloadCache = useCallback(async () => {
     if (versionId == null) return
@@ -199,6 +201,22 @@ export default function TagEditPage() {
 
   const onAfterRestore = async () => { await reloadCache(); await reload() }
 
+  const exportForCnb = async () => {
+    if (dirty) {
+      toast('先保存标签，再导出给 CNB', 'error')
+      return
+    }
+    setExporting(true)
+    try {
+      const filename = `${project.slug}-${activeVersion.label}.train.zip`
+      await downloadBlob(api.versionTrainZipUrl(project.id, activeVersion.id), filename)
+    } catch (e) {
+      toast(`导出失败: ${e}`, 'error')
+    } finally {
+      setExporting(false)
+    }
+  }
+
   const stats = activeVersion.stats
   const trainTotal = stats?.train_image_count ?? 0
   const taggedTotal = stats?.tagged_image_count ?? 0
@@ -223,6 +241,14 @@ export default function TagEditPage() {
               {taggedTotal}/{trainTotal} 已打标
             </span>
           )}
+          <button
+            className="btn btn-primary btn-sm"
+            disabled={exporting || dirty || trainTotal === 0}
+            onClick={exportForCnb}
+            title={dirty ? '先保存标签再导出' : '导出当前版本训练集 zip，上传到 CNB 训练'}
+          >
+            {exporting ? '打包中…' : '导出给 CNB'}
+          </button>
           <SaveBar
             pid={project.id}
             vid={activeVersion.id}

--- a/studio/workers/reg_build_worker.py
+++ b/studio/workers/reg_build_worker.py
@@ -39,6 +39,11 @@ for _stream in (sys.stdout, sys.stderr):
     except (AttributeError, OSError):
         pass
 
+# PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload。
+# auto_tag 路径会内联调 wd14_tagger（line ~105 `get_tagger("wd14")`），worker 是独立
+# subprocess，必须自己 import；否则 CUDA EP 静默降级到 CPU，用户看不到任何信号。
+from studio.services import onnxruntime_setup  # noqa: F401
+
 from studio import db, project_jobs, projects, secrets, versions
 from studio.datasets import IMAGE_EXTS
 from studio.services import reg_builder, reg_postprocess, tagedit

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -29,6 +29,12 @@ for _stream in (sys.stdout, sys.stderr):
     except (AttributeError, OSError):
         pass
 
+# PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload
+# （Linux: RTLD_GLOBAL 加载 torch 自带 CUDA so；Windows: os.add_dll_directory）。
+# cli.py / server.py 已覆盖各自进程；worker 是独立 subprocess，靠 get_tagger
+# 懒加载链触发太晚（懒加载在 main() 里，某些路径下来不及）—— worker 顶层显式 import。
+from studio.services import onnxruntime_setup  # noqa: F401
+
 from studio import db, project_jobs, projects, versions
 from studio.datasets import IMAGE_EXTS
 from studio.services import tagedit

--- a/tests/test_onnx_tagger_base.py
+++ b/tests/test_onnx_tagger_base.py
@@ -65,6 +65,101 @@ def test_is_cuda_inference_error_ignores_unrelated_failures(msg: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _create_session — CUDA EP 静默降级检测
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_session(providers: list[str]):
+    """构造一个 mock onnxruntime session：input/output name + 指定 providers。"""
+    sess = MagicMock()
+    sess.get_inputs.return_value = [MagicMock()]
+    sess.get_inputs.return_value[0].name = "x"
+    sess.get_outputs.return_value = [MagicMock()]
+    sess.get_outputs.return_value[0].name = "y"
+    sess.get_providers.return_value = list(providers)
+    return sess
+
+
+def test_create_session_records_error_on_silent_cuda_downgrade(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """onnxruntime 在 CUDA dlopen 失败时不抛而是 silently 降 CPU；
+    `_create_session` 必须比对实际 providers 并 stash 错误，否则 UI 看不到。"""
+    t = _StubTagger()
+
+    fake_session = _make_fake_session(["CPUExecutionProvider"])  # 装的是 GPU，但实际只剩 CPU
+    requested_providers: list[list[str]] = []
+
+    def fake_session_ctor(path, providers):
+        requested_providers.append(list(providers))
+        return fake_session
+
+    fake_ort = MagicMock(InferenceSession=fake_session_ctor)
+    fake_ort.get_available_providers.return_value = [
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+    monkeypatch.setitem(__import__("sys").modules, "onnxruntime", fake_ort)
+    # 起始无旧错记录
+    onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+    try:
+        t._create_session(Path("/fake/model.onnx"))
+        # 用户请求过 CUDA
+        assert requested_providers and "CUDAExecutionProvider" in requested_providers[0]
+        # 但 onnxruntime 内部静默降 CPU → 必须有 cuda_load_error 让 UI 显示
+        err = onnx_tagger_base.onnxruntime_setup.get_cuda_load_error()
+        assert err is not None
+        assert "静默降级" in err or "silently" in err.lower()
+    finally:
+        onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+
+def test_create_session_clears_error_when_cuda_actually_works(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """请求 CUDA 且实际 providers 含 CUDA → 清空旧错（成功路径）。"""
+    t = _StubTagger()
+    fake_session = _make_fake_session(
+        ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    )
+
+    fake_ort = MagicMock(InferenceSession=lambda _p, providers: fake_session)
+    fake_ort.get_available_providers.return_value = [
+        "CUDAExecutionProvider",
+        "CPUExecutionProvider",
+    ]
+    monkeypatch.setitem(__import__("sys").modules, "onnxruntime", fake_ort)
+    # 预置一个旧错
+    onnx_tagger_base.onnxruntime_setup.record_cuda_load_error("old failure")
+
+    try:
+        t._create_session(Path("/fake/model.onnx"))
+        assert onnx_tagger_base.onnxruntime_setup.get_cuda_load_error() is None
+    finally:
+        onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+
+def test_create_session_no_false_positive_when_cuda_not_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """机器没 GPU → 根本没请求 CUDA → providers 只有 CPU 是正常的，不应记错。"""
+    t = _StubTagger()
+    fake_session = _make_fake_session(["CPUExecutionProvider"])
+
+    fake_ort = MagicMock(InferenceSession=lambda _p, providers: fake_session)
+    fake_ort.get_available_providers.return_value = ["CPUExecutionProvider"]
+    monkeypatch.setitem(__import__("sys").modules, "onnxruntime", fake_ort)
+    onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+    try:
+        t._create_session(Path("/fake/model.onnx"))
+        assert onnx_tagger_base.onnxruntime_setup.get_cuda_load_error() is None
+    finally:
+        onnx_tagger_base.onnxruntime_setup.record_cuda_load_error(None)
+
+
+# ---------------------------------------------------------------------------
 # _fallback_to_cpu_session
 # ---------------------------------------------------------------------------
 

--- a/tests/test_onnxruntime_setup.py
+++ b/tests/test_onnxruntime_setup.py
@@ -597,22 +597,22 @@ def test_current_runtime_exposes_cuda_load_error(
 def test_has_system_cuda_libs_via_cuda_home(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
-    """CUDA_HOME 指向带 lib64 的目录 → True。"""
+    """CUDA_HOME + 系统也有 cuDNN → True。"""
     fake_root = tmp_path / "fake-cuda"
     (fake_root / "lib64").mkdir(parents=True)
     monkeypatch.setenv("CUDA_HOME", str(fake_root))
     monkeypatch.delenv("CUDA_PATH", raising=False)
-    # 确保 /usr/local/cuda/lib64 不存在 + ctypes.find_library 不命中（隔离环境）
     monkeypatch.setattr(ors.os.path, "isdir", lambda p: p.endswith(str(fake_root / "lib64")))
     import ctypes.util as _cu  # noqa: PLC0415
-    monkeypatch.setattr(_cu, "find_library", lambda _name: None)
+    # cuDNN 在系统 ld 里
+    monkeypatch.setattr(_cu, "find_library", lambda name: "libcudnn.so.9" if name == "cudnn" else None)
     assert ors._has_system_cuda_libs() is True
 
 
 def test_has_system_cuda_libs_via_default_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """没设 CUDA_HOME 但 /usr/local/cuda/lib64 存在 → True。"""
+    """/usr/local/cuda/lib64 + 系统 cuDNN → True。"""
     monkeypatch.delenv("CUDA_HOME", raising=False)
     monkeypatch.delenv("CUDA_PATH", raising=False)
     monkeypatch.setattr(
@@ -621,7 +621,7 @@ def test_has_system_cuda_libs_via_default_path(
         lambda p: p == "/usr/local/cuda/lib64",
     )
     import ctypes.util as _cu  # noqa: PLC0415
-    monkeypatch.setattr(_cu, "find_library", lambda _name: None)
+    monkeypatch.setattr(_cu, "find_library", lambda name: "libcudnn.so.9" if name == "cudnn" else None)
     assert ors._has_system_cuda_libs() is True
 
 
@@ -633,6 +633,38 @@ def test_has_system_cuda_libs_returns_false_when_no_signals(
     monkeypatch.setattr(ors.os.path, "isdir", lambda _p: False)
     import ctypes.util as _cu  # noqa: PLC0415
     monkeypatch.setattr(_cu, "find_library", lambda _name: None)
+    assert ors._has_system_cuda_libs() is False
+
+
+def test_has_system_cuda_libs_returns_false_when_cudnn_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """关键修复回归：系统有 CUDA Toolkit（cuBLAS 在 /usr/local/cuda）但**没装 cuDNN** —
+    必须返回 False，让 torch wheel preload 兜底补 cuDNN。否则 onnxruntime
+    dlopen libcudnn.so.9 失败 → 静默降 CPU（用户在云上实测踩到）。"""
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    monkeypatch.setattr(
+        ors.os.path,
+        "isdir",
+        lambda p: p == "/usr/local/cuda/lib64",
+    )
+    import ctypes.util as _cu  # noqa: PLC0415
+    # cuBLAS 在系统里，cuDNN 不在
+    monkeypatch.setattr(_cu, "find_library", lambda name: "libcublas.so.12" if name == "cublas" else None)
+    assert ors._has_system_cuda_libs() is False
+
+
+def test_has_system_cuda_libs_returns_false_when_only_cublas_in_ld(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """没 CUDA_HOME、没 /usr/local/cuda，只有 ld 路径里的 cuBLAS（apt 装的）+
+    没 cuDNN → False（同上：部分系统 CUDA 也算不完整）。"""
+    monkeypatch.delenv("CUDA_HOME", raising=False)
+    monkeypatch.delenv("CUDA_PATH", raising=False)
+    monkeypatch.setattr(ors.os.path, "isdir", lambda _p: False)
+    import ctypes.util as _cu  # noqa: PLC0415
+    monkeypatch.setattr(_cu, "find_library", lambda name: "libcublas.so.12" if name == "cublas" else None)
     assert ors._has_system_cuda_libs() is False
 
 

--- a/tests/test_onnxruntime_setup.py
+++ b/tests/test_onnxruntime_setup.py
@@ -293,13 +293,79 @@ def test_bootstrap_install_failure_returns_error(
 # ---------------------------------------------------------------------------
 
 
-def test_preload_skips_on_non_linux(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(ors.sys, "platform", "win32")
+def test_preload_skips_on_unsupported_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    """非 Linux / 非 Windows（如 macOS）→ 整体跳过。"""
+    monkeypatch.setattr(ors.sys, "platform", "darwin")
     res = ors._preload_torch_cuda_libs()
     assert res["platform_skip"] is True
     assert res["applied"] is False
     assert res["preloaded"] == []
     assert res["candidates"] == 0
+
+
+def test_preload_windows_adds_torch_lib_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Windows + 装了 torch GPU build → os.add_dll_directory(torch/lib) 被调，
+    返回结果 preloaded 含目录路径（onnxruntime dlopen cublasLt 等找得到）。"""
+    monkeypatch.setattr(ors.sys, "platform", "win32")
+
+    # 仿造 torch.__file__ 指向带 lib/ 的目录
+    torch_pkg = tmp_path / "torch"
+    (torch_pkg / "lib").mkdir(parents=True)
+    fake_torch = MagicMock()
+    fake_torch.__file__ = str(torch_pkg / "__init__.py")
+
+    def _import(name: str):
+        if name == "torch":
+            return fake_torch
+        raise ImportError(name)
+
+    monkeypatch.setattr(ors.importlib, "import_module", _import)
+    # 旁路：venv/Scripts/python.exe 下 `import torch` 走 sys.modules，
+    # 但 _add_torch_dll_dirs_windows 用的是 `import torch` 函数局部 —— 用
+    # monkeypatch sys.modules 直接喂
+    monkeypatch.setitem(__import__("sys").modules, "torch", fake_torch)
+
+    called: list[str] = []
+    monkeypatch.setattr(
+        ors.os,
+        "add_dll_directory",
+        lambda d: called.append(d) or MagicMock(),
+        raising=False,
+    )
+
+    res = ors._preload_torch_cuda_libs()
+    assert res["applied"] is True
+    assert res["platform_skip"] is False
+    assert str(torch_pkg / "lib") in res["preloaded"]
+    assert called == [str(torch_pkg / "lib")]
+
+
+def test_preload_windows_noop_without_torch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Windows 但 venv 没 torch → applied 仍为 True（平台支持），candidates=0。"""
+    monkeypatch.setattr(ors.sys, "platform", "win32")
+    monkeypatch.delitem(__import__("sys").modules, "torch", raising=False)
+
+    # 让 `import torch` 失败：覆盖 importlib.import_module 不够，因为函数内
+    # 用的是字面 import；改 sys.modules 哨兵 + meta_path 不太干净。简单做法：
+    # 把 ors.os.path.isdir 在没 torch 时也走 False 路径 —— 但实际函数体先 import
+    # 失败就提前 return。这里直接构造 import 错误：
+    import builtins
+    real_import = builtins.__import__
+
+    def _fake_import(name, *a, **k):
+        if name == "torch":
+            raise ImportError("not installed")
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", _fake_import)
+    res = ors._preload_torch_cuda_libs()
+    assert res["applied"] is True
+    assert res["candidates"] == 0
+    assert res["preloaded"] == []
 
 
 def test_preload_noop_when_no_torch_nvidia_packages(

--- a/tests/test_reg_build_worker.py
+++ b/tests/test_reg_build_worker.py
@@ -158,3 +158,19 @@ def test_worker_skips_auto_tag_when_disabled(env) -> None:
     # 没 auto_tag → 不写 .txt
     txts = list((rdir / "1_data").glob("*.txt"))
     assert txts == []
+
+
+def test_worker_imports_onnxruntime_setup_at_module_level() -> None:
+    """worker 是独立 subprocess —— auto_tag 路径会 get_tagger("wd14")，必须
+    在任何 onnxruntime import 之前触发 onnxruntime_setup 顶层 preload。
+    """
+    import re
+    import sys
+    src = Path(reg_build_worker.__file__).read_text(encoding="utf-8")
+    assert "from studio.services import onnxruntime_setup" in src, (
+        "reg_build_worker.py 顶层必须 import onnxruntime_setup 触发 preload；"
+        "见 onnxruntime_setup.py 顶部 PP9.5 注释。"
+    )
+    bad = re.findall(r"^\s*(?:import onnxruntime|from onnxruntime\b)", src, re.MULTILINE)
+    assert not bad, f"worker 不应直接 import onnxruntime；命中: {bad}"
+    assert "studio.services.onnxruntime_setup" in sys.modules

--- a/tests/test_tag_worker.py
+++ b/tests/test_tag_worker.py
@@ -141,3 +141,21 @@ def test_run_passes_cltagger_overrides_through(env, monkeypatch) -> None:
 
 def test_run_unknown_job(env) -> None:
     assert tag_worker.run(99999) == 1
+
+
+def test_worker_imports_onnxruntime_setup_at_module_level() -> None:
+    """worker 是独立 subprocess —— 必须在任何 `import onnxruntime` 之前触发
+    onnxruntime_setup 的顶层 preload。回归测试：防止有人删掉那行 import 后
+    Linux 上又出 CUDA EP 静默降级，UI 看不到任何信号。"""
+    import re
+    import sys
+    src = Path(tag_worker.__file__).read_text(encoding="utf-8")
+    assert "from studio.services import onnxruntime_setup" in src, (
+        "tag_worker.py 顶层必须 import onnxruntime_setup 触发 preload；"
+        "见 onnxruntime_setup.py 顶部 PP9.5 注释。"
+    )
+    # worker 文件本身不应出现 `^import onnxruntime` / `^from onnxruntime`（行首真 import）
+    bad = re.findall(r"^\s*(?:import onnxruntime|from onnxruntime\b)", src, re.MULTILINE)
+    assert not bad, f"worker 不应直接 import onnxruntime；命中: {bad}"
+    # 模块加载本身把 onnxruntime_setup 拉进 sys.modules
+    assert "studio.services.onnxruntime_setup" in sys.modules

--- a/tools/diagnose_onnx_gpu.py
+++ b/tools/diagnose_onnx_gpu.py
@@ -1,0 +1,116 @@
+"""onnxruntime-gpu 静默降级 CPU 诊断 — 在跑这个 PR 的分支后，
+跑一次打标遇到「CUDA EP 静默降级到 CPU」warning 后用本脚本定位根因。
+
+用法（在 studio 同一个 venv 里）：
+
+    python tools/diagnose_onnx_gpu.py
+
+把整段 stdout 贴回 PR 评论 / issue。
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+
+def section(title: str) -> None:
+    print()
+    print("=" * 60)
+    print("==", title)
+    print("=" * 60)
+
+
+def main() -> None:
+    section("platform")
+    print("python:", sys.version.split()[0])
+    print("platform:", sys.platform)
+    print("executable:", sys.executable)
+
+    section("onnxruntime_setup.current_runtime()")
+    try:
+        from studio.services import onnxruntime_setup as o
+    except ImportError as exc:
+        print("studio import 失败 — 是不是没在 studio 仓库根目录跑？")
+        print("原因:", exc)
+        return
+    rt = o.current_runtime()
+    print(json.dumps(rt, indent=2, ensure_ascii=False, default=str))
+
+    section("系统 CUDA 检测（决定 preload 是否被 skip）")
+    print("CUDA_HOME:", os.environ.get("CUDA_HOME"))
+    print("CUDA_PATH:", os.environ.get("CUDA_PATH"))
+    print("/usr/local/cuda/lib64 存在:", os.path.isdir("/usr/local/cuda/lib64"))
+    import ctypes.util
+    print("ld 路径里 cublas:", ctypes.util.find_library("cublas"))
+    print("ld 路径里 cudnn:", ctypes.util.find_library("cudnn"))
+    print("_has_system_cuda_libs():", o._has_system_cuda_libs())
+
+    section("torch")
+    try:
+        import torch
+        print("torch:", torch.__version__)
+        print("torch.version.cuda:", torch.version.cuda)
+        print("torch.cuda.is_available():", torch.cuda.is_available())
+        if torch.cuda.is_available():
+            print("device_name:", torch.cuda.get_device_name(0))
+            print("cudnn_version:", torch.backends.cudnn.version())
+    except Exception as exc:  # noqa: BLE001
+        print("torch import 失败:", exc)
+
+    section("nvidia-*-cu12 wheels（torch wheel preload 来源） + onnxruntime")
+    out = subprocess.run(
+        [sys.executable, "-m", "pip", "list"],
+        capture_output=True, text=True,
+    ).stdout
+    keep = ("nvidia", "cudnn", "onnxruntime", "torch")
+    for line in out.splitlines():
+        low = line.lower()
+        if any(k in low for k in keep):
+            print(" ", line)
+
+    section("nvidia-smi")
+    try:
+        nv = subprocess.run(
+            ["nvidia-smi", "--query-gpu=driver_version,name", "--format=csv,noheader"],
+            capture_output=True, text=True, timeout=10,
+        )
+        print("rc:", nv.returncode)
+        print("stdout:", nv.stdout.strip())
+        print("stderr:", nv.stderr.strip())
+    except FileNotFoundError:
+        print("nvidia-smi 不在 PATH（云机器可能在 docker 里没暴露）")
+    except Exception as exc:  # noqa: BLE001
+        print("nvidia-smi 跑失败:", exc)
+
+    section("尝试真创 InferenceSession（用 onnxruntime 内置 test model 或现有 wd14 模型）")
+    try:
+        import onnxruntime as ort
+        print("ort.__version__:", ort.__version__)
+        print("ort.get_available_providers():", ort.get_available_providers())
+        import glob
+        candidates = (
+            glob.glob("models/wd14/**/model.onnx", recursive=True)
+            + glob.glob("models/cltagger/**/*.onnx", recursive=True)
+        )
+        if not candidates:
+            print("没找到本地 onnx 模型，跳过 session 创建测试")
+            return
+        path = candidates[0]
+        print("用模型:", path)
+        sess = ort.InferenceSession(
+            path, providers=["CUDAExecutionProvider", "CPUExecutionProvider"]
+        )
+        actual = sess.get_providers()
+        print("实际 session.get_providers():", actual)
+        if "CUDAExecutionProvider" not in actual:
+            print(">>> 确认静默降级：请求过 CUDA 但 session 用的是", actual)
+        else:
+            print(">>> CUDA EP 真生效")
+    except Exception as exc:  # noqa: BLE001
+        print("session 创建抛异常:", exc)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## v0.5.1

UI 体验小改进 + onnxruntime-gpu 跨平台修复（Windows / Linux 都踩到「装了 GPU 包但实际跑 CPU」）。

### 改进

- **打标 curation 工作流**（#27）
  - 全屏 preview 取代弹窗预览
  - 键盘 accept / remove 快捷键，过单张图更快
  - tag 保存后明确的 CNB export 入口

### 修复

- **onnxruntime-gpu 静默降级 CPU**（#29 Windows / #30 Linux）
  - 根因：onnxruntime 在 CUDA EP dlopen 失败时**不抛异常**，会内部 silently fallback 到 CPU；`ort.get_available_providers()` 仍报 CUDA 可用，UI 显示一切正常，用户只看到 CPU 占用飙升
  - 加监控：`_create_session` 比对实际 `session.get_providers()`，请求过 CUDA 但实际不在 → 上报 `cuda_load_error` 让 UI 可见
  - Windows：Python 3.8+ 废除 PATH 自动加载 DLL，新增 `os.add_dll_directory(torch/lib)` 让 onnxruntime 找得到 torch 自带的 `cublasLt64_12.dll` / `cudnn_*.dll`
  - Linux：worker subprocess 顶层显式 `import onnxruntime_setup` 触发 preload；修 `_has_system_cuda_libs()` 误判（云镜像装 CUDA Toolkit 但没装 cuDNN → 之前被误判为完整系统 CUDA → 跳过 preload）
  - 新增 `tools/diagnose_onnx_gpu.py` 诊断脚本

### 文档

- `CONTRIBUTING.md`：PR / commit / release / 版本号 / hotfix 流程

### Bump 说明

按 CONTRIBUTING 严格说法 #27 是 `feat`，理应 MINOR bump（0.6.0）。本次 maintainer 判断 #27 为现有 curation 工作流的体验优化（无 schema / API / 行为破坏性变更），用 PATCH bump (0.5.1)。
