### PR TITLE
fix(ui): 队列输出页面下载体验改造（直链 + 批量 + 排序 + 命名对齐）

### DIFF
--- a/studio/server.py
+++ b/studio/server.py
@@ -2435,6 +2435,24 @@ def _task_output_dir(task: dict[str, Any]) -> Optional[Path]:
     return versions.version_dir(int(pid), p["slug"], v["label"]) / "output"
 
 
+def _task_archive_basename(task: dict[str, Any]) -> Optional[str]:
+    """task 关联 project / version → "{slug}-{label}"，用作 outputs zip 文件名
+    前缀。和 train.zip 命名风格一致（PP7：{slug}-{label}.train.zip）。
+
+    没 project / version → None，调用方 fallback 到 task_{id}。
+    """
+    pid = task.get("project_id")
+    vid = task.get("version_id")
+    if not (pid and vid):
+        return None
+    with db.connection_for() as conn:
+        v = versions.get_version(conn, int(vid))
+        p = projects.get_project(conn, int(pid))
+    if not v or not p or v["project_id"] != pid:
+        return None
+    return f"{p['slug']}-{v['label']}"
+
+
 def _is_loopback(request: Request) -> bool:
     client = request.client
     return bool(client and client.host in _LOCALHOST_HOSTS)
@@ -2473,6 +2491,7 @@ def list_task_outputs(task_id: int, request: Request) -> dict[str, Any]:
         "exists": bool(out_dir and out_dir.exists()),
         "supports_open_folder": _is_loopback(request),
         "files": files,
+        "archive_basename": _task_archive_basename(task),
     }
 
 
@@ -2548,9 +2567,10 @@ def download_task_outputs_zip(
     bus.publish({"type": "task_outputs_zip_ready", "task_id": task_id})
     background.add_task(lambda: tmp_path.unlink(missing_ok=True))
 
+    basename = _task_archive_basename(task) or f"task_{task_id}"
     archive_name = (
-        f"task_{task_id}_outputs_selected.zip" if partial
-        else f"task_{task_id}_outputs.zip"
+        f"{basename}_outputs_selected.zip" if partial
+        else f"{basename}_outputs.zip"
     )
     return FileResponse(
         tmp_path,

--- a/studio/server.py
+++ b/studio/server.py
@@ -2507,10 +2507,16 @@ def download_task_outputs_zip(
         ) as zf:
             for f in files:
                 zf.write(f, arcname=f.name)
-    except Exception:
+    except Exception as e:
         tmp_path.unlink(missing_ok=True)
+        bus.publish({
+            "type": "task_outputs_zip_failed",
+            "task_id": task_id,
+            "error": str(e),
+        })
         raise
 
+    bus.publish({"type": "task_outputs_zip_ready", "task_id": task_id})
     background.add_task(lambda: tmp_path.unlink(missing_ok=True))
 
     archive_name = f"task_{task_id}_outputs.zip"

--- a/studio/server.py
+++ b/studio/server.py
@@ -2478,9 +2478,15 @@ def list_task_outputs(task_id: int, request: Request) -> dict[str, Any]:
 
 @app.get("/api/queue/{task_id}/outputs.zip")
 def download_task_outputs_zip(
-    task_id: int, background: BackgroundTasks
+    task_id: int,
+    background: BackgroundTasks,
+    files: Optional[str] = None,
 ) -> FileResponse:
-    """把 output 目录全部文件打包成 zip 一次性下载。
+    """把 output 目录里的文件打包成 zip 一次性下载。
+
+    没传 `files` → 全量打包（向后兼容）。
+    传了 `files`（逗号分隔的文件名）→ 仅打包这些，路径必须是 out_dir 下的直接
+    子文件，禁止 path traversal / 子目录。
 
     实现：写到临时文件再 FileResponse；响应发完后用 BackgroundTasks 清理。
     safetensors / pt 几乎都是已压缩二进制，用 ZIP_STORED（不再压缩，CPU 省一倍）。
@@ -2494,9 +2500,32 @@ def download_task_outputs_zip(
     out_dir = _task_output_dir(task)
     if not out_dir or not out_dir.exists():
         raise HTTPException(404, "no output dir")
-    files = [f for f in sorted(out_dir.iterdir()) if f.is_file()]
-    if not files:
+    all_files = [f for f in sorted(out_dir.iterdir()) if f.is_file()]
+    if not all_files:
         raise HTTPException(404, "empty output dir")
+
+    selected: list[Path]
+    partial = False
+    if files is None or files == "":
+        selected = all_files
+    else:
+        wanted = [n for n in files.split(",") if n]
+        if not wanted:
+            raise HTTPException(400, "empty files list")
+        by_name = {f.name: f for f in all_files}
+        missing: list[str] = []
+        selected = []
+        for name in wanted:
+            if "/" in name or "\\" in name or ".." in name:
+                raise HTTPException(400, f"invalid filename: {name}")
+            f = by_name.get(name)
+            if not f:
+                missing.append(name)
+                continue
+            selected.append(f)
+        if missing:
+            raise HTTPException(404, f"file(s) not found: {', '.join(missing)}")
+        partial = True
 
     tmp = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
     tmp.close()
@@ -2505,7 +2534,7 @@ def download_task_outputs_zip(
         with zipfile.ZipFile(
             tmp_path, "w", compression=zipfile.ZIP_STORED, allowZip64=True
         ) as zf:
-            for f in files:
+            for f in selected:
                 zf.write(f, arcname=f.name)
     except Exception as e:
         tmp_path.unlink(missing_ok=True)
@@ -2519,7 +2548,10 @@ def download_task_outputs_zip(
     bus.publish({"type": "task_outputs_zip_ready", "task_id": task_id})
     background.add_task(lambda: tmp_path.unlink(missing_ok=True))
 
-    archive_name = f"task_{task_id}_outputs.zip"
+    archive_name = (
+        f"task_{task_id}_outputs_selected.zip" if partial
+        else f"task_{task_id}_outputs.zip"
+    )
     return FileResponse(
         tmp_path,
         media_type="application/zip",

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -808,6 +808,9 @@ export interface TaskOutputs {
   /** 仅 loopback 请求为 true；云端永远 false。前端按此控制「打开文件夹」按钮可见性。 */
   supports_open_folder: boolean
   files: TaskOutputFile[]
+  /** "{slug}-{label}"，用作打包下载的 zip 文件名前缀（和 train.zip 命名风格一致）。
+   * 老任务没绑 project / version → null，调用方 fallback 到 task_{id}。 */
+  archive_basename: string | null
 }
 
 export interface DatasetFolder {

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1376,9 +1376,15 @@ export const api = {
   /** 下载单个 output 文件的直链，不发请求。<a href={...} download> 即可。 */
   taskOutputDownloadUrl: (id: number, filename: string) =>
     `/api/queue/${id}/output/${encodeURIComponent(filename)}`,
-  /** 把 output 目录全部文件打包成 zip 下载的直链。
-   * 推荐用 downloadBlob() 调它，能显示 loading（后端打 zip 要时间）。 */
-  taskOutputsZipUrl: (id: number) => `/api/queue/${id}/outputs.zip`,
+  /** output 目录打包 zip 下载直链。
+   * 不传 files → 全量；传文件名数组 → 仅打包这些（后端 whitelist 校验）。
+   * 配合 <a href download> 触发，浏览器原生接管下载条；后端 zip 写完会
+   * publish task_outputs_zip_ready / task_outputs_zip_failed 事件供前端清 loading。 */
+  taskOutputsZipUrl: (id: number, files?: ReadonlyArray<string>) => {
+    if (!files || files.length === 0) return `/api/queue/${id}/outputs.zip`
+    const q = files.map((n) => encodeURIComponent(n)).join(',')
+    return `/api/queue/${id}/outputs.zip?files=${q}`
+  },
 
   // PP8 — WD14 运行时 / GPU 装包 ------------------------------------------
   /** 当前 onnxruntime 状态：包名 / 版本 / providers / nvidia-smi 检测结果。 */

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -234,7 +234,7 @@ export default function QueueDetailPage() {
         )}
         {tab === 'log' && <LogTab taskId={taskId} />}
         {tab === 'monitor' && <MonitorTab taskId={taskId} />}
-        {tab === 'outputs' && <OutputsTab taskId={taskId} taskName={task?.name ?? ''} />}
+        {tab === 'outputs' && <OutputsTab taskId={taskId} />}
       </div>
 
 
@@ -389,7 +389,7 @@ function MonitorTab({ taskId }: { taskId: number }) {
 
 // ── OutputsTab ──────────────────────────────────────────────────────────────
 
-function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) {
+function OutputsTab({ taskId }: { taskId: number }) {
   const { toast } = useToast()
   const [data, setData] = useState<TaskOutputs | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -508,8 +508,10 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
     const partial = selectMode && selected.size > 0
     if (selectMode && !partial) return  // 批量模式下没选任何文件，按钮应已 disabled
     setZipping(true)
-    const safe = taskName && /^[A-Za-z0-9_.-]+$/.test(taskName)
-    const baseName = safe ? taskName : `task_${taskId}`
+    // 优先用后端给的 archive_basename ({slug}-{label})，老任务没 project/version
+    // 时 fallback task_{id}。download 属性是兜底 —— 浏览器优先用响应头
+    // Content-Disposition.filename，所以最终下载名以后端为准。
+    const baseName = data?.archive_basename ?? `task_${taskId}`
     const zipName = partial ? `${baseName}_outputs_selected.zip` : `${baseName}_outputs.zip`
     const files = partial ? Array.from(selected) : undefined
     const a = document.createElement('a')

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -427,7 +427,35 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
     return () => window.clearTimeout(t)
   }, [zipping, toast])
 
-  const sortedFiles = useMemo(() => data ? [...data.files].sort((a, b) => b.mtime - a.mtime) : [], [data])
+  // 列排序：默认按 mtime desc（最新的在上，和之前行为一致）。点表头同 key
+  // 切方向，换 key 切到该 key 的默认方向（name=asc / size,mtime=desc）。
+  type SortKey = 'name' | 'size' | 'mtime'
+  const [sortKey, setSortKey] = useState<SortKey>('mtime')
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc')
+
+  const sortedFiles = useMemo(() => {
+    if (!data) return []
+    const sign = sortDir === 'asc' ? 1 : -1
+    return [...data.files].sort((a, b) => {
+      if (sortKey === 'name') {
+        // numeric: true 让 ep_002 排在 ep_010 之前，避免字典序的 ep_10 < ep_2
+        return a.name.localeCompare(b.name, undefined, { numeric: true }) * sign
+      }
+      if (sortKey === 'size') return (a.size - b.size) * sign
+      return (a.mtime - b.mtime) * sign
+    })
+  }, [data, sortKey, sortDir])
+
+  const onHeaderClick = (key: SortKey) => {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortKey(key)
+      setSortDir(key === 'name' ? 'asc' : 'desc')
+    }
+  }
+  const sortArrow = (key: SortKey) =>
+    sortKey === key ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''
 
   // 刷新后剔除选中里已不存在的文件名（比如有人手动删了 ep_001.safetensors）
   useEffect(() => {
@@ -556,9 +584,18 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
               className="grid gap-2 px-4 py-2 text-xs text-fg-tertiary border-b border-subtle font-mono"
               style={{ gridTemplateColumns: '1fr 100px 160px 80px' }}
             >
-              <span>文件</span>
-              <span className="text-right">大小</span>
-              <span className="text-right">修改时间</span>
+              <button
+                onClick={() => onHeaderClick('name')}
+                className="text-left bg-transparent border-0 p-0 text-xs font-mono text-fg-tertiary hover:text-fg-primary cursor-pointer"
+              >文件{sortArrow('name')}</button>
+              <button
+                onClick={() => onHeaderClick('size')}
+                className="text-right bg-transparent border-0 p-0 text-xs font-mono text-fg-tertiary hover:text-fg-primary cursor-pointer"
+              >大小{sortArrow('size')}</button>
+              <button
+                onClick={() => onHeaderClick('mtime')}
+                className="text-right bg-transparent border-0 p-0 text-xs font-mono text-fg-tertiary hover:text-fg-primary cursor-pointer"
+              >修改时间{sortArrow('mtime')}</button>
               <span className="text-right">
                 {selectMode ? (
                   <input

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -396,6 +396,8 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
   const [busy, setBusy] = useState(false)
   const [zipping, setZipping] = useState(false)
   const [refreshKey, setRefreshKey] = useState(0)
+  const [selectMode, setSelectMode] = useState(false)
+  const [selected, setSelected] = useState<Set<string>>(() => new Set())
 
   useEffect(() => {
     let alive = true
@@ -403,7 +405,7 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
     return () => { alive = false }
   }, [taskId, refreshKey])
 
-  // 压缩中状态：点 "下载全部" 时 setZipping(true)，浏览器直链接管下载，
+  // 压缩中状态：点 "下载全部 / 下载所选" 时 setZipping(true)，浏览器直链接管下载，
   // 后端打包完 publish task_outputs_zip_ready → SSE 清状态。
   // 60s 兜底防止事件丢失 / 后端失败时按钮卡死。
   useEventStream((evt) => {
@@ -427,6 +429,45 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
 
   const sortedFiles = useMemo(() => data ? [...data.files].sort((a, b) => b.mtime - a.mtime) : [], [data])
 
+  // 刷新后剔除选中里已不存在的文件名（比如有人手动删了 ep_001.safetensors）
+  useEffect(() => {
+    if (selected.size === 0) return
+    const names = new Set(sortedFiles.map((f) => f.name))
+    let dropped = false
+    const next = new Set<string>()
+    for (const n of selected) {
+      if (names.has(n)) next.add(n); else dropped = true
+    }
+    if (dropped) setSelected(next)
+  }, [sortedFiles, selected])
+
+  const selectedSize = useMemo(() => {
+    let total = 0
+    for (const f of sortedFiles) if (selected.has(f.name)) total += f.size
+    return total
+  }, [sortedFiles, selected])
+
+  const allSelected = sortedFiles.length > 0 && selected.size === sortedFiles.length
+  const noneSelected = selected.size === 0
+  const partialSelected = !allSelected && !noneSelected
+
+  const toggleSelectAll = () => {
+    setSelected(allSelected ? new Set() : new Set(sortedFiles.map((f) => f.name)))
+  }
+  const toggleOne = (name: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev)
+      if (next.has(name)) next.delete(name); else next.add(name)
+      return next
+    })
+  }
+  const toggleSelectMode = () => {
+    setSelectMode((m) => {
+      if (m) setSelected(new Set())  // 退出批量时清空选中
+      return !m
+    })
+  }
+
   const openFolder = async () => {
     setBusy(true)
     try { const r = await api.openTaskFolder(taskId); toast(`已打开 ${r.opened}`, 'success') }
@@ -436,11 +477,15 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
 
   const handleDownloadZip = () => {
     if (zipping) return
+    const partial = selectMode && selected.size > 0
+    if (selectMode && !partial) return  // 批量模式下没选任何文件，按钮应已 disabled
     setZipping(true)
     const safe = taskName && /^[A-Za-z0-9_.-]+$/.test(taskName)
-    const zipName = safe ? `${taskName}_outputs.zip` : `task_${taskId}_outputs.zip`
+    const baseName = safe ? taskName : `task_${taskId}`
+    const zipName = partial ? `${baseName}_outputs_selected.zip` : `${baseName}_outputs.zip`
+    const files = partial ? Array.from(selected) : undefined
     const a = document.createElement('a')
-    a.href = api.taskOutputsZipUrl(taskId)
+    a.href = api.taskOutputsZipUrl(taskId, files)
     a.download = zipName
     document.body.appendChild(a)
     a.click()
@@ -469,9 +514,25 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
           )}
           <button onClick={() => setRefreshKey((k) => k + 1)} className="btn btn-ghost btn-sm">刷新</button>
           {data.exists && data.files.length > 0 && (
-            <button onClick={handleDownloadZip} disabled={zipping} className="btn btn-primary btn-sm">
-              {zipping ? '压缩中...' : '下载全部'}
-            </button>
+            <>
+              <button
+                onClick={toggleSelectMode}
+                className={selectMode ? 'btn btn-secondary btn-sm' : 'btn btn-ghost btn-sm'}
+              >
+                {selectMode ? '退出批量' : '批量'}
+              </button>
+              <button
+                onClick={handleDownloadZip}
+                disabled={zipping || (selectMode && noneSelected)}
+                className="btn btn-primary btn-sm"
+              >
+                {zipping
+                  ? '压缩中...'
+                  : selectMode
+                    ? (noneSelected ? '下载所选 (0)' : `下载所选 (${selected.size} · ${fmtBytes(selectedSize)})`)
+                    : '下载全部'}
+              </button>
+            </>
           )}
         </div>
       ) : data && !data.output_dir ? (
@@ -498,12 +559,26 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
               <span>文件</span>
               <span className="text-right">大小</span>
               <span className="text-right">修改时间</span>
-              <span className="text-right"></span>
+              <span className="text-right">
+                {selectMode ? (
+                  <input
+                    type="checkbox"
+                    checked={allSelected}
+                    ref={(el) => { if (el) el.indeterminate = partialSelected }}
+                    onChange={toggleSelectAll}
+                    style={{ width: 14, height: 14, accentColor: 'var(--accent)', cursor: 'pointer' }}
+                    aria-label="全选"
+                  />
+                ) : null}
+              </span>
             </div>
-            {sortedFiles.map((f) => (
+            {sortedFiles.map((f) => {
+              const isSel = selected.has(f.name)
+              return (
               <div
                 key={f.name}
-                className="grid gap-2 px-4 py-2 items-center border-b border-subtle text-xs hover:bg-overlay transition-colors"
+                onClick={selectMode ? () => toggleOne(f.name) : undefined}
+                className={`grid gap-2 px-4 py-2 items-center border-b border-subtle text-xs transition-colors ${selectMode ? `cursor-pointer ${isSel ? 'bg-accent-soft' : 'hover:bg-overlay'}` : 'hover:bg-overlay'}`}
                 style={{ gridTemplateColumns: '1fr 100px 160px 80px' }}
               >
                 <div className="flex items-center gap-1.5 min-w-0">
@@ -513,12 +588,24 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
                 <span className="text-right font-mono text-fg-tertiary">{fmtBytes(f.size)}</span>
                 <span className="text-right font-mono text-fg-tertiary">{fmtTime(f.mtime)}</span>
                 <span className="text-right">
-                  <a href={api.taskOutputDownloadUrl(taskId, f.name)} download={f.name}
-                    className="text-accent no-underline hover:underline text-xs"
-                  >下载</a>
+                  {selectMode ? (
+                    <input
+                      type="checkbox"
+                      checked={isSel}
+                      onChange={() => toggleOne(f.name)}
+                      onClick={(e) => e.stopPropagation()}
+                      style={{ width: 14, height: 14, accentColor: 'var(--accent)', cursor: 'pointer' }}
+                      aria-label={`选中 ${f.name}`}
+                    />
+                  ) : (
+                    <a href={api.taskOutputDownloadUrl(taskId, f.name)} download={f.name}
+                      className="text-accent no-underline hover:underline text-xs"
+                    >下载</a>
+                  )}
                 </span>
               </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </div>

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import {
   api,
-  downloadBlob,
   type Task,
   type TaskOutputs,
   type TaskStatus,
@@ -404,6 +403,28 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
     return () => { alive = false }
   }, [taskId, refreshKey])
 
+  // 压缩中状态：点 "下载全部" 时 setZipping(true)，浏览器直链接管下载，
+  // 后端打包完 publish task_outputs_zip_ready → SSE 清状态。
+  // 60s 兜底防止事件丢失 / 后端失败时按钮卡死。
+  useEventStream((evt) => {
+    if (evt.task_id !== taskId) return
+    if (evt.type === 'task_outputs_zip_ready') {
+      setZipping(false)
+    } else if (evt.type === 'task_outputs_zip_failed') {
+      setZipping(false)
+      toast(`压缩失败: ${typeof evt.error === 'string' ? evt.error : '未知错误'}`, 'error')
+    }
+  })
+
+  useEffect(() => {
+    if (!zipping) return
+    const t = window.setTimeout(() => {
+      setZipping(false)
+      toast('压缩超时（60s），如下载已开始可忽略', 'info')
+    }, 60_000)
+    return () => window.clearTimeout(t)
+  }, [zipping, toast])
+
   const sortedFiles = useMemo(() => data ? [...data.files].sort((a, b) => b.mtime - a.mtime) : [], [data])
 
   const openFolder = async () => {
@@ -413,15 +434,17 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
     finally { setBusy(false) }
   }
 
-  const handleDownloadZip = async () => {
+  const handleDownloadZip = () => {
     if (zipping) return
     setZipping(true)
-    try {
-      const safe = taskName && /^[A-Za-z0-9_.-]+$/.test(taskName)
-      const zipName = safe ? `${taskName}_outputs.zip` : `task_${taskId}_outputs.zip`
-      await downloadBlob(api.taskOutputsZipUrl(taskId), zipName)
-    } catch (e) { toast(`下载失败: ${e}`, 'error') }
-    finally { setZipping(false) }
+    const safe = taskName && /^[A-Za-z0-9_.-]+$/.test(taskName)
+    const zipName = safe ? `${taskName}_outputs.zip` : `task_${taskId}_outputs.zip`
+    const a = document.createElement('a')
+    a.href = api.taskOutputsZipUrl(taskId)
+    a.download = zipName
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
   }
 
   const copyPath = async () => {
@@ -447,7 +470,7 @@ function OutputsTab({ taskId, taskName }: { taskId: number; taskName: string }) 
           <button onClick={() => setRefreshKey((k) => k + 1)} className="btn btn-ghost btn-sm">刷新</button>
           {data.exists && data.files.length > 0 && (
             <button onClick={handleDownloadZip} disabled={zipping} className="btn btn-primary btn-sm">
-              {zipping ? '打包中...' : '下载全部'}
+              {zipping ? '压缩中...' : '下载全部'}
             </button>
           )}
         </div>

--- a/tests/test_studio_queue_endpoints.py
+++ b/tests/test_studio_queue_endpoints.py
@@ -240,13 +240,38 @@ def test_download_outputs_zip(
     resp = client.get(f"/api/queue/{tid}/outputs.zip")
     assert resp.status_code == 200
     assert resp.headers.get("content-type") == "application/zip"
-    assert "task_%d_outputs.zip" % tid in resp.headers.get("content-disposition", "")
+    # 命名格式：{slug}-{label}_outputs.zip，和 train.zip 命名风格一致
+    expected_name = f"{p['slug']}-{v['label']}_outputs.zip"
+    assert expected_name in resp.headers.get("content-disposition", "")
 
     with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
         names = sorted(zf.namelist())
         assert names == ["lora_final.safetensors", "training_state_step100.pt"]
         assert zf.read("lora_final.safetensors") == b"AAA"
         assert zf.read("training_state_step100.pt") == b"BB"
+
+
+def test_list_task_outputs_returns_archive_basename(
+    client: TestClient, isolated, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """list_task_outputs 返回里带 archive_basename = "{slug}-{label}"，前端用作
+    打包下载的 zip 文件名前缀。老任务（无 project/version）→ null。"""
+    from studio import projects as projects_mod, versions as versions_mod
+    monkeypatch.setattr(projects_mod, "PROJECTS_DIR", isolated / "projects")
+    with db.connection_for() as conn:
+        p = projects_mod.create_project(conn, title="P")
+        v = versions_mod.create_version(conn, project_id=p["id"], label="v1")
+        bound = db.create_task(conn, name="t", config_name="good")
+        db.update_task(conn, bound, status="done", project_id=p["id"], version_id=v["id"])
+        legacy = db.create_task(conn, name="老", config_name="good")
+
+    resp = client.get(f"/api/queue/{bound}/outputs")
+    assert resp.status_code == 200
+    assert resp.json()["archive_basename"] == f"{p['slug']}-{v['label']}"
+
+    resp = client.get(f"/api/queue/{legacy}/outputs")
+    assert resp.status_code == 200
+    assert resp.json()["archive_basename"] is None
 
 
 def test_download_outputs_zip_partial(
@@ -272,9 +297,8 @@ def test_download_outputs_zip_partial(
         f"/api/queue/{tid}/outputs.zip?files=ep_001.safetensors,ep_003.safetensors"
     )
     assert resp.status_code == 200
-    assert "task_%d_outputs_selected.zip" % tid in resp.headers.get(
-        "content-disposition", ""
-    )
+    expected_name = f"{p['slug']}-{v['label']}_outputs_selected.zip"
+    assert expected_name in resp.headers.get("content-disposition", "")
     with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
         names = sorted(zf.namelist())
         assert names == ["ep_001.safetensors", "ep_003.safetensors"]

--- a/tests/test_studio_queue_endpoints.py
+++ b/tests/test_studio_queue_endpoints.py
@@ -249,6 +249,79 @@ def test_download_outputs_zip(
         assert zf.read("training_state_step100.pt") == b"BB"
 
 
+def test_download_outputs_zip_partial(
+    client: TestClient, isolated, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """传 ?files=a,b 只打包指定文件，文件名带 _selected 后缀。"""
+    import io
+    import zipfile
+    from studio import projects as projects_mod, versions as versions_mod
+    monkeypatch.setattr(projects_mod, "PROJECTS_DIR", isolated / "projects")
+    with db.connection_for() as conn:
+        p = projects_mod.create_project(conn, title="P")
+        v = versions_mod.create_version(conn, project_id=p["id"], label="v1")
+        tid = db.create_task(conn, name="t", config_name="good")
+        db.update_task(conn, tid, status="done", project_id=p["id"], version_id=v["id"])
+    out_dir = versions_mod.version_dir(p["id"], p["slug"], v["label"]) / "output"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "ep_001.safetensors").write_bytes(b"E1")
+    (out_dir / "ep_002.safetensors").write_bytes(b"E2")
+    (out_dir / "ep_003.safetensors").write_bytes(b"E3")
+
+    resp = client.get(
+        f"/api/queue/{tid}/outputs.zip?files=ep_001.safetensors,ep_003.safetensors"
+    )
+    assert resp.status_code == 200
+    assert "task_%d_outputs_selected.zip" % tid in resp.headers.get(
+        "content-disposition", ""
+    )
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        names = sorted(zf.namelist())
+        assert names == ["ep_001.safetensors", "ep_003.safetensors"]
+        assert zf.read("ep_001.safetensors") == b"E1"
+
+
+def test_download_outputs_zip_partial_missing_file_404(
+    client: TestClient, isolated, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """选中文件里有 output 目录不存在的 → 404。"""
+    from studio import projects as projects_mod, versions as versions_mod
+    monkeypatch.setattr(projects_mod, "PROJECTS_DIR", isolated / "projects")
+    with db.connection_for() as conn:
+        p = projects_mod.create_project(conn, title="P")
+        v = versions_mod.create_version(conn, project_id=p["id"], label="v1")
+        tid = db.create_task(conn, name="t", config_name="good")
+        db.update_task(conn, tid, status="done", project_id=p["id"], version_id=v["id"])
+    out_dir = versions_mod.version_dir(p["id"], p["slug"], v["label"]) / "output"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "a.safetensors").write_bytes(b"A")
+
+    resp = client.get(f"/api/queue/{tid}/outputs.zip?files=a.safetensors,ghost.safetensors")
+    assert resp.status_code == 404
+
+
+def test_download_outputs_zip_partial_blocks_traversal(
+    client: TestClient, isolated, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """?files= 里含路径分隔符 / .. → 400，防止读 output 目录之外的文件。"""
+    from studio import projects as projects_mod, versions as versions_mod
+    monkeypatch.setattr(projects_mod, "PROJECTS_DIR", isolated / "projects")
+    with db.connection_for() as conn:
+        p = projects_mod.create_project(conn, title="P")
+        v = versions_mod.create_version(conn, project_id=p["id"], label="v1")
+        tid = db.create_task(conn, name="t", config_name="good")
+        db.update_task(conn, tid, status="done", project_id=p["id"], version_id=v["id"])
+    out_dir = versions_mod.version_dir(p["id"], p["slug"], v["label"]) / "output"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "a.safetensors").write_bytes(b"A")
+
+    for bad in ("../secret", "..\\secret", "sub/x", "sub\\x"):
+        resp = client.get(
+            f"/api/queue/{tid}/outputs.zip", params={"files": bad}
+        )
+        assert resp.status_code == 400, f"{bad!r} should be 400, got {resp.status_code}"
+
+
 def test_download_outputs_zip_empty_dir_404(
     client: TestClient, isolated, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## 背景

队列详情 → 输出页的「下载全部」原实现用 `fetch + blob`：

- 后端打包 + blob 缓冲全程沉默，云上观感是「点完几十秒静默 → 突然下载完成」
- 整个 zip 缓进浏览器内存，GB 级会爆
- 浏览器原生下载条 / 字节进度不出现（fetch 不是 navigation）
- 文件列表只有「下载单个」和「下载全部」两档，没法挑选特定 epoch

## 这次改了什么

### 1. 打包下载改回直链 + SSE 通知压缩完成 (`04367e8`)
- 前端 `<a href download>` 直链触发，浏览器原生接管下载（原生进度条 + 不再 blob 缓冲爆内存）。
- 后端 zip 写完 publish `task_outputs_zip_ready` / 失败 publish `task_outputs_zip_failed`。
- 前端 SSE 监听清按钮 loading；60s fallback 兜底防事件丢失。
- 按钮文字「打包中...」→「压缩中...」，只反映打包阶段。

### 2. 批量选择下载 (`9f7ddab`)
- 工具栏加「批量 / 退出批量」toggle 按钮。批量模式下每行右侧从「下载」直链变 checkbox，整行点击也可切换，选中行 `bg-accent-soft` 高亮，表头三态全选。
- 主按钮上下文化：普通模式「下载全部」；批量模式「下载所选 (N · X MB)」；0 选时 disabled。
- 退出批量自动清空选中；刷新后剔除已不存在的文件名。
- 后端 `/outputs.zip` 加可选 `?files=a,b` 查询参数：没传走全量（向后兼容），传了 whitelist 校验仅打包这些。防 path traversal（含 `/` `\` `..` 一律 400）；缺失文件 → 404。部分打包文件名带 `_selected` 后缀以便用户区分。

### 3. 列表表头加排序 (`1b7720a`)
- 文件 / 大小 / 修改时间三列点表头切排序方向。默认 `mtime desc`（保持原行为）；`name` 默认 asc，`size` / `mtime` 默认 desc；同 key 再点切方向。
- 文件名排序用 `localeCompare(..., { numeric: true })`，让 `ep_002` 排在 `ep_010` 前面而不是字典序 `ep_010 < ep_2`。
- 活跃列尾巴显示 ↑ / ↓。

### 4. zip 文件名对齐 train.zip 风格 (`1a4d7c3`)
- 之前 outputs zip 一直叫 `task_{id}_outputs.zip`，前端额外做 ASCII safe 检查 fallback 到 `task_{id}`（中文 / 空格 task name 完全无语义）。
- PP7 的 train.zip 用 `{slug}-{label}.train.zip` 早就定了风格，这次 outputs 跟上。
- 后端新增 `_task_archive_basename(task)`；`download_task_outputs_zip` 用它拼 `{slug}-{label}_outputs.zip`（或 `_selected`）。老任务没绑 project/version → fallback `task_{id}` 保兼容。
- `list_task_outputs` 返回里加 `archive_basename` 字段供前端 download 属性兜底用（浏览器优先用响应头 Content-Disposition.filename）。
- 前端删 taskName ASCII safe 检查，改用 `data.archive_basename`。`OutputsTab` 不再需要 `taskName` prop。

## Test plan
- [x] `tests/test_studio_queue_endpoints.py` 全绿（25 个，新加 4 个 cover：partial happy / missing file 404 / traversal 400 / archive_basename 字段）
- [x] `tsc --noEmit` 通过
- [x] 用户云上手测：单文件下载 / 下载全部 / 进入批量 / 全选 / 部分选 / 排序 / 文件名格式 — 全部 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)