### PR TITLE
fix(pr18): P0 followups — caption dedup / wandb 默认关 / 采样图缩图 / custom output_format

### DIFF
--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -226,10 +226,21 @@ def render_curve_panel(losses, width=60, height=10):
 # ============================================================================
 
 class WandBMonitor:
-    def __init__(self, wandb_module, run, *, log_samples: bool = True) -> None:
+    def __init__(
+        self,
+        wandb_module,
+        run,
+        *,
+        log_samples: bool = False,
+        sample_max_side: int = 512,
+        sample_every_n_steps: int = 0,
+    ) -> None:
         self._wandb = wandb_module
         self._run = run
         self.log_samples = log_samples
+        self.sample_max_side = max(64, int(sample_max_side or 512))
+        self.sample_every_n_steps = max(0, int(sample_every_n_steps or 0))
+        self._last_logged_step: Optional[int] = None
 
     @property
     def enabled(self) -> bool:
@@ -243,14 +254,46 @@ class WandBMonitor:
         except Exception as exc:
             logger.warning(f"W&B log 失败: {exc}")
 
+    def _should_log_step(self, key: str, step: Optional[int]) -> bool:
+        # baseline / epoch 边界一律放行；step 模式按 sample_every_n_steps 节流。
+        if self.sample_every_n_steps <= 0:
+            return True
+        if not key.startswith("samples/step"):
+            return True
+        if step is None or step <= 0:
+            return True
+        if step == self._last_logged_step:
+            return True  # 同步重复调用允许
+        return step % self.sample_every_n_steps == 0
+
+    def _prepare_image(self, image_path: Path, caption: str):
+        # 原图常 2K+，wandb 面板浏览 512px 已足够；JPEG 流量比 PNG 小一个数量级。
+        try:
+            from PIL import Image
+        except Exception:
+            return self._wandb.Image(str(image_path), caption=caption)
+        try:
+            with Image.open(image_path) as img:
+                img = img.convert("RGB")
+                max_side = self.sample_max_side
+                w, h = img.size
+                if max(w, h) > max_side:
+                    scale = max_side / float(max(w, h))
+                    new_size = (max(1, int(w * scale)), max(1, int(h * scale)))
+                    img = img.resize(new_size, Image.LANCZOS)
+                return self._wandb.Image(img, caption=caption)
+        except Exception as exc:
+            logger.warning(f"W&B 图片缩放失败，改传原图: {exc}")
+            return self._wandb.Image(str(image_path), caption=caption)
+
     def log_image(self, key: str, image_path: Path, *, caption: str, step: Optional[int] = None) -> None:
         if not self.enabled:
             return
+        if not self._should_log_step(key, step):
+            return
         try:
-            self._run.log(
-                {key: [self._wandb.Image(str(image_path), caption=caption)]},
-                step=step,
-            )
+            self._run.log({key: [self._prepare_image(image_path, caption)]}, step=step)
+            self._last_logged_step = step
         except Exception as exc:
             logger.warning(f"W&B 图片记录失败: {exc}")
 
@@ -281,9 +324,18 @@ def init_wandb_monitor(args, output_dir: Path, config_path: Optional[Path]) -> W
     project = os.environ.get("WANDB_PROJECT") or "AnimaLoraStudio"
     entity = os.environ.get("WANDB_ENTITY") or None
     run_name = os.environ.get("WANDB_RUN_NAME") or str(args.output_name)
-    log_samples = str(os.environ.get("WANDB_LOG_SAMPLES", "1")).strip().lower() not in {
+    # 默认关 — supervisor 已经按 secrets.wandb.log_samples 设过 env；env 缺省时也保持关闭。
+    log_samples = str(os.environ.get("WANDB_LOG_SAMPLES", "0")).strip().lower() not in {
         "0", "false", "no", "off",
     }
+    try:
+        sample_max_side = int(os.environ.get("WANDB_SAMPLE_MAX_SIDE", "512") or 512)
+    except ValueError:
+        sample_max_side = 512
+    try:
+        sample_every_n_steps = int(os.environ.get("WANDB_SAMPLE_EVERY_N_STEPS", "0") or 0)
+    except ValueError:
+        sample_every_n_steps = 0
     wandb_dir = output_dir / "wandb"
     wandb_dir.mkdir(parents=True, exist_ok=True)
     cfg = {
@@ -301,7 +353,13 @@ def init_wandb_monitor(args, output_dir: Path, config_path: Optional[Path]) -> W
         dir=str(wandb_dir),
     )
     logger.info(f"W&B 监控已启用: project={project}, run={run_name}, mode={mode}")
-    return WandBMonitor(wandb, run, log_samples=log_samples)
+    return WandBMonitor(
+        wandb,
+        run,
+        log_samples=log_samples,
+        sample_max_side=sample_max_side,
+        sample_every_n_steps=sample_every_n_steps,
+    )
 
 
 # ============================================================================

--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -61,12 +61,21 @@ class WandBConfig(BaseModel):
     entity: str = ""
     base_url: str = ""
     mode: str = "online"
-    log_samples: bool = True
+    # 默认关 — 训练采样图会上传到 wandb.ai 公网，对私有 IP / NSFW 数据集是合规风险，
+    # 让用户在 Settings 显式打开。
+    log_samples: bool = False
+    # 上传前缩到最长边像素；原图常 2K+，512 已足够 wandb 面板浏览，省流量。
+    sample_max_side: int = 512
+    # step 节流：>0 时只在 `global_step % N == 0` 上传，避免长训练上 GB 级图。
+    # 0 = 不额外节流（按训练循环已有 sample 频率上传），baseline / epoch 边界始终上传。
+    sample_every_n_steps: int = 0
 
     @model_validator(mode="after")
     def _normalize_values(self) -> "WandBConfig":
         if self.mode not in {"online", "offline", "disabled"}:
             self.mode = "online"
+        self.sample_max_side = max(64, int(self.sample_max_side or 512))
+        self.sample_every_n_steps = max(0, int(self.sample_every_n_steps or 0))
         return self
 
 

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -898,6 +898,8 @@ class Supervisor:
                 env.setdefault("WANDB_ENABLED", "1")
                 env.setdefault("WANDB_MODE", wandb_cfg.mode)
                 env.setdefault("WANDB_LOG_SAMPLES", "1" if wandb_cfg.log_samples else "0")
+                env.setdefault("WANDB_SAMPLE_MAX_SIDE", str(wandb_cfg.sample_max_side))
+                env.setdefault("WANDB_SAMPLE_EVERY_N_STEPS", str(wandb_cfg.sample_every_n_steps))
                 if wandb_cfg.api_key:
                     env.setdefault("WANDB_API_KEY", wandb_cfg.api_key)
                 if wandb_cfg.project:

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1226,7 +1226,9 @@ export const api = {
         add_model_tag?: boolean | null
         blacklist_tags?: string[] | null
       }
-      llm_overrides?: Omit<Partial<LLMTaggerConfig>, 'api_key' | 'model_ids' | 'prompt_presets'>
+      llm_overrides?:
+        & Omit<Partial<LLMTaggerConfig>, 'api_key' | 'model_ids' | 'prompt_presets'>
+        & { _output_format?: 'json' | 'text' }
     }
   ) =>
     req<Job>(`/api/projects/${pid}/versions/${vid}/tag`, {

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -90,6 +90,10 @@ export interface WandBConfig {
   base_url: string
   mode: 'online' | 'offline' | 'disabled'
   log_samples: boolean
+  /** 上传前缩到最长边像素，默认 512 */
+  sample_max_side: number
+  /** step 节流：>0 时只在 global_step % N == 0 上传，0 = 不额外节流 */
+  sample_every_n_steps: number
 }
 
 export interface ModelScopeConfig {

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -52,6 +52,9 @@ type LLMTaggerForm = {
   endpoint: LLMTaggerConfig['endpoint']
   prompt_preset: string
   custom_prompt: string
+  // 仅 prompt_preset === 'custom' 时生效；写入 llm_overrides._output_format。
+  // 非 custom 时由所选 preset 的 output_format 决定（后端读 LLMTaggerConfig.prompt_presets）。
+  custom_output_format: 'json' | 'text'
   temperature: number
   max_tokens: number
   timeout: number
@@ -92,6 +95,7 @@ function fromLLMTaggerConfig(cfg: LLMTaggerConfig): LLMTaggerForm {
     endpoint: cfg.endpoint,
     prompt_preset: cfg.prompt_preset,
     custom_prompt: cfg.custom_prompt,
+    custom_output_format: 'json',
     temperature: cfg.temperature,
     max_tokens: cfg.max_tokens,
     timeout: cfg.timeout,
@@ -240,10 +244,15 @@ export default function TaggingPage() {
     if (!llmForm || !llmDefaults) return undefined
     const out: Record<string, unknown> = {}
     for (const key of Object.keys(llmForm) as Array<keyof LLMTaggerForm>) {
+      // custom_output_format 不是 LLMTaggerConfig 字段，单独写到 _output_format 里
+      if (key === 'custom_output_format') continue
       const value = llmForm[key]
-      const base = llmDefaults[key]
+      const base = (llmDefaults as unknown as Record<string, unknown>)[key]
       if (value === '***') continue
       if (JSON.stringify(value) !== JSON.stringify(base)) out[key] = value
+    }
+    if (llmForm.prompt_preset === 'custom') {
+      out._output_format = llmForm.custom_output_format
     }
     return Object.keys(out).length ? out : undefined
   }
@@ -831,15 +840,29 @@ function LLMTaggerPanel({
       </div>
 
       {form.prompt_preset === 'custom' && (
-        <label className="grid grid-cols-[140px_1fr] items-start gap-2">
-          <span className="text-fg-tertiary font-mono text-xs pt-1">custom_prompt</span>
-          <textarea
-            value={form.custom_prompt}
-            onChange={(e) => onChange({ ...form, custom_prompt: e.target.value })}
-            disabled={disabled}
-            className={`input input-mono min-h-28 ${form.custom_prompt !== defaults.custom_prompt ? 'border-warn' : ''}`}
-          />
-        </label>
+        <>
+          <label className="grid grid-cols-[140px_1fr] items-center gap-2">
+            <span className="text-fg-tertiary font-mono text-xs">output_format</span>
+            <select
+              value={form.custom_output_format}
+              onChange={(e) => onChange({ ...form, custom_output_format: e.target.value as 'json' | 'text' })}
+              disabled={disabled}
+              className="input input-mono"
+            >
+              <option value="json">JSON caption（按字段标准化后写入 caption）</option>
+              <option value="text">Text caption（自然语言原文写入 .txt / .json.tags）</option>
+            </select>
+          </label>
+          <label className="grid grid-cols-[140px_1fr] items-start gap-2">
+            <span className="text-fg-tertiary font-mono text-xs pt-1">custom_prompt</span>
+            <textarea
+              value={form.custom_prompt}
+              onChange={(e) => onChange({ ...form, custom_prompt: e.target.value })}
+              disabled={disabled}
+              className={`input input-mono min-h-28 ${form.custom_prompt !== defaults.custom_prompt ? 'border-warn' : ''}`}
+            />
+          </label>
+        </>
       )}
 
       <div className="flex items-center gap-3 flex-wrap">

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -27,7 +27,9 @@ const initialServerState = {
     entity: '',
     base_url: '',
     mode: 'online',
-    log_samples: true,
+    log_samples: false,
+    sample_max_side: 512,
+    sample_every_n_steps: 0,
   },
   llm_tagger: {
     base_url: 'http://localhost:8000/v1',

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -91,7 +91,9 @@ const EMPTY: Secrets = {
     entity: '',
     base_url: '',
     mode: 'online',
-    log_samples: true,
+    log_samples: false,
+    sample_max_side: 512,
+    sample_every_n_steps: 0,
   },
   modelscope: { token: '' },
   download_source: 'huggingface',
@@ -881,10 +883,34 @@ export default function SettingsPage() {
               <option value="disabled">disabled</option>
             </select>
           </SettingsField>
-          <SettingsField label="记录采样图">
+          <SettingsField label="记录采样图" desc="开启后训练采样图会上传到 wandb.ai 公网；私有 IP / NSFW 数据集请保持关闭">
             <Bool value={draft.wandb.log_samples} onChange={(v) => update('wandb', 'log_samples', v)} />
           </SettingsField>
         </div>
+        {draft.wandb.log_samples && (
+          <div className="grid grid-cols-2 gap-3">
+            <SettingsField label="采样图最长边" desc="上传前缩到此像素，原图常 2K+，512 已够 wandb 浏览">
+              <input
+                type="number"
+                min={64}
+                step={64}
+                value={draft.wandb.sample_max_side}
+                onChange={(e) => update('wandb', 'sample_max_side', Math.max(64, parseInt(e.target.value) || 512))}
+                className={textInputClass}
+              />
+            </SettingsField>
+            <SettingsField label="step 节流" desc="0 = 不额外节流；>0 时只在 global_step % N == 0 上传，避免长训练上 GB 级图">
+              <input
+                type="number"
+                min={0}
+                step={50}
+                value={draft.wandb.sample_every_n_steps}
+                onChange={(e) => update('wandb', 'sample_every_n_steps', Math.max(0, parseInt(e.target.value) || 0))}
+                className={textInputClass}
+              />
+            </SettingsField>
+          </div>
+        )}
       </SettingsSection>
 
       <SettingsSection title="ModelScope（魔搭社区）">

--- a/utils/caption_utils.py
+++ b/utils/caption_utils.py
@@ -1,13 +1,25 @@
 """
 Caption 处理工具
 - 读取 JSON 标签文件
-- 标准化格式
+- 标准化格式（实现在 studio.services.caption_format，本模块只 re-export）
 - 分类 shuffle
 """
 import json
 import random
+import sys
 from pathlib import Path
 from typing import Optional
+
+# 兼容 `python utils/caption_utils.py` 直接当脚本跑：python 默认只把脚本目录加入
+# sys.path，导致 studio.* 不可见。手动把仓库根注入一次，作为模块导入时 sys.path
+# 已包含仓库根，这里 setdefault 即可。
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# normalize_caption_json 的权威实现集中在 studio.services.caption_format —— PR #18
+# review 发现两份实现微妙不同（去重 / appearance 合并策略），改回单一源。
+from studio.services.caption_format import normalize_caption_json  # noqa: E402, F401
 
 
 def load_caption_json(json_path: Path) -> dict | None:
@@ -19,87 +31,6 @@ def load_caption_json(json_path: Path) -> dict | None:
             return json.load(f)
     except Exception:
         return None
-
-
-def normalize_caption_json(raw_json: dict) -> dict:
-    """
-    将 batch_tag.py 生成的 JSON 转换为标准格式
-    
-    标准格式按 Anima 官方顺序:
-    quality → count → character → series → artist → appearance → tags → environment → nl
-    """
-    # 提取各部分
-    fixed = raw_json.get("fixed", {})
-    character_info = raw_json.get("character", {})
-    character_text = ""
-    if isinstance(character_info, dict):
-        character_text = character_info.get(
-            "full",
-            ", ".join(
-                t for t in (
-                    character_info.get("name", ""),
-                    character_info.get("variant", ""),
-                ) if t
-            ),
-        )
-    else:
-        character_text = str(character_info or "")
-    from_path = raw_json.get("from_path", {})
-    ai_output = raw_json.get("ai_output", {})
-    
-    # 解析 quality（可能是 "newest, safe" 字符串）；简化格式允许顶层字段
-    quality_str = fixed.get("quality", raw_json.get("quality", "newest, safe"))
-    if isinstance(quality_str, str):
-        quality = [t.strip() for t in quality_str.split(",") if t.strip()]
-    else:
-        quality = list(quality_str)
-    
-    # 合并 appearance（AI + from_path）
-    appearance = []
-    ai_appearance = ai_output.get("appearance", raw_json.get("appearance", []))
-    if isinstance(ai_appearance, list):
-        appearance.extend(ai_appearance)
-    elif isinstance(ai_appearance, str):
-        appearance.extend([t.strip() for t in ai_appearance.split(",") if t.strip()])
-    appearance.extend(from_path.get("appearance", []))
-    appearance.extend(from_path.get("extra_appearance", []))
-    
-    # 合并 tags（AI + from_path）
-    tags = []
-    ai_tags = ai_output.get("tags", raw_json.get("tags", []))
-    if isinstance(ai_tags, list):
-        tags.extend(ai_tags)
-    elif isinstance(ai_tags, str):
-        tags.extend([t.strip() for t in ai_tags.split(",") if t.strip()])
-    tags.extend(from_path.get("tags", []))
-    tags.extend(from_path.get("extra_tags", []))
-    
-    # environment
-    environment = []
-    ai_env = ai_output.get("environment", raw_json.get("environment", []))
-    if isinstance(ai_env, list):
-        environment.extend(ai_env)
-    elif isinstance(ai_env, str):
-        environment.extend([t.strip() for t in ai_env.split(",") if t.strip()])
-    
-    # 构建标准格式
-    return {
-        "meta": {
-            "path": raw_json.get("path", ""),
-            "source_path_parts": raw_json.get("path_parts", []),
-        },
-        "tags": {
-            "quality": quality,                           # ["newest", "safe"]
-            "count": ai_output.get("count", raw_json.get("count", "")),  # "1girl"
-            "character": character_text,                  # "asahi sakayori"
-            "series": fixed.get("series", raw_json.get("series", "")),  # "cosmic princess kaguya"
-            "artist": fixed.get("artist", raw_json.get("artist", "")),  # "@spacetime kaguya"
-            "appearance": appearance,                     # [...]
-            "tags": tags,                                 # [...]
-            "environment": environment,                   # [...]
-            "nl": ai_output.get("nl", raw_json.get("nl", "")),  # "A boy..."
-        }
-    }
 
 
 def dedupe_list(tags: list) -> list:


### PR DESCRIPTION
## Summary

PR #18 (LLM tagger + WandB) 合并后二轮 review 识别的 4 条 P0 阻塞项修复。

- **P0-1** `normalize_caption_json` 改回单一源 — `utils/caption_utils.py` 改为 re-export `studio.services.caption_format`，避免两份实现 schema 漂移
- **P0-2** LLM custom prompt 加 `output_format` 选项 — Tagging 页 custom 模式下显示 json/text 切换，通过 `llm_overrides._output_format` 传后端（后端已支持）
- **P0-3** `wandb.log_samples` 默认改 `False` — 采样图默认上传公网是合规风险，UI 加描述提示
- **P0-4** WandB 采样图加缩图 + step 节流 — `WandBMonitor` 用 PIL 缩到 `sample_max_side`（默认 512）；新增 `sample_every_n_steps` 节流，baseline / epoch 边界一律放行

完整 review 文档（本地）：\`pr18_review.md\`

## Test plan

- [x] pytest 35 (studio_configs + supervisor + llm_tagger) + 77 (joycaption + tag_endpoints + tag_worker + tagedit + secrets) = 112 全过
- [x] tsc 0 错
- [x] vitest 108/108
- [ ] 云上启用 wandb 跑训练，验证：默认 log_samples=False；开启后采样图 ≤ 512px；step 节流生效
- [ ] Tagging 页选 custom prompt + 写自然语言，确认 text output_format radio 出现并生效

## Followups 跟踪

完整 P1 / P2 清单见 `memory/llm_tagger_pr18_followups.md`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)