### PR TITLE
feat(observability): topbar 系统监控 + monitor SSE 增量协议

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,9 @@ pyyaml>=6.0.1
 psutil>=5.9.0
 # topbar 系统监控小组件用：拿 GPU/VRAM。非 NVIDIA / 无驱动时 services/system_stats.py
 # 会 try/except 兜底，前端只显示 CPU/RAM；安装本身在所有平台都能 succeed (纯 Python wrapper)。
-pynvml>=11.5.0
+# 用 nvidia-ml-py (NVIDIA 官方维护、新版 PyTorch 也是切到它) 而不是老的 pynvml；
+# 两者都导出 `import pynvml` 模块名，但老 pynvml 已 unmaintained 会打 deprecation 警告。
+nvidia-ml-py>=12.0
 rich>=13.7.0
 requests>=2.31.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,6 +35,9 @@ python-multipart>=0.0.6
 pydantic>=2.5.0
 pyyaml>=6.0.1
 psutil>=5.9.0
+# topbar 系统监控小组件用：拿 GPU/VRAM。非 NVIDIA / 无驱动时 services/system_stats.py
+# 会 try/except 兜底，前端只显示 CPU/RAM；安装本身在所有平台都能 succeed (纯 Python wrapper)。
+pynvml>=11.5.0
 rich>=13.7.0
 requests>=2.31.0
 

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -354,7 +354,7 @@ def _apply_axis(
 def _setup_monitor(cfg: dict[str, Any]) -> Any:
     """初始化 train_monitor（每个 task 一份独立 monitor_state.json）。
 
-    前端通过 SSE monitor_state_updated 拿 samples + xy 元信息；图本身的
+    前端通过 SSE monitor_progress 拿 samples + xy 元信息；图本身的
     bytes 走协议 image_done 事件入 server 内存 cache（commit 10 起）。
     sample_path 字段写虚拟路径（前端只用 split+pop 拿 filename 来构建
     /api/generate/{tid}/sample/{fn} URL），磁盘上不会有这个文件。

--- a/studio/log_tail.py
+++ b/studio/log_tail.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import json
 import re
 import threading
+import time
 from pathlib import Path
 from typing import Any, Callable
 
@@ -96,29 +97,55 @@ class LogTailer:
 
 
 class MonitorStatePoller:
-    """轮询 monitor_state.json 的 mtime，变化时把解析后的 dict 推给 callback。
+    """轮询 monitor_state.json 的 mtime，变化时**构造增量 delta** 推给 callback。
 
-    设计取舍：
-    - 不用 watchdog/inotify：跨平台一致性 + 0 依赖；anima_train 写入频率 ~1Hz，
-      poll 0.5s 足够低延迟。
-    - 直接 publish 整个 state（含 losses 数组）：服务端读一次 → 所有 SSE
-      订阅者共享，比 N 个客户端各自 GET /api/state 便宜得多。
-    - mtime 没变就不读、不 publish；文件不存在静默跳过。
+    协议（PR #37 改造）：早期版本每次推全量 state（losses/lr 数组每步都全
+    量重传，2000 步训练单次推 ~200KB）。云部署跨公网时这是 O(N²) 浪费。
+
+    新设计：poller 维护 last_step / last_loss_count / last_lr_count /
+    last_sample_count，每次只把「自上次发布以来的新增」打成 delta：
+
+        {
+          "step": 234, "total_steps": 2000,
+          "epoch": 3, "total_epochs": 10,
+          "speed": 1.2, "start_time": 1234567890.0,
+          "appended_losses": [{step, loss, time}],   # 可能为空数组
+          "appended_lr":     [{step, lr}],
+          "appended_samples":[{path, step, time, xy?}],
+          "config": {...},        # 仅在变化时携带（首次推送 / config 改）
+        }
+
+    Throttle 规则（混合 step + 时间）：
+    - poll_interval 0.5s 探测 mtime
+    - min_publish_interval 1.0s 强制下界 — 即使训练每 100ms 一步，也不会推
+      超过 1Hz；累积的 loss 点会在下次推送里 batch 一起送
+    - 「step 没变 + 没新 sample + config 没变」时跳过推送，避免空 delta
+      （例如训练只更新了 speed 这种衍生指标）
     """
 
     def __init__(
         self,
         path: Path,
-        on_change: Callable[[dict[str, Any]], None],
+        on_delta: Callable[[dict[str, Any]], None],
         *,
         poll_interval: float = 0.5,
+        min_publish_interval: float = 1.0,
     ) -> None:
         self._path = path
-        self._on_change = on_change
+        self._on_delta = on_delta
         self._poll = poll_interval
+        self._min_pub = min_publish_interval
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._last_mtime: float = 0.0
+        self._last_publish_at: float = 0.0
+
+        # 增量追踪
+        self._last_step: int = -1
+        self._last_loss_count: int = 0
+        self._last_lr_count: int = 0
+        self._last_sample_count: int = 0
+        self._last_config: dict[str, Any] | None = None
 
     def start(self) -> None:
         if self._thread:
@@ -142,13 +169,13 @@ class MonitorStatePoller:
                 # IO/解析异常静默重试，避免拖死 supervisor
                 pass
             self._stop.wait(self._poll)
-        # 退出前再读一次，捕获结束瞬间的最终 state
+        # 退出前再读一次，捕获结束瞬间的最终 state；带 force=True 绕过 throttle
         try:
-            self._check_once()
+            self._check_once(force=True)
         except Exception:
             pass
 
-    def _check_once(self) -> None:
+    def _check_once(self, *, force: bool = False) -> None:
         if not self._path.exists():
             return
         mtime = self._path.stat().st_mtime
@@ -160,4 +187,54 @@ class MonitorStatePoller:
             # 写一半的 JSON / 临时锁住 → 下一轮再试
             return
         self._last_mtime = mtime
-        self._on_change(data)
+
+        # ── 节流：未到最小发布间隔时退出，下一轮再检查（含新累积的数据） ──
+        now = time.time()
+        if not force and (now - self._last_publish_at) < self._min_pub:
+            return
+
+        # ── 计算 delta ──
+        step = int(data.get("step", 0) or 0)
+        losses = data.get("losses") or []
+        lr_hist = data.get("lr_history") or []
+        samples = data.get("samples") or []
+        config = data.get("config") or {}
+
+        appended_losses = losses[self._last_loss_count:]
+        appended_lr = lr_hist[self._last_lr_count:]
+        appended_samples = samples[self._last_sample_count:]
+        config_changed = config != self._last_config
+
+        has_progress = (
+            step != self._last_step
+            or appended_losses
+            or appended_lr
+            or appended_samples
+            or config_changed
+        )
+        if not (force or has_progress):
+            return
+
+        delta: dict[str, Any] = {
+            "step": step,
+            "total_steps": int(data.get("total_steps", 0) or 0),
+            "epoch": int(data.get("epoch", 0) or 0),
+            "total_epochs": int(data.get("total_epochs", 0) or 0),
+            "speed": float(data.get("speed", 0.0) or 0.0),
+            "start_time": data.get("start_time"),
+            "appended_losses": appended_losses,
+            "appended_lr": appended_lr,
+            "appended_samples": appended_samples,
+        }
+        if config_changed:
+            delta["config"] = config
+
+        # 推送 + 更新游标
+        self._last_step = step
+        self._last_loss_count = len(losses)
+        self._last_lr_count = len(lr_hist)
+        self._last_sample_count = len(samples)
+        self._last_config = config
+        self._last_publish_at = now
+
+        self._on_delta(delta)

--- a/studio/server.py
+++ b/studio/server.py
@@ -158,6 +158,16 @@ async def _lifespan(app_: FastAPI) -> AsyncIterator[None]:
     sup = Supervisor(on_event=bus.publish)
     sup.start()
     app_.state.supervisor = sup
+
+    # PR #37: system stats SSE — 后台 sampler 每 2.5s 采集 + bus.publish。前端
+    # 只 mount 时 GET 一次冷启动，避免 cloud 部署被每客户端独立轮询污染。
+    def _publish_system_stats(payload: dict[str, Any]) -> None:
+        bus.publish({"type": "system_stats_updated", "payload": payload})
+
+    sys_sampler = system_stats.SystemStatsSampler(_publish_system_stats)
+    sys_sampler.start()
+    app_.state.system_stats_sampler = sys_sampler
+
     try:
         yield
     finally:
@@ -165,6 +175,7 @@ async def _lifespan(app_: FastAPI) -> AsyncIterator[None]:
         timer = _disconnect_timer.get("t")
         if timer is not None:
             timer.cancel()
+        sys_sampler.stop()
         sup.stop()
         # commit 11：lifespan shutdown 清掉所有图 cache（释放内存 + 干净退出）
         generate_cache.clear_all()
@@ -203,7 +214,7 @@ def get_system_stats() -> dict[str, Any]:
 
 
 @app.get("/api/state")
-def get_state(task_id: Optional[int] = None) -> JSONResponse:
+def get_state(task_id: Optional[int] = None, max_points: int = 1000) -> JSONResponse:
     """读取训练监控 state.json（PP6.1 改造 — per-task）。
 
     `task_id` 给了 → 查 tasks.monitor_state_path 对应文件；没有 / 文件缺失 →
@@ -211,6 +222,10 @@ def get_state(task_id: Optional[int] = None) -> JSONResponse:
     `task_id` 没给 → 优先 running 的 task；没 running 时回退到**最近一次**
     （done / failed / canceled）带 monitor_state_path 的 task，让监控页结束
     后还能看到上一次训练的曲线。都没有再返回 EMPTY_STATE。
+
+    `max_points` (PR #37) — losses / lr_history 超过此点数时均匀降采样。前端
+    chart 内部还会再 downsample 到 600，所以服务端给到 1000 已经够。这一步
+    把跨公网冷启动 payload 从 O(N) 降到 O(1)。
 
     旧的全局 `monitor_data/state.json` 路径已退役（PP6.1）。
     """
@@ -247,6 +262,15 @@ def get_state(task_id: Optional[int] = None) -> JSONResponse:
         data = json.loads(target_path.read_text(encoding="utf-8"))
     except Exception as exc:
         raise HTTPException(500, f"failed to read state: {exc}")
+
+    # 服务端下采样 losses / lr_history（samples cap 50 已经在 train_monitor 端做了）
+    if max_points and max_points > 0:
+        from runtime.train_monitor import _downsample_uniform
+        if isinstance(data.get("losses"), list):
+            data["losses"] = _downsample_uniform(data["losses"], max_points)
+        if isinstance(data.get("lr_history"), list):
+            data["lr_history"] = _downsample_uniform(data["lr_history"], max_points)
+
     return JSONResponse(data)
 
 

--- a/studio/server.py
+++ b/studio/server.py
@@ -65,6 +65,7 @@ from .services import (
     pending_install,
     torch_setup,
     reg_builder,
+    system_stats,
     tagedit,
     train_io,
     uploads as uploads_svc,
@@ -193,6 +194,12 @@ EMPTY_STATE: dict[str, Any] = {
 @app.get("/api/health")
 def health() -> dict[str, Any]:
     return {"status": "ok", "version": app.version}
+
+
+@app.get("/api/system/stats")
+def get_system_stats() -> dict[str, Any]:
+    """Topbar 系统资源小组件用 (CPU/RAM/GPU/VRAM)。前端按 2-3s 轮询。"""
+    return system_stats.stats_to_json(system_stats.collect_stats())
 
 
 @app.get("/api/state")

--- a/studio/services/system_stats.py
+++ b/studio/services/system_stats.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import logging
 import threading
 from dataclasses import asdict, dataclass
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import psutil
 
@@ -130,3 +130,47 @@ def stats_to_json(s: SystemStats) -> dict[str, Any]:
         "ram_total_gb": s.ram_total_gb,
         "gpu": [asdict(g) for g in s.gpu] if s.gpu is not None else None,
     }
+
+
+# ── SSE sampler ──────────────────────────────────────────────────────
+class SystemStatsSampler:
+    """后台线程：周期性采集系统资源 → callback (通常是 bus.publish)。
+
+    取代每个客户端独立轮询 /api/system/stats — 云部署场景下避免污染
+    server access log、DevTools Network 面板、跨公网 RTT 开销。前端只在
+    mount 时 GET 一次冷启动，之后走 SSE 持续接收。
+    """
+
+    def __init__(
+        self,
+        on_sample: Callable[[dict[str, Any]], None],
+        *,
+        interval: float = 2.5,
+    ) -> None:
+        self._on_sample = on_sample
+        self._interval = interval
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        if self._thread:
+            return
+        self._thread = threading.Thread(
+            target=self._run, name="system-stats-sampler", daemon=True,
+        )
+        self._thread.start()
+
+    def stop(self, timeout: float = 2.0) -> None:
+        self._stop.set()
+        if self._thread:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                payload = stats_to_json(collect_stats())
+                self._on_sample(payload)
+            except Exception:
+                logger.exception("system stats sampler tick failed")
+            self._stop.wait(self._interval)

--- a/studio/services/system_stats.py
+++ b/studio/services/system_stats.py
@@ -1,0 +1,132 @@
+"""系统资源采集 (CPU / RAM / GPU / VRAM)。
+
+供 topbar 实时小组件按 2-3s 轮询使用。
+
+设计：
+    - pynvml 懒初始化一次；失败 (无 NVIDIA / 驱动缺失 / 库未装) 永久标记，
+      之后所有调用直接返回 gpu=None — 不重试、不刷日志。
+    - psutil 几乎不会失败；仍 try/except 兜底，让前端轮询不会因偶发问题挂掉。
+    - 模块无状态导出，调用 collect_stats() 即可。
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+import psutil
+
+logger = logging.getLogger(__name__)
+
+# psutil.cpu_percent(interval=None) 第一次调用返回 0.0 (无 baseline)，
+# 之后返回「距上次调用以来」的平均占用。模块导入时 prime 一下，让首请求
+# 就能拿到从启动到首请求的平均值，避免前端首次轮询永远显示 0%。
+psutil.cpu_percent(interval=None)
+
+
+# ── NVML 懒初始化 ─────────────────────────────────────────────────────
+_nvml_lock = threading.Lock()
+_nvml_state: dict[str, Any] = {"inited": False, "ok": False}
+
+
+def _ensure_nvml() -> bool:
+    with _nvml_lock:
+        if _nvml_state["inited"]:
+            return _nvml_state["ok"]
+        _nvml_state["inited"] = True
+        try:
+            import pynvml  # type: ignore[import-untyped]
+            pynvml.nvmlInit()
+            _nvml_state["ok"] = True
+        except Exception as e:
+            _nvml_state["ok"] = False
+            logger.info("pynvml unavailable; GPU stats disabled (%s)", e)
+        return _nvml_state["ok"]
+
+
+# ── 数据结构 ─────────────────────────────────────────────────────────
+@dataclass(frozen=True)
+class GpuStats:
+    index: int
+    name: str
+    util_pct: int
+    vram_used_gb: float
+    vram_total_gb: float
+    temp_c: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class SystemStats:
+    cpu_pct: float
+    ram_used_gb: float
+    ram_total_gb: float
+    # None = NVML 不可用；[] = NVML 可用但 0 卡 (前端两种都隐藏 GPU pill)
+    gpu: Optional[list[GpuStats]]
+
+
+# ── 采集 ─────────────────────────────────────────────────────────────
+def _bytes_to_gb(n: int) -> float:
+    return round(n / (1024 ** 3), 2)
+
+
+def _collect_gpu() -> Optional[list[GpuStats]]:
+    if not _ensure_nvml():
+        return None
+    try:
+        import pynvml  # type: ignore[import-untyped]
+        count = pynvml.nvmlDeviceGetCount()
+        out: list[GpuStats] = []
+        for i in range(count):
+            h = pynvml.nvmlDeviceGetHandleByIndex(i)
+            name = pynvml.nvmlDeviceGetName(h)
+            if isinstance(name, bytes):
+                name = name.decode(errors="replace")
+            mem = pynvml.nvmlDeviceGetMemoryInfo(h)
+            util = pynvml.nvmlDeviceGetUtilizationRates(h)
+            try:
+                temp = pynvml.nvmlDeviceGetTemperature(h, pynvml.NVML_TEMPERATURE_GPU)
+            except Exception:
+                temp = None
+            out.append(GpuStats(
+                index=i,
+                name=name,
+                util_pct=int(util.gpu),
+                vram_used_gb=_bytes_to_gb(mem.used),
+                vram_total_gb=_bytes_to_gb(mem.total),
+                temp_c=int(temp) if temp is not None else None,
+            ))
+        return out
+    except Exception:
+        logger.exception("gpu stats collection failed")
+        return None
+
+
+def collect_stats() -> SystemStats:
+    try:
+        # interval=None: 返回自上次调用以来的 CPU 占用；首次调用返回 0.0，
+        # 后续轮询拿到的就是 2-3s 平均值，对实时监控刚好。
+        cpu = psutil.cpu_percent(interval=None)
+        mem = psutil.virtual_memory()
+        ram_used = _bytes_to_gb(mem.total - mem.available)
+        ram_total = _bytes_to_gb(mem.total)
+    except Exception:
+        logger.exception("psutil stats collection failed")
+        cpu = 0.0
+        ram_used = 0.0
+        ram_total = 0.0
+    return SystemStats(
+        cpu_pct=round(float(cpu), 1),
+        ram_used_gb=ram_used,
+        ram_total_gb=ram_total,
+        gpu=_collect_gpu(),
+    )
+
+
+def stats_to_json(s: SystemStats) -> dict[str, Any]:
+    return {
+        "cpu_pct": s.cpu_pct,
+        "ram_used_gb": s.ram_used_gb,
+        "ram_total_gb": s.ram_total_gb,
+        "gpu": [asdict(g) for g in s.gpu] if s.gpu is not None else None,
+    }

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -555,15 +555,17 @@ class Supervisor:
         slot.tailer = LogTailer(log_path, _on_task_log)
         slot.tailer.start()
 
-        # PP6.4 — monitor_state.json 变化 → SSE（取代前端 1Hz 轮询 /api/state）
-        def _on_state(state: dict[str, Any]) -> None:
+        # PP6.4 → PR #37: monitor_state.json 变化 → SSE monitor_progress (增量协议)
+        # payload 是 delta（appended_losses/lr/samples + 最新 step/speed/...），
+        # 客户端首次 GET /api/state 拿快照后用这个增量持续 merge。
+        def _on_state_delta(delta: dict[str, Any]) -> None:
             self._on_event({
-                "type": "monitor_state_updated",
+                "type": "monitor_progress",
                 "task_id": tid,
-                "state": state,
+                "delta": delta,
             })
 
-        slot.state_poller = MonitorStatePoller(monitor_state_path, _on_state)
+        slot.state_poller = MonitorStatePoller(monitor_state_path, _on_state_delta)
         slot.state_poller.start()
 
         with db.connection_for(self._db_path) as conn:
@@ -687,15 +689,15 @@ class Supervisor:
             self._daemon_active_task_id = task_id
             self._daemon_cancel_pending = False
 
-        # poller：daemon 写 monitor_state.json → SSE monitor_state_updated
-        def _on_state(state: dict[str, Any]) -> None:
+        # poller：daemon 写 monitor_state.json → SSE monitor_progress (增量协议)
+        def _on_state_delta(delta: dict[str, Any]) -> None:
             self._on_event({
-                "type": "monitor_state_updated",
+                "type": "monitor_progress",
                 "task_id": task_id,
-                "state": state,
+                "delta": delta,
             })
 
-        self._daemon_state_poller = MonitorStatePoller(monitor_state_path, _on_state)
+        self._daemon_state_poller = MonitorStatePoller(monitor_state_path, _on_state_delta)
         self._daemon_state_poller.start()
 
         with db.connection_for(self._db_path) as conn:

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -6,6 +6,23 @@ export interface HealthResponse {
   version: string
 }
 
+export interface GpuStats {
+  index: number
+  name: string
+  util_pct: number
+  vram_used_gb: number
+  vram_total_gb: number
+  temp_c: number | null
+}
+
+export interface SystemStats {
+  cpu_pct: number
+  ram_used_gb: number
+  ram_total_gb: number
+  /** null = NVML 不可用 (无 NVIDIA / 驱动缺失)；[] = NVML 可用但 0 卡。两种都不显示 GPU pill。 */
+  gpu: GpuStats[] | null
+}
+
 export interface SchemaProperty {
   type?: string | string[]
   default?: unknown
@@ -975,6 +992,7 @@ export async function downloadBlob(url: string, filename: string): Promise<void>
 
 export const api = {
   health: () => req<HealthResponse>('/api/health'),
+  systemStats: () => req<SystemStats>('/api/system/stats'),
   state: () => req<Record<string, unknown>>('/api/state'),
 
   schema: () => req<SchemaResponse>('/api/schema'),

--- a/studio/web/src/components/MonitorDashboard.tsx
+++ b/studio/web/src/components/MonitorDashboard.tsx
@@ -1,11 +1,12 @@
 /**
  * MonitorDashboard — native React training monitor
  * Replaces the monitor_smooth.html iframe.
- * Data source: GET /api/state?task_id=N  +  SSE monitor_state_updated
+ * Data source: GET /api/state?task_id=N 拉降采样快照 + SSE monitor_progress
+ * 走 useMonitorProgress hook 做 delta merge（PR #37 增量协议）。
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { api, type MonitorState } from '../api/client'
-import { useEventStream } from '../lib/useEventStream'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { api } from '../api/client'
+import { useMonitorProgress } from '../lib/useMonitorProgress'
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -255,44 +256,8 @@ function SampleViewer({ samples, taskId }: {
 // ── Main Component ─────────────────────────────────────────────────────────
 
 export default function MonitorDashboard({ taskId }: { taskId: number }) {
-  const [state, setState] = useState<MonitorState | null>(null)
-  const [connected, setConnected] = useState(false)
+  const { state, connected } = useMonitorProgress(taskId)
   const [emaAlpha, setEmaAlpha] = useState(0.02)
-  const lastUpdateRef = useRef(0)
-
-  const load = useCallback(async () => {
-    try {
-      const s = await api.getMonitorState(taskId)
-      setState(s)
-      setConnected(true)
-      lastUpdateRef.current = Date.now()
-    } catch {
-      if (Date.now() - lastUpdateRef.current > 5000) setConnected(false)
-    }
-  }, [taskId])
-
-  // mount 时拉一次冷启动；之后 SSE 推送（monitor_state_updated 带全量 state
-  // payload）。SSE 重连后 onOpen 也补一次冷启动防漏事件。删了原来的 5s 轮询
-  // fallback——SSE 通了就够用，断了 EventSource 自动重连 + onOpen 触发重 fetch。
-  useEffect(() => {
-    void load()
-  }, [load])
-
-  useEventStream(
-    (evt) => {
-      if (evt.type === 'monitor_state_updated' && String(evt.task_id) === String(taskId)) {
-        if (evt.state) {
-          setState(evt.state as MonitorState)
-          setConnected(true)
-          lastUpdateRef.current = Date.now()
-        } else {
-          // 兜底：极少数情况 SSE 不带 state（旧 backend 行为），退回 fetch
-          void load()
-        }
-      }
-    },
-    { onOpen: () => void load() },
-  )
 
   // Derived stats
   const losses = useMemo(() => state?.losses ?? [], [state?.losses])

--- a/studio/web/src/components/SystemStats.test.tsx
+++ b/studio/web/src/components/SystemStats.test.tsx
@@ -1,7 +1,11 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import SystemStats from './SystemStats'
 import { api, type SystemStats as Stats } from '../api/client'
+
+// useEventStream 在 jsdom 下不会真起 EventSource (源码有 typeof 守卫)，所以
+// 这里测的主要是：mount 时 GET 一次冷启动 + 各种 stats 形态下的渲染。SSE
+// delta 的合并行为另测（手动验证或 e2e）。
 
 function makeStats(overrides: Partial<Stats> = {}): Stats {
   return {
@@ -24,7 +28,6 @@ function makeStats(overrides: Partial<Stats> = {}): Stats {
 
 describe('SystemStats', () => {
   afterEach(() => {
-    vi.useRealTimers()
     vi.restoreAllMocks()
   })
 
@@ -34,7 +37,7 @@ describe('SystemStats', () => {
     expect(container.firstChild).toBeNull()
   })
 
-  it('shows CPU / MEM / GPU / VRAM pills with values', async () => {
+  it('shows CPU / MEM / GPU / VRAM pills with values after mount fetch', async () => {
     vi.spyOn(api, 'systemStats').mockResolvedValue(makeStats())
     render(<SystemStats />)
     await waitFor(() => expect(screen.getByText('CPU')).toBeInTheDocument())
@@ -70,28 +73,12 @@ describe('SystemStats', () => {
     expect(el.className).toContain('text-err')
   })
 
-  it('keeps last value when polling fails', async () => {
-    const spy = vi
-      .spyOn(api, 'systemStats')
-      .mockResolvedValueOnce(makeStats({ cpu_pct: 5.0 }))
-      .mockRejectedValueOnce(new Error('network'))
-    vi.useFakeTimers({ shouldAdvanceTime: true })
-    render(<SystemStats />)
-    await waitFor(() => expect(screen.getByText('5%')).toBeInTheDocument())
-    await vi.advanceTimersByTimeAsync(3000)
-    // 第二次轮询失败：仍然显示上次的 5%
-    expect(screen.getByText('5%')).toBeInTheDocument()
-    expect(spy).toHaveBeenCalledTimes(2)
-  })
-
-  it('polls on interval', async () => {
+  it('only fetches once on mount (SSE 化后无轮询)', async () => {
     const spy = vi.spyOn(api, 'systemStats').mockResolvedValue(makeStats())
-    vi.useFakeTimers({ shouldAdvanceTime: true })
     render(<SystemStats />)
     await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
-    await act(async () => { await vi.advanceTimersByTimeAsync(3000) })
-    expect(spy).toHaveBeenCalledTimes(2)
-    await act(async () => { await vi.advanceTimersByTimeAsync(3000) })
-    expect(spy).toHaveBeenCalledTimes(3)
+    // 等一段实际时间让任何潜在的轮询有机会触发
+    await new Promise((r) => setTimeout(r, 200))
+    expect(spy).toHaveBeenCalledTimes(1)
   })
 })

--- a/studio/web/src/components/SystemStats.test.tsx
+++ b/studio/web/src/components/SystemStats.test.tsx
@@ -1,0 +1,97 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import SystemStats from './SystemStats'
+import { api, type SystemStats as Stats } from '../api/client'
+
+function makeStats(overrides: Partial<Stats> = {}): Stats {
+  return {
+    cpu_pct: 12.5,
+    ram_used_gb: 8.0,
+    ram_total_gb: 32.0,
+    gpu: [
+      {
+        index: 0,
+        name: 'Test GPU',
+        util_pct: 50,
+        vram_used_gb: 4.0,
+        vram_total_gb: 24.0,
+        temp_c: 55,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe('SystemStats', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('renders nothing before first fetch resolves', () => {
+    vi.spyOn(api, 'systemStats').mockReturnValue(new Promise(() => {}))
+    const { container } = render(<SystemStats />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('shows CPU / MEM / GPU / VRAM pills with values', async () => {
+    vi.spyOn(api, 'systemStats').mockResolvedValue(makeStats())
+    render(<SystemStats />)
+    await waitFor(() => expect(screen.getByText('CPU')).toBeInTheDocument())
+    expect(screen.getByText('13%')).toBeInTheDocument()
+    expect(screen.getByText('MEM')).toBeInTheDocument()
+    expect(screen.getByText('8.0/32G')).toBeInTheDocument()
+    expect(screen.getByText('GPU')).toBeInTheDocument()
+    expect(screen.getByText('50%')).toBeInTheDocument()
+    expect(screen.getByText('VRAM')).toBeInTheDocument()
+    expect(screen.getByText('4.0/24G')).toBeInTheDocument()
+  })
+
+  it('hides GPU / VRAM when stats.gpu is null', async () => {
+    vi.spyOn(api, 'systemStats').mockResolvedValue(makeStats({ gpu: null }))
+    render(<SystemStats />)
+    await waitFor(() => expect(screen.getByText('CPU')).toBeInTheDocument())
+    expect(screen.queryByText('GPU')).toBeNull()
+    expect(screen.queryByText('VRAM')).toBeNull()
+  })
+
+  it('hides GPU / VRAM when stats.gpu is empty array', async () => {
+    vi.spyOn(api, 'systemStats').mockResolvedValue(makeStats({ gpu: [] }))
+    render(<SystemStats />)
+    await waitFor(() => expect(screen.getByText('CPU')).toBeInTheDocument())
+    expect(screen.queryByText('GPU')).toBeNull()
+    expect(screen.queryByText('VRAM')).toBeNull()
+  })
+
+  it('shows high-tone class when util exceeds 90%', async () => {
+    vi.spyOn(api, 'systemStats').mockResolvedValue(makeStats({ cpu_pct: 95 }))
+    render(<SystemStats />)
+    const el = await screen.findByText('95%')
+    expect(el.className).toContain('text-err')
+  })
+
+  it('keeps last value when polling fails', async () => {
+    const spy = vi
+      .spyOn(api, 'systemStats')
+      .mockResolvedValueOnce(makeStats({ cpu_pct: 5.0 }))
+      .mockRejectedValueOnce(new Error('network'))
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    render(<SystemStats />)
+    await waitFor(() => expect(screen.getByText('5%')).toBeInTheDocument())
+    await vi.advanceTimersByTimeAsync(3000)
+    // 第二次轮询失败：仍然显示上次的 5%
+    expect(screen.getByText('5%')).toBeInTheDocument()
+    expect(spy).toHaveBeenCalledTimes(2)
+  })
+
+  it('polls on interval', async () => {
+    const spy = vi.spyOn(api, 'systemStats').mockResolvedValue(makeStats())
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    render(<SystemStats />)
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1))
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000) })
+    expect(spy).toHaveBeenCalledTimes(2)
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000) })
+    expect(spy).toHaveBeenCalledTimes(3)
+  })
+})

--- a/studio/web/src/components/SystemStats.tsx
+++ b/studio/web/src/components/SystemStats.tsx
@@ -3,10 +3,10 @@ import { api, type SystemStats as SystemStatsData } from '../api/client'
 
 const POLL_MS = 2500
 
-function toneClass(pct: number): string {
-  if (pct >= 90) return 'text-err'
-  if (pct >= 70) return 'text-warn'
-  return 'text-fg-primary'
+function toneClasses(pct: number): { text: string; bg: string } {
+  if (pct >= 90) return { text: 'text-err', bg: 'bg-err-soft' }
+  if (pct >= 70) return { text: 'text-warn', bg: 'bg-warn-soft' }
+  return { text: 'text-fg-primary', bg: 'bg-accent-soft' }
 }
 
 function fmtGb(used: number, total: number): string {
@@ -16,16 +16,28 @@ function fmtGb(used: number, total: number): string {
 interface PillProps {
   label: string
   value: string
-  toneCls: string
+  pct: number
   tooltip: string
 }
 
-function Pill({ label, value, toneCls, tooltip }: PillProps) {
+/** 进度条胶囊 — 整个 pill 背景按占用百分比填色 (>=70% warn, >=90% err)，
+ *  高度与 topbar 上其他元素 (搜索 icon 32px) 一致。 */
+function Pill({ label, value, pct, tooltip }: PillProps) {
+  const tone = toneClasses(pct)
+  const clamped = Math.min(100, Math.max(0, pct))
   return (
-    <span className="flex items-baseline gap-1.5" title={tooltip}>
-      <span className="text-2xs uppercase tracking-wider text-fg-tertiary">{label}</span>
-      <span className={`font-mono text-xs tabular-nums ${toneCls}`}>{value}</span>
-    </span>
+    <div
+      className="relative flex items-center gap-1.5 h-8 px-2 rounded-md border border-dim bg-surface overflow-hidden shrink-0"
+      title={tooltip}
+    >
+      <div
+        aria-hidden
+        className={`absolute inset-y-0 left-0 ${tone.bg} transition-[width] duration-500 ease-out`}
+        style={{ width: `${clamped}%` }}
+      />
+      <span className="relative z-10 text-2xs uppercase tracking-wider text-fg-tertiary">{label}</span>
+      <span className={`relative z-10 font-mono text-xs tabular-nums ${tone.text}`}>{value}</span>
+    </div>
   )
 }
 
@@ -71,17 +83,17 @@ export default function SystemStats() {
   const gpuLabel = gpu0 ? `${gpu0.name}${gpuTempText}${gpuExtra}` : ''
 
   return (
-    <div className="hidden md:flex items-center gap-4 shrink-0">
+    <div className="hidden md:flex items-center gap-2 shrink-0">
       <Pill
         label="CPU"
         value={`${stats.cpu_pct.toFixed(0)}%`}
-        toneCls={toneClass(stats.cpu_pct)}
+        pct={stats.cpu_pct}
         tooltip={`CPU 占用 ${stats.cpu_pct.toFixed(1)}%`}
       />
       <Pill
         label="MEM"
         value={fmtGb(stats.ram_used_gb, stats.ram_total_gb)}
-        toneCls={toneClass(ramPct)}
+        pct={ramPct}
         tooltip={`内存 ${stats.ram_used_gb.toFixed(1)} / ${stats.ram_total_gb.toFixed(1)} GB (${ramPct.toFixed(0)}%)`}
       />
       {gpu0 && (
@@ -89,13 +101,13 @@ export default function SystemStats() {
           <Pill
             label="GPU"
             value={`${gpu0.util_pct}%`}
-            toneCls={toneClass(gpu0.util_pct)}
+            pct={gpu0.util_pct}
             tooltip={`GPU 利用率 · ${gpuLabel}`}
           />
           <Pill
             label="VRAM"
             value={fmtGb(gpu0.vram_used_gb, gpu0.vram_total_gb)}
-            toneCls={toneClass(vramPct)}
+            pct={vramPct}
             tooltip={`显存 ${gpu0.vram_used_gb.toFixed(1)} / ${gpu0.vram_total_gb.toFixed(1)} GB (${vramPct.toFixed(0)}%) · ${gpuLabel}`}
           />
         </>

--- a/studio/web/src/components/SystemStats.tsx
+++ b/studio/web/src/components/SystemStats.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react'
 import { api, type SystemStats as SystemStatsData } from '../api/client'
-
-const POLL_MS = 2500
+import { useEventStream } from '../lib/useEventStream'
 
 function toneClasses(pct: number): { text: string; bg: string } {
   if (pct >= 90) return { text: 'text-err', bg: 'bg-err-soft' }
@@ -44,31 +43,30 @@ function Pill({ label, value, pct, tooltip }: PillProps) {
 export default function SystemStats() {
   const [stats, setStats] = useState<SystemStatsData | null>(null)
 
+  // mount 时拉一次冷启动 (避免空白等 2.5s 首个 SSE 事件)，之后纯靠后端
+  // sampler 通过 SSE 推送。SSE 重连时 onOpen 也补一次冷启动，防漏。
   useEffect(() => {
     let cancelled = false
-    let firstFetchDone = false
-
-    const tick = async () => {
-      try {
-        const s = await api.systemStats()
-        if (!cancelled) {
-          setStats(s)
-          firstFetchDone = true
-        }
-      } catch {
-        // 单次失败保留上次的数据；后端临时挂掉时 topbar 不闪烁
-        if (!firstFetchDone && !cancelled) {
-          // 首次拉就失败：组件保持不可见，避免空白 pill 占位
-        }
-      }
-    }
-    void tick()
-    const id = setInterval(tick, POLL_MS)
-    return () => {
-      cancelled = true
-      clearInterval(id)
-    }
+    api.systemStats().then((s) => {
+      if (!cancelled) setStats(s)
+    }).catch(() => {/* 首次失败：等 SSE 第一帧就行 */})
+    return () => { cancelled = true }
   }, [])
+
+  useEventStream(
+    (evt) => {
+      if (evt.type !== 'system_stats_updated') return
+      const payload = evt.payload as SystemStatsData | undefined
+      if (payload) setStats(payload)
+    },
+    {
+      onOpen: () => {
+        // SSE 重连：补一次冷启动；服务端 sampler 仍在跑，下次 tick 会自然推
+        // 上来，但这一次显式 GET 让 UI 立刻刷新
+        api.systemStats().then((s) => setStats(s)).catch(() => {})
+      },
+    },
+  )
 
   if (!stats) return null
 

--- a/studio/web/src/components/SystemStats.tsx
+++ b/studio/web/src/components/SystemStats.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react'
+import { api, type SystemStats as SystemStatsData } from '../api/client'
+
+const POLL_MS = 2500
+
+function toneClass(pct: number): string {
+  if (pct >= 90) return 'text-err'
+  if (pct >= 70) return 'text-warn'
+  return 'text-fg-primary'
+}
+
+function fmtGb(used: number, total: number): string {
+  return `${used.toFixed(1)}/${Math.round(total)}G`
+}
+
+interface PillProps {
+  label: string
+  value: string
+  toneCls: string
+  tooltip: string
+}
+
+function Pill({ label, value, toneCls, tooltip }: PillProps) {
+  return (
+    <span className="flex items-baseline gap-1.5" title={tooltip}>
+      <span className="text-2xs uppercase tracking-wider text-fg-tertiary">{label}</span>
+      <span className={`font-mono text-xs tabular-nums ${toneCls}`}>{value}</span>
+    </span>
+  )
+}
+
+export default function SystemStats() {
+  const [stats, setStats] = useState<SystemStatsData | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    let firstFetchDone = false
+
+    const tick = async () => {
+      try {
+        const s = await api.systemStats()
+        if (!cancelled) {
+          setStats(s)
+          firstFetchDone = true
+        }
+      } catch {
+        // 单次失败保留上次的数据；后端临时挂掉时 topbar 不闪烁
+        if (!firstFetchDone && !cancelled) {
+          // 首次拉就失败：组件保持不可见，避免空白 pill 占位
+        }
+      }
+    }
+    void tick()
+    const id = setInterval(tick, POLL_MS)
+    return () => {
+      cancelled = true
+      clearInterval(id)
+    }
+  }, [])
+
+  if (!stats) return null
+
+  const gpu0 = stats.gpu && stats.gpu.length > 0 ? stats.gpu[0] : null
+  const ramPct = stats.ram_total_gb > 0 ? (stats.ram_used_gb / stats.ram_total_gb) * 100 : 0
+  const vramPct = gpu0 && gpu0.vram_total_gb > 0 ? (gpu0.vram_used_gb / gpu0.vram_total_gb) * 100 : 0
+
+  const gpuExtra = stats.gpu && stats.gpu.length > 1
+    ? ` (+${stats.gpu.length - 1} more)`
+    : ''
+  const gpuTempText = gpu0?.temp_c != null ? ` · ${gpu0.temp_c}°C` : ''
+  const gpuLabel = gpu0 ? `${gpu0.name}${gpuTempText}${gpuExtra}` : ''
+
+  return (
+    <div className="hidden md:flex items-center gap-4 shrink-0">
+      <Pill
+        label="CPU"
+        value={`${stats.cpu_pct.toFixed(0)}%`}
+        toneCls={toneClass(stats.cpu_pct)}
+        tooltip={`CPU 占用 ${stats.cpu_pct.toFixed(1)}%`}
+      />
+      <Pill
+        label="MEM"
+        value={fmtGb(stats.ram_used_gb, stats.ram_total_gb)}
+        toneCls={toneClass(ramPct)}
+        tooltip={`内存 ${stats.ram_used_gb.toFixed(1)} / ${stats.ram_total_gb.toFixed(1)} GB (${ramPct.toFixed(0)}%)`}
+      />
+      {gpu0 && (
+        <>
+          <Pill
+            label="GPU"
+            value={`${gpu0.util_pct}%`}
+            toneCls={toneClass(gpu0.util_pct)}
+            tooltip={`GPU 利用率 · ${gpuLabel}`}
+          />
+          <Pill
+            label="VRAM"
+            value={fmtGb(gpu0.vram_used_gb, gpu0.vram_total_gb)}
+            toneCls={toneClass(vramPct)}
+            tooltip={`显存 ${gpu0.vram_used_gb.toFixed(1)} / ${gpu0.vram_total_gb.toFixed(1)} GB (${vramPct.toFixed(0)}%) · ${gpuLabel}`}
+          />
+        </>
+      )}
+    </div>
+  )
+}

--- a/studio/web/src/components/Topbar.tsx
+++ b/studio/web/src/components/Topbar.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { useProjectCtx } from '../context/ProjectContext'
-import { api, type MonitorState, type Task } from '../api/client'
+import { api, type Task } from '../api/client'
 import { useEventStream, type StudioEvent } from '../lib/useEventStream'
+import { useMonitorProgress } from '../lib/useMonitorProgress'
 import CommandPalette from './CommandPalette'
 import SystemStats from './SystemStats'
 
@@ -100,7 +101,11 @@ export default function Topbar() {
   // 队列详细状态
   const [runningTask, setRunningTask] = useState<Task | null>(null)
   const [pendingCount, setPendingCount] = useState(0)
-  const [monitor, setMonitor] = useState<MonitorState | null>(null)
+
+  // monitor 状态走 useMonitorProgress hook (PR #37 增量协议)：自动管理
+  // /api/state 冷启动 + monitor_progress delta 合并 + 重连补拉，本组件只
+  // 关心结果的 step/total_steps/speed/start_time 几个 scalar 字段。
+  const { state: monitor } = useMonitorProgress(runningTask?.id ?? null)
 
   const refreshQueue = useCallback(async () => {
     try {
@@ -108,29 +113,16 @@ export default function Topbar() {
         api.listQueue('running'),
         api.listQueue('pending'),
       ])
-      const firstRunning = running.length > 0 ? running[0] : null
-      setRunningTask(firstRunning)
+      setRunningTask(running.length > 0 ? running[0] : null)
       setPendingCount(pending.length)
-
-      if (firstRunning) {
-        try {
-          const ms = await api.getMonitorState(firstRunning.id)
-          setMonitor(ms)
-        } catch {
-          setMonitor(null)
-        }
-      } else {
-        setMonitor(null)
-      }
     } catch {
       // 忽略
     }
   }, [])
 
-  // 队列状态走 SSE：mount 拉一次冷启动，之后只在 task_state_changed /
-  // monitor_state_updated 事件来时更新。SSE 重连后 onOpen 也补一次冷启动
-  // 防漏事件。不再轮询（之前 3-10s setInterval 在 1 个 running task 下会
-  // 攒成每秒 7+ 请求的死循环 bug，根因是 useEffect deps 用了 Task 对象）。
+  // 队列任务列表走 SSE task_state_changed；mount + 重连各拉一次冷启动。
+  // 之前 3-10s setInterval 在 1 个 running task 下会攒成每秒 7+ 请求的死
+  // 循环 bug，根因是 useEffect deps 用了 Task 对象。
   useEffect(() => {
     void refreshQueue()
   }, [refreshQueue])
@@ -139,14 +131,6 @@ export default function Topbar() {
     (evt: StudioEvent) => {
       if (evt.type === 'task_state_changed') {
         void refreshQueue()
-      } else if (
-        evt.type === 'monitor_state_updated' &&
-        runningTask &&
-        String(evt.task_id) === String(runningTask.id) &&
-        evt.state
-      ) {
-        // 后端 SSE 已经把 state 全量塞 payload 里，直接 setState，不再 fetch
-        setMonitor(evt.state as MonitorState)
       }
     },
     { onOpen: () => void refreshQueue() },

--- a/studio/web/src/components/Topbar.tsx
+++ b/studio/web/src/components/Topbar.tsx
@@ -4,6 +4,7 @@ import { useProjectCtx } from '../context/ProjectContext'
 import { api, type MonitorState, type Task } from '../api/client'
 import { useEventStream, type StudioEvent } from '../lib/useEventStream'
 import CommandPalette from './CommandPalette'
+import SystemStats from './SystemStats'
 
 const SearchIcon = (
   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
@@ -237,15 +238,18 @@ export default function Topbar() {
           })}
         </div>
 
-        {/* 搜索按钮 */}
+        {/* 实时系统监控 (CPU / RAM / GPU / VRAM)，每 ~2.5s 轮询；无 NVIDIA 时只显示 CPU/RAM。 */}
+        <SystemStats />
+
+        {/* 搜索按钮 — 缩成 icon-only，⌘K 仍可弹出完整 palette (含跨图标签搜索)。 */}
         <button
           ref={searchBtnRef}
           onClick={() => setPaletteOpen(true)}
-          className="flex items-center gap-2 text-fg-tertiary text-sm bg-surface border border-dim rounded-md cursor-pointer min-w-[200px] py-[5px] pl-3 pr-[10px] hover:border-bold transition-colors shrink-0"
+          title="搜索 (⌘K)"
+          aria-label="搜索"
+          className="flex items-center justify-center text-fg-tertiary bg-surface border border-dim rounded-md cursor-pointer w-8 h-8 hover:border-bold hover:text-fg-secondary transition-colors shrink-0"
         >
           {SearchIcon}
-          <span className="flex-1 text-left">跳转 / 搜索…</span>
-          <span className="kbd">⌘K</span>
         </button>
 
         {/* 运行中训练胶囊 */}

--- a/studio/web/src/lib/useMonitorProgress.test.ts
+++ b/studio/web/src/lib/useMonitorProgress.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest'
+import { _mergeDeltaForTest as mergeDelta } from './useMonitorProgress'
+
+describe('mergeDelta (PR #37 增量协议)', () => {
+  it('initial merge populates state from null prev', () => {
+    const out = mergeDelta(null, {
+      step: 5, total_steps: 100, epoch: 1,
+      appended_losses: [{ step: 1, loss: 0.5 }, { step: 5, loss: 0.3 }],
+      appended_lr: [{ step: 1, lr: 1e-4 }],
+      appended_samples: [{ path: '/a.png', step: 5 }],
+      config: { model: 'X' },
+    })
+    expect(out.step).toBe(5)
+    expect(out.losses).toHaveLength(2)
+    expect(out.lr_history).toHaveLength(1)
+    expect(out.samples).toHaveLength(1)
+    expect(out.config).toEqual({ model: 'X' })
+  })
+
+  it('appends new losses to existing array', () => {
+    const out = mergeDelta(
+      {
+        step: 1, losses: [{ step: 1, loss: 0.5 }], lr_history: [], samples: [],
+      },
+      {
+        step: 3,
+        appended_losses: [{ step: 2, loss: 0.4 }, { step: 3, loss: 0.3 }],
+      },
+    )
+    expect(out.losses).toHaveLength(3)
+    expect(out.losses?.map((l) => l.step)).toEqual([1, 2, 3])
+    expect(out.step).toBe(3)
+  })
+
+  it('dedups losses whose step <= last known step', () => {
+    // 模拟重连场景：snapshot 已包含 step 1-3，delta 又重复推送 step 2-4
+    const out = mergeDelta(
+      {
+        step: 3,
+        losses: [
+          { step: 1, loss: 0.5 },
+          { step: 2, loss: 0.4 },
+          { step: 3, loss: 0.3 },
+        ],
+        lr_history: [],
+        samples: [],
+      },
+      {
+        step: 4,
+        appended_losses: [
+          { step: 2, loss: 0.4 },
+          { step: 3, loss: 0.3 },
+          { step: 4, loss: 0.2 },
+        ],
+      },
+    )
+    // 只保留 > 3 的，即 step 4
+    expect(out.losses).toHaveLength(4)
+    expect(out.losses?.map((l) => l.step)).toEqual([1, 2, 3, 4])
+  })
+
+  it('dedups samples by (step, path) tuple', () => {
+    const out = mergeDelta(
+      {
+        samples: [{ path: '/a.png', step: 1 }, { path: '/b.png', step: 1 }],
+        losses: [], lr_history: [],
+      },
+      {
+        appended_samples: [
+          { path: '/b.png', step: 1 },  // dup
+          { path: '/c.png', step: 1 },  // 同 step 不同 path → 新
+          { path: '/d.png', step: 2 },  // 新 step
+        ],
+      },
+    )
+    expect(out.samples).toHaveLength(4)
+    expect(out.samples?.map((s) => s.path)).toEqual(['/a.png', '/b.png', '/c.png', '/d.png'])
+  })
+
+  it('caps losses at MAX_LOSSES=5000', () => {
+    const prev = {
+      losses: Array.from({ length: 4500 }, (_, i) => ({ step: i, loss: 0.0 })),
+      lr_history: [],
+      samples: [],
+    }
+    const out = mergeDelta(prev, {
+      appended_losses: Array.from({ length: 1000 }, (_, i) => ({ step: 4500 + i, loss: 0.0 })),
+    })
+    expect(out.losses).toHaveLength(5000)
+    // 留尾部
+    expect(out.losses?.[0].step).toBe(500)
+    expect(out.losses?.[4999].step).toBe(5499)
+  })
+
+  it('caps samples at MAX_SAMPLES=50 (same as backend)', () => {
+    const prev = {
+      losses: [], lr_history: [],
+      samples: Array.from({ length: 45 }, (_, i) => ({ path: `/p${i}`, step: i })),
+    }
+    const out = mergeDelta(prev, {
+      appended_samples: Array.from({ length: 10 }, (_, i) => ({ path: `/n${i}`, step: 45 + i })),
+    })
+    expect(out.samples).toHaveLength(50)
+    expect(out.samples?.[0].path).toBe('/p5')  // 头部被裁
+    expect(out.samples?.[49].path).toBe('/n9')
+  })
+
+  it('replaces scalar fields each merge', () => {
+    const out = mergeDelta(
+      { step: 1, speed: 0.5, losses: [], lr_history: [], samples: [] },
+      { step: 10, speed: 2.0 },
+    )
+    expect(out.step).toBe(10)
+    expect(out.speed).toBe(2.0)
+  })
+
+  it('keeps old config when delta has no config', () => {
+    const out = mergeDelta(
+      { config: { rank: 32 }, losses: [], lr_history: [], samples: [] },
+      { step: 5 },
+    )
+    expect(out.config).toEqual({ rank: 32 })
+  })
+})

--- a/studio/web/src/lib/useMonitorProgress.ts
+++ b/studio/web/src/lib/useMonitorProgress.ts
@@ -1,0 +1,129 @@
+/**
+ * useMonitorProgress — 共享的 monitor state 订阅 hook（PR #37 增量协议）。
+ *
+ * 协议：
+ *   - mount + SSE 重连：GET /api/state?task_id=X&max_points=1000 拉降采样快照
+ *   - 之后 SSE monitor_progress 推 delta，本 hook 把 appended_losses/lr/samples
+ *     合并进 state；scalar 字段（step/speed/...）每次替换
+ *   - dedup：appended_losses/lr 按 step 过滤已知；samples 按 (step, path) 过滤
+ *     —— 防止重连时 snapshot 与 poller delta 边界重叠造成的重复点
+ *   - cap：losses/lr_history 各 5000 上限；samples 50 上限（同 backend cap）
+ *
+ * taskId 为 null 时 hook 完全 idle（用于 Queue/Topbar 跨 task 视图，无运行
+ * 任务时不订阅）。taskId 切换时清状态 + 重新拉快照。
+ */
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { api, type MonitorState } from '../api/client'
+import { useEventStream } from './useEventStream'
+
+interface MonitorProgressDelta {
+  step?: number
+  total_steps?: number
+  epoch?: number
+  total_epochs?: number
+  speed?: number
+  start_time?: number | null
+  appended_losses?: Array<{ step: number; loss: number; time?: number }>
+  appended_lr?: Array<{ step: number; lr: number }>
+  appended_samples?: NonNullable<MonitorState['samples']>
+  config?: Record<string, string | number | boolean>
+}
+
+const MAX_LOSSES = 5000
+const MAX_LR = 5000
+const MAX_SAMPLES = 50
+
+function mergeDelta(prev: MonitorState | null, delta: MonitorProgressDelta): MonitorState {
+  const base: MonitorState = prev ?? {}
+
+  // dedup cursors — 由 prev 末尾推断，避免重连时 snapshot 与下条 delta 重叠
+  const losses = base.losses ?? []
+  const lrHistory = base.lr_history ?? []
+  const samples = base.samples ?? []
+  const lastLossStep = losses.length ? losses[losses.length - 1].step : -1
+  const lastLrStep = lrHistory.length ? lrHistory[lrHistory.length - 1].step : -1
+  const knownSamples = new Set(samples.map((s) => `${s.step ?? ''}|${s.path}`))
+
+  const newLosses = (delta.appended_losses ?? []).filter((l) => l.step > lastLossStep)
+  const newLr = (delta.appended_lr ?? []).filter((l) => l.step > lastLrStep)
+  const newSamples = (delta.appended_samples ?? []).filter(
+    (s) => !knownSamples.has(`${s.step ?? ''}|${s.path}`),
+  )
+
+  const mergedLosses = newLosses.length ? [...losses, ...newLosses] : losses
+  const mergedLr = newLr.length ? [...lrHistory, ...newLr] : lrHistory
+  const mergedSamples = newSamples.length ? [...samples, ...newSamples] : samples
+
+  return {
+    ...base,
+    step: delta.step ?? base.step,
+    total_steps: delta.total_steps ?? base.total_steps,
+    epoch: delta.epoch ?? base.epoch,
+    total_epochs: delta.total_epochs ?? base.total_epochs,
+    speed: delta.speed ?? base.speed,
+    start_time: delta.start_time ?? base.start_time,
+    losses: mergedLosses.length > MAX_LOSSES ? mergedLosses.slice(-MAX_LOSSES) : mergedLosses,
+    lr_history: mergedLr.length > MAX_LR ? mergedLr.slice(-MAX_LR) : mergedLr,
+    samples: mergedSamples.length > MAX_SAMPLES ? mergedSamples.slice(-MAX_SAMPLES) : mergedSamples,
+    config: delta.config ?? base.config,
+  }
+}
+
+export interface MonitorProgress {
+  state: MonitorState | null
+  connected: boolean
+  /** 主动重新拉一次快照（消费者一般不用，hook 内部自动调）。 */
+  refetch: () => Promise<void>
+}
+
+export function useMonitorProgress(taskId: number | null): MonitorProgress {
+  const [state, setState] = useState<MonitorState | null>(null)
+  const [connected, setConnected] = useState(false)
+  const lastUpdateRef = useRef(0)
+  // 用 ref 接 taskId 给事件 handler 闭包用，避免每次 taskId 变化重订阅 SSE
+  const taskIdRef = useRef(taskId)
+  taskIdRef.current = taskId
+
+  const refetch = useCallback(async () => {
+    const tid = taskIdRef.current
+    if (tid == null) return
+    try {
+      const s = await api.getMonitorState(tid)
+      setState(s)
+      setConnected(true)
+      lastUpdateRef.current = Date.now()
+    } catch {
+      if (Date.now() - lastUpdateRef.current > 5000) setConnected(false)
+    }
+  }, [])
+
+  // taskId 切换 → 清 state + 重新拉
+  useEffect(() => {
+    setState(null)
+    if (taskId == null) {
+      setConnected(false)
+      return
+    }
+    void refetch()
+  }, [taskId, refetch])
+
+  useEventStream(
+    (evt) => {
+      const tid = taskIdRef.current
+      if (tid == null) return
+      if (evt.type !== 'monitor_progress') return
+      if (String(evt.task_id) !== String(tid)) return
+      const delta = evt.delta as MonitorProgressDelta | undefined
+      if (!delta) return
+      setState((prev) => mergeDelta(prev, delta))
+      setConnected(true)
+      lastUpdateRef.current = Date.now()
+    },
+    { onOpen: () => void refetch() },
+  )
+
+  return { state, connected, refetch }
+}
+
+// 暴露给测试用
+export { mergeDelta as _mergeDeltaForTest }

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -1,9 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
-import { api, type MonitorState, type Task, type TaskStatus } from '../api/client'
+import { api, type Task, type TaskStatus } from '../api/client'
 import StepShell from '../components/StepShell'
 import { useToast } from '../components/Toast'
 import { useEventStream } from '../lib/useEventStream'
+import { useMonitorProgress } from '../lib/useMonitorProgress'
 
 async function downloadJson(filename: string, data: unknown) {
   const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
@@ -91,12 +92,6 @@ export default function QueuePage() {
   const reloadTimer = useRef<number | null>(null)
   const { toast } = useToast()
   const navigate = useNavigate()
-  // 给「运行中」那一行的进度条用：拉当前 running task 的 monitor state，
-  // 用 step / total_steps 算实际百分比。Topbar 胶囊也用同一个数据源，俩地方
-  // 会显示一致。
-  const [monitor, setMonitor] = useState<MonitorState | null>(null)
-  const [monitorTaskId, setMonitorTaskId] = useState<number | null>(null)
-
   const reload = useCallback(async () => {
     try { setTasks(await api.listQueue()); setError(null) }
     catch (e) { setError(String(e)) }
@@ -110,10 +105,6 @@ export default function QueuePage() {
         reloadTimer.current = window.setTimeout(() => {
           reloadTimer.current = null; void reload()
         }, 100)
-      } else if (evt.type === 'monitor_state_updated' && evt.state) {
-        // SSE payload 里已带全量 state，直接 setState，不再 fetch。
-        setMonitor(evt.state as MonitorState)
-        setMonitorTaskId(Number(evt.task_id))
       }
     },
     { onOpen: () => void reload() },
@@ -135,14 +126,9 @@ export default function QueuePage() {
     () => tasks.find((t) => t.status === 'running')?.id ?? null,
     [tasks],
   )
-  // running task 切换时清掉 stale monitor state（避免进度条短暂显示上一个
-  // 任务的进度）；新任务的真实 monitor 数据由 SSE monitor_state_updated 推过来。
-  useEffect(() => {
-    if (!runningTaskId) {
-      setMonitor(null)
-      setMonitorTaskId(null)
-    }
-  }, [runningTaskId])
+  // monitor 进度走 useMonitorProgress hook (PR #37 增量协议)：runningTaskId
+  // 切换时 hook 自动清状态 + 重拉 /api/state 冷启动；不需要本组件再写清理逻辑。
+  const { state: monitor } = useMonitorProgress(runningTaskId)
 
   const clearDone = async () => {
     const done = tasks.filter((t) => t.status === 'done')
@@ -311,7 +297,7 @@ export default function QueuePage() {
                               // monitor 在这一行任务上有 step/total → 显示 step；
                               // 否则 fallback 时长（采样阶段或非训练任务）。
                               if (
-                                monitorTaskId === t.id &&
+                                t.id === runningTaskId &&
                                 monitor?.step != null &&
                                 monitor.total_steps != null &&
                                 monitor.total_steps > 0
@@ -324,7 +310,7 @@ export default function QueuePage() {
                           <div className="h-1 bg-overlay rounded-sm overflow-hidden">
                             {(() => {
                               const haveSteps =
-                                monitorTaskId === t.id &&
+                                t.id === runningTaskId &&
                                 monitor?.step != null &&
                                 monitor.total_steps != null &&
                                 monitor.total_steps > 0

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -3,13 +3,13 @@ import {
   api,
   type GenerateRequest,
   type LoraEntry,
-  type MonitorState,
   type Task,
   type XYMatrixSpec,
 } from '../../api/client'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
 import { useEventStream } from '../../lib/useEventStream'
+import { useMonitorProgress } from '../../lib/useMonitorProgress'
 import AspectChips, { aspectFromDimensions, type AspectName } from './generate/AspectChips'
 import DaemonControls from './generate/DaemonControls'
 import GenerateProgressBar, { type GenerateProgress } from './generate/GenerateProgress'
@@ -59,7 +59,10 @@ export default function GeneratePage() {
   // 没法重试也没法取消（status=failed 时 cancelable=false）
   const [submitting, setSubmitting] = useState(false)
   const [currentTask, setCurrentTask] = useState<Task | null>(null)
-  const [monitorState, setMonitorState] = useState<MonitorState | null>(null)
+  // monitor 走 useMonitorProgress hook (PR #37 增量协议)：currentTask 变 →
+  // hook 自动重拉快照 + 订阅 SSE delta 合并；本组件只用 samples 字段，其余
+  // 字段在这页生成场景下不需要。
+  const { state: monitorState } = useMonitorProgress(currentTask?.id ?? null)
   // commit 14：中间步预览（仅 single 模式有意义；XY/对比 cell 多预览意义小）
   const [previewStep, setPreviewStep] = useState<{ step: number; total: number; dataUrl: string } | null>(null)
   // 生成进度（image_started + preview_step 聚合）
@@ -123,12 +126,6 @@ export default function GeneratePage() {
           setProgress({ batchIdx: null, batchTotal: null, currentStep: null, totalSteps: null })
         }
       }).catch(() => { /* task 已清也走这里 */ })
-    } else if (
-      evt.type === 'monitor_state_updated'
-      && String(evt.task_id) === String(tid)
-      && evt.state
-    ) {
-      setMonitorState(evt.state as MonitorState)
     } else if (
       evt.type === 'generate_preview_step'
       && String(evt.task_id) === String(tid)
@@ -265,7 +262,7 @@ export default function GeneratePage() {
 
     setSubmitting(true)
     setCurrentTask(null)
-    setMonitorState(null)
+    // monitorState 由 useMonitorProgress hook 自动随 currentTask 切 null → 清空
     setSelectedIndices([])  // 新一轮生成 — 旧选择已失效
     setProgress({ batchIdx: null, batchTotal: null, currentStep: null, totalSteps: null })
     try {

--- a/tests/test_log_tail.py
+++ b/tests/test_log_tail.py
@@ -1,10 +1,11 @@
-"""PP2 — LogTailer 增量推送行 callback。"""
+"""PP2 — LogTailer 增量推送行 callback；PR #37 — MonitorStatePoller 增量 delta。"""
 from __future__ import annotations
 
+import json
 import time
 from pathlib import Path
 
-from studio.log_tail import LogTailer
+from studio.log_tail import LogTailer, MonitorStatePoller
 
 
 def _wait_lines(received: list[str], n: int, timeout: float = 2.0) -> None:
@@ -57,6 +58,122 @@ def test_tailer_flushes_partial_line_on_stop(tmp_path: Path) -> None:
     time.sleep(0.1)
     tailer.stop()
     assert received == ["abc"]
+
+
+# ── MonitorStatePoller 增量协议 (PR #37) ───────────────────────────────
+
+
+def _write_state(path: Path, state: dict) -> None:
+    """写 state.json，并故意把 mtime 向前推 1s，保证 poller 看见变化。"""
+    prev_mtime = path.stat().st_mtime if path.exists() else 0
+    path.write_text(json.dumps(state), encoding="utf-8")
+    import os
+    new_mtime = max(prev_mtime + 1.0, time.time())
+    os.utime(path, (new_mtime, new_mtime))
+
+
+def _wait_for(n: int, deltas: list, timeout: float = 3.0) -> None:
+    deadline = time.time() + timeout
+    while len(deltas) < n and time.time() < deadline:
+        time.sleep(0.05)
+
+
+def test_poller_first_publish_is_full_delta(tmp_path: Path) -> None:
+    """从 0 起步：losses/lr/samples 全部进 appended_*。"""
+    sf = tmp_path / "state.json"
+    _write_state(sf, {
+        "step": 3, "total_steps": 100,
+        "losses": [{"step": 1, "loss": 0.5}, {"step": 2, "loss": 0.4}, {"step": 3, "loss": 0.3}],
+        "lr_history": [{"step": 1, "lr": 1e-4}],
+        "samples": [{"path": "/x/y.png", "step": 1}],
+        "config": {"model": "X"},
+    })
+    deltas: list[dict] = []
+    poller = MonitorStatePoller(sf, deltas.append, poll_interval=0.05, min_publish_interval=0.0)
+    poller.start()
+    try:
+        _wait_for(1, deltas)
+    finally:
+        poller.stop()
+    assert len(deltas) >= 1
+    d = deltas[0]
+    assert d["step"] == 3
+    assert len(d["appended_losses"]) == 3
+    assert len(d["appended_lr"]) == 1
+    assert len(d["appended_samples"]) == 1
+    assert d.get("config") == {"model": "X"}
+
+
+def test_poller_second_publish_only_new_entries(tmp_path: Path) -> None:
+    """state 增量更新后，第二次 delta 只带新增的 loss/lr/sample。"""
+    sf = tmp_path / "state.json"
+    _write_state(sf, {
+        "step": 1, "losses": [{"step": 1, "loss": 0.5}], "lr_history": [], "samples": [],
+    })
+    deltas: list[dict] = []
+    poller = MonitorStatePoller(sf, deltas.append, poll_interval=0.05, min_publish_interval=0.0)
+    poller.start()
+    try:
+        _wait_for(1, deltas)
+        # 再加 2 个 loss + 1 个 sample
+        _write_state(sf, {
+            "step": 3,
+            "losses": [{"step": 1, "loss": 0.5}, {"step": 2, "loss": 0.4}, {"step": 3, "loss": 0.3}],
+            "lr_history": [{"step": 3, "lr": 1e-5}],
+            "samples": [{"path": "/x/new.png", "step": 3}],
+        })
+        _wait_for(2, deltas)
+    finally:
+        poller.stop()
+    assert len(deltas) >= 2
+    d2 = deltas[1]
+    assert d2["step"] == 3
+    # 只带新增的 2 个 loss
+    assert [l["step"] for l in d2["appended_losses"]] == [2, 3]
+    assert len(d2["appended_lr"]) == 1
+    assert len(d2["appended_samples"]) == 1
+    # config 没变 → 不带
+    assert "config" not in d2
+
+
+def test_poller_min_publish_interval_throttles(tmp_path: Path) -> None:
+    """同一秒内连续 2 次 mtime 变化只发 1 次 (min_publish_interval=1s)。"""
+    sf = tmp_path / "state.json"
+    _write_state(sf, {"step": 1, "losses": [{"step": 1, "loss": 0.5}], "lr_history": [], "samples": []})
+    deltas: list[dict] = []
+    poller = MonitorStatePoller(sf, deltas.append, poll_interval=0.05, min_publish_interval=1.0)
+    poller.start()
+    try:
+        _wait_for(1, deltas, timeout=1.0)
+        # 立刻再写一次 → 应被节流跳过
+        _write_state(sf, {"step": 2, "losses": [{"step": 1, "loss": 0.5}, {"step": 2, "loss": 0.4}],
+                          "lr_history": [], "samples": []})
+        time.sleep(0.3)
+        # 这 0.3s 内不应有新 publish
+        assert len(deltas) == 1, f"expected throttled, got {len(deltas)} deltas"
+    finally:
+        poller.stop()
+
+
+def test_poller_no_progress_no_publish(tmp_path: Path) -> None:
+    """只改了文件 mtime 但 step/losses/samples/config 都没动 → 不 publish。"""
+    sf = tmp_path / "state.json"
+    state = {"step": 0, "losses": [], "lr_history": [], "samples": [], "config": {}}
+    _write_state(sf, state)
+    deltas: list[dict] = []
+    poller = MonitorStatePoller(sf, deltas.append, poll_interval=0.05, min_publish_interval=0.0)
+    poller.start()
+    try:
+        # 第一次会 publish（首次推送，has_progress 总为真）
+        _wait_for(1, deltas)
+        assert len(deltas) == 1
+        # 改 mtime 但 content 没变 → has_progress 为 False
+        _write_state(sf, state)
+        time.sleep(0.3)
+        # 仍应是 1
+        assert len(deltas) == 1
+    finally:
+        poller.stop()
 
 
 def test_tailer_strips_ansi_and_nul(tmp_path: Path) -> None:

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -313,6 +313,47 @@ def test_state_running_task_used_when_no_task_id(
     assert resp.json()["step"] == 7
 
 
+def test_state_max_points_downsamples_losses(
+    client: TestClient, isolated_paths: dict[str, Path]
+) -> None:
+    """PR #37：/api/state 兑现 max_points，losses/lr 长度超过时均匀降采样。"""
+    losses = [{"step": i, "loss": 1.0 / (i + 1), "time": float(i)} for i in range(5000)]
+    lr_history = [{"step": i, "lr": 1e-4} for i in range(5000)]
+    payload = {
+        "losses": losses, "lr_history": lr_history, "epoch": 0, "step": 4999,
+        "total_steps": 5000, "speed": 0.0, "samples": [],
+        "start_time": None, "config": {},
+    }
+    tid = _make_task_with_state(isolated_paths, payload)
+
+    # max_points=500 → 都被压到 500
+    resp = client.get(f"/api/state?task_id={tid}&max_points=500")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["losses"]) == 500
+    assert len(body["lr_history"]) == 500
+    # 首尾保留
+    assert body["losses"][0]["step"] == 0
+    assert body["losses"][-1]["step"] == 4999
+    # 其他字段透传
+    assert body["step"] == 4999
+    assert body["total_steps"] == 5000
+
+
+def test_state_max_points_zero_disables_downsample(
+    client: TestClient, isolated_paths: dict[str, Path]
+) -> None:
+    """max_points=0 (无穷) → 不降采样，原样返回。"""
+    losses = [{"step": i, "loss": 0.0} for i in range(100)]
+    payload = {"losses": losses, "lr_history": [], "epoch": 0, "step": 99,
+               "total_steps": 100, "speed": 0.0, "samples": [],
+               "start_time": None, "config": {}}
+    tid = _make_task_with_state(isolated_paths, payload)
+    resp = client.get(f"/api/state?task_id={tid}&max_points=0")
+    assert resp.status_code == 200
+    assert len(resp.json()["losses"]) == 100
+
+
 # ---------------------------------------------------------------------------
 # /samples/{filename}
 # ---------------------------------------------------------------------------

--- a/tests/test_system_stats.py
+++ b/tests/test_system_stats.py
@@ -1,7 +1,9 @@
-"""services/system_stats.py — 采集 + NVML 优雅降级。"""
+"""services/system_stats.py — 采集 + NVML 优雅降级 + SSE sampler 线程。"""
 from __future__ import annotations
 
 import sys
+import threading
+import time
 import types
 
 import pytest
@@ -107,6 +109,57 @@ def test_nvml_one_fake_gpu(monkeypatch: pytest.MonkeyPatch):
     assert g.vram_used_gb == 4.0
     assert g.vram_total_gb == 24.0
     assert g.temp_c == 50
+
+
+def test_sampler_emits_payloads(monkeypatch: pytest.MonkeyPatch):
+    """SystemStatsSampler 启动后会定期 callback；stop() 干净退出。"""
+    samples: list[dict] = []
+    event = threading.Event()
+
+    def on_sample(payload: dict) -> None:
+        samples.append(payload)
+        if len(samples) >= 2:
+            event.set()
+
+    sampler = system_stats.SystemStatsSampler(on_sample, interval=0.05)
+    sampler.start()
+    try:
+        assert event.wait(timeout=2.0), f"only got {len(samples)} samples"
+    finally:
+        sampler.stop()
+
+    assert len(samples) >= 2
+    for p in samples:
+        assert set(p.keys()) == {"cpu_pct", "ram_used_gb", "ram_total_gb", "gpu"}
+
+
+def test_sampler_swallows_collection_errors(monkeypatch: pytest.MonkeyPatch):
+    """采集抛错时 sampler 不应崩溃，继续下一轮。"""
+    fail_count = [0]
+    samples: list[dict] = []
+
+    real_collect = system_stats.collect_stats
+
+    def flaky_collect() -> system_stats.SystemStats:
+        fail_count[0] += 1
+        if fail_count[0] == 1:
+            raise RuntimeError("simulated transient failure")
+        return real_collect()
+
+    monkeypatch.setattr(system_stats, "collect_stats", flaky_collect)
+
+    sampler = system_stats.SystemStatsSampler(samples.append, interval=0.05)
+    sampler.start()
+    try:
+        deadline = time.time() + 2.0
+        while len(samples) < 1 and time.time() < deadline:
+            time.sleep(0.05)
+    finally:
+        sampler.stop()
+
+    # 第一次 collect 抛错被吞，第二次成功 → samples >= 1
+    assert fail_count[0] >= 2
+    assert len(samples) >= 1
 
 
 def test_nvml_temp_failure_keeps_other_fields(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_system_stats.py
+++ b/tests/test_system_stats.py
@@ -1,0 +1,141 @@
+"""services/system_stats.py — 采集 + NVML 优雅降级。"""
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from studio.services import system_stats
+
+
+def test_collect_stats_returns_sane_basic():
+    """实环境采集：CPU/RAM 范围合理，结构完整。"""
+    stats = system_stats.collect_stats()
+    assert 0.0 <= stats.cpu_pct <= 100.0
+    assert stats.ram_used_gb >= 0.0
+    assert stats.ram_total_gb > 0.0
+    assert stats.ram_used_gb <= stats.ram_total_gb
+    # gpu 字段在 CI 环境通常是 None；本地有卡时是 list[GpuStats]
+
+
+def test_stats_to_json_no_gpu():
+    s = system_stats.SystemStats(
+        cpu_pct=12.5, ram_used_gb=8.0, ram_total_gb=32.0, gpu=None,
+    )
+    j = system_stats.stats_to_json(s)
+    assert set(j.keys()) == {"cpu_pct", "ram_used_gb", "ram_total_gb", "gpu"}
+    assert j["gpu"] is None
+
+
+def test_stats_to_json_with_gpu():
+    g = system_stats.GpuStats(
+        index=0, name="Test GPU", util_pct=42,
+        vram_used_gb=4.0, vram_total_gb=24.0, temp_c=55,
+    )
+    s = system_stats.SystemStats(
+        cpu_pct=1.0, ram_used_gb=8.0, ram_total_gb=32.0, gpu=[g],
+    )
+    j = system_stats.stats_to_json(s)
+    assert isinstance(j["gpu"], list) and len(j["gpu"]) == 1
+    g0 = j["gpu"][0]
+    assert g0["index"] == 0
+    assert g0["name"] == "Test GPU"
+    assert g0["util_pct"] == 42
+    assert g0["temp_c"] == 55
+
+
+def test_nvml_init_failure_returns_none(monkeypatch: pytest.MonkeyPatch):
+    """模拟 nvmlInit 抛错：collect_gpu 永久返回 None。"""
+    monkeypatch.setattr(
+        system_stats, "_nvml_state", {"inited": False, "ok": False},
+    )
+    fake = types.ModuleType("pynvml")
+
+    def boom() -> None:
+        raise RuntimeError("simulated init failure")
+
+    fake.nvmlInit = boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pynvml", fake)
+
+    assert system_stats._collect_gpu() is None
+    # 第二次调用走缓存，仍是 None；不应再次抛错
+    assert system_stats._collect_gpu() is None
+
+
+def test_nvml_zero_devices_returns_empty_list(monkeypatch: pytest.MonkeyPatch):
+    """NVML 可用但没卡：返回 [] (前端跟 None 一样隐藏 GPU pill)。"""
+    monkeypatch.setattr(
+        system_stats, "_nvml_state", {"inited": True, "ok": True},
+    )
+    fake = types.ModuleType("pynvml")
+    fake.nvmlDeviceGetCount = lambda: 0  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pynvml", fake)
+
+    assert system_stats._collect_gpu() == []
+
+
+def test_nvml_one_fake_gpu(monkeypatch: pytest.MonkeyPatch):
+    """单张 mock 卡：字段按预期映射。"""
+    monkeypatch.setattr(
+        system_stats, "_nvml_state", {"inited": True, "ok": True},
+    )
+
+    class FakeMem:
+        used = 4 * 1024 ** 3
+        total = 24 * 1024 ** 3
+
+    class FakeUtil:
+        gpu = 67
+
+    fake = types.ModuleType("pynvml")
+    fake.NVML_TEMPERATURE_GPU = 0  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetCount = lambda: 1  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetHandleByIndex = lambda i: f"h{i}"  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetName = lambda h: "Mock GPU"  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetMemoryInfo = lambda h: FakeMem()  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetUtilizationRates = lambda h: FakeUtil()  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetTemperature = lambda h, t: 50  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pynvml", fake)
+
+    result = system_stats._collect_gpu()
+    assert result is not None and len(result) == 1
+    g = result[0]
+    assert g.index == 0
+    assert g.name == "Mock GPU"
+    assert g.util_pct == 67
+    assert g.vram_used_gb == 4.0
+    assert g.vram_total_gb == 24.0
+    assert g.temp_c == 50
+
+
+def test_nvml_temp_failure_keeps_other_fields(monkeypatch: pytest.MonkeyPatch):
+    """部分指标 (温度) 抛错时不应让整张卡丢失。"""
+    monkeypatch.setattr(
+        system_stats, "_nvml_state", {"inited": True, "ok": True},
+    )
+
+    class FakeMem:
+        used = 1 * 1024 ** 3
+        total = 8 * 1024 ** 3
+
+    class FakeUtil:
+        gpu = 10
+
+    def temp_boom(*a, **k):
+        raise RuntimeError("temp sensor unavailable")
+
+    fake = types.ModuleType("pynvml")
+    fake.NVML_TEMPERATURE_GPU = 0  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetCount = lambda: 1  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetHandleByIndex = lambda i: f"h{i}"  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetName = lambda h: "Old GPU"  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetMemoryInfo = lambda h: FakeMem()  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetUtilizationRates = lambda h: FakeUtil()  # type: ignore[attr-defined]
+    fake.nvmlDeviceGetTemperature = temp_boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pynvml", fake)
+
+    result = system_stats._collect_gpu()
+    assert result is not None and len(result) == 1
+    assert result[0].temp_c is None
+    assert result[0].util_pct == 10


### PR DESCRIPTION
3 commits 渐次推进：先做 topbar 系统监控（最初目标），讨论中发现 polling 模型在 cloud 部署下会污染 server log / DevTools Network / 跨公网 RTT，扩展到 monitor SSE 协议重构。

## 1. Topbar 系统监控小组件

### 背景

Topbar 右侧 200px 的「跳转 / 搜索…」按钮平时空闲，信息密度低；训练 / 打标 / 测试 (推理) 三类工作负载都吃 GPU，但缺一个**常驻可见**的资源指示器（监控页跟训练 task 绑定，不适合这个用途）。

### 改动

- `studio/services/system_stats.py` — psutil + nvidia-ml-py 采集 CPU / RAM / GPU / VRAM
  - NVML 懒初始化 + 失败永久标记 → 无 NVIDIA / 驱动缺失时 `gpu = null` 优雅降级（沿用 onnxruntime 静默降级思路）
  - 模块导入时 prime `psutil.cpu_percent()`，避免首请求恒为 0%
- `server.py` 加 `GET /api/system/stats`
- `components/SystemStats.tsx`：4 个进度条 pill（CPU / MEM / GPU / VRAM），h-8 与搜索 icon 高度对齐；整 pill 背景按占用百分比填色（≥70% 黄、≥90% 红）；tooltip 给 GPU 名 + 温度 + 多卡数量
- `Topbar.tsx`：搜索按钮 200px → **32px icon-only**（⌘K 行为完全保留，含独家的跨图标签搜索），左侧插入 `<SystemStats />`
- `requirements.txt`：`nvidia-ml-py>=12.0`（PyTorch 官方推荐版，老 pynvml 已 deprecate）

## 2. System stats: polling → SSE

讨论中确认 cloud 部署场景下 polling 模型几个问题被放大：DevTools Network 每 2.5s 一条调试时不能看；uvicorn access log 被同样污染；跨公网每请求 ~250B header × 1440/h 无谓 RTT。

### 改动

- 后端：`SystemStatsSampler` 后台线程每 2.5s 采集 + `bus.publish('system_stats_updated', payload)`
- 前端：`SystemStats` 去掉 setInterval，改用 `useEventStream` 订阅；保留 GET 端点作 mount 冷启动 + SSE 重连补一次

## 3. Monitor SSE 增量协议（顺手把 monitor 老问题也修了）

讨论中发现现有 `monitor_state_updated` 事件每次推**全量 state**（losses 数组每步重传）：2000 步训练单次 ~200KB × 2Hz = **3.2 Mb/s 持续 SSE 流量**，且累计带宽 O(N²)；前端每帧 setState 整个 chart 性能也差。

### 协议重构（事件改名 `monitor_state_updated` → `monitor_progress`）

- `log_tail.MonitorStatePoller` 维护 `last_step / last_*_count / last_config` 游标，每次只把「自上次发布以来的新增」打成 delta：
  ```
  { step, total_steps, epoch, speed, start_time,
    appended_losses, appended_lr, appended_samples,
    config?  /* 仅首次或变化时 */ }
  ```
- Throttle（混合 step + 时间）：`poll_interval=0.5s` 探测 mtime + `min_publish_interval=1.0s` 强制下界 + 无 progress 跳过推送。慢训练（step >1s）每 step 推一次；快训练（step <1s）自动 batch 到 1Hz
- `/api/state` 兑现前端早就在传但 server 忽略的 `max_points` 参数（默认 1000），调 `_downsample_uniform` 把 losses/lr_history 压到固定大小，冷启动 payload 从 O(N) 降到 O(1)

### 前端统一 hook

新建 `useMonitorProgress(taskId)`：
- mount + SSE 重连：GET `/api/state` 拉降采样快照
- SSE delta：合并 appended_*，scalar 字段每次替换
- dedup：appended_losses/lr 按 step 过滤已知；samples 按 (step, path)；防重连边界重复
- cap：losses/lr_history 各 5000、samples 50

4 个消费者全部迁移到 hook：MonitorDashboard / Topbar / Queue / Generate (XY)。

## 测试

- **后端 pytest** +12：MonitorStatePoller 增量发布 / 节流 / no-progress 跳过（`test_log_tail`）；`/api/state` max_points 上下采样（`test_studio_server`）；SystemStatsSampler 线程行为 + 异常吞咽（`test_system_stats`）
- **前端 vitest** +9：`mergeDelta` 初始 / 追加 / dedup / 上限 / scalar 替换 各路径；`SystemStats.test` 删轮询相关，加单次 fetch 回归

整库：pytest 823 全绿（+12）；vitest 122 全绿（+9）；tsc 干净；vite build OK。

## 手动验证清单

- [ ] 启动 server，首屏看 topbar 4 个 pill 是否在 ~2.5s 内出现
- [ ] 跑训练，monitor 页 loss chart 实时更新，DevTools Network 不再每 2.5s 一条同名请求
- [ ] 关 monitor tab 后训练继续，重开 tab 应能从 `/api/state` 拿到当前进度 + 后续 SSE delta
- [ ] hover GPU pill 看 tooltip 有没有显示卡名 + 温度
- [ ] ⌘K 在 icon-only 状态下仍能弹出搜索 palette

🤖 Generated with [Claude Code](https://claude.com/claude-code)