### PR TITLE
fix(booru): estimate API 同样带应用 UA（v0.5.2 hotfix 漏修）

### DIFF
--- a/studio/services/downloader.py
+++ b/studio/services/downloader.py
@@ -288,8 +288,16 @@ def _download_with_client(
 
 
 def estimate(opts: DownloadOptions) -> int:
-    """轻量调用 API 估算 tag（含 exclude）命中量；失败返回 -1（未知）。"""
+    """轻量调用 API 估算 tag（含 exclude）命中量；失败返回 -1（未知）。
+
+    v0.5.2 hotfix 漏修：search_posts 已经走 booru_api 的 UA / Accept 头过 CF，
+    但 estimate 这条单独的"轻量"路径仍是裸 requests.get（默认 UA
+    python-requests/X.Y.Z）→ danbooru 的 CF 把它当 bot 拦掉 → 抛异常 →
+    永远返回 -1（未知）。修：复用 booru_api._api_headers 同款 UA；danbooru
+    端有 basic auth 时一并带上让 rate limit 按账户算。
+    """
     query = opts.effective_tag_query()
+    headers = booru_api._api_headers(opts.username)
     if opts.api_source == "gelbooru":
         try:
             params: dict[str, Any] = {
@@ -305,7 +313,8 @@ def estimate(opts: DownloadOptions) -> int:
                 params["api_key"] = opts.api_key
                 params["user_id"] = opts.user_id
             r = requests.get(
-                f"{opts.base_url()}/index.php", params=params, timeout=15
+                f"{opts.base_url()}/index.php",
+                params=params, headers=headers, timeout=15,
             )
             r.raise_for_status()
             data = r.json()
@@ -315,10 +324,11 @@ def estimate(opts: DownloadOptions) -> int:
             return -1
         return -1
     try:
+        auth = (opts.username, opts.api_key) if opts.username and opts.api_key else None
         r = requests.get(
             f"{opts.base_url()}/counts/posts.json",
             params={"tags": query},
-            timeout=15,
+            headers=headers, auth=auth, timeout=15,
         )
         r.raise_for_status()
         return int(r.json().get("counts", {}).get("posts", -1))

--- a/tests/test_downloader.py
+++ b/tests/test_downloader.py
@@ -110,6 +110,99 @@ def test_download_rejects_empty_tag(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# estimate — UA / auth 透传（v0.5.2 hotfix 漏修：estimate 走单独路径，绕过了
+# booru_api 加的 headers，danbooru 端 CF 一律 403 → 永远返回 -1）
+# ---------------------------------------------------------------------------
+
+
+def test_estimate_danbooru_sends_app_user_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """回归 v0.5.2 漏修：estimate 调 /counts/posts.json 必须带应用 UA，不能
+    用 requests 默认 UA（python-requests/X.Y.Z 会被 CF 直接 403）。"""
+    captured: dict = {}
+
+    def fake_get(url, **kw):
+        captured["url"] = url
+        captured["headers"] = kw.get("headers") or {}
+        captured["auth"] = kw.get("auth")
+        resp = MagicMock()
+        resp.json.return_value = {"counts": {"posts": 343}}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    monkeypatch.setattr(downloader.requests, "get", fake_get)
+
+    opts = downloader.DownloadOptions(
+        tag="chen_bin", count=2, api_source="danbooru",
+        username="", api_key="",  # 匿名 estimate（PR 还允许：estimate 不强制 auth）
+    )
+    n = downloader.estimate(opts)
+    assert n == 343
+    assert "counts/posts.json" in captured["url"]
+    ua = captured["headers"].get("User-Agent", "")
+    assert "AnimaLoraStudio" in ua
+
+
+def test_estimate_danbooru_ua_includes_username_when_provided(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """有 username 时 UA 带 (by username)，与 search 路径一致。"""
+    captured: dict = {}
+
+    def fake_get(url, **kw):
+        captured["headers"] = kw.get("headers") or {}
+        captured["auth"] = kw.get("auth")
+        resp = MagicMock()
+        resp.json.return_value = {"counts": {"posts": 10}}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    monkeypatch.setattr(downloader.requests, "get", fake_get)
+
+    opts = downloader.DownloadOptions(
+        tag="x", count=1, api_source="danbooru",
+        username="alice", api_key="secret",
+    )
+    downloader.estimate(opts)
+    assert "(by alice)" in captured["headers"]["User-Agent"]
+    # auth 也带上，danbooru 端按账户算 rate
+    assert captured["auth"] == ("alice", "secret")
+
+
+def test_estimate_gelbooru_sends_app_user_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """gelbooru 估算路径同样要带 UA（CF 行业趋势收紧，做一致兜底）。"""
+    captured: dict = {}
+
+    def fake_get(url, **kw):
+        captured["url"] = url
+        captured["headers"] = kw.get("headers") or {}
+        resp = MagicMock()
+        resp.json.return_value = {"@attributes": {"count": 100}}
+        resp.raise_for_status.return_value = None
+        return resp
+
+    monkeypatch.setattr(downloader.requests, "get", fake_get)
+
+    opts = downloader.DownloadOptions(
+        tag="x", count=1, api_source="gelbooru",
+        user_id="u", api_key="k",
+    )
+    n = downloader.estimate(opts)
+    assert n == 100
+    assert "/index.php" in captured["url"]
+    assert "AnimaLoraStudio" in captured["headers"]["User-Agent"]
+
+
+def test_estimate_returns_negative_one_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """语义保持：网络异常 / 解析失败时返回 -1（前端 UI 显示 '未知'）。"""
+    def fake_get(*a, **kw):
+        raise Exception("simulated network failure")
+    monkeypatch.setattr(downloader.requests, "get", fake_get)
+
+    opts = downloader.DownloadOptions(tag="x", count=1, api_source="danbooru")
+    assert downloader.estimate(opts) == -1
+
+
+# ---------------------------------------------------------------------------
 # happy path
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 症状

[Image #17 引用] danbooru 下载页 estimate 永远显示「匹配 **未知**」，实际下载却能跑（saved=2 done）。

## 根因

v0.5.2 修了 \`search_posts\` / \`download_image\` 路径，但 \`downloader.estimate()\` 是单独的"轻量"路径，直接 \`requests.get\` 拉 \`/counts/posts.json\` 没设 headers → 默认 UA \`python-requests/X.Y.Z\` → 被 danbooru 的 Cloudflare 一律 403 → 抛异常 → 永远返回 -1（前端 UI 显 "未知"）。

实测：
\`\`\`
status: 403
body[:200]: <!DOCTYPE html>...Just a moment...
\`\`\`

## 修

\`\`\`python
headers = booru_api._api_headers(opts.username)   # 同 search 那条
auth = (opts.username, opts.api_key) if ... else None
r = requests.get(..., headers=headers, auth=auth, timeout=15)
\`\`\`

danbooru basic auth 一并带上让 rate limit 按账户算；gelbooru 估算路径同样加 headers，做一致兜底（CF 收紧是行业趋势）。

实测：\`estimate('chen_bin', source='danbooru')\` **修复前 -1（未知），修复后 343（实际命中数）**。

## 范围讨论

属于 v0.5.2 hotfix 的次要遗漏，不开 v0.5.3——理由：
- 实际下载没坏（走 search_posts 路径，已修）
- 只是 UI 少显示个预览数字，用户能手动输入 count 后照样下载
- 不算 v0.5.2 引入的回归（CF 开始拦截后这个端点就一直拿不到数据）

随 dev 下一波 release 一起出。

## 测试

+4 用例锁定 estimate 路径不变量：UA 含 \`AnimaLoraStudio\` / UA 带 \`(by username)\` 当提供时 / auth tuple 透传 / gelbooru 同样带 UA / 网络异常回退 -1 语义保持。后端 pytest 825 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)