### PR TITLE
feat(optimizer): add ProdigyPlusScheduleFree support

### DIFF
--- a/docs/user-guide/training-tips.md
+++ b/docs/user-guide/training-tips.md
@@ -59,6 +59,39 @@
 | LoRA | 简单稳定，兼容性好 | 表达力有限 | 单角色、简单画风 |
 | LoKr | 表达力强，参数高效 | 需要调参 | 多角色、复杂画风 |
 
+### 优化器选择
+
+| 优化器 | 何时用 | 关键参数 |
+|--------|--------|---------|
+| `adamw` | 默认。手调 lr 不嫌烦、想稳定可预期的训练 | `learning_rate` 1e-4 起步 |
+| `prodigy` | 不想调 lr。**注意**：扩散 LoRA 上易出"风格突变 ep" | `prodigy_d_coef` 小数据集设 0.5 |
+| `prodigy_plus_schedulefree` | **DiT LoRA 推荐**。在 Prodigy 基础上加 Schedule-Free averaged weights，sample/save 走 averaged 权重，**风格突变现象基本消失** | 见下方说明 |
+
+#### ProdigyPlusScheduleFree (PPSF) 使用要点
+
+Anima 是 Cosmos DiT + Flow Matching，跟 Flux/Qwen-Image 同型问题。这些社区已经把 PPSF
+作为 LoRA 训练事实默认，原因是 Prodigy 在 timestep 随机性 + 小数据集场景下 `d` 估计抖动，
+表现为某些 epoch 的 sample 风格突变。PPSF 通过维护 averaged weights 平滑了这个观感。
+
+- **学习率**：固定 `1.0`（PPSF 内部估计真实步长，外部 lr 只是缩放系数；UI 会强制）
+- **lr_scheduler**：**必须 `none`**（Schedule-Free 自带调度，叠 cosine 会破坏 averaged
+  weights 的收敛保证；UI 自动 disable，pydantic 也会拦下）
+- **ppsf_d_coef**：小数据集（<50 张）建议 `0.5`；正常 `1.0`；过拟合可试 `2.0`
+- **ppsf_prodigy_steps**：建议设为总步数的 1/4 到 1/2（如总 2000 步设 500-1000），后期
+  冻结 `d`、防跳档；不确定就留 `0`（不冻结）
+- **ppsf_fused_back_pass**：显存吃紧时开
+- **save / sample 行为**：训练代码自动在 sample 和 save 前调 `optimizer.eval()` 切到
+  averaged weights、事后切回。保存的 LoRA 是 averaged 状态，直接可用
+
+#### 怎么知道 Prodigy → PPSF 是不是真的能解决我的"突变 ep"问题
+
+切换后再训一遍同样的 dataset，对比相邻 ep 的 sample：
+- 之前：某些 ep 风格突然偏离，下一个 ep 又回来或漂到新位置
+- PPSF 后：sample 应该平滑过渡，没有"跳档"的视觉断层
+
+如果 PPSF 之后仍有跳档，多半是 `ppsf_d_coef` 过大或数据集本身太小 — 降到 `0.5` 或
+`0.3` 再试。
+
 ---
 
 ## 常见问题

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,9 @@ peft>=0.8.0
 # bitsandbytes>=0.41.0   # Optional: 8-bit AdamW (may not work on Windows)
 lycoris-lora>=1.9.0
 prodigyopt>=1.0          # Prodigy 优化器（anima_train.py optimizer=prodigy 时必需）
+# ProdigyPlusScheduleFree (LoganBooker) — Flux/Qwen-Image LoRA 社区主流，解决 Prodigy 的
+# mutation ep 问题。pin >=2.0.0 因为 v1.9.2 ↔ v2.0.0 的 state_dict 不兼容。
+prodigy-plus-schedule-free>=2.0.0  # optimizer_type=prodigy_plus_schedulefree 时必需
 safetensors>=0.4.0
 Pillow>=10.0.0
 numpy>=1.24.0

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -2222,16 +2222,39 @@ def main():
     weight_decay = float(getattr(args, "weight_decay", 0.01) or 0.0)
     param_groups = injector.get_param_groups(weight_decay)
     optimizer_type = (getattr(args, "optimizer_type", "adamw") or "adamw").lower()
-    from utils.optimizer_utils import create_optimizer
-    optimizer_extra = {}
+    from utils.optimizer_utils import create_optimizer, optimizer_eval_mode
+    optimizer_extra: dict = {}
+    optimizer_overrides: dict = {}
     if optimizer_type == "prodigy":
         optimizer_extra["d_coef"] = float(getattr(args, "prodigy_d_coef", 1.0))
         optimizer_extra["safeguard_warmup"] = bool(getattr(args, "prodigy_safeguard_warmup", True))
+    elif optimizer_type == "prodigy_plus_schedulefree":
+        # Schedule-Free 不需要 scheduler，启动期强校验
+        lr_sched_cfg = (getattr(args, "lr_scheduler", "none") or "none").lower()
+        if lr_sched_cfg != "none":
+            raise SystemExit(
+                f"ProdigyPlusScheduleFree requires lr_scheduler=none "
+                f"(Schedule-Free is scheduler-free by construction); got "
+                f"lr_scheduler={lr_sched_cfg!r}. Set lr_scheduler=none or pick a "
+                f"different optimizer."
+            )
+        optimizer_extra["d_coef"] = float(getattr(args, "ppsf_d_coef", 1.0))
+        optimizer_extra["prodigy_steps"] = int(getattr(args, "ppsf_prodigy_steps", 0))
+        optimizer_extra["split_groups"] = bool(getattr(args, "ppsf_split_groups", True))
+        optimizer_extra["split_groups_mean"] = bool(getattr(args, "ppsf_split_groups_mean", False))
+        optimizer_extra["use_speed"] = bool(getattr(args, "ppsf_use_speed", False))
+        optimizer_extra["fused_back_pass"] = bool(getattr(args, "ppsf_fused_back_pass", False))
+        optimizer_extra["use_stableadamw"] = bool(getattr(args, "ppsf_use_stableadamw", True))
+        optimizer_overrides["betas"] = (
+            float(getattr(args, "ppsf_beta1", 0.9)),
+            float(getattr(args, "ppsf_beta2", 0.99)),
+        )
     optimizer = create_optimizer(
         optimizer_type=optimizer_type,
         params=param_groups,
         learning_rate=args.learning_rate,
         weight_decay=weight_decay,
+        **optimizer_overrides,
         **optimizer_extra,
     )
     if weight_decay > 0:
@@ -2366,10 +2389,13 @@ def main():
                 monitor_data = get_state()
             except Exception:
                 pass
-        save_training_state(state_path, injector, optimizer, current_epoch, global_step, loss_history, monitor_state=monitor_data, scheduler=scheduler)
-        # 同时保存 LoRA 权重
-        lora_path = output_dir / f"{args.output_name}_interrupted_step{global_step}.safetensors"
-        injector.save(lora_path)
+        # Schedule-Free 系优化器（PPSF）保存前切到 averaged weights — 否则存的是
+        # 训练用的 y 而不是真正应该被使用的 x。非 SF 优化器此 ctx 静默 no-op。
+        with optimizer_eval_mode(optimizer):
+            save_training_state(state_path, injector, optimizer, current_epoch, global_step, loss_history, monitor_state=monitor_data, scheduler=scheduler)
+            # 同时保存 LoRA 权重
+            lora_path = output_dir / f"{args.output_name}_interrupted_step{global_step}.safetensors"
+            injector.save(lora_path)
         wandb_monitor.finish()
         emit(f"已保存！下次使用 --resume-state \"{state_path}\" 继续训练")
         sys.exit(0)
@@ -2401,42 +2427,44 @@ def main():
     sampling_enabled = args.sample_steps > 0 or args.sample_every > 0
     if global_step == 0 and sampling_enabled:
         emit("采样中 (step 0, 基线)...")
-        model.eval()
-        s_w = int(getattr(args, "sample_width", 0) or 0) or int(args.resolution)
-        s_h = int(getattr(args, "sample_height", 0) or 0) or int(args.resolution)
-        s_cfg = float(getattr(args, "sample_cfg_scale", 4.0) or 4.0)
-        s_neg = str(getattr(args, "sample_negative_prompt", "") or "")
-        s_seed = int(getattr(args, "sample_seed", 0) or 0)
-        s_steps = int(getattr(args, "sample_infer_steps", 25) or 25)
-        s_sampler = str(getattr(args, "sample_sampler_name", "er_sde") or "er_sde")
-        s_sched = str(getattr(args, "sample_scheduler", "simple") or "simple")
-        for i, prompt in enumerate(sample_prompts[:3]):  # 最多测试 3 个
-            if s_seed:
-                torch.manual_seed(s_seed + i)
-            img = sample_image(
-                model, vae, qwen_model, qwen_tok, t5_tok,
-                prompt, height=s_h, width=s_w, steps=s_steps, cfg_scale=s_cfg,
-                negative_prompt=(s_neg or None),
-                sampler_name=s_sampler,
-                scheduler=s_sched,
-                device=device, dtype=dtype
-            )
-            sample_path = sample_dir / f"step_0_baseline_{i}.png"
-            img.save(sample_path)
-            emit(f"基线采样保存: step_0_baseline_{i}.png")
-            if wandb_monitor.log_samples:
-                wandb_monitor.log_image(
-                    "samples/baseline",
-                    sample_path,
-                    caption=f"step 0 baseline {i}: {prompt}",
-                    step=0,
+        # PPSF：sample 时切到 averaged weights，事后切回训练权重
+        with optimizer_eval_mode(optimizer):
+            model.eval()
+            s_w = int(getattr(args, "sample_width", 0) or 0) or int(args.resolution)
+            s_h = int(getattr(args, "sample_height", 0) or 0) or int(args.resolution)
+            s_cfg = float(getattr(args, "sample_cfg_scale", 4.0) or 4.0)
+            s_neg = str(getattr(args, "sample_negative_prompt", "") or "")
+            s_seed = int(getattr(args, "sample_seed", 0) or 0)
+            s_steps = int(getattr(args, "sample_infer_steps", 25) or 25)
+            s_sampler = str(getattr(args, "sample_sampler_name", "er_sde") or "er_sde")
+            s_sched = str(getattr(args, "sample_scheduler", "simple") or "simple")
+            for i, prompt in enumerate(sample_prompts[:3]):  # 最多测试 3 个
+                if s_seed:
+                    torch.manual_seed(s_seed + i)
+                img = sample_image(
+                    model, vae, qwen_model, qwen_tok, t5_tok,
+                    prompt, height=s_h, width=s_w, steps=s_steps, cfg_scale=s_cfg,
+                    negative_prompt=(s_neg or None),
+                    sampler_name=s_sampler,
+                    scheduler=s_sched,
+                    device=device, dtype=dtype
                 )
-            if monitor_server:
-                try:
-                    update_monitor(sample_path=sample_path)
-                except Exception:
-                    pass
-        model.train()
+                sample_path = sample_dir / f"step_0_baseline_{i}.png"
+                img.save(sample_path)
+                emit(f"基线采样保存: step_0_baseline_{i}.png")
+                if wandb_monitor.log_samples:
+                    wandb_monitor.log_image(
+                        "samples/baseline",
+                        sample_path,
+                        caption=f"step 0 baseline {i}: {prompt}",
+                        step=0,
+                    )
+                if monitor_server:
+                    try:
+                        update_monitor(sample_path=sample_path)
+                    except Exception:
+                        pass
+            model.train()
     elif global_step > 0 and sampling_enabled:
         emit(f"跳过启动基线采样（从 step {global_step} 恢复，非 step 0）")
 
@@ -2561,6 +2589,91 @@ def main():
                     prompt = get_next_sample_prompt()
                     prompt_short = prompt[:50] + "..." if len(prompt) > 50 else prompt
                     emit(f"采样中 (step {global_step}): {prompt_short}")
+                    # PPSF：sample 走 averaged weights
+                    with optimizer_eval_mode(optimizer):
+                        model.eval()
+                        s_w = int(getattr(args, "sample_width", 0) or 0) or int(args.resolution)
+                        s_h = int(getattr(args, "sample_height", 0) or 0) or int(args.resolution)
+                        s_cfg = float(getattr(args, "sample_cfg_scale", 4.0) or 4.0)
+                        s_neg = str(getattr(args, "sample_negative_prompt", "") or "")
+                        s_steps = int(getattr(args, "sample_infer_steps", 25) or 25)
+                        s_sampler = str(getattr(args, "sample_sampler_name", "er_sde") or "er_sde")
+                        s_sched = str(getattr(args, "sample_scheduler", "simple") or "simple")
+                        img = sample_image(
+                            model, vae, qwen_model, qwen_tok, t5_tok,
+                            prompt, height=s_h, width=s_w, steps=s_steps, cfg_scale=s_cfg,
+                            negative_prompt=(s_neg or None),
+                            sampler_name=s_sampler,
+                            scheduler=s_sched,
+                            device=device, dtype=dtype
+                        )
+                        sample_path = sample_dir / f"step_{global_step}.png"
+                        img.save(sample_path)
+                        emit(f"采样保存: step_{global_step}.png")
+                        if wandb_monitor.log_samples:
+                            wandb_monitor.log_image(
+                                "samples/step",
+                                sample_path,
+                                caption=f"step {global_step}: {prompt}",
+                                step=global_step,
+                            )
+                        if monitor_server:
+                            try:
+                                update_monitor(sample_path=sample_path)
+                            except Exception:
+                                pass
+                        model.train()
+
+                # 定期保存 LoRA 权重（按 step）
+                save_every_steps = getattr(args, "save_every_steps", 0)
+                if save_every_steps > 0 and global_step % save_every_steps == 0:
+                    lora_path = output_dir / f"{args.output_name}_step{global_step}.safetensors"
+                    # PPSF：保存 averaged weights 的 LoRA
+                    with optimizer_eval_mode(optimizer):
+                        injector.save(lora_path)
+                    emit(f"Saved LoRA: {lora_path}")
+
+                # 定期保存训练状态（断点续训）
+                save_state_every = getattr(args, "save_state_every", 0)
+                if save_state_every > 0 and global_step % save_state_every == 0:
+                    state_path = output_dir / f"training_state_step{global_step}.pt"
+                    # 获取监控面板数据用于恢复 loss 曲线
+                    monitor_data = None
+                    if monitor_server:
+                        try:
+                            from train_monitor import get_state
+                            monitor_data = get_state()
+                        except Exception:
+                            pass
+                    # PPSF：state + LoRA 都走 averaged weights
+                    with optimizer_eval_mode(optimizer):
+                        save_training_state(state_path, injector, optimizer, epoch, global_step, loss_history, monitor_state=monitor_data, scheduler=scheduler)
+                        # 同时保存 LoRA 权重
+                        lora_path = output_dir / f"{args.output_name}_step{global_step}.safetensors"
+                        injector.save(lora_path)
+
+                # 检查 max_steps
+                if args.max_steps and global_step >= args.max_steps:
+                    break
+
+        # epoch 结束后的操作
+        current_epoch = epoch + 1
+        if not args.max_steps or global_step < args.max_steps:
+            # 保存 checkpoint
+            if args.save_every > 0 and current_epoch % args.save_every == 0:
+                save_path = output_dir / f"{args.output_name}_epoch{current_epoch}.safetensors"
+                # PPSF：保存 averaged weights 的 LoRA
+                with optimizer_eval_mode(optimizer):
+                    injector.save(save_path)
+                emit(f"Saved LoRA: {save_path}")
+
+            # 采样（轮换提示词）
+            if args.sample_every > 0 and current_epoch % args.sample_every == 0:
+                prompt = get_next_sample_prompt()
+                prompt_short = prompt[:50] + "..." if len(prompt) > 50 else prompt
+                emit(f"采样中 (epoch {current_epoch}): {prompt_short}")
+                # PPSF：sample 走 averaged weights
+                with optimizer_eval_mode(optimizer):
                     model.eval()
                     s_w = int(getattr(args, "sample_width", 0) or 0) or int(args.resolution)
                     s_h = int(getattr(args, "sample_height", 0) or 0) or int(args.resolution)
@@ -2577,99 +2690,24 @@ def main():
                         scheduler=s_sched,
                         device=device, dtype=dtype
                     )
-                    sample_path = sample_dir / f"step_{global_step}.png"
+                    sample_path = sample_dir / f"epoch_{current_epoch}.png"
                     img.save(sample_path)
-                    emit(f"采样保存: step_{global_step}.png")
+                    emit(f"采样保存: epoch_{current_epoch}.png")
                     if wandb_monitor.log_samples:
                         wandb_monitor.log_image(
-                            "samples/step",
+                            "samples/epoch",
                             sample_path,
-                            caption=f"step {global_step}: {prompt}",
+                            caption=f"epoch {current_epoch}: {prompt}",
                             step=global_step,
                         )
+                    model.train()
+
+                    # 更新监控面板
                     if monitor_server:
                         try:
                             update_monitor(sample_path=sample_path)
                         except Exception:
                             pass
-                    model.train()
-
-                # 定期保存 LoRA 权重（按 step）
-                save_every_steps = getattr(args, "save_every_steps", 0)
-                if save_every_steps > 0 and global_step % save_every_steps == 0:
-                    lora_path = output_dir / f"{args.output_name}_step{global_step}.safetensors"
-                    injector.save(lora_path)
-                    emit(f"Saved LoRA: {lora_path}")
-
-                # 定期保存训练状态（断点续训）
-                save_state_every = getattr(args, "save_state_every", 0)
-                if save_state_every > 0 and global_step % save_state_every == 0:
-                    state_path = output_dir / f"training_state_step{global_step}.pt"
-                    # 获取监控面板数据用于恢复 loss 曲线
-                    monitor_data = None
-                    if monitor_server:
-                        try:
-                            from train_monitor import get_state
-                            monitor_data = get_state()
-                        except Exception:
-                            pass
-                    save_training_state(state_path, injector, optimizer, epoch, global_step, loss_history, monitor_state=monitor_data, scheduler=scheduler)
-                    # 同时保存 LoRA 权重
-                    lora_path = output_dir / f"{args.output_name}_step{global_step}.safetensors"
-                    injector.save(lora_path)
-
-                # 检查 max_steps
-                if args.max_steps and global_step >= args.max_steps:
-                    break
-
-        # epoch 结束后的操作
-        current_epoch = epoch + 1
-        if not args.max_steps or global_step < args.max_steps:
-            # 保存 checkpoint
-            if args.save_every > 0 and current_epoch % args.save_every == 0:
-                save_path = output_dir / f"{args.output_name}_epoch{current_epoch}.safetensors"
-                injector.save(save_path)
-                emit(f"Saved LoRA: {save_path}")
-
-            # 采样（轮换提示词）
-            if args.sample_every > 0 and current_epoch % args.sample_every == 0:
-                prompt = get_next_sample_prompt()
-                prompt_short = prompt[:50] + "..." if len(prompt) > 50 else prompt
-                emit(f"采样中 (epoch {current_epoch}): {prompt_short}")
-                model.eval()
-                s_w = int(getattr(args, "sample_width", 0) or 0) or int(args.resolution)
-                s_h = int(getattr(args, "sample_height", 0) or 0) or int(args.resolution)
-                s_cfg = float(getattr(args, "sample_cfg_scale", 4.0) or 4.0)
-                s_neg = str(getattr(args, "sample_negative_prompt", "") or "")
-                s_steps = int(getattr(args, "sample_infer_steps", 25) or 25)
-                s_sampler = str(getattr(args, "sample_sampler_name", "er_sde") or "er_sde")
-                s_sched = str(getattr(args, "sample_scheduler", "simple") or "simple")
-                img = sample_image(
-                    model, vae, qwen_model, qwen_tok, t5_tok,
-                    prompt, height=s_h, width=s_w, steps=s_steps, cfg_scale=s_cfg,
-                    negative_prompt=(s_neg or None),
-                    sampler_name=s_sampler,
-                    scheduler=s_sched,
-                    device=device, dtype=dtype
-                )
-                sample_path = sample_dir / f"epoch_{current_epoch}.png"
-                img.save(sample_path)
-                emit(f"采样保存: epoch_{current_epoch}.png")
-                if wandb_monitor.log_samples:
-                    wandb_monitor.log_image(
-                        "samples/epoch",
-                        sample_path,
-                        caption=f"epoch {current_epoch}: {prompt}",
-                        step=global_step,
-                    )
-                model.train()
-                
-                # 更新监控面板
-                if monitor_server:
-                    try:
-                        update_monitor(sample_path=sample_path)
-                    except Exception:
-                        pass
 
         # 检查 max_steps
         if args.max_steps and global_step >= args.max_steps:
@@ -2677,7 +2715,9 @@ def main():
 
     # 最终保存
     final_path = output_dir / f"{args.output_name}.safetensors"
-    injector.save(final_path)
+    # PPSF：最终输出走 averaged weights
+    with optimizer_eval_mode(optimizer):
+        injector.save(final_path)
 
     # 清理进度显示
     if live:

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -243,8 +243,12 @@ class TrainingConfig(BaseModel):
     )
     lr_scheduler: Literal["none", "cosine", "cosine_with_restart"] = Field(
         "none",
-        description="学习率调度",
-        json_schema_extra=_meta("training"),
+        description="学习率调度（选 prodigy_plus_schedulefree 时必须 none）",
+        json_schema_extra=_meta(
+            "training",
+            disable_when="optimizer_type==prodigy_plus_schedulefree",
+            disable_hint="Schedule-Free 自带调度",
+        ),
     )
     lr_scheduler_t0: int = Field(
         500, ge=1,
@@ -261,9 +265,9 @@ class TrainingConfig(BaseModel):
         description="最小学习率",
         json_schema_extra=_meta("training", show_when="lr_scheduler!=none"),
     )
-    optimizer_type: Literal["adamw", "prodigy"] = Field(
+    optimizer_type: Literal["adamw", "prodigy", "prodigy_plus_schedulefree"] = Field(
         "adamw",
-        description="优化器（prodigy 需 pip install prodigyopt）",
+        description="优化器（prodigy 需 pip install prodigyopt；prodigy_plus_schedulefree 需 prodigy-plus-schedule-free，DiT LoRA 训练推荐，解决 Prodigy 风格突变 ep 问题）",
         json_schema_extra=_meta("training"),
     )
     prodigy_d_coef: float = Field(
@@ -275,6 +279,54 @@ class TrainingConfig(BaseModel):
         True,
         description="Prodigy warmup 期间保护 d 增长",
         json_schema_extra=_meta("training", show_when="optimizer_type==prodigy"),
+    )
+    # ---------------- ProdigyPlusScheduleFree (PPSF) 专属字段 ----------------
+    # 选 PPSF 时 lr_scheduler 必须为 none（Schedule-Free 不需要 scheduler，
+    # 启动期校验会 fatal）。lr 强制 1.0（工厂内部覆盖）。
+    ppsf_d_coef: float = Field(
+        1.0, ge=0.1, le=10.0,
+        description="PPSF d 缩放系数（小数据集 0.5，过拟合 2.0）",
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+    )
+    ppsf_prodigy_steps: int = Field(
+        0, ge=0,
+        description="PPSF 在第 N 步后冻结 d（0=训练全程不冻结，建议为总步数 1/4 到 1/2）",
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+    )
+    ppsf_beta1: float = Field(
+        0.9, ge=0.0, le=1.0,
+        description="PPSF Adam β1（PPSF 默认 0.9）",
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+    )
+    ppsf_beta2: float = Field(
+        0.99, ge=0.0, le=1.0,
+        description="PPSF Adam β2（PPSF 默认 0.99，比 AdamW 默认 0.999 更适合小 epoch）",
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+    )
+    ppsf_split_groups: bool = Field(
+        True,
+        description="PPSF 按 param group 分别估计 d（推荐开启）",
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+    )
+    ppsf_split_groups_mean: bool = Field(
+        False,
+        description="PPSF split_groups 启用时取各组 d 均值（LoRA 多 param group 建议关闭）",
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+    )
+    ppsf_use_speed: bool = Field(
+        False,
+        description="PPSF 加速模式（实验性，可能引入不稳定）",
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+    )
+    ppsf_fused_back_pass: bool = Field(
+        False,
+        description="PPSF 与 fused backward 集成（显存吃紧时开，可显著降显存）",
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+    )
+    ppsf_use_stableadamw: bool = Field(
+        True,
+        description="PPSF 用 stable AdamW 归一化（推荐开启）",
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
     )
     weight_decay: float = Field(
         0.0, ge=0.0,
@@ -311,6 +363,17 @@ class TrainingConfig(BaseModel):
     @classmethod
     def _migrate_attention(cls, data: Any) -> Any:
         return migrate_legacy_attention(data)
+
+    @model_validator(mode="after")
+    def _validate_ppsf_scheduler(self) -> "TrainingConfig":
+        """ProdigyPlusScheduleFree 内置 Schedule-Free，外面再叠 scheduler 会破坏
+        averaged weights 的收敛保证。UI/CLI/YAML 三个入口在这里统一拦下来。"""
+        if self.optimizer_type == "prodigy_plus_schedulefree" and self.lr_scheduler != "none":
+            raise ValueError(
+                "optimizer_type=prodigy_plus_schedulefree requires lr_scheduler=none "
+                "(Schedule-Free 不需要 scheduler；强行叠加会破坏 averaged weights)."
+            )
+        return self
 
     # ---------------------------------------------------------------- 输出/保存
     output_dir: str = Field(

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -36,6 +36,12 @@ export interface SchemaProperty {
   control?: string
   cli_alias?: string
   show_when?: string
+  /** 当此表达式为真时字段在 UI 上 disabled（值由 SchemaForm 自动回退到 default）。
+   * 表达式语法与 show_when 一致：`key==value` / `key!=value`。
+   * 例：lr_scheduler 在 optimizer_type=prodigy_plus_schedulefree 时被 disable。 */
+  disable_when?: string
+  /** disable_when 触发时显示的提示徽章文本。 */
+  disable_hint?: string
   /** 后端打了 hidden=True 的字段：值仍随 ConfigData 透传 / 保存，但 SchemaForm
    * 不渲染。用于「该字段对当前用户群无意义但 schema 必须保留」的兜底场景。 */
   hidden?: boolean

--- a/studio/web/src/components/SchemaForm.tsx
+++ b/studio/web/src/components/SchemaForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { SchemaResponse, ConfigData } from '../api/client'
 import { evalShowWhen } from '../lib/schema'
 import Field from './Field'
@@ -39,6 +39,26 @@ export default function SchemaForm({
 
   const props = schema.schema.properties
 
+  // disable_when 触发时把字段值强制回到 default。避免「切换 optimizer 到
+  // prodigy_plus_schedulefree 之后 lr_scheduler 还停在 cosine，保存时被 pydantic
+  // model_validator 拒绝」这种死锁 UX。
+  useEffect(() => {
+    let nextValues = values
+    let changed = false
+    for (const [name, prop] of Object.entries(props)) {
+      if (!prop.disable_when) continue
+      if (!evalShowWhen(prop.disable_when, values)) continue
+      const def = prop.default
+      if (def !== undefined && values[name] !== def) {
+        nextValues = { ...nextValues, [name]: def }
+        changed = true
+      }
+    }
+    if (changed) onChange(nextValues)
+    // 故意只监听 values；onChange / props 引用稳定，加进去会无限循环。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [values])
+
   // 按 group 分桶。hidden=true 的字段直接跳过：值仍由 ConfigData 透传（PUT 时不丢），
   // 只是不在 UI 上渲染。如果一个组所有字段都 hidden，下面 `fields.length === 0`
   // 会让整个 section 自动消失。
@@ -78,8 +98,18 @@ export default function SchemaForm({
                 {fields.map((name) => {
                   const prop = props[name]
                   if (!evalShowWhen(prop.show_when, values)) return null
-                  const isDisabled = disabledSet.has(name)
-                  const hint = isDisabled ? dHints[name] : aHints[name]
+                  // disable_when（schema 驱动条件 disable，如 PPSF → lr_scheduler）
+                  // 优先级低于全局 disabledFields（项目预填）。
+                  const conditionallyDisabled =
+                    !!prop.disable_when &&
+                    evalShowWhen(prop.disable_when, values)
+                  const isDisabled =
+                    disabledSet.has(name) || conditionallyDisabled
+                  const hint = disabledSet.has(name)
+                    ? dHints[name]
+                    : conditionallyDisabled
+                      ? prop.disable_hint
+                      : aHints[name]
                   return (
                     <Field
                       key={name}

--- a/studio/web/src/lib/schema.test.ts
+++ b/studio/web/src/lib/schema.test.ts
@@ -70,6 +70,20 @@ describe('evalShowWhen', () => {
   it('returns true on unparseable expressions (failsafe)', () => {
     expect(evalShowWhen('garbage', {})).toBe(true)
   })
+
+  // evalShowWhen 同时被 show_when 和 disable_when 复用（同一表达式语法）
+  it('works for PPSF disable_when use case', () => {
+    expect(
+      evalShowWhen('optimizer_type==prodigy_plus_schedulefree', {
+        optimizer_type: 'prodigy_plus_schedulefree',
+      })
+    ).toBe(true)
+    expect(
+      evalShowWhen('optimizer_type==prodigy_plus_schedulefree', {
+        optimizer_type: 'adamw',
+      })
+    ).toBe(false)
+  })
 })
 
 describe('fieldLabel', () => {

--- a/tests/test_argparse_bridge.py
+++ b/tests/test_argparse_bridge.py
@@ -176,3 +176,43 @@ def test_training_config_help_does_not_crash() -> None:
     text = parser.format_help()
     assert "--lora-rank" in text
     assert "--no-cache-latents" in text  # bool 字段的反向 flag
+
+
+def test_training_config_cli_ppsf() -> None:
+    """ProdigyPlusScheduleFree CLI 字段都能解析出来。"""
+    parser = bridge.build_parser(TrainingConfig)
+    ns = parser.parse_args([
+        "--optimizer-type", "prodigy_plus_schedulefree",
+        "--ppsf-d-coef", "0.5",
+        "--ppsf-prodigy-steps", "500",
+        "--ppsf-beta2", "0.95",
+        "--ppsf-use-speed",
+        "--no-ppsf-split-groups-mean",
+    ])
+    assert ns.optimizer_type == "prodigy_plus_schedulefree"
+    assert ns.ppsf_d_coef == 0.5
+    assert ns.ppsf_prodigy_steps == 500
+    assert ns.ppsf_beta2 == 0.95
+    assert ns.ppsf_use_speed is True
+    assert ns.ppsf_split_groups_mean is False
+
+
+def test_training_config_yaml_ppsf() -> None:
+    """PPSF 字段能通过 YAML 合并到 namespace。"""
+    parser = bridge.build_parser(TrainingConfig)
+    args = parser.parse_args([])
+    yaml_data = {
+        "optimizer_type": "prodigy_plus_schedulefree",
+        "ppsf_d_coef": 0.3,
+        "ppsf_beta1": 0.9,
+        "ppsf_beta2": 0.99,
+        "ppsf_prodigy_steps": 1000,
+        "ppsf_use_stableadamw": True,
+    }
+    bridge.merge_yaml_into_namespace(args, yaml_data, TrainingConfig)
+    assert args.optimizer_type == "prodigy_plus_schedulefree"
+    assert args.ppsf_d_coef == 0.3
+    assert args.ppsf_beta1 == 0.9
+    assert args.ppsf_beta2 == 0.99
+    assert args.ppsf_prodigy_steps == 1000
+    assert args.ppsf_use_stableadamw is True

--- a/tests/test_optimizer_utils.py
+++ b/tests/test_optimizer_utils.py
@@ -1,0 +1,125 @@
+"""Optimizer utils 测试 — 重点覆盖 PPSF 接入。
+
+- optimizer_eval_mode context manager 对 PPSF / 非 PPSF 行为
+- create_prodigy_plus_schedulefree 工厂在依赖缺失时友好报错
+- 工厂 lr 强制 1.0 + betas 默认覆盖逻辑
+"""
+from __future__ import annotations
+
+import builtins
+import importlib
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from torch import nn
+
+from utils.optimizer_utils import (
+    create_prodigy_plus_schedulefree,
+    optimizer_eval_mode,
+)
+
+
+# ---------------------------------------------------------------------------
+# optimizer_eval_mode
+# ---------------------------------------------------------------------------
+
+
+def test_eval_mode_noop_for_plain_adamw() -> None:
+    """AdamW 没有 .eval/.train 方法，ctx 静默 no-op，不抛错。"""
+    model = nn.Linear(4, 4)
+    optim = torch.optim.AdamW(model.parameters(), lr=1e-3)
+    # AdamW 没有 .train / .eval 方法 — ctx 应该静默走过
+    with optimizer_eval_mode(optim):
+        # 还能正常调用 — 没有 side effect
+        assert optim.param_groups[0]["lr"] == 1e-3
+
+
+def test_eval_mode_calls_eval_and_train_on_schedulefree_like() -> None:
+    """PPSF-like 优化器 ctx 进入调 .eval()，退出调 .train()。"""
+    fake_opt = MagicMock(spec=["eval", "train"])
+    with optimizer_eval_mode(fake_opt):
+        fake_opt.eval.assert_called_once_with()
+        fake_opt.train.assert_not_called()
+    fake_opt.train.assert_called_once_with()
+
+
+def test_eval_mode_restores_train_on_exception() -> None:
+    """ctx 内部抛异常时也要保证切回 .train() —— 否则训练权重永远停在 averaged 状态。"""
+    fake_opt = MagicMock(spec=["eval", "train"])
+
+    class Boom(RuntimeError):
+        pass
+
+    with pytest.raises(Boom):
+        with optimizer_eval_mode(fake_opt):
+            raise Boom()
+
+    fake_opt.eval.assert_called_once_with()
+    fake_opt.train.assert_called_once_with()
+
+
+def test_eval_mode_skips_if_only_partial_methods() -> None:
+    """只有 .eval 没有 .train（或反过来）的优化器 — 视为非 PPSF，no-op。
+    防止误调单边方法把内部状态搞坏。"""
+    fake_opt = MagicMock(spec=["eval"])  # 只有 eval 没 train
+    with optimizer_eval_mode(fake_opt):
+        pass
+    fake_opt.eval.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# create_prodigy_plus_schedulefree
+# ---------------------------------------------------------------------------
+
+
+def _has_ppsf() -> bool:
+    try:
+        importlib.import_module("prodigyplus")
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(_has_ppsf(), reason="PPSF 已安装，无法测 ImportError 路径")
+def test_create_ppsf_import_error_message() -> None:
+    """没装 PPSF 时报错信息要包含安装提示，而不是裸 ImportError。"""
+    model = nn.Linear(4, 4)
+    with pytest.raises(ImportError, match="prodigy-plus-schedule-free"):
+        create_prodigy_plus_schedulefree(model.parameters(), lr=1.0)
+
+
+@pytest.mark.skipif(not _has_ppsf(), reason="PPSF 未安装")
+def test_create_ppsf_forces_lr_to_one(capsys: pytest.CaptureFixture[str]) -> None:
+    """传非 1.0 的 lr 时强制覆盖并 WARN（PPSF 要求 lr=1.0）。"""
+    model = nn.Linear(4, 4)
+    optim = create_prodigy_plus_schedulefree(model.parameters(), lr=1e-4)
+    captured = capsys.readouterr().out
+    assert "lr=1.0" in captured
+    assert "WARN" in captured
+    assert optim.param_groups[0]["lr"] == 1.0
+
+
+@pytest.mark.skipif(not _has_ppsf(), reason="PPSF 未安装")
+def test_create_ppsf_overrides_pytorch_default_betas() -> None:
+    """上层 create_optimizer 默认 betas=(0.9, 0.999) 时，工厂内部覆盖为 PPSF 推荐 (0.9, 0.99)。
+    用户显式传别的值就尊重。"""
+    model = nn.Linear(4, 4)
+    # 不显式传 betas — 应被工厂覆盖
+    optim = create_prodigy_plus_schedulefree(model.parameters(), lr=1.0, betas=(0.9, 0.999))
+    assert optim.param_groups[0]["betas"] == (0.9, 0.99)
+
+    # 显式传则尊重
+    model2 = nn.Linear(4, 4)
+    optim2 = create_prodigy_plus_schedulefree(model2.parameters(), lr=1.0, betas=(0.95, 0.98))
+    assert optim2.param_groups[0]["betas"] == (0.95, 0.98)
+
+
+@pytest.mark.skipif(not _has_ppsf(), reason="PPSF 未安装")
+def test_create_ppsf_exposes_train_eval_methods() -> None:
+    """实例化后必须有 .train / .eval 方法 — 否则 optimizer_eval_mode 永远 no-op。"""
+    model = nn.Linear(4, 4)
+    optim = create_prodigy_plus_schedulefree(model.parameters(), lr=1.0)
+    assert hasattr(optim, "train") and callable(optim.train)
+    assert hasattr(optim, "eval") and callable(optim.eval)

--- a/tests/test_studio_configs.py
+++ b/tests/test_studio_configs.py
@@ -37,10 +37,18 @@ def test_schema_is_complete() -> None:
     for name in (
         "transformer_path", "data_dir", "lora_type", "lora_rank", "epochs",
         "optimizer_type", "prodigy_d_coef", "prodigy_safeguard_warmup",
+        # ProdigyPlusScheduleFree 字段
+        "ppsf_d_coef", "ppsf_prodigy_steps", "ppsf_beta1", "ppsf_beta2",
+        "ppsf_split_groups", "ppsf_split_groups_mean", "ppsf_use_speed",
+        "ppsf_fused_back_pass", "ppsf_use_stableadamw",
         "sample_prompt", "sample_prompts", "no_monitor",
     ):
         assert name in fields, f"missing: {name}"
     assert "wandb_enabled" not in fields
+    # optimizer_type Literal 包含 PPSF
+    optimizer_annotation = fields["optimizer_type"].annotation
+    # Literal 的 __args__ 包含所有合法值
+    assert "prodigy_plus_schedulefree" in getattr(optimizer_annotation, "__args__", ())
 
 
 def test_schema_endpoint_returns_groups(client: TestClient) -> None:
@@ -61,11 +69,36 @@ def test_schema_carries_ui_metadata(client: TestClient) -> None:
     assert props["transformer_path"]["control"] == "path"
     assert "show_when" in props["prodigy_d_coef"]
     assert "wandb_enabled" not in props
+    # PPSF 字段都按 optimizer_type==prodigy_plus_schedulefree 显示
+    for ppsf_field in (
+        "ppsf_d_coef", "ppsf_prodigy_steps", "ppsf_beta1", "ppsf_beta2",
+        "ppsf_split_groups", "ppsf_use_speed", "ppsf_fused_back_pass",
+    ):
+        assert "show_when" in props[ppsf_field], f"{ppsf_field} missing show_when"
+        assert "prodigy_plus_schedulefree" in props[ppsf_field]["show_when"]
 
 
 def test_extra_fields_are_forbidden() -> None:
     with pytest.raises(Exception):
         TrainingConfig.model_validate({"learning_ratee": 1e-4})
+
+
+def test_ppsf_rejects_non_none_scheduler() -> None:
+    """PPSF + lr_scheduler != none 应该在 pydantic 层就被拒。"""
+    payload = TrainingConfig().model_dump(mode="python")
+    payload["optimizer_type"] = "prodigy_plus_schedulefree"
+    payload["lr_scheduler"] = "cosine"
+    with pytest.raises(Exception):  # pydantic ValidationError
+        TrainingConfig.model_validate(payload)
+
+
+def test_ppsf_accepts_none_scheduler() -> None:
+    """PPSF + lr_scheduler=none 是合法组合。"""
+    payload = TrainingConfig().model_dump(mode="python")
+    payload["optimizer_type"] = "prodigy_plus_schedulefree"
+    payload["lr_scheduler"] = "none"
+    cfg = TrainingConfig.model_validate(payload)
+    assert cfg.optimizer_type == "prodigy_plus_schedulefree"
 
 
 # ---------------------------------------------------------------------------

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -17,6 +17,8 @@ from .optimizer_utils import (
     create_8bit_adamw,
     create_standard_adamw,
     create_prodigy,
+    create_prodigy_plus_schedulefree,
+    optimizer_eval_mode,
     get_optimizer_info,
 )
 from .checkpoint import CheckpointManager, save_final_model
@@ -43,6 +45,8 @@ __all__ = [
     "create_8bit_adamw",
     "create_standard_adamw",
     "create_prodigy",
+    "create_prodigy_plus_schedulefree",
+    "optimizer_eval_mode",
     "get_optimizer_info",
     # Checkpoint
     "CheckpointManager",

--- a/utils/optimizer_utils.py
+++ b/utils/optimizer_utils.py
@@ -5,8 +5,11 @@ Optimizer Utils Module - 优化器创建
 1. 标准 AdamW - PyTorch 内置
 2. 8-bit AdamW (bitsandbytes) - 内存高效
 3. Prodigy (prodigyopt) - 无需调 lr 的自适应优化器
+4. ProdigyPlusScheduleFree (prodigy-plus-schedule-free) - Schedule-Free + Prodigy，
+   解决 Prodigy 在扩散 LoRA 训练中的 mutation ep / 风格突变问题。
 """
 
+from contextlib import contextmanager
 from typing import List, Dict, Any, Optional, Iterator
 
 import torch
@@ -84,10 +87,20 @@ def create_optimizer(
             **kwargs
         )
 
+    elif optimizer_type == "prodigy_plus_schedulefree":
+        return create_prodigy_plus_schedulefree(
+            params=params,
+            lr=learning_rate,
+            betas=betas,
+            weight_decay=weight_decay,
+            eps=eps,
+            **kwargs,
+        )
+
     else:
         raise ValueError(
             f"Unknown optimizer type: {optimizer_type}. "
-            f"Choose from: adamw, adamw8bit, prodigy"
+            f"Choose from: adamw, adamw8bit, prodigy, prodigy_plus_schedulefree"
         )
 
 
@@ -283,6 +296,140 @@ def create_prodigy(
     return optimizer
 
 
+def create_prodigy_plus_schedulefree(
+    params: Iterator[nn.Parameter],
+    lr: float,
+    betas: tuple = (0.9, 0.999),
+    weight_decay: float = 0.0,
+    eps: float = 1e-8,
+    d_coef: float = 1.0,
+    prodigy_steps: int = 0,
+    split_groups: bool = True,
+    split_groups_mean: bool = False,
+    use_speed: bool = False,
+    fused_back_pass: bool = False,
+    use_stableadamw: bool = True,
+    **kwargs,
+) -> Optimizer:
+    """
+    创建 ProdigyPlusScheduleFree 优化器
+    (https://github.com/LoganBooker/prodigy-plus-schedule-free)
+
+    Prodigy + Schedule-Free 的合体。相对普通 Prodigy 解决的核心问题：
+    - **Schedule-Free 的 averaged weights**: 维护训练权重 y 和 averaged 权重 x，
+      sample/save 用 x 出图 → 风格突变 ep 现象基本消失。
+      *使用要求*: sample/eval/save 前必须调 optimizer.eval()，事后 optimizer.train()。
+      用 optimizer_eval_mode(optimizer) context manager 包装最稳。
+    - **prodigy_steps 冻结 d**: 到某 step 后不再更新 d，避免后期跳档。
+    - **split_groups 细粒度估计**: 按 param group 分别估 d。
+
+    *学习率*: 必须固定为 1.0（如同普通 Prodigy）。Schedule-Free 不需要 scheduler，
+    调用方应强制 lr_scheduler=none 并在启动期校验。
+
+    *betas 默认*: PPSF 上游默认 (0.9, 0.99) 而非 PyTorch AdamW 的 (0.9, 0.999)。
+    本工厂检测到传入是 PyTorch 默认时自动覆盖到 PPSF 推荐值；如调用方显式传入则尊重。
+
+    Args:
+        params: 模型参数
+        lr: 学习率（PPSF 要求 1.0）
+        betas: Adam beta 参数（PPSF 推荐 (0.9, 0.99)）
+        weight_decay: 权重衰减
+        eps: epsilon
+        d_coef: d 的初始缩放系数（小数据集建议 0.5）
+        prodigy_steps: 在第 N 步后冻结 d（0 = 不冻结，整个训练继续更新）
+        split_groups: 按 param group 分别估 d
+        split_groups_mean: split_groups=True 时是否取各组 d 的均值
+            (PPSF 默认 False；SimpleTuner 改成 True 但理由是给 transformer-only 训练，
+             我们走 LoRA + LoKr 多 param group 不适合，保持 False)
+        use_speed: 启用加速模式（实验性）
+        fused_back_pass: 与 PyTorch fused-backward 路径集成（显存吃紧时开）
+        use_stableadamw: 用 stable AdamW 归一化策略
+
+    Returns:
+        ProdigyPlusScheduleFree: 优化器实例
+    """
+    try:
+        # pip 包名 `prodigy-plus-schedule-free`，import 名 `prodigyplus`
+        from prodigyplus import ProdigyPlusScheduleFree
+    except ImportError as e:
+        raise ImportError(
+            "prodigy-plus-schedule-free is required for ProdigyPlusScheduleFree "
+            "optimizer. Install with: pip install 'prodigy-plus-schedule-free>=2.0.0'"
+        ) from e
+
+    if abs(lr - 1.0) > 1e-9:
+        print(
+            f"[WARN] ProdigyPlusScheduleFree requires lr=1.0 (received {lr}); forcing lr=1.0. "
+            f"Tune d_coef instead of lr."
+        )
+        lr = 1.0
+
+    # 上层 create_optimizer 默认 betas=(0.9, 0.999)（适合 AdamW），但 PPSF 推荐
+    # (0.9, 0.99)。如果调用方没改默认，覆盖到 PPSF 推荐值。
+    if tuple(betas) == (0.9, 0.999):
+        betas = (0.9, 0.99)
+
+    print(
+        f"Creating ProdigyPlusScheduleFree optimizer "
+        f"(lr={lr}, betas={tuple(betas)}, weight_decay={weight_decay}, "
+        f"d_coef={d_coef}, prodigy_steps={prodigy_steps}, "
+        f"split_groups={split_groups}, use_speed={use_speed}, "
+        f"fused_back_pass={fused_back_pass})"
+    )
+
+    param_list = list(params)
+
+    optimizer = ProdigyPlusScheduleFree(
+        param_list,
+        lr=lr,
+        betas=tuple(betas),
+        eps=eps,
+        weight_decay=weight_decay,
+        d_coef=d_coef,
+        prodigy_steps=prodigy_steps,
+        split_groups=split_groups,
+        split_groups_mean=split_groups_mean,
+        use_speed=use_speed,
+        fused_back_pass=fused_back_pass,
+        use_stableadamw=use_stableadamw,
+        **kwargs,
+    )
+
+    print("  [OK] ProdigyPlusScheduleFree optimizer created")
+
+    return optimizer
+
+
+@contextmanager
+def optimizer_eval_mode(optimizer: Optimizer):
+    """切换 Schedule-Free 系优化器（PPSF 等）到 eval 模式的 context manager。
+
+    Schedule-Free 优化器在内部维护两套权重：训练权重 y 和 averaged 权重 x。
+    sample / validation / save 应该用 x（averaged），训练 step 用 y。
+    PPSF 的 optimizer.eval() / optimizer.train() 通过 p.lerp_() in-place 切换参数张量
+    指向哪一套；忘记切回 train() 会让训练继续用 averaged 权重，结果错乱。
+
+    用法:
+        with optimizer_eval_mode(optimizer):
+            model.eval()
+            img = sample_image(...)
+            model.train()
+
+    对非 Schedule-Free 优化器（AdamW / Prodigy 等）无 .train/.eval 方法 — 此 context
+    manager 静默 no-op，所以调用方不需要分支判断 optimizer_type。
+    """
+    has_eval = hasattr(optimizer, "eval") and callable(getattr(optimizer, "eval"))
+    has_train = hasattr(optimizer, "train") and callable(getattr(optimizer, "train"))
+    if has_eval and has_train:
+        optimizer.eval()
+        try:
+            yield
+        finally:
+            optimizer.train()
+    else:
+        yield
+
+
 def create_optimizer_grouped_parameters(
     model: nn.Module,
     weight_decay: float,
@@ -377,11 +524,17 @@ def get_optimizer_info(optimizer: Optimizer) -> Dict[str, Any]:
             total_params += p.numel()
     
     info["total_trainable_params"] = total_params
-    
-    # 添加优化器特定信息
-    if isinstance(optimizer, (AdamW,)) or (BITSANDBYTES_AVAILABLE and isinstance(optimizer, bnb.optim.AdamW8bit)):
-        info["betas"] = optimizer.param_groups[0].get("betas", (0.9, 0.999))
-        info["weight_decay"] = optimizer.param_groups[0].get("weight_decay", 0.0)
-        info["eps"] = optimizer.param_groups[0].get("eps", 1e-8)
-    
+
+    # 添加优化器特定信息（duck typing：AdamW / Prodigy / PPSF / bnb AdamW8bit 都有这些字段）
+    pg0 = optimizer.param_groups[0] if optimizer.param_groups else {}
+    if "betas" in pg0:
+        info["betas"] = pg0["betas"]
+    if "weight_decay" in pg0:
+        info["weight_decay"] = pg0["weight_decay"]
+    if "eps" in pg0:
+        info["eps"] = pg0["eps"]
+    # PPSF 内部 d 估计 — 调试时有用
+    if "d" in pg0:
+        info["d"] = pg0["d"]
+
     return info


### PR DESCRIPTION
> 本 PR 替换 #44(那个 PR base 错乱,带进了已被 squash 进 0.6.0 的 10 个旧 commit;本 PR 从干净 origin/dev cherry-pick 4 个 PPSF commit)。

## 背景 / 动机

用户反馈使用 Prodigy 训练 Anima LoRA 时,某些 epoch 的 sample 会突然出现风格突变("mutation ep"),与相邻 ep 的画风完全不一致。

根本原因:Prodigy 内部 \`d\` 估计在 **Flow Matching timestep 随机性 + 小数据集 + LoRA 低参数量** 三重噪声下会"跳档" — \`d\` 是不会下降的累积量,一旦某几个梯度异常大的 batch 把它推上一档,后续整段训练就用更大的有效步长,直到下一次跳档。

社区调研结论:Flux / Qwen-Image / HiDream / 视频 DiT LoRA 训练已经把 **ProdigyPlusScheduleFree** (LoganBooker, 简称 PPSF) 作为事实默认。Ostris ai-toolkit / SimpleTuner / Kohya sd-scripts 三家都已接入。Anima 是 Cosmos DiT + Flow Matching,跟这些社区训练同型,可以直接吃红利。

## 三 kit 实现调研对比

| 维度 | ai-toolkit | SimpleTuner | sd-scripts | **本 PR** |
|------|-----------|-------------|-----------|-----------|
| 命名 | 未原生支持 | \`prodigy\` (撞名) | \`prodigyplus.ProdigyPlusScheduleFree\` (模块路径) | \`prodigy_plus_schedulefree\` (snake_case,避免撞名) |
| eval/train 切换 | **未实现** | \`mark_optimizer_train/eval()\` helper | 显式 lambda 对在每个 sample/save 处调 | **context manager \`optimizer_eval_mode()\`** (比 SimpleTuner 少传引用) |
| Save 时切 eval | ✗ | ✓ | ✓ | ✓ |
| Scheduler 兼容 | n/a | 允许 + flag | DummyScheduler 静默 | **fatal 拒绝**(Anima 跑得久,翻车成本高,启动期硬拦更稳) |
| betas 默认 | n/a | (0.9, 0.99) | PPSF 默认 (0.9, 0.99) | (0.9, 0.99) + 显式覆盖 PyTorch AdamW 默认 |
| split_groups_mean | n/a | **True** (改了上游默认) | False (跟上游) | **False** (LoRA 多 param group 不适合 mean) |

## 改动概要 (4 个 commit)

1. **\`feat(optimizer)\`**: \`create_prodigy_plus_schedulefree\` 工厂 + \`optimizer_eval_mode\` context manager + 单测
2. **\`feat(train)\`**: 接入 anima_train(配置透传 + 双层 scheduler 校验) + schema 扩 9 个 ppsf_\* 字段 + \`model_validator\` 拦不合法组合 + 所有 sample/save 入口包 \`optimizer_eval_mode\`
3. **\`feat(ui)\`**: 通用化 \`disable_when\` schema 元数据(复用 show_when 表达式语法) + SchemaForm 实现 (\`evalShowWhen → disabled + hint + force value to default\`)。lr_scheduler 字段在选 PPSF 时被 disable 并自动 reset 到 \`none\`
4. **\`docs\`**: training-tips 加优化器选择章节 + PPSF 使用要点 + 验证步骤

## 关键设计决策

- **命名**: \`prodigy_plus_schedulefree\` (snake_case 全名),避免和未来上的 vanilla Prodigy 撞名
- **eval/train 切换**: context manager 比 helper pair 更难漏掉一边
- **Scheduler 互斥三层防御**: (a) 前端 disable + 自动 reset → (b) pydantic model_validator(UI/API 入口拦) → (c) anima_train CLI 启动期 raise SystemExit(CLI 直跑也拦得住)
- **保存的 LoRA 是 averaged weights x**: 所有 \`injector.save\` 都在 \`optimizer_eval_mode\` 内,出来的 .safetensors 直接可用,不需要后处理
- **依赖 pin >=2.0.0**: PPSF v1.9.2 ↔ v2.0.0 state_dict 不兼容,避免 resume 时 \`optimizer.load_state_dict()\` 炸

## Test Plan

- [x] 后端 pytest: \`tests/test_optimizer_utils.py\` (PPSF 工厂 + eval_mode ctx 共 8 个用例) / \`tests/test_argparse_bridge.py\` (PPSF CLI + YAML merge) / \`tests/test_studio_configs.py\` (schema 字段 + show_when 元数据 + scheduler 互斥校验) — **新增 19 个用例全过**
- [x] \`python -m studio test\` 909 个后端测试通过 (3 个 pre-existing 失败跟本 PR 无关,均为 Windows subprocess + npm/onnxruntime 环境问题,clean tree 也复现)
- [x] 前端 vitest: 124 个用例全过
- [x] \`npm run lint\`: 0 errors
- [x] \`npx tsc --noEmit\`: 0 errors
- [ ] **手测 (用户)**: 切换 optimizer_type 到 prodigy_plus_schedulefree,确认 (1) lr_scheduler 字段在 UI 自动 disable 并 reset 到 none (2) ppsf_\* 字段按 show_when 显示出来 (3) 实际跑一段训练,sample 没有 mutation ep 现象