### PR TITLE
feat(ui): 训练页内联新建预设 / 标签拖拽排序 / CNB→下载训练集 / 优化器描述清理

### DIFF
--- a/studio/schema.py
+++ b/studio/schema.py
@@ -267,7 +267,7 @@ class TrainingConfig(BaseModel):
     )
     optimizer_type: Literal["adamw", "prodigy", "prodigy_plus_schedulefree"] = Field(
         "adamw",
-        description="优化器（prodigy 需 pip install prodigyopt；prodigy_plus_schedulefree 需 prodigy-plus-schedule-free，DiT LoRA 训练推荐，解决 Prodigy 风格突变 ep 问题）",
+        description="优化器（prodigy_plus_schedulefree 是 DiT LoRA 训练推荐，averaged weights 解决 Prodigy 的风格突变 ep 问题）",
         json_schema_extra=_meta("training"),
     )
     prodigy_d_coef: float = Field(

--- a/studio/web/package-lock.json
+++ b/studio/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "anima-studio-web",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "anima-studio-web",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/studio/web/src/components/TagEditor.test.tsx
+++ b/studio/web/src/components/TagEditor.test.tsx
@@ -10,13 +10,13 @@ describe('TagEditor (PP4 chip mode)', () => {
     expect(screen.getByText('b')).toBeInTheDocument()
   })
 
-  it('Enter adds a tag at the front (default position)', async () => {
+  it('Enter adds a tag at the end (chip 拖拽心智 — 新东西落底部)', async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
     render(<TagEditor tags={['a']} onChange={onChange} />)
     const input = screen.getByPlaceholderText(/添加标签/)
     await user.type(input, 'new{Enter}')
-    expect(onChange).toHaveBeenCalledWith(['new', 'a'])
+    expect(onChange).toHaveBeenCalledWith(['a', 'new'])
   })
 
   it('comma also adds a tag', async () => {

--- a/studio/web/src/components/TagEditor.tsx
+++ b/studio/web/src/components/TagEditor.tsx
@@ -1,4 +1,19 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  useSortable,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 
 interface Props {
   tags: string[]
@@ -22,6 +37,11 @@ export default function TagEditor({
   const [mode, setMode] = useState<Mode>(natural ? 'text' : 'chip')
   const [textBuf, setTextBuf] = useState(() => tagsJoined)
 
+  // PointerSensor + 6px 启动距离：拖拽手感不会跟「点 × 删除」/ 误触冲突。
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 6 } }),
+  )
+
   // Reset draft when image switches
   useEffect(() => { setDraft('') }, [tags])
 
@@ -38,12 +58,22 @@ export default function TagEditor({
     const t = raw.trim().replace(/^[,，]+|[,，]+$/g, '')
     if (!t) return
     if (tags.includes(t)) { setDraft(''); return }
-    onChange([t, ...tags])
+    // 加到末尾：跟 chip 拖拽重排的心智一致（新东西落在底部，用户拖到想要的位置）
+    onChange([...tags, t])
     setDraft('')
   }
 
   const removeTag = (t: string) => {
     onChange(tags.filter((x) => x !== t))
+  }
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = tags.indexOf(String(active.id))
+    const newIndex = tags.indexOf(String(over.id))
+    if (oldIndex < 0 || newIndex < 0) return
+    onChange(arrayMove(tags, oldIndex, newIndex))
   }
 
   const commitText = () => {
@@ -103,26 +133,22 @@ export default function TagEditor({
       {/* content area — both modes use flex:1 so no height jitter */}
       {mode === 'chip' ? (
         <>
-          <div className="flex flex-wrap gap-1 overflow-y-auto flex-1 min-h-0 content-start py-1">
-            {tags.length === 0 && (
-              <span className="text-xs text-fg-tertiary">还没有标签</span>
-            )}
-            {tags.map((t) => (
-              <span
-                key={t}
-                className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-overlay border border-subtle text-sm font-mono text-fg-primary"
-              >
-                {t}
-                <button
-                  onClick={() => removeTag(t)}
-                  aria-label={`删除 ${t}`}
-                  className="bg-transparent border-none text-fg-tertiary hover:text-err cursor-pointer p-0 text-sm leading-none"
-                >
-                  ×
-                </button>
-              </span>
-            ))}
-          </div>
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext items={tags} strategy={rectSortingStrategy}>
+              <div className="flex flex-wrap gap-1 overflow-y-auto flex-1 min-h-0 content-start py-1">
+                {tags.length === 0 && (
+                  <span className="text-xs text-fg-tertiary">还没有标签</span>
+                )}
+                {tags.map((t) => (
+                  <SortableChip key={t} id={t} onRemove={() => removeTag(t)} />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
           <div className="flex items-center gap-1.5 shrink-0">
             <input
               value={draft}
@@ -190,5 +216,43 @@ function ModeBtn({ active, onClick, children }: {
     >
       {children}
     </button>
+  )
+}
+
+/** 单个可拖拽 chip。dnd-kit 用 useSortable 给我们 setNodeRef / 拖拽 listeners /
+ * transform / transition;CSS.Transform.toString 把 dnd-kit 算出的 (x,y,scale)
+ * 翻译成 CSS transform 字符串。
+ *
+ * × 删除按钮要 stopPropagation onPointerDown —— 否则 6px 移动阈值过后 × 也成了
+ * 拖拽起点,点 × 反而触发拖拽。
+ */
+function SortableChip({ id, onRemove }: { id: string; onRemove: () => void }) {
+  const {
+    attributes, listeners, setNodeRef, transform, transition, isDragging,
+  } = useSortable({ id })
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 1 : undefined,
+  }
+  return (
+    <span
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-overlay border border-subtle text-sm font-mono text-fg-primary cursor-grab active:cursor-grabbing select-none touch-none"
+    >
+      {id}
+      <button
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={onRemove}
+        aria-label={`删除 ${id}`}
+        className="bg-transparent border-none text-fg-tertiary hover:text-err cursor-pointer p-0 text-sm leading-none"
+      >
+        ×
+      </button>
+    </span>
   )
 }

--- a/studio/web/src/lib/preset-helpers.ts
+++ b/studio/web/src/lib/preset-helpers.ts
@@ -1,0 +1,38 @@
+// preset-helpers.ts —— Presets 页面 / Train 页面共享的预设相关工具。
+// 拆出来避免 Train.tsx 加内联「新建预设」表单时把这几样复制一份。
+import type { ConfigData, SchemaResponse } from '../api/client'
+
+/** 预设名合法字符：字母 / 数字 / _ / -。/api/presets/<name> 路由对名字
+ * 也按这个集合校验。 */
+export const PRESET_NAME_RE = /^[A-Za-z0-9_\-]+$/
+
+const DESC_KEY = 'studio.preset.descriptions'
+
+/** 预设副标题（"描述"）走 localStorage 按 name 索引存。后端 schema 里 preset
+ * 没有 description 字段；这是纯前端展示用的辅助文案。 */
+export function loadPresetDescriptions(): Record<string, string> {
+  try {
+    const raw = localStorage.getItem(DESC_KEY)
+    return raw ? (JSON.parse(raw) as Record<string, string>) : {}
+  } catch {
+    return {}
+  }
+}
+
+export function savePresetDescriptions(d: Record<string, string>) {
+  try {
+    localStorage.setItem(DESC_KEY, JSON.stringify(d))
+  } catch {
+    /* ignore quota errors */
+  }
+}
+
+/** 从 schema 抽默认值字典。新建预设时表单的初始内容。 */
+export function defaultsFromSchema(schema: SchemaResponse | null): ConfigData {
+  if (!schema) return {}
+  const out: ConfigData = {}
+  for (const [name, prop] of Object.entries(schema.schema.properties)) {
+    if (prop.default !== undefined) out[name] = prop.default
+  }
+  return out
+}

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -201,9 +201,9 @@ export default function TagEditPage() {
 
   const onAfterRestore = async () => { await reloadCache(); await reload() }
 
-  const exportForCnb = async () => {
+  const downloadTrainZip = async () => {
     if (dirty) {
-      toast('先保存标签，再导出给 CNB', 'error')
+      toast('先保存标签，再下载训练集', 'error')
       return
     }
     setExporting(true)
@@ -211,7 +211,7 @@ export default function TagEditPage() {
       const filename = `${project.slug}-${activeVersion.label}.train.zip`
       await downloadBlob(api.versionTrainZipUrl(project.id, activeVersion.id), filename)
     } catch (e) {
-      toast(`导出失败: ${e}`, 'error')
+      toast(`下载失败: ${e}`, 'error')
     } finally {
       setExporting(false)
     }
@@ -244,10 +244,10 @@ export default function TagEditPage() {
           <button
             className="btn btn-primary btn-sm"
             disabled={exporting || dirty || trainTotal === 0}
-            onClick={exportForCnb}
-            title={dirty ? '先保存标签再导出' : '导出当前版本训练集 zip，上传到 CNB 训练'}
+            onClick={downloadTrainZip}
+            title={dirty ? '先保存标签再下载' : '下载当前版本训练集 zip'}
           >
-            {exporting ? '打包中…' : '导出给 CNB'}
+            {exporting ? '打包中…' : '下载训练集'}
           </button>
           <SaveBar
             pid={project.id}

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -13,6 +13,12 @@ import {
 import SchemaForm from '../../../components/SchemaForm'
 import StepShell from '../../../components/StepShell'
 import { useToast } from '../../../components/Toast'
+import {
+  PRESET_NAME_RE,
+  defaultsFromSchema,
+  loadPresetDescriptions,
+  savePresetDescriptions,
+} from '../../../lib/preset-helpers'
 
 // 全局模型字段来自全局设置，对版本维度只读
 const GLOBAL_MODEL_FIELDS = [
@@ -59,6 +65,13 @@ export default function TrainPage() {
   const [pickerSearch, setPickerSearch] = useState('')
   const pickerAnchorRef = useRef<HTMLButtonElement | null>(null)
   const pickerPopRef = useRef<HTMLDivElement | null>(null)
+
+  // 内联「新建预设」模式：避免用户跳转到 /tools/presets 创建后再回来选用
+  const [creatingPreset, setCreatingPreset] = useState(false)
+  const [newPresetName, setNewPresetName] = useState('')
+  const [newPresetDesc, setNewPresetDesc] = useState('')
+  const [newPresetConfig, setNewPresetConfig] = useState<ConfigData | null>(null)
+  const [newNameError, setNewNameError] = useState('')
 
   /** 包装 setConfig：先同步写 configRef（绕 React state flush 延迟），再调
    * setConfig 触发 React 渲染。 SchemaForm.onChange / 任何想改 config 的入口
@@ -294,6 +307,63 @@ export default function TrainPage() {
     }
   }
 
+  /** 默认预设名 = `<slug>_<label>`；label 含非法字符时 fallback 到 `<slug>_v<id>`。
+   * 用户在表单输入框里可改。 */
+  const defaultPresetName = (): string => {
+    if (!activeVersion) return project.slug
+    const candidate = `${project.slug}_${activeVersion.label}`
+    if (PRESET_NAME_RE.test(candidate)) return candidate
+    return `${project.slug}_v${activeVersion.id}`
+  }
+
+  const startCreatePreset = () => {
+    setPickerOpen(false)
+    setNewPresetName(defaultPresetName())
+    setNewPresetDesc('')
+    setNewPresetConfig(defaultsFromSchema(schema))
+    setNewNameError('')
+    setCreatingPreset(true)
+  }
+
+  const cancelCreatePreset = () => {
+    setCreatingPreset(false)
+    setNewNameError('')
+  }
+
+  const saveNewPreset = async () => {
+    const name = newPresetName.trim()
+    if (!name) { setNewNameError('请输入名字'); return }
+    if (!PRESET_NAME_RE.test(name)) {
+      setNewNameError('仅允许字母 / 数字 / _ / -'); return
+    }
+    if (!newPresetConfig || !vid) return
+    if (presets.some((p) => p.name === name)) {
+      if (!window.confirm(`预设 ${name} 已存在，覆盖？`)) return
+    }
+    setBusy(true)
+    try {
+      await api.savePreset(name, newPresetConfig)
+      const desc = newPresetDesc.trim()
+      if (desc) {
+        const all = loadPresetDescriptions()
+        all[name] = desc
+        savePresetDescriptions(all)
+      }
+      const list = await api.listPresets()
+      setPresets(list)
+      // 套用到当前 version —— 避免用户保存完还要再手动选一次
+      await api.forkPresetForVersion(project.id, vid, name)
+      await refreshConfig()
+      void refreshPresetBaseline(name)
+      setCreatingPreset(false)
+      toast(`已创建预设 ${name} 并套用到当前 version`, 'success')
+    } catch (e) {
+      toast(String(e), 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   const onEnqueue = async () => {
     if (!configResp?.has_config) {
       toast('先选预设', 'error')
@@ -424,39 +494,52 @@ export default function TrainPage() {
 
                 {/* grid */}
                 <div className="flex-1 min-h-0 overflow-y-auto p-2.5">
-                  {filteredPresets.length > 0 ? (
-                    <div className="grid grid-cols-2 gap-2">
-                      {filteredPresets.map((p) => {
-                        const active = p.name === activeVersion.config_name
-                        return (
-                          <button
-                            key={p.name}
-                            onClick={() => { setPickerOpen(false); void onForkPreset(p.name) }}
-                            disabled={busy}
-                            className={[
-                              'rounded-sm px-2.5 py-2 text-left border transition-colors',
-                              active
-                                ? 'border-accent bg-accent-soft'
-                                : 'border-subtle bg-sunken hover:border-bold',
-                              busy ? 'cursor-default' : 'cursor-pointer',
-                            ].join(' ')}
-                          >
-                            <div className={[
-                              'text-sm font-mono font-semibold truncate',
-                              active ? 'text-accent' : 'text-fg-primary',
-                            ].join(' ')}>{p.name}</div>
-                            <div className="text-xs text-fg-tertiary mt-0.5">
-                              {active ? '当前使用' : '点击套用'}
-                            </div>
-                          </button>
-                        )
-                      })}
-                    </div>
-                  ) : (
+                  <div className="grid grid-cols-2 gap-2">
+                    {/* + 新建预设 永远第一格（跟 Presets 页面一致）。pickerSearch
+                        非空时藏起来 —— 用户在搜旧的，新建是另一条意图。 */}
+                    {!pickerSearch && (
+                      <button
+                        onClick={startCreatePreset}
+                        disabled={busy}
+                        className={[
+                          'rounded-sm px-2.5 py-2 text-left border border-dashed transition-colors',
+                          'border-subtle text-accent hover:border-accent hover:bg-accent-soft',
+                          busy ? 'cursor-default' : 'cursor-pointer',
+                          'bg-transparent text-sm font-semibold',
+                        ].join(' ')}
+                      >
+                        + 新建预设
+                      </button>
+                    )}
+                    {filteredPresets.map((p) => {
+                      const active = p.name === activeVersion.config_name
+                      return (
+                        <button
+                          key={p.name}
+                          onClick={() => { setPickerOpen(false); void onForkPreset(p.name) }}
+                          disabled={busy}
+                          className={[
+                            'rounded-sm px-2.5 py-2 text-left border transition-colors',
+                            active
+                              ? 'border-accent bg-accent-soft'
+                              : 'border-subtle bg-sunken hover:border-bold',
+                            busy ? 'cursor-default' : 'cursor-pointer',
+                          ].join(' ')}
+                        >
+                          <div className={[
+                            'text-sm font-mono font-semibold truncate',
+                            active ? 'text-accent' : 'text-fg-primary',
+                          ].join(' ')}>{p.name}</div>
+                          <div className="text-xs text-fg-tertiary mt-0.5">
+                            {active ? '当前使用' : '点击套用'}
+                          </div>
+                        </button>
+                      )
+                    })}
+                  </div>
+                  {presets.length > 0 && filteredPresets.length === 0 && (
                     <div className="text-fg-tertiary text-sm text-center py-4">
-                      {pickerSearch
-                        ? `没有匹配「${pickerSearch}」`
-                        : '尚无预设，去 /tools/presets 创建'}
+                      没有匹配「{pickerSearch}」
                     </div>
                   )}
                 </div>
@@ -464,7 +547,67 @@ export default function TrainPage() {
             )}
           </section>
 
-            {configResp === null || !schema ? (
+            {creatingPreset && schema && newPresetConfig ? (
+              /* 新建预设内联表单 —— 跟 /tools/presets 新建模式视觉对齐 */
+              <section className="flex-1 min-h-0 overflow-y-auto pr-1">
+                <div className="flex flex-col gap-3">
+                  {/* 名称 + 描述 */}
+                  <div className="rounded-md border border-subtle bg-surface px-3.5 py-2.5">
+                    <div className="flex gap-2.5">
+                      <label className="flex-1 flex flex-col gap-1">
+                        <span className="text-sm font-medium text-fg-secondary">预设名称</span>
+                        <input
+                          autoFocus
+                          className="input input-mono font-mono"
+                          placeholder="my-training-preset"
+                          value={newPresetName}
+                          onChange={(e) => { setNewPresetName(e.target.value); setNewNameError('') }}
+                          disabled={busy}
+                        />
+                        {newNameError && (
+                          <span className="text-xs text-err">{newNameError}</span>
+                        )}
+                      </label>
+                      <label className="flex-[1.5] flex flex-col gap-1">
+                        <span className="text-sm font-medium text-fg-secondary">描述 / 副标题</span>
+                        <input
+                          className="input"
+                          placeholder="（可选）显示在预设卡片上的副标题"
+                          value={newPresetDesc}
+                          onChange={(e) => setNewPresetDesc(e.target.value)}
+                          disabled={busy}
+                        />
+                      </label>
+                    </div>
+                  </div>
+                  {/* 参数表单 —— 用 schema 默认值 */}
+                  <div className="rounded-md border border-subtle bg-surface px-3.5 py-2.5">
+                    <SchemaForm
+                      schema={schema}
+                      values={newPresetConfig}
+                      onChange={setNewPresetConfig}
+                    />
+                  </div>
+                  {/* 操作 */}
+                  <div className="flex gap-2 shrink-0">
+                    <button
+                      onClick={() => void saveNewPreset()}
+                      disabled={busy}
+                      className="btn btn-primary"
+                    >
+                      {busy ? '保存中…' : '创建并套用到当前 version'}
+                    </button>
+                    <button
+                      onClick={cancelCreatePreset}
+                      disabled={busy}
+                      className="btn btn-ghost"
+                    >
+                      取消
+                    </button>
+                  </div>
+                </div>
+              </section>
+            ) : configResp === null || !schema ? (
               <ConfigSkeleton />
             ) : !configResp.has_config ? (
               <div className="flex-1 flex items-center justify-center text-fg-tertiary text-sm rounded-md border border-dashed border-dim">

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -7,6 +7,12 @@ import {
 } from '../../api/client'
 import SchemaForm from '../../components/SchemaForm'
 import { useToast } from '../../components/Toast'
+import {
+  PRESET_NAME_RE,
+  defaultsFromSchema,
+  loadPresetDescriptions,
+  savePresetDescriptions,
+} from '../../lib/preset-helpers'
 
 // ── TOML 生成（键按字母排序，值尽量保留原始类型） ──────────────────────────
 function toTomlValue(v: unknown): string {
@@ -32,29 +38,8 @@ function generateToml(config: ConfigData): string {
   return keys.map((k) => `${k} = ${toTomlValue(config[k])}`).join('\n')
 }
 
-// ── 描述存储（localStorage，按 preset 名索引） ──────────────────────────────
-const DESC_KEY = 'studio.preset.descriptions'
-function loadDescriptions(): Record<string, string> {
-  try {
-    const raw = localStorage.getItem(DESC_KEY)
-    return raw ? JSON.parse(raw) : {}
-  } catch { return {} }
-}
-function saveDescriptions(d: Record<string, string>) {
-  try { localStorage.setItem(DESC_KEY, JSON.stringify(d)) } catch { /* ignore */ }
-}
-
-// ── 工具：从 schema 抽默认值 ──────────────────────────────────────────────
-function defaultsFromSchema(schema: SchemaResponse | null): ConfigData {
-  if (!schema) return {}
-  const out: ConfigData = {}
-  for (const [name, prop] of Object.entries(schema.schema.properties)) {
-    if (prop.default !== undefined) out[name] = prop.default
-  }
-  return out
-}
-
-const NAME_RE = /^[A-Za-z0-9_\-]+$/
+// 预设名校验 / 描述存储 / schema 默认值 抽到 lib/preset-helpers.ts，
+// 跟 Train 页面「新建预设」内联表单共享，避免两份维护。
 
 interface DraftSeed {
   config: ConfigData
@@ -76,7 +61,7 @@ export default function PresetsPage() {
   const savedJsonRef = useRef<string | null>(null)
 
   // 描述
-  const [descriptions, setDescriptions] = useState<Record<string, string>>(loadDescriptions)
+  const [descriptions, setDescriptions] = useState<Record<string, string>>(loadPresetDescriptions)
   const [descDraft, setDescDraft] = useState('')
   const [descDirty, setDescDirty] = useState(false)
 
@@ -205,7 +190,7 @@ export default function PresetsPage() {
     }
     if (!config) return
     if (isNew) {
-      if (!NAME_RE.test(name)) { setNewNameError('仅允许字母、数字、_、-'); return }
+      if (!PRESET_NAME_RE.test(name)) { setNewNameError('仅允许字母、数字、_、-'); return }
       if (presets.find((p) => p.name === name)) { setNewNameError('名称已存在'); return }
     }
     setBusy(true)
@@ -213,10 +198,10 @@ export default function PresetsPage() {
       await api.savePreset(name, config)
       if (descDraft) {
         const next = { ...descriptions, [name]: descDraft }
-        setDescriptions(next); saveDescriptions(next)
+        setDescriptions(next); savePresetDescriptions(next)
       } else if (descriptions[name]) {
         const { [name]: _, ...rest } = descriptions
-        setDescriptions(rest); saveDescriptions(rest)
+        setDescriptions(rest); savePresetDescriptions(rest)
       }
       savedJsonRef.current = JSON.stringify(config)
       setDescDirty(false)
@@ -262,7 +247,7 @@ export default function PresetsPage() {
     setBusy(true)
     api.deletePreset(selected).then(() => {
       const { [selected]: _, ...rest } = descriptions
-      setDescriptions(rest); saveDescriptions(rest)
+      setDescriptions(rest); savePresetDescriptions(rest)
       setSelected(null)
       refreshList()
       toast('已删除', 'success')


### PR DESCRIPTION
4 个独立但都不大的 UI polish,4 个 commit 一一对应。

## 1. \`style(schema)\` 清理"需 pip install"误导

\`studio/schema.py:266\` 的 optimizer description 写"prodigy 需 pip install prodigyopt;prodigy_plus_schedulefree 需 prodigy-plus-schedule-free"会让用户以为是可选依赖。实际上两个包都已在 \`requirements.txt\` 里(分别在 v0.5 / v0.6 加),用户按 README 装依赖就有。删"需 pip install"字样,保留 PPSF 功能描述(DiT LoRA 推荐 / averaged weights 解决 mutation ep)。

## 2. \`refactor(tag-edit)\` "导出给 CNB" → "下载训练集"

\`TagEdit.tsx\` 的按钮本质就是把当前 version 训练集打包成 zip 给用户下。绑死"CNB"(一个外部训练平台)过度具体 —— 用户拿去做什么是用户的事。按钮文字 / toast / title 同步去掉 CNB;函数名 \`exportForCnb\` → \`downloadTrainZip\`。

## 3. \`feat(train)\` 训练页 picker 加 + 新建预设 + 内联表单

之前训练页面 picker 没预设时只显示"尚无预设,去 /tools/presets 创建",用户被迫**跳走 → 创建 → 跳回 → 再选用**。这次让创建发生在原地。

- picker grid 加 + 新建预设 虚线卡片(永远第一格,跟 Presets 页面一致),\`pickerSearch\` 非空时藏起来
- 点击后右侧 SchemaForm 区切到"新建预设"内联表单:
  - 名字默认 \`<project.slug>_<version.label>\`(label 含非法字符 fallback \`<slug>_v<version.id>\`)
  - 描述/副标题(可选,默认空,存 localStorage)
  - 参数表单用 schema 默认值,跟 \`/tools/presets\` 新建模式视觉对齐
- 保存 = \`api.savePreset\` + \`api.forkPresetForVersion\`(套用到当前 version,避免用户保存后还要再手动选一遍)+ refresh picker + refresh baseline
- 抽 \`lib/preset-helpers.ts\` 共享 \`PRESET_NAME_RE\` / \`defaultsFromSchema\` / \`load/savePresetDescriptions\`,Presets.tsx 同步切到 helper —— 避免两份维护

## 4. \`feat(tag-editor)\` chip 拖拽重排 + 新 tag 加末尾

之前 chip 模式下 tag 顺序锁死,新 tag 自动插开头 \`[t, ...tags]\`,想调顺序只能切到文本模式手动剪贴。

- 引入 \`@dnd-kit/{core,sortable,utilities}\`(dev 已有,本 commit 实际激活使用)
- \`PointerSensor\` + 6px 启动距离 → 拖拽手感不跟「点 × 删除」/ 误触冲突
- \`SortableChip\` 子组件:\`setNodeRef\` + listeners + \`CSS.Transform.toString\`;× 删除按钮 \`onPointerDown stopPropagation\`,防止 6px 阈值过后 × 也成拖拽起点
- \`addTag\` 改 \`[...tags, t]\` 加到末尾 —— 跟拖拽心智一致(新东西落底部,用户拖到想要的位置)
- TagEditor.test.tsx 「Enter adds at front」用例更新为「at end」

## Test plan

- [x] \`python -m studio test\` 后端 pytest 909 passed (3 个 pre-existing 失败跟本 PR 无关,均为 Windows subprocess + cmd.exe 环境问题,clean tree 也复现)
- [x] 前端 vitest: 17 files / 124 tests 全过(含 TagEditor 6 个用例)
- [x] \`npm run lint\` / \`npx tsc --noEmit\`: 0 errors
- [ ] **手测(用户)**:
  - (1) 训练页 picker 看到 + 新建预设 卡片,点击进入新建表单,默认名字 \`<slug>_<label>\`,保存后预设出现在 picker 且套用到当前 version
  - (2) TagEdit 步骤的"下载训练集"按钮(原"导出给 CNB")能正常下载 zip
  - (3) TagEditor chip 模式下能鼠标拖拽 chip 改顺序,Enter 添加新 tag 落在末尾,点 × 删除不会触发拖拽