### PR TITLE
fix(ui): topbar / sidebar / overview polish + useDialog 替换 22 处 window.confirm/prompt/alert

### DIFF
--- a/studio/web/src/components/Dialog.test.tsx
+++ b/studio/web/src/components/Dialog.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it } from 'vitest'
+import { DialogProvider, useDialog } from './Dialog'
+import { useState } from 'react'
+
+// Test harness:外层组件触发 confirm/prompt/alert,把 Promise resolve 值放到
+// 屏幕上,断言 user 交互结果。
+function Harness({
+  run,
+}: {
+  run: (api: ReturnType<typeof useDialog>) => Promise<unknown>
+}) {
+  const api = useDialog()
+  const [result, setResult] = useState<string>('')
+  return (
+    <div>
+      <button
+        onClick={() =>
+          void run(api).then((v) => setResult('resolved:' + JSON.stringify(v)))
+        }
+      >
+        trigger
+      </button>
+      <div data-testid="result">{result}</div>
+    </div>
+  )
+}
+
+const wrap = (run: (api: ReturnType<typeof useDialog>) => Promise<unknown>) =>
+  render(
+    <DialogProvider>
+      <Harness run={run} />
+    </DialogProvider>,
+  )
+
+describe('Dialog (useDialog API)', () => {
+  it('confirm 点确认返回 true', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.confirm('删除？'))
+    await user.click(screen.getByText('trigger'))
+    await user.click(screen.getByText('确认'))
+    expect(screen.getByTestId('result')).toHaveTextContent('resolved:true')
+  })
+
+  it('confirm 点取消返回 false', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.confirm('删除？'))
+    await user.click(screen.getByText('trigger'))
+    await user.click(screen.getByText('取消'))
+    expect(screen.getByTestId('result')).toHaveTextContent('resolved:false')
+  })
+
+  it('confirm Esc 关闭返回 false', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.confirm('删除？'))
+    await user.click(screen.getByText('trigger'))
+    await user.keyboard('{Escape}')
+    expect(screen.getByTestId('result')).toHaveTextContent('resolved:false')
+  })
+
+  it('confirm 自定义按钮文案', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.confirm('删除？', { okText: '焚毁', cancelText: '算了' }))
+    await user.click(screen.getByText('trigger'))
+    expect(screen.getByText('焚毁')).toBeInTheDocument()
+    expect(screen.getByText('算了')).toBeInTheDocument()
+  })
+
+  it('confirm tone=danger 给确认按钮加 btn-danger', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.confirm('删除？', { tone: 'danger' }))
+    await user.click(screen.getByText('trigger'))
+    expect(screen.getByText('确认')).toHaveClass('btn-danger')
+  })
+
+  it('prompt 输入后点确定返回字符串', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.prompt('名称'))
+    await user.click(screen.getByText('trigger'))
+    const input = screen.getByRole('textbox')
+    await user.type(input, 'my-preset')
+    await user.click(screen.getByText('确定'))
+    expect(screen.getByTestId('result')).toHaveTextContent('resolved:"my-preset"')
+  })
+
+  it('prompt 取消返回 null', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.prompt('名称'))
+    await user.click(screen.getByText('trigger'))
+    await user.click(screen.getByText('取消'))
+    expect(screen.getByTestId('result')).toHaveTextContent('resolved:null')
+  })
+
+  it('prompt defaultValue 预填到输入框', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.prompt('名称', { defaultValue: 'v3' }))
+    await user.click(screen.getByText('trigger'))
+    expect(screen.getByRole('textbox')).toHaveValue('v3')
+  })
+
+  it('prompt validate 阻止提交并显示错误', async () => {
+    const user = userEvent.setup()
+    wrap((api) =>
+      api.prompt('名称', { validate: (v) => (v.length < 3 ? '至少 3 字符' : null) }),
+    )
+    await user.click(screen.getByText('trigger'))
+    await user.type(screen.getByRole('textbox'), 'ab')
+    await user.click(screen.getByText('确定'))
+    expect(screen.getByText('至少 3 字符')).toBeInTheDocument()
+    // 错误显示后 dialog 未关闭 — result 仍空
+    expect(screen.getByTestId('result')).toHaveTextContent('')
+  })
+
+  it('alert 点知道了 resolve', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.alert('完成'))
+    await user.click(screen.getByText('trigger'))
+    expect(screen.getByText('知道了')).toBeInTheDocument()
+    await user.click(screen.getByText('知道了'))
+    expect(screen.getByTestId('result')).toHaveTextContent('resolved:')
+  })
+
+  it('alert 没有取消按钮', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.alert('完成'))
+    await user.click(screen.getByText('trigger'))
+    expect(screen.queryByText('取消')).not.toBeInTheDocument()
+  })
+})

--- a/studio/web/src/components/Dialog.tsx
+++ b/studio/web/src/components/Dialog.tsx
@@ -42,6 +42,8 @@ export interface PromptOptions {
   okText?: string
   cancelText?: string
   title?: string
+  /** 跟 ConfirmOptions 对齐 — 用于「输入后会做危险操作」的场景。 */
+  tone?: DialogTone
 }
 
 export interface AlertOptions {

--- a/studio/web/src/components/Dialog.tsx
+++ b/studio/web/src/components/Dialog.tsx
@@ -1,0 +1,284 @@
+// Dialog.tsx —— 命令式 confirm / prompt / alert,替代浏览器原生 window.* 三件套。
+//
+// 设计动机:浏览器原生对话框样式跟应用 UI 完全脱节(灰蒙蒙系统弹框),且无法
+// 支持自定义按钮文案 / 危险操作配色 / 输入校验。仓库里散落 20+ 处 confirm/
+// prompt/alert,这里集中成一个 Provider + hook 的命令式 API,call site 改动
+// 最小(`if (!confirm(...))` → `if (!await confirm(...))`)。
+//
+// API 形态:
+//   const { confirm, prompt, alert } = useDialog()
+//   const ok    = await confirm('删除版本 v1？', { tone: 'danger' })   // Promise<boolean>
+//   const name  = await prompt('新预设名称', { defaultValue, validate }) // Promise<string|null>
+//   await alert('JSON 解析失败', { tone: 'error' })
+//
+// 不替代:已有的复杂表单对话框(NewVersionDialog 之类),那些有自定义字段/
+// 嵌入 SchemaForm,声明式 JSX 写更清楚,继续保留。
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+
+export type DialogTone = 'default' | 'danger' | 'warn'
+
+export interface ConfirmOptions {
+  /** 决定确认按钮颜色:default=accent / danger=err 红 / warn=warn 橙 */
+  tone?: DialogTone
+  okText?: string
+  cancelText?: string
+  /** 对话框标题(默认"确认操作") */
+  title?: string
+}
+
+export interface PromptOptions {
+  defaultValue?: string
+  placeholder?: string
+  /** 同步校验:返回 null = 通过,返回 string = 错误信息。每次输入立刻跑。 */
+  validate?: (v: string) => string | null
+  okText?: string
+  cancelText?: string
+  title?: string
+}
+
+export interface AlertOptions {
+  tone?: DialogTone
+  okText?: string
+  title?: string
+}
+
+type DialogState =
+  | {
+      type: 'confirm'
+      message: string
+      options: ConfirmOptions
+      resolve: (ok: boolean) => void
+    }
+  | {
+      type: 'prompt'
+      label: string
+      options: PromptOptions
+      resolve: (v: string | null) => void
+    }
+  | {
+      type: 'alert'
+      message: string
+      options: AlertOptions
+      resolve: () => void
+    }
+
+interface DialogApi {
+  confirm: (message: string, options?: ConfirmOptions) => Promise<boolean>
+  prompt: (label: string, options?: PromptOptions) => Promise<string | null>
+  alert: (message: string, options?: AlertOptions) => Promise<void>
+}
+
+const Ctx = createContext<DialogApi | null>(null)
+
+export function DialogProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<DialogState | null>(null)
+
+  const confirm = useCallback(
+    (message: string, options: ConfirmOptions = {}): Promise<boolean> =>
+      new Promise((resolve) => {
+        setState({ type: 'confirm', message, options, resolve })
+      }),
+    [],
+  )
+
+  const prompt = useCallback(
+    (label: string, options: PromptOptions = {}): Promise<string | null> =>
+      new Promise((resolve) => {
+        setState({ type: 'prompt', label, options, resolve })
+      }),
+    [],
+  )
+
+  const alert = useCallback(
+    (message: string, options: AlertOptions = {}): Promise<void> =>
+      new Promise((resolve) => {
+        setState({ type: 'alert', message, options, resolve })
+      }),
+    [],
+  )
+
+  // 取消通用入口(ESC / 点遮罩 / 取消按钮):confirm → false, prompt → null,
+  // alert → 直接 resolve。
+  const cancel = useCallback(() => {
+    setState((cur) => {
+      if (!cur) return null
+      if (cur.type === 'confirm') cur.resolve(false)
+      else if (cur.type === 'prompt') cur.resolve(null)
+      else cur.resolve()
+      return null
+    })
+  }, [])
+
+  const confirmOk = useCallback((value: boolean | string) => {
+    setState((cur) => {
+      if (!cur) return null
+      if (cur.type === 'confirm') cur.resolve(value as boolean)
+      else if (cur.type === 'prompt') cur.resolve(value as string)
+      else cur.resolve()
+      return null
+    })
+  }, [])
+
+  // ESC 关闭(等价取消)
+  useEffect(() => {
+    if (!state) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        cancel()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [state, cancel])
+
+  return (
+    <Ctx.Provider value={{ confirm, prompt, alert }}>
+      {children}
+      {state && (
+        <DialogRoot state={state} onCancel={cancel} onOk={confirmOk} />
+      )}
+    </Ctx.Provider>
+  )
+}
+
+export function useDialog(): DialogApi {
+  const ctx = useContext(Ctx)
+  if (!ctx) throw new Error('useDialog must be used inside <DialogProvider>')
+  return ctx
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+
+function toneButtonClass(tone: DialogTone | undefined): string {
+  switch (tone) {
+    case 'danger': return 'btn btn-danger'
+    case 'warn':   return 'btn btn-warn'
+    default:       return 'btn btn-primary'
+  }
+}
+
+interface RootProps {
+  state: DialogState
+  onCancel: () => void
+  onOk: (value: boolean | string) => void
+}
+
+function DialogRoot({ state, onCancel, onOk }: RootProps) {
+  // input value 用 ref 而非 state,避免每次按键触发 DialogRoot rerender。
+  // 错误信息走 state,因为要触发 re-render。
+  const [inputValue, setInputValue] = useState(
+    state.type === 'prompt' ? (state.options.defaultValue ?? '') : '',
+  )
+  const [error, setError] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  // Prompt 自动 focus + select 默认值,方便用户改名
+  useEffect(() => {
+    if (state.type === 'prompt') {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus()
+        inputRef.current?.select()
+      })
+    }
+  }, [state.type])
+
+  const handleSubmit = (e?: React.FormEvent) => {
+    e?.preventDefault()
+    if (state.type === 'confirm') {
+      onOk(true)
+    } else if (state.type === 'prompt') {
+      const v = inputValue
+      const err = state.options.validate?.(v) ?? null
+      if (err) {
+        setError(err)
+        inputRef.current?.focus()
+        return
+      }
+      onOk(v)
+    } else {
+      onOk(true)
+    }
+  }
+
+  const title =
+    state.options.title ??
+    (state.type === 'confirm'
+      ? '确认操作'
+      : state.type === 'prompt'
+        ? '输入'
+        : '提示')
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/50"
+      onMouseDown={(e) => {
+        // 只在点击在背景上时关 — 点 form 内部 mouseDown 不触发
+        if (e.target === e.currentTarget) onCancel()
+      }}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="bg-elevated border border-dim rounded-lg w-[90%] max-w-[440px] p-6 flex flex-col gap-4 shadow-xl"
+      >
+        <h2 className="m-0 text-lg font-semibold text-fg-primary">{title}</h2>
+
+        {state.type === 'prompt' ? (
+          <label className="flex flex-col gap-1.5">
+            <span className="text-sm text-fg-secondary">{state.label}</span>
+            <input
+              ref={inputRef}
+              className="input input-mono font-mono"
+              value={inputValue}
+              placeholder={state.options.placeholder}
+              onChange={(e) => {
+                setInputValue(e.target.value)
+                if (error) setError(null)
+              }}
+            />
+            {error && (
+              <span className="text-xs text-err">{error}</span>
+            )}
+          </label>
+        ) : (
+          <p className="m-0 text-sm text-fg-secondary whitespace-pre-wrap">
+            {state.type === 'confirm' ? state.message : state.message}
+          </p>
+        )}
+
+        <div className="flex gap-2 justify-end mt-1">
+          {state.type !== 'alert' && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="btn btn-secondary"
+            >
+              {state.options.cancelText ?? '取消'}
+            </button>
+          )}
+          <button
+            type="submit"
+            className={toneButtonClass(state.options.tone)}
+          >
+            {state.options.okText ??
+              (state.type === 'confirm'
+                ? '确认'
+                : state.type === 'prompt'
+                  ? '确定'
+                  : '知道了')}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/studio/web/src/components/SaveBar.tsx
+++ b/studio/web/src/components/SaveBar.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { api, type CaptionSnapshot } from '../api/client'
+import { useDialog } from './Dialog'
 import { useToast } from './Toast'
 
 interface Props {
@@ -28,6 +29,7 @@ export default function SaveBar({
   pid, vid, dirtyCount, onSave, onAfterRestore,
 }: Props) {
   const { toast } = useToast()
+  const { confirm } = useDialog()
   const [open, setOpen] = useState(false)
   const [items, setItems] = useState<CaptionSnapshot[]>([])
   const [busyId, setBusyId] = useState<string | null>(null)
@@ -55,7 +57,7 @@ export default function SaveBar({
   }
 
   const restore = async (sid: string) => {
-    if (!confirm('还原会覆盖当前所有 caption（含未保存的本地改动）。确定？')) return
+    if (!(await confirm('还原会覆盖当前所有 caption（含未保存的本地改动）。确定？', { tone: 'warn', okText: '还原' }))) return
     setBusyId(sid)
     try {
       const r = await api.restoreCaptionSnapshot(pid, vid, sid)
@@ -66,7 +68,7 @@ export default function SaveBar({
   }
 
   const del = async (sid: string) => {
-    if (!confirm(`删除还原点 ${sid}？此操作不可撤销。`)) return
+    if (!(await confirm(`删除还原点 ${sid}？此操作不可撤销。`, { tone: 'danger', okText: '删除' }))) return
     setBusyId(sid)
     try { await api.deleteCaptionSnapshot(pid, vid, sid); await refresh() }
     catch (e) { toast(String(e), 'error') }

--- a/studio/web/src/components/Sidebar.tsx
+++ b/studio/web/src/components/Sidebar.tsx
@@ -348,7 +348,10 @@ export default function Sidebar() {
     } catch { return null }
   })
 
-  const expanded = expandedOverride ?? !inProject
+  // 默认始终展开（用户手动折叠后 sessionStorage 持久,此后保持折叠）。
+  // 旧逻辑 `?? !inProject` 让进项目时自动折叠 — 用户反馈这会突然遮 sidebar
+  // 信息,违反「点项目 = 进入工作流」的预期。
+  const expanded = expandedOverride ?? true
   const collapsed = !expanded
 
   const toggle = () => {

--- a/studio/web/src/components/Topbar.tsx
+++ b/studio/web/src/components/Topbar.tsx
@@ -225,17 +225,6 @@ export default function Topbar() {
         {/* 实时系统监控 (CPU / RAM / GPU / VRAM)，每 ~2.5s 轮询；无 NVIDIA 时只显示 CPU/RAM。 */}
         <SystemStats />
 
-        {/* 搜索按钮 — 缩成 icon-only，⌘K 仍可弹出完整 palette (含跨图标签搜索)。 */}
-        <button
-          ref={searchBtnRef}
-          onClick={() => setPaletteOpen(true)}
-          title="搜索 (⌘K)"
-          aria-label="搜索"
-          className="flex items-center justify-center text-fg-tertiary bg-surface border border-dim rounded-md cursor-pointer w-8 h-8 hover:border-bold hover:text-fg-secondary transition-colors shrink-0"
-        >
-          {SearchIcon}
-        </button>
-
         {/* 运行中训练胶囊 */}
         {runningTask && (
           <button
@@ -260,6 +249,18 @@ export default function Topbar() {
             <span>{pendingCount} 排队中</span>
           </button>
         )}
+
+        {/* 搜索按钮 — icon-only,⌘K 仍可弹完整 palette。放最右,避免被
+            训练胶囊 / 队列胶囊推得忽前忽后跳动。 */}
+        <button
+          ref={searchBtnRef}
+          onClick={() => setPaletteOpen(true)}
+          title="搜索 (⌘K)"
+          aria-label="搜索"
+          className="flex items-center justify-center text-fg-tertiary bg-surface border border-dim rounded-md cursor-pointer w-8 h-8 hover:border-bold hover:text-fg-secondary transition-colors shrink-0"
+        >
+          {SearchIcon}
+        </button>
       </header>
 
       <CommandPalette

--- a/studio/web/src/main.tsx
+++ b/studio/web/src/main.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import { DialogProvider } from './components/Dialog'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { ToastProvider } from './components/Toast'
 import { initTheme } from './lib/theme'
@@ -12,7 +13,9 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>
       <ToastProvider>
-        <App />
+        <DialogProvider>
+          <App />
+        </DialogProvider>
       </ToastProvider>
     </ErrorBoundary>
   </React.StrictMode>,

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { api, type ProjectStage, type ProjectSummary } from '../api/client'
 import PageHeader from '../components/PageHeader'
 import StageBadge from '../components/StageBadge'
+import { useDialog } from '../components/Dialog'
 import { useToast } from '../components/Toast'
 import { useEventStream } from '../lib/useEventStream'
 
@@ -35,6 +36,7 @@ export default function ProjectsPage() {
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const navigate = useNavigate()
   const { toast } = useToast()
+  const { confirm } = useDialog()
 
   const refresh = async () => {
     try {
@@ -75,7 +77,7 @@ export default function ProjectsPage() {
   const handleDelete = async (p: ProjectSummary, e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    if (!confirm(`移到回收站？\n${p.title} (${p.slug})`)) return
+    if (!(await confirm(`移到回收站？\n${p.title} (${p.slug})`, { tone: 'warn', okText: '移到回收站' }))) return
     try {
       await api.deleteProject(p.id)
       toast(`已移到回收站: ${p.title}`, 'success')
@@ -104,7 +106,7 @@ export default function ProjectsPage() {
   }
 
   const handleEmptyTrash = async () => {
-    if (!confirm('物理删除所有回收站项目？此操作不可恢复。')) return
+    if (!(await confirm('物理删除所有回收站项目？此操作不可恢复。', { tone: 'danger', okText: '清空回收站' }))) return
     try {
       const r = await api.emptyTrash()
       toast(`清空了 ${r.removed} 个项目`, 'success')

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
 import { api, type Task, type TaskStatus } from '../api/client'
 import StepShell from '../components/StepShell'
+import { useDialog } from '../components/Dialog'
 import { useToast } from '../components/Toast'
 import { useEventStream } from '../lib/useEventStream'
 import { useMonitorProgress } from '../lib/useMonitorProgress'
@@ -15,14 +16,14 @@ async function downloadJson(filename: string, data: unknown) {
 }
 
 async function pickJsonFile(): Promise<unknown | null> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const input = document.createElement('input')
     input.type = 'file'; input.accept = '.json,application/json'
     input.onchange = async () => {
       const f = input.files?.[0]
       if (!f) { resolve(null); return }
       try { resolve(JSON.parse(await f.text())) }
-      catch { alert('JSON 解析失败'); resolve(null) }
+      catch { reject(new Error('JSON 解析失败')) }
     }
     input.click()
   })
@@ -91,6 +92,7 @@ export default function QueuePage() {
   const [busy, setBusy] = useState(false)
   const reloadTimer = useRef<number | null>(null)
   const { toast } = useToast()
+  const { confirm } = useDialog()
   const navigate = useNavigate()
   const reload = useCallback(async () => {
     try { setTasks(await api.listQueue()); setError(null) }
@@ -133,7 +135,7 @@ export default function QueuePage() {
   const clearDone = async () => {
     const done = tasks.filter((t) => t.status === 'done')
     if (done.length === 0) { toast('没有已完成的任务', 'success'); return }
-    if (!confirm(`删除 ${done.length} 个已完成任务？`)) return
+    if (!(await confirm(`删除 ${done.length} 个已完成任务？`, { tone: 'danger', okText: '删除' }))) return
     setBusy(true)
     try {
       for (const t of done) await api.deleteTask(t.id)
@@ -186,7 +188,9 @@ export default function QueuePage() {
           <button
             disabled={busy}
             onClick={async () => {
-              const payload = await pickJsonFile()
+              let payload: unknown
+              try { payload = await pickJsonFile() }
+              catch (e) { toast(String(e), 'error'); return }
               if (!payload) return
               setBusy(true)
               try {

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Outlet, useNavigate, useParams } from 'react-router-dom'
 import { api, downloadBlob, type ProjectDetail } from '../../api/client'
 import { useProjectCtxSetter } from '../../context/ProjectContext'
+import { useDialog } from '../../components/Dialog'
 import { useToast } from '../../components/Toast'
 import { useEventStream } from '../../lib/useEventStream'
 
@@ -10,6 +11,7 @@ export default function ProjectLayout() {
   const projectId = pid ? Number(pid) : NaN
   const navigate = useNavigate()
   const { toast } = useToast()
+  const { confirm } = useDialog()
   const setCtx = useProjectCtxSetter()
   const [project, setProject] = useState<ProjectDetail | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -81,7 +83,7 @@ export default function ProjectLayout() {
     if (!projectRef.current) return
     const v = projectRef.current.versions.find((x) => x.id === vid)
     if (!v) return
-    if (!confirm(`删除版本 ${v.label}？目录将移到回收站。`)) return
+    if (!(await confirm(`删除版本 ${v.label}？目录将移到回收站。`, { tone: 'warn', okText: '删版本' }))) return
     const pid = projectRef.current.id
     try {
       await api.deleteVersion(pid, vid)
@@ -91,7 +93,7 @@ export default function ProjectLayout() {
     } catch (e) {
       toast(String(e), 'error')
     }
-  }, [reload, toast, navigate])
+  }, [reload, toast, navigate, confirm])
 
   const handleCreateVersion = useCallback(async (label: string, forkFromVersionId: number | null) => {
     if (!projectRef.current || creatingBusy) return

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -149,7 +149,15 @@ export default function ProjectLayout() {
 
   return (
     <div className="flex flex-col h-full">
-      <Outlet context={{ project, activeVersion, reload }} />
+      {/* outlet context 透传 onCreateVersion + busy,Overview 的「新版本」按钮
+          复用同一个 NewVersionDialog,避免 Overview 单独维护 window.prompt 版本。 */}
+      <Outlet context={{
+        project,
+        activeVersion,
+        reload,
+        onCreateVersion: () => setCreating(true),
+        creatingVersionBusy: creatingBusy,
+      }} />
       {creating && (
         <NewVersionDialog
           existingLabels={project.versions.map((v) => v.label)}

--- a/studio/web/src/pages/project/Overview.tsx
+++ b/studio/web/src/pages/project/Overview.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import { useNavigate, useOutletContext } from 'react-router-dom'
 import { api, type ProjectDetail, type Version } from '../../api/client'
 import PageHeader from '../../components/PageHeader'
@@ -9,6 +8,9 @@ interface Ctx {
   project: ProjectDetail
   activeVersion: Version | null
   reload: () => Promise<void>
+  /** Layout 透传:复用侧边栏 NewVersionDialog,避免 Overview 重复实现 window.prompt 版本。 */
+  onCreateVersion: () => void
+  creatingVersionBusy: boolean
 }
 
 // ── StatCard ────────────────────────────────────────────────────
@@ -173,35 +175,26 @@ function PipelineTimeline({ steps }: { steps: PipelineStep[] }) {
 // ── Overview ─────────────────────────────────────────────────────
 
 export default function ProjectOverview() {
-  const { project, activeVersion, reload } = useOutletContext<Ctx>()
+  const { project, activeVersion, reload, onCreateVersion, creatingVersionBusy } = useOutletContext<Ctx>()
   const navigate = useNavigate()
   const { toast } = useToast()
-  const [newVersionBusy, setNewVersionBusy] = useState(false)
 
   const handleActivate = async (v: Version) => {
     try {
       await api.activateVersion(project.id, v.id)
       await reload()
-      navigate(`/projects/${project.id}/v/${v.id}/curate`)
+      // 选版本 → 跳项目级 download(不是直接跳 curate)。download 是工作流真起点,
+      // 用户从这里决定要不要重新下,还是直接往下走 curate/tag/...。Sidebar 切
+      // 版本不 navigate(只 activate),两边语义分开:Overview 卡片点击 = 进入版本
+      // 工作流,Sidebar 版本切换 = 改上下文不离当前页。
+      navigate(`/projects/${project.id}/download`)
     } catch (e) {
       toast(String(e), 'error')
     }
   }
 
-  const handleNewVersion = async () => {
-    const label = prompt('版本标签', `v${project.versions.length + 1}`)
-    if (!label) return
-    setNewVersionBusy(true)
-    try {
-      await api.createVersion(project.id, { label })
-      await reload()
-      toast(`已创建版本 ${label}`, 'success')
-    } catch (e) {
-      toast(String(e), 'error')
-    } finally {
-      setNewVersionBusy(false)
-    }
-  }
+  // 「新版本」按钮调 onCreateVersion → Layout 弹 NewVersionDialog(label + 可选
+  // fork from + 自动 activate)。Overview 不再自己维护创建逻辑。
 
   const stats = [
     {
@@ -287,13 +280,13 @@ export default function ProjectOverview() {
             <h2 className="text-md font-semibold flex-1" style={{ margin: 0 }}>版本</h2>
             <button
               className="btn btn-ghost btn-sm border border-dashed border-dim"
-              onClick={handleNewVersion}
-              disabled={newVersionBusy}
+              onClick={onCreateVersion}
+              disabled={creatingVersionBusy}
             >
               <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
                 <path d="M12 5v14M5 12h14" />
               </svg>
-              {newVersionBusy ? '创建中…' : '新版本'}
+              {creatingVersionBusy ? '创建中…' : '新版本'}
             </button>
           </div>
 

--- a/studio/web/src/pages/project/steps/Curation.tsx
+++ b/studio/web/src/pages/project/steps/Curation.tsx
@@ -10,6 +10,7 @@ import {
 import ImageGrid, { applySelection } from '../../../components/ImageGrid'
 import ImagePreviewModal from '../../../components/ImagePreviewModal'
 import StepShell from '../../../components/StepShell'
+import { useDialog } from '../../../components/Dialog'
 import { useToast } from '../../../components/Toast'
 import { useEventStream } from '../../../lib/useEventStream'
 
@@ -114,6 +115,8 @@ const SCROLL_BOX = 'flex-1 min-h-0 overflow-y-auto pr-1'
 export default function CurationPage() {
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
   const { toast } = useToast()
+  // Curation 有 `options.confirm: boolean` 字段,跟 useDialog().confirm 同名 — 不解构,用 dialog.confirm。
+  const dialog = useDialog()
   const [view, setView] = useState<CurationView | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -376,7 +379,8 @@ export default function CurationPage() {
     options: { clearSelection?: boolean; confirm?: boolean } = {}
   ) => {
     if (!folder || files.length === 0 || busy) return false
-    if (options.confirm && !confirm(`从 ${folder}/ 移除 ${files.length} 张?`)) {
+    if (options.confirm &&
+        !(await dialog.confirm(`从 ${folder}/ 移除 ${files.length} 张?`, { tone: 'warn', okText: '移除' }))) {
       return false
     }
     setBusy(true)
@@ -463,12 +467,10 @@ export default function CurationPage() {
 
   const doDeleteFolder = async (name: string) => {
     const cnt = view.right[name]?.length ?? 0
-    if (
-      !confirm(
-        `删除文件夹 ${name}? 将清掉 ${cnt} 张训练副本（download/ 不动）`
-      )
-    )
-      return
+    if (!(await dialog.confirm(
+      `删除文件夹 ${name}? 将清掉 ${cnt} 张训练副本（download/ 不动）`,
+      { tone: 'warn', okText: '删文件夹' },
+    ))) return
     setBusy(true)
     try {
       await api.folderOp(project.id, activeVersion.id, {

--- a/studio/web/src/pages/project/steps/Download.tsx
+++ b/studio/web/src/pages/project/steps/Download.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../api/client'
 import ImageGrid, { applySelection } from '../../../components/ImageGrid'
 import StepShell from '../../../components/StepShell'
+import { useDialog } from '../../../components/Dialog'
 import { useToast } from '../../../components/Toast'
 import { useEventStream } from '../../../lib/useEventStream'
 
@@ -43,6 +44,7 @@ const STATUS_COLOR: Record<Job['status'], string> = {
 export default function DownloadPage() {
   const { project, reload } = useOutletContext<Ctx>()
   const { toast } = useToast()
+  const { confirm } = useDialog()
   const [job, setJob] = useState<Job | null>(null)
   const [logs, setLogs] = useState<string[]>([])
   const [files, setFiles] = useState<DownloadFile[]>([])
@@ -252,12 +254,10 @@ export default function DownloadPage() {
             }}
             onDelete={async () => {
               if (selected.size === 0) return
-              if (
-                !window.confirm(
-                  `从 download/ 删除 ${selected.size} 张图片（含同名 caption metadata）？\n操作不可恢复。`
-                )
-              )
-                return
+              if (!(await confirm(
+                `从 download/ 删除 ${selected.size} 张图片（含同名 caption metadata）？\n操作不可恢复。`,
+                { tone: 'danger', okText: '删除' },
+              ))) return
               setDeleting(true)
               try {
                 const r = await api.deleteProjectFiles(

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -16,6 +16,7 @@ import ImageGrid from '../../../components/ImageGrid'
 import ImagePreviewModal from '../../../components/ImagePreviewModal'
 import JobProgress from '../../../components/JobProgress'
 import StepShell from '../../../components/StepShell'
+import { useDialog } from '../../../components/Dialog'
 import { useToast } from '../../../components/Toast'
 import { useEventStream } from '../../../lib/useEventStream'
 
@@ -48,6 +49,7 @@ const ADVANCED_DEFAULTS: AdvancedParams = {
 export default function RegularizationPage() {
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
   const { toast } = useToast()
+  const { confirm } = useDialog()
 
   const [reg, setReg] = useState<RegStatus | null>(null)
   const [trainTags, setTrainTags] = useState<RegTagCount[]>([])
@@ -251,7 +253,7 @@ export default function RegularizationPage() {
 
   const onDelete = async () => {
     if (!vid) return
-    if (!confirm('删除当前 reg 集？这是不可恢复的（meta + 所有图片都会清掉）。')) return
+    if (!(await confirm('删除当前 reg 集？这是不可恢复的（meta + 所有图片都会清掉）。', { tone: 'danger', okText: '删除' }))) return
     try {
       await api.deleteReg(project.id, vid)
       toast('已删除', 'success')

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -10,6 +10,7 @@ import {
   type Version,
   type VersionConfigResponse,
 } from '../../../api/client'
+import { useDialog } from '../../../components/Dialog'
 import SchemaForm from '../../../components/SchemaForm'
 import StepShell from '../../../components/StepShell'
 import { useToast } from '../../../components/Toast'
@@ -37,6 +38,7 @@ interface Ctx {
 export default function TrainPage() {
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
   const { toast } = useToast()
+  const { confirm, prompt } = useDialog()
   const navigate = useNavigate()
 
   const [schema, setSchema] = useState<SchemaResponse | null>(null)
@@ -254,13 +256,12 @@ export default function TrainPage() {
 
   const onForkPreset = async (name: string) => {
     if (!name) return
-    if (
-      configResp?.has_config &&
-      !window.confirm(
-        `换预设会覆盖当前 version 的配置（已保存的内容会丢失）。继续？`
+    if (configResp?.has_config) {
+      const ok = await confirm(
+        '换预设会覆盖当前 version 的配置（已保存的内容会丢失）。继续？',
+        { tone: 'warn', okText: '换预设' },
       )
-    ) {
-      return
+      if (!ok) return
     }
     setBusy(true)
     try {
@@ -275,26 +276,36 @@ export default function TrainPage() {
   }
 
   const onSaveAsPreset = async () => {
-    const name = window.prompt(
-      '保存为新预设。预设名（字母 / 数字 / _ / -，会清掉项目特定字段）：',
-      ''
-    )
+    const name = await prompt('预设名（会自动清掉项目特定字段如 data_dir）', {
+      placeholder: 'my-preset',
+      validate: (v) => {
+        const t = v.trim()
+        if (!t) return '不能为空'
+        if (!PRESET_NAME_RE.test(t)) return '仅允许字母 / 数字 / _ / -'
+        return null
+      },
+    })
     if (!name) return
+    const trimmed = name.trim()
     setBusy(true)
     try {
-      await api.saveVersionConfigAsPreset(project.id, vid, name, false)
+      await api.saveVersionConfigAsPreset(project.id, vid, trimmed, false)
       const list = await api.listPresets()
       setPresets(list)
-      toast(`已保存为预设 ${name}`, 'success')
+      toast(`已保存为预设 ${trimmed}`, 'success')
     } catch (e) {
       const msg = String(e)
       if (msg.includes('已存在')) {
-        if (window.confirm(`预设 ${name} 已存在，覆盖？`)) {
+        const overwrite = await confirm(`预设 ${trimmed} 已存在，覆盖？`, {
+          tone: 'danger',
+          okText: '覆盖',
+        })
+        if (overwrite) {
           try {
-            await api.saveVersionConfigAsPreset(project.id, vid, name, true)
+            await api.saveVersionConfigAsPreset(project.id, vid, trimmed, true)
             const list = await api.listPresets()
             setPresets(list)
-            toast(`已覆盖预设 ${name}`, 'success')
+            toast(`已覆盖预设 ${trimmed}`, 'success')
           } catch (e2) {
             toast(String(e2), 'error')
           }
@@ -338,7 +349,11 @@ export default function TrainPage() {
     }
     if (!newPresetConfig || !vid) return
     if (presets.some((p) => p.name === name)) {
-      if (!window.confirm(`预设 ${name} 已存在，覆盖？`)) return
+      const overwrite = await confirm(`预设 ${name} 已存在，覆盖？`, {
+        tone: 'danger',
+        okText: '覆盖',
+      })
+      if (!overwrite) return
     }
     setBusy(true)
     try {

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -5,6 +5,7 @@ import {
   type PresetSummary,
   type SchemaResponse,
 } from '../../api/client'
+import { useDialog } from '../../components/Dialog'
 import SchemaForm from '../../components/SchemaForm'
 import { useToast } from '../../components/Toast'
 import {
@@ -49,6 +50,7 @@ interface DraftSeed {
 
 export default function PresetsPage() {
   const { toast } = useToast()
+  const { confirm } = useDialog()
 
   // ── backend state ──
   const [schema, setSchema] = useState<SchemaResponse | null>(null)
@@ -241,9 +243,9 @@ export default function PresetsPage() {
     setPickerOpen(false)
   }
 
-  const handleDelete = () => {
+  const handleDelete = async () => {
     if (!selected) return
-    if (!window.confirm(`删除预设 ${selected}？`)) return
+    if (!(await confirm(`删除预设 ${selected}？`, { tone: 'danger', okText: '删除' }))) return
     setBusy(true)
     api.deletePreset(selected).then(() => {
       const { [selected]: _, ...rest } = descriptions

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DialogProvider } from '../../components/Dialog'
 import { ToastProvider } from '../../components/Toast'
 import SettingsPage from './Settings'
 
@@ -212,7 +213,9 @@ afterEach(() => {
 function renderPage() {
   return render(
     <ToastProvider>
-      <SettingsPage />
+      <DialogProvider>
+        <SettingsPage />
+      </DialogProvider>
     </ToastProvider>
   )
 }

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -15,6 +15,7 @@ import {
   type WandBConfig,
   type WD14Runtime,
 } from '../../api/client'
+import { useDialog } from '../../components/Dialog'
 import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
@@ -212,6 +213,7 @@ export default function SettingsPage() {
   const [llmModelsBusy, setLlmModelsBusy] = useState(false)
   const [llmTestBusy, setLlmTestBusy] = useState(false)
   const { toast } = useToast()
+  const { prompt } = useDialog()
   // 右侧 section index 用：sticky nav 的 IntersectionObserver root + 滚动平移容器
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
@@ -352,8 +354,12 @@ export default function SettingsPage() {
     // current_preset 不变；validator 会重建 preset
   }
 
-  const saveAsNewPreset = () => {
-    const label = window.prompt('新预设名称：', `${currentPreset.label} 副本`)
+  const saveAsNewPreset = async () => {
+    const label = await prompt('新预设名称', {
+      defaultValue: `${currentPreset.label} 副本`,
+      placeholder: 'my-preset',
+      validate: (v) => (v.trim() ? null : '不能为空'),
+    })
     if (!label) return
     const slug = label.toLowerCase().replace(/[^a-z0-9_-]+/g, '_').replace(/^_+|_+$/g, '') || 'preset'
     const used = new Set(draft.llm_tagger.presets.map((p) => p.id))
@@ -1550,6 +1556,7 @@ function DownloadButton({ exists, status, busy, onClick }: {
 // ── ONNX Runtime Section（WD14 + CLTagger 共用 onnxruntime 包管理） ─────────
 
 function ONNXRuntimeSection() {
+  const dialog = useDialog()
   const [rt, setRt] = useState<WD14Runtime | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState<null | 'auto' | 'gpu' | 'cpu'>(null)
@@ -1572,7 +1579,11 @@ function ONNXRuntimeSection() {
     const detail = target === 'auto' ? '将按 nvidia-smi 检测自动选 GPU/CPU 包'
       : target === 'gpu' ? '将卸载现有 onnxruntime 并安装 onnxruntime-gpu'
       : '将卸载现有 onnxruntime-gpu 并安装 onnxruntime（CPU）'
-    if (!confirm(`${detail}。装包需要几分钟。\n\n注意：装完后必须重启 Studio 才能生效。继续？`)) return
+    const ok = await dialog.confirm(
+      `${detail}。装包需要几分钟。\n\n注意：装完后必须重启 Studio 才能生效。继续？`,
+      { tone: 'warn', okText: '开始装' },
+    )
+    if (!ok) return
     setBusy(target)
     try {
       const result = await api.installWD14Runtime(target)
@@ -1693,6 +1704,7 @@ function ONNXRuntimeSection() {
 // - is_cuda_build_unavailable=True     → 黄色驱动警告（pip 修不了，给文档链接）
 
 function PyTorchSection() {
+  const dialog = useDialog()
   const [status, setStatus] = useState<TorchStatus | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -1717,7 +1729,7 @@ function PyTorchSection() {
     // 当前 server 进程锁住，没法直接 replace；只能 defer 到 launcher。
     const msg = `将注册 torch 重装请求（${tag} 版）。\n` +
       `提交后请 Ctrl+C 关闭 Studio 重新运行 studio.bat —— 启动时会装 torch（~3 GB，5-30 分钟）。继续？`
-    if (!confirm(msg)) return
+    if (!(await dialog.confirm(msg, { tone: 'warn', okText: '注册请求' }))) return
     setBusy(true)
     try {
       const result = await api.reinstallTorch(target)
@@ -1874,6 +1886,7 @@ function PyTorchSection() {
 // - GitHub API 限流时 candidates=[] + fetch_error，给手动 URL 输入兜底
 
 function FlashAttentionSection() {
+  const dialog = useDialog()
   const [status, setStatus] = useState<FlashAttnStatus | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -1897,7 +1910,7 @@ function FlashAttentionSection() {
     const msg = url
       ? '将 pip install 该 wheel，装包需要几分钟。\n装完后必须重启 Studio 才能生效。继续？'
       : '将自动从 GitHub Releases 选择最匹配的 flash_attn wheel 并安装。\n装包需要几分钟，装完后必须重启 Studio。继续？'
-    if (!confirm(msg)) return
+    if (!(await dialog.confirm(msg, { tone: 'warn', okText: '开始装' }))) return
     setBusy(true)
     try {
       const result = await api.installFlashAttn(url)
@@ -2055,6 +2068,7 @@ function FlashAttentionSection() {
 // 不需要 flash_attn 那种 GitHub 候选 wheel 列表。失败时给 stderr 让用户排错。
 
 function XformersSection() {
+  const dialog = useDialog()
   const [status, setStatus] = useState<XformersStatus | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
@@ -2073,10 +2087,13 @@ function XformersSection() {
   useEffect(() => { void refresh() }, [refresh])
 
   const install = async () => {
-    if (!confirm(
-      '将 pip install xformers，按当前 torch+cu 选 PyTorch index URL。\n' +
-      '装包几分钟到十几分钟，装完后必须重启 Studio。继续？'
-    )) return
+    if (
+      !(await dialog.confirm(
+        '将 pip install xformers，按当前 torch+cu 选 PyTorch index URL。\n' +
+        '装包几分钟到十几分钟，装完后必须重启 Studio。继续？',
+        { tone: 'warn', okText: '开始装' },
+      ))
+    ) return
     setBusy(true)
     try {
       const r = await api.installXformers()

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -206,6 +206,10 @@ select option:checked {
 .btn-secondary:hover { background: var(--bg-overlay); border-color: var(--border-strong); }
 .btn-ghost { background: transparent; color: var(--fg-secondary); }
 .btn-ghost:hover { background: var(--bg-overlay); color: var(--fg-primary); }
+.btn-danger { background: var(--err); color: white; border-color: var(--err); }
+.btn-danger:hover { filter: brightness(1.08); }
+.btn-warn { background: var(--warn); color: white; border-color: var(--warn); }
+.btn-warn:hover { filter: brightness(1.08); }
 .btn-sm { padding: 4px 10px; font-size: var(--t-sm); }
 
 .card {


### PR DESCRIPTION
两批 UI polish 合并在一个 PR 里,base = dev,7 个 commit。

## 第一批 — UI 行为修复(3 commit)

### 1. \`fix(topbar)\` 搜索 icon 移到最右
之前顺序 \`SystemStats → 🔍 → 训练胶囊\`,有训练任务时 🔍 被胶囊推得左右跳。挪到 header 最右,固定位置。

### 2. \`fix(sidebar)\` 进项目时不再自动折叠
\`expanded = expandedOverride ?? !inProject\` → \`?? true\`。手动折叠走 sessionStorage 持久。

### 3. \`fix(overview)\` 选版本跳 download + 复用 NewVersionDialog
- handleActivate \`v/{id}/curate\` → \`/{id}/download\`(Sidebar 切版本仍然不 navigate,两边语义分开)
- 「新版本」按钮删 \`window.prompt\` 实现,复用 Layout 的 \`NewVersionDialog\`(支持 fork from + 自动 activate),Layout outletContext 透传 \`onCreateVersion + creatingVersionBusy\`

## 第二批 — useDialog 统一替换浏览器原生 dialog(4 commit)

调研发现仓库散落 22 处 \`window.confirm/prompt/alert\`,样式跟应用 UI 完全脱节(灰蒙蒙系统弹框)。集中抽象成命令式 \`useDialog()\` hook。

### 4. \`feat(dialog)\` 加 \`useDialog\` API
\`src/components/Dialog.tsx\` — DialogProvider + 命令式 confirm/prompt/alert,promise-based:

\`\`\`tsx
const ok = await confirm('删除？', { tone: 'danger' })   // Promise<boolean>
const name = await prompt('名称', { defaultValue, validate }) // Promise<string|null>
await alert('完成', { tone: 'warn' })
\`\`\`

- tone: default / danger / warn 控制确认按钮颜色
- prompt: defaultValue / placeholder / validate(同步校验,显示错误)
- ESC + 点遮罩 = 取消
- 复杂表单 Modal(NewVersionDialog 等)继续走声明式,不用此 API
- \`Dialog.test.tsx\` 11 个用例覆盖

附:tokens.css 加 \`.btn-danger\` / \`.btn-warn\` 基于现有 \`--err\` / \`--warn\` token。

### 5. \`refactor(train)\` 4 处
onForkPreset 换预设 confirm(warn) / onSaveAsPreset prompt+validate / 同名覆盖 confirm(danger) / saveNewPreset 同名覆盖 confirm(danger)。

### 6. \`refactor(settings)\` 5 处
saveAsNewPreset(LLM 预设)prompt / 4 个 install 大动作 confirm(warn,系统级)。Settings.test.tsx 加 DialogProvider wrap。

### 7. \`refactor\` 剩下 12 处
Queue / Projects / Layout / Presets / SaveBar / Regularization / Curation / Download。tone 按场景选 danger(不可逆删除)/ warn(可回收 / 大动作可逆)。

**清零检查**: \`rg 'window\.(prompt|alert|confirm)|[^.\w](prompt|alert|confirm)\('\` 仅剩 Dialog.tsx 的 jsdoc 注释和历史注释引用。

## Test plan

- [x] 后端 pytest 909 passed(3 pre-existing 失败跟本 PR 无关 — Windows subprocess 环境问题,clean tree 也复现)
- [x] 前端 vitest 18 files / **135** tests(原 124 + 11 新 Dialog 用例)
- [x] \`npm run lint\` / \`npx tsc --noEmit\` 0 errors
- [ ] **手测**:
  - (1) 顶栏 🔍 在最右,SystemStats/训练胶囊/🔍 顺序不变
  - (2) 点项目卡片 sidebar 默认展开;手动折叠后刷新仍折叠
  - (3) Overview 点版本卡片 → \`/download\`
  - (4) Train 页用 Sidebar 切版本 → 仍在 Train 页
  - (5) Overview 点「新版本」→ Modal(不是 prompt),有「从…创建」
  - (6) **任何**原来弹 window.confirm/prompt/alert 的地方(删项目 / 删版本 / 删预设 / 还原 caption / 复制预设 / 装包等)现在弹应用风格的 Modal,危险操作按钮变红