### PR TITLE
test(web): quiet router and generate test warnings

### DIFF
--- a/studio/web/src/App.tsx
+++ b/studio/web/src/App.tsx
@@ -38,7 +38,10 @@ export default function App() {
   return (
     <ProjectContext.Provider value={projectCtx}>
       <ProjectSetterContext.Provider value={setProjectCtx}>
-    <BrowserRouter basename="/studio">
+    <BrowserRouter
+      basename="/studio"
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
       <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
         <Sidebar />
         <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>

--- a/studio/web/src/components/ProjectStepper.test.tsx
+++ b/studio/web/src/components/ProjectStepper.test.tsx
@@ -34,7 +34,7 @@ function version(stage: Version['stage']): Version {
 
 function renderStepper(p: ProjectDetail, v: Version | null) {
   return render(
-    <MemoryRouter>
+    <MemoryRouter future={{ v7_relativeSplatPath: true, v7_startTransition: true }}>
       <ProjectStepper project={p} version={v} />
     </MemoryRouter>
   )

--- a/studio/web/src/components/Sidebar.test.tsx
+++ b/studio/web/src/components/Sidebar.test.tsx
@@ -5,7 +5,10 @@ import Sidebar from './Sidebar'
 
 function renderAt(path: string) {
   return render(
-    <MemoryRouter initialEntries={[path]}>
+    <MemoryRouter
+      initialEntries={[path]}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
       <Sidebar />
     </MemoryRouter>
   )

--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -60,6 +60,12 @@ function setup() {
   )
 }
 
+async function waitForInitialLorasLoad() {
+  await waitFor(() =>
+    expect(fetchMock.mock.calls.some(([url]) => url === '/api/projects')).toBe(true)
+  )
+}
+
 describe('GeneratePage 端到端 smoke', () => {
   it('mode=single：enqueue payload 含 xy_matrix=null + 完整字段', async () => {
     const user = userEvent.setup()
@@ -101,8 +107,9 @@ describe('GeneratePage 端到端 smoke', () => {
     expect(body.count).toBe(1)
   })
 
-  it('多 prompt 轮换功能已隐藏：只有一个 textarea，"添加 prompt"按钮不存在', () => {
+  it('多 prompt 轮换功能已隐藏：只有一个 textarea，"添加 prompt"按钮不存在', async () => {
     setup()
+    await waitForInitialLorasLoad()
     // 单 textarea
     const promptInputs = screen.getAllByPlaceholderText('输入正向提示词…')
     expect(promptInputs.length).toBe(1)


### PR DESCRIPTION
## Summary
- enable React Router v7 future flags for the app router and router-backed tests
- wait for the initial Generate LoRA fetch in the smoke test before synchronous assertions
- keep this PR scoped to test/runtime warning cleanup only

## Verification
- npm run test
- npm run build