### PR TITLE
feat: webui 自更新（ADR 0002 — 重启 + git pull + 回滚 + dev 通道）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,8 @@ CLAUDE.md
 # 工具生成的临时目录
 .spec-workflow/
 
+# Self-update 进程间通信用的瞬时标志（server 写 → cli.py / wrapper 读后立即删）
+tmp/
+
 # 文档本地草稿（个人 TODO / 未定稿设计 / 临时笔记）
 docs/_local/

--- a/docs/adr/0002-webui-self-update.md
+++ b/docs/adr/0002-webui-self-update.md
@@ -1,0 +1,389 @@
+# 0002 — Webui 内自更新（flag + shell wrapper loop）
+
+**状态**：Proposed
+**日期**：2026-05-12
+**决策者**：@WalkingMeatAxolotl
+
+## 背景
+
+当前用户升级必须走 CLI：`git pull` + 重启 `studio.sh` / `studio.bat`。痛点：
+
+- 技术不熟的用户卡在 git 操作
+- 跨 minor 版本 `requirements.txt` 变化要手动 `pip install`；CHANGELOG 写在那但不直观
+- 我们这一类长任务工具的特殊点：训练任务跑到一半时升级会丢进度，没有暂停-恢复的话用户不敢点更新
+
+讨论顺序：
+
+1. 暂停 + resume 训练（[Ctrl+C 现成机制](../../runtime/anima_train.py#L2374-L2401)，差 supervisor 发对信号 + UI 接线）
+2. webui 一键更新（本 ADR）
+
+两者配套出"无痛升级 + 长任务护盘" 完整故事。
+
+## 关键现状盘点
+
+仓库已经隐式具备"启动期 bootstrap"层，只是不循环、不接受外部触发：
+
+- `studio.sh` / `studio.bat` shell wrapper（一次性 venv / 系统级 setup，单次调用 `python -m studio`）
+- `studio/cli.py:cmd_run` Python 启动器：`_ensure_python_deps` / `_web_dist_is_stale` 触发前端 rebuild / `_apply_pending_install` / `_check_torch_cuda` / `_bootstrap_onnxruntime`，最后 `subprocess.call(server)` 阻塞
+- `studio/services/pending_install.py` 实现"延迟到下次启动执行的 pip 操作"（为 torch 重装设计）
+- `cli.py:_web_dist_is_stale` 已实现 git HEAD 比对 + mtime 比对的 stale 检测
+- `studio.sh:135-148` 已实现 `requirements.txt` sha256 marker 比对 → 增量 `pip install -r`
+
+## 业界调研
+
+详细见对话记录（2026-05-12）。三大流派：
+
+| 流派 | 代表 | 重启机制 | 优劣 |
+| --- | --- | --- | --- |
+| A. flag + shell wrapper loop | A1111, SwarmUI | 服务写 `tmp/restart` + `os._exit(0)`，外层 wrapper 检测后跳回入口 | 最稳，跨平台一致；要求用 wrapper 启动 |
+| B. `os.execv` 进程内重启 | ComfyUI-Manager, SD.Next | Python 自己 `os.execv(sys.executable, ['python'] + sys.argv)` 原地变身 | 不依赖 wrapper；Linux+CUDA VRAM 不释放（issue #576）、Windows 含空格路径找不到 sys.executable |
+| C. 外部启动器代管 | InvokeAI Launcher, StabilityMatrix, Pinokio | 桌面应用（Electron / Avalonia / etc）spawn/kill 子进程 | 最干净，Python 零自更新代码；要做独立桌面应用 |
+
+**业界共识**：
+
+- 没人热替换代码或 native module（torch / onnxruntime dlopen 后锁文件，Windows 直接装不上）
+- 依赖更新永远走两步：pull → 重启 → entry 比对 → 再 pip
+- 几乎没人保护运行中任务，按下 update 直接强杀
+- ComfyUI-Manager 的 `install-scripts.txt`（LAZY 脚本）和我们的 `pending_install.py` 是同一个 pattern
+- oobabooga 的 `update_wizard` pull 后检查 installer 自身 hash，变了就 abort 让用户重跑 wizard —— 防"半成品启动器"，值得借鉴
+
+## 决策
+
+采用 **A 流派（flag + shell wrapper loop）为主，B 流派（execv）为 fallback**。差异化点 ——
+**强制约束：所有 task 必须 paused / done / canceled 才允许 update**。
+
+### 配套决策
+
+| 维度 | 决策 |
+| --- | --- |
+| Scope | **仅 git clone 部署用户**；未来 PyPI / Docker 走另外的 update 路径，单独 ADR |
+| 自动检查 | **默认开**；启动期**异步**触发（不阻塞冷启动），结果写 `studio_data/.update_cache` (TTL 24h)；后续启动 24h 内复用 cache。失败静默 |
+| 检查目标 | **永远只检查 master**（即使 toggle 开了 / 当前本地是 dev） |
+| 更新通知 | **Topbar 加 update badge**（小红点），仅 master 有新版时显示；点击跳 Settings → 系统 section |
+| 通道 | **默认仅 master**；Settings 高级 toggle「显示开发版更新」开启后解锁"手动检查 dev" + "更新到 dev"按钮；自动检查行为不变 |
+| Telemetry | **不上报**。失败 UI 提供"复制 `.update_log` 到 GitHub Issue 模板"按钮代替 |
+
+## 理由
+
+- 仓库 `studio.sh`/`studio.bat` + `cli.py` + `server.py` 三层结构正好对齐 A1111；改动最小
+- 现有 `pending_install` / `_STALE` / `_web_dist_is_stale` 三大块本来就是为"启动期 bootstrap"设计的，循环复用即可
+- B 的 VRAM 不释放 / 含空格路径 bug 对训练工具特别致命（显存泄漏 = 下一轮 OOM）；保留 fallback 给开发者用
+- C 需要做桌面应用，超出当前项目 scope
+- 任务保护是行业空白点；训练任务损失代价远高于出图，必做
+
+## 架构
+
+### 进程层
+
+```
+studio.sh / studio.bat                    ← OS 级 setup（一次性）
+    while true; do                        ← 新增 loop
+        python -m studio                  ← cli.py 主循环（基本不变）
+        rc=$?
+        if [[ ! -f tmp/restart ]]; then break; fi
+        rm tmp/restart
+        if [[ $rc -eq 42 ]]; then         ← installer 自身变化的退出码
+            echo "[studio] launcher updated, re-exec wrapper"
+            exec "$0" "$@"                ← wrapper 本身也重新执行
+        fi
+    done
+    exit $rc
+```
+
+`studio.bat` 同等改造（goto 语法）。
+
+### Flag 协议
+
+| 文件 | 含义 | 作者 → 读者 |
+| --- | --- | --- |
+| `tmp/restart` | 需要重启 | server → wrapper |
+| `studio_data/.update_pending` | 启动期要 git pull，内容是 target ref（默认 `origin/master`） | server → cli.py |
+| `studio_data/.last_version` | 上一版 HEAD（rollback 用） | cli.py（每次 pull 前写） |
+| `studio_data/.update_log` | 最近一次 update 的日志（pull / pip / 错误） | cli.py |
+
+两层 flag 解耦的原因：`tmp/restart` 只管"重启"，`.update_pending` 管"重启后做什么"。`tmp/` 用 git 忽略，重启即焚；`studio_data/` 是持久化的，保留历史。
+
+### Server 端点
+
+```
+GET  /api/system/version              当前 HEAD / tag / commit 时间 / dirty 状态 / current_branch
+GET  /api/system/update_check?channel=master|dev
+                                       git fetch + 比对，返回 {has_update, latest_tag, latest_sha,
+                                       commits_ahead, changelog_md}
+                                       默认 channel=master；channel=dev 仅当 settings.show_dev_channel=true
+                                       才接受请求（前端 toggle 关时连查询都不发）
+POST /api/system/update               body: {target: "origin/master" | "origin/dev" | "<sha>"}
+                                       前置 has_running_task() 校验 → 写两 flag → 触发 graceful shutdown
+POST /api/system/restart              仅写 tmp/restart（不 pull）
+POST /api/system/rollback             以 .last_version 内容为 target 重新 update
+GET  /api/system/update_log           tail .update_log
+```
+
+每个写操作端点都先调 `supervisor.has_running_task()`，true 则返回 422 + 当前 running task 列表。
+
+**自动检查路径**：cli.py 启动期异步线程 → `updater.check(channel="master")` → 结果写 `studio_data/.update_cache` (含 `checked_at` 时间戳)。下次启动若 cache 未过期（mtime < 24h）则跳过 fetch。Settings 页"手动重新检查"覆盖 cache。
+
+**Dev 通道路径**：toggle 关闭时 UI 完全不暴露 dev 入口；toggle 开后 Settings 加一个"手动检查 dev"按钮（不自动触发，避免开发者 flush master 信号）。点击后单次 `update_check?channel=dev`，结果**不写入** cache（不影响 master 的 update_available 状态）。Topbar badge **仅由 master cache 驱动**，dev 永远不亮 badge。
+
+### Cli.py 改动
+
+`cmd_run` 主流程：
+
+```python
+def cmd_run(args):
+    while True:
+        rc = _ensure_python_deps()
+        if rc != 0: return rc
+
+        # 新增：检测 update pending，先 git pull 再走 bootstrap
+        _apply_update_pending()             # 读 .update_pending, git pull, 写 .last_version, 清 flag
+
+        # 现有：build / pending_install / torch / onnx
+        ...
+
+        # 新增：installer 自身变化检测（学 oobabooga）
+        if _installer_changed_since_start():
+            print("[studio] launcher 代码已更新，请用 wrapper 重启")
+            return 42                       # 特殊退出码，wrapper 看到会 exec 自己
+
+        rc = subprocess.call([sys.executable, "-m", "studio.server", ...])
+
+        # 现有：阻塞结束后判断是否要重启
+        flag = REPO_ROOT / "tmp" / "restart"
+        if not flag.exists():
+            return rc
+        flag.unlink()
+        # loop continue
+```
+
+`_installer_changed_since_start()`：进程启动期记录 `cli.py` + `studio.sh` + `studio.bat` 的 sha256，server 退出后再算，变化即 true。**必须在 wrapper loop 之外退出**（exit 42），否则跑的还是旧 wrapper / 旧 cli.py。
+
+### Updater 模块
+
+`studio/services/updater.py`：
+
+```python
+def check() -> UpdateInfo: ...
+    # git fetch origin
+    # git rev-list HEAD..origin/master --count
+    # 拉 latest tag + changelog 段落
+
+def request_update(target: str = "origin/master") -> None:
+    # 1. precondition: 无 running task
+    # 2. precondition: git status --porcelain 干净
+    # 3. write .update_pending = target
+    # 4. write tmp/restart
+    # 5. trigger uvicorn graceful shutdown (server.should_exit = True)
+
+def apply_pending() -> ApplyResult:                # cli.py 启动期调
+    if not has_pending(): return
+    target = read_pending()
+    write(LAST_VERSION, current_head())
+
+    rc = subprocess.call(["git", "pull", "--ff-only", "origin", target])
+    if rc != 0: return failed("git pull failed")
+
+    if requirements_sha_changed():
+        new_native = diff_requirements_for_native_packages()  # torch / onnx
+        for pkg in new_native:
+            pending_install.queue(pkg)                        # 复用现有机制
+        # pure python deps 直接装
+        subprocess.call([sys.executable, "-m", "pip", "install", "-r", "requirements.txt"])
+
+    if web_package_json_changed():
+        subprocess.call(["npm", "install"], cwd=WEB_DIR)
+
+    clear_pending()
+    return ok()
+
+def rollback() -> None:
+    target = read(LAST_VERSION)
+    request_update(target)                          # 走相同的 update 流程
+```
+
+`apply_pending` 在 `cli.py:cmd_run` 主流程顶端调，**先于** `_ensure_python_deps` 之外的所有 bootstrap 步（因为新版可能改了 deps 列表）。
+
+### UI
+
+Settings → 新加「系统」section（或独立 tab，跟 #36 重排后的 6 tab 结构契合）。
+
+**默认状态**（toggle 关，绝大多数用户看到的样子）：
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 版本                                                │
+│   当前  v0.6.0  (commit 879378e · 2 days ago)       │
+│   最新  v0.6.1  (commit abc1234 · 3h ago)           │
+│   ↑ 5 commits ahead                                 │
+│                                                     │
+│   [查看 CHANGELOG]  [立即更新]  [回滚到 v0.6.0]    │
+│                                                     │
+│   自动检查更新  ☑   每 24 小时                      │
+│                                                     │
+│   ─────────────────────────────                     │
+│   ▸ 高级设置                                        │
+└─────────────────────────────────────────────────────┘
+```
+
+**Toggle 开启后**（点开"高级设置"折叠 → 勾选"显示开发版更新"）：
+
+```
+┌─────────────────────────────────────────────────────┐
+│ 版本                                                │
+│   当前  v0.6.0  (commit 879378e · 2 days ago)       │
+│   最新  v0.6.1  (commit abc1234 · 3h ago)           │
+│   ↑ 5 commits ahead                                 │
+│                                                     │
+│   [查看 CHANGELOG]  [立即更新 (稳定)]               │
+│   [回滚到 v0.6.0]                                   │
+│                                                     │
+│   自动检查更新  ☑   每 24 小时（仅检查稳定通道）    │
+│                                                     │
+│   ─────────────────────────────                     │
+│   ▾ 高级设置                                        │
+│   显示开发版更新  ☑                                 │
+│                                                     │
+│   开发版通道（dev，用于开发 / 测试）                │
+│   [手动检查 dev]                                    │
+│   ─ 检查后显示 ─                                    │
+│   dev  commit ef56789                               │
+│   ↑ 12 commits ahead of master (2h ago)             │
+│   [查看 dev diff]  [更新到 dev]                     │
+│   ⚠️ dev 未经发布测试，可能引入崩溃 / 训练异常       │
+└─────────────────────────────────────────────────────┘
+```
+
+**「立即更新」点击流程**（master 通道）：
+
+1. 前端检查 `/api/queue/running` —— 有 running task 则禁用按钮 + tooltip 显示当前 task
+2. 弹模态："将关闭并重启 studio。预计 1-3 分钟。期间 webui 不可访问。"
+3. POST `/api/system/update` `{target: "origin/master"}`，server 写 flag 后 200 响应
+4. 前端进入"更新中"状态卡片：阶段（git pull → pip → 重启）+ 自动轮询 `/api/health`
+5. server 起来后 reconnect → toast "已更新到 v0.6.1" + 自动刷新页面
+6. 失败时：拉 `/api/system/update_log` 显示 + 提示"请用 shell wrapper 重启 / 联系开发者"
+
+**「更新到 dev」点击流程**：
+
+1. 同样的 running task 检查
+2. 弹模态额外加红色警告："这是开发版，可能不稳定。回滚需要单独操作。"
+3. POST `/api/system/update` `{target: "origin/dev"}`，其余路径同上
+4. 成功后 toast "已更新到 dev (commit ef56789)" —— 不显示 tag（dev 没有）
+
+**Topbar badge**：
+
+- 仅 master cache `has_update=true` 时显示小红点
+- Dev 即使有新 commit 也不亮 badge（避免持续骚扰开发者）
+- 点击 badge 直接跳 Settings → 系统 section
+
+### Pending install 复用
+
+新版 `requirements.txt` 含 native module 改版（torch / onnxruntime）时，**不在 update 当下 install**（旧 venv 进程仍 import 着），写到 `pending_install` 队列。下次启动期 `_apply_pending_install` 阶段执行 —— 那时新 venv 进程 freshly 起，没有 torch 已 loaded 的问题。
+
+这条逻辑已经现成（[`studio/services/pending_install.py`](../../studio/services/pending_install.py)），不需要新代码。
+
+## 状态机
+
+```
+Idle ──[check]──> HasUpdate ──[update click]──> CheckPrecondition
+                                                    │
+                              has running task ─────┤ → 422 "暂停所有任务后再试"
+                                                    │
+                              local dirty ──────────┤ → 422 "本地有未提交修改"
+                                                    │
+                                              all clean
+                                                    ↓
+                                          WriteFlag + ServerShutdown
+                                                    ↓
+                                      CliLoop._apply_update_pending
+                                                    ↓
+                                            git pull, write .last_version
+                                                    ↓
+                                  requirements 改？──── yes ──> pip install / pending_install.queue
+                                                    │
+                                                    ↓
+                                  installer 改？──── yes ──> exit 42 → wrapper exec self
+                                                    │
+                                                    no
+                                                    ↓
+                                       subprocess.call(server) → Idle
+```
+
+## 失败模式
+
+| 故障 | 影响 | 兜底 |
+| --- | --- | --- |
+| `git pull` 冲突（本地未提交） | 不更新，server 重新起 | precondition 检查阶段拒绝；UI 显示 dirty 文件列表 |
+| `git pull` 网络失败 | 同上 | `.update_log` 记录，UI 显示 |
+| `pip install` 失败 | server 可能起不来 | `.last_version` 自动 rollback + UI 提示 |
+| Native module 锁定 | 改装 venv 时 .pyd 占用 | 走 `pending_install` 延迟到 fresh 进程；新版 entry 检测不到必装件则 fail-fast |
+| 用户 direct `python -m studio` 启动 | restart 不工作（执行 `tmp/restart` 创建但无 wrapper loop） | cli.py 检测 `parent_pid` 是不是 studio.sh / studio.bat，否则 update 端点返回 400 提示用 wrapper |
+| 更新到坏版本（server 起不来） | webui 一直黑屏 | wrapper 检测连续 N 次 server 启动失败后 abort + 命令行 hint 用户 `git reset --hard <last_version>` |
+| 训练任务跑一半被强杀 | LoRA 进度丢失 | precondition 强制约束（必须前置完成「暂停训练」feature） |
+| `os.execv` 路径含空格（Windows） | execv fallback 走不通 | cli.py 启动期检测路径含空格则禁用 execv，强制要求用 wrapper |
+
+## 实施步骤（按 PR 拆分）
+
+1. **PR-A：基础重启链路**（不含 git pull）
+   - `tmp/restart` flag + `cli.py` loop + `studio.sh`/`studio.bat` 改 wrapper loop
+   - `/api/system/restart` 端点 + Settings UI「重启 server」按钮
+   - 验证：webui 重启 server，shell wrapper / direct python 两路径都通
+   - 工作量 ~1 天
+
+2. **PR-B：update 主路径**
+   - `updater.py` + `/api/system/update_check` / `/update` 端点
+   - `apply_pending` 在 cli.py 启动期 hook
+   - Settings UI 版本 section
+   - 工作量 ~1.5 天
+
+3. **PR-C：回滚 + 日志 + 失败处理**
+   - `.last_version` rollback + `/api/system/rollback`
+   - `update_log` tail + UI 失败提示
+   - 工作量 ~1 天
+
+4. **PR-D：installer 自检**
+   - cli.py / studio.sh / studio.bat sha256 比对
+   - 退出码 42 协议 + wrapper exec self 路径
+   - 工作量 ~半天
+
+5. **PR-E：跨平台 QA**
+   - Windows + Linux + macOS（如有）wrapper loop / 进程退出 / flag 文件竞态
+   - 含空格路径 / 中文路径 / 异常退出 / 持续故障的 fallback
+   - 工作量 ~1 天
+
+**总 ~5 天**。前置依赖：**暂停训练 feature 必须先落地**（PR-B 的 precondition 才有意义）。
+
+## 已决细节
+
+讨论后确认的设计选择（与「配套决策」表对应的扩展说明）：
+
+1. **自动检查（合并原 Q1 + Q6）**：默认开 + 异步触发 + 24h cache。Cache 写到 `studio_data/.update_cache`，TTL 用 mtime 判断。失败静默（公司网络 / 国内访问 github 不稳，不应阻塞启动）。Settings 提供"手动重新检查"覆盖 cache
+2. **通知**：Topbar 加 update badge（小红点），点击跳 Settings → 系统 section。仅 master 触发 badge
+3. **dev 通道**：默认隐藏在 Settings 高级设置；toggle 开后解锁"手动检查 dev" + "更新到 dev"两个按钮。自动检查仍只 fetch master，避免开发者被高频 commit 持续骚扰。Rollback 协议**必须兼容 commit hash**（dev 没有 tag）
+4. **Telemetry**：不做。失败 UI 给"复制 update_log 到 GitHub Issue 模板"按钮代替
+5. **Scope**：仅 git clone 用户。PyPI / Docker 路径不在本 ADR scope，未来另起 ADR
+
+## 后果
+
+**收益**：
+
+- 用户不再走 CLI 即可升级
+- 跟暂停 feature 配套形成完整"无痛升级"故事，差异化竞争点
+- 复用现有 bootstrap / pending_install / stale_check 三大块，最大化代码复用
+
+**新增约束**：
+
+- 必须用 `studio.sh` / `studio.bat` 启动才能享受完整 update 流程（已经是文档推荐路径，但现在变成事实必须）
+- 自动 git pull 意味着 master commit 即用户的生产代码，回归测试压力变大（建议未来引入 staging：dev → master 前内部跑一轮全 e2e）
+- 训练任务暂停 feature 成为前置 hard dependency
+
+**未来的债**：
+
+- 大版本（0.x → 1.0 含 db schema 迁移）的 update 路径要单独设计，本 ADR 不覆盖
+- 多用户场景（如果以后做 server 共享）update 触发权限要加 ACL
+- update 失败 rollback 路径如果 venv 也坏了（pending_install 卸载半完成态）不工作 —— 真坏的情况只能让用户走 shell `./studio.sh --reinstall`，UI 端不补救
+
+## 参考
+
+- 业界调研：[A1111 restart.py](https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/restart.py) / [ComfyUI-Manager manager_server.py](https://github.com/Comfy-Org/ComfyUI-Manager/blob/main/glob/manager_server.py) / [oobabooga one_click.py](https://github.com/oobabooga/text-generation-webui/blob/main/one_click.py) / [SwarmUI AdminAPI.cs](https://github.com/mcmonkeyprojects/SwarmUI/blob/master/src/WebAPI/AdminAPI.cs)
+- 仓库现有机制：[`studio/cli.py:cmd_run`](../../studio/cli.py) / [`studio/services/pending_install.py`](../../studio/services/pending_install.py) / [`studio.sh:135-148`](../../studio.sh) / [`runtime/anima_train.py:2374-2401`](../../runtime/anima_train.py)
+- 暂停训练前置 feature：单独 ADR / PR 跟进

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -7,6 +7,7 @@
 | # | 标题 | 状态 | 日期 |
 |---|---|---|---|
 | 0001 | [LoKr 适配器走 lycoris-lora 而不切 sd-scripts](0001-lokr-via-lycoris-lora.md) | Accepted | 2025 |
+| 0002 | [Webui 内自更新（flag + shell wrapper loop）](0002-webui-self-update.md) | Proposed | 2026-05-12 |
 
 ## 状态值
 

--- a/studio.bat
+++ b/studio.bat
@@ -143,12 +143,24 @@ if "!STALE!"=="stale" (
 
 REM Restart loop (PR-A): if cli.py exits but tmp\restart still present, loop
 REM back. cli.py's own inner loop handles the common case (server requests
-REM restart); this outer loop is the safety net for PR-D's installer self-update
-REM path. See docs\adr\0002-webui-self-update.md.
+REM restart); this outer loop is the safety net.
+REM
+REM Special exit code 42 (PR-D, installer self-update): cli.py detected that
+REM cli.py / studio.sh / studio.bat itself was just replaced. cmd.exe has the
+REM .bat parsed in memory; if we keep looping, we risk running stale wrapper
+REM logic. So we `start` a fresh copy of ourselves and exit. Unlike POSIX
+REM `exec`, this spawns a new process (different PID) -- /b keeps the same
+REM console window, so the user-visible effect is the same. See ADR 0002.
 :run_loop
 !PYTHON! -m studio %PASSTHROUGH%
 set STUDIO_ERR=%ERRORLEVEL%
 if exist tmp\restart (
+    if !STUDIO_ERR! EQU 42 (
+        echo [studio] launcher updated, re-exec wrapper
+        del /q tmp\restart 2>nul
+        start "" /b "%~f0" %PASSTHROUGH%
+        exit /b 0
+    )
     echo [studio] restart requested ^(wrapper loop^)
     del /q tmp\restart 2>nul
     goto run_loop

--- a/studio.bat
+++ b/studio.bat
@@ -141,8 +141,19 @@ if "!STALE!"=="stale" (
     )
 )
 
+REM Restart loop (PR-A): if cli.py exits but tmp\restart still present, loop
+REM back. cli.py's own inner loop handles the common case (server requests
+REM restart); this outer loop is the safety net for PR-D's installer self-update
+REM path. See docs\adr\0002-webui-self-update.md.
+:run_loop
 !PYTHON! -m studio %PASSTHROUGH%
 set STUDIO_ERR=%ERRORLEVEL%
+if exist tmp\restart (
+    echo [studio] restart requested ^(wrapper loop^)
+    del /q tmp\restart 2>nul
+    goto run_loop
+)
+
 if %STUDIO_ERR% NEQ 0 (
     echo.
     echo [studio] Exit code %STUDIO_ERR%. Press any key to close...

--- a/studio.sh
+++ b/studio.sh
@@ -148,8 +148,22 @@ if [ "$_STALE" = "stale" ]; then
 fi
 
 echo "studio.sh: using $PYTHON"
-"$PYTHON" -m studio "${_PASSTHROUGH[@]}"
-EXIT_CODE=$?
+
+# Restart loop (PR-A): if cli.py exits but tmp/restart is still present, loop
+# back and re-run. cli.py's own inner loop handles the common case (server
+# requests restart from /api/system/restart); this outer loop is the safety net
+# for PR-D's installer self-update path where cli.py itself was just replaced.
+# See docs/adr/0002-webui-self-update.md.
+while true; do
+    "$PYTHON" -m studio "${_PASSTHROUGH[@]}"
+    EXIT_CODE=$?
+    if [ ! -f tmp/restart ]; then
+        break
+    fi
+    echo "[studio] restart requested (wrapper loop)"
+    rm -f tmp/restart
+done
+
 if [ $EXIT_CODE -ne 0 ]; then
     echo ""
     echo "[studio] Exit code $EXIT_CODE, see error messages above."

--- a/studio.sh
+++ b/studio.sh
@@ -151,14 +151,25 @@ echo "studio.sh: using $PYTHON"
 
 # Restart loop (PR-A): if cli.py exits but tmp/restart is still present, loop
 # back and re-run. cli.py's own inner loop handles the common case (server
-# requests restart from /api/system/restart); this outer loop is the safety net
-# for PR-D's installer self-update path where cli.py itself was just replaced.
-# See docs/adr/0002-webui-self-update.md.
+# requests restart from /api/system/restart); this outer loop is the safety net.
+#
+# Special exit code 42 (PR-D, installer self-update): cli.py detected that
+# cli.py / studio.sh / studio.bat itself was just replaced by `git reset`, and
+# kept tmp/restart so we'd see it. We `exec` ourselves so the new wrapper code
+# is loaded from disk (bash has the old loop body in memory; the new wrapper
+# might have different bootstrap / dep-install logic). See ADR 0002.
+# We exec with _PASSTHROUGH only (not original "$@") so --reinstall does not
+# get re-triggered.
 while true; do
     "$PYTHON" -m studio "${_PASSTHROUGH[@]}"
     EXIT_CODE=$?
     if [ ! -f tmp/restart ]; then
         break
+    fi
+    if [ "$EXIT_CODE" -eq 42 ]; then
+        echo "[studio] launcher updated, re-exec wrapper"
+        rm -f tmp/restart
+        exec "$0" "${_PASSTHROUGH[@]}"
     fi
     echo "[studio] restart requested (wrapper loop)"
     rm -f tmp/restart

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -511,32 +511,61 @@ def _web_dist_is_stale() -> bool:
     return False
 
 
+_RESTART_FLAG = REPO_ROOT / "tmp" / "restart"
+
+
 def cmd_run(args: argparse.Namespace) -> int:
-    rc = _ensure_python_deps()
-    if rc != 0:
-        return rc
-    if not args.no_build:
-        if not WEB_DIST.exists():
-            print("[studio] studio/web/dist 不存在，先构建前端...")
-            rc = cmd_build(args)
-            if rc != 0:
-                return rc
-        elif _web_dist_is_stale():
-            print("[studio] studio/web/dist 比 src 旧（git pull 后未重建？），重新构建前端...")
-            rc = cmd_build(args)
-            if rc != 0:
-                return rc
-    _apply_pending_install()
-    _check_torch_cuda()
-    _try_enable_flash_attn()
-    _bootstrap_onnxruntime()
-    url = f"http://{args.host}:{args.port}/studio/"
-    print(f"[studio] 启动后端 → {url}")
-    if not args.no_browser:
-        _spawn_browser_opener(url)
-    return subprocess.call(
-        [find_python(), "-m", "studio.server", "--host", args.host, "--port", str(args.port)]
-    )
+    """`run` 主循环。
+
+    内层 loop：每次 server 退出后检查 `tmp/restart` 标志（由 server 端
+    `/api/system/restart` 写）。存在则删除标志 + 重走 bootstrap + 重起 server；
+    不存在则跳出，正常退出。
+
+    重启协议详见 `docs/adr/0002-webui-self-update.md`。外层 shell wrapper
+    (`studio.sh` / `studio.bat`) 也有同样的 loop 兜底（cli.py 异常退出但
+    flag 还在的场景，主要给后续 PR-D 的 installer 自更新用）。
+
+    冷启动只打开一次浏览器；重启时复用已存在的 webui 标签页（前端轮询
+    `/api/health` 自动 reconnect），不重复弹新窗口。
+    """
+    opened_browser = False
+    while True:
+        rc = _ensure_python_deps()
+        if rc != 0:
+            return rc
+        if not args.no_build:
+            if not WEB_DIST.exists():
+                print("[studio] studio/web/dist 不存在，先构建前端...")
+                rc = cmd_build(args)
+                if rc != 0:
+                    return rc
+            elif _web_dist_is_stale():
+                print("[studio] studio/web/dist 比 src 旧（git pull 后未重建？），重新构建前端...")
+                rc = cmd_build(args)
+                if rc != 0:
+                    return rc
+        _apply_pending_install()
+        _check_torch_cuda()
+        _try_enable_flash_attn()
+        _bootstrap_onnxruntime()
+        url = f"http://{args.host}:{args.port}/studio/"
+        print(f"[studio] 启动后端 → {url}")
+        if not args.no_browser and not opened_browser:
+            _spawn_browser_opener(url)
+            opened_browser = True
+        rc = subprocess.call(
+            [find_python(), "-m", "studio.server", "--host", args.host, "--port", str(args.port)]
+        )
+
+        if not _RESTART_FLAG.exists():
+            return rc
+
+        # 收到重启请求：删除标志 + loop 回去重新 bootstrap
+        try:
+            _RESTART_FLAG.unlink()
+        except OSError:
+            pass
+        print("[studio] 收到重启请求，重新启动...")
 
 
 def cmd_dev(args: argparse.Namespace) -> int:

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import os
 import shutil
 import signal
@@ -513,6 +514,35 @@ def _web_dist_is_stale() -> bool:
 
 _RESTART_FLAG = REPO_ROOT / "tmp" / "restart"
 
+# PR-D — installer 自检（ADR 0002）。cmd_run 入口快照这三个文件的 sha256；
+# 每次 server 退出 + 收到 restart 请求时再算一次，任一变化 → 返回退出码 42
+# 让 wrapper（studio.sh / studio.bat）整体 exec 自己。原因：
+#
+# - cli.py 本身变更 → 旧 python 进程加载的是旧 cli.py，next-iteration 的 inner
+#   loop 仍走老逻辑；只有让 wrapper 重新拉 `python -m studio` 才能拿到新 cli.py。
+# - studio.sh / studio.bat 变更 → bash 已把 loop 体加载进内存，cmd.exe 也可能
+#   缓存 .bat 解析结果；必须让 shell 进程 exec 自己拿到新 wrapper。
+#
+# 三个文件中任一变化都走同一协议（最简单 / 最稳）。
+_INSTALLER_FILES: tuple[Path, ...] = (
+    REPO_ROOT / "studio" / "cli.py",
+    REPO_ROOT / "studio.sh",
+    REPO_ROOT / "studio.bat",
+)
+_INSTALLER_RELOAD_EXIT_CODE = 42
+
+
+def _installer_hashes() -> dict[str, Optional[str]]:
+    """快照 installer 文件 sha256。文件不存在 → 值为 None（跨平台：Linux 上
+    studio.bat 不存在，Windows 上 studio.sh 不存在；存在性也算入比对）。"""
+    result: dict[str, Optional[str]] = {}
+    for p in _INSTALLER_FILES:
+        try:
+            result[p.name] = hashlib.sha256(p.read_bytes()).hexdigest()
+        except OSError:
+            result[p.name] = None
+    return result
+
 
 def _apply_update_pending() -> None:
     """启动期处理 webui 触发的 update 请求（ADR 0002 / PR-B）。
@@ -550,12 +580,17 @@ def cmd_run(args: argparse.Namespace) -> int:
 
     重启协议详见 `docs/adr/0002-webui-self-update.md`。外层 shell wrapper
     (`studio.sh` / `studio.bat`) 也有同样的 loop 兜底（cli.py 异常退出但
-    flag 还在的场景，主要给后续 PR-D 的 installer 自更新用）。
+    flag 还在的场景），并且响应退出码 42 把自己 exec 一遍（PR-D installer
+    自检：当 cli.py / studio.sh / studio.bat 本身被 update 修改后，需要从
+    磁盘重新加载 wrapper + Python 解释器）。
 
     冷启动只打开一次浏览器；重启时复用已存在的 webui 标签页（前端轮询
     `/api/health` 自动 reconnect），不重复弹新窗口。
     """
     opened_browser = False
+    # PR-D：快照启动期 installer 文件 sha256；server 退出后重算，变化则
+    # 退出码 42 让 wrapper 整体 exec 自己。
+    startup_installer = _installer_hashes()
     while True:
         rc = _ensure_python_deps()
         if rc != 0:
@@ -593,6 +628,15 @@ def cmd_run(args: argparse.Namespace) -> int:
 
         if not _RESTART_FLAG.exists():
             return rc
+
+        # PR-D：installer 自检。restart flag 存在的前提下，若 cli.py /
+        # studio.sh / studio.bat 任一变化，**保留** flag 并返回 42，让 wrapper
+        # 走 exec self 路径。flag 保留是关键 —— wrapper 检测到 (exit==42 &&
+        # flag exists) 才会 re-exec；只剩 flag 而 exit!=42 则走普通 restart。
+        if _installer_hashes() != startup_installer:
+            print("[studio] 检测到 launcher 文件更新（cli.py / studio.sh / studio.bat），"
+                  "退出码 42 让 wrapper 重新加载...")
+            return _INSTALLER_RELOAD_EXIT_CODE
 
         # 收到重启请求：删除标志 + loop 回去重新 bootstrap
         try:

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -514,6 +514,33 @@ def _web_dist_is_stale() -> bool:
 _RESTART_FLAG = REPO_ROOT / "tmp" / "restart"
 
 
+def _apply_update_pending() -> None:
+    """启动期处理 webui 触发的 update 请求（ADR 0002 / PR-B）。
+
+    server 端 POST /api/system/update 写 studio_data/.update_pending 后通过
+    SIGINT 退出。我们在 cli.py 主循环里下一轮 bootstrap 之前调这个函数完成：
+
+    1. git fetch + git reset --hard {target}
+    2. requirements.txt 变了 → pip install -r（增量）
+    3. studio/web/package.json 变了 → npm install
+    4. 清 update cache 让下次 check_update 重 fetch
+
+    失败不抛 —— `apply_pending` 内部把错误写到 studio_data/.update_log，
+    让 cli.py 继续走后面的 bootstrap 把 server 至少起回来（用户能在 UI
+    看到"上次 update 失败"提示）。
+    """
+    try:
+        from studio.services import updater  # noqa: PLC0415
+        if not updater.has_pending():
+            return
+        updater.apply_pending(emit=print)
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[studio] 警告：apply update pending 时异常（{exc}），跳过",
+            file=sys.stderr,
+        )
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     """`run` 主循环。
 
@@ -533,6 +560,13 @@ def cmd_run(args: argparse.Namespace) -> int:
         rc = _ensure_python_deps()
         if rc != 0:
             return rc
+
+        # 检测 update pending（ADR 0002 / PR-B）：上一轮 server 写了
+        # studio_data/.update_pending 并请求重启，这里在重新 bootstrap 之前
+        # 先 git pull + 必要时 pip install / npm install，确保后续的 stale
+        # 检查 / native module 加载用的都是新版代码 / 新版依赖。
+        _apply_update_pending()
+
         if not args.no_build:
             if not WEB_DIST.exists():
                 print("[studio] studio/web/dist 不存在，先构建前端...")

--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -390,6 +390,17 @@ class GenerateConfig(BaseModel):
     attention_backend: str = "auto"
 
 
+class SystemConfig(BaseModel):
+    """系统级偏好（ADR 0002 / PR-D）。
+
+    - `show_dev_channel`：Settings 高级里勾选"显示开发版更新"后变 True。
+      开启时 UI 暴露"手动检查 dev"+"更新到 dev"按钮；自动检查仍只 fetch
+      master，Topbar badge 永不亮 dev（避免开发者被 dev commit 持续骚扰）。
+      默认 False —— 绝大多数用户看到的是只 master 的简化界面。
+    """
+    show_dev_channel: bool = False
+
+
 class Secrets(BaseModel):
     gelbooru: GelbooruConfig = Field(default_factory=GelbooruConfig)
     danbooru: DanbooruConfig = Field(default_factory=DanbooruConfig)
@@ -408,6 +419,7 @@ class Secrets(BaseModel):
     models: ModelsConfig = Field(default_factory=ModelsConfig)
     queue: QueueConfig = Field(default_factory=QueueConfig)
     generate: GenerateConfig = Field(default_factory=GenerateConfig)
+    system: SystemConfig = Field(default_factory=SystemConfig)
 
 
 # ---------------------------------------------------------------------------

--- a/studio/server.py
+++ b/studio/server.py
@@ -3191,21 +3191,25 @@ def system_rollback(background: BackgroundTasks) -> dict[str, Any]:
 
 @app.get("/api/system/update_status")
 def system_update_status() -> dict[str, Any]:
-    """最近一次 update 的结构化结果（PR-C）。
+    """最近一次 update 的结构化结果 + rollback target（PR-C）。
+
+    rollback_target 与 status 解耦：即使从未走过 update（.update_status 不存在），
+    只要 .last_version 指向的 commit 还在仓库里，回滚按钮就应当能用（user 手动
+    git reset 后想"还原到上一版"也是合法场景）。
 
     UI 上：
-    - 文件不存在 / null：没有 update 历史，不展示 banner
+    - status=null：没有 update 历史，不展示 banner / 不展示"查看上次日志"按钮
     - status='ok'：可选展示"已更新到 X，X 秒前"
-    - status='aborted' / 'failed' / 'partial'：红色 banner + 原因 + 跳到日志
+    - status='aborted' / 'failed' / 'partial'：红色 banner + reason + 跳日志
+    - rollback_target 非 null（不依赖 status）：显示"切换到 sha"按钮
     """
     from dataclasses import asdict
+    rollback_to = updater.rollback_target()
     st = updater.last_status()
     if st is None:
-        return {"status": None}
-    rollback_to = updater.rollback_target()
+        return {"status": None, "rollback_target": rollback_to}
     return {
         **asdict(st),
-        # 顺带把 rollback target 也带回去，UI 用这个判断"是否显示回滚按钮"
         "rollback_target": rollback_to,
     }
 

--- a/studio/server.py
+++ b/studio/server.py
@@ -3029,6 +3029,59 @@ if WEB_DIST.exists():
     )
 
 
+# ---------------------------------------------------------------------------
+# /api/system — 进程生命周期（重启 / 更新 / 回滚）
+# ---------------------------------------------------------------------------
+#
+# 重启协议（参见 docs/adr/0002-webui-self-update.md）：
+#   1. server 写 REPO_ROOT/tmp/restart 标志
+#   2. server 通过 BackgroundTask 在响应发出后给自己发 SIGINT
+#   3. uvicorn 捕获 SIGINT 走 graceful shutdown（lifespan teardown + 在飞请求收尾）
+#   4. 进程退出 → cli.py 的 subprocess.call 返回
+#   5. cli.py 检测到 tmp/restart 存在 → 删除标志 → loop 回去重新 bootstrap + 起 server
+#
+# 跨平台 SIGINT：用 signal.raise_signal(SIGINT)（Python 3.8+），它在 Windows /
+# POSIX 都把当前进程置为收到 SIGINT，uvicorn 的内置 handler 会按 graceful
+# 路径处理。os.kill(getpid, SIGINT) 在 Windows 上不工作。
+#
+# PR-A 仅实现 /restart（不带 git pull / 不检查 running task）。PR-B / PR-C
+# 在此基础上叠加 update / rollback / 任务保护。
+
+
+_RESTART_FLAG = REPO_ROOT / "tmp" / "restart"
+
+
+def _raise_sigint_after_response() -> None:
+    """在响应已经发完后给自己发 SIGINT，触发 uvicorn graceful shutdown。
+
+    BackgroundTask 在 starlette 路径上是 response 完成后调度的；这里再 sleep
+    一点点保险（防止某些代理 / keep-alive 情况下还有数据没冲走）。
+    """
+    import signal
+    time.sleep(0.3)
+    try:
+        signal.raise_signal(signal.SIGINT)
+    except Exception:
+        # 兜底：硬退（不应该走到）
+        os._exit(0)
+
+
+@app.post("/api/system/restart")
+def system_restart(background: BackgroundTasks) -> dict[str, Any]:
+    """重启 server（不 pull 代码）。
+
+    流程：写 tmp/restart 标志 → 响应 200 → BackgroundTask 发 SIGINT 触发
+    uvicorn graceful shutdown → cli.py loop 拾起 → 重新起新 server。
+
+    PR-A 范围：不检查 running task（用户自己判断）。PR-B 会加 has_running_task
+    强制约束（训练任务进行中拒绝重启）。
+    """
+    _RESTART_FLAG.parent.mkdir(parents=True, exist_ok=True)
+    _RESTART_FLAG.touch()
+    background.add_task(_raise_sigint_after_response)
+    return {"ok": True, "message": "restart scheduled"}
+
+
 @app.get("/", response_model=None)
 def root() -> RedirectResponse | JSONResponse:
     """根路径 302 跳转到 React 应用 `/studio/`。

--- a/studio/server.py
+++ b/studio/server.py
@@ -69,6 +69,7 @@ from .services import (
     system_stats,
     tagedit,
     train_io,
+    updater,
     uploads as uploads_svc,
     version_config,
     xformers_setup,
@@ -3066,6 +3067,31 @@ def _raise_sigint_after_response() -> None:
         os._exit(0)
 
 
+def _check_no_running_tasks() -> None:
+    """重启 / 更新前置：所有 task 必须 done / failed / canceled / pending。
+
+    有 running 直接 422 + task 列表，让前端给用户友好的提示（"先暂停以下任务"）。
+    """
+    with db.connection_for() as conn:
+        running = db.list_tasks(conn, status="running")
+    if running:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "running_tasks_present",
+                "message": "有任务正在运行，请先取消 / 等待完成",
+                "tasks": [
+                    {
+                        "id": t["id"],
+                        "name": t.get("name", ""),
+                        "task_type": t.get("task_type", "train"),
+                    }
+                    for t in running
+                ],
+            },
+        )
+
+
 @app.post("/api/system/restart")
 def system_restart(background: BackgroundTasks) -> dict[str, Any]:
     """重启 server（不 pull 代码）。
@@ -3073,13 +3099,59 @@ def system_restart(background: BackgroundTasks) -> dict[str, Any]:
     流程：写 tmp/restart 标志 → 响应 200 → BackgroundTask 发 SIGINT 触发
     uvicorn graceful shutdown → cli.py loop 拾起 → 重新起新 server。
 
-    PR-A 范围：不检查 running task（用户自己判断）。PR-B 会加 has_running_task
-    强制约束（训练任务进行中拒绝重启）。
+    PR-B 起加 running task 强制约束。
     """
+    _check_no_running_tasks()
     _RESTART_FLAG.parent.mkdir(parents=True, exist_ok=True)
     _RESTART_FLAG.touch()
     background.add_task(_raise_sigint_after_response)
     return {"ok": True, "message": "restart scheduled"}
+
+
+@app.get("/api/system/version")
+def system_version() -> dict[str, Any]:
+    """当前仓库状态：__version__ / commit / tag / branch / dirty。"""
+    from dataclasses import asdict
+    return asdict(updater.current_version())
+
+
+@app.get("/api/system/update_check")
+def system_update_check(channel: str = "master", force: bool = False) -> dict[str, Any]:
+    """git fetch + 比对。master 通道用 24h cache（force=true 强制重 fetch）；
+    dev 通道每次都 fetch，不缓存（开发者主动触发，避免污染 master 信号）。
+    """
+    from dataclasses import asdict
+    if channel not in ("master", "dev"):
+        raise HTTPException(400, f"invalid channel: {channel}")
+    return asdict(updater.check_update(channel=channel, use_cache=not force))
+
+
+class UpdateRequest(BaseModel):
+    target: str = "origin/master"  # ref / commit sha / origin/branch
+
+
+@app.post("/api/system/update")
+def system_update(body: UpdateRequest, background: BackgroundTasks) -> dict[str, Any]:
+    """请求 update：precondition 校验 + 写 .update_pending + 触发重启。
+
+    实际 git pull 在 cli.py 启动期 updater.apply_pending() 完成（避免在 server
+    进程里跑 git pull，规避 native module 已锁的问题）。
+    """
+    _check_no_running_tasks()
+
+    cur = updater.current_version()
+    if cur.is_dirty:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "dirty_working_tree",
+                "message": "本地有未提交的修改，请先 commit / stash",
+            },
+        )
+
+    updater.request_update(body.target)
+    background.add_task(_raise_sigint_after_response)
+    return {"ok": True, "message": f"update scheduled → {body.target}"}
 
 
 @app.get("/", response_model=None)

--- a/studio/server.py
+++ b/studio/server.py
@@ -3154,6 +3154,68 @@ def system_update(body: UpdateRequest, background: BackgroundTasks) -> dict[str,
     return {"ok": True, "message": f"update scheduled → {body.target}"}
 
 
+@app.post("/api/system/rollback")
+def system_rollback(background: BackgroundTasks) -> dict[str, Any]:
+    """回滚到 .last_version 记录的上一版本（PR-C）。
+
+    走与正向 update 完全一致的路径（写 .update_pending=<sha> + tmp/restart
+    → cli.py 启动期 apply_pending 实际 reset），所以 dirty / running task
+    precondition 一样适用，回滚成功后 .last_version 会被写成"回滚前的版本"
+    （即正向)，支持来回切。
+    """
+    _check_no_running_tasks()
+
+    cur = updater.current_version()
+    if cur.is_dirty:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "dirty_working_tree",
+                "message": "本地有未提交的修改，请先 commit / stash",
+            },
+        )
+
+    target = updater.request_rollback()
+    if target is None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "no_rollback_target",
+                "message": ".last_version 不存在或 commit 已不在仓库里（被 GC？）",
+            },
+        )
+
+    background.add_task(_raise_sigint_after_response)
+    return {"ok": True, "message": f"rollback scheduled → {target[:8]}", "target": target}
+
+
+@app.get("/api/system/update_status")
+def system_update_status() -> dict[str, Any]:
+    """最近一次 update 的结构化结果（PR-C）。
+
+    UI 上：
+    - 文件不存在 / null：没有 update 历史，不展示 banner
+    - status='ok'：可选展示"已更新到 X，X 秒前"
+    - status='aborted' / 'failed' / 'partial'：红色 banner + 原因 + 跳到日志
+    """
+    from dataclasses import asdict
+    st = updater.last_status()
+    if st is None:
+        return {"status": None}
+    rollback_to = updater.rollback_target()
+    return {
+        **asdict(st),
+        # 顺带把 rollback target 也带回去，UI 用这个判断"是否显示回滚按钮"
+        "rollback_target": rollback_to,
+    }
+
+
+@app.get("/api/system/update_log")
+def system_update_log() -> dict[str, Any]:
+    """完整 .update_log 文本内容（PR-C 失败时 UI 弹 modal 用）。"""
+    return {"content": updater.read_update_log()}
+
+
 @app.get("/", response_model=None)
 def root() -> RedirectResponse | JSONResponse:
     """根路径 302 跳转到 React 应用 `/studio/`。

--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -1,0 +1,372 @@
+"""Webui 内自更新机制（ADR 0002）— git pull + 重启 + apply pending deps。
+
+详见 [`docs/adr/0002-webui-self-update.md`](../../docs/adr/0002-webui-self-update.md)。
+
+模块职责：
+- 查询当前 git 状态（HEAD / branch / tag / dirty）
+- 检查远端是否有新版本（git fetch + rev-list 比对，TTL 24h 缓存）
+- 写 `studio_data/.update_pending` + `tmp/restart` 让 cli.py 启动期接管
+- cli.py 启动期 `apply_pending()` 执行 git pull + 增量 pip install / npm install
+
+关键 flag / 文件协议：
+
+| 路径 | 含义 | 作者 → 读者 |
+| --- | --- | --- |
+| `tmp/restart` | 需要重启 | server → cli.py / wrapper |
+| `studio_data/.update_pending` | 启动期要 git pull，内容是 target ref | server → cli.py |
+| `studio_data/.update_cache` | 自动检查结果缓存（TTL 24h） | check_update() 自管 |
+| `studio_data/.last_version` | 上一版 commit（rollback 用，PR-C 启用） | apply_pending |
+| `studio_data/.update_log` | 最近一次 update 的日志（PR-C 展示） | apply_pending |
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from .. import __version__
+from ..paths import REPO_ROOT, STUDIO_DATA
+
+logger = logging.getLogger(__name__)
+
+# ----- Flag / 缓存文件路径 ------------------------------------------------
+RESTART_FLAG = REPO_ROOT / "tmp" / "restart"
+UPDATE_PENDING = STUDIO_DATA / ".update_pending"
+UPDATE_CACHE = STUDIO_DATA / ".update_cache"
+LAST_VERSION = STUDIO_DATA / ".last_version"
+UPDATE_LOG = STUDIO_DATA / ".update_log"
+
+UPDATE_CACHE_TTL_SECONDS = 24 * 3600
+GIT_FETCH_TIMEOUT = 30.0
+GIT_PULL_TIMEOUT = 120.0
+
+
+# ----- 数据类型 -----------------------------------------------------------
+@dataclass
+class VersionInfo:
+    """当前仓库 git 状态。"""
+    version: str               # studio.__version__ (0.6.0)
+    commit: str                # 完整 sha
+    commit_short: str          # 前 8 位
+    commit_time_iso: str       # ISO8601
+    branch: str                # master / dev / detached
+    tag: Optional[str]         # HEAD 上的 tag（仅 exact match），无则 None
+    is_dirty: bool             # working tree 有未提交改动
+
+
+@dataclass
+class UpdateCheckResult:
+    """git fetch + 比对结果。"""
+    channel: str               # master / dev
+    current_commit: str
+    latest_commit: str
+    commits_ahead: int         # local 落后 remote 多少 commit
+    has_update: bool
+    latest_tag: Optional[str]  # remote 最新 tag（仅 master 通道有）
+    checked_at: float          # epoch
+    error: Optional[str] = None  # fetch 失败时填
+
+
+# ----- Git 调用 helper ----------------------------------------------------
+def _git(*args: str, timeout: float = 15.0) -> tuple[int, str, str]:
+    """跑 git 命令，返回 (rc, stdout, stderr)。"""
+    try:
+        proc = subprocess.run(
+            ["git", *args],
+            cwd=str(REPO_ROOT),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    except FileNotFoundError:
+        return 1, "", "git not found on PATH"
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return 1, "", str(exc)
+
+
+# ----- 公开 API -----------------------------------------------------------
+def current_version() -> VersionInfo:
+    """读当前仓库状态。git 不可用时返回占位值（不抛）。"""
+    rc, head, _ = _git("rev-parse", "HEAD")
+    commit = head if rc == 0 else "unknown"
+    short = commit[:8] if commit != "unknown" else "?"
+
+    rc, branch, _ = _git("rev-parse", "--abbrev-ref", "HEAD")
+    if rc != 0 or branch == "HEAD":
+        branch = "detached"
+
+    rc, ctime, _ = _git("log", "-1", "--format=%cI", "HEAD")
+    ctime_iso = ctime if rc == 0 else ""
+
+    rc, tag, _ = _git("describe", "--tags", "--exact-match", "HEAD")
+    exact_tag = tag if rc == 0 else None
+
+    rc, status, _ = _git("status", "--porcelain")
+    is_dirty = rc == 0 and bool(status)
+
+    return VersionInfo(
+        version=__version__,
+        commit=commit,
+        commit_short=short,
+        commit_time_iso=ctime_iso,
+        branch=branch,
+        tag=exact_tag,
+        is_dirty=is_dirty,
+    )
+
+
+def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheckResult:
+    """`git fetch origin {channel}` + 比对本地 HEAD 与 `origin/{channel}`。
+
+    channel 仅接受 'master' / 'dev'。Master 走 24h 缓存（cache 写到磁盘）；
+    dev 不写缓存（开发者主动检查，避免污染 master 的"有更新"信号）。
+    """
+    if channel not in ("master", "dev"):
+        raise ValueError(f"invalid channel: {channel}")
+
+    if channel == "master" and use_cache:
+        cached = _read_cache()
+        if cached is not None:
+            return cached
+
+    cur = current_version()
+
+    rc, _, stderr = _git("fetch", "origin", channel, timeout=GIT_FETCH_TIMEOUT)
+    if rc != 0:
+        return UpdateCheckResult(
+            channel=channel, current_commit=cur.commit, latest_commit="",
+            commits_ahead=0, has_update=False, latest_tag=None,
+            checked_at=time.time(), error=f"git fetch failed: {stderr[:200]}",
+        )
+
+    rc, latest, _ = _git("rev-parse", f"origin/{channel}")
+    if rc != 0:
+        return UpdateCheckResult(
+            channel=channel, current_commit=cur.commit, latest_commit="",
+            commits_ahead=0, has_update=False, latest_tag=None,
+            checked_at=time.time(), error=f"git rev-parse origin/{channel} failed",
+        )
+
+    rc, ahead_str, _ = _git("rev-list", "--count", f"HEAD..origin/{channel}")
+    commits_ahead = int(ahead_str) if rc == 0 and ahead_str.isdigit() else 0
+    has_update = commits_ahead > 0 and cur.commit != latest
+
+    latest_tag: Optional[str] = None
+    if channel == "master" and has_update:
+        rc, tag, _ = _git("describe", "--tags", "--abbrev=0", latest)
+        if rc == 0:
+            latest_tag = tag
+
+    result = UpdateCheckResult(
+        channel=channel,
+        current_commit=cur.commit,
+        latest_commit=latest,
+        commits_ahead=commits_ahead,
+        has_update=has_update,
+        latest_tag=latest_tag,
+        checked_at=time.time(),
+    )
+
+    if channel == "master":
+        _write_cache(result)
+
+    return result
+
+
+def request_update(target: str = "origin/master") -> None:
+    """server 端调：写 .update_pending + tmp/restart 让 cli.py 启动期接管。"""
+    UPDATE_PENDING.parent.mkdir(parents=True, exist_ok=True)
+    UPDATE_PENDING.write_text(target, encoding="utf-8")
+    RESTART_FLAG.parent.mkdir(parents=True, exist_ok=True)
+    RESTART_FLAG.touch()
+
+
+def has_pending() -> bool:
+    return UPDATE_PENDING.exists()
+
+
+def apply_pending(emit: Callable[[str], None] = print) -> bool:
+    """cli.py 启动期调。返回 True = 走过 pull 路径；False = 无 pending 跳过。
+
+    流程：
+    1. 读 .update_pending 拿 target ref
+    2. 写 .last_version（rollback 用，PR-C 启用）
+    3. precondition：working tree 必须干净（理论上 server 已查过，这里再保一层）
+    4. `git fetch origin` + `git reset --hard {target}`（避免 merge 冲突）
+    5. requirements.txt sha256 marker 比对 → 改了就 `pip install -r`
+    6. studio/web/package.json mtime > node_modules/.package-lock.json → `npm install`
+    7. 清 cache（让下次 check_update 重 fetch）+ 清 .update_pending
+
+    失败的每一步都写 .update_log（PR-C UI 展示），但不抛异常 — 让 cli.py
+    继续走后面的 bootstrap，server 至少能起来（可能起来后用户看到的是
+    "上次 update 失败"提示）。
+    """
+    if not has_pending():
+        return False
+
+    target = UPDATE_PENDING.read_text(encoding="utf-8").strip() or "origin/master"
+    emit(f"[updater] applying pending update → {target}")
+
+    cur = current_version()
+    log_lines: list[str] = [
+        f"=== {time.strftime('%Y-%m-%d %H:%M:%S')} update {cur.commit_short} → {target} ===",
+        f"branch={cur.branch} tag={cur.tag or '-'} dirty={cur.is_dirty}",
+    ]
+
+    # 保存上一版本（PR-C rollback 用）
+    try:
+        LAST_VERSION.parent.mkdir(parents=True, exist_ok=True)
+        LAST_VERSION.write_text(cur.commit, encoding="utf-8")
+    except OSError as e:
+        log_lines.append(f"[warn] failed to write .last_version: {e}")
+
+    # 1. precondition：working tree 干净
+    if cur.is_dirty:
+        log_lines.append("[abort] working tree dirty")
+        emit("[updater] working tree dirty, aborting update")
+        _finalize(log_lines)
+        return True
+
+    # 2. git fetch
+    log_lines.append("[git] fetch origin")
+    rc, _, stderr = _git("fetch", "origin", timeout=GIT_FETCH_TIMEOUT)
+    if rc != 0:
+        log_lines.append(f"[git fetch] FAILED rc={rc} stderr={stderr}")
+        emit(f"[updater] git fetch failed: {stderr[:200]}")
+        _finalize(log_lines)
+        return True
+
+    # 3. git reset --hard target（避免 merge conflict；working tree 干净已验过）
+    log_lines.append(f"[git] reset --hard {target}")
+    rc, _, stderr = _git("reset", "--hard", target, timeout=GIT_PULL_TIMEOUT)
+    if rc != 0:
+        log_lines.append(f"[git reset] FAILED rc={rc} stderr={stderr}")
+        emit(f"[updater] git reset failed: {stderr[:200]}")
+        _finalize(log_lines)
+        return True
+
+    new = current_version()
+    log_lines.append(f"[ok] now at {new.commit_short} ({new.tag or new.branch})")
+    emit(f"[updater] git updated → {new.commit_short}")
+
+    # 4. requirements.txt 改了 → 增量 pip install（不 --upgrade，仅补缺）
+    if _requirements_marker_stale():
+        log_lines.append("[pip] requirements.txt changed; pip install -r")
+        emit("[updater] requirements.txt changed, pip install (may take a few minutes)...")
+        rc = subprocess.call(
+            [sys.executable, "-m", "pip", "install", "-r", str(REPO_ROOT / "requirements.txt")]
+        )
+        log_lines.append(f"[pip] exit code {rc}")
+        if rc == 0:
+            # 更新 sha256 marker
+            marker = REPO_ROOT / "venv" / ".studio-requirements.sha256"
+            tool = REPO_ROOT / "tools" / "check_requirements_changed.py"
+            if tool.exists():
+                subprocess.call([
+                    sys.executable, str(tool),
+                    "--marker", str(marker), "--update-marker",
+                ])
+
+    # 5. package.json 改了 → npm install
+    if _package_json_changed():
+        log_lines.append("[npm] package.json changed; npm install")
+        emit("[updater] studio/web/package.json changed, npm install...")
+        npm = shutil.which("npm") or shutil.which("npm.cmd")
+        if npm:
+            rc = subprocess.call([npm, "install"], cwd=str(REPO_ROOT / "studio" / "web"))
+            log_lines.append(f"[npm] exit code {rc}")
+        else:
+            log_lines.append("[npm] not found on PATH, skipping (cli.py bootstrap will retry)")
+
+    log_lines.append("[done]")
+    _finalize(log_lines)
+
+    # 清 update cache，让下次 check_update 重 fetch（不依赖 24h TTL）
+    try:
+        if UPDATE_CACHE.exists():
+            UPDATE_CACHE.unlink()
+    except OSError:
+        pass
+
+    return True
+
+
+# ----- 内部 helpers ------------------------------------------------------
+def _read_cache() -> Optional[UpdateCheckResult]:
+    if not UPDATE_CACHE.exists():
+        return None
+    try:
+        data = json.loads(UPDATE_CACHE.read_text(encoding="utf-8"))
+        age = time.time() - float(data.get("checked_at", 0))
+        if age > UPDATE_CACHE_TTL_SECONDS or age < 0:
+            return None
+        return UpdateCheckResult(**data)
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None
+
+
+def _write_cache(result: UpdateCheckResult) -> None:
+    """原子写：先写 .tmp 再 rename，避免并发读 corrupt。"""
+    try:
+        UPDATE_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        tmp = UPDATE_CACHE.with_suffix(UPDATE_CACHE.suffix + ".tmp")
+        tmp.write_text(json.dumps(asdict(result), indent=2), encoding="utf-8")
+        tmp.replace(UPDATE_CACHE)
+    except OSError as e:
+        logger.warning("failed to write update cache: %s", e)
+
+
+def _finalize(log_lines: list[str]) -> None:
+    """写 update.log + 清 .update_pending 标志。"""
+    try:
+        UPDATE_LOG.parent.mkdir(parents=True, exist_ok=True)
+        UPDATE_LOG.write_text("\n".join(log_lines) + "\n", encoding="utf-8")
+    except OSError:
+        pass
+    try:
+        if UPDATE_PENDING.exists():
+            UPDATE_PENDING.unlink()
+    except OSError:
+        pass
+
+
+def _requirements_marker_stale() -> bool:
+    """requirements.txt sha256 vs venv/.studio-requirements.sha256 marker。
+
+    复用 studio.sh / studio.bat 已用的 marker（兼容 cold-start bootstrap）。
+    """
+    req = REPO_ROOT / "requirements.txt"
+    marker = REPO_ROOT / "venv" / ".studio-requirements.sha256"
+    if not req.exists():
+        return False
+    digest = hashlib.sha256(req.read_bytes()).hexdigest()
+    if not marker.exists():
+        return True  # 没 marker：可能从未装过，安全起见按 stale
+    try:
+        return marker.read_text(encoding="utf-8").strip() != digest
+    except OSError:
+        return True
+
+
+def _package_json_changed() -> bool:
+    """package.json mtime > node_modules/.package-lock.json mtime 即视为改了。
+
+    npm install 后会刷新 .package-lock.json mtime，这是 npm 自带行为。
+    没 node_modules / 没 lock 文件返回 False（cli.py 的 npm_install_if_missing 会兜底）。
+    """
+    pkg = REPO_ROOT / "studio" / "web" / "package.json"
+    lock = REPO_ROOT / "studio" / "web" / "node_modules" / ".package-lock.json"
+    if not pkg.exists() or not lock.exists():
+        return False
+    try:
+        return pkg.stat().st_mtime > lock.stat().st_mtime
+    except OSError:
+        return False

--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -42,6 +42,7 @@ UPDATE_PENDING = STUDIO_DATA / ".update_pending"
 UPDATE_CACHE = STUDIO_DATA / ".update_cache"
 LAST_VERSION = STUDIO_DATA / ".last_version"
 UPDATE_LOG = STUDIO_DATA / ".update_log"
+UPDATE_STATUS = STUDIO_DATA / ".update_status"   # PR-C：结构化最近一次 update 结果
 
 UPDATE_CACHE_TTL_SECONDS = 24 * 3600
 GIT_FETCH_TIMEOUT = 30.0
@@ -72,6 +73,21 @@ class UpdateCheckResult:
     latest_tag: Optional[str]  # remote 最新 tag（仅 master 通道有）
     checked_at: float          # epoch
     error: Optional[str] = None  # fetch 失败时填
+
+
+@dataclass
+class UpdateStatus:
+    """最近一次 update 的结构化结果（PR-C）。apply_pending 完成时写到磁盘，
+    UI 用来判断"上次更新成功 / 失败 / 中止"，失败时展示原因。"""
+    status: str                # ok / aborted / failed / partial
+    reason: str                # 失败 / 中止时的简短原因；成功时空串
+    target: str                # 用户请求的 ref (origin/master / commit hash)
+    from_commit: str           # 走 git reset 之前的 commit
+    to_commit: str             # 走 git reset 之后的 commit (失败时 = from_commit)
+    started_at: float
+    finished_at: float
+    deps_changed: bool         # 走了 pip install 或 npm install
+    log_excerpt: str           # 末尾几行 .update_log 内容
 
 
 # ----- Git 调用 helper ----------------------------------------------------
@@ -198,16 +214,22 @@ def apply_pending(emit: Callable[[str], None] = print) -> bool:
 
     流程：
     1. 读 .update_pending 拿 target ref
-    2. 写 .last_version（rollback 用，PR-C 启用）
+    2. 写 .last_version（rollback 用）
     3. precondition：working tree 必须干净（理论上 server 已查过，这里再保一层）
     4. `git fetch origin` + `git reset --hard {target}`（避免 merge 冲突）
     5. requirements.txt sha256 marker 比对 → 改了就 `pip install -r`
     6. studio/web/package.json mtime > node_modules/.package-lock.json → `npm install`
     7. 清 cache（让下次 check_update 重 fetch）+ 清 .update_pending
+    8. 写结构化 .update_status（PR-C，UI 展示"上次更新结果"用）
 
-    失败的每一步都写 .update_log（PR-C UI 展示），但不抛异常 — 让 cli.py
-    继续走后面的 bootstrap，server 至少能起来（可能起来后用户看到的是
-    "上次 update 失败"提示）。
+    失败的每一步都写 .update_log 和 .update_status，但不抛异常 — 让 cli.py
+    继续走后面的 bootstrap，server 至少能起来（UI 端会看到失败 banner）。
+
+    状态枚举：
+    - ok：git 切换成功，无 deps 失败
+    - aborted：precondition 失败（dirty tree）
+    - failed：git fetch / reset 失败
+    - partial：git 切换成功但 pip / npm 失败（功能可能不完整）
     """
     if not has_pending():
         return False
@@ -215,25 +237,47 @@ def apply_pending(emit: Callable[[str], None] = print) -> bool:
     target = UPDATE_PENDING.read_text(encoding="utf-8").strip() or "origin/master"
     emit(f"[updater] applying pending update → {target}")
 
+    started_at = time.time()
     cur = current_version()
     log_lines: list[str] = [
         f"=== {time.strftime('%Y-%m-%d %H:%M:%S')} update {cur.commit_short} → {target} ===",
         f"branch={cur.branch} tag={cur.tag or '-'} dirty={cur.is_dirty}",
     ]
 
-    # 保存上一版本（PR-C rollback 用）
+    # 保存上一版本（rollback 用）
     try:
         LAST_VERSION.parent.mkdir(parents=True, exist_ok=True)
         LAST_VERSION.write_text(cur.commit, encoding="utf-8")
     except OSError as e:
         log_lines.append(f"[warn] failed to write .last_version: {e}")
 
+    def _done(status: str, reason: str, to_commit: str, deps_changed: bool) -> bool:
+        """收尾：写 .update_status + .update_log + 清 .update_pending + 清 cache。"""
+        finished_at = time.time()
+        _write_status(UpdateStatus(
+            status=status,
+            reason=reason,
+            target=target,
+            from_commit=cur.commit,
+            to_commit=to_commit,
+            started_at=started_at,
+            finished_at=finished_at,
+            deps_changed=deps_changed,
+            log_excerpt="\n".join(log_lines[-20:]),
+        ))
+        _finalize(log_lines)
+        try:
+            if UPDATE_CACHE.exists():
+                UPDATE_CACHE.unlink()
+        except OSError:
+            pass
+        return True
+
     # 1. precondition：working tree 干净
     if cur.is_dirty:
         log_lines.append("[abort] working tree dirty")
         emit("[updater] working tree dirty, aborting update")
-        _finalize(log_lines)
-        return True
+        return _done("aborted", "working tree dirty", cur.commit, False)
 
     # 2. git fetch
     log_lines.append("[git] fetch origin")
@@ -241,8 +285,7 @@ def apply_pending(emit: Callable[[str], None] = print) -> bool:
     if rc != 0:
         log_lines.append(f"[git fetch] FAILED rc={rc} stderr={stderr}")
         emit(f"[updater] git fetch failed: {stderr[:200]}")
-        _finalize(log_lines)
-        return True
+        return _done("failed", f"git fetch: {stderr[:120]}", cur.commit, False)
 
     # 3. git reset --hard target（避免 merge conflict；working tree 干净已验过）
     log_lines.append(f"[git] reset --hard {target}")
@@ -250,15 +293,18 @@ def apply_pending(emit: Callable[[str], None] = print) -> bool:
     if rc != 0:
         log_lines.append(f"[git reset] FAILED rc={rc} stderr={stderr}")
         emit(f"[updater] git reset failed: {stderr[:200]}")
-        _finalize(log_lines)
-        return True
+        return _done("failed", f"git reset: {stderr[:120]}", cur.commit, False)
 
     new = current_version()
     log_lines.append(f"[ok] now at {new.commit_short} ({new.tag or new.branch})")
     emit(f"[updater] git updated → {new.commit_short}")
 
+    deps_changed = False
+    deps_failed_reason = ""
+
     # 4. requirements.txt 改了 → 增量 pip install（不 --upgrade，仅补缺）
     if _requirements_marker_stale():
+        deps_changed = True
         log_lines.append("[pip] requirements.txt changed; pip install -r")
         emit("[updater] requirements.txt changed, pip install (may take a few minutes)...")
         rc = subprocess.call(
@@ -266,7 +312,6 @@ def apply_pending(emit: Callable[[str], None] = print) -> bool:
         )
         log_lines.append(f"[pip] exit code {rc}")
         if rc == 0:
-            # 更新 sha256 marker
             marker = REPO_ROOT / "venv" / ".studio-requirements.sha256"
             tool = REPO_ROOT / "tools" / "check_requirements_changed.py"
             if tool.exists():
@@ -274,29 +319,86 @@ def apply_pending(emit: Callable[[str], None] = print) -> bool:
                     sys.executable, str(tool),
                     "--marker", str(marker), "--update-marker",
                 ])
+        else:
+            deps_failed_reason = f"pip exit {rc}"
 
     # 5. package.json 改了 → npm install
     if _package_json_changed():
+        deps_changed = True
         log_lines.append("[npm] package.json changed; npm install")
         emit("[updater] studio/web/package.json changed, npm install...")
         npm = shutil.which("npm") or shutil.which("npm.cmd")
         if npm:
             rc = subprocess.call([npm, "install"], cwd=str(REPO_ROOT / "studio" / "web"))
             log_lines.append(f"[npm] exit code {rc}")
+            if rc != 0:
+                deps_failed_reason = (
+                    f"{deps_failed_reason + '; ' if deps_failed_reason else ''}npm exit {rc}"
+                )
         else:
             log_lines.append("[npm] not found on PATH, skipping (cli.py bootstrap will retry)")
 
+    if deps_failed_reason:
+        log_lines.append(f"[partial] git ok 但 deps 失败: {deps_failed_reason}")
+        return _done("partial", deps_failed_reason, new.commit, deps_changed)
+
     log_lines.append("[done]")
-    _finalize(log_lines)
+    return _done("ok", "", new.commit, deps_changed)
 
-    # 清 update cache，让下次 check_update 重 fetch（不依赖 24h TTL）
+
+def last_status() -> Optional[UpdateStatus]:
+    """读 .update_status；不存在 / 损坏 → None。"""
+    if not UPDATE_STATUS.exists():
+        return None
     try:
-        if UPDATE_CACHE.exists():
-            UPDATE_CACHE.unlink()
-    except OSError:
-        pass
+        data = json.loads(UPDATE_STATUS.read_text(encoding="utf-8"))
+        return UpdateStatus(**data)
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return None
 
-    return True
+
+def read_update_log() -> str:
+    """完整 .update_log 内容；不存在返回空串。"""
+    if not UPDATE_LOG.exists():
+        return ""
+    try:
+        return UPDATE_LOG.read_text(encoding="utf-8")
+    except OSError:
+        return ""
+
+
+def rollback_target() -> Optional[str]:
+    """读 .last_version。返回 commit sha 或 None（首次未更新过 / 文件缺失）。
+
+    校验 commit 在仓库里存在 — 防止仓库被强制 GC 掉 .last_version 指向的孤儿
+    commit。验不过返 None，UI 隐藏回滚按钮。
+    """
+    if not LAST_VERSION.exists():
+        return None
+    try:
+        sha = LAST_VERSION.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    if not sha:
+        return None
+    rc, _, _ = _git("cat-file", "-e", sha)
+    return sha if rc == 0 else None
+
+
+def request_rollback() -> Optional[str]:
+    """读 .last_version 内容，调 request_update(target=<sha>)。
+
+    没有 .last_version 或 commit 不存在 → 返回 None（调用方应当返 409 / 422）。
+    成功调度 → 返回 target sha。
+
+    回滚流程与正向 update 完全一样（同一个 apply_pending 处理），所以下次
+    UI 上 .last_version 会自动被更新成"现在的版本"，支持来回切。
+    """
+    sha = rollback_target()
+    if sha is None:
+        return None
+    request_update(sha)
+    return sha
 
 
 # ----- 内部 helpers ------------------------------------------------------
@@ -336,6 +438,17 @@ def _finalize(log_lines: list[str]) -> None:
             UPDATE_PENDING.unlink()
     except OSError:
         pass
+
+
+def _write_status(status: UpdateStatus) -> None:
+    """原子写 .update_status（PR-C）。"""
+    try:
+        UPDATE_STATUS.parent.mkdir(parents=True, exist_ok=True)
+        tmp = UPDATE_STATUS.with_suffix(UPDATE_STATUS.suffix + ".tmp")
+        tmp.write_text(json.dumps(asdict(status), indent=2), encoding="utf-8")
+        tmp.replace(UPDATE_STATUS)
+    except OSError as e:
+        logger.warning("failed to write .update_status: %s", e)
 
 
 def _requirements_marker_stale() -> bool:

--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -125,7 +125,9 @@ def current_version() -> VersionInfo:
     rc, tag, _ = _git("describe", "--tags", "--exact-match", "HEAD")
     exact_tag = tag if rc == 0 else None
 
-    rc, status, _ = _git("status", "--porcelain")
+    # --untracked-files=no：untracked 文件（pr18_review.md / 临时笔记 / 没进 gitignore
+    # 的草稿等）不影响 git reset --hard，它们会原地保留。dirty 仅指"修改了 tracked 文件"。
+    rc, status, _ = _git("status", "--porcelain", "--untracked-files=no")
     is_dirty = rc == 0 and bool(status)
 
     return VersionInfo(

--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -236,7 +236,7 @@ def apply_pending(emit: Callable[[str], None] = print) -> bool:
     if not has_pending():
         return False
 
-    target = UPDATE_PENDING.read_text(encoding="utf-8").strip() or "origin/master"
+    target = UPDATE_PENDING.read_text(encoding="utf-8-sig").strip() or "origin/master"
     emit(f"[updater] applying pending update → {target}")
 
     started_at = time.time()
@@ -353,7 +353,7 @@ def last_status() -> Optional[UpdateStatus]:
     if not UPDATE_STATUS.exists():
         return None
     try:
-        data = json.loads(UPDATE_STATUS.read_text(encoding="utf-8"))
+        data = json.loads(UPDATE_STATUS.read_text(encoding="utf-8-sig"))
         return UpdateStatus(**data)
     except (OSError, json.JSONDecodeError, TypeError, ValueError):
         return None
@@ -364,7 +364,7 @@ def read_update_log() -> str:
     if not UPDATE_LOG.exists():
         return ""
     try:
-        return UPDATE_LOG.read_text(encoding="utf-8")
+        return UPDATE_LOG.read_text(encoding="utf-8-sig")
     except OSError:
         return ""
 
@@ -378,7 +378,7 @@ def rollback_target() -> Optional[str]:
     if not LAST_VERSION.exists():
         return None
     try:
-        sha = LAST_VERSION.read_text(encoding="utf-8").strip()
+        sha = LAST_VERSION.read_text(encoding="utf-8-sig").strip()
     except OSError:
         return None
     if not sha:
@@ -408,7 +408,7 @@ def _read_cache() -> Optional[UpdateCheckResult]:
     if not UPDATE_CACHE.exists():
         return None
     try:
-        data = json.loads(UPDATE_CACHE.read_text(encoding="utf-8"))
+        data = json.loads(UPDATE_CACHE.read_text(encoding="utf-8-sig"))
         age = time.time() - float(data.get("checked_at", 0))
         if age > UPDATE_CACHE_TTL_SECONDS or age < 0:
             return None
@@ -466,7 +466,7 @@ def _requirements_marker_stale() -> bool:
     if not marker.exists():
         return True  # 没 marker：可能从未装过，安全起见按 stale
     try:
-        return marker.read_text(encoding="utf-8").strip() != digest
+        return marker.read_text(encoding="utf-8-sig").strip() != digest
     except OSError:
         return True
 

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -940,6 +940,17 @@ export interface ImportResult {
   renamed: Record<string, string>
 }
 
+/**
+ * API 错误：除了 `message`（用于直接 toast 的字符串），额外保留 `status` 和
+ * `detail`（FastAPI 端 raise HTTPException(status, detail=dict(...)) 时
+ * detail 是结构化对象，调用方可以 `e.detail.error` 区分类型）。
+ *
+ * 用 Error 而非自定义 class 是因为不少现有 callsite 是 `catch (e) { toast(String(e)) }`
+ * 这种通用写法；保留 `Error.prototype.toString()` 行为不破坏它们。需要结构化
+ * 处理的新 callsite 强制 cast：`(e as ApiError).detail`。
+ */
+export type ApiError = Error & { status?: number; detail?: unknown }
+
 async function req<T>(
   path: string,
   init?: RequestInit
@@ -953,13 +964,23 @@ async function req<T>(
   })
   if (!resp.ok) {
     let detail = `${resp.status} ${resp.statusText}`
+    let rawDetail: unknown = null
     try {
       const body = await resp.json()
-      if (body?.detail) detail = body.detail
+      if (typeof body?.detail === 'string') {
+        detail = body.detail
+      } else if (body?.detail && typeof body.detail === 'object') {
+        rawDetail = body.detail
+        // 结构化 detail：取 .message 作为可读字符串；callsite 想拿完整结构走 e.detail
+        detail = (body.detail as { message?: string }).message ?? JSON.stringify(body.detail)
+      }
     } catch {
-      // ignore
+      // body 不是 JSON / 解析失败：保持 statusText 默认
     }
-    throw new Error(detail)
+    const err = new Error(detail) as ApiError
+    err.status = resp.status
+    err.detail = rawDetail
+    throw err
   }
   if (resp.status === 204) return undefined as T
   return (await resp.json()) as T
@@ -1632,6 +1653,45 @@ export const api = {
     req<{ ok: boolean; message: string }>('/api/system/restart', {
       method: 'POST',
     }),
+
+  // 当前仓库 git 状态：__version__ / commit / tag / branch / dirty
+  getSystemVersion: () => req<SystemVersion>('/api/system/version'),
+
+  // git fetch + 比对。master 通道 24h cache；force=true 强制重 fetch。
+  // dev 通道（PR-D）每次都 fetch，不缓存。
+  checkSystemUpdate: (channel: 'master' | 'dev' = 'master', force = false) => {
+    const qs = new URLSearchParams({ channel, force: String(force) })
+    return req<SystemUpdateCheck>(`/api/system/update_check?${qs.toString()}`)
+  },
+
+  // 请求 update：写 .update_pending + 触发 SIGINT 重启。
+  // 422 = running task 或 dirty working tree。
+  performSystemUpdate: (target: string = 'origin/master') =>
+    req<{ ok: boolean; message: string }>('/api/system/update', {
+      method: 'POST',
+      body: JSON.stringify({ target }),
+    }),
+}
+
+export interface SystemVersion {
+  version: string
+  commit: string
+  commit_short: string
+  commit_time_iso: string
+  branch: string
+  tag: string | null
+  is_dirty: boolean
+}
+
+export interface SystemUpdateCheck {
+  channel: 'master' | 'dev'
+  current_commit: string
+  latest_commit: string
+  commits_ahead: number
+  has_update: boolean
+  latest_tag: string | null
+  checked_at: number
+  error: string | null
 }
 
 export interface BrowseEntry {

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1623,6 +1623,15 @@ export const api = {
     const qs = path ? `?path=${encodeURIComponent(path)}` : ''
     return req<BrowseResult>(`/api/browse${qs}`)
   },
+
+  // System lifecycle (ADR 0002) ----------------------------------------
+  // 重启 server。后端写 tmp/restart + 给自己发 SIGINT 触发 uvicorn graceful
+  // shutdown；cli.py 的 loop 拾起并重启。前端调完后应进入"重启中"等待状态，
+  // 轮询 /api/health 直到服务回来。
+  restartServer: () =>
+    req<{ ok: boolean; message: string }>('/api/system/restart', {
+      method: 'POST',
+    }),
 }
 
 export interface BrowseEntry {

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -334,6 +334,12 @@ export interface GenerateSecretsConfig {
   attention_backend: AttentionBackend
 }
 
+/** 系统级偏好（ADR 0002 / PR-D）。show_dev_channel 开启后 Settings 暴露 dev
+ *  通道按钮（手动检查 / 更新到 dev）；自动检查 + Topbar badge 仍然只看 master。 */
+export interface SystemPrefsConfig {
+  show_dev_channel: boolean
+}
+
 export interface Secrets {
   gelbooru: GelbooruConfig
   danbooru: DanbooruConfig
@@ -351,6 +357,7 @@ export interface Secrets {
   models: ModelsConfig
   queue: QueueConfig
   generate: GenerateSecretsConfig
+  system: SystemPrefsConfig
 }
 
 /** PUT /api/secrets 的 body：嵌套的 partial dict；MASK ("***") 表示「保持不变」。 */

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1671,6 +1671,19 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ target }),
     }),
+
+  // 回滚到 .last_version 记录的上一版本（PR-C）。
+  // 422 = running task / dirty；409 = 没有 .last_version 或 commit 已 GC。
+  rollbackSystem: () =>
+    req<{ ok: boolean; message: string; target: string }>('/api/system/rollback', {
+      method: 'POST',
+    }),
+
+  // 最近一次 update 的结构化结果（PR-C）。status: null = 从未 update 过。
+  getSystemUpdateStatus: () => req<SystemUpdateStatus>('/api/system/update_status'),
+
+  // 完整 .update_log 文本（PR-C，失败时 UI 弹 modal 用）。
+  getSystemUpdateLog: () => req<{ content: string }>('/api/system/update_log'),
 }
 
 export interface SystemVersion {
@@ -1692,6 +1705,25 @@ export interface SystemUpdateCheck {
   latest_tag: string | null
   checked_at: number
   error: string | null
+}
+
+/** PR-C — 最近一次 update 的结构化结果。
+ *  - status=null：从未 update 过，UI 不展示 banner
+ *  - status='ok'：可选展示"已更新到 X"
+ *  - status='aborted' / 'failed' / 'partial'：红色 banner + reason + "查看日志"
+ *  - rollback_target：.last_version 内容（commit sha），UI 用它判断是否显示回滚按钮
+ */
+export interface SystemUpdateStatus {
+  status: 'ok' | 'aborted' | 'failed' | 'partial' | null
+  reason?: string
+  target?: string
+  from_commit?: string
+  to_commit?: string
+  started_at?: number
+  finished_at?: number
+  deps_changed?: boolean
+  log_excerpt?: string
+  rollback_target?: string | null
 }
 
 export interface BrowseEntry {

--- a/studio/web/src/components/Topbar.tsx
+++ b/studio/web/src/components/Topbar.tsx
@@ -102,6 +102,21 @@ export default function Topbar() {
   const [runningTask, setRunningTask] = useState<Task | null>(null)
   const [pendingCount, setPendingCount] = useState(0)
 
+  // 升级可用 badge（ADR 0002 / PR-B）。Topbar mount 时调一次 /api/system/update_check
+  // （master 通道，走 24h cache），有更新就显示红点。dev 通道永不亮 badge
+  // （PR-D 加 toggle 后只在 Settings 系统 tab 暴露手动检查入口）。
+  const [updateInfo, setUpdateInfo] = useState<{ has_update: boolean; latest_tag: string | null; latest_commit: string } | null>(null)
+  useEffect(() => {
+    let cancelled = false
+    void api.checkSystemUpdate('master').then((r) => {
+      if (cancelled) return
+      if (r.has_update) {
+        setUpdateInfo({ has_update: true, latest_tag: r.latest_tag, latest_commit: r.latest_commit })
+      }
+    }).catch(() => { /* silent — 没网 / git fetch 失败时不打扰用户 */ })
+    return () => { cancelled = true }
+  }, [])
+
   // monitor 状态走 useMonitorProgress hook (PR #37 增量协议)：自动管理
   // /api/state 冷启动 + monitor_progress delta 合并 + 重连补拉，本组件只
   // 关心结果的 step/total_steps/speed/start_time 几个 scalar 字段。
@@ -224,6 +239,22 @@ export default function Topbar() {
 
         {/* 实时系统监控 (CPU / RAM / GPU / VRAM)，每 ~2.5s 轮询；无 NVIDIA 时只显示 CPU/RAM。 */}
         <SystemStats />
+
+        {/* 升级可用 badge：仅 master 有新版时显示，点击跳 Settings 系统 tab。 */}
+        {updateInfo?.has_update && (
+          <button
+            onClick={() => {
+              // Settings 用 localStorage 持久化 tab，提前切到 system 让进入即看到
+              try { localStorage.setItem('studio.settings.activeTab', 'system') } catch { /* ignore */ }
+              navigate('/tools/settings')
+            }}
+            title={`新版本 ${updateInfo.latest_tag ?? updateInfo.latest_commit.slice(0, 8)} 可用`}
+            className="flex items-center gap-1.5 px-2 py-[5px] rounded-md text-xs font-mono text-accent bg-accent-soft border border-accent cursor-pointer hover:bg-accent/10 transition-colors shrink-0"
+          >
+            <span className="w-1.5 h-1.5 rounded-full bg-accent" />
+            <span>{updateInfo.latest_tag ?? '新版本'}</span>
+          </button>
+        )}
 
         {/* 运行中训练胶囊 */}
         {runningTask && (

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -10,6 +10,8 @@ import {
   type ModelsCatalog,
   type Secrets,
   type SecretsPatch,
+  type SystemUpdateCheck,
+  type SystemVersion,
   type TorchCuTag,
   type TorchStatus,
   type WandBConfig,
@@ -82,6 +84,7 @@ const TAB_SECTIONS: Record<Tab, { id: string; label: string }[]> = {
     { id: 'display', label: '显示' },
   ],
   system: [
+    { id: 'version', label: '版本' },
     { id: 'service', label: '服务' },
   ],
 }
@@ -2296,21 +2299,196 @@ function DisplaySection() {
 
 // ── System Section（系统 tab）─────────────────────────────────────────────
 //
-// PR-A：仅"重启 server"按钮。PR-B 会在此 Section 上方加版本显示 / 检查更新 /
-// 立即更新 / 回滚 等。
+// PR-B 起拆成两个 sub-section：
+//   - VersionSection：当前版本 / 检查更新 / 立即更新（master 通道）
+//   - ServiceSection：重启 server
 //
-// 重启流程：
-//   1. confirm 弹窗（说明断开时间）
-//   2. POST /api/system/restart → 后端写 tmp/restart + 发 SIGINT
-//   3. 进入"重启中"状态卡片：每 500ms 轮询 /api/health
-//   4. health 200 → toast "已重启" + reload 当前页面（前端重新挂载，SSE 重连）
-//   5. 5 分钟超时 → toast "重启超时，请检查终端" + 保留状态卡片让用户手动刷新
-//
-// 实测耗时（单 GPU、本地 SSD）：~1 分钟。瓶颈在 cli.py 主循环每轮重跑的
-// bootstrap：前端 dist stale 检测 / torch / onnxruntime cold import / uvicorn
-// 起 lifespan。所以 timeout 设 5 分钟兜底慢盘 / 慢解释器 / pending_install
-// 真有 pip 装包要跑的场景。
+// 共用流程"触发后端退出 → 轮询 /api/health 等回来 → 刷新页面"由
+// `pollHealthThenReload` 抽出。restart 超时 5 分钟，update 超时 10 分钟
+// （要多跑 git pull + 可能 pip install / npm install 的时间）。
 function SystemSection() {
+  return (
+    <>
+      <VersionSection />
+      <ServiceSection />
+    </>
+  )
+}
+
+// ── 公共：触发后端退出后轮询 health 并刷新 ─────────────────────────────
+//
+// 调用者负责在 await 之前已经成功触发了 server 退出（POST /restart 或 /update
+// 已经 200 回来）。这里只管"等服务回来 + 刷页面 + 失败提示"。
+type ToastFn = (msg: string, kind?: 'info' | 'success' | 'error') => void
+
+async function pollHealthThenReload(
+  toast: ToastFn,
+  timeoutMs: number,
+  label: string,
+  onTimeout: () => void,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs
+  const pollInterval = 500
+  // 间隔后开始轮询：给 server 时间真正退出，避免命中还没死的旧进程
+  await new Promise((r) => setTimeout(r, 1500))
+  while (Date.now() < deadline) {
+    try {
+      await api.health()
+      toast(`${label}完成，正在刷新页面...`, 'success')
+      setTimeout(() => window.location.reload(), 800)
+      return
+    } catch {
+      // server 还没回来，继续轮询
+    }
+    await new Promise((r) => setTimeout(r, pollInterval))
+  }
+  const mins = Math.round(timeoutMs / 60_000)
+  toast(`${label}超时（${mins} 分钟），请检查终端输出后手动刷新页面`, 'error')
+  onTimeout()
+}
+
+// ── 版本 Section ────────────────────────────────────────────────────────
+//
+// 加载时自动 fetch /api/system/version + /api/system/update_check（master 通道，
+// 走 cache）。"检查更新"按钮 force=true 强制重 fetch。"立即更新"按钮仅在
+// has_update=true 时显示，点击走 POST /api/system/update 流程（precondition
+// 422 时拿 e.detail 区分提示）。
+function VersionSection() {
+  const { toast } = useToast()
+  const dialog = useDialog()
+  const [version, setVersion] = useState<SystemVersion | null>(null)
+  const [check, setCheck] = useState<SystemUpdateCheck | null>(null)
+  const [checking, setChecking] = useState(false)
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    void api.getSystemVersion().then(setVersion).catch(() => { /* silent */ })
+    void api.checkSystemUpdate('master').then(setCheck).catch(() => { /* silent */ })
+  }, [])
+
+  const handleCheck = async () => {
+    setChecking(true)
+    try {
+      const r = await api.checkSystemUpdate('master', true)
+      setCheck(r)
+      if (r.error) {
+        toast(`检查失败: ${r.error}`, 'error')
+      } else if (r.has_update) {
+        toast(`有新版本：${r.latest_tag ?? r.latest_commit.slice(0, 8)}（${r.commits_ahead} commits）`, 'info')
+      } else {
+        toast('已是最新版本', 'success')
+      }
+    } catch (e) {
+      toast(`检查更新失败: ${e}`, 'error')
+    } finally {
+      setChecking(false)
+    }
+  }
+
+  const handleUpdate = async () => {
+    if (!check?.has_update) return
+    const targetLabel = check.latest_tag ?? check.latest_commit.slice(0, 8)
+    const ok = await dialog.confirm(
+      `将更新到 ${targetLabel}（${check.commits_ahead} commits）。\n\n` +
+      'Studio 会关闭后台 server，pull 新代码，按需 pip / npm install，再重启。\n' +
+      '预计 1-5 分钟（首次或依赖大改时更久），期间 webui 无法访问，页面会自动等待并刷新。\n\n' +
+      '若有训练 / 打标任务正在运行将被拒绝；本地有未提交修改也会被拒绝。',
+      { tone: 'warn', okText: '更新' },
+    )
+    if (!ok) return
+
+    setBusy(true)
+    try {
+      await api.performSystemUpdate('origin/master')
+    } catch (e) {
+      const err = e as Error & { status?: number; detail?: { error?: string; tasks?: { name: string }[] } }
+      if (err.status === 422 && err.detail?.error === 'running_tasks_present') {
+        const names = (err.detail.tasks ?? []).map((t) => t.name || `task#${(t as { id?: number }).id ?? '?'}`).join(', ')
+        toast(`有任务在跑，请先取消：${names}`, 'error')
+      } else if (err.status === 422 && err.detail?.error === 'dirty_working_tree') {
+        toast('本地有未提交修改，请先 commit 或 stash 后再更新', 'error')
+      } else {
+        toast(`触发更新失败: ${err.message ?? e}`, 'error')
+      }
+      setBusy(false)
+      return
+    }
+
+    void pollHealthThenReload(toast, 10 * 60_000, '更新', () => setBusy(false))
+  }
+
+  const headDescr = version
+    ? `${version.tag ?? `v${version.version}`} · ${version.commit_short} · ${version.branch}${version.is_dirty ? ' · 本地有改动' : ''}`
+    : '加载中...'
+
+  return (
+    <SettingsSection id="version" title="版本">
+      <SettingsField label="当前">
+        <div className="flex flex-col gap-0.5 text-fg-primary text-sm font-mono">
+          <span>{headDescr}</span>
+          {version?.commit_time_iso && (
+            <span className="text-2xs text-fg-dim">
+              {new Date(version.commit_time_iso).toLocaleString()}
+            </span>
+          )}
+        </div>
+      </SettingsField>
+
+      {check && (
+        <SettingsField label="远端 (master)">
+          {check.error ? (
+            <span className="text-err text-sm">{check.error}</span>
+          ) : check.has_update ? (
+            <div className="flex flex-col gap-0.5 text-fg-primary text-sm font-mono">
+              <span>
+                {check.latest_tag ?? check.latest_commit.slice(0, 8)} · ↑ {check.commits_ahead} commits
+              </span>
+              <span className="text-2xs text-fg-dim">
+                上次检查 {new Date(check.checked_at * 1000).toLocaleString()}
+              </span>
+            </div>
+          ) : (
+            <span className="text-fg-dim text-sm">已是最新版本</span>
+          )}
+        </SettingsField>
+      )}
+
+      <SettingsField label="操作">
+        <div className="flex flex-col gap-1.5">
+          <div className="flex gap-2 flex-wrap">
+            <button
+              onClick={() => void handleCheck()}
+              disabled={checking || busy}
+              className="btn btn-secondary btn-sm"
+            >
+              {checking ? '检查中...' : '检查更新'}
+            </button>
+            {check?.has_update && (
+              <button
+                onClick={() => void handleUpdate()}
+                disabled={busy || checking}
+                className="btn btn-primary btn-sm"
+              >
+                {busy ? '更新中...' : `立即更新 → ${check.latest_tag ?? check.latest_commit.slice(0, 8)}`}
+              </button>
+            )}
+          </div>
+          <p className="text-2xs text-fg-dim leading-snug">
+            自动检查每 24 小时一次（master 通道，关闭 webui 不影响）。
+            更新会执行 <code>git reset --hard origin/master</code> + 必要时 pip / npm install。
+            <br />
+            <span className="text-warn">
+              当前有训练 / 打标任务运行时不允许更新；本地未提交的改动也会被拒绝。
+            </span>
+          </p>
+        </div>
+      </SettingsField>
+    </SettingsSection>
+  )
+}
+
+// ── 服务 Section（重启 server）─────────────────────────────────────────
+function ServiceSection() {
   const { toast } = useToast()
   const dialog = useDialog()
   const [busy, setBusy] = useState(false)
@@ -2319,7 +2497,7 @@ function SystemSection() {
     const ok = await dialog.confirm(
       '将关闭并重新启动 Studio 后端服务。\n\n' +
       '通常 30 秒到 1 分钟，期间 webui 无法访问（页面会自动等待并刷新）。\n\n' +
-      '注意（PR-A 暂未做任务保护）：当前若有训练 / 打标任务在跑，将被强制取消，丢失未保存进度。',
+      '若有训练 / 打标任务在跑会被拒绝（PR-B 起加保护）。',
       { tone: 'warn', okText: '重启' },
     )
     if (!ok) return
@@ -2328,34 +2506,18 @@ function SystemSection() {
     try {
       await api.restartServer()
     } catch (e) {
-      toast(`触发重启失败: ${e}`, 'error')
+      const err = e as Error & { status?: number; detail?: { error?: string; tasks?: { name: string; id?: number }[] } }
+      if (err.status === 422 && err.detail?.error === 'running_tasks_present') {
+        const names = (err.detail.tasks ?? []).map((t) => t.name || `task#${t.id ?? '?'}`).join(', ')
+        toast(`有任务在跑，请先取消：${names}`, 'error')
+      } else {
+        toast(`触发重启失败: ${err.message ?? e}`, 'error')
+      }
       setBusy(false)
       return
     }
 
-    // 轮询 /api/health 等服务回来。5 分钟超时兜底慢盘 / cold torch import。
-    const TIMEOUT_MS = 5 * 60_000
-    const deadline = Date.now() + TIMEOUT_MS
-    const pollInterval = 500
-    const poll = async () => {
-      // 间隔后开始轮询：给 server 时间真正退出，避免命中还没死的旧进程
-      await new Promise((r) => setTimeout(r, 1500))
-      while (Date.now() < deadline) {
-        try {
-          await api.health()
-          toast('Studio 已重启，正在刷新页面...', 'success')
-          // 给 toast 一点显示时间再刷
-          setTimeout(() => window.location.reload(), 800)
-          return
-        } catch {
-          // server 还没回来，继续轮询
-        }
-        await new Promise((r) => setTimeout(r, pollInterval))
-      }
-      toast('重启超时（5 分钟），请检查终端输出后手动刷新页面', 'error')
-      setBusy(false)
-    }
-    void poll()
+    void pollHealthThenReload(toast, 5 * 60_000, '重启', () => setBusy(false))
   }
 
   return (
@@ -2372,10 +2534,6 @@ function SystemSection() {
           <p className="text-2xs text-fg-dim leading-snug">
             关闭并重新启动后端进程。常用场景：修改 secrets.json 后强制刷新、
             装完新 onnxruntime / PyTorch 让 EP 生效。
-            <br />
-            <span className="text-warn">
-              当前未做运行中任务保护（PR-B 会加），有训练 / 打标在跑时不要点。
-            </span>
           </p>
         </div>
       </SettingsField>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -38,7 +38,7 @@ type Section =
   | 'queue'
   | 'generate'
 
-type Tab = 'dataset' | 'tagging' | 'training' | 'monitor' | 'testing' | 'appearance'
+type Tab = 'dataset' | 'tagging' | 'training' | 'monitor' | 'testing' | 'appearance' | 'system'
 
 const TAB_LIST: { id: Tab; label: string }[] = [
   { id: 'dataset', label: '数据集' },
@@ -47,6 +47,7 @@ const TAB_LIST: { id: Tab; label: string }[] = [
   { id: 'monitor', label: '监控' },
   { id: 'testing', label: '测试' },
   { id: 'appearance', label: '页面' },
+  { id: 'system', label: '系统' },
 ]
 
 // 每个 tab 的 section index — 用于右侧 sticky 导航。id 与各 section 的 DOM id
@@ -79,6 +80,9 @@ const TAB_SECTIONS: Record<Tab, { id: string; label: string }[]> = {
   ],
   appearance: [
     { id: 'display', label: '显示' },
+  ],
+  system: [
+    { id: 'service', label: '服务' },
   ],
 }
 
@@ -131,6 +135,7 @@ function getStoredTab(): Tab {
     if (
       v === 'dataset' || v === 'tagging' || v === 'training'
       || v === 'monitor' || v === 'testing' || v === 'appearance'
+      || v === 'system'
     ) return v
   } catch {
     /* ignore localStorage errors */
@@ -893,6 +898,10 @@ export default function SettingsPage() {
 
       {tab === 'appearance' && (
         <DisplaySection />
+      )}
+
+      {tab === 'system' && (
+        <SystemSection />
       )}
     </div>
 
@@ -2278,6 +2287,88 @@ function DisplaySection() {
           </div>
           <p className="text-xs text-fg-tertiary m-0">
             {densityDesc(density)}
+          </p>
+        </div>
+      </SettingsField>
+    </SettingsSection>
+  )
+}
+
+// ── System Section（系统 tab）─────────────────────────────────────────────
+//
+// PR-A：仅"重启 server"按钮。PR-B 会在此 Section 上方加版本显示 / 检查更新 /
+// 立即更新 / 回滚 等。
+//
+// 重启流程：
+//   1. confirm 弹窗（强调 webui 会断开 ~5-10s）
+//   2. POST /api/system/restart → 后端写 tmp/restart + 发 SIGINT
+//   3. 进入"重启中"状态卡片：每 500ms 轮询 /api/health
+//   4. health 200 → toast "已重启" + reload 当前页面（前端重新挂载，SSE 重连）
+//   5. 30s 超时 → toast "重启超时，请检查终端" + 保留状态卡片让用户手动刷新
+function SystemSection() {
+  const { toast } = useToast()
+  const dialog = useDialog()
+  const [busy, setBusy] = useState(false)
+
+  const handleRestart = async () => {
+    const ok = await dialog.confirm(
+      '将关闭并重新启动 Studio 后端服务。webui 会断开 5-10 秒，期间无法访问。\n\n' +
+      '注意（PR-A 暂未做任务保护）：当前若有训练 / 打标任务在跑，将被强制取消，丢失未保存进度。',
+      { tone: 'warn', okText: '重启' },
+    )
+    if (!ok) return
+
+    setBusy(true)
+    try {
+      await api.restartServer()
+    } catch (e) {
+      toast(`触发重启失败: ${e}`, 'error')
+      setBusy(false)
+      return
+    }
+
+    // 轮询 /api/health 等服务回来
+    const deadline = Date.now() + 30_000
+    const pollInterval = 500
+    const poll = async () => {
+      // 间隔后开始轮询：给 server 时间真正退出，避免命中还没死的旧进程
+      await new Promise((r) => setTimeout(r, 1500))
+      while (Date.now() < deadline) {
+        try {
+          await api.health()
+          toast('Studio 已重启，正在刷新页面...', 'success')
+          // 给 toast 一点显示时间再刷
+          setTimeout(() => window.location.reload(), 800)
+          return
+        } catch {
+          // server 还没回来，继续轮询
+        }
+        await new Promise((r) => setTimeout(r, pollInterval))
+      }
+      toast('重启超时（30s），请检查终端输出后手动刷新页面', 'error')
+      setBusy(false)
+    }
+    void poll()
+  }
+
+  return (
+    <SettingsSection id="service" title="服务">
+      <SettingsField label="重启 Studio">
+        <div className="flex flex-col gap-1.5">
+          <button
+            onClick={() => void handleRestart()}
+            disabled={busy}
+            className="btn btn-secondary btn-sm self-start"
+          >
+            {busy ? '重启中...' : '重启 server'}
+          </button>
+          <p className="text-2xs text-fg-dim leading-snug">
+            关闭并重新启动后端进程。常用场景：修改 secrets.json 后强制刷新、
+            装完新 onnxruntime / PyTorch 让 EP 生效。
+            <br />
+            <span className="text-warn">
+              当前未做运行中任务保护（PR-B 会加），有训练 / 打标在跑时不要点。
+            </span>
           </p>
         </div>
       </SettingsField>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -2440,6 +2440,33 @@ function VersionSection() {
     void pollHealthThenReload(toast, 10 * 60_000, '更新', () => setBusy(false))
   }
 
+  // PR-D — 当用户已经在 dev 通道时，"立即更新"按钮文案歧义（听起来像"前进"
+  // 实际是"切回 master"）。单独走这个 handler，dialog 文案明确告知方向，
+  // 不依赖 has_update（dev 上 master 即使一致也允许显式切回 stable）。
+  const handleSwitchToMaster = async () => {
+    const targetLabel = check?.latest_tag ?? check?.latest_commit?.slice(0, 8) ?? 'master HEAD'
+    const ok = await dialog.confirm(
+      `将切回稳定通道 master（${targetLabel}）。\n\n` +
+      '你当前在 dev 通道。切回会 git reset --hard origin/master —— ' +
+      'dev 独有但未合并进 master 的 commit 会从本地工作树消失（git reflog 仍可找回）。\n' +
+      '其余流程与 update 一致：关闭 server，按需补依赖，重启。\n\n' +
+      '若有训练 / 打标任务在跑将被拒绝；本地未提交修改也会被拒绝。',
+      { tone: 'warn', okText: '切回稳定' },
+    )
+    if (!ok) return
+
+    setBusy(true)
+    try {
+      await api.performSystemUpdate('origin/master')
+    } catch (e) {
+      toast(_formatActionError(e, '切回稳定'), 'error')
+      setBusy(false)
+      return
+    }
+
+    void pollHealthThenReload(toast, 10 * 60_000, '切回稳定', () => setBusy(false))
+  }
+
   const handleRollback = async () => {
     if (!status?.rollback_target) return
     const target = status.rollback_target
@@ -2532,12 +2559,20 @@ function VersionSection() {
     void pollHealthThenReload(toast, 10 * 60_000, '更新', () => setBusy(false))
   }
 
+  // 不再把 branch 塞 headDescr —— 单独显示成 channel pill 让用户一眼看出
+  // 自己在哪个通道（master = 稳定 / dev = 开发版 / 其它 = 自定义分支）。
   const headDescr = version
-    ? `${version.tag ?? `v${version.version}`} · ${version.commit_short} · ${version.branch}${version.is_dirty ? ' · 本地有改动' : ''}`
+    ? `${version.tag ?? `v${version.version}`} · ${version.commit_short}${version.is_dirty ? ' · 本地有改动' : ''}`
     : '加载中...'
 
   // 上次 update 失败 banner（aborted / failed / partial 时显示红色提示）
   const statusBadFailed = status && (status.status === 'failed' || status.status === 'aborted' || status.status === 'partial')
+
+  // PR-D — 通道判定。on dev + toggle 开启时把主按钮从"立即更新 master"
+  // 改成"切回稳定 master"（文案 + dialog 明确方向）；同时主按钮独立于
+  // has_update（dev 上想随时切回 stable 是合法操作）。
+  const onDev = version?.branch === 'dev'
+  const showSwitchToStable = onDev && !!prefs?.show_dev_channel
 
   return (
     <SettingsSection id="version" title="版本">
@@ -2566,7 +2601,10 @@ function VersionSection() {
 
       <SettingsField label="当前">
         <div className="flex flex-col gap-0.5 text-fg-primary text-sm font-mono">
-          <span>{headDescr}</span>
+          <div className="flex items-center gap-2 flex-wrap">
+            <span>{headDescr}</span>
+            {version && <ChannelPill branch={version.branch} />}
+          </div>
           {version?.commit_time_iso && (
             <span className="text-2xs text-fg-dim">
               {new Date(version.commit_time_iso).toLocaleString()}
@@ -2588,6 +2626,17 @@ function VersionSection() {
                 上次检查 {new Date(check.checked_at * 1000).toLocaleString()}
               </span>
             </div>
+          ) : onDev ? (
+            // dev 用户看到 has_update=false 说明 dev 已含 master 所有 commit；
+            // 此时给个 master HEAD 提示而不是误导的"已是最新版本"。
+            <div className="flex flex-col gap-0.5 text-fg-primary text-sm font-mono">
+              <span className="text-fg-dim">
+                master HEAD: {check.latest_commit.slice(0, 8)}（你领先 / 持平）
+              </span>
+              <span className="text-2xs text-fg-dim">
+                上次检查 {new Date(check.checked_at * 1000).toLocaleString()}
+              </span>
+            </div>
           ) : (
             <span className="text-fg-dim text-sm">已是最新版本</span>
           )}
@@ -2604,13 +2653,26 @@ function VersionSection() {
             >
               {checking ? '检查中...' : '检查更新'}
             </button>
-            {check?.has_update && (
+            {showSwitchToStable ? (
+              // dev 上的用户：主按钮永远显示"切回稳定"（不依赖 has_update）。
+              // 跟踪 dev 新提交走高级折叠里的 [更新到 dev]；主区是 stable 出口。
+              <button
+                onClick={() => void handleSwitchToMaster()}
+                disabled={busy || checking}
+                className="btn btn-primary btn-sm"
+              >
+                {busy ? '切回稳定中...' : '切回稳定通道 → master'}
+              </button>
+            ) : check?.has_update && (
               <button
                 onClick={() => void handleUpdate()}
                 disabled={busy || checking}
                 className="btn btn-primary btn-sm"
               >
-                {busy ? '更新中...' : `立即更新 → ${check.latest_tag ?? check.latest_commit.slice(0, 8)}`}
+                {busy
+                  ? '更新中...'
+                  : `立即更新 → ${check.latest_tag ?? check.latest_commit.slice(0, 8)}`
+                    + (prefs?.show_dev_channel ? '（稳定）' : '')}
               </button>
             )}
             {status?.rollback_target && (
@@ -2723,6 +2785,27 @@ function VersionSection() {
         />
       )}
     </SettingsSection>
+  )
+}
+
+// PR-D — 通道指示徽章。master = 稳定（绿）/ dev = 开发版（橙）/ 其它 = 自定义
+// 分支（灰）。用现有 .badge-ok / .badge-warn / .badge-info 复用站内统一色板。
+function ChannelPill({ branch }: { branch: string }) {
+  const meta = branch === 'master'
+    ? { cls: 'badge-ok', label: '稳定' }
+    : branch === 'dev'
+      ? { cls: 'badge-warn', label: '开发版' }
+      : branch === 'detached'
+        ? { cls: 'badge-info', label: '游离 HEAD' }
+        : { cls: 'badge-info', label: '自定义分支' }
+  return (
+    <span
+      className={`${meta.cls} inline-flex items-center gap-1 px-1.5 py-0.5 rounded-sm text-2xs font-sans font-medium`}
+      title={`当前分支：${branch}`}
+    >
+      <span>{meta.label}</span>
+      <span className="font-mono opacity-70">{branch}</span>
+    </span>
   )
 }
 

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -11,6 +11,7 @@ import {
   type Secrets,
   type SecretsPatch,
   type SystemUpdateCheck,
+  type SystemUpdateStatus,
   type SystemVersion,
   type TorchCuTag,
   type TorchStatus,
@@ -2350,20 +2351,25 @@ async function pollHealthThenReload(
 // ── 版本 Section ────────────────────────────────────────────────────────
 //
 // 加载时自动 fetch /api/system/version + /api/system/update_check（master 通道，
-// 走 cache）。"检查更新"按钮 force=true 强制重 fetch。"立即更新"按钮仅在
-// has_update=true 时显示，点击走 POST /api/system/update 流程（precondition
-// 422 时拿 e.detail 区分提示）。
+// 走 cache）+ /api/system/update_status（PR-C：上次 update 结果）。
+// 操作按钮：检查更新 / 立即更新 / 切换到上一版本（rollback，仅在 .last_version
+// 存在时显示）/ 查看上次日志（仅在失败时主动暴露）。
 function VersionSection() {
   const { toast } = useToast()
   const dialog = useDialog()
   const [version, setVersion] = useState<SystemVersion | null>(null)
   const [check, setCheck] = useState<SystemUpdateCheck | null>(null)
+  const [status, setStatus] = useState<SystemUpdateStatus | null>(null)
   const [checking, setChecking] = useState(false)
   const [busy, setBusy] = useState(false)
+  const [logModal, setLogModal] = useState<{ open: boolean; content: string; loading: boolean }>(
+    { open: false, content: '', loading: false },
+  )
 
   useEffect(() => {
     void api.getSystemVersion().then(setVersion).catch(() => { /* silent */ })
     void api.checkSystemUpdate('master').then(setCheck).catch(() => { /* silent */ })
+    void api.getSystemUpdateStatus().then(setStatus).catch(() => { /* silent */ })
   }, [])
 
   const handleCheck = async () => {
@@ -2385,6 +2391,22 @@ function VersionSection() {
     }
   }
 
+  // 公用的 422 / 其它错误分流（update 和 rollback 都用）
+  const _formatActionError = (e: unknown, action: string): string => {
+    const err = e as Error & { status?: number; detail?: { error?: string; tasks?: { name: string; id?: number }[] } }
+    if (err.status === 422 && err.detail?.error === 'running_tasks_present') {
+      const names = (err.detail.tasks ?? []).map((t) => t.name || `task#${t.id ?? '?'}`).join(', ')
+      return `有任务在跑，请先取消：${names}`
+    }
+    if (err.status === 422 && err.detail?.error === 'dirty_working_tree') {
+      return '本地有未提交修改，请先 commit 或 stash'
+    }
+    if (err.status === 409 && err.detail?.error === 'no_rollback_target') {
+      return '没有可回滚的版本（首次启动 / .last_version 已被清理）'
+    }
+    return `触发${action}失败: ${err.message ?? e}`
+  }
+
   const handleUpdate = async () => {
     if (!check?.has_update) return
     const targetLabel = check.latest_tag ?? check.latest_commit.slice(0, 8)
@@ -2401,15 +2423,7 @@ function VersionSection() {
     try {
       await api.performSystemUpdate('origin/master')
     } catch (e) {
-      const err = e as Error & { status?: number; detail?: { error?: string; tasks?: { name: string }[] } }
-      if (err.status === 422 && err.detail?.error === 'running_tasks_present') {
-        const names = (err.detail.tasks ?? []).map((t) => t.name || `task#${(t as { id?: number }).id ?? '?'}`).join(', ')
-        toast(`有任务在跑，请先取消：${names}`, 'error')
-      } else if (err.status === 422 && err.detail?.error === 'dirty_working_tree') {
-        toast('本地有未提交修改，请先 commit 或 stash 后再更新', 'error')
-      } else {
-        toast(`触发更新失败: ${err.message ?? e}`, 'error')
-      }
+      toast(_formatActionError(e, '更新'), 'error')
       setBusy(false)
       return
     }
@@ -2417,12 +2431,72 @@ function VersionSection() {
     void pollHealthThenReload(toast, 10 * 60_000, '更新', () => setBusy(false))
   }
 
+  const handleRollback = async () => {
+    if (!status?.rollback_target) return
+    const target = status.rollback_target
+    const ok = await dialog.confirm(
+      `将切换到上一版本（commit ${target.slice(0, 8)}）。\n\n` +
+      '走与正向 update 同样的流程：关闭 server，git reset --hard <commit>，按需补依赖，重启。\n' +
+      '切换成功后 .last_version 会变成"切换前的版本"，再点同样的按钮即可回到此处。\n\n' +
+      '若有训练 / 打标任务正在运行将被拒绝；本地有未提交修改也会被拒绝。',
+      { tone: 'warn', okText: '切换' },
+    )
+    if (!ok) return
+
+    setBusy(true)
+    try {
+      await api.rollbackSystem()
+    } catch (e) {
+      toast(_formatActionError(e, '回滚'), 'error')
+      setBusy(false)
+      return
+    }
+
+    void pollHealthThenReload(toast, 10 * 60_000, '回滚', () => setBusy(false))
+  }
+
+  const handleViewLog = async () => {
+    setLogModal({ open: true, content: '', loading: true })
+    try {
+      const r = await api.getSystemUpdateLog()
+      setLogModal({ open: true, content: r.content || '(空)', loading: false })
+    } catch (e) {
+      setLogModal({ open: true, content: `加载失败: ${e}`, loading: false })
+    }
+  }
+
   const headDescr = version
     ? `${version.tag ?? `v${version.version}`} · ${version.commit_short} · ${version.branch}${version.is_dirty ? ' · 本地有改动' : ''}`
     : '加载中...'
 
+  // 上次 update 失败 banner（aborted / failed / partial 时显示红色提示）
+  const statusBadFailed = status && (status.status === 'failed' || status.status === 'aborted' || status.status === 'partial')
+
   return (
     <SettingsSection id="version" title="版本">
+      {statusBadFailed && (
+        <div className="flex flex-col gap-1.5 rounded-md border border-err bg-err-soft p-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-err">
+            <span>上次更新{status?.status === 'aborted' ? '中止' : status?.status === 'partial' ? '部分成功' : '失败'}</span>
+            {status?.finished_at && (
+              <span className="text-2xs text-fg-dim font-normal font-mono">
+                {new Date(status.finished_at * 1000).toLocaleString()}
+              </span>
+            )}
+          </div>
+          <div className="text-xs text-fg-secondary">
+            {status?.reason || '原因未知'}
+            {status?.target && <span className="text-fg-dim"> · target = {status.target}</span>}
+          </div>
+          <button
+            onClick={() => void handleViewLog()}
+            className="btn btn-secondary btn-xs self-start"
+          >
+            查看完整日志
+          </button>
+        </div>
+      )}
+
       <SettingsField label="当前">
         <div className="flex flex-col gap-0.5 text-fg-primary text-sm font-mono">
           <span>{headDescr}</span>
@@ -2472,10 +2546,29 @@ function VersionSection() {
                 {busy ? '更新中...' : `立即更新 → ${check.latest_tag ?? check.latest_commit.slice(0, 8)}`}
               </button>
             )}
+            {status?.rollback_target && (
+              <button
+                onClick={() => void handleRollback()}
+                disabled={busy || checking}
+                className="btn btn-secondary btn-sm"
+                title={`切换到 ${status.rollback_target}`}
+              >
+                {busy ? '切换中...' : `切换到 ${status.rollback_target.slice(0, 8)}`}
+              </button>
+            )}
+            {status?.status && (
+              <button
+                onClick={() => void handleViewLog()}
+                disabled={busy}
+                className="btn btn-ghost btn-sm"
+              >
+                查看上次日志
+              </button>
+            )}
           </div>
           <p className="text-2xs text-fg-dim leading-snug">
             自动检查每 24 小时一次（master 通道，关闭 webui 不影响）。
-            更新会执行 <code>git reset --hard origin/master</code> + 必要时 pip / npm install。
+            更新 / 回滚都执行 <code>git reset --hard &lt;target&gt;</code> + 必要时 pip / npm install。
             <br />
             <span className="text-warn">
               当前有训练 / 打标任务运行时不允许更新；本地未提交的改动也会被拒绝。
@@ -2483,7 +2576,56 @@ function VersionSection() {
           </p>
         </div>
       </SettingsField>
+
+      {logModal.open && (
+        <UpdateLogModal
+          loading={logModal.loading}
+          content={logModal.content}
+          onClose={() => setLogModal({ open: false, content: '', loading: false })}
+        />
+      )}
     </SettingsSection>
+  )
+}
+
+// 简易的 modal：点遮罩 / 按 ESC 关闭，pre + 等宽字体显示日志。
+// 没用 useDialog 是因为它返回的是命令式 confirm/prompt 接口，不适合长文本展示。
+function UpdateLogModal({
+  loading, content, onClose,
+}: { loading: boolean; content: string; onClose: () => void }) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface border border-subtle rounded-md shadow-lg max-w-4xl w-[92vw] max-h-[80vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b border-subtle px-4 py-2.5">
+          <h3 className="text-sm font-semibold text-fg-primary">上次更新日志</h3>
+          <button
+            onClick={onClose}
+            className="text-fg-dim hover:text-fg-primary text-lg leading-none"
+            aria-label="关闭"
+          >×</button>
+        </div>
+        <div className="flex-1 overflow-y-auto p-4">
+          {loading ? (
+            <span className="text-fg-dim text-sm">加载中...</span>
+          ) : (
+            <pre className="text-2xs font-mono text-fg-primary whitespace-pre-wrap break-words">
+              {content}
+            </pre>
+          )}
+        </div>
+      </div>
+    </div>
   )
 }
 

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -10,6 +10,7 @@ import {
   type ModelsCatalog,
   type Secrets,
   type SecretsPatch,
+  type SystemPrefsConfig,
   type SystemUpdateCheck,
   type SystemUpdateStatus,
   type SystemVersion,
@@ -204,6 +205,7 @@ const EMPTY: Secrets = {
   models: { root: null, selected_anima: 'preview3-base' },
   queue: { allow_gpu_during_train: false },
   generate: { preview_every_n_steps: 3, attention_backend: 'auto' },
+  system: { show_dev_channel: false },
 }
 
 const textInputClass = 'w-full px-2 py-1 outline-none rounded-sm bg-sunken border border-subtle text-sm text-fg-primary focus:border-accent'
@@ -2351,16 +2353,22 @@ async function pollHealthThenReload(
 // ── 版本 Section ────────────────────────────────────────────────────────
 //
 // 加载时自动 fetch /api/system/version + /api/system/update_check（master 通道，
-// 走 cache）+ /api/system/update_status（PR-C：上次 update 结果）。
+// 走 cache）+ /api/system/update_status（PR-C：上次 update 结果）+ /api/secrets
+// （读 system.show_dev_channel，PR-D：dev 通道 toggle）。
 // 操作按钮：检查更新 / 立即更新 / 切换到上一版本（rollback，仅在 .last_version
 // 存在时显示）/ 查看上次日志（仅在失败时主动暴露）。
+// 高级折叠：显示开发版更新 toggle；开启后暴露 dev 通道按钮（手动检查 / 更新到 dev）。
+//          自动检查仍只 fetch master，Topbar badge 也仅 master 触发（设计文档明确）。
 function VersionSection() {
   const { toast } = useToast()
   const dialog = useDialog()
   const [version, setVersion] = useState<SystemVersion | null>(null)
   const [check, setCheck] = useState<SystemUpdateCheck | null>(null)
   const [status, setStatus] = useState<SystemUpdateStatus | null>(null)
+  const [prefs, setPrefs] = useState<SystemPrefsConfig | null>(null)
+  const [devCheck, setDevCheck] = useState<SystemUpdateCheck | null>(null)
   const [checking, setChecking] = useState(false)
+  const [checkingDev, setCheckingDev] = useState(false)
   const [busy, setBusy] = useState(false)
   const [logModal, setLogModal] = useState<{ open: boolean; content: string; loading: boolean }>(
     { open: false, content: '', loading: false },
@@ -2370,6 +2378,7 @@ function VersionSection() {
     void api.getSystemVersion().then(setVersion).catch(() => { /* silent */ })
     void api.checkSystemUpdate('master').then(setCheck).catch(() => { /* silent */ })
     void api.getSystemUpdateStatus().then(setStatus).catch(() => { /* silent */ })
+    void api.getSecrets().then((s) => setPrefs(s.system)).catch(() => { /* silent */ })
   }, [])
 
   const handleCheck = async () => {
@@ -2463,6 +2472,64 @@ function VersionSection() {
     } catch (e) {
       setLogModal({ open: true, content: `加载失败: ${e}`, loading: false })
     }
+  }
+
+  // PR-D — dev 通道 toggle 持久化到 secrets.json。乐观更新 + 失败回滚。
+  const handleToggleDevChannel = async (next: boolean) => {
+    const prev = prefs
+    setPrefs((p) => p ? { ...p, show_dev_channel: next } : { show_dev_channel: next })
+    if (!next) setDevCheck(null)        // 关掉时清掉缓存的 dev 检查结果
+    try {
+      const updated = await api.updateSecrets({ system: { show_dev_channel: next } })
+      setPrefs(updated.system)
+    } catch (e) {
+      setPrefs(prev)                    // 失败回滚 UI
+      toast(`保存失败: ${(e as Error).message ?? e}`, 'error')
+    }
+  }
+
+  const handleCheckDev = async () => {
+    setCheckingDev(true)
+    try {
+      const r = await api.checkSystemUpdate('dev', true)
+      setDevCheck(r)
+      if (r.error) {
+        toast(`dev 检查失败: ${r.error}`, 'error')
+      } else if (r.has_update) {
+        toast(`dev 通道有 ${r.commits_ahead} commits 新提交`, 'info')
+      } else {
+        toast('dev 通道与当前一致', 'success')
+      }
+    } catch (e) {
+      toast(`dev 检查失败: ${e}`, 'error')
+    } finally {
+      setCheckingDev(false)
+    }
+  }
+
+  const handleUpdateDev = async () => {
+    if (!devCheck?.has_update) return
+    const targetLabel = devCheck.latest_commit.slice(0, 8)
+    const ok = await dialog.confirm(
+      `切换到 dev 通道（commit ${targetLabel}，${devCheck.commits_ahead} commits）。\n\n` +
+      'dev 通道是开发版，未经发布验证，可能引入崩溃 / 训练异常。\n\n' +
+      '其余流程与正向 update 一致：关闭 server，git reset --hard origin/dev，按需补依赖，重启。\n' +
+      '完成后回滚按钮会显示当前 commit 让你能切回此处。\n\n' +
+      '若有训练 / 打标任务在跑将被拒绝；本地未提交修改也会被拒绝。',
+      { tone: 'danger', okText: '更新到 dev' },
+    )
+    if (!ok) return
+
+    setBusy(true)
+    try {
+      await api.performSystemUpdate('origin/dev')
+    } catch (e) {
+      toast(_formatActionError(e, '更新到 dev'), 'error')
+      setBusy(false)
+      return
+    }
+
+    void pollHealthThenReload(toast, 10 * 60_000, '更新', () => setBusy(false))
   }
 
   const headDescr = version
@@ -2576,6 +2643,77 @@ function VersionSection() {
           </p>
         </div>
       </SettingsField>
+
+      {/* PR-D — 高级设置：dev 通道 toggle + 手动操作。默认折叠；勾选 toggle
+          会持久化到 secrets.json (system.show_dev_channel)。Topbar badge /
+          自动检查仍然只看 master —— dev 必须显式手动触发，避免开发者被
+          dev commit 持续骚扰（设计文档明确）。 */}
+      <details className="border-t border-subtle pt-2 mt-1 group">
+        <summary className="cursor-pointer text-sm text-fg-secondary hover:text-fg-primary select-none list-none flex items-center gap-1.5 py-1">
+          <span className="inline-block transition-transform group-open:rotate-90">▸</span>
+          <span>高级设置</span>
+        </summary>
+        <div className="pt-2 pl-4 flex flex-col gap-3">
+          <SettingsField label="显示开发版更新">
+            <div className="flex items-center gap-2">
+              <Bool
+                value={!!prefs?.show_dev_channel}
+                onChange={(v) => void handleToggleDevChannel(v)}
+              />
+              <span className="text-2xs text-fg-dim leading-snug">
+                开启后下方暴露 dev 通道操作（手动检查 / 更新到 dev）。
+                自动检查 + Topbar 红点仍然只看 master。
+              </span>
+            </div>
+          </SettingsField>
+
+          {prefs?.show_dev_channel && (
+            <div className="rounded-md border border-subtle bg-surface-alt p-3 flex flex-col gap-2">
+              <div className="text-xs font-semibold text-fg-primary">
+                dev 通道（开发版）
+              </div>
+              {devCheck && (
+                devCheck.error ? (
+                  <span className="text-err text-xs">{devCheck.error}</span>
+                ) : devCheck.has_update ? (
+                  <div className="text-xs text-fg-primary font-mono flex flex-col gap-0.5">
+                    <span>
+                      {devCheck.latest_commit.slice(0, 8)} · ↑ {devCheck.commits_ahead} commits
+                    </span>
+                    <span className="text-2xs text-fg-dim">
+                      检查于 {new Date(devCheck.checked_at * 1000).toLocaleString()}
+                    </span>
+                  </div>
+                ) : (
+                  <span className="text-fg-dim text-xs">dev 通道与当前一致</span>
+                )
+              )}
+              <div className="flex gap-2 flex-wrap">
+                <button
+                  onClick={() => void handleCheckDev()}
+                  disabled={checkingDev || busy}
+                  className="btn btn-secondary btn-sm"
+                >
+                  {checkingDev ? '检查中...' : '手动检查 dev'}
+                </button>
+                {devCheck?.has_update && (
+                  <button
+                    onClick={() => void handleUpdateDev()}
+                    disabled={busy || checkingDev}
+                    className="btn btn-danger btn-sm"
+                  >
+                    {busy ? '更新中...' : `更新到 dev (${devCheck.latest_commit.slice(0, 8)})`}
+                  </button>
+                )}
+              </div>
+              <p className="text-2xs text-warn leading-snug">
+                ⚠ dev 通道未经发布验证，可能引入崩溃 / 训练异常 / schema 不兼容。
+                更新后用主区"切换到 ..."按钮可回到当前 commit。
+              </p>
+            </div>
+          )}
+        </div>
+      </details>
 
       {logModal.open && (
         <UpdateLogModal

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -2300,11 +2300,16 @@ function DisplaySection() {
 // 立即更新 / 回滚 等。
 //
 // 重启流程：
-//   1. confirm 弹窗（强调 webui 会断开 ~5-10s）
+//   1. confirm 弹窗（说明断开时间）
 //   2. POST /api/system/restart → 后端写 tmp/restart + 发 SIGINT
 //   3. 进入"重启中"状态卡片：每 500ms 轮询 /api/health
 //   4. health 200 → toast "已重启" + reload 当前页面（前端重新挂载，SSE 重连）
-//   5. 30s 超时 → toast "重启超时，请检查终端" + 保留状态卡片让用户手动刷新
+//   5. 5 分钟超时 → toast "重启超时，请检查终端" + 保留状态卡片让用户手动刷新
+//
+// 实测耗时（单 GPU、本地 SSD）：~1 分钟。瓶颈在 cli.py 主循环每轮重跑的
+// bootstrap：前端 dist stale 检测 / torch / onnxruntime cold import / uvicorn
+// 起 lifespan。所以 timeout 设 5 分钟兜底慢盘 / 慢解释器 / pending_install
+// 真有 pip 装包要跑的场景。
 function SystemSection() {
   const { toast } = useToast()
   const dialog = useDialog()
@@ -2312,7 +2317,8 @@ function SystemSection() {
 
   const handleRestart = async () => {
     const ok = await dialog.confirm(
-      '将关闭并重新启动 Studio 后端服务。webui 会断开 5-10 秒，期间无法访问。\n\n' +
+      '将关闭并重新启动 Studio 后端服务。\n\n' +
+      '通常 30 秒到 1 分钟，期间 webui 无法访问（页面会自动等待并刷新）。\n\n' +
       '注意（PR-A 暂未做任务保护）：当前若有训练 / 打标任务在跑，将被强制取消，丢失未保存进度。',
       { tone: 'warn', okText: '重启' },
     )
@@ -2327,8 +2333,9 @@ function SystemSection() {
       return
     }
 
-    // 轮询 /api/health 等服务回来
-    const deadline = Date.now() + 30_000
+    // 轮询 /api/health 等服务回来。5 分钟超时兜底慢盘 / cold torch import。
+    const TIMEOUT_MS = 5 * 60_000
+    const deadline = Date.now() + TIMEOUT_MS
     const pollInterval = 500
     const poll = async () => {
       // 间隔后开始轮询：给 server 时间真正退出，避免命中还没死的旧进程
@@ -2345,7 +2352,7 @@ function SystemSection() {
         }
         await new Promise((r) => setTimeout(r, pollInterval))
       }
-      toast('重启超时（30s），请检查终端输出后手动刷新页面', 'error')
+      toast('重启超时（5 分钟），请检查终端输出后手动刷新页面', 'error')
       setBusy(false)
     }
     void poll()

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -360,3 +360,41 @@ def test_has_gelbooru_credentials(secrets_file: Path) -> None:
     assert secrets.has_gelbooru_credentials() is False
     secrets.update({"gelbooru": {"user_id": "u", "api_key": "k"}})
     assert secrets.has_gelbooru_credentials() is True
+
+
+# ---------------------------------------------------------------------------
+# PR-D — system.show_dev_channel（dev 通道 toggle 持久化）
+# ---------------------------------------------------------------------------
+
+
+def test_system_defaults_show_dev_channel_false(secrets_file: Path) -> None:
+    """新装默认 toggle 关 —— 绝大多数用户看简化 UI，不暴露 dev 入口。"""
+    s = secrets.load()
+    assert s.system.show_dev_channel is False
+
+
+def test_system_show_dev_channel_round_trip(secrets_file: Path) -> None:
+    """update + load 持久化（webui 勾选 toggle 后刷页应保留）。"""
+    secrets.update({"system": {"show_dev_channel": True}})
+    assert secrets.load().system.show_dev_channel is True
+    # 关掉也持久化
+    secrets.update({"system": {"show_dev_channel": False}})
+    assert secrets.load().system.show_dev_channel is False
+
+
+def test_system_legacy_file_without_system_field(secrets_file: Path) -> None:
+    """老 secrets.json 没有 system 字段时，加载用默认值（show_dev_channel=False）。"""
+    secrets_file.write_text(
+        json.dumps({"gelbooru": {"user_id": "alice"}}),
+        encoding="utf-8",
+    )
+    s = secrets.load()
+    assert s.system.show_dev_channel is False
+    assert s.gelbooru.user_id == "alice"  # 其它字段不受影响
+
+
+def test_system_show_dev_channel_in_masked_dict(secrets_file: Path) -> None:
+    """show_dev_channel 不是敏感字段，掩码后应保留原值。"""
+    secrets.update({"system": {"show_dev_channel": True}})
+    masked = secrets.to_masked_dict(secrets.load())
+    assert masked["system"]["show_dev_channel"] is True

--- a/tests/test_studio_cli.py
+++ b/tests/test_studio_cli.py
@@ -4,6 +4,7 @@
 """
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 from typing import Any
 
@@ -381,3 +382,144 @@ def test_cmd_build_no_npm_prints_install_hint(
     err = capsys.readouterr().err
     assert "winget" in err
     assert "Node.js 18+" in err
+
+
+# ---------------------------------------------------------------------------
+# PR-D — installer 自检（sha256 + exit 42）
+# ---------------------------------------------------------------------------
+
+
+def test_installer_hashes_sha256_per_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """三个 installer 文件存在 → sha256；缺失 → None。键是文件名。"""
+    cli_py = tmp_path / "cli.py"
+    sh = tmp_path / "studio.sh"
+    bat = tmp_path / "studio.bat"   # 故意不创建，模拟跨平台一边没有
+    cli_py.write_bytes(b"print('hello')\n")
+    sh.write_bytes(b"#!/bin/sh\n")
+    monkeypatch.setattr(cli, "_INSTALLER_FILES", (cli_py, sh, bat))
+    h = cli._installer_hashes()
+    assert h == {
+        "cli.py": hashlib.sha256(b"print('hello')\n").hexdigest(),
+        "studio.sh": hashlib.sha256(b"#!/bin/sh\n").hexdigest(),
+        "studio.bat": None,
+    }
+
+
+def test_installer_hashes_changes_when_content_changes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    p = tmp_path / "cli.py"
+    p.write_bytes(b"v1")
+    monkeypatch.setattr(cli, "_INSTALLER_FILES", (p,))
+    before = cli._installer_hashes()
+    p.write_bytes(b"v2")
+    assert cli._installer_hashes() != before
+
+
+def _stub_run_bootstrap(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Path:
+    """共享 fixture：把 cmd_run 的所有 bootstrap helper 短路，返回伪 dist 目录。
+
+    cmd_run 在每轮 loop 里调一堆 helper（_ensure_python_deps / _apply_*
+    / _check_torch_cuda / etc）；本身这些都已经在别处测过，PR-D 的测试
+    只关心 server 退出后的 dispatch 逻辑。"""
+    dist = tmp_path / "dist"
+    dist.mkdir()
+    (dist / "index.html").write_text("<html/>")
+    monkeypatch.setattr(cli, "WEB_DIST", dist)
+    monkeypatch.setattr(cli, "_web_dist_is_stale", lambda: False)
+    monkeypatch.setattr(cli, "_ensure_python_deps", lambda: 0)
+    monkeypatch.setattr(cli, "_apply_update_pending", lambda: None)
+    monkeypatch.setattr(cli, "_apply_pending_install", lambda: None)
+    monkeypatch.setattr(cli, "_check_torch_cuda", lambda: None)
+    monkeypatch.setattr(cli, "_try_enable_flash_attn", lambda: None)
+    monkeypatch.setattr(cli, "_bootstrap_onnxruntime", lambda: None)
+    monkeypatch.setattr(cli, "_spawn_browser_opener", lambda *a, **k: None)
+    return dist
+
+
+def test_cmd_run_returns_42_when_installer_changed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """server 退出 + restart flag 在 + installer hash 变了 → return 42, flag 保留。
+
+    保留 flag 是关键：studio.sh / studio.bat wrapper 看到 (exit_code==42 且
+    tmp/restart 存在) 才会触发 exec self；只剩 flag 而 exit!=42 走普通 restart。
+    """
+    _stub_run_bootstrap(monkeypatch, tmp_path)
+
+    fake_flag = tmp_path / "restart"
+    fake_flag.touch()
+    monkeypatch.setattr(cli, "_RESTART_FLAG", fake_flag)
+
+    # 第一次 (startup snapshot) 返 A；第二次 (server 退出后) 返 B
+    call_count = [0]
+    def fake_hashes() -> dict[str, str]:
+        call_count[0] += 1
+        return {"cli.py": "B"} if call_count[0] > 1 else {"cli.py": "A"}
+    monkeypatch.setattr(cli, "_installer_hashes", fake_hashes)
+
+    # subprocess.call 直接返 0（不真起 server）
+    monkeypatch.setattr(cli.subprocess, "call", lambda *a, **k: 0)
+
+    rc = cli.main(["run", "--no-browser"])
+    assert rc == cli._INSTALLER_RELOAD_EXIT_CODE == 42
+    assert fake_flag.exists(), "flag 必须保留给 wrapper 走 exec-self 路径"
+    assert "launcher 文件更新" in capsys.readouterr().out
+
+
+def test_cmd_run_normal_restart_when_installer_unchanged(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """server 退出 + restart flag 在 + installer hash 没变 → 删 flag, 重新 loop。"""
+    _stub_run_bootstrap(monkeypatch, tmp_path)
+
+    fake_flag = tmp_path / "restart"
+    monkeypatch.setattr(cli, "_RESTART_FLAG", fake_flag)
+    monkeypatch.setattr(cli, "_installer_hashes", lambda: {"cli.py": "stable"})
+
+    # 第一轮 server 退出时写 flag（模拟 /api/system/restart），第二轮不写
+    server_calls = [0]
+    def fake(cmd, **_: Any) -> int:
+        if "studio.server" in " ".join(cmd):
+            if server_calls[0] == 0:
+                fake_flag.touch()
+            server_calls[0] += 1
+        return 0
+    monkeypatch.setattr(cli.subprocess, "call", fake)
+
+    rc = cli.main(["run", "--no-browser"])
+    assert rc == 0
+    assert not fake_flag.exists(), "normal restart 走完后 flag 应被删"
+    assert server_calls[0] == 2, "正常 restart 应当 loop 两次"
+
+
+def test_cmd_run_no_flag_no_dispatch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """server 退出但 tmp/restart 不存在 → 直接 return rc，不查 installer hash。
+
+    这条保证 PR-D 的 dispatch 不会拦截"用户 Ctrl+C 退出 server"这种正常下班路径。
+    """
+    _stub_run_bootstrap(monkeypatch, tmp_path)
+
+    fake_flag = tmp_path / "restart"  # 不 touch
+    monkeypatch.setattr(cli, "_RESTART_FLAG", fake_flag)
+
+    # 如果 dispatch 看了 installer hash，这里会因为返回值变化导致 rc==42；
+    # 测试期望根本不查
+    hash_calls = [0]
+    def fake_hashes() -> dict[str, str]:
+        hash_calls[0] += 1
+        return {"cli.py": "v"} if hash_calls[0] == 1 else {"cli.py": "v-changed"}
+    monkeypatch.setattr(cli, "_installer_hashes", fake_hashes)
+
+    monkeypatch.setattr(cli.subprocess, "call", lambda *a, **k: 7)
+
+    rc = cli.main(["run", "--no-browser"])
+    assert rc == 7  # 直接 return server 退出码
+    # startup 时调过一次；server 退出后 flag 不在，不应再调
+    assert hash_calls[0] == 1

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -467,3 +467,40 @@ def test_root_fallback_when_no_dist(
     assert resp.status_code == 200
     body = resp.json()
     assert "AnimaStudio" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# /api/system/restart (ADR 0002 / PR-A)
+# ---------------------------------------------------------------------------
+
+def test_system_restart_writes_flag_and_schedules_shutdown(
+    client: TestClient,
+    isolated_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POST /api/system/restart 应该：
+    1. 写 tmp/restart 标志文件
+    2. 触发 BackgroundTask 走 _raise_sigint_after_response（实际发 SIGINT 会杀
+       测试进程，所以这里 monkeypatch 成 no-op + 记录是否被调用）
+    3. 返回 200 + {"ok": true}
+    """
+    # 把 SIGINT helper 替换为记录器，避免真发信号杀测试
+    called: dict[str, bool] = {"ran": False}
+    def _stub_shutdown() -> None:
+        called["ran"] = True
+    monkeypatch.setattr(server, "_raise_sigint_after_response", _stub_shutdown)
+
+    # 把 flag 路径指向 tmp，避免污染仓库 tmp/
+    flag = isolated_paths["tmp"] / "restart"
+    monkeypatch.setattr(server, "_RESTART_FLAG", flag)
+
+    assert not flag.exists()
+    resp = client.post("/api/system/restart")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert flag.exists(), "tmp/restart flag 应被写入"
+    # BackgroundTask 在 starlette TestClient 上是同步执行的（response 走完后），
+    # 所以这里 stub 一定被调用过
+    assert called["ran"], "_raise_sigint_after_response BackgroundTask 应被调度"

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -683,7 +683,8 @@ def test_system_restart_rejects_when_running_task(
 def test_system_update_status_null_when_no_history(
     client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """没有 update 历史时返 {status: null}。"""
+    """没有 update 历史时返 {status: null, rollback_target: null}。
+    rollback_target 必须存在（即便 null），前端用它判断按钮显隐。"""
     from studio.services import updater
     monkeypatch.setattr(updater, "UPDATE_STATUS", tmp_path / ".update_status")
     monkeypatch.setattr(updater, "LAST_VERSION", tmp_path / ".last_version")
@@ -691,6 +692,24 @@ def test_system_update_status_null_when_no_history(
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] is None
+    assert "rollback_target" in body
+    assert body["rollback_target"] is None
+
+
+def test_system_update_status_rollback_without_status(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """.update_status 不存在但 .last_version 存在（用户手动 git reset 后的场景）：
+    应当返 status=null 但 rollback_target=sha，让 UI 显示回滚按钮。"""
+    from studio.services import updater
+    monkeypatch.setattr(updater, "last_status", lambda: None)
+    monkeypatch.setattr(updater, "rollback_target", lambda: "cafebabe" * 5)
+
+    resp = client.get("/api/system/update_status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] is None
+    assert body["rollback_target"] == "cafebabe" * 5
 
 
 def test_system_update_status_returns_recorded(

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -504,3 +504,173 @@ def test_system_restart_writes_flag_and_schedules_shutdown(
     # BackgroundTask 在 starlette TestClient 上是同步执行的（response 走完后），
     # 所以这里 stub 一定被调用过
     assert called["ran"], "_raise_sigint_after_response BackgroundTask 应被调度"
+
+
+# ---------------------------------------------------------------------------
+# /api/system/version (ADR 0002 / PR-B)
+# ---------------------------------------------------------------------------
+
+def test_system_version_returns_fields(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """GET /api/system/version 应返回 VersionInfo dataclass 的所有字段。"""
+    from studio.services import updater
+
+    fake = updater.VersionInfo(
+        version="0.6.0", commit="abc123", commit_short="abc123",
+        commit_time_iso="2026-05-13T10:00:00+00:00", branch="master",
+        tag="v0.6.0", is_dirty=False,
+    )
+    monkeypatch.setattr(updater, "current_version", lambda: fake)
+
+    resp = client.get("/api/system/version")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["version"] == "0.6.0"
+    assert body["branch"] == "master"
+    assert body["tag"] == "v0.6.0"
+    assert body["is_dirty"] is False
+
+
+# ---------------------------------------------------------------------------
+# /api/system/update_check (ADR 0002 / PR-B)
+# ---------------------------------------------------------------------------
+
+def test_system_update_check_master_default(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """默认 channel=master，返回 UpdateCheckResult 字段。"""
+    from studio.services import updater
+
+    fake = updater.UpdateCheckResult(
+        channel="master", current_commit="abc", latest_commit="def",
+        commits_ahead=2, has_update=True, latest_tag="v0.6.1",
+        checked_at=1234567890.0,
+    )
+    captured: dict = {}
+    def _fake_check(channel="master", use_cache=True):
+        captured["channel"] = channel
+        captured["use_cache"] = use_cache
+        return fake
+    monkeypatch.setattr(updater, "check_update", _fake_check)
+
+    resp = client.get("/api/system/update_check")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["channel"] == "master"
+    assert body["has_update"] is True
+    assert body["latest_tag"] == "v0.6.1"
+    assert captured == {"channel": "master", "use_cache": True}
+
+
+def test_system_update_check_force_skips_cache(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """force=true 应传 use_cache=False 给 updater.check_update。"""
+    from studio.services import updater
+
+    captured: dict = {}
+    def _fake_check(channel="master", use_cache=True):
+        captured["use_cache"] = use_cache
+        return updater.UpdateCheckResult(
+            channel=channel, current_commit="", latest_commit="",
+            commits_ahead=0, has_update=False, latest_tag=None,
+            checked_at=0.0,
+        )
+    monkeypatch.setattr(updater, "check_update", _fake_check)
+
+    client.get("/api/system/update_check?force=true")
+    assert captured["use_cache"] is False
+
+
+def test_system_update_check_invalid_channel(client: TestClient) -> None:
+    resp = client.get("/api/system/update_check?channel=feature%2Fwhatever")
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# /api/system/update (ADR 0002 / PR-B)
+# ---------------------------------------------------------------------------
+
+def test_system_update_rejects_when_running_task(
+    client: TestClient,
+    isolated_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """有 status='running' 任务时 update 应返 422 + 任务列表。"""
+    from studio import db
+    with db.connection_for(isolated_paths["db"]) as conn:
+        tid = db.create_task(conn, name="炼丹中", config_name="train", priority=0)
+        db.update_task(conn, tid, status="running", task_type="train")
+
+    resp = client.post("/api/system/update", json={"target": "origin/master"})
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["detail"]["error"] == "running_tasks_present"
+    assert len(body["detail"]["tasks"]) == 1
+    assert body["detail"]["tasks"][0]["id"] == tid
+
+
+def test_system_update_rejects_when_dirty(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """working tree dirty 时 update 应返 422。"""
+    from studio.services import updater
+    dirty = updater.VersionInfo(
+        version="0.6.0", commit="abc", commit_short="abc", commit_time_iso="",
+        branch="master", tag=None, is_dirty=True,
+    )
+    monkeypatch.setattr(updater, "current_version", lambda: dirty)
+
+    resp = client.post("/api/system/update", json={"target": "origin/master"})
+    assert resp.status_code == 422
+    body = resp.json()
+    assert body["detail"]["error"] == "dirty_working_tree"
+
+
+def test_system_update_writes_pending_and_restart_flag(
+    client: TestClient,
+    isolated_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """正常路径：写 .update_pending（含 target）+ tmp/restart + 调度 SIGINT。"""
+    from studio.services import updater
+
+    # 干净 working tree
+    clean = updater.VersionInfo(
+        version="0.6.0", commit="abc", commit_short="abc", commit_time_iso="",
+        branch="master", tag=None, is_dirty=False,
+    )
+    monkeypatch.setattr(updater, "current_version", lambda: clean)
+
+    # 重定向 flag 路径到隔离 tmp
+    pending = tmp_path / ".update_pending"
+    restart_flag = tmp_path / "tmp" / "restart"
+    monkeypatch.setattr(updater, "UPDATE_PENDING", pending)
+    monkeypatch.setattr(updater, "RESTART_FLAG", restart_flag)
+
+    # 拦截 SIGINT
+    monkeypatch.setattr(server, "_raise_sigint_after_response", lambda: None)
+
+    resp = client.post("/api/system/update", json={"target": "origin/dev"})
+    assert resp.status_code == 200
+    assert pending.exists()
+    assert pending.read_text(encoding="utf-8") == "origin/dev"
+    assert restart_flag.exists()
+
+
+def test_system_restart_rejects_when_running_task(
+    client: TestClient,
+    isolated_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PR-B 新加：restart 也要查 running task。"""
+    from studio import db
+    with db.connection_for(isolated_paths["db"]) as conn:
+        tid = db.create_task(conn, name="跑数据", config_name="tag", priority=0)
+        db.update_task(conn, tid, status="running", task_type="tag")
+
+    resp = client.post("/api/system/restart")
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["error"] == "running_tasks_present"

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -674,3 +674,137 @@ def test_system_restart_rejects_when_running_task(
     resp = client.post("/api/system/restart")
     assert resp.status_code == 422
     assert resp.json()["detail"]["error"] == "running_tasks_present"
+
+
+# ---------------------------------------------------------------------------
+# /api/system/rollback + update_status + update_log (ADR 0002 / PR-C)
+# ---------------------------------------------------------------------------
+
+def test_system_update_status_null_when_no_history(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """没有 update 历史时返 {status: null}。"""
+    from studio.services import updater
+    monkeypatch.setattr(updater, "UPDATE_STATUS", tmp_path / ".update_status")
+    monkeypatch.setattr(updater, "LAST_VERSION", tmp_path / ".last_version")
+    resp = client.get("/api/system/update_status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] is None
+
+
+def test_system_update_status_returns_recorded(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """update_status 把 last_status() + rollback_target() 合并返回。"""
+    from studio.services import updater
+    fake = updater.UpdateStatus(
+        status="failed", reason="git fetch: timeout", target="origin/master",
+        from_commit="abc", to_commit="abc", started_at=1000.0, finished_at=1010.0,
+        deps_changed=False, log_excerpt="[git fetch] FAILED",
+    )
+    monkeypatch.setattr(updater, "last_status", lambda: fake)
+    monkeypatch.setattr(updater, "rollback_target", lambda: "deadbeef" * 5)
+
+    resp = client.get("/api/system/update_status")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "failed"
+    assert body["reason"] == "git fetch: timeout"
+    assert body["rollback_target"] == "deadbeef" * 5
+
+
+def test_system_update_log_empty(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from studio.services import updater
+    monkeypatch.setattr(updater, "read_update_log", lambda: "")
+    resp = client.get("/api/system/update_log")
+    assert resp.status_code == 200
+    assert resp.json() == {"content": ""}
+
+
+def test_system_update_log_with_content(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from studio.services import updater
+    monkeypatch.setattr(updater, "read_update_log", lambda: "=== run ===\n[ok]\n")
+    resp = client.get("/api/system/update_log")
+    assert resp.json()["content"].startswith("=== run ===")
+
+
+def test_system_rollback_409_when_no_target(
+    client: TestClient,
+    isolated_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """没 .last_version 或 commit 不在仓库时返 409。"""
+    from studio.services import updater
+    monkeypatch.setattr(updater, "current_version", lambda: updater.VersionInfo(
+        version="0.0.0", commit="abc", commit_short="abc", commit_time_iso="",
+        branch="master", tag=None, is_dirty=False,
+    ))
+    monkeypatch.setattr(updater, "request_rollback", lambda: None)
+
+    resp = client.post("/api/system/rollback")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["error"] == "no_rollback_target"
+
+
+def test_system_rollback_rejects_dirty(
+    client: TestClient,
+    isolated_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rollback 共用 update 的 dirty precondition。"""
+    from studio.services import updater
+    monkeypatch.setattr(updater, "current_version", lambda: updater.VersionInfo(
+        version="0.0.0", commit="abc", commit_short="abc", commit_time_iso="",
+        branch="master", tag=None, is_dirty=True,
+    ))
+
+    resp = client.post("/api/system/rollback")
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["error"] == "dirty_working_tree"
+
+
+def test_system_rollback_rejects_running_task(
+    client: TestClient,
+    isolated_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """rollback 共用 update 的 running task precondition。"""
+    from studio import db
+    with db.connection_for(isolated_paths["db"]) as conn:
+        tid = db.create_task(conn, name="炼丹", config_name="train", priority=0)
+        db.update_task(conn, tid, status="running", task_type="train")
+
+    resp = client.post("/api/system/rollback")
+    assert resp.status_code == 422
+    assert resp.json()["detail"]["error"] == "running_tasks_present"
+
+
+def test_system_rollback_success_writes_flag(
+    client: TestClient,
+    isolated_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """正常路径：reads .last_version → request_update(target=<sha>) → 200。"""
+    from studio.services import updater
+    monkeypatch.setattr(updater, "current_version", lambda: updater.VersionInfo(
+        version="0.0.0", commit="abc", commit_short="abc", commit_time_iso="",
+        branch="master", tag=None, is_dirty=False,
+    ))
+    captured: dict = {}
+    def _fake_rollback() -> str:
+        captured["called"] = True
+        return "feedbeef" * 5
+    monkeypatch.setattr(updater, "request_rollback", _fake_rollback)
+    monkeypatch.setattr(server, "_raise_sigint_after_response", lambda: None)
+
+    resp = client.post("/api/system/rollback")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["target"] == "feedbeef" * 5
+    assert captured["called"]

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,269 @@
+"""ADR 0002 self-update — updater 模块单测。
+
+覆盖：
+- current_version() smoke：跑真 git 拿 HEAD 状态（CI 上跑也行，工作区干净就 dirty=False）
+- check_update() 缓存路径：写 cache + 读 cache + TTL 过期
+- request_update / has_pending / apply_pending 干净退出：flag 文件读写
+- apply_pending dirty tree 中止：working tree 脏时正确 abort + 写 log
+
+不覆盖（需要网络 / 真 git fetch / pip / npm）：
+- check_update fetch 失败时的 error 路径
+- apply_pending 真正 pull 路径
+
+那部分由手测覆盖（用户在本地 webui 点更新按钮验证端到端）。
+"""
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict
+from pathlib import Path
+
+import pytest
+
+from studio.services import updater
+
+
+@pytest.fixture(autouse=True)
+def _isolate_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """把 updater 模块里指向真 studio_data / tmp 的路径全部重定向到 tmp_path，
+    避免污染开发机的标志文件。"""
+    monkeypatch.setattr(updater, "RESTART_FLAG", tmp_path / "tmp" / "restart")
+    monkeypatch.setattr(updater, "UPDATE_PENDING", tmp_path / ".update_pending")
+    monkeypatch.setattr(updater, "UPDATE_CACHE", tmp_path / ".update_cache")
+    monkeypatch.setattr(updater, "LAST_VERSION", tmp_path / ".last_version")
+    monkeypatch.setattr(updater, "UPDATE_LOG", tmp_path / ".update_log")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# current_version
+# ---------------------------------------------------------------------------
+
+def test_current_version_smoke() -> None:
+    """跑真 git，返回字段都是字符串 / bool。仓库目录里这个一定能跑。"""
+    v = updater.current_version()
+    assert isinstance(v.version, str) and v.version
+    # commit 在 git 仓里至少是 sha 或 'unknown'
+    assert isinstance(v.commit, str) and v.commit
+    assert isinstance(v.commit_short, str)
+    assert isinstance(v.branch, str)
+    assert isinstance(v.is_dirty, bool)
+    # tag 可能为 None
+    assert v.tag is None or isinstance(v.tag, str)
+
+
+# ---------------------------------------------------------------------------
+# request_update / has_pending
+# ---------------------------------------------------------------------------
+
+def test_request_update_writes_flags(_isolate_flags: Path) -> None:
+    assert not updater.has_pending()
+    assert not updater.RESTART_FLAG.exists()
+
+    updater.request_update("origin/master")
+
+    assert updater.has_pending()
+    assert updater.UPDATE_PENDING.read_text(encoding="utf-8") == "origin/master"
+    assert updater.RESTART_FLAG.exists()
+
+
+def test_request_update_custom_target(_isolate_flags: Path) -> None:
+    updater.request_update("abc1234567")
+    assert updater.UPDATE_PENDING.read_text(encoding="utf-8") == "abc1234567"
+
+
+# ---------------------------------------------------------------------------
+# apply_pending — 各种 abort 路径（不真 pull）
+# ---------------------------------------------------------------------------
+
+def test_apply_pending_no_pending_returns_false(_isolate_flags: Path) -> None:
+    assert updater.apply_pending(emit=lambda _: None) is False
+
+
+def test_apply_pending_dirty_tree_aborts(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """working tree dirty 时 apply_pending 应该 abort + 写 log + 清 .update_pending，
+    不调 git fetch / reset。"""
+    fake_version = updater.VersionInfo(
+        version="0.0.0", commit="abc", commit_short="abc",
+        commit_time_iso="", branch="master", tag=None, is_dirty=True,
+    )
+    monkeypatch.setattr(updater, "current_version", lambda: fake_version)
+
+    git_calls: list[tuple] = []
+    def _fake_git(*args, **kwargs):
+        git_calls.append(args)
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    updater.request_update("origin/master")
+    result = updater.apply_pending(emit=lambda _: None)
+
+    assert result is True  # 走过 apply 路径（即便 abort 也返 True）
+    assert not updater.UPDATE_PENDING.exists()  # 清了 pending
+    assert updater.UPDATE_LOG.exists()
+    log = updater.UPDATE_LOG.read_text(encoding="utf-8")
+    assert "[abort] working tree dirty" in log
+    # 不应该调任何 git 命令（fetch / reset / pull 都不该跑）
+    assert git_calls == []
+
+
+def test_apply_pending_records_last_version(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """apply_pending 必须把当前 commit 写到 .last_version（rollback 用）。
+    用 dirty tree 路径触发，因为它在 abort 之前已经写了。"""
+    fake_version = updater.VersionInfo(
+        version="0.0.0", commit="deadbeef" * 5, commit_short="deadbeef",
+        commit_time_iso="", branch="master", tag=None, is_dirty=True,
+    )
+    monkeypatch.setattr(updater, "current_version", lambda: fake_version)
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
+
+    updater.request_update("origin/master")
+    updater.apply_pending(emit=lambda _: None)
+
+    assert updater.LAST_VERSION.exists()
+    assert updater.LAST_VERSION.read_text(encoding="utf-8") == "deadbeef" * 5
+
+
+# ---------------------------------------------------------------------------
+# check_update — 缓存路径
+# ---------------------------------------------------------------------------
+
+def test_check_update_cache_hit(_isolate_flags: Path) -> None:
+    """master 通道缓存命中：缓存还没过期就直接返回 cached 值，不调 git。"""
+    cached = updater.UpdateCheckResult(
+        channel="master", current_commit="abc", latest_commit="def",
+        commits_ahead=3, has_update=True, latest_tag="v0.7.0",
+        checked_at=time.time(),  # 刚刚
+    )
+    updater.UPDATE_CACHE.write_text(json.dumps(asdict(cached)), encoding="utf-8")
+
+    result = updater.check_update(channel="master", use_cache=True)
+    assert result.commits_ahead == 3
+    assert result.latest_tag == "v0.7.0"
+    assert result.has_update is True
+
+
+def test_check_update_cache_expired(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """cache TTL 超过 24h 就忽略 cache，回退到 git fetch（这里 mock）。"""
+    stale = updater.UpdateCheckResult(
+        channel="master", current_commit="abc", latest_commit="def",
+        commits_ahead=1, has_update=True, latest_tag=None,
+        checked_at=time.time() - updater.UPDATE_CACHE_TTL_SECONDS - 100,
+    )
+    updater.UPDATE_CACHE.write_text(json.dumps(asdict(stale)), encoding="utf-8")
+
+    git_calls: list[tuple] = []
+    def _fake_git(*args, **kwargs):
+        git_calls.append(args)
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/master"):
+            return 0, "newsha", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/master"):
+            return 0, "0", ""
+        if args[:2] == ("rev-parse", "HEAD"):
+            return 0, "newsha", ""
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    result = updater.check_update(channel="master", use_cache=True)
+    # 走了真 fetch 路径，cache 被覆盖
+    assert any(c[:2] == ("fetch", "origin") for c in git_calls), "应当调 git fetch"
+    # commits_ahead 来自新结果（0），不是旧 cache 的 1
+    assert result.commits_ahead == 0
+
+
+def test_check_update_force_skips_cache(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """force=true (use_cache=False) 即便 cache 还新也要重 fetch。"""
+    cached = updater.UpdateCheckResult(
+        channel="master", current_commit="abc", latest_commit="def",
+        commits_ahead=5, has_update=True, latest_tag="v0.7.0",
+        checked_at=time.time(),
+    )
+    updater.UPDATE_CACHE.write_text(json.dumps(asdict(cached)), encoding="utf-8")
+
+    git_calls: list[tuple] = []
+    def _fake_git(*args, **kwargs):
+        git_calls.append(args)
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/master"):
+            return 0, "remote_sha", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/master"):
+            return 0, "2", ""
+        if args[:2] == ("rev-parse", "HEAD"):
+            return 0, "local_sha", ""
+        if args[0] == "describe":
+            return 0, "v0.8.0", ""
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.7.0", commit="local_sha", commit_short="local_sh",
+            commit_time_iso="", branch="master", tag=None, is_dirty=False,
+        ),
+    )
+
+    result = updater.check_update(channel="master", use_cache=False)
+    assert any(c[:2] == ("fetch", "origin") for c in git_calls), "force 应当跳过 cache 直接 fetch"
+    assert result.commits_ahead == 2
+
+
+def test_check_update_fetch_failure_returns_error(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """git fetch 失败时返回 error 字段非 None，不抛异常。"""
+    def _fake_git(*args, **kwargs):
+        if args[:2] == ("fetch", "origin"):
+            return 128, "", "fatal: unable to access 'github.com'"
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    result = updater.check_update(channel="master", use_cache=False)
+    assert result.error is not None
+    assert "fetch failed" in result.error.lower() or "fatal" in result.error.lower()
+    assert result.has_update is False
+
+
+def test_check_update_invalid_channel_raises() -> None:
+    with pytest.raises(ValueError, match="invalid channel"):
+        updater.check_update(channel="weird-branch")
+
+
+# ---------------------------------------------------------------------------
+# requirements / package.json stale 检测
+# ---------------------------------------------------------------------------
+
+def test_requirements_marker_stale_no_marker(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """没 sha256 marker 文件（全新装的 venv）应该返回 True。"""
+    fake_req = tmp_path / "requirements.txt"
+    fake_req.write_text("torch>=2.0\n", encoding="utf-8")
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+    assert updater._requirements_marker_stale() is True
+
+
+def test_requirements_marker_stale_match(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """marker 内容与 requirements.txt sha256 一致时返回 False。"""
+    import hashlib
+    fake_req = tmp_path / "requirements.txt"
+    content = b"torch>=2.0\nfastapi>=0.100\n"
+    fake_req.write_bytes(content)
+    marker = tmp_path / "venv" / ".studio-requirements.sha256"
+    marker.parent.mkdir(parents=True, exist_ok=True)
+    marker.write_text(hashlib.sha256(content).hexdigest(), encoding="utf-8")
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+    assert updater._requirements_marker_stale() is False

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -33,6 +33,7 @@ def _isolate_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(updater, "UPDATE_CACHE", tmp_path / ".update_cache")
     monkeypatch.setattr(updater, "LAST_VERSION", tmp_path / ".last_version")
     monkeypatch.setattr(updater, "UPDATE_LOG", tmp_path / ".update_log")
+    monkeypatch.setattr(updater, "UPDATE_STATUS", tmp_path / ".update_status")
     return tmp_path
 
 
@@ -267,3 +268,113 @@ def test_requirements_marker_stale_match(
     marker.write_text(hashlib.sha256(content).hexdigest(), encoding="utf-8")
     monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
     assert updater._requirements_marker_stale() is False
+
+
+# ---------------------------------------------------------------------------
+# PR-C：update status / rollback
+# ---------------------------------------------------------------------------
+
+def test_apply_pending_writes_aborted_status(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """dirty tree abort 时 .update_status 应当被写入 status='aborted'。"""
+    fake = updater.VersionInfo(
+        version="0.0.0", commit="abc", commit_short="abc",
+        commit_time_iso="", branch="master", tag=None, is_dirty=True,
+    )
+    monkeypatch.setattr(updater, "current_version", lambda: fake)
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
+
+    updater.request_update("origin/master")
+    updater.apply_pending(emit=lambda _: None)
+
+    st = updater.last_status()
+    assert st is not None
+    assert st.status == "aborted"
+    assert "dirty" in st.reason.lower()
+    assert st.from_commit == "abc"
+
+
+def test_apply_pending_writes_failed_status_on_fetch_error(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """git fetch 失败应当写 status='failed' + reason 含 stderr 摘要。"""
+    fake = updater.VersionInfo(
+        version="0.0.0", commit="abc", commit_short="abc",
+        commit_time_iso="", branch="master", tag=None, is_dirty=False,
+    )
+    monkeypatch.setattr(updater, "current_version", lambda: fake)
+    def _fake_git(*args, **kwargs):
+        if args[:2] == ("fetch", "origin"):
+            return 128, "", "fatal: Could not resolve host"
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    updater.request_update("origin/master")
+    updater.apply_pending(emit=lambda _: None)
+
+    st = updater.last_status()
+    assert st is not None
+    assert st.status == "failed"
+    assert "Could not resolve host" in st.reason or "git fetch" in st.reason
+
+
+def test_last_status_returns_none_when_missing(_isolate_flags: Path) -> None:
+    assert updater.last_status() is None
+
+
+def test_rollback_target_no_file(_isolate_flags: Path) -> None:
+    """没 .last_version 时返回 None。"""
+    assert updater.rollback_target() is None
+
+
+def test_rollback_target_validates_commit_exists(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """.last_version 存在但 commit 已 GC 时返回 None。"""
+    updater.LAST_VERSION.write_text("deadbeef" * 5, encoding="utf-8")
+    def _fake_git(*args, **kwargs):
+        if args[:2] == ("cat-file", "-e"):
+            return 1, "", "fatal: not a valid object name"
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    assert updater.rollback_target() is None
+
+
+def test_rollback_target_valid(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """.last_version + commit 存在 → 返回 sha。"""
+    updater.LAST_VERSION.write_text("cafebabe" * 5, encoding="utf-8")
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
+    assert updater.rollback_target() == "cafebabe" * 5
+
+
+def test_request_rollback_writes_pending(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """rollback 应当走 request_update 路径，target 是 .last_version 的 sha。"""
+    updater.LAST_VERSION.write_text("c0ffeec0ffee" + "0" * 28, encoding="utf-8")
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
+
+    target = updater.request_rollback()
+    assert target is not None
+    assert updater.has_pending()
+    assert updater.UPDATE_PENDING.read_text(encoding="utf-8") == target
+
+
+def test_request_rollback_returns_none_without_target(_isolate_flags: Path) -> None:
+    """没 .last_version 时 request_rollback 返回 None 且不写 pending。"""
+    assert updater.request_rollback() is None
+    assert not updater.has_pending()
+
+
+def test_read_update_log(_isolate_flags: Path) -> None:
+    """read_update_log 应当返回完整文件内容。"""
+    updater.UPDATE_LOG.parent.mkdir(parents=True, exist_ok=True)
+    updater.UPDATE_LOG.write_text("line 1\nline 2\n", encoding="utf-8")
+    assert updater.read_update_log() == "line 1\nline 2\n"
+
+
+def test_read_update_log_missing(_isolate_flags: Path) -> None:
+    assert updater.read_update_log() == ""

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -378,3 +378,32 @@ def test_read_update_log(_isolate_flags: Path) -> None:
 
 def test_read_update_log_missing(_isolate_flags: Path) -> None:
     assert updater.read_update_log() == ""
+
+
+def test_last_status_tolerates_utf8_bom(_isolate_flags: Path) -> None:
+    """Windows PowerShell 5.1 写文件默认带 UTF-8 BOM；read_text(utf-8) 不剥 BOM
+    导致 json.loads 抛 JSONDecodeError，UI 看到 status=null 什么都不显示。
+    用 utf-8-sig 读应当透明剥 BOM 并正常 parse。"""
+    BOM = "﻿"
+    json_str = '{"status": "failed", "reason": "test", "target": "origin/master", ' \
+               '"from_commit": "abc", "to_commit": "abc", "started_at": 1.0, ' \
+               '"finished_at": 2.0, "deps_changed": false, "log_excerpt": ""}'
+    updater.UPDATE_STATUS.parent.mkdir(parents=True, exist_ok=True)
+    updater.UPDATE_STATUS.write_text(BOM + json_str, encoding="utf-8")
+
+    st = updater.last_status()
+    assert st is not None, "带 BOM 的 .update_status 应当被正常 parse"
+    assert st.status == "failed"
+    assert st.reason == "test"
+
+
+def test_rollback_target_tolerates_utf8_bom(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """同上，针对 .last_version 文本。"""
+    BOM = "﻿"
+    sha = "deadbeef" * 5
+    updater.LAST_VERSION.parent.mkdir(parents=True, exist_ok=True)
+    updater.LAST_VERSION.write_text(BOM + sha, encoding="utf-8")
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
+    assert updater.rollback_target() == sha


### PR DESCRIPTION
## Summary

实现 ADR 0002 的 webui 内一键更新功能 — 4 个 PR 合一，11 个本地 commit。

- **PR-A**：基础重启链路（`tmp/restart` flag + cli.py inner loop + studio.sh/bat wrapper loop + `POST /api/system/restart` + Settings 系统 tab）
- **PR-B**：update 主路径（`studio/services/updater.py` + `/api/system/version` `/update_check` `/update` + running task 保护 422 + cli.py 启动期 `apply_pending()` git reset + 增量 pip/npm install + Topbar update badge）
- **PR-C**：回滚 + 日志（`.update_status` / `.last_version` / `.update_log` + `/api/system/rollback` + 失败 banner + 切换按钮 + 查看日志 modal）
- **PR-D**：installer 自检（cli.py/studio.sh/studio.bat sha256 + 退出码 42 + wrapper exec self）+ dev 通道 toggle（`SystemConfig.show_dev_channel` 持久化 + UI 高级折叠 + 手动检查 dev / 更新到 dev）+ ChannelPill 通道指示徽章

设计文档：[`docs/adr/0002-webui-self-update.md`](docs/adr/0002-webui-self-update.md) Proposed 状态。

## 关键决策

- **流派 A**（flag + shell wrapper loop，学 A1111 / SwarmUI）—— 不用 `os.execv`，跨平台稳。强制约束：running task 时拒绝 update / restart / rollback
- **自动检查 master only**（24h cache 写 `.update_cache`）；dev 必须手动触发，避免开发者被 dev 高频 commit 持续骚扰 badge
- **Native module 走 pending_install 兜底**（torch / onnxruntime 复用现有 PR-S 机制，next 启动期补装；不在 update 当下处理）
- **exit 42 协议**（PR-D）：cli.py/wrapper 任一变化 → cli.py keep flag + exit 42，wrapper 看到 (exit==42 && tmp/restart) 走 exec self
- **Telemetry：不做**。失败 UI 提供 "复制 .update_log 到 issue 模板" 按钮

## 不在本 PR scope

- PyPI / Docker 部署的 update 路径（git clone only）
- 大版本 / db schema 迁移的 update
- 训练任务暂停 + resume（独立 PR，前置 dep；当前用 "拒绝有 running task" 兜底）
- 多用户 / ACL（如果未来 server 共享）

## Test plan

### 自动化（已跑过）
- [x] pytest：125 全过（secrets 29 含 PR-D 4 + cli 26 含 PR-D 5 + server 8 + updater 25 + 周边）
- [x] vitest：135 全过
- [x] tsc：clean
- [x] `bash -n studio.sh` 通过

### 人工实测（dev merge 后在本地 dev 上跑）
- [ ] **PR-A 重启**：webui 点 [重启 server] → 30s-1min 后页面自动 reconnect
- [ ] **任务保护**：有 running task 时点 [重启] / [立即更新] 返 422 + 列出 running tasks
- [ ] **PR-B 主路径**：造一个 fake "新 commit" 推到 origin/dev → 本地 [立即更新] → fetch + reset + 必要时 pip → 重启 → 新代码生效
- [ ] **PR-C 回滚**：上面 update 后，"切换到 ..." 按钮可见 → 点 → reset 回前一版 → 再点切回新版
- [ ] **PR-C 失败 banner**：手动 dirty working tree 后点 update → 422 + UI 红色 banner + "查看完整日志" modal
- [ ] **PR-D 自检 exit 42**：推一个改了 cli.py / studio.sh / studio.bat 的 commit → update → 控制台应看到 `[studio] 检测到 launcher 文件更新` + wrapper exec self
- [ ] **PR-D dev 通道 toggle**：Settings → 版本 → ▾ 高级设置 → 勾选 → dev 卡片显示；刷页持久化（落到 secrets.json `system.show_dev_channel`）
- [ ] **PR-D 通道徽章**：master 上看 "稳定/绿" pill；切到 dev 后看 "开发版/橙" pill
- [ ] **PR-D 切回稳定**：在 dev 上时主按钮文案变 "切回稳定通道 → master"，dialog 提示会丢失 dev 独有 commit
- [ ] **Topbar badge 只看 master**：dev 有新提交 + master 无新 → badge **不**亮
- [ ] 跨平台：Windows + Linux wrapper 路径都过一遍

🤖 Generated with [Claude Code](https://claude.com/claude-code)