### PR TITLE
refactor(settings): InfoButton 抽组件 + 全页 help text 减法 / 历史显示 tag

### DIFF
--- a/studio/server.py
+++ b/studio/server.py
@@ -3220,12 +3220,18 @@ def system_update_status() -> dict[str, Any]:
     """
     from dataclasses import asdict
     rollback_to = updater.rollback_target()
+    rollback_tag = updater.exact_tag_for(rollback_to) if rollback_to else None
     st = updater.last_status()
     if st is None:
-        return {"status": None, "rollback_target": rollback_to}
+        return {
+            "status": None,
+            "rollback_target": rollback_to,
+            "rollback_target_tag": rollback_tag,
+        }
     return {
         **asdict(st),
         "rollback_target": rollback_to,
+        "rollback_target_tag": rollback_tag,
     }
 
 

--- a/studio/server.py
+++ b/studio/server.py
@@ -104,9 +104,41 @@ db.init_db()
 logger = logging.getLogger(__name__)
 
 
+def _install_proactor_disconnect_filter(loop: asyncio.AbstractEventLoop) -> None:
+    """吞 Windows + asyncio Proactor 的 cosmetic ConnectionResetError 噪声。
+
+    Python asyncio 在 Windows 上有 [bpo-44291](https://github.com/python/cpython/issues/87691) 类问题：
+    远端 TCP 强制断开（用户关 tab / 刷新 / SSE 重连，WinError 10054 / 10053）
+    时 `_ProactorBasePipeTransport._call_connection_lost` 走 `socket.shutdown()`
+    抛 `ConnectionResetError` / `ConnectionAbortedError`，但 callback 内部
+    没 catch 这两个 expected error，asyncio 默认 handler 打 traceback 到
+    stderr。server 完全没事，只是日志被刷一行无意义 stack。
+
+    精确过滤：只在 exception 是 ConnectionResetError / ConnectionAbortedError
+    且 handle repr 含 `_call_connection_lost` 时静默吞掉；其它 asyncio
+    异常仍交给 default handler。仅 Windows 装；其它平台用 SelectorEventLoop
+    没这个 bug。
+    """
+    if os.name != "nt":
+        return
+
+    def _filter(loop_: asyncio.AbstractEventLoop, context: dict[str, Any]) -> None:
+        exc = context.get("exception")
+        if isinstance(exc, (ConnectionResetError, ConnectionAbortedError)):
+            handle = context.get("handle")
+            if handle and "_call_connection_lost" in repr(handle):
+                return
+        loop_.default_exception_handler(context)
+
+    loop.set_exception_handler(_filter)
+
+
 @asynccontextmanager
 async def _lifespan(app_: FastAPI) -> AsyncIterator[None]:
     """启动绑定 event bus 到当前 loop 并起 supervisor；关闭时停 supervisor。"""
+    # 装 Windows ProactorEventLoop 的 ConnectionResetError 过滤器（详见 helper docstring）
+    _install_proactor_disconnect_filter(asyncio.get_running_loop())
+
     # 测试出图 tempdir 遗留清扫（防 supervisor crash 泄漏 anima_gen_* 目录）
     from .services.inference_core import cleanup_stale_generate_tempdirs
     from .services import generate_cache, model_downloader as _md

--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -224,6 +224,17 @@ def resolve_ref(ref: str) -> Optional[str]:
     return out if rc == 0 else None
 
 
+def exact_tag_for(sha: str) -> Optional[str]:
+    """`git describe --tags --exact-match <sha>` → tag 字符串；commit 上没打
+    tag → None。给 UI 用：rollback 按钮文案优先显示 tag（v0.6.0）而非
+    裸 sha；没 tag 时 caller fallback 到 sha[:8]。
+    """
+    if not sha:
+        return None
+    rc, out, _ = _git("describe", "--tags", "--exact-match", sha)
+    return out if rc == 0 and out else None
+
+
 # Self-update feature 引入的 marker 文件。target 上不存在 → 切过去就丢失
 # webui 升级能力（只能 CLI git pull 救援）。preflight() err 级别阻断。
 _SELF_UPDATE_MARKER = "studio/services/updater.py"

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1747,6 +1747,10 @@ export interface SystemUpdateStatus {
   deps_changed?: boolean
   log_excerpt?: string
   rollback_target?: string | null
+  /** rollback target commit 的 exact tag（如 v0.6.0）。后端 git describe
+   *  --tags --exact-match 拿；commit 没打 tag → null。UI 优先显示 tag，
+   *  fallback 到 sha 前 8 位 */
+  rollback_target_tag?: string | null
 }
 
 /** chunk 2 重做 — release_notes.yaml 派生的 release notes。

--- a/studio/web/src/components/InfoButton.tsx
+++ b/studio/web/src/components/InfoButton.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+
+/**
+ * ⓘ 风格的 click-toggle 弹层。给字段名 / section title / 卡片角加帮助说明，
+ * 不在主流 UI 占空间，用户需要时才显示。
+ *
+ * 行为：
+ * - 点 trigger 切换；点外部 / Esc 关
+ * - aria-expanded 给屏幕阅读器；trigger 自带 aria-label
+ * - 默认 trigger 是 unicode ⓘ；可通过 label prop 换
+ *
+ * 不做的事（YAGNI；将来真有别的 trigger 需求再扩）：
+ * - 不支持 hover 触发（手机不友好）
+ * - 不动态计算 placement（统一 bottom-left；视口溢出靠 max-width 收）
+ * - 不接受 trigger 自定义 element（统一 ⓘ button，保持视觉一致性）
+ */
+interface InfoButtonProps {
+  children: ReactNode
+  label?: string
+  ariaLabel?: string
+}
+
+export function InfoButton({ children, label = 'ⓘ', ariaLabel = '更多信息' }: InfoButtonProps) {
+  const [open, setOpen] = useState(false)
+  const wrapRef = useRef<HTMLSpanElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  return (
+    <span ref={wrapRef} className="info-btn-anchor">
+      <button
+        type="button"
+        className="info-btn-trigger"
+        onClick={(e) => {
+          // stopPropagation：避免放在 <summary> / clickable row 里触发外层 toggle
+          e.stopPropagation()
+          setOpen((v) => !v)
+        }}
+        aria-expanded={open}
+        aria-label={ariaLabel}
+      >
+        {label}
+      </button>
+      {open && (
+        <div className="info-btn-panel" role="dialog">
+          {children}
+        </div>
+      )}
+    </span>
+  )
+}

--- a/studio/web/src/components/InfoButton.tsx
+++ b/studio/web/src/components/InfoButton.tsx
@@ -1,26 +1,45 @@
 import { useEffect, useRef, useState, type ReactNode } from 'react'
 
 /**
- * ⓘ 风格的 click-toggle 弹层。给字段名 / section title / 卡片角加帮助说明，
- * 不在主流 UI 占空间，用户需要时才显示。
+ * click-toggle 弹层。给字段名 / section title / 卡片角加帮助说明，不在主流
+ * UI 占空间，用户需要时才显示。
  *
  * 行为：
  * - 点 trigger 切换；点外部 / Esc 关
  * - aria-expanded 给屏幕阅读器；trigger 自带 aria-label
- * - 默认 trigger 是 unicode ⓘ；可通过 label prop 换
+ * - trigger 是 SVG i-in-circle 图标（之前用 Unicode ⓘ 字符在不同字体里
+ *   垂直位置不一致跟相邻文字基线对不齐；SVG 用固定 viewBox 严格居中）
  *
  * 不做的事（YAGNI；将来真有别的 trigger 需求再扩）：
  * - 不支持 hover 触发（手机不友好）
  * - 不动态计算 placement（统一 bottom-left；视口溢出靠 max-width 收）
- * - 不接受 trigger 自定义 element（统一 ⓘ button，保持视觉一致性）
  */
 interface InfoButtonProps {
   children: ReactNode
-  label?: string
   ariaLabel?: string
 }
 
-export function InfoButton({ children, label = 'ⓘ', ariaLabel = '更多信息' }: InfoButtonProps) {
+function InfoIcon() {
+  return (
+    <svg
+      width={12}
+      height={12}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx={8} cy={8} r={6.5} />
+      <line x1={8} y1={7.5} x2={8} y2={11.5} />
+      <circle cx={8} cy={4.8} r={0.6} fill="currentColor" stroke="none" />
+    </svg>
+  )
+}
+
+export function InfoButton({ children, ariaLabel = '更多信息' }: InfoButtonProps) {
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLSpanElement>(null)
 
@@ -53,7 +72,7 @@ export function InfoButton({ children, label = 'ⓘ', ariaLabel = '更多信息'
         aria-expanded={open}
         aria-label={ariaLabel}
       >
-        {label}
+        <InfoIcon />
       </button>
       {open && (
         <div className="info-btn-panel" role="dialog">

--- a/studio/web/src/index.css
+++ b/studio/web/src/index.css
@@ -1,4 +1,5 @@
 @import './styles/tokens.css';
+@import './styles/info-button.css';
 @import './styles/version-section.css';
 @tailwind base;
 @tailwind components;

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -24,6 +24,7 @@ import {
   type WD14Runtime,
 } from '../../api/client'
 import { useDialog } from '../../components/Dialog'
+import { InfoButton } from '../../components/InfoButton'
 import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
@@ -570,7 +571,8 @@ export default function SettingsPage() {
       <SettingsSection id="download-global" title="下载（全局）">
         <SettingsField
           label="exclude_tags"
-          desc="逗号分隔；搜索时自动追加 -tag，Gelbooru / Danbooru 同样生效"
+          desc="逗号分隔"
+          helpTooltip={<p>搜索时自动追加 <code>-tag</code>，Gelbooru / Danbooru 同样生效。</p>}
         >
           <input
             type="text"
@@ -751,7 +753,12 @@ export default function SettingsPage() {
 
       {tab === 'training' && (<>
       <SettingsSection id="download-source" title="模型下载源">
-        <SettingsField label="下载源" desc="魔搭（ModelScope）对国内用户更快；无映射的模型自动回退 HuggingFace">
+        <SettingsField
+          label="下载源"
+          helpTooltip={
+            <p>魔搭（ModelScope）对国内用户更快；无映射的模型自动回退 HuggingFace。</p>
+          }
+        >
           <DownloadSourceSelect
             value={draft.download_source}
             onChange={(v) => updateTop('download_source', v)}
@@ -762,14 +769,22 @@ export default function SettingsPage() {
          * secrets 里（即便切换源也不丢失），只是 UI 一次只露面一份。 */}
         {draft.download_source === 'huggingface' ? (
           <>
-            <SettingsField label="token" desc="用于 HF 私有 repo 鉴权；公开仓库（含 SmilingWolf WD14 / cella110n CLTagger）不用填">
+            <SettingsField
+              label="token"
+              helpTooltip={
+                <p>用于 HF 私有 repo 鉴权。公开仓库（含 SmilingWolf WD14 / cella110n CLTagger）不用填。</p>
+              }
+            >
               <SensitiveInput
                 value={draft.huggingface.token}
                 serverValue={server?.huggingface.token ?? ''}
                 onChange={(v) => update('huggingface', 'token', v)}
               />
             </SettingsField>
-            <SettingsField label="endpoint" desc="模型下载端点。国内推荐 hf-mirror，海外推荐官方源">
+            <SettingsField
+              label="endpoint"
+              helpTooltip={<p>模型下载端点。国内推荐 hf-mirror，海外推荐官方源。</p>}
+            >
               <HFEndpointSelect
                 value={draft.huggingface.endpoint}
                 onChange={(v) => update('huggingface', 'endpoint', v)}
@@ -777,7 +792,15 @@ export default function SettingsPage() {
             </SettingsField>
           </>
         ) : (
-          <SettingsField label="token" desc="公开模型不用填；私有仓库或限速时需要。需先 pip install modelscope 安装命令行工具。">
+          <SettingsField
+            label="token"
+            helpTooltip={
+              <>
+                <p>公开模型不用填；私有仓库或限速时需要。</p>
+                <p>使用前请先 <code>pip install modelscope</code> 安装命令行工具。</p>
+              </>
+            }
+          >
             <SensitiveInput
               value={draft.modelscope.token}
               serverValue={server?.modelscope.token ?? ''}
@@ -816,12 +839,7 @@ export default function SettingsPage() {
       {tab === 'monitor' && (<>
       <SettingsSection id="wandb" title="Weights & Biases">
         <SettingsField label="启用 WandB" desc="打开后所有训练任务都会写入 W&B；不再占用训练配置字段">
-          <div className="flex items-center gap-3">
-            <Bool value={draft.wandb.enabled} onChange={(v) => update('wandb', 'enabled', v)} />
-            <span className="text-xs text-fg-tertiary">
-              需要训练环境已安装 wandb 包
-            </span>
-          </div>
+          <Bool value={draft.wandb.enabled} onChange={(v) => update('wandb', 'enabled', v)} />
         </SettingsField>
         <SettingsField label="api_key">
           <SensitiveInput
@@ -868,13 +886,21 @@ export default function SettingsPage() {
               <option value="disabled">disabled</option>
             </select>
           </SettingsField>
-          <SettingsField label="记录采样图" desc="开启后训练采样图会上传到 wandb.ai 公网；私有 IP / NSFW 数据集请保持关闭">
+          <SettingsField
+            label="记录采样图"
+            helpTooltip={
+              <p>开启后训练采样图会上传到 <code>wandb.ai</code> 公网；私有 IP / NSFW 数据集请保持关闭。</p>
+            }
+          >
             <Bool value={draft.wandb.log_samples} onChange={(v) => update('wandb', 'log_samples', v)} />
           </SettingsField>
         </div>
         {draft.wandb.log_samples && (
           <div className="grid grid-cols-2 gap-3">
-            <SettingsField label="采样图最长边" desc="上传前缩到此像素，原图常 2K+，512 已够 wandb 浏览">
+            <SettingsField
+              label="采样图最长边"
+              helpTooltip={<p>上传前缩到此像素。原图常 2K+，512 已够 wandb 浏览。</p>}
+            >
               <input
                 type="number"
                 min={64}
@@ -884,7 +910,12 @@ export default function SettingsPage() {
                 className={textInputClass}
               />
             </SettingsField>
-            <SettingsField label="step 节流" desc="0 = 不额外节流；>0 时只在 global_step % N == 0 上传，避免长训练上 GB 级图">
+            <SettingsField
+              label="step 节流"
+              helpTooltip={
+                <p>0 = 不额外节流。&gt; 0 时只在 <code>global_step % N == 0</code> 上传，避免长训练上 GB 级图。</p>
+              }
+            >
               <input
                 type="number"
                 min={0}
@@ -1026,15 +1057,21 @@ function SectionIndex({
   )
 }
 
-function SettingsField({ label, desc, children }: {
+function SettingsField({ label, desc, helpTooltip, children }: {
   label: string
   desc?: string
+  /** 可选 ⓘ tooltip slot，渲染在 label 旁边。中长说明（≥20 字 / 详细用法）
+   *  适合放这里，避免 inline desc 把字段名行撑得过长。一般和 desc 二选一。 */
+  helpTooltip?: React.ReactNode
   children: React.ReactNode
 }) {
   return (
     <div className="grid grid-cols-[240px_1fr] gap-3 items-start">
       <div className="flex flex-col gap-0.5 pt-1.5">
-        <label className="text-xs text-fg-secondary font-mono leading-none">{label}</label>
+        <div className="flex items-center gap-0.5 min-w-0">
+          <label className="text-xs text-fg-secondary font-mono leading-none">{label}</label>
+          {helpTooltip && <InfoButton>{helpTooltip}</InfoButton>}
+        </div>
         {desc && <p className="text-[10px] text-fg-tertiary m-0 leading-snug">{desc}</p>}
       </div>
       <div className="min-w-0">{children}</div>
@@ -1215,10 +1252,12 @@ function WD14ModelCard({
     return <p className="text-fg-tertiary text-xs">加载模型清单...</p>
   }
   return (
-    <ModelGroupCard title={wd14.name + '（候选模型）'}>
-      <p className="text-xs text-fg-tertiary m-0">
-        {wd14.description} · 选中作为当前 model_id；下载缺的版本。
-      </p>
+    <ModelGroupCard
+      title={wd14.name + '（候选模型）'}
+      helpTooltip={
+        <p>{wd14.description}。选中作为当前 <code>model_id</code>；下载缺的版本。</p>
+      }
+    >
       <ul className="list-none m-0 p-0 flex flex-col gap-1">
         {wd14.variants.map((v) => {
           const key = `wd14:${v.model_id}`
@@ -1282,10 +1321,12 @@ function CLTaggerModelCard({
     return <p className="text-fg-tertiary text-xs">加载模型清单...</p>
   }
   return (
-    <ModelGroupCard title={cl.name + '（版本）'}>
-      <p className="text-xs text-fg-tertiary m-0">
-        {cl.description} · <code>{cl.repo}</code>
-      </p>
+    <ModelGroupCard
+      title={cl.name + '（版本）'}
+      helpTooltip={
+        <p>{cl.description}。仓库：<code>{cl.repo}</code></p>
+      }
+    >
       <ul className="list-none m-0 p-0 flex flex-col gap-1">
         {cl.variants.map((v) => {
           const key = `cltagger:${v.label}`
@@ -1450,11 +1491,15 @@ function ModelsSection({ catalog, busy, start, reloadCatalog, catalogError }: {
       ) : (
         <div className="flex flex-col gap-2">
           {/* Anima 主模型 */}
-          <ModelGroupCard title={catalog.anima_main.name}>
-            <p className="text-xs text-fg-tertiary m-0">
-              {catalog.anima_main.description} · <code>{catalog.anima_main.repo}</code>
-              <br />选中的版本会作为<strong className="text-fg-primary">新建 version</strong>的默认 transformer。
-            </p>
+          <ModelGroupCard
+            title={catalog.anima_main.name}
+            helpTooltip={
+              <>
+                <p>{catalog.anima_main.description}。仓库：<code>{catalog.anima_main.repo}</code></p>
+                <p>选中的版本会作为<strong>新建 version</strong> 的默认 transformer。</p>
+              </>
+            }
+          >
             <ul className="list-none m-0 p-0 flex flex-col gap-1">
               {catalog.anima_main.variants.map((v) => {
                 const key = `anima_main:${v.variant}`
@@ -1537,10 +1582,19 @@ function ModelsSection({ catalog, busy, start, reloadCatalog, catalogError }: {
   )
 }
 
-function ModelGroupCard({ title, children }: { title: string; children: React.ReactNode }) {
+function ModelGroupCard({
+  title, helpTooltip, children,
+}: {
+  title: string
+  helpTooltip?: React.ReactNode
+  children: React.ReactNode
+}) {
   return (
     <div className="rounded-sm border border-subtle bg-sunken p-2.5">
-      <h4 className="text-xs font-semibold text-fg-primary mb-1.5">{title}</h4>
+      <h4 className="text-xs font-semibold text-fg-primary mb-1.5 flex items-center gap-0.5">
+        <span>{title}</span>
+        {helpTooltip && <InfoButton>{helpTooltip}</InfoButton>}
+      </h4>
       {children}
     </div>
   )
@@ -2156,6 +2210,18 @@ function XformersSection() {
         <span className="text-fg-tertiary text-xs transition-transform group-open:rotate-90 inline-block w-3">▸</span>
         <h2 className="text-sm font-semibold text-fg-primary m-0">xformers</h2>
         <span className="text-xs text-fg-tertiary">attention 加速（与 Flash Attention 二选一）</span>
+        <InfoButton>
+          <p>
+            xformers 与 Flash Attention <strong>互斥</strong>，每个训练 / 出图任务的{' '}
+            <code>attention_backend</code> 字段三选一（无 / xformers / flash_attn）。
+          </p>
+          <p>xformers 泛用性更广（支持 sm_70+），flash_attn 性能更高（sm_80+ Ampere 起）。</p>
+          <p>
+            装失败多数是上游 PyPI / PyTorch index 没出对应 torch+cu 组合的 wheel
+            （5090 / 新 GPU 常见）。失败时按钮 toast 会显示 stderr 末尾，可根据提示
+            降 torch 版本或等上游覆盖。
+          </p>
+        </InfoButton>
         <span className={`ml-auto text-xs font-mono ${statusOk ? 'text-ok' : 'text-warn'}`}>{statusLabel}</span>
       </summary>
 
@@ -2171,13 +2237,6 @@ function XformersSection() {
             </code>
             {status.installed && <StatusLabel bg="bg-ok-soft" fg="text-ok" text="已安装" />}
           </div>
-
-          <p className="text-2xs text-fg-tertiary m-0 leading-relaxed">
-            xformers 与 Flash Attention <strong>互斥</strong>，每个训练/出图任务的{' '}
-            <code className="font-mono">attention_backend</code>{' '}
-            字段三选一（无 / xformers / flash_attn）。xformers 泛用性更广（支持
-            sm_70+），flash_attn 性能更高（sm_80+ Ampere 起）。
-          </p>
 
           <div className="flex gap-2">
             <button
@@ -2198,12 +2257,6 @@ function XformersSection() {
               title="刷新状态"
             >↻</button>
           </div>
-
-          <p className="text-2xs text-fg-tertiary m-0">
-            装失败多数是上游 PyPI / PyTorch index 没出对应 torch+cu 组合的 wheel
-            （5090 / 新 GPU 常见）。失败时按钮 toast 会显示 stderr 末尾，可
-            根据提示降 torch 版本或等上游覆盖。
-          </p>
         </>)}
       </div>
     </details>
@@ -2229,7 +2282,10 @@ function TaeFluxSection({
     <SettingsSection id="preview" title="中间步预览">
       <SettingsField
         label="节流（每 N 步推一次预览）"
-        desc="0 = 关闭中间步预览；推荐 3-5。模型 server 启动时已后台下载，UI 不需要操作。"
+        desc="0 = 关闭中间步预览；推荐 3-5"
+        helpTooltip={
+          <p>TAEFlux 解码模型 server 启动时已后台下载，UI 不需要单独操作。<code>0</code> 关闭中间步预览；推荐 <code>3-5</code>。</p>
+        }
       >
         <div className="flex items-center gap-2">
           <input
@@ -2769,44 +2825,6 @@ const VERSION_ICON_PATHS: Record<string, React.ReactNode> = {
   lock:     <><rect x="3.5" y="7" width="9" height="6.5" rx="1" /><path d="M5.5 7v-2a2.5 2.5 0 0 1 5 0v2" /></>,
 }
 
-// click-toggle 弹层。原 meta-foot 一整行（autocheck 周期 / git reset 实现细节 /
-// 拒绝条件）对普通用户都是 noise，搬到这里隐式可见；外部 click 自动关闭。
-function InfoButton({ children, label = 'ⓘ' }: { children: React.ReactNode; label?: string }) {
-  const [open, setOpen] = useState(false)
-  const wrapRef = useRef<HTMLSpanElement>(null)
-  useEffect(() => {
-    if (!open) return
-    const onDown = (e: MouseEvent) => {
-      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false)
-    }
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false) }
-    document.addEventListener('mousedown', onDown)
-    document.addEventListener('keydown', onKey)
-    return () => {
-      document.removeEventListener('mousedown', onDown)
-      document.removeEventListener('keydown', onKey)
-    }
-  }, [open])
-  return (
-    <span ref={wrapRef} className="vs-info-wrap">
-      <button
-        type="button"
-        className="vs-info-trigger"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        aria-label="更多信息"
-      >
-        {label}
-      </button>
-      {open && (
-        <div className="vs-info-panel" role="dialog">
-          {children}
-        </div>
-      )}
-    </span>
-  )
-}
-
 function VersionIcon({ name }: { name: keyof typeof VERSION_ICON_PATHS | string }) {
   const path = VERSION_ICON_PATHS[name]
   if (!path) return null
@@ -3195,27 +3213,34 @@ function MasterCard(p: MasterCardProps) {
         </div>
       </div>
 
-      {p.hasRollback && p.status?.rollback_target && (
-        // 回滚是潜在破坏性操作（reset --hard 丢失当前 commit 上的本地未
-        // commit 改动 / GC 后 reflog 也可能消失），UI 默认折叠成小字提示
-        // 让用户主动确认才展开按钮，降低误触概率。
-        <details className="vs-rollback-collapse">
-          <summary className="vs-rollback-summary">
-            <span className="vs-caret">▸</span>
-            历史版本可切回（{p.status.rollback_target.slice(0, 8)}）
-          </summary>
-          <div className="vs-rollback-inline-row">
-            <div className="vs-lhs">
-              <span className="vs-ico"><VersionIcon name="rollback" /></span>
-              <span>上一版本</span>
-              <b>{p.status.rollback_target.slice(0, 8)}</b>
+      {p.hasRollback && p.status?.rollback_target && (() => {
+        // rollback 显示优先 tag（"v0.6.0"），否则 sha 前 8 位
+        const sha = p.status.rollback_target
+        const tag = p.status.rollback_target_tag
+        const label = tag || sha.slice(0, 8)
+        return (
+          // 回滚是潜在破坏性操作（reset --hard 丢失当前 commit 上的本地未
+          // commit 改动 / GC 后 reflog 也可能消失），UI 默认折叠成小字提示
+          // 让用户主动确认才展开按钮，降低误触概率。
+          <details className="vs-rollback-collapse">
+            <summary className="vs-rollback-summary">
+              <span className="vs-caret">▸</span>
+              历史版本可切回（{label}）
+            </summary>
+            <div className="vs-rollback-inline-row">
+              <div className="vs-lhs">
+                <span className="vs-ico"><VersionIcon name="rollback" /></span>
+                <span>上一版本</span>
+                <b>{label}</b>
+                {tag && <span className="vs-when">{sha.slice(0, 8)}</span>}
+              </div>
+              <button onClick={p.onRollback} disabled={p.busy || p.checking} className="btn btn-sm">
+                切回 {label}
+              </button>
             </div>
-            <button onClick={p.onRollback} disabled={p.busy || p.checking} className="btn btn-sm">
-              切回 {p.status.rollback_target.slice(0, 8)}
-            </button>
-          </div>
-        </details>
-      )}
+          </details>
+        )
+      })()}
     </div>
   )
 }
@@ -3600,20 +3625,22 @@ function ServiceSection() {
 
   return (
     <SettingsSection id="service" title="服务">
-      <SettingsField label="重启 Studio">
-        <div className="flex flex-col gap-1.5">
-          <button
-            onClick={() => void handleRestart()}
-            disabled={busy}
-            className="btn btn-secondary btn-sm self-start"
-          >
-            {busy ? '重启中...' : '重启 server'}
-          </button>
-          <p className="text-2xs text-fg-dim leading-snug">
-            关闭并重新启动后端进程。常用场景：修改 secrets.json 后强制刷新、
-            装完新 onnxruntime / PyTorch 让 EP 生效。
-          </p>
-        </div>
+      <SettingsField
+        label="重启 Studio"
+        helpTooltip={
+          <>
+            <p>关闭并重新启动后端进程。</p>
+            <p>常用场景：修改 <code>secrets.json</code> 后强制刷新、装完新 onnxruntime / PyTorch 让 EP 生效。</p>
+          </>
+        }
+      >
+        <button
+          onClick={() => void handleRestart()}
+          disabled={busy}
+          className="btn btn-secondary btn-sm self-start"
+        >
+          {busy ? '重启中...' : '重启 server'}
+        </button>
       </SettingsField>
     </SettingsSection>
   )

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -1068,7 +1068,7 @@ function SettingsField({ label, desc, helpTooltip, children }: {
   return (
     <div className="grid grid-cols-[240px_1fr] gap-3 items-start">
       <div className="flex flex-col gap-0.5 pt-1.5">
-        <div className="flex items-center gap-1.5 min-w-0">
+        <div className="flex items-center gap-2 min-w-0">
           <label className="text-xs text-fg-secondary font-mono leading-none">{label}</label>
           {helpTooltip && <InfoButton>{helpTooltip}</InfoButton>}
         </div>
@@ -1591,7 +1591,7 @@ function ModelGroupCard({
 }) {
   return (
     <div className="rounded-sm border border-subtle bg-sunken p-2.5">
-      <h4 className="text-xs font-semibold text-fg-primary mb-1.5 flex items-center gap-1.5">
+      <h4 className="text-xs font-semibold text-fg-primary mb-1.5 flex items-center gap-2">
         <span>{title}</span>
         {helpTooltip && <InfoButton>{helpTooltip}</InfoButton>}
       </h4>
@@ -2277,7 +2277,6 @@ function TaeFluxSection({
   ) => void
 }) {
   const n = draft.generate.preview_every_n_steps
-  const enabled = n > 0
   return (
     <SettingsSection id="preview" title="中间步预览">
       <SettingsField
@@ -2287,20 +2286,15 @@ function TaeFluxSection({
           <p>TAEFlux 解码模型 server 启动时已后台下载，UI 不需要单独操作。</p>
         }
       >
-        <div className="flex items-center gap-2">
-          <input
-            type="number"
-            min={0}
-            max={50}
-            value={n}
-            onChange={(e) => update('generate', 'preview_every_n_steps', Number(e.target.value) || 0)}
-            className="input"
-            style={{ width: 80 }}
-          />
-          <span className="text-2xs text-fg-tertiary">
-            {enabled ? `每 ${n} 步推一张 256px JPEG（~10KB/步）` : '不推预览（0）'}
-          </span>
-        </div>
+        <input
+          type="number"
+          min={0}
+          max={50}
+          value={n}
+          onChange={(e) => update('generate', 'preview_every_n_steps', Number(e.target.value) || 0)}
+          className="input"
+          style={{ width: 80 }}
+        />
       </SettingsField>
     </SettingsSection>
   )

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -1068,7 +1068,7 @@ function SettingsField({ label, desc, helpTooltip, children }: {
   return (
     <div className="grid grid-cols-[240px_1fr] gap-3 items-start">
       <div className="flex flex-col gap-0.5 pt-1.5">
-        <div className="flex items-center gap-0.5 min-w-0">
+        <div className="flex items-center gap-1.5 min-w-0">
           <label className="text-xs text-fg-secondary font-mono leading-none">{label}</label>
           {helpTooltip && <InfoButton>{helpTooltip}</InfoButton>}
         </div>
@@ -1591,7 +1591,7 @@ function ModelGroupCard({
 }) {
   return (
     <div className="rounded-sm border border-subtle bg-sunken p-2.5">
-      <h4 className="text-xs font-semibold text-fg-primary mb-1.5 flex items-center gap-0.5">
+      <h4 className="text-xs font-semibold text-fg-primary mb-1.5 flex items-center gap-1.5">
         <span>{title}</span>
         {helpTooltip && <InfoButton>{helpTooltip}</InfoButton>}
       </h4>
@@ -2282,9 +2282,9 @@ function TaeFluxSection({
     <SettingsSection id="preview" title="中间步预览">
       <SettingsField
         label="节流（每 N 步推一次预览）"
-        desc="0 = 关闭中间步预览；推荐 3-5"
+        desc="0 = 关闭；推荐 3-5"
         helpTooltip={
-          <p>TAEFlux 解码模型 server 启动时已后台下载，UI 不需要单独操作。<code>0</code> 关闭中间步预览；推荐 <code>3-5</code>。</p>
+          <p>TAEFlux 解码模型 server 启动时已后台下载，UI 不需要单独操作。</p>
         }
       >
         <div className="flex items-center gap-2">
@@ -2331,12 +2331,6 @@ function DisplaySection() {
     return '默认'
   }
 
-  const densityDesc = (d: Density): string => {
-    if (d === 'tight') return '字号更小，间距更紧，适合小屏或高信息密度'
-    if (d === 'loose') return '字号更大，间距更宽，适合阅读舒适'
-    return '标准字号与间距'
-  }
-
   return (
     <SettingsSection id="display" title="显示">
       <SettingsField label="主题">
@@ -2353,22 +2347,26 @@ function DisplaySection() {
         </div>
       </SettingsField>
 
-      <SettingsField label="界面缩放">
-        <div className="flex flex-col gap-1.5">
-          <div className="flex gap-1">
-            {(['tight', 'default', 'loose'] as Density[]).map((d) => (
-              <button
-                key={d}
-                onClick={() => handleDensityChange(d)}
-                className={`btn btn-sm ${density === d ? 'btn-primary' : 'btn-secondary'}`}
-              >
-                {densityLabel(d)}
-              </button>
-            ))}
-          </div>
-          <p className="text-xs text-fg-tertiary m-0">
-            {densityDesc(density)}
-          </p>
+      <SettingsField
+        label="界面缩放"
+        helpTooltip={
+          <>
+            <p><strong>紧凑</strong>：字号更小，间距更紧，适合小屏或高信息密度</p>
+            <p><strong>默认</strong>：标准字号与间距</p>
+            <p><strong>宽松</strong>：字号更大，间距更宽，适合阅读舒适</p>
+          </>
+        }
+      >
+        <div className="flex gap-1">
+          {(['tight', 'default', 'loose'] as Density[]).map((d) => (
+            <button
+              key={d}
+              onClick={() => handleDensityChange(d)}
+              className={`btn btn-sm ${density === d ? 'btn-primary' : 'btn-secondary'}`}
+            >
+              {densityLabel(d)}
+            </button>
+          ))}
         </div>
       </SettingsField>
     </SettingsSection>

--- a/studio/web/src/styles/info-button.css
+++ b/studio/web/src/styles/info-button.css
@@ -1,0 +1,88 @@
+/* InfoButton —— click-toggle ⓘ 弹层。给字段名 / section title / 卡片角
+ * 加帮助说明用。组件实现在 components/InfoButton.tsx。
+ *
+ * 之前同样功能的样式以 .vs-info-* 前缀放在 version-section.css 里
+ * （只给版本卡用）；抽组件后改 .info-btn-* 中性前缀。
+ */
+
+.info-btn-anchor {
+  position: relative;
+  display: inline-flex;
+}
+
+.info-btn-trigger {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  color: var(--fg-tertiary);
+  font-size: 14px;
+  padding: 2px 4px;
+  line-height: 1;
+  border-radius: 4px;
+  font-family: inherit;
+}
+.info-btn-trigger:hover {
+  color: var(--fg-primary);
+  background: var(--bg-overlay);
+}
+.info-btn-trigger[aria-expanded="true"] {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.info-btn-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 20;
+  width: 380px;
+  max-width: calc(100vw - 32px);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  box-shadow: var(--sh-md);
+  padding: 12px 14px;
+  font-size: 12px;
+  color: var(--fg-secondary);
+  line-height: 1.6;
+}
+
+.info-btn-panel p {
+  margin: 0 0 6px 0;
+}
+.info-btn-panel p:last-child {
+  margin-bottom: 0;
+}
+
+.info-btn-panel ul {
+  padding: 0;
+  margin: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.info-btn-panel li {
+  display: flex;
+  gap: 8px;
+  align-items: flex-start;
+}
+.info-btn-panel li::before {
+  content: '·';
+  color: var(--fg-disabled);
+  flex-shrink: 0;
+  margin-top: -1px;
+}
+
+.info-btn-panel strong {
+  color: var(--fg-primary);
+  font-weight: 500;
+}
+
+.info-btn-panel code {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  background: var(--bg-sunken);
+  padding: 0 4px;
+  border-radius: 3px;
+}

--- a/studio/web/src/styles/info-button.css
+++ b/studio/web/src/styles/info-button.css
@@ -13,10 +13,9 @@
 }
 
 .info-btn-trigger {
-  /* 固定 18x18 圆按钮，font 14px ⓘ 字符居中。固定尺寸方便在不同字号
-     容器（h2 / label / 副标题）里都视觉一致；inline-flex + align-items
-     center 让按钮对齐到相邻文字的中线（之前 inline 基线对齐有些字体
-     会偏低）。 */
+  /* 固定 18x18 圆按钮，里面装 12x12 SVG。固定尺寸 + flex 居中：跟相邻
+     文字的中线对齐稳定（不受字体 / 字号差异影响，之前 Unicode ⓘ 字符在
+     不同字体里垂直位置不齐）。 */
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -24,11 +23,9 @@
   border: 0;
   cursor: pointer;
   color: var(--fg-tertiary);
-  font-size: 14px;
   width: 18px;
   height: 18px;
   padding: 0;
-  line-height: 1;
   border-radius: 50%;
   font-family: inherit;
 }

--- a/studio/web/src/styles/info-button.css
+++ b/studio/web/src/styles/info-button.css
@@ -8,17 +8,28 @@
 .info-btn-anchor {
   position: relative;
   display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
 }
 
 .info-btn-trigger {
+  /* 固定 18x18 圆按钮，font 14px ⓘ 字符居中。固定尺寸方便在不同字号
+     容器（h2 / label / 副标题）里都视觉一致；inline-flex + align-items
+     center 让按钮对齐到相邻文字的中线（之前 inline 基线对齐有些字体
+     会偏低）。 */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: transparent;
   border: 0;
   cursor: pointer;
   color: var(--fg-tertiary);
   font-size: 14px;
-  padding: 2px 4px;
+  width: 18px;
+  height: 18px;
+  padding: 0;
   line-height: 1;
-  border-radius: 4px;
+  border-radius: 50%;
   font-family: inherit;
 }
 .info-btn-trigger:hover {

--- a/studio/web/src/styles/version-section.css
+++ b/studio/web/src/styles/version-section.css
@@ -380,70 +380,9 @@
   opacity: 0.7;
 }
 
-/* ==================== InfoButton（title 旁 ⓘ click 开关 tooltip） ==================== */
-/* 之前的 meta-foot 一整行（autocheck 周期 / git reset 实现细节 / 拒绝
-   条件 / 上次日志链接）对普通用户都是 noise；移进此 click-toggle 弹层 */
-.vs-info-wrap {
-  position: relative;
-  display: inline-flex;
-}
-.vs-info-trigger {
-  background: transparent;
-  border: 0;
-  cursor: pointer;
-  color: var(--fg-tertiary);
-  font-size: 14px;
-  padding: 2px 4px;
-  line-height: 1;
-  border-radius: 4px;
-}
-.vs-info-trigger:hover { color: var(--fg-primary); background: var(--bg-overlay); }
-.vs-info-trigger[aria-expanded="true"] {
-  color: var(--accent);
-  background: var(--accent-soft);
-}
-.vs-info-panel {
-  position: absolute;
-  top: calc(100% + 8px);
-  left: 0;
-  z-index: 20;
-  width: 380px;
-  max-width: calc(100vw - 32px);
-  background: var(--bg-elevated);
-  border: 1px solid var(--border-default);
-  border-radius: 8px;
-  box-shadow: var(--sh-md);
-  padding: 12px 14px;
-  font-size: 12px;
-  color: var(--fg-secondary);
-  line-height: 1.6;
-}
-.vs-info-panel ul {
-  padding: 0;
-  margin: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-.vs-info-panel li {
-  display: flex;
-  gap: 8px;
-  align-items: flex-start;
-}
-.vs-info-panel li::before {
-  content: '·';
-  color: var(--fg-disabled);
-  flex-shrink: 0;
-  margin-top: -1px;
-}
-.vs-info-panel code {
-  font-family: var(--font-mono);
-  font-size: 11px;
-  background: var(--bg-sunken);
-  padding: 1px 5px;
-  border-radius: 3px;
-}
+/* InfoButton ⓘ 弹层（之前的 .vs-info-* 类）已抽到
+   components/InfoButton.tsx + styles/info-button.css，所有 .info-btn-*
+   类供全 Settings 页面复用，本文件不再持有相关样式。 */
 
 /* ==================== meta foot 行 ==================== */
 .vs-meta-foot {

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -434,6 +434,33 @@ def test_target_has_self_update_false_on_git_error(monkeypatch: pytest.MonkeyPat
 
 
 # ---------------------------------------------------------------------------
+# exact_tag_for (rollback UI 显示 tag 而非 sha 用)
+# ---------------------------------------------------------------------------
+
+
+def test_exact_tag_for_returns_tag_when_commit_tagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """git describe --tags --exact-match 命中 → 返回 tag 字符串。"""
+    monkeypatch.setattr(updater, "_git",
+                       lambda *args, **_k: (0, "v0.6.0", "") if args[0] == "describe" else (1, "", ""))
+    assert updater.exact_tag_for("deadbeef" * 5) == "v0.6.0"
+
+
+def test_exact_tag_for_none_when_no_tag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """commit 上没打精确 tag → describe 返非 0 → None（caller fallback 到 sha[:8]）。"""
+    monkeypatch.setattr(updater, "_git",
+                       lambda *args, **_k: (128, "", "fatal: no exact match"))
+    assert updater.exact_tag_for("deadbeef" * 5) is None
+
+
+def test_exact_tag_for_empty_sha_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """空 sha 早退；不调 git。"""
+    called = []
+    monkeypatch.setattr(updater, "_git", lambda *a, **_k: (called.append(a), (0, "v", ""))[1])
+    assert updater.exact_tag_for("") is None
+    assert called == []
+
+
+# ---------------------------------------------------------------------------
 # dev_commits (chunk 3)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

讨论后通过的全套 Settings 页面减法 + InfoButton 组件抽象 + 历史版本 tag 显示。

## 后端

- 新加 \`updater.exact_tag_for(sha)\`：跑 \`git describe --tags --exact-match\`，命中精确 tag → 返回字符串；未命中 → \`None\`
- \`/api/system/update_status\` 返回多加 \`rollback_target_tag\` 字段

## 前端 — 组件抽取

- 新组件 \`components/InfoButton.tsx\`：click-toggle ⓘ 弹层；外部 click / Esc 关；button \`stopPropagation\` 防止放在 \`<summary>\` 里触发外层 toggle
- 新 \`styles/info-button.css\` 中性 \`.info-btn-*\` 前缀；删 \`version-section.css\` 内的 \`.vs-info-*\` 旧样式 + Settings.tsx 内嵌 InfoButton
- \`SettingsSection\` 已有 \`headerExtras\` slot（PR #53）；\`ModelGroupCard\` / \`SettingsField\` 加同款可选 \`helpTooltip\` slot

## 前端 — 应用 tooltip 化

| 位置 | 之前 | 现在 |
|---|---|---|
| \`ServiceSection\` 重启说明 | 按钮下 \`<p>\` 灰字 | label 旁 ⓘ tooltip |
| \`WD14\` / \`CLTagger\` / \`anima_main\` 模型卡 | 卡标题下 \`<p>\` description | ModelGroupCard title 旁 ⓘ |
| \`xformers\` section 两段 \`<p>\`（互斥说明 + 装失败排查） | 展开后 always-visible | summary 旁 ⓘ |
| Layer 1 长 desc 7 项（≥ 20 字）| inline \`desc=...\` | helpTooltip |

涉及的 Layer 1 字段：\`下载源\` / \`hf token\` / \`hf endpoint\` / \`modelscope token\` / \`wandb 记录采样图\` / \`wandb 采样图最长边\` / \`wandb step 节流\` / \`generate 中间步预览\`

## 前端 — 历史版本显示 tag

\`MasterCard\` 回滚行（折叠 details）现在优先显示 release tag：

- summary："历史版本可切回（v0.6.0）" 而非 \`8cd62384\`
- expanded：\`v0.6.0\` 主标 + sha 副标 + \`[切回 v0.6.0]\` 按钮
- commit 没 tag（如 dev 切换的中间 commit）→ fallback 到 sha[:8]

## 前端 — 删冗余

- wandb "启用 WandB" 字段旁 "需要训练环境已安装 wandb 包" 提示删除
- 理由：错误位置 — 该提示应在 wandb 实际报错（导入失败）时显示，平时占位增加视觉噪声

## Test plan

- [x] pytest：88 全过（含 3 个新 \`exact_tag_for\` 测试）
- [x] vitest：135 全过
- [x] tsc：clean
- [ ] 实测：
  - [ ] ⓘ 点开 / 外部 click 关 / Esc 关
  - [ ] 弹层不超出视口（max-width: calc(100vw - 32px)）
  - [ ] \`<details>\` 内的 ⓘ click 不会 toggle details
  - [ ] 历史版本显示 tag（master 上有 .last_version 指向 tagged commit 时）
  - [ ] 历史版本 fallback sha（指向无 tag commit 时）

🤖 Generated with [Claude Code](https://claude.com/claude-code)