### PR TITLE
cherry-pick PR #49 训练稳定性 + 噪声/loss/timestep + kv_trim（不含 T-LoRA / Ortho-Hydra / OrthoGrad）

### DIFF
--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -1814,12 +1814,35 @@ def sample_image(
 # 训练辅助
 # ============================================================================
 
-def sample_t(bs, device):
-    """采样时间步 (logit-normal)"""
-    t = torch.sigmoid(torch.randn(bs, device=device))
-    shift = 3.0
-    t = (t * shift) / (1 + (shift - 1) * t)
-    return t
+def sample_t(bs, device, mode: str = "logit_normal", shift: float = 3.0) -> torch.Tensor:
+    """采样 Flow Matching 时间步 t ∈ (0, 1)。
+
+    mode:
+      logit_normal      — SD3/Anima 默认，偏向中间 t；shift>1 推向高噪声端
+      uniform           — 均匀采样，对细节端和结构端覆盖更均衡
+      logit_normal_low  — logit-normal 反向 shift，偏向低噪声/细节端
+      mode              — SD3 mode-distribution，集中在某个 sigma 附近
+    """
+    mode = (mode or "logit_normal").lower()
+    u = torch.sigmoid(torch.randn(bs, device=device))
+
+    if mode == "uniform":
+        return torch.rand(bs, device=device).clamp(1e-4, 1 - 1e-4)
+
+    if mode == "logit_normal_low":
+        s = max(float(shift), 1e-4)
+        u = (u * (1.0 / s)) / (1 + (1.0 / s - 1) * u)
+        return u.clamp(1e-4, 1 - 1e-4)
+
+    if mode == "mode":
+        s = float(shift)
+        u = 1 - u - s * (torch.cos(torch.pi * 0.5 * u) ** 2 - 1 + u)
+        return u.clamp(1e-4, 1 - 1e-4)
+
+    # logit_normal（默认）+ shift
+    s = float(shift)
+    u = (u * s) / (1 + (s - 1) * u)
+    return u.clamp(1e-4, 1 - 1e-4)
 
 
 def compute_loss_weight(
@@ -2087,7 +2110,7 @@ def main():
         update_monitor(
             total_epochs=int(args.epochs or 0),
             config={
-                "model": "Anima LoKr" if args.lora_type == "lokr" else "Anima LoRA",
+                "model": {"lokr": "Anima LoKr", "tlora": "Anima T-LoRA"}.get(args.lora_type, "Anima LoRA"),
                 "rank": args.lora_rank,
                 "alpha": args.lora_alpha,
                 "epochs": args.epochs,
@@ -2152,20 +2175,28 @@ def main():
         args.text_encoder_path, args.t5_tokenizer_path, device, dtype
     )
 
-    # 注入 LoRA（lycoris-lora backend，Stage 3 切换）
+    # 注入 LoRA
     logger.info(f"注入 {args.lora_type.upper()}...")
-    from utils.lycoris_adapter import AnimaLycorisAdapter
-    injector = AnimaLycorisAdapter(
-        algo=args.lora_type,
-        rank=args.lora_rank,
-        alpha=args.lora_alpha,
-        factor=args.lokr_factor,
-        dropout=float(getattr(args, "lora_dropout", 0.0) or 0.0),
-        rank_dropout=float(getattr(args, "lora_rank_dropout", 0.0) or 0.0),
-        module_dropout=float(getattr(args, "lora_module_dropout", 0.0) or 0.0),
-        weight_decompose=bool(getattr(args, "lora_dora", False)),
-        rs_lora=bool(getattr(args, "lora_rs", False)),
-    )
+    if args.lora_type == "tlora":
+        from utils.tlora_adapter import AnimaTLoRAAdapter
+        injector = AnimaTLoRAAdapter(
+            rank=args.lora_rank,
+            alpha=args.lora_alpha,
+            min_rank=int(getattr(args, "tlora_min_rank", 1) or 1),
+        )
+    else:
+        from utils.lycoris_adapter import AnimaLycorisAdapter
+        injector = AnimaLycorisAdapter(
+            algo=args.lora_type,
+            rank=args.lora_rank,
+            alpha=args.lora_alpha,
+            factor=args.lokr_factor,
+            dropout=float(getattr(args, "lora_dropout", 0.0) or 0.0),
+            rank_dropout=float(getattr(args, "lora_rank_dropout", 0.0) or 0.0),
+            module_dropout=float(getattr(args, "lora_module_dropout", 0.0) or 0.0),
+            weight_decompose=bool(getattr(args, "lora_dora", False)),
+            rs_lora=bool(getattr(args, "lora_rs", False)),
+        )
     injector.inject(model)
     
     # 从已有 LoRA 继续训练
@@ -2447,6 +2478,8 @@ def main():
     
     current_epoch = start_epoch
     model.train()
+    if optimizer_type == "prodigy_plus_schedulefree" and hasattr(optimizer, "train"):
+        optimizer.train()
     step_start_time = time.perf_counter()
 
     # 设置采样提示词列表（支持多角色轮换）
@@ -2546,7 +2579,13 @@ def main():
                     cross = F.pad(cross, (0, 0, 0, 512 - cross.shape[1]))
 
             # Flow Matching
-            t = sample_t(bs, device)
+            t = sample_t(
+                bs, device,
+                mode=str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal"),
+                shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
+            )
+            if args.lora_type == "tlora":
+                injector.set_mask(injector.build_sigma_mask(t, device))
             t_exp = t.view(-1, 1, 1, 1, 1)
             noise = torch.randn_like(latents)
             noisy = (1 - t_exp) * latents + t_exp * noise
@@ -2600,7 +2639,7 @@ def main():
                 if grad_clip > 0:
                     torch.nn.utils.clip_grad_norm_(trainable_params, max_norm=grad_clip)
                 optimizer.step()
-                if scheduler is not None:
+                if scheduler is not None and optimizer_type != "prodigy_plus_schedulefree":
                     scheduler.step()
                 optimizer.zero_grad()
                 global_step += 1

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -16,6 +16,7 @@ Anima LoRA Trainer v2 - 支持 LyCORIS + 训练时推理
 
 import argparse
 import logging
+import math
 import os
 import random
 import subprocess
@@ -1821,6 +1822,47 @@ def sample_t(bs, device):
     return t
 
 
+def compute_loss_weight(
+    t: torch.Tensor,
+    scheme: str = "none",
+    min_snr_gamma: float = 5.0,
+    weight_cap_ratio: float = 0.0,
+) -> torch.Tensor:
+    """返回每样本 loss 权重 (B,)，Flow Matching CONST 调度下：SNR(t) = ((1-t)/t)^2。
+
+    scheme:
+      none          — 全 1，与原始行为一致
+      min_snr       — w = min(gamma/SNR, 1)，下调高 SNR 简单步（推荐基础款）
+      detail_inv_t  — w = 1/t clamp [1,5]，温和细节强化，小 batch + Prodigy 友好
+      cosmap        — SD3 cosmap weighting，中间 t 更均匀（max/min ≈ 1.81×）
+
+    weight_cap_ratio — batch 内 max/min 比上限（0=禁用），防单样本主导破坏 Prodigy d 估计
+    """
+    scheme = (scheme or "none").lower()
+    if scheme == "none":
+        return torch.ones_like(t)
+
+    eps = 1e-4
+    t_c = t.clamp(eps, 1 - eps)
+
+    if scheme == "min_snr":
+        snr = ((1 - t_c) / t_c) ** 2
+        w = torch.minimum(torch.tensor(float(min_snr_gamma), device=t.device) / snr, torch.ones_like(t_c))
+    elif scheme == "detail_inv_t":
+        w = (1.0 / t_c).clamp(min=1.0, max=5.0)
+    elif scheme == "cosmap":
+        bot = (1 - 2 * t_c + 2 * t_c ** 2).clamp(min=eps)
+        w = 2.0 / (math.pi * bot)
+    else:
+        return torch.ones_like(t)
+
+    if weight_cap_ratio and weight_cap_ratio > 1.0:
+        w_min = w.min().clamp(min=eps)
+        w = w.clamp(max=w_min * float(weight_cap_ratio))
+
+    return w
+
+
 def collate_fn(batch):
     """DataLoader collate"""
     pixels = torch.stack([b["pixel_values"] for b in batch])
@@ -2522,6 +2564,16 @@ def main():
                 if "loss_weight" in batch:
                     w = batch["loss_weight"].to(device).view(-1, *([1] * (loss_per_sample.dim() - 1)))
                     loss_per_sample = loss_per_sample * w
+                # timestep-dependent loss 权重
+                lw_scheme = str(getattr(args, "loss_weighting", "none") or "none")
+                if lw_scheme != "none":
+                    lw = compute_loss_weight(
+                        t,
+                        scheme=lw_scheme,
+                        min_snr_gamma=float(getattr(args, "min_snr_gamma", 5.0) or 5.0),
+                        weight_cap_ratio=float(getattr(args, "weight_cap_ratio", 0.0) or 0.0),
+                    ).to(device=device, dtype=torch.float32)
+                    loss_per_sample = loss_per_sample * lw.view(-1, *([1] * (loss_per_sample.dim() - 1)))
                 loss = loss_per_sample.mean()
 
             # NaN 检测：forward 出 NaN 时跳过本 micro-batch

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -2524,11 +2524,27 @@ def main():
                     loss_per_sample = loss_per_sample * w
                 loss = loss_per_sample.mean()
 
+            # NaN 检测：forward 出 NaN 时跳过本 micro-batch
+            if not torch.isfinite(loss):
+                logger.warning(f"step {global_step} micro-batch {batch_idx}: loss={loss.item():.4g}，跳过")
+                optimizer.zero_grad()
+                continue
+
             # 反向传播
             loss = loss / args.grad_accum
             loss.backward()
 
             if (batch_idx + 1) % args.grad_accum == 0:
+                # NaN 梯度检测：跳过本次 update，清零继续
+                has_nan_grad = any(
+                    p.grad is not None and not torch.isfinite(p.grad).all()
+                    for p in trainable_params
+                )
+                if has_nan_grad:
+                    logger.warning(f"step {global_step}: 梯度含 NaN/Inf，跳过 optimizer.step()")
+                    optimizer.zero_grad()
+                    continue
+
                 if grad_clip > 0:
                     torch.nn.utils.clip_grad_norm_(trainable_params, max_norm=grad_clip)
                 optimizer.step()

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -1845,6 +1845,56 @@ def sample_t(bs, device, mode: str = "logit_normal", shift: float = 3.0) -> torc
     return u.clamp(1e-4, 1 - 1e-4)
 
 
+def make_noise(
+    latents: torch.Tensor,
+    noise_offset: float = 0.0,
+    pyramid_iters: int = 0,
+    pyramid_discount: float = 0.35,
+) -> torch.Tensor:
+    """生成训练噪声，可叠加低频扰动。
+
+    noise_offset   — 给每样本/通道加低频偏移，缓解亮度均值偏差（SDXL 思路）
+    pyramid_iters  — 叠加多尺度低频噪声，帮助模型快速学习全局光照/构图；
+                     bilinear 插值避免 nearest 的块状结构干扰
+    """
+    noise = torch.randn_like(latents)
+
+    if noise_offset > 0:
+        shape = list(latents.shape)
+        for ax in range(2, latents.ndim):
+            shape[ax] = 1
+        offset = torch.randn(*shape, device=latents.device, dtype=latents.dtype)
+        noise = noise + noise_offset * offset
+
+    if pyramid_iters > 0:
+        try:
+            spatial = list(latents.shape[-2:])
+            cur = noise.clone()
+            for i in range(pyramid_iters):
+                r = 2 ** (i + 1)
+                sh, sw = max(spatial[0] // r, 1), max(spatial[1] // r, 1)
+                if latents.ndim == 5:
+                    extra = torch.randn(
+                        latents.shape[0], latents.shape[1], latents.shape[2], sh, sw,
+                        device=latents.device, dtype=latents.dtype,
+                    )
+                    extra = F.interpolate(
+                        extra.flatten(0, 1), size=spatial, mode="bilinear", align_corners=False,
+                    ).view(latents.shape[0], latents.shape[1], latents.shape[2], *spatial)
+                else:
+                    extra = torch.randn(latents.shape[0], latents.shape[1], sh, sw,
+                                        device=latents.device, dtype=latents.dtype)
+                    extra = F.interpolate(extra, size=spatial, mode="bilinear", align_corners=False)
+                cur = cur + extra * (pyramid_discount ** (i + 1))
+                if min(sh, sw) <= 1:
+                    break
+            noise = cur / cur.std().clamp(min=1e-6)
+        except Exception as exc:
+            logger.warning(f"pyramid_noise 失败，回退标准噪声: {exc}")
+
+    return noise
+
+
 def compute_loss_weight(
     t: torch.Tensor,
     scheme: str = "none",
@@ -2587,7 +2637,12 @@ def main():
             if args.lora_type == "tlora":
                 injector.set_mask(injector.build_sigma_mask(t, device))
             t_exp = t.view(-1, 1, 1, 1, 1)
-            noise = torch.randn_like(latents)
+            noise = make_noise(
+                latents,
+                noise_offset=float(getattr(args, "noise_offset", 0.0) or 0.0),
+                pyramid_iters=int(getattr(args, "pyramid_noise_iters", 0) or 0),
+                pyramid_discount=float(getattr(args, "pyramid_noise_discount", 0.35) or 0.35),
+            )
             noisy = (1 - t_exp) * latents + t_exp * noise
             target = noise - latents
 

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -2160,7 +2160,7 @@ def main():
         update_monitor(
             total_epochs=int(args.epochs or 0),
             config={
-                "model": {"lokr": "Anima LoKr", "tlora": "Anima T-LoRA"}.get(args.lora_type, "Anima LoRA"),
+                "model": {"lokr": "Anima LoKr"}.get(args.lora_type, "Anima LoRA"),
                 "rank": args.lora_rank,
                 "alpha": args.lora_alpha,
                 "epochs": args.epochs,
@@ -2227,26 +2227,18 @@ def main():
 
     # 注入 LoRA
     logger.info(f"注入 {args.lora_type.upper()}...")
-    if args.lora_type == "tlora":
-        from utils.tlora_adapter import AnimaTLoRAAdapter
-        injector = AnimaTLoRAAdapter(
-            rank=args.lora_rank,
-            alpha=args.lora_alpha,
-            min_rank=int(getattr(args, "tlora_min_rank", 1) or 1),
-        )
-    else:
-        from utils.lycoris_adapter import AnimaLycorisAdapter
-        injector = AnimaLycorisAdapter(
-            algo=args.lora_type,
-            rank=args.lora_rank,
-            alpha=args.lora_alpha,
-            factor=args.lokr_factor,
-            dropout=float(getattr(args, "lora_dropout", 0.0) or 0.0),
-            rank_dropout=float(getattr(args, "lora_rank_dropout", 0.0) or 0.0),
-            module_dropout=float(getattr(args, "lora_module_dropout", 0.0) or 0.0),
-            weight_decompose=bool(getattr(args, "lora_dora", False)),
-            rs_lora=bool(getattr(args, "lora_rs", False)),
-        )
+    from utils.lycoris_adapter import AnimaLycorisAdapter
+    injector = AnimaLycorisAdapter(
+        algo=args.lora_type,
+        rank=args.lora_rank,
+        alpha=args.lora_alpha,
+        factor=args.lokr_factor,
+        dropout=float(getattr(args, "lora_dropout", 0.0) or 0.0),
+        rank_dropout=float(getattr(args, "lora_rank_dropout", 0.0) or 0.0),
+        module_dropout=float(getattr(args, "lora_module_dropout", 0.0) or 0.0),
+        weight_decompose=bool(getattr(args, "lora_dora", False)),
+        rs_lora=bool(getattr(args, "lora_rs", False)),
+    )
     injector.inject(model)
     
     # 从已有 LoRA 继续训练
@@ -2644,8 +2636,6 @@ def main():
                 mode=str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal"),
                 shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
             )
-            if args.lora_type == "tlora":
-                injector.set_mask(injector.build_sigma_mask(t, device))
             t_exp = t.view(-1, 1, 1, 1, 1)
             noise = make_noise(
                 latents,

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -2627,6 +2627,16 @@ def main():
                 cross = model.preprocess_text_embeds(qwen_emb, t5_ids)
                 if cross.shape[1] < 512:
                     cross = F.pad(cross, (0, 0, 0, 512 - cross.shape[1]))
+                # KV trim：把 padding 截到最近有效 token bucket（64/128/256/512）
+                # t5_attn=1 表示有效 token；取批次内最大实际长度再 round up
+                if getattr(args, "kv_trim", False):
+                    _actual = int(t5_attn.sum(dim=-1).max().item())
+                    _bucket = 512  # _actual > 512 时兜底（不裁，保持原行为）
+                    for _b in (64, 128, 256, 512):
+                        if _b >= _actual:
+                            _bucket = _b
+                            break
+                    cross = cross[:, :_bucket, :].contiguous()
 
             # Flow Matching
             t = sample_t(

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -333,6 +333,21 @@ class TrainingConfig(BaseModel):
         description="权重衰减（0=禁用）",
         json_schema_extra=_meta("training"),
     )
+    loss_weighting: Literal["none", "min_snr", "detail_inv_t", "cosmap"] = Field(
+        "none",
+        description="Loss 加权方案（min_snr 推荐；detail_inv_t 细节强化；cosmap SD3 风格）",
+        json_schema_extra=_meta("training"),
+    )
+    min_snr_gamma: float = Field(
+        5.0, ge=0.1, le=20.0,
+        description="Min-SNR gamma 值（仅 loss_weighting=min_snr）",
+        json_schema_extra=_meta("training", show_when="loss_weighting==min_snr"),
+    )
+    weight_cap_ratio: float = Field(
+        0.0, ge=0.0, le=50.0,
+        description="Batch 内 loss 权重 max/min 比上限（0=禁用；小 batch+Prodigy 建议 5）",
+        json_schema_extra=_meta("training", show_when="loss_weighting!=none"),
+    )
     grad_clip_max_norm: float = Field(
         0.0, ge=0.0,
         description="梯度裁剪最大范数（0=禁用）",

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -333,6 +333,16 @@ class TrainingConfig(BaseModel):
         description="权重衰减（0=禁用）",
         json_schema_extra=_meta("training"),
     )
+    timestep_sampling: Literal["logit_normal", "uniform", "logit_normal_low", "mode"] = Field(
+        "logit_normal",
+        description="时间步采样分布（logit_normal 为 SD3/Anima 默认）",
+        json_schema_extra=_meta("training"),
+    )
+    timestep_shift: float = Field(
+        3.0, ge=0.1, le=10.0,
+        description="logit-normal / mode shift（>1 偏向高噪声端，<1 偏向细节端）",
+        json_schema_extra=_meta("training", show_when="timestep_sampling!=uniform"),
+    )
     loss_weighting: Literal["none", "min_snr", "detail_inv_t", "cosmap"] = Field(
         "none",
         description="Loss 加权方案（min_snr 推荐；detail_inv_t 细节强化；cosmap SD3 风格）",

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -333,6 +333,21 @@ class TrainingConfig(BaseModel):
         description="权重衰减（0=禁用）",
         json_schema_extra=_meta("training"),
     )
+    noise_offset: float = Field(
+        0.0, ge=0.0, le=0.2,
+        description="噪声低频偏移强度，缓解亮度均值偏差（0=禁用，推荐 0.05-0.1）",
+        json_schema_extra=_meta("training"),
+    )
+    pyramid_noise_iters: int = Field(
+        0, ge=0, le=6,
+        description="多尺度噪声叠加层数（0=禁用；2-3 帮助全局光照构图学习）",
+        json_schema_extra=_meta("training"),
+    )
+    pyramid_noise_discount: float = Field(
+        0.35, ge=0.1, le=0.9,
+        description="每层噪声衰减系数（仅 pyramid_noise_iters > 0）",
+        json_schema_extra=_meta("training", show_when="pyramid_noise_iters!=0"),
+    )
     timestep_sampling: Literal["logit_normal", "uniform", "logit_normal_low", "mode"] = Field(
         "logit_normal",
         description="时间步采样分布（logit_normal 为 SD3/Anima 默认）",

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -333,6 +333,11 @@ class TrainingConfig(BaseModel):
         description="权重衰减（0=禁用）",
         json_schema_extra=_meta("training"),
     )
+    kv_trim: bool = Field(
+        False,
+        description="Cross-attention KV trim：按实际 token 数裁到最近 bucket（64/128/256/512），减少 padding 计算量",
+        json_schema_extra=_meta("training"),
+    )
     noise_offset: float = Field(
         0.0, ge=0.0, le=0.2,
         description="噪声低频偏移强度，缓解亮度均值偏差（0=禁用，推荐 0.05-0.1）",

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -335,47 +335,47 @@ class TrainingConfig(BaseModel):
     )
     kv_trim: bool = Field(
         False,
-        description="Cross-attention KV trim：按实际 token 数裁到最近 bucket（64/128/256/512），减少 padding 计算量",
+        description="【性能】Cross-attention KV trim：按实际 token 数裁到最近 bucket（64/128/256/512），减少 padding 计算量",
         json_schema_extra=_meta("training"),
     )
     noise_offset: float = Field(
         0.0, ge=0.0, le=0.2,
-        description="噪声低频偏移强度，缓解亮度均值偏差（0=禁用，推荐 0.05-0.1）",
+        description="【噪声增强】低频偏移强度，缓解亮度均值偏差（0=禁用，推荐 0.05-0.1）",
         json_schema_extra=_meta("training"),
     )
     pyramid_noise_iters: int = Field(
         0, ge=0, le=6,
-        description="多尺度噪声叠加层数（0=禁用；2-3 帮助全局光照构图学习）",
+        description="【噪声增强】多尺度噪声叠加层数（0=禁用；2-3 帮助全局光照构图学习）",
         json_schema_extra=_meta("training"),
     )
     pyramid_noise_discount: float = Field(
         0.35, ge=0.1, le=0.9,
-        description="每层噪声衰减系数（仅 pyramid_noise_iters > 0）",
+        description="【噪声增强】金字塔每层衰减系数（仅 pyramid_noise_iters > 0）",
         json_schema_extra=_meta("training", show_when="pyramid_noise_iters!=0"),
     )
     timestep_sampling: Literal["logit_normal", "uniform", "logit_normal_low", "mode"] = Field(
         "logit_normal",
-        description="时间步采样分布（logit_normal 为 SD3/Anima 默认）",
+        description="【时间步采样】分布（logit_normal 为 SD3/Anima 默认）",
         json_schema_extra=_meta("training"),
     )
     timestep_shift: float = Field(
         3.0, ge=0.1, le=10.0,
-        description="logit-normal / mode shift（>1 偏向高噪声端，<1 偏向细节端）",
+        description="【时间步采样】logit-normal / mode shift（>1 偏向高噪声端，<1 偏向细节端）",
         json_schema_extra=_meta("training", show_when="timestep_sampling!=uniform"),
     )
     loss_weighting: Literal["none", "min_snr", "detail_inv_t", "cosmap"] = Field(
         "none",
-        description="Loss 加权方案（min_snr 推荐；detail_inv_t 细节强化；cosmap SD3 风格）",
+        description="【损失加权】方案（min_snr 推荐；detail_inv_t 细节强化；cosmap SD3 风格）",
         json_schema_extra=_meta("training"),
     )
     min_snr_gamma: float = Field(
         5.0, ge=0.1, le=20.0,
-        description="Min-SNR gamma 值（仅 loss_weighting=min_snr）",
+        description="【损失加权】Min-SNR gamma 值（仅 loss_weighting=min_snr）",
         json_schema_extra=_meta("training", show_when="loss_weighting==min_snr"),
     )
     weight_cap_ratio: float = Field(
         0.0, ge=0.0, le=50.0,
-        description="Batch 内 loss 权重 max/min 比上限（0=禁用；小 batch+Prodigy 建议 5）",
+        description="【损失加权】Batch 内权重 max/min 比上限（0=禁用；小 batch+Prodigy 建议 5）",
         json_schema_extra=_meta("training", show_when="loss_weighting!=none"),
     )
     grad_clip_max_norm: float = Field(

--- a/tests/test_optimizer_utils.py
+++ b/tests/test_optimizer_utils.py
@@ -91,13 +91,16 @@ def test_create_ppsf_import_error_message() -> None:
 
 
 @pytest.mark.skipif(not _has_ppsf(), reason="PPSF 未安装")
-def test_create_ppsf_forces_lr_to_one(capsys: pytest.CaptureFixture[str]) -> None:
+def test_create_ppsf_forces_lr_to_one(caplog: pytest.LogCaptureFixture) -> None:
     """传非 1.0 的 lr 时强制覆盖并 WARN（PPSF 要求 lr=1.0）。"""
+    import logging
     model = nn.Linear(4, 4)
-    optim = create_prodigy_plus_schedulefree(model.parameters(), lr=1e-4)
-    captured = capsys.readouterr().out
-    assert "lr=1.0" in captured
-    assert "WARN" in captured
+    with caplog.at_level(logging.WARNING, logger="utils.optimizer_utils"):
+        optim = create_prodigy_plus_schedulefree(model.parameters(), lr=1e-4)
+    assert any(
+        "lr=1.0" in r.getMessage() and r.levelno >= logging.WARNING
+        for r in caplog.records
+    ), f"expected WARNING with 'lr=1.0', got: {[r.getMessage() for r in caplog.records]}"
     assert optim.param_groups[0]["lr"] == 1.0
 
 

--- a/utils/optimizer_utils.py
+++ b/utils/optimizer_utils.py
@@ -9,12 +9,18 @@ Optimizer Utils Module - 优化器创建
    解决 Prodigy 在扩散 LoRA 训练中的 mutation ep / 风格突变问题。
 """
 
+from __future__ import annotations
+
 from contextlib import contextmanager
+import inspect
+import logging
 from typing import List, Dict, Any, Optional, Iterator
 
 import torch
 from torch import nn
 from torch.optim import Optimizer, AdamW
+
+logger = logging.getLogger(__name__)
 
 # 尝试导入 bitsandbytes
 try:
@@ -22,6 +28,38 @@ try:
     BITSANDBYTES_AVAILABLE = True
 except ImportError:
     BITSANDBYTES_AVAILABLE = False
+
+
+def _is_param_groups(params: Any) -> bool:
+    if isinstance(params, (list, tuple)) and len(params) > 0:
+        return isinstance(params[0], dict) and "params" in params[0]
+    return False
+
+
+def _filter_kwargs_by_signature(cls_or_fn, kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        sig = inspect.signature(cls_or_fn)
+    except (TypeError, ValueError):
+        return dict(kwargs)
+
+    accepted, has_var_keyword = set(), False
+    for name, param in sig.parameters.items():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            has_var_keyword = True
+            break
+        accepted.add(name)
+
+    if has_var_keyword:
+        return dict(kwargs)
+
+    filtered = {k: v for k, v in kwargs.items() if k in accepted}
+    dropped = [k for k in kwargs if k not in accepted]
+    if dropped:
+        logger.warning(
+            f"[optimizer] Dropped unsupported kwargs for "
+            f"{getattr(cls_or_fn, '__name__', cls_or_fn)}: {dropped}"
+        )
+    return filtered
 
 
 def create_optimizer(
@@ -301,7 +339,7 @@ def create_prodigy_plus_schedulefree(
     lr: float,
     betas: tuple = (0.9, 0.999),
     weight_decay: float = 0.0,
-    eps: float = 1e-8,
+    eps: Optional[float] = None,
     d_coef: float = 1.0,
     prodigy_steps: int = 0,
     split_groups: bool = True,
@@ -358,29 +396,22 @@ def create_prodigy_plus_schedulefree(
         ) from e
 
     if abs(lr - 1.0) > 1e-9:
-        print(
-            f"[WARN] ProdigyPlusScheduleFree requires lr=1.0 (received {lr}); forcing lr=1.0. "
-            f"Tune d_coef instead of lr."
+        logger.warning(
+            f"[ProdigyPlus] Forcing lr=1.0 (got {lr}); "
+            f"Prodigy adapts step size internally via d."
         )
-        lr = 1.0
+    lr = 1.0
+
+    if isinstance(eps, (int, float)) and eps <= 0:
+        logger.warning(f"[ProdigyPlus] eps={eps} non-positive, falling back to None (Adam-atan2).")
+        eps = None
 
     # 上层 create_optimizer 默认 betas=(0.9, 0.999)（适合 AdamW），但 PPSF 推荐
     # (0.9, 0.99)。如果调用方没改默认，覆盖到 PPSF 推荐值。
     if tuple(betas) == (0.9, 0.999):
         betas = (0.9, 0.99)
 
-    print(
-        f"Creating ProdigyPlusScheduleFree optimizer "
-        f"(lr={lr}, betas={tuple(betas)}, weight_decay={weight_decay}, "
-        f"d_coef={d_coef}, prodigy_steps={prodigy_steps}, "
-        f"split_groups={split_groups}, use_speed={use_speed}, "
-        f"fused_back_pass={fused_back_pass})"
-    )
-
-    param_list = list(params)
-
-    optimizer = ProdigyPlusScheduleFree(
-        param_list,
+    candidate = dict(
         lr=lr,
         betas=tuple(betas),
         eps=eps,
@@ -394,9 +425,21 @@ def create_prodigy_plus_schedulefree(
         use_stableadamw=use_stableadamw,
         **kwargs,
     )
+    safe_kwargs = _filter_kwargs_by_signature(ProdigyPlusScheduleFree, candidate)
 
-    print("  [OK] ProdigyPlusScheduleFree optimizer created")
+    param_list = params if _is_param_groups(params) else list(params)
 
+    logger.info(
+        f"Creating ProdigyPlusScheduleFree "
+        f"(d_coef={d_coef}, betas={tuple(betas)}, wd={weight_decay}, "
+        f"eps={eps}, stableadamw={use_stableadamw})"
+    )
+    logger.info(f"[ProdigyPlus] Effective kwargs: {list(safe_kwargs.keys())}")
+
+    optimizer = ProdigyPlusScheduleFree(param_list, **safe_kwargs)
+
+    total = sum(p.numel() for g in optimizer.param_groups for p in g["params"] if p.requires_grad)
+    logger.info(f"[ProdigyPlus] Trainable params: {total:,}")
     return optimizer
 
 

--- a/utils/optimizer_utils.py
+++ b/utils/optimizer_utils.py
@@ -36,6 +36,17 @@ def _is_param_groups(params: Any) -> bool:
     return False
 
 
+# 用户通过 schema (ppsf_* 字段) 显式配置的 kwarg。如果上游版本不接受这些，
+# silent drop 会让用户的勾选/数值悄悄失效，可能 8 小时后才发现训练效果不对——
+# 所以这些必须 fail loud，而不是只 log warning。
+_USER_EXPOSED_PPSF_KWARGS = frozenset({
+    "d_coef", "prodigy_steps",
+    "split_groups", "split_groups_mean",
+    "use_speed", "fused_back_pass",
+    "use_stableadamw",
+})
+
+
 def _filter_kwargs_by_signature(cls_or_fn, kwargs: Dict[str, Any]) -> Dict[str, Any]:
     try:
         sig = inspect.signature(cls_or_fn)
@@ -55,6 +66,15 @@ def _filter_kwargs_by_signature(cls_or_fn, kwargs: Dict[str, Any]) -> Dict[str, 
     filtered = {k: v for k, v in kwargs.items() if k in accepted}
     dropped = [k for k in kwargs if k not in accepted]
     if dropped:
+        exposed_dropped = [k for k in dropped if k in _USER_EXPOSED_PPSF_KWARGS]
+        if exposed_dropped:
+            cls_name = getattr(cls_or_fn, "__name__", str(cls_or_fn))
+            raise RuntimeError(
+                f"[optimizer] {cls_name} 不支持以下用户配置的 kwarg："
+                f"{exposed_dropped}。可能是 prodigy-plus-schedule-free 库版本不匹配 "
+                f"（pip show prodigy-plus-schedule-free 检查版本）。"
+                f"升级/降级依赖，或在 yaml 关掉对应字段。"
+            )
         logger.warning(
             f"[optimizer] Dropped unsupported kwargs for "
             f"{getattr(cls_or_fn, '__name__', cls_or_fn)}: {dropped}"


### PR DESCRIPTION
## Summary

PR #49（saltysalrua）三方 review 后的处置：cherry-pick 5 个低风险高价值 commit + 我们的 4 项加固。两个新 adapter（T-LoRA + Ortho-Hydra）和手动 OrthoGrad **不进主仓**，将另开长期分支 `experimental/pr49-adapters` 做 parking lot。

来源 PR：#49
Review 结论参考：本地 review thread（正方 / 反方 / PM 三视角）

## 包含的内容

**cherry-pick 自原 PR**（保留作者 authorship）：
- `751221e` ProdigyPlus 上游 version-compat filter + eps=None + StableAdamW（修上游 API 飘移导致的 TypeError）
- `dde10fa` NaN detection and skip（loss/grad 非有限时跳过 step，bf16 + Prodigy 偶发 spike 不再炸整训练）
- `47c4f03` 时间步相关 loss weighting（min_snr / detail_inv_t / cosmap + weight_cap_ratio）
- `75dc409` 可配置 timestep sampling（logit_normal / uniform / logit_normal_low / mode）+ shift
- `8bb4c4d` noise_offset + pyramid_noise 噪声增强

**手术拆分 c5e81c2**（原 commit 混了 T-LoRA 改动 + kv_trim 两个无关 feature）：
- `b83d217` 只挑 cross-attn kv_trim 部分；丢弃 tlora_alpha_rank_scale / tlora_sig_type / tlora_adapter.py 改动；附加修复 `_bucket = 512` 兜底（`_actual > 512` 时原代码会 NameError）

**我们的加固**：
- `f2d9ac8` 清理 `47a6edb` 顺带泄漏的死 T-LoRA dispatch（schema Literal 没有 \"tlora\"，但调度块 import 了我们不合的 `utils.tlora_adapter`，是隐性 ImportError 雷）
- `77888dc` 9 个新字段 description 加【噪声增强】/【时间步采样】/【损失加权】/【性能】4 簇前缀，tooltip 里能看出归属
- `6f31f84` `_filter_kwargs_by_signature` 加 `_USER_EXPOSED_PPSF_KWARGS` 白名单——schema 暴露给用户的 ppsf_* 字段如果被上游 drop，显式 raise 而非 silent log（之前 silent drop 会让用户的勾选悄悄失效，8 小时训练后才发现）
- `10d3496` 修 `test_create_ppsf_forces_lr_to_one` 用 caplog 抓日志（PR #49 把 print 改成 logger.warning 后 capsys 失效）

## 不包含的内容（带理由）

| 不合入 | 主要理由 |
|---|---|
| T-LoRA adapter (`66df791` + `c5e81c2` 部分) | 目标用户 <5%；schema 字段 `tlora_min_rank` 缺失、`reg_dims`/`reg_lrs` 前端 dict 不渲染（反方 P0#1/#2）；不阻断长期价值，留 parking lot |
| Ortho-Hydra adapter (`817414c`) | 输出格式自造 `ss_network_module: orthohydra`，不是标准 LoRA key 结构，a1111/ComfyUI 加载不了 |
| 手动 OrthoGrad (`2bb1973`) | 跟 ProdigyPlus 内置 `use_orthograd` 双开 = 训练近乎冻住，只 warn 不阻断；默认排除关键字 `lokr_w1` 子串匹配会误伤 `lokr_w1_a`（反方 P0#4）；Ortho-Hydra drop 后失去主要使用场景 |

后续会建 `experimental/pr49-adapters` 长期分支保留 T-LoRA + Ortho-Hydra + OrthoGrad，方便未来真有需求时测试，不阻塞 dev → master。

## Test plan

- [x] `pytest tests/` — 967 passed / 1 skipped；2 个 pre-existing failures（`test_onnxruntime_setup` mock 签名 drift、`test_studio_cli` 找不到 npm），跟本 PR 无关，已对照 origin/dev 复现
- [x] `npm test` — 135 passed
- [x] `tsc --noEmit` — exit 0
- [ ] dev 上端到端训练一次 LoKr 验证不回归（用户测试）
- [ ] 至少试一次 noise_offset / loss_weighting / timestep_sampling 开非默认值

🤖 Generated with [Claude Code](https://claude.com/claude-code)