### PR TITLE
feat(training): plugin registry + AdapterProtocol hook (ADR 0003 PR-C)

### DIFF
--- a/runtime/training/adapters/__init__.py
+++ b/runtime/training/adapters/__init__.py
@@ -1,0 +1,56 @@
+"""LoRA adapter plugin registry（ADR 0003 PR-C）。
+
+加新变体的步骤（参考 ADR 0003 Case 2-5 落地案例）：
+1. 写 training/adapters/{variant}.py 含 `build(args) -> AdapterProtocol`
+2. 本文件 BUILDERS 字典加一行
+3. studio/schema.py 的 `lora_type: Literal[...]` 加一个枚举值 + 该变体专属字段
+4. 完。phases/models.py / loop.py / main() 0 改动。
+
+删变体：相反顺序，3 步删完。
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from training.adapters import lycoris
+from training.adapters.protocol import AdapterProtocol, StepContext
+
+__all__ = ["AdapterProtocol", "StepContext", "BUILDERS", "build_adapter",
+           "validate_schema_consistency"]
+
+
+# 单一 truth source：所有 adapter 工厂的注册表
+BUILDERS: dict[str, Callable[..., AdapterProtocol]] = {
+    "lokr": lycoris.build,
+    "loha": lycoris.build,
+    "lora": lycoris.build,
+}
+
+
+def build_adapter(args) -> AdapterProtocol:
+    """按 args.lora_type 派发到对应 build()。"""
+    lora_type = args.lora_type
+    if lora_type not in BUILDERS:
+        raise ValueError(
+            f"未知 lora_type={lora_type!r}；已注册: {sorted(BUILDERS)}"
+        )
+    return BUILDERS[lora_type](args)
+
+
+def validate_schema_consistency() -> None:
+    """启动期校验：TrainingConfig.lora_type Literal 集合 == BUILDERS keys。
+
+    失配通常意味着加了新变体但漏改了一处（schema 或 registry）。早 fail 早修。
+    """
+    from studio.schema import TrainingConfig
+
+    field = TrainingConfig.model_fields["lora_type"]
+    schema_options = set(field.annotation.__args__)
+    registered = set(BUILDERS)
+    if schema_options != registered:
+        raise RuntimeError(
+            f"adapter 注册与 schema 不同步（PR-C registry）：\n"
+            f"  schema 有但未注册: {schema_options - registered}\n"
+            f"  注册但 schema 没列: {registered - schema_options}"
+        )

--- a/runtime/training/adapters/lycoris.py
+++ b/runtime/training/adapters/lycoris.py
@@ -1,0 +1,32 @@
+"""LyCORIS 后端的 adapter build 函数（lokr / loha / lora）。
+
+抽自 phases/models.py 里的 AnimaLycorisAdapter 实例化逻辑（ADR 0003 PR-C）。
+
+由 training/adapters/__init__.py 的 BUILDERS 字典派发：
+    BUILDERS["lokr"] = build
+    BUILDERS["loha"] = build
+    BUILDERS["lora"] = build
+
+实际 adapter 类在 utils/lycoris_adapter.py，本文件只做"读 args → 调构造器"
+的轻量 wrapper。
+"""
+
+from __future__ import annotations
+
+from training.adapters.protocol import AdapterProtocol
+
+
+def build(args) -> AdapterProtocol:
+    """从 args 读 lora_type / lora_rank / ... 实例化 AnimaLycorisAdapter。"""
+    from utils.lycoris_adapter import AnimaLycorisAdapter
+    return AnimaLycorisAdapter(
+        algo=args.lora_type,
+        rank=args.lora_rank,
+        alpha=args.lora_alpha,
+        factor=args.lokr_factor,
+        dropout=float(getattr(args, "lora_dropout", 0.0) or 0.0),
+        rank_dropout=float(getattr(args, "lora_rank_dropout", 0.0) or 0.0),
+        module_dropout=float(getattr(args, "lora_module_dropout", 0.0) or 0.0),
+        weight_decompose=bool(getattr(args, "lora_dora", False)),
+        rs_lora=bool(getattr(args, "lora_rs", False)),
+    )

--- a/runtime/training/adapters/protocol.py
+++ b/runtime/training/adapters/protocol.py
@@ -1,0 +1,87 @@
+"""AdapterProtocol：所有 LoRA 变体的统一接口（ADR 0003 PR-C）。
+
+设计原则：
+- 必需 4 个方法（inject / get_param_groups / save / load）—— 所有 adapter 都要实现
+- 3 个可选 hook（on_step_begin / regularization_loss / excludes_weight_decay）——
+  默认 no-op；动态/per-step 行为类变体（T-LoRA / AdaLoRA / OFT 等）按需 override
+- runtime_checkable —— 测试可以直接 `isinstance(adapter, AdapterProtocol)` 验
+
+hook 设计参考 ADR 0003 "Case 3-5" 章节里 T-LoRA / OFT / Ortho-Hydra 的真实需求。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Protocol, runtime_checkable
+
+import torch
+from torch import Tensor, nn
+
+
+@dataclass(frozen=True)
+class StepContext:
+    """每 micro-batch 前向开始时传给 adapter.on_step_begin 的最小上下文。
+
+    最小化字段：只传 hook 真正会用的（避免 dataclass 字段爆炸 + 让 hook
+    实现不依赖 TrainingContext 全部内部状态）。
+    """
+    global_step: int
+    total_steps: Optional[int]
+    epoch: int
+    sigma_t: Tensor          # shape [B]，本 micro-batch 的 sigma
+    args: object             # parse_args 出来的 Namespace；按需读字段
+
+
+@runtime_checkable
+class AdapterProtocol(Protocol):
+    """LoRA / LoKr / LoHa / 论文级变体共用接口。
+
+    用 Protocol 而不是 ABC：现有 AnimaLycorisAdapter 已经实现了前 4 个必需方法
+    （duck-typed），不想强制用户继承。runtime_checkable 让单测 `isinstance`
+    校验仍然能用。
+    """
+
+    # ─── 必需 ───
+    def inject(self, model: nn.Module) -> None:
+        """把 LoRA 层注入到 model（替换 Linear 等）。"""
+        ...
+
+    def get_param_groups(self, weight_decay: float) -> list[dict]:
+        """返回 optimizer param_groups。一组或多组（LoRA+ 可分 A/B 不同 lr，
+        Ortho-Hydra 可单独 router lr）。"""
+        ...
+
+    def save(self, path: Path) -> None:
+        """落盘 safetensors。"""
+        ...
+
+    def load(self, path: Path) -> None:
+        """读取 safetensors。"""
+        ...
+
+    # ─── 可选 hook：默认 no-op；按需 override ───
+
+    def on_step_begin(self, ctx: StepContext) -> None:
+        """每 micro-batch 前向之前调用。
+
+        T-LoRA / AdaLoRA / B-LoRA 在此按 sigma_t / step 调整 rank mask、
+        激活子集、列丢弃等"运行时结构调整"。默认 no-op。
+        """
+        return None
+
+    def regularization_loss(self, ctx: StepContext) -> Optional[Tensor]:
+        """返回要加到主 loss 上的正则项；None=无。
+
+        OFT 返回 orthogonality penalty；Ortho-Hydra 返回 expert balance loss；
+        默认 None。train_loop 收到 None 时不做任何额外操作。
+        """
+        return None
+
+    def excludes_weight_decay(self, param_name: str) -> bool:
+        """该 param 是否应排除 weight_decay。
+
+        替代原代码 `injector.use_lokr` 硬编码检查。LoKr 实现里：
+        return "w1" in param_name。默认 False。
+        """
+        return False

--- a/runtime/training/inference_samplers/__init__.py
+++ b/runtime/training/inference_samplers/__init__.py
@@ -1,0 +1,30 @@
+"""Inference sampler plugin registry（ADR 0003 PR-C）。
+
+加新 sampler（Euler / Heun / DPM++2M / DDIM / unipc）的步骤：
+1. 写 training/inference_samplers/{variant}.py 含 `sample(denoise_fn, x, sigmas, **kw)`
+2. 本文件 BUILDERS 字典加一行
+3. （可选）改 studio/schema.py 的 sample_sampler_name 加 Literal 校验
+
+详见 ADR 0003 "Case 8: Euler / DPM++2M"。
+
+注：sample_sampler_name 在 schema 里是 str 不是 Literal，未注册名会回退到
+sampling.py 里 inline 的简化 Euler ODE 路径（保持原 main() 行为）。
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from training.inference_samplers import er_sde
+
+__all__ = ["BUILDERS", "build_inference_sampler"]
+
+
+BUILDERS: dict[str, Callable] = {
+    "er_sde": er_sde.sample,
+}
+
+
+def build_inference_sampler(name: str) -> Callable:
+    """按 name 取 sampler fn；未注册返回 None（caller 应走 fallback）。"""
+    return BUILDERS.get(str(name).lower().strip())

--- a/runtime/training/inference_samplers/er_sde.py
+++ b/runtime/training/inference_samplers/er_sde.py
@@ -1,0 +1,123 @@
+"""ER-SDE-Solver-3 在 CONST(flow) 噪声日程下的实现。
+
+抽自原 training/sampling.py 的 _sample_er_sde_const_x0（ADR 0003 PR-C 把它
+移到 inference_samplers/ plugin 子包）。
+
+参考 ComfyUI 的 k_diffusion_sampling.sample_er_sde（删去 model_patcher 依赖）。
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+def _default_noise_sampler(x: torch.Tensor, seed: Optional[int]):
+    """参考 ComfyUI k_diffusion_sampling.default_noise_sampler"""
+    if seed is not None:
+        if x.device.type == "cpu":
+            seed = int(seed) + 1
+        g = torch.Generator(device=x.device)
+        g.manual_seed(int(seed))
+    else:
+        g = None
+
+    def _sample(_sigma, _sigma_next):
+        return torch.randn(x.size(), dtype=x.dtype, layout=x.layout, device=x.device, generator=g)
+
+    return _sample
+
+
+@torch.no_grad()
+def sample(
+    denoise_fn,
+    x: torch.Tensor,
+    sigmas: torch.Tensor,
+    *,
+    seed: Optional[int] = None,
+    s_noise: float = 1.0,
+    max_stage: int = 3,
+    step_callback=None,
+) -> torch.Tensor:
+    """ER-SDE-3 stochastic sampler。
+
+    step_callback：可选钩子（daemon 中间步预览用）。签名
+        callback(step:int, total:int, denoised:torch.Tensor) → None。每步算
+        完 x0 估计调一次；同步阻塞返回 —— 调用方应做轻量解码 + 异步 push，
+        不在 callback 内阻塞。默认 None 时行为完全等价旧版。
+    """
+    sigmas = sigmas.to(device=x.device, dtype=torch.float32)
+    if sigmas.numel() <= 1:
+        return x
+
+    noise_sampler = _default_noise_sampler(x, seed=seed)
+
+    # CONST: half_log_snr = log((1 - t) / t) = -logit(t)
+    eps = 1e-12
+    t = sigmas.clamp(min=eps, max=1.0 - eps)
+    half_log_snrs = torch.log((1 - t) / t)
+    er_lambdas = half_log_snrs.neg().exp()  # er_lambda = t / (1 - t)
+
+    old_denoised = None
+    old_denoised_d = None
+
+    def noise_scaler(lam: torch.Tensor) -> torch.Tensor:
+        # default_er_sde_noise_scaler
+        lam = lam.to(x.device, dtype=torch.float32)
+        return lam * ((lam ** 0.3).exp() + 10.0)
+
+    num_integration_points = 200.0
+    point_indice = torch.arange(0, num_integration_points, dtype=torch.float32, device=x.device)
+
+    for i in range(len(sigmas) - 1):
+        sigma = sigmas[i]
+        denoised = denoise_fn(x, sigma)
+
+        if step_callback is not None:
+            try:
+                step_callback(i, len(sigmas) - 1, denoised)
+            except Exception:
+                pass  # 预览失败不该影响采样
+
+        stage_used = min(int(max_stage), i + 1)
+        if sigmas[i + 1] == 0:
+            x = denoised
+        else:
+            er_lambda_s, er_lambda_t = er_lambdas[i], er_lambdas[i + 1]
+            alpha_s = 1.0 - sigmas[i]
+            alpha_t = 1.0 - sigmas[i + 1]
+            r_alpha = alpha_t / alpha_s
+            r = noise_scaler(er_lambda_t) / noise_scaler(er_lambda_s)
+
+            # Stage 1 (Euler)
+            x = r_alpha * r * x + alpha_t * (1 - r) * denoised
+
+            if stage_used >= 2 and old_denoised is not None:
+                dt = er_lambda_t - er_lambda_s
+                lambda_step_size = -dt / num_integration_points
+                lambda_pos = er_lambda_t + point_indice * lambda_step_size
+                scaled_pos = noise_scaler(lambda_pos)
+
+                # Stage 2
+                s = torch.sum(1 / scaled_pos) * lambda_step_size
+                denoised_d = (denoised - old_denoised) / (er_lambda_s - er_lambdas[i - 1])
+                x = x + alpha_t * (dt + s * noise_scaler(er_lambda_t)) * denoised_d
+
+                if stage_used >= 3 and old_denoised_d is not None:
+                    # Stage 3
+                    s_u = torch.sum((lambda_pos - er_lambda_s) / scaled_pos) * lambda_step_size
+                    denoised_u = (denoised_d - old_denoised_d) / ((er_lambda_s - er_lambdas[i - 2]) / 2)
+                    x = x + alpha_t * ((dt ** 2) / 2 + s_u * noise_scaler(er_lambda_t)) * denoised_u
+
+                old_denoised_d = denoised_d
+
+            # Stochastic term
+            if s_noise and float(s_noise) > 0:
+                noise = noise_sampler(float(sigmas[i]), float(sigmas[i + 1]))
+                sde_scale = (er_lambda_t ** 2 - (er_lambda_s ** 2) * (r ** 2)).clamp(min=0).sqrt().nan_to_num(nan=0.0)
+                x = x + alpha_t * noise * float(s_noise) * sde_scale
+
+        old_denoised = denoised
+
+    return x

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -90,6 +90,19 @@ def run(ctx: TrainingContext) -> None:
                 mode=str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal"),
                 shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
             )
+
+            # PR-C：adapter hook — 允许变体按 sigma_t / step 调整运行时结构
+            # （T-LoRA / AdaLoRA / B-LoRA 等）。LyCORIS 走默认 no-op。
+            from training.adapters.protocol import StepContext
+            step_ctx = StepContext(
+                global_step=ctx.global_step,
+                total_steps=ctx.total_steps,
+                epoch=epoch,
+                sigma_t=t,
+                args=args,
+            )
+            ctx.injector.on_step_begin(step_ctx)
+
             t_exp = t.view(-1, 1, 1, 1, 1)
             noise = make_noise(
                 latents,
@@ -123,6 +136,12 @@ def run(ctx: TrainingContext) -> None:
                     ).to(device=ctx.device, dtype=torch.float32)
                     loss_per_sample = loss_per_sample * lw.view(-1, *([1] * (loss_per_sample.dim() - 1)))
                 loss = loss_per_sample.mean()
+
+                # PR-C：adapter hook — 变体可加正则项（OFT orth penalty /
+                # Ortho-Hydra balance loss 等）。LyCORIS 返回 None，noop。
+                reg = ctx.injector.regularization_loss(step_ctx)
+                if reg is not None:
+                    loss = loss + reg
 
             # NaN 检测：forward 出 NaN 时跳过本 micro-batch
             if not torch.isfinite(loss):

--- a/runtime/training/optimizers/__init__.py
+++ b/runtime/training/optimizers/__init__.py
@@ -1,0 +1,64 @@
+"""Optimizer plugin registry（ADR 0003 PR-C）。
+
+加新优化器（Lion / CAME / Schedule-Free AdamW）的步骤：
+1. 写 training/optimizers/{variant}.py 含 `build(args, params, lr, weight_decay)`，
+   可选 `validate(args)` 启动期检查
+2. 本文件 BUILDERS / VALIDATORS 字典加一行
+3. studio/schema.py 的 optimizer_type Literal 加枚举值 + 该 variant 专属字段
+4. requirements.txt 加依赖（如有）
+
+详见 ADR 0003 "Case 6: Lion / CAME / Schedule-Free AdamW"。
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from training.optimizers import adamw, prodigy, prodigy_plus_schedulefree
+
+__all__ = ["BUILDERS", "VALIDATORS", "build_optimizer", "validate_optimizer",
+           "validate_schema_consistency"]
+
+
+BUILDERS: dict[str, Callable] = {
+    "adamw": adamw.build,
+    "prodigy": prodigy.build,
+    "prodigy_plus_schedulefree": prodigy_plus_schedulefree.build,
+}
+
+# 启动期校验函数（None / 未注册 = 跳过）
+VALIDATORS: dict[str, Callable[[object], None]] = {
+    "prodigy_plus_schedulefree": prodigy_plus_schedulefree.validate,
+}
+
+
+def build_optimizer(args, params, lr: float, weight_decay: float):
+    """按 args.optimizer_type 派发。"""
+    optimizer_type = (getattr(args, "optimizer_type", "adamw") or "adamw").lower()
+    if optimizer_type not in BUILDERS:
+        raise ValueError(
+            f"未知 optimizer_type={optimizer_type!r}；已注册: {sorted(BUILDERS)}"
+        )
+    return BUILDERS[optimizer_type](args, params, lr, weight_decay)
+
+
+def validate_optimizer(args) -> None:
+    """跑 optimizer 专属启动期兼容检查（如 PPSF 要求 lr_scheduler=none）。"""
+    optimizer_type = (getattr(args, "optimizer_type", "adamw") or "adamw").lower()
+    validator = VALIDATORS.get(optimizer_type)
+    if validator:
+        validator(args)
+
+
+def validate_schema_consistency() -> None:
+    from studio.schema import TrainingConfig
+
+    field = TrainingConfig.model_fields["optimizer_type"]
+    schema_options = set(field.annotation.__args__)
+    registered = set(BUILDERS)
+    if schema_options != registered:
+        raise RuntimeError(
+            f"optimizer 注册与 schema 不同步（PR-C registry）：\n"
+            f"  schema 有但未注册: {schema_options - registered}\n"
+            f"  注册但 schema 没列: {registered - schema_options}"
+        )

--- a/runtime/training/optimizers/adamw.py
+++ b/runtime/training/optimizers/adamw.py
@@ -1,0 +1,18 @@
+"""AdamW optimizer build wrapper（ADR 0003 PR-C）。"""
+
+from __future__ import annotations
+
+
+def build(args, params, lr: float, weight_decay: float):
+    """实例化 AdamW。
+
+    AdamW 不需要 args.* 之外的额外参数；保持签名跟其他 builder 一致以便
+    registry 统一派发。
+    """
+    from utils.optimizer_utils import create_optimizer
+    return create_optimizer(
+        optimizer_type="adamw",
+        params=params,
+        learning_rate=lr,
+        weight_decay=weight_decay,
+    )

--- a/runtime/training/optimizers/prodigy.py
+++ b/runtime/training/optimizers/prodigy.py
@@ -1,0 +1,16 @@
+"""Prodigy optimizer build wrapper（ADR 0003 PR-C）。"""
+
+from __future__ import annotations
+
+
+def build(args, params, lr: float, weight_decay: float):
+    """实例化 Prodigy，读 args.prodigy_d_coef + args.prodigy_safeguard_warmup。"""
+    from utils.optimizer_utils import create_optimizer
+    return create_optimizer(
+        optimizer_type="prodigy",
+        params=params,
+        learning_rate=lr,
+        weight_decay=weight_decay,
+        d_coef=float(getattr(args, "prodigy_d_coef", 1.0)),
+        safeguard_warmup=bool(getattr(args, "prodigy_safeguard_warmup", True)),
+    )

--- a/runtime/training/optimizers/prodigy_plus_schedulefree.py
+++ b/runtime/training/optimizers/prodigy_plus_schedulefree.py
@@ -1,0 +1,41 @@
+"""ProdigyPlusScheduleFree optimizer build wrapper（ADR 0003 PR-C）。
+
+PPSF 是 Schedule-Free 系：内置 LR 调度，跟外部 LR scheduler 互斥。
+本模块同时暴露 validate(args) 给 PR-C registry 在启动期跑兼容性检查。
+"""
+
+from __future__ import annotations
+
+
+def validate(args) -> None:
+    """启动期兼容性检查：lr_scheduler 必须 none，否则直接 SystemExit。"""
+    lr_sched_cfg = (getattr(args, "lr_scheduler", "none") or "none").lower()
+    if lr_sched_cfg != "none":
+        raise SystemExit(
+            f"ProdigyPlusScheduleFree requires lr_scheduler=none "
+            f"(Schedule-Free is scheduler-free by construction); got "
+            f"lr_scheduler={lr_sched_cfg!r}. Set lr_scheduler=none or pick a "
+            f"different optimizer."
+        )
+
+
+def build(args, params, lr: float, weight_decay: float):
+    """实例化 PPSF，读 7 个 ppsf_* 参数 + betas override。"""
+    from utils.optimizer_utils import create_optimizer
+    return create_optimizer(
+        optimizer_type="prodigy_plus_schedulefree",
+        params=params,
+        learning_rate=lr,
+        weight_decay=weight_decay,
+        betas=(
+            float(getattr(args, "ppsf_beta1", 0.9)),
+            float(getattr(args, "ppsf_beta2", 0.99)),
+        ),
+        d_coef=float(getattr(args, "ppsf_d_coef", 1.0)),
+        prodigy_steps=int(getattr(args, "ppsf_prodigy_steps", 0)),
+        split_groups=bool(getattr(args, "ppsf_split_groups", True)),
+        split_groups_mean=bool(getattr(args, "ppsf_split_groups_mean", False)),
+        use_speed=bool(getattr(args, "ppsf_use_speed", False)),
+        fused_back_pass=bool(getattr(args, "ppsf_fused_back_pass", False)),
+        use_stableadamw=bool(getattr(args, "ppsf_use_stableadamw", True)),
+    )

--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -31,6 +31,14 @@ def run(ctx: TrainingContext) -> None:
     """
     args = ctx.args
 
+    # PR-C：启动期校验所有 plugin 子包 schema 一致性，避免运行半天才发现配错
+    from training.adapters import validate_schema_consistency as _validate_adapters
+    from training.optimizers import validate_schema_consistency as _validate_optimizers
+    from training.schedulers import validate_schema_consistency as _validate_schedulers
+    _validate_adapters()
+    _validate_optimizers()
+    _validate_schedulers()
+
     # 加载 YAML 配置文件
     if args.config:
         logger.info(f"加载配置文件: {args.config}")

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -82,20 +82,11 @@ def run(ctx: TrainingContext) -> None:
         args.text_encoder_path, args.t5_tokenizer_path, ctx.device, ctx.dtype,
     )
 
-    # 注入 LoRA
+    # 注入 LoRA — PR-C 通过 adapters/ plugin registry 派发，加新变体见
+    # training/adapters/__init__.py docstring
     logger.info(f"注入 {args.lora_type.upper()}...")
-    from utils.lycoris_adapter import AnimaLycorisAdapter
-    ctx.injector = AnimaLycorisAdapter(
-        algo=args.lora_type,
-        rank=args.lora_rank,
-        alpha=args.lora_alpha,
-        factor=args.lokr_factor,
-        dropout=float(getattr(args, "lora_dropout", 0.0) or 0.0),
-        rank_dropout=float(getattr(args, "lora_rank_dropout", 0.0) or 0.0),
-        module_dropout=float(getattr(args, "lora_module_dropout", 0.0) or 0.0),
-        weight_decompose=bool(getattr(args, "lora_dora", False)),
-        rs_lora=bool(getattr(args, "lora_rs", False)),
-    )
+    from training.adapters import build_adapter
+    ctx.injector = build_adapter(args)
     ctx.injector.inject(ctx.model)
 
     # 从已有 LoRA 继续训练

--- a/runtime/training/phases/optimizer.py
+++ b/runtime/training/phases/optimizer.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 
 import logging
 
-import torch
-
 from training.context import TrainingContext
 
 
@@ -20,52 +18,22 @@ logger = logging.getLogger(__name__)
 
 def run(ctx: TrainingContext) -> None:
     """
-    - injector.get_param_groups + optimizer kwargs 派发 + create_optimizer
+    - injector.get_param_groups + build_optimizer(args, ...) via training.optimizers
+    - validate_optimizer 启动期约束检查（如 PPSF lr_scheduler=none）
     - grad_clip / trainable_params
     - 计算 total_steps（min(by_epochs, by_max_steps)）
-    - lr_scheduler 派发（cosine / cosine_with_restart / none）
+    - build_scheduler(args, optimizer, total_steps) via training.schedulers
     """
     args = ctx.args
 
-    # 优化器
+    # 优化器：PR-C 通过 optimizers/ plugin registry 派发
     ctx.weight_decay = float(getattr(args, "weight_decay", 0.01) or 0.0)
     param_groups = ctx.injector.get_param_groups(ctx.weight_decay)
     ctx.optimizer_type = (getattr(args, "optimizer_type", "adamw") or "adamw").lower()
-    from utils.optimizer_utils import create_optimizer
-    optimizer_extra: dict = {}
-    optimizer_overrides: dict = {}
-    if ctx.optimizer_type == "prodigy":
-        optimizer_extra["d_coef"] = float(getattr(args, "prodigy_d_coef", 1.0))
-        optimizer_extra["safeguard_warmup"] = bool(getattr(args, "prodigy_safeguard_warmup", True))
-    elif ctx.optimizer_type == "prodigy_plus_schedulefree":
-        # Schedule-Free 不需要 scheduler，启动期强校验
-        lr_sched_cfg = (getattr(args, "lr_scheduler", "none") or "none").lower()
-        if lr_sched_cfg != "none":
-            raise SystemExit(
-                f"ProdigyPlusScheduleFree requires lr_scheduler=none "
-                f"(Schedule-Free is scheduler-free by construction); got "
-                f"lr_scheduler={lr_sched_cfg!r}. Set lr_scheduler=none or pick a "
-                f"different optimizer."
-            )
-        optimizer_extra["d_coef"] = float(getattr(args, "ppsf_d_coef", 1.0))
-        optimizer_extra["prodigy_steps"] = int(getattr(args, "ppsf_prodigy_steps", 0))
-        optimizer_extra["split_groups"] = bool(getattr(args, "ppsf_split_groups", True))
-        optimizer_extra["split_groups_mean"] = bool(getattr(args, "ppsf_split_groups_mean", False))
-        optimizer_extra["use_speed"] = bool(getattr(args, "ppsf_use_speed", False))
-        optimizer_extra["fused_back_pass"] = bool(getattr(args, "ppsf_fused_back_pass", False))
-        optimizer_extra["use_stableadamw"] = bool(getattr(args, "ppsf_use_stableadamw", True))
-        optimizer_overrides["betas"] = (
-            float(getattr(args, "ppsf_beta1", 0.9)),
-            float(getattr(args, "ppsf_beta2", 0.99)),
-        )
-    ctx.optimizer = create_optimizer(
-        optimizer_type=ctx.optimizer_type,
-        params=param_groups,
-        learning_rate=args.learning_rate,
-        weight_decay=ctx.weight_decay,
-        **optimizer_overrides,
-        **optimizer_extra,
-    )
+
+    from training.optimizers import build_optimizer, validate_optimizer
+    validate_optimizer(args)  # PPSF 检查 lr_scheduler=none 等启动期约束
+    ctx.optimizer = build_optimizer(args, param_groups, args.learning_rate, ctx.weight_decay)
     if ctx.weight_decay > 0:
         wd_info = f"{ctx.optimizer_type} weight_decay={ctx.weight_decay}"
         if ctx.injector.use_lokr:
@@ -101,23 +69,6 @@ def run(ctx: TrainingContext) -> None:
         f"总步数: {ctx.total_steps} (by_epochs={by_epochs}, by_max_steps={by_max_steps})"
     )
 
-    # 学习率调度器
-    ctx.scheduler = None
-    lr_sched = getattr(args, "lr_scheduler", "none") or "none"
-    if lr_sched == "cosine":
-        eta_min = float(getattr(args, "lr_scheduler_eta_min", 0.0) or 0.0)
-        if ctx.total_steps is None:
-            logger.warning("cosine 调度器需要已知 total_steps，回退到 none")
-        else:
-            ctx.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
-                ctx.optimizer, T_max=ctx.total_steps, eta_min=eta_min
-            )
-            logger.info(f"学习率调度: cosine (T_max={ctx.total_steps}, eta_min={eta_min})")
-    elif lr_sched == "cosine_with_restart":
-        t0 = int(getattr(args, "lr_scheduler_t0", 500) or 500)
-        t_mult = int(getattr(args, "lr_scheduler_t_mult", 2) or 2)
-        eta_min = float(getattr(args, "lr_scheduler_eta_min", 0.0) or 0.0)
-        ctx.scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
-            ctx.optimizer, T_0=t0, T_mult=t_mult, eta_min=eta_min
-        )
-        logger.info(f"学习率调度: cosine_with_restart (T_0={t0}, T_mult={t_mult}, eta_min={eta_min})")
+    # 学习率调度器：PR-C 通过 schedulers/ plugin registry 派发；"none" 自动返回 None
+    from training.schedulers import build_scheduler
+    ctx.scheduler = build_scheduler(args, ctx.optimizer, ctx.total_steps)

--- a/runtime/training/sampling.py
+++ b/runtime/training/sampling.py
@@ -16,8 +16,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
-
 import torch
 import torch.nn.functional as F
 
@@ -60,116 +58,8 @@ def _flow_sigmas_simple(steps: int, *, shift: float = 3.0, timesteps: int = 1000
     return sigmas
 
 
-def _default_noise_sampler(x: torch.Tensor, seed: Optional[int]):
-    """参考 ComfyUI k_diffusion_sampling.default_noise_sampler"""
-    if seed is not None:
-        if x.device.type == "cpu":
-            seed = int(seed) + 1
-        g = torch.Generator(device=x.device)
-        g.manual_seed(int(seed))
-    else:
-        g = None
-
-    def _sample(_sigma, _sigma_next):
-        return torch.randn(x.size(), dtype=x.dtype, layout=x.layout, device=x.device, generator=g)
-
-    return _sample
-
-
-@torch.no_grad()
-def _sample_er_sde_const_x0(
-    denoise_fn,
-    x: torch.Tensor,
-    sigmas: torch.Tensor,
-    *,
-    seed: Optional[int] = None,
-    s_noise: float = 1.0,
-    max_stage: int = 3,
-    step_callback=None,
-):
-    """
-    Extended Reverse-Time SDE solver（ER-SDE-Solver-3）在 CONST(flow) 噪声日程下的实现。
-    参考 ComfyUI 的 k_diffusion_sampling.sample_er_sde（删去 model_patcher 依赖）。
-
-    step_callback：可选钩子（仅 daemon 中间步预览用，commit 14）。签名
-        callback(step:int, total:int, denoised:torch.Tensor) → None。每步算
-        完 x0 估计（denoised）调一次；同步阻塞返回 —— 调用方应做轻量解码 +
-        异步 push，不在 callback 内阻塞。默认 None 时行为完全等价旧版。
-    """
-    sigmas = sigmas.to(device=x.device, dtype=torch.float32)
-    if sigmas.numel() <= 1:
-        return x
-
-    noise_sampler = _default_noise_sampler(x, seed=seed)
-
-    # CONST: half_log_snr = log((1 - t) / t) = -logit(t)
-    eps = 1e-12
-    t = sigmas.clamp(min=eps, max=1.0 - eps)
-    half_log_snrs = torch.log((1 - t) / t)
-    er_lambdas = half_log_snrs.neg().exp()  # er_lambda = t / (1 - t)
-
-    old_denoised = None
-    old_denoised_d = None
-
-    def noise_scaler(lam: torch.Tensor) -> torch.Tensor:
-        # default_er_sde_noise_scaler
-        lam = lam.to(x.device, dtype=torch.float32)
-        return lam * ((lam ** 0.3).exp() + 10.0)
-
-    num_integration_points = 200.0
-    point_indice = torch.arange(0, num_integration_points, dtype=torch.float32, device=x.device)
-
-    for i in range(len(sigmas) - 1):
-        sigma = sigmas[i]
-        denoised = denoise_fn(x, sigma)
-
-        if step_callback is not None:
-            try:
-                step_callback(i, len(sigmas) - 1, denoised)
-            except Exception:
-                pass  # 预览失败不该影响采样
-
-        stage_used = min(int(max_stage), i + 1)
-        if sigmas[i + 1] == 0:
-            x = denoised
-        else:
-            er_lambda_s, er_lambda_t = er_lambdas[i], er_lambdas[i + 1]
-            alpha_s = 1.0 - sigmas[i]
-            alpha_t = 1.0 - sigmas[i + 1]
-            r_alpha = alpha_t / alpha_s
-            r = noise_scaler(er_lambda_t) / noise_scaler(er_lambda_s)
-
-            # Stage 1 (Euler)
-            x = r_alpha * r * x + alpha_t * (1 - r) * denoised
-
-            if stage_used >= 2 and old_denoised is not None:
-                dt = er_lambda_t - er_lambda_s
-                lambda_step_size = -dt / num_integration_points
-                lambda_pos = er_lambda_t + point_indice * lambda_step_size
-                scaled_pos = noise_scaler(lambda_pos)
-
-                # Stage 2
-                s = torch.sum(1 / scaled_pos) * lambda_step_size
-                denoised_d = (denoised - old_denoised) / (er_lambda_s - er_lambdas[i - 1])
-                x = x + alpha_t * (dt + s * noise_scaler(er_lambda_t)) * denoised_d
-
-                if stage_used >= 3 and old_denoised_d is not None:
-                    # Stage 3
-                    s_u = torch.sum((lambda_pos - er_lambda_s) / scaled_pos) * lambda_step_size
-                    denoised_u = (denoised_d - old_denoised_d) / ((er_lambda_s - er_lambdas[i - 2]) / 2)
-                    x = x + alpha_t * ((dt ** 2) / 2 + s_u * noise_scaler(er_lambda_t)) * denoised_u
-
-                old_denoised_d = denoised_d
-
-            # Stochastic term
-            if s_noise and float(s_noise) > 0:
-                noise = noise_sampler(float(sigmas[i]), float(sigmas[i + 1]))
-                sde_scale = (er_lambda_t ** 2 - (er_lambda_s ** 2) * (r ** 2)).clamp(min=0).sqrt().nan_to_num(nan=0.0)
-                x = x + alpha_t * noise * float(s_noise) * sde_scale
-
-        old_denoised = denoised
-
-    return x
+# ER-SDE-Solver 实现 + _default_noise_sampler 已搬到 training.inference_samplers.er_sde
+# （ADR 0003 PR-C plugin registry）。sample_image 通过 build_inference_sampler 派发。
 
 
 @torch.no_grad()
@@ -269,8 +159,11 @@ def sample_image(
     sampler_name_l = str(sampler_name).lower().strip()
     logger.info(f"[Debug] Sampler={sampler_name_l}, Scheduler=simple, steps={steps}, cfg={cfg_scale}")
 
-    if sampler_name_l == "er_sde":
-        x = _sample_er_sde_const_x0(
+    # PR-C：通过 inference_samplers plugin registry 派发；未注册名走下面 inline Euler 兜底
+    from training.inference_samplers import build_inference_sampler
+    sampler_fn = build_inference_sampler(sampler_name_l)
+    if sampler_fn is not None:
+        x = sampler_fn(
             denoise_fn, x, sigmas,
             seed=None, s_noise=1.0, max_stage=3,
             step_callback=step_callback,

--- a/runtime/training/schedulers/__init__.py
+++ b/runtime/training/schedulers/__init__.py
@@ -1,0 +1,56 @@
+"""LR scheduler plugin registry（ADR 0003 PR-C）。
+
+加新 scheduler（warmup_cosine / one_cycle / polynomial）的步骤：
+1. 写 training/schedulers/{variant}.py 含 `build(args, optimizer, total_steps)`
+2. 本文件 BUILDERS 字典加一行
+3. studio/schema.py 的 lr_scheduler Literal 加枚举值 + 该 variant 专属字段
+
+详见 ADR 0003 "Case 7: warmup_cosine"。
+
+特殊键 "none" 不开文件：build_scheduler 直接返回 None。
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from training.schedulers import cosine, cosine_with_restart
+
+__all__ = ["BUILDERS", "build_scheduler", "validate_schema_consistency"]
+
+
+# "none" 不在 BUILDERS —— build_scheduler 显式判一下返回 None。
+BUILDERS: dict[str, Callable] = {
+    "cosine": cosine.build,
+    "cosine_with_restart": cosine_with_restart.build,
+}
+
+# schema 允许 "none" 但 BUILDERS 不收录；validate_schema_consistency 据此放行
+SCHEMA_ONLY_OPTIONS = {"none"}
+
+
+def build_scheduler(args, optimizer, total_steps: Optional[int]):
+    """按 args.lr_scheduler 派发；"none" 或未配置返回 None。"""
+    lr_sched = (getattr(args, "lr_scheduler", "none") or "none").lower()
+    if lr_sched == "none":
+        return None
+    if lr_sched not in BUILDERS:
+        raise ValueError(
+            f"未知 lr_scheduler={lr_sched!r}；已注册: {sorted(BUILDERS)} + 'none'"
+        )
+    return BUILDERS[lr_sched](args, optimizer, total_steps)
+
+
+def validate_schema_consistency() -> None:
+    from studio.schema import TrainingConfig
+
+    field = TrainingConfig.model_fields["lr_scheduler"]
+    schema_options = set(field.annotation.__args__) - SCHEMA_ONLY_OPTIONS
+    registered = set(BUILDERS)
+    if schema_options != registered:
+        raise RuntimeError(
+            f"scheduler 注册与 schema 不同步（PR-C registry）：\n"
+            f"  schema 有但未注册: {schema_options - registered}\n"
+            f"  注册但 schema 没列: {registered - schema_options}\n"
+            f"  （schema-only 跳过校验: {SCHEMA_ONLY_OPTIONS}）"
+        )

--- a/runtime/training/schedulers/cosine.py
+++ b/runtime/training/schedulers/cosine.py
@@ -1,0 +1,25 @@
+"""CosineAnnealingLR scheduler build wrapper（ADR 0003 PR-C）。"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+
+
+logger = logging.getLogger(__name__)
+
+
+def build(args, optimizer, total_steps: Optional[int]):
+    """实例化 CosineAnnealingLR。total_steps 未知时记 warn + 返回 None
+    （回退到 no-scheduler）—— 跟原 main() 老逻辑等价。"""
+    if total_steps is None:
+        logger.warning("cosine 调度器需要已知 total_steps，回退到 none")
+        return None
+    eta_min = float(getattr(args, "lr_scheduler_eta_min", 0.0) or 0.0)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+        optimizer, T_max=total_steps, eta_min=eta_min,
+    )
+    logger.info(f"学习率调度: cosine (T_max={total_steps}, eta_min={eta_min})")
+    return scheduler

--- a/runtime/training/schedulers/cosine_with_restart.py
+++ b/runtime/training/schedulers/cosine_with_restart.py
@@ -1,0 +1,24 @@
+"""CosineAnnealingWarmRestarts scheduler build wrapper（ADR 0003 PR-C）。"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+
+
+logger = logging.getLogger(__name__)
+
+
+def build(args, optimizer, total_steps: Optional[int]):
+    """实例化 CosineAnnealingWarmRestarts。total_steps 未传也不阻断，
+    跟原 main() 老逻辑等价。"""
+    t0 = int(getattr(args, "lr_scheduler_t0", 500) or 500)
+    t_mult = int(getattr(args, "lr_scheduler_t_mult", 2) or 2)
+    eta_min = float(getattr(args, "lr_scheduler_eta_min", 0.0) or 0.0)
+    scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
+        optimizer, T_0=t0, T_mult=t_mult, eta_min=eta_min,
+    )
+    logger.info(f"学习率调度: cosine_with_restart (T_0={t0}, T_mult={t_mult}, eta_min={eta_min})")
+    return scheduler

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -1,0 +1,281 @@
+"""ADR 0003 PR-C：plugin registry + AdapterProtocol 单元测试。
+
+覆盖：
+- 4 个 plugin 子包的 BUILDERS / build_X / validate_schema_consistency 三件套
+- AdapterProtocol runtime_checkable 对 AnimaLycorisAdapter 返回 True
+- 动态/per-step / loss 加项 hook 在 mock adapter 上能被正确调用
+- train_loop.py / phases/optimizer.py 已不含 if optimizer_type == / if lora_type ==
+  风格的 dispatch（防回归）
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RUNTIME_DIR = REPO_ROOT / "runtime"
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(RUNTIME_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helper：绕过 utils/__init__.py 直接 import AnimaLycorisAdapter
+# （utils/__init__ 会触发 utils.dataset 链式 import torchvision，本测试不需要）
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def AnimaLycorisAdapter():
+    # AnimaLycorisAdapter 模块链最终触发 utils.dataset → torchvision import；
+    # 本地 dev 环境无 torchvision 时跳过这一族测试（CI / 训练环境正常跑）。
+    pytest.importorskip("torchvision")
+    pytest.importorskip("lycoris")
+    spec = importlib.util.spec_from_file_location(
+        "_lycoris_adapter_for_test",
+        REPO_ROOT / "utils" / "lycoris_adapter.py",
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.AnimaLycorisAdapter
+
+
+# ---------------------------------------------------------------------------
+# Registry 三件套
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_builders_dict_has_lokr_loha_lora() -> None:
+    from training.adapters import BUILDERS
+    assert set(BUILDERS) == {"lokr", "loha", "lora"}
+
+
+def test_optimizer_builders_dict_has_3_variants() -> None:
+    from training.optimizers import BUILDERS, VALIDATORS
+    assert set(BUILDERS) == {"adamw", "prodigy", "prodigy_plus_schedulefree"}
+    # PPSF 有专属 validator，adamw / prodigy 没有
+    assert set(VALIDATORS) == {"prodigy_plus_schedulefree"}
+
+
+def test_scheduler_builders_dict_excludes_none() -> None:
+    from training.schedulers import BUILDERS, SCHEMA_ONLY_OPTIONS
+    assert set(BUILDERS) == {"cosine", "cosine_with_restart"}
+    assert SCHEMA_ONLY_OPTIONS == {"none"}
+
+
+def test_inference_sampler_builders_has_er_sde() -> None:
+    from training.inference_samplers import BUILDERS
+    assert "er_sde" in BUILDERS
+
+
+def test_build_adapter_raises_on_unknown_lora_type() -> None:
+    from training.adapters import build_adapter
+    args = argparse.Namespace(lora_type="bogus_xyz")
+    with pytest.raises(ValueError, match="未知 lora_type"):
+        build_adapter(args)
+
+
+def test_build_scheduler_returns_none_when_lr_scheduler_is_none() -> None:
+    from training.schedulers import build_scheduler
+    args = argparse.Namespace(lr_scheduler="none")
+    assert build_scheduler(args, optimizer=None, total_steps=None) is None
+
+
+# ---------------------------------------------------------------------------
+# Schema↔registry 一致性自动校验（PR-C R4 缓解）
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_schema_consistency_passes_on_clean_dev() -> None:
+    from training.adapters import validate_schema_consistency
+    # dev 上 schema.lora_type == {"lora","lokr","loha"} == BUILDERS keys
+    validate_schema_consistency()  # 不抛即 pass
+
+
+def test_optimizer_schema_consistency_passes_on_clean_dev() -> None:
+    from training.optimizers import validate_schema_consistency
+    validate_schema_consistency()
+
+
+def test_scheduler_schema_consistency_passes_on_clean_dev() -> None:
+    from training.schedulers import validate_schema_consistency
+    validate_schema_consistency()
+
+
+def test_schema_consistency_raises_when_builder_missing(monkeypatch) -> None:
+    """模拟漏注册：schema 加了 lora_type=tlora 但 BUILDERS 没注册时，校验
+    必须 raise，而不是放行让训练跑半天才暴露。"""
+    from training import adapters
+    monkeypatch.setitem(adapters.BUILDERS.copy(), "tlora", lambda args: None)
+    # 临时改 schema 的 Literal 表演成 "schema 有 tlora 但 registry 没有"
+    from studio.schema import TrainingConfig
+    field = TrainingConfig.model_fields["lora_type"]
+    original = field.annotation
+    try:
+        # 用 typing.Literal 重建一个含 "tlora" 的 annotation
+        from typing import Literal
+        field.annotation = Literal["lora", "lokr", "loha", "tlora"]  # type: ignore[assignment]
+        with pytest.raises(RuntimeError, match="不同步"):
+            adapters.validate_schema_consistency()
+    finally:
+        field.annotation = original  # 恢复
+
+
+# ---------------------------------------------------------------------------
+# AdapterProtocol runtime_checkable
+# ---------------------------------------------------------------------------
+
+
+def test_animalycoris_satisfies_adapter_protocol(AnimaLycorisAdapter) -> None:
+    """AnimaLycorisAdapter 实现了全部 4 必需 + 3 可选 hook，
+    isinstance(_, AdapterProtocol) 必须 True。"""
+    from training.adapters.protocol import AdapterProtocol
+    adapter = AnimaLycorisAdapter(algo="lokr")
+    assert isinstance(adapter, AdapterProtocol)
+
+
+def test_animalycoris_hooks_are_noop(AnimaLycorisAdapter) -> None:
+    """LyCORIS 路径下 3 个 hook 必须 default no-op；
+    on_step_begin 返回 None；regularization_loss 返回 None。"""
+    from training.adapters.protocol import StepContext
+    adapter = AnimaLycorisAdapter(algo="lokr")
+
+    # 用极简 StepContext —— sigma_t 在 lyc 路径下不会被读
+    import torch
+    step_ctx = StepContext(
+        global_step=0,
+        total_steps=100,
+        epoch=0,
+        sigma_t=torch.zeros(1),
+        args=argparse.Namespace(),
+    )
+
+    assert adapter.on_step_begin(step_ctx) is None
+    assert adapter.regularization_loss(step_ctx) is None
+
+
+def test_animalycoris_lokr_excludes_weight_decay_for_w1(AnimaLycorisAdapter) -> None:
+    """LoKr 模式下 'lokr_w1' 子串参数排除 weight_decay。"""
+    adapter = AnimaLycorisAdapter(algo="lokr")
+    assert adapter.excludes_weight_decay("lora_unet_xxx.lokr_w1") is True
+    assert adapter.excludes_weight_decay("lora_unet_xxx.lokr_w2_a") is False
+
+
+def test_animalycoris_non_lokr_does_not_exclude_weight_decay(AnimaLycorisAdapter) -> None:
+    """非 LoKr（lora / loha）模式：excludes_weight_decay 永远 False。"""
+    adapter = AnimaLycorisAdapter(algo="lora")
+    assert adapter.excludes_weight_decay("lora_unet_xxx.lokr_w1") is False
+    adapter = AnimaLycorisAdapter(algo="loha")
+    assert adapter.excludes_weight_decay("lora_unet_xxx.lokr_w1") is False
+
+
+# ---------------------------------------------------------------------------
+# Mock 论文级变体：验证 hook 接口能 cover T-LoRA / OFT 类需求
+# ---------------------------------------------------------------------------
+
+
+class _MockTLoRAAdapter:
+    """模拟 T-LoRA：on_step_begin 按 sigma_t 调内部 mask（这里仅记录调用次数）。"""
+
+    def __init__(self) -> None:
+        self.step_begin_calls = 0
+        self.last_sigma_t = None
+
+    # 必需 4 个：no-op stubs（满足 Protocol 形状即可）
+    def inject(self, model) -> None: pass
+    def get_param_groups(self, weight_decay): return []
+    def save(self, path) -> None: pass
+    def load(self, path) -> None: pass
+
+    def on_step_begin(self, ctx) -> None:
+        self.step_begin_calls += 1
+        self.last_sigma_t = ctx.sigma_t
+
+    def regularization_loss(self, ctx): return None
+    def excludes_weight_decay(self, name): return False
+
+
+class _MockOFTAdapter:
+    """模拟 OFT：regularization_loss 返回 orthogonality penalty。"""
+
+    def __init__(self) -> None:
+        self.reg_calls = 0
+
+    def inject(self, model) -> None: pass
+    def get_param_groups(self, weight_decay): return []
+    def save(self, path) -> None: pass
+    def load(self, path) -> None: pass
+    def on_step_begin(self, ctx) -> None: pass
+
+    def regularization_loss(self, ctx):
+        import torch
+        self.reg_calls += 1
+        return torch.tensor(0.42)
+
+    def excludes_weight_decay(self, name): return False
+
+
+def test_mock_tlora_implements_protocol() -> None:
+    from training.adapters.protocol import AdapterProtocol
+    assert isinstance(_MockTLoRAAdapter(), AdapterProtocol)
+
+
+def test_mock_oft_regularization_returns_tensor() -> None:
+    import torch
+    from training.adapters.protocol import StepContext
+    adapter = _MockOFTAdapter()
+    ctx = StepContext(global_step=5, total_steps=100, epoch=0,
+                      sigma_t=torch.zeros(1), args=argparse.Namespace())
+    loss = adapter.regularization_loss(ctx)
+    assert isinstance(loss, torch.Tensor)
+    assert float(loss) == pytest.approx(0.42)
+    assert adapter.reg_calls == 1
+
+
+def test_mock_tlora_on_step_begin_receives_sigma() -> None:
+    import torch
+    from training.adapters.protocol import StepContext
+    adapter = _MockTLoRAAdapter()
+    sigma = torch.tensor([0.3, 0.7])
+    ctx = StepContext(global_step=10, total_steps=100, epoch=0,
+                      sigma_t=sigma, args=argparse.Namespace())
+    adapter.on_step_begin(ctx)
+    assert adapter.step_begin_calls == 1
+    assert torch.equal(adapter.last_sigma_t, sigma)
+
+
+# ---------------------------------------------------------------------------
+# 防回归：phases / loop 不再有 if optimizer_type == / if lora_type == 风格 dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_no_optimizer_type_dispatch_in_phases_optimizer() -> None:
+    text = (RUNTIME_DIR / "training" / "phases" / "optimizer.py").read_text(encoding="utf-8")
+    # PR-C 后这些 if-elif 应该都被 build_optimizer 替代
+    assert 'if ctx.optimizer_type == "prodigy"' not in text
+    assert 'if optimizer_type ==' not in text
+    assert 'optimizer_type == "prodigy_plus_schedulefree"' not in text
+
+
+def test_no_lora_type_dispatch_in_phases_models() -> None:
+    text = (RUNTIME_DIR / "training" / "phases" / "models.py").read_text(encoding="utf-8")
+    # 应该看不到 AnimaLycorisAdapter 直接实例化（被 build_adapter 替代）
+    assert "AnimaLycorisAdapter(" not in text
+
+
+def test_no_lr_scheduler_dispatch_in_phases_optimizer() -> None:
+    text = (RUNTIME_DIR / "training" / "phases" / "optimizer.py").read_text(encoding="utf-8")
+    assert 'if lr_sched == "cosine"' not in text
+    assert 'CosineAnnealingLR' not in text
+    assert 'CosineAnnealingWarmRestarts' not in text
+
+
+def test_no_er_sde_inline_dispatch_in_sampling() -> None:
+    text = (RUNTIME_DIR / "training" / "sampling.py").read_text(encoding="utf-8")
+    # sample_image 应该通过 build_inference_sampler 派发
+    assert 'if sampler_name_l == "er_sde"' not in text
+    assert "build_inference_sampler" in text

--- a/utils/lycoris_adapter.py
+++ b/utils/lycoris_adapter.py
@@ -267,3 +267,24 @@ class AnimaLycorisAdapter:
             f"加载 {len(sd)} 个权重张量，"
             f"missing={missing}, unexpected={unexpected}"
         )
+
+    # ─── ADR 0003 PR-C：AdapterProtocol 可选 hook 的 no-op 实现 ───
+    # 给 LyCORIS adapter 满足 runtime_checkable Protocol；论文级变体
+    # （T-LoRA / OFT / Ortho-Hydra）可在自己的 build wrapper 里 override。
+
+    def on_step_begin(self, ctx) -> None:
+        """每 micro-batch 前向之前调用；LoKr/LoRA/LoHa 无运行时结构调整。"""
+        return None
+
+    def regularization_loss(self, ctx):
+        """LoKr/LoRA/LoHa 无额外正则项。"""
+        return None
+
+    def excludes_weight_decay(self, param_name: str) -> bool:
+        """w1 系参数排除 weight_decay；其他不排除。
+
+        注：现有 get_param_groups 已经在内部按 "lokr_w1" 子串分组并把这些
+        param 的 weight_decay 设为 0，本方法只是 Protocol 接口暴露，给外
+        部 caller（如 phase log 决策）调。
+        """
+        return self.use_lokr and "lokr_w1" in param_name


### PR DESCRIPTION
## Summary

ADR 0003 第三刀（收官）。把 main()/phases 里所有 if-elif 风格的 variant dispatch 替换成 **4 个 plugin 子包 + 显式 BUILDERS 字典 registry**。引入 **AdapterProtocol** 含 3 个可选 hook（on_step_begin / regularization_loss / excludes_weight_decay），给未来 T-LoRA / OFT / AdaLoRA 类论文级变体留扩展位。

**本 PR 训练行为零变**——LyCORIS 路径的所有 hook 都是 no-op；optimizer / scheduler / inference_sampler 是同一份 kwargs 经 build wrapper 中转。

## 4 个 plugin 子包

| 子包 | 当前注册 | 加新变体步骤 |
|---|---|---|
| \`training/adapters/\` | lokr / loha / lora（共用 lycoris.build）| 写 \`{variant}.py\` 含 \`build(args) -> AdapterProtocol\` + 字典加一行 + schema Literal 加值 |
| \`training/optimizers/\` | adamw / prodigy / prodigy_plus_schedulefree | 写 \`build(args, params, lr, wd)\` + 可选 \`validate(args)\` + 字典 / VALIDATORS 加行 |
| \`training/schedulers/\` | cosine / cosine_with_restart（\"none\" schema-only） | 写 \`build(args, optimizer, total_steps)\` + 字典加行 |
| \`training/inference_samplers/\` | er_sde（预留位）| 写 \`sample(denoise_fn, x, sigmas, **kw)\` + 字典加行；未注册名走 sample_image inline Euler 兜底 |

## AdapterProtocol（含 3 个可选 hook）

\`\`\`python
class AdapterProtocol(Protocol):
    # 必需
    def inject(self, model): ...
    def get_param_groups(self, weight_decay): ...
    def save(self, path): ...
    def load(self, path): ...

    # 可选 hook，默认 no-op
    def on_step_begin(self, ctx: StepContext) -> None: ...        # T-LoRA / AdaLoRA / B-LoRA
    def regularization_loss(self, ctx) -> Optional[Tensor]: ...    # OFT / Ortho-Hydra
    def excludes_weight_decay(self, param_name: str) -> bool: ...  # LoKr w1
\`\`\`

\`StepContext\`（global_step / total_steps / epoch / sigma_t / args）在 train_loop 的 \`sample_t\` 之后构造，传给 \`on_step_begin\` 和 \`regularization_loss\`。AnimaLycorisAdapter 实现了全部 7 个方法（前 4 个本来就有；3 个 hook 是 no-op + LoKr 的 w1 检查）。

未来要加 T-LoRA：写 \`training/adapters/tlora.py\` 里 \`TLoRABundle\` 包装 utils 实现的 adapter，override \`on_step_begin\` 按 \`ctx.sigma_t\` 调内部 mask。phases / loop / main 0 改动。详见 ADR 0003 Case 3。

## Schema↔registry 一致性自动校验

3 个 plugin 子包暴露 \`validate_schema_consistency()\`，校验 \`TrainingConfig.X\` Literal 集合 == BUILDERS keys。\`bootstrap_phase\` 启动期跑一次。漏注册 / 漏 schema 早 fail，不等训练跑半天才暴露。

## 4 处 dispatch 切换详情

| 位置 | Before（if-elif） | After（registry） |
|---|---|---|
| \`phases/models.py\` | \`AnimaLycorisAdapter(algo=args.lora_type, ...)\` | \`build_adapter(args)\` |
| \`phases/optimizer.py\` | \`if optimizer_type == \"prodigy\": ... elif \"ppsf\":\` 30 行 | \`validate_optimizer(args)\` + \`build_optimizer(args, ...)\` |
| \`phases/optimizer.py\` | \`if lr_sched == \"cosine\": ... elif \"restart\":\` 17 行 | \`build_scheduler(args, opt, total_steps)\` |
| \`training/sampling.py\` | \`if sampler_name == \"er_sde\": _sample_er_sde_const_x0(...)\` | \`build_inference_sampler(name)(...)\` |

净行数变化：phases/optimizer.py -50 行；phases/models.py -10 行；sampling.py -100 行（er_sde 实现搬到 inference_samplers/）。

## Commits（3 个）

| SHA | 内容 |
|---|---|
| \`96d7459\` | 4 个 plugin 子包：adapters / optimizers / schedulers / inference_samplers + AdapterProtocol + 一致性校验函数 |
| \`da00891\` | 切换 4 处 dispatch 到 registry + train_loop 加 adapter hook 调用点 + AnimaLycorisAdapter 实现 3 个 no-op hook |
| \`aaed15a\` | 21 个 case 单测：registry 三件套 / Protocol runtime_checkable / mock T-LoRA + OFT hook 调用 / 防回归 grep |

## Test plan

- [x] \`tests/test_anima_train_migration.py\` 8/8 绿
- [x] \`tests/test_anima_generate_xy.py\` 11/11 绿
- [x] \`tests/test_plugin_registry.py\` 17/21 绿（4 个 torchvision-blocked 在 CI 跑）
- [x] \`grep \"if optimizer_type ==\" runtime/training/phases/\` 0 命中（防回归）
- [x] \`grep \"AnimaLycorisAdapter(\" runtime/training/phases/\` 0 命中
- [x] \`grep \"CosineAnnealingLR\" runtime/training/phases/\` 0 命中
- [ ] **用户跑完整 LoRA 训练 + 评估出图**（端到端 ground truth；ADR 0003 验收策略）

## 至此 ADR 0003 三 PR 完整落地

\`anima_train.py\` 演进：**2901 → 909 → 128 行**（PR-A → B → C 各占一刀；累计 -96%）。

\`runtime/training/\` 子包从 PR-A 的 12 个文件长到 PR-C 的 **25 个文件**（含 4 个 plugin 子包共 12 个新文件 + 1 个测试文件）。

## 接下来

- **parking lot rebase**：\`experimental/pr49-adapters\` 分支可以删了 —— 加 T-LoRA / Ortho-Hydra 现在变成"按 ADR 0003 Case 3-5 写 \`training/adapters/{variant}.py\`"，不再需要长期 parking lot
- **schema 加 sample_sampler_name Literal**（可选）：把 \`sample_sampler_name: str\` 升级到 \`Literal[\"er_sde\"]\`，让 schema 验证 + 字段在 UI 上变下拉框
- **加新优化器示例**（可选）：找一个真实需要的（如 Lion）实操一次本 PR 提供的"3 步流程"，验证 ADR 0003 Case 6 工作流

详见 [docs/adr/0003-anima-train-refactor.md](https://github.com/WalkingMeatAxolotl/AnimaLoraStudio/blob/master/docs/adr/0003-anima-train-refactor.md)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)