### PR TITLE
fix(wandb): install tracking dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ sentencepiece>=0.1.99
 protobuf>=3.20.0
 accelerate>=0.24.0
 peft>=0.8.0
-# wandb>=0.16.0          # Optional: experiment tracking
+wandb>=0.16.0          # Optional feature: experiment tracking
 # bitsandbytes>=0.41.0   # Optional: 8-bit AdamW (may not work on Windows)
 lycoris-lora>=1.9.0
 prodigyopt>=1.0          # Prodigy 优化器（anima_train.py optimizer=prodigy 时必需）


### PR DESCRIPTION
## Summary
- install wandb from the main requirements file so fresh Studio environments can use the WandB settings toggle without a manual pip install
- keep the change scoped to dependency declaration only

## Verification
- python tools/check_requirements_changed.py --marker venv/.studio-requirements.sha256 returns stale, confirming launch scripts will resync requirements