### PR TITLE
feat(model): 支持 Anima 1.0 主模型 + latest 切换到 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ studio/web/node_modules/
 studio/web/dist/
 studio/web/.vite/
 
+# 顶层意外创建的 node_modules（vitest / 某些工具可能在 repo root 拉一份）
+/node_modules/
+
 # Studio 走 preset 池（studio_data/presets/，已被 studio_data/ 总规则覆盖），
 # 旧的 config/ 目录已删，不再需要 user yaml 排除规则。
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ python -m studio test         # pytest + vitest
 
 | 项 | 来源 | 路径 | 大小 |
 |---|---|---|---|
-| Anima 主模型（latest = preview3-base）| [circlestone-labs/Anima](https://huggingface.co/circlestone-labs/Anima) | `models/diffusion_models/` | ~4 GB |
+| Anima 主模型（latest = 1.0）| [circlestone-labs/Anima](https://huggingface.co/circlestone-labs/Anima) | `models/diffusion_models/` | ~4 GB |
 | Anima VAE | 同上 | `models/vae/` | ~250 MB |
 | Qwen3-0.6B-Base 文本编码器 | [Qwen/Qwen3-0.6B-Base](https://huggingface.co/Qwen/Qwen3-0.6B-Base) | `models/text_encoders/` | ~1.2 GB |
 | T5 tokenizer（仅 3 文件，不下权重）| [google/t5-v1_1-xxl](https://huggingface.co/google/t5-v1_1-xxl) | `models/t5_tokenizer/` | <1 MB |
@@ -115,7 +115,7 @@ python -m studio test         # pytest + vitest
 ```bash
 python tools/download_models.py                   # 全量下
 python tools/download_models.py --no-mirror       # 走 HF 官方源
-python tools/download_models.py --variant preview2
+python tools/download_models.py --variant preview3-base
 python tools/download_models.py --skip-main --skip-vae
 python tools/download_models.py --output /data/anima
 ```

--- a/runtime/training/cli.py
+++ b/runtime/training/cli.py
@@ -97,7 +97,7 @@ def _guess_default_paths():
     根目录：优先 `secrets.models.root`（Studio 设置页配置），否则 `REPO_ROOT/models/`
     （与 schema.py 默认 + WD14 已用的 `models/wd14/` 对齐）。
 
-    Transformer：用户可能装多个 Anima 版本（preview / preview2 / preview3-base），
+    Transformer：用户可能装多个 Anima 版本（preview / preview2 / preview3-base / 1.0），
     按 ANIMA_VARIANTS 顺序找第一个存在的（latest 优先）。
     """
     # 注：原 runtime/anima_train.py 用 Path(__file__).resolve().parent 拿 runtime/；
@@ -118,7 +118,7 @@ def _guess_default_paths():
         base = repo_root / "models"
     if not transformer_path:
         # services 不可用 / 都没下载 → 给最新版默认名作为提示，方便用户填路径
-        candidate = base / "diffusion_models" / "anima-preview3-base.safetensors"
+        candidate = base / "diffusion_models" / "anima-base-v1.0.safetensors"
         transformer_path = str(candidate) if candidate.exists() else ""
 
     vae = base / "vae" / "qwen_image_vae.safetensors"

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -89,7 +89,7 @@ class TrainingConfig(BaseModel):
     # 这里的默认值仅 fallback：裸 CLI 跑训练 + yaml 完全没填时，按 repo
     # 相对路径解析（与历史行为一致）。
     transformer_path: str = Field(
-        "models/diffusion_models/anima-preview3-base.safetensors",
+        "models/diffusion_models/anima-base-v1.0.safetensors",
         description="主 transformer 权重 (.safetensors)",
         json_schema_extra=_meta("model", "path", cli_alias="--transformer"),
     )
@@ -669,7 +669,7 @@ class GenerateConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     # 模型路径（服务端从 secrets 填充）
-    transformer_path: str = Field("models/diffusion_models/anima-preview3-base.safetensors")
+    transformer_path: str = Field("models/diffusion_models/anima-base-v1.0.safetensors")
     vae_path: str = Field("models/vae/qwen_image_vae.safetensors")
     text_encoder_path: str = Field("models/text_encoders")
     t5_tokenizer_path: str = Field("models/t5_tokenizer")

--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -373,7 +373,7 @@ class ModelsConfig(BaseModel):
       （保证训练重现性）。
     """
     root: Optional[str] = None
-    selected_anima: str = "preview3-base"
+    selected_anima: str = "1.0"
 
 
 class GenerateConfig(BaseModel):

--- a/studio/server.py
+++ b/studio/server.py
@@ -1972,7 +1972,7 @@ def _resolve_anima_model_paths() -> dict[str, str]:
     from .services.model_downloader import models_root
     root = models_root()
     return {
-        "transformer_path": str(root / "diffusion_models" / "anima-preview3-base.safetensors"),
+        "transformer_path": str(root / "diffusion_models" / "anima-base-v1.0.safetensors"),
         "vae_path": str(root / "vae" / "qwen_image_vae.safetensors"),
         "text_encoder_path": str(root / "text_encoders"),
         "t5_tokenizer_path": str(root / "t5_tokenizer"),

--- a/studio/services/model_downloader.py
+++ b/studio/services/model_downloader.py
@@ -35,12 +35,16 @@ from .onnx_tagger_base import safe_dir_name
 # ---------------------------------------------------------------------------
 
 ANIMA_REPO = "circlestone-labs/Anima"
+# 顺序：最新在前。`find_anima_main` 的 fallback 查找按本 dict 序遍历，
+# `build_catalog` 给 UI 的 variants 列表也直接复用本顺序——所以新版本
+# 加在最前，老版本往下排。
 ANIMA_VARIANTS: dict[str, str] = {
-    "preview":       "split_files/diffusion_models/anima-preview.safetensors",
-    "preview2":      "split_files/diffusion_models/anima-preview2.safetensors",
+    "1.0":           "split_files/diffusion_models/anima-base-v1.0.safetensors",
     "preview3-base": "split_files/diffusion_models/anima-preview3-base.safetensors",
+    "preview2":      "split_files/diffusion_models/anima-preview2.safetensors",
+    "preview":       "split_files/diffusion_models/anima-preview.safetensors",
 }
-LATEST_ANIMA = "preview3-base"
+LATEST_ANIMA = "1.0"
 ANIMA_VAE_PATH = "split_files/vae/qwen_image_vae.safetensors"
 
 QWEN_REPO = "Qwen/Qwen3-0.6B-Base"

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -312,7 +312,7 @@ export const DEFAULT_WD14_MODELS: readonly string[] = [
 export interface ModelsConfig {
   /** 训练模型根目录；null/空 → 回退 REPO_ROOT/models/（云端机改这里） */
   root: string | null
-  /** 当前默认主模型 variant（preview3-base / preview2 / preview）。
+  /** 当前默认主模型 variant（1.0 / preview3-base / preview2 / preview）。
    * Studio 创建新 version 时把它展开成绝对路径写到 yaml.transformer_path；
    * 已存在 version 不动（保证训练重现性）。 */
   selected_anima: string

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -101,7 +101,7 @@ const initialServerState = {
     blacklist_tags: [],
     batch_size: 8,
   },
-  models: { root: null, selected_anima: 'preview3-base' },
+  models: { root: null, selected_anima: '1.0' },
   queue: { allow_gpu_during_train: false },
 }
 

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -207,7 +207,7 @@ const EMPTY: Secrets = {
     blacklist_tags: [],
     batch_size: 8,
   },
-  models: { root: null, selected_anima: 'preview3-base' },
+  models: { root: null, selected_anima: '1.0' },
   queue: { allow_gpu_during_train: false },
   generate: { preview_every_n_steps: 3, attention_backend: 'auto' },
   system: { show_dev_channel: false },
@@ -1421,7 +1421,7 @@ function ModelsSection({ catalog, busy, start, reloadCatalog, catalogError }: {
   const [rootDraft, setRootDraft] = useState<string>('')
   const [serverRoot, setServerRoot] = useState<string | null>(null)
   const [savingRoot, setSavingRoot] = useState(false)
-  const [selectedAnima, setSelectedAnima] = useState<string>('preview3-base')
+  const [selectedAnima, setSelectedAnima] = useState<string>('1.0')
 
   // 一次性拉一份 secrets 取 models.root + selected_anima（这两项走独立 PUT，
   // 不进 SettingsPage 的全局 dirty 流程）。catalog 由父级注入。
@@ -1429,7 +1429,7 @@ function ModelsSection({ catalog, busy, start, reloadCatalog, catalogError }: {
     void api.getSecrets().then((sec) => {
       setServerRoot(sec.models?.root ?? null)
       setRootDraft(sec.models?.root ?? '')
-      setSelectedAnima(sec.models?.selected_anima ?? 'preview3-base')
+      setSelectedAnima(sec.models?.selected_anima ?? '1.0')
     }).catch(() => {})
   }, [])
 

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -175,10 +175,16 @@ def test_find_anima_main_picks_latest(secrets_file: Path, tmp_path: Path) -> Non
     (dm / "anima-preview2.safetensors").write_bytes(b"x")
     assert model_downloader.find_anima_main().name == "anima-preview2.safetensors"
 
-    # preview3-base 装上 → latest 优先返回 preview3-base
+    # preview3-base 装上 → latest 优先返回 preview3-base（preview3-base 在 1.0 缺席时是次新）
     (dm / "anima-preview3-base.safetensors").write_bytes(b"y")
     assert (
         model_downloader.find_anima_main().name == "anima-preview3-base.safetensors"
+    )
+
+    # 1.0 装上 → latest 优先返回 1.0
+    (dm / "anima-base-v1.0.safetensors").write_bytes(b"z")
+    assert (
+        model_downloader.find_anima_main().name == "anima-base-v1.0.safetensors"
     )
 
 

--- a/tools/download_models.py
+++ b/tools/download_models.py
@@ -5,14 +5,14 @@
 
 最终落地结构（默认 ./anima/，与 anima_train._guess_default_paths 一致）：
     anima/
-      diffusion_models/anima-preview3-base.safetensors
+      diffusion_models/anima-base-v1.0.safetensors
       vae/qwen_image_vae.safetensors
       text_encoders/                # Qwen3 模型 + tokenizer
       t5_tokenizer/                 # T5 仅 tokenizer，不要权重
 
 用法:
     python tools/download_models.py
-    python tools/download_models.py --variant preview2
+    python tools/download_models.py --variant preview3-base
     python tools/download_models.py --no-mirror
     python tools/download_models.py --skip-main --skip-vae
     python tools/download_models.py --output /data/anima


### PR DESCRIPTION
## 背景 / 动机

上游 [`circlestone-labs/Anima`](https://huggingface.co/circlestone-labs/Anima) 发布了正式 1.0 版本（`split_files/diffusion_models/anima-base-v1.0.safetensors`）。把它加进 `ANIMA_VARIANTS` 清单 + 把 `LATEST_ANIMA` 切到 `"1.0"`，让新装用户开箱拉 1.0。

## 改动

### 后端清单
- `studio/services/model_downloader.py`：`ANIMA_VARIANTS` 加 `"1.0"`；**dict 顺序改成「latest 在前」**——之前 `[LATEST] + [其他按 dict 插入序]` 在 LATEST 不在磁盘时 fallback 顺序是「最老优先」（preview → preview2 → preview3-base），违背直觉；调整后 fallback 走 1.0 → preview3-base → preview2 → preview，`build_catalog` 给 UI 的列表也复用此顺序
- `LATEST_ANIMA = "1.0"`

### 默认值同步
所有「fallback / 新装用户开箱默认」位置切到 1.0：
- `studio/schema.py` 两处 `transformer_path` 默认 → `anima-base-v1.0.safetensors`
- `studio/server.py` resolve 默认路径
- `studio/secrets.py:selected_anima` 默认值 → `"1.0"`
- `runtime/training/cli.py` fallback 候选路径 + docstring
- `studio/web/src/pages/tools/Settings.tsx` 两处 fallback（GET /api/secrets 失败时占位）+ `Settings.test.tsx` mock fixture
- `studio/web/src/api/client.ts` 注释里枚举值

> 只影响**新装用户 + 未写过 secrets.json 的**；已存 version 的 yaml 里 `transformer_path` 是绝对路径，**不会跟着变**，保证训练重现性。

### 文档
- `README.md`：「latest = preview3-base」→「latest = 1.0」；CLI 例子 `--variant preview2` → `--variant preview3-base`（举近版更有意义）
- `tools/download_models.py` docstring 同步

### Test
- `tests/test_secrets.py:test_find_anima_main_picks_latest`：加 `anima-base-v1.0` 装上时返回 1.0 的 case，验证 latest 优先

### 顺手清理
- `.gitignore`：根目录 `node_modules/` 加 ignore 规则（vitest / 某些工具偶尔在 repo root 拉一份，之前没被 cover，会被 `git add -A` 吞进 commit）

## Test plan

- [x] `pytest tests/test_secrets.py tests/test_model_downloader.py tests/test_studio_configs.py tests/test_studio_server.py` — 107 passed
- [x] `npx vitest run` — 18 files / 135 passed
- [ ] **手测（用户）**：新建一个空 project，确认 yaml 里 `transformer_path` 默认指向 `anima-base-v1.0.safetensors`；Settings → 训练 → 训练模型 看到 4 个 variant 选项，「1.0」标 `is_latest`

## 设计讨论：为什么不动态化？

reviewer 可能会问「变体清单不应该动态从 HF API 拉吗」。短答：值得做 ADR 单独讨论，但当下不做。理由：
- `hf-mirror.com` 不一定代理 `/api/models/`（只代理文件下载），国内用户走镜像时这条路径直接断 → 仍需 hardcoded fallback，复杂度反而上升
- 上游命名不规范（`anima-preview3-base` / `anima-base-v1.0`），从文件名反推变体 key 容易碰壁
- LATEST 没 meta 字段，没法自动判断
- 上游 4 个变体 / 几个月一发，hardcoded 1 行的维护成本远低于动态化的复杂度

🤖 Generated with [Claude Code](https://claude.com/claude-code)