### PR TITLE
feat: InfoNoise adaptive sampler + simple/advanced UI mode + CLI improvements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ sentencepiece>=0.1.99
 protobuf>=3.20.0
 accelerate>=0.24.0
 peft>=0.8.0
-# wandb>=0.16.0          # Optional: experiment tracking
+wandb>=0.16.0
 # bitsandbytes>=0.41.0   # Optional: 8-bit AdamW (may not work on Windows)
 lycoris-lora>=1.9.0
 prodigyopt>=1.0          # Prodigy 优化器（anima_train.py optimizer=prodigy 时必需）

--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -61,6 +61,7 @@ class TrainingContext:
     steps_per_epoch: Optional[int] = None
     total_steps: Optional[int] = None
     scheduler: Any = None
+    info_noise: Any = None          # training.infonoise.InfoNoiseScheduler | None
 
     # ─── resume_phase 填充 ───
     global_step: int = 0

--- a/runtime/training/infonoise.py
+++ b/runtime/training/infonoise.py
@@ -1,0 +1,168 @@
+"""InfoNoise 自适应时间步采样器。
+
+基于 I-MMSE 恒等式 d/dσ H[x0|xσ] = mmse(σ)/σ³，动态估计各噪声区间的信息量，
+把采样概率集中在"信息窗口"内，跳过极高/极低噪声的低效区间。
+
+在 Flow Matching 的 t ∈ (0,1) 空间工作，内部把 t 映射到 σ = t/(1-t)
+后在 log-σ 空间均匀分 bin，以保持与原始论文的一致性。
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class InfoNoiseScheduler:
+    """InfoNoise 自适应时间步采样器。"""
+
+    def __init__(
+        self,
+        K: int = 64,
+        t_min: float = 0.001,
+        t_max: float = 0.999,
+        N_warm: int = 5000,
+        M: int = 100,
+        B: int = 256,
+        beta: float = 0.9,
+        n_gate: int = 3,
+        p_onset: float = 0.002,
+        N_min: int = 50,
+        baseline_shift: float = 3.0,
+    ):
+        import numpy as np
+        from collections import deque
+
+        self.K = K
+        self.N_warm = N_warm
+        self.M = M
+        self.B = B
+        self.beta = beta
+        self.n_gate = n_gate
+        self.p_onset = p_onset
+        self.N_min = N_min
+        self.baseline_shift = baseline_shift
+        self._internal_step = 0
+
+        sigma_min = t_min / (1.0 - t_min)
+        sigma_max = t_max / (1.0 - t_max)
+        log_edges = np.linspace(np.log(sigma_min), np.log(sigma_max), K + 1)
+        self._log_sigma_edges = log_edges
+        self._delta_log_sigma = float(log_edges[1] - log_edges[0])
+        self._sigma_centers = np.exp(0.5 * (log_edges[:-1] + log_edges[1:]))
+
+        self._fifo = [deque(maxlen=B) for _ in range(K)]
+        self._mse_ema = np.zeros(K, dtype=np.float64)
+        self._n_count = np.zeros(K, dtype=np.int32)
+        self._cdf_values: Optional["np.ndarray"] = None
+
+    def sample(self, bs: int, device) -> torch.Tensor:
+        """采样 t ∈ (0,1)。热身期用 logit-normal baseline，之后用自适应 CDF。"""
+        if self._cdf_values is None:
+            return self._sample_baseline(bs, device)
+        import numpy as np
+        u = torch.rand(bs).numpy()
+        log_sigma = np.interp(u, self._cdf_values, self._log_sigma_edges)
+        sigma = np.exp(log_sigma)
+        t = sigma / (1.0 + sigma)
+        return torch.tensor(t, device=device, dtype=torch.float32).clamp(1e-4, 1 - 1e-4)
+
+    def _sample_baseline(self, bs: int, device) -> torch.Tensor:
+        u = torch.sigmoid(torch.randn(bs, device=device))
+        s = self.baseline_shift
+        t = (u * s) / (1 + (s - 1) * u)
+        return t.clamp(1e-4, 1 - 1e-4)
+
+    def record(self, t: torch.Tensor, raw_mse: torch.Tensor):
+        """记录 per-sample 原始 MSE（不含任何 loss weight）到对应 bin。"""
+        import numpy as np
+        t_np = t.detach().cpu().float().numpy()
+        mse_np = raw_mse.detach().cpu().float().numpy()
+        sigma_np = t_np / np.clip(1.0 - t_np, 1e-8, None)
+        log_sigma_np = np.log(np.clip(sigma_np, 1e-8, None))
+        edges_inner = self._log_sigma_edges[1:-1]
+        for i in range(len(t_np)):
+            k = int(np.searchsorted(edges_inner, log_sigma_np[i]))
+            self._fifo[k].append(float(mse_np[i]))
+            self._n_count[k] = min(self._n_count[k] + 1, self.B)
+        self._internal_step += 1
+
+    def maybe_refresh(self, global_step: int):
+        """条件满足时刷新 schedule（每 M 步、热身结束后、每 bin 有足够样本）。"""
+        if self._internal_step < self.N_warm:
+            return
+        if global_step % self.M != 0:
+            return
+        import numpy as np
+        if int(np.min(self._n_count)) < self.N_min:
+            return
+        self._refresh()
+
+    def _refresh(self):
+        import numpy as np
+
+        # Step A+B: 平均 loss + EMA 平滑
+        l_bar = np.array([
+            float(np.mean(list(buf))) if buf else 0.0
+            for buf in self._fifo
+        ])
+        self._mse_ema = (1.0 - self.beta) * self._mse_ema + self.beta * l_bar
+
+        # Step C: entropy rate r̂_k = mse_k / σ_k³
+        r_hat = self._mse_ema / (self._sigma_centers ** 3 + 1e-30)
+
+        # Step D: 找 gate pivot c（从低 σ 向高 σ 扫，取第一个超过 p_onset 的前一个 bin）
+        r_max = float(r_hat.max())
+        if r_max < 1e-30:
+            return
+        r_norm = r_hat / r_max
+        above = r_norm >= self.p_onset
+        if not any(above):
+            return
+        first_above = int(above.argmax())
+        c = float(self._sigma_centers[max(0, first_above - 1)])
+
+        # Step E: gate g(σ) = σⁿ / (σⁿ + cⁿ)
+        sn = self._sigma_centers ** self.n_gate
+        cn = c ** self.n_gate
+        r_tilde = r_hat * sn / (sn + cn + 1e-30)
+
+        # Step F+G: 归一化 + 构建 CDF（log-σ 空间梯形积分，bins 等宽所以直接求和）
+        q = r_tilde.clip(0.0)
+        Z = float(q.sum() * self._delta_log_sigma)
+        if Z < 1e-30:
+            return
+        q_norm = q / Z
+        cdf = np.concatenate([[0.0], np.cumsum(q_norm * self._delta_log_sigma)])
+        cdf[-1] = 1.0
+        self._cdf_values = cdf.clip(0.0, 1.0)
+
+
+def build_info_noise(args, total_steps: Optional[int]) -> Optional[InfoNoiseScheduler]:
+    """按 args 构建 InfoNoiseScheduler；未启用时返回 None。"""
+    if not getattr(args, "infonoise_enabled", False):
+        return None
+
+    n_warm_cfg = int(getattr(args, "infonoise_N_warm", 0) or 0)
+    if n_warm_cfg <= 0:
+        n_warm_cfg = max(200, int((total_steps or 5000) * 0.2))
+        logger.info(f"InfoNoise N_warm 自动设置为 {n_warm_cfg} 步（总步数 {total_steps} × 20%）")
+
+    scheduler = InfoNoiseScheduler(
+        K=int(getattr(args, "infonoise_K", 64) or 64),
+        N_warm=n_warm_cfg,
+        M=int(getattr(args, "infonoise_M", 100) or 100),
+        B=int(getattr(args, "infonoise_B", 256) or 256),
+        beta=float(getattr(args, "infonoise_beta", 0.9) or 0.9),
+        N_min=int(getattr(args, "infonoise_N_min", 50) or 50),
+        baseline_shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
+    )
+    logger.info(
+        f"InfoNoise 已启用：K={scheduler.K}, N_warm={scheduler.N_warm}, "
+        f"M={scheduler.M}, B={scheduler.B}, beta={scheduler.beta}"
+    )
+    return scheduler

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -41,6 +41,8 @@ def run(ctx: TrainingContext) -> None:
 
     for epoch in range(ctx.start_epoch, args.epochs):
         ctx.current_epoch = epoch
+        epoch_loss_sum = 0.0
+        epoch_step_count = 0
         if ctx.use_cached and hasattr(ctx.dataloader, "batch_sampler") and hasattr(ctx.dataloader.batch_sampler, "set_epoch"):
             ctx.dataloader.batch_sampler.set_epoch(epoch)
         for batch_idx, batch in enumerate(ctx.dataloader):
@@ -187,6 +189,8 @@ def run(ctx: TrainingContext) -> None:
 
                 # 记录 loss 历史
                 loss_val = float(loss.item() * args.grad_accum)
+                epoch_loss_sum += loss_val
+                epoch_step_count += 1
                 if args.loss_curve_steps and len(ctx.loss_history) < args.loss_curve_steps:
                     ctx.loss_history.append(loss_val)
 
@@ -213,7 +217,6 @@ def run(ctx: TrainingContext) -> None:
                     {
                         "train/loss": loss_val,
                         "train/lr": float(lr),
-                        "train/epoch": epoch + 1,
                         "train/speed_it_s": float(ctx.speed_ema or 0),
                     },
                     step=ctx.global_step,
@@ -286,6 +289,14 @@ def run(ctx: TrainingContext) -> None:
 
         # epoch 结束后的操作
         ctx.current_epoch = epoch + 1
+        if epoch_step_count > 0:
+            ctx.wandb_monitor.log(
+                {
+                    "train/loss_epoch": epoch_loss_sum / epoch_step_count,
+                    "train/epoch": ctx.current_epoch,
+                },
+                step=ctx.global_step,
+            )
         if not args.max_steps or ctx.global_step < args.max_steps:
             # 保存 checkpoint
             if args.save_every > 0 and ctx.current_epoch % args.save_every == 0:

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -309,6 +309,27 @@ def run(ctx: TrainingContext) -> None:
                     wandb_step=ctx.global_step,
                 )
 
+            # 定期保存训练状态（epoch 版）
+            save_state_every_epochs = int(getattr(args, "save_state_every_epochs", 0) or 0)
+            if save_state_every_epochs > 0 and ctx.current_epoch % save_state_every_epochs == 0:
+                state_path = ctx.output_dir / f"training_state_epoch{ctx.current_epoch}.pt"
+                monitor_data = None
+                if ctx.monitor_server:
+                    try:
+                        from train_monitor import get_state
+                        monitor_data = get_state()
+                    except Exception:
+                        pass
+                with optimizer_eval_mode(ctx.optimizer):
+                    save_training_state(
+                        state_path, ctx.injector, ctx.optimizer, epoch, ctx.global_step,
+                        ctx.loss_history, monitor_state=monitor_data, scheduler=ctx.scheduler,
+                    )
+                    lora_path = ctx.output_dir / f"{args.output_name}_epoch{ctx.current_epoch}.safetensors"
+                    if not lora_path.exists():
+                        ctx.injector.save(lora_path)
+                ctx.emit(f"Saved training state: training_state_epoch{ctx.current_epoch}.pt")
+
         # 检查 max_steps
         if args.max_steps and ctx.global_step >= args.max_steps:
             break

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -85,11 +85,14 @@ def run(ctx: TrainingContext) -> None:
                     cross = cross[:, :_bucket, :].contiguous()
 
             # Flow Matching
-            t = sample_t(
-                bs, ctx.device,
-                mode=str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal"),
-                shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
-            )
+            if ctx.info_noise is not None:
+                t = ctx.info_noise.sample(bs, ctx.device)
+            else:
+                t = sample_t(
+                    bs, ctx.device,
+                    mode=str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal"),
+                    shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
+                )
 
             # PR-C：adapter hook — 允许变体按 sigma_t / step 调整运行时结构
             # （T-LoRA / AdaLoRA / B-LoRA 等）。LyCORIS 走默认 no-op。
@@ -121,6 +124,12 @@ def run(ctx: TrainingContext) -> None:
                     use_checkpoint=args.grad_checkpoint,
                 )
                 loss_per_sample = F.mse_loss(pred.float(), target.float(), reduction="none")
+                # InfoNoise：记录原始 per-sample MSE（加权前）
+                if ctx.info_noise is not None:
+                    _raw_mse = loss_per_sample.detach().mean(
+                        dim=list(range(1, loss_per_sample.dim()))
+                    )
+                    ctx.info_noise.record(t.detach(), _raw_mse)
                 # 按样本加权（正则集可降低权重）
                 if "loss_weight" in batch:
                     w = batch["loss_weight"].to(ctx.device).view(-1, *([1] * (loss_per_sample.dim() - 1)))
@@ -171,6 +180,10 @@ def run(ctx: TrainingContext) -> None:
                     ctx.scheduler.step()
                 ctx.optimizer.zero_grad()
                 ctx.global_step += 1
+
+                # InfoNoise：刷新采样分布
+                if ctx.info_noise is not None:
+                    ctx.info_noise.maybe_refresh(ctx.global_step)
 
                 # 记录 loss 历史
                 loss_val = float(loss.item() * args.grad_accum)

--- a/runtime/training/observability.py
+++ b/runtime/training/observability.py
@@ -67,7 +67,7 @@ class WandBMonitor:
         run,
         *,
         log_samples: bool = False,
-        sample_max_side: int = 512,
+        sample_max_side: int = 1216,
         sample_every_n_steps: int = 0,
     ) -> None:
         self._wandb = wandb_module
@@ -164,7 +164,7 @@ def init_wandb_monitor(args, output_dir: Path, config_path: Optional[Path]) -> W
         "0", "false", "no", "off",
     }
     try:
-        sample_max_side = int(os.environ.get("WANDB_SAMPLE_MAX_SIDE", "512") or 512)
+        sample_max_side = int(os.environ.get("WANDB_SAMPLE_MAX_SIDE", "1216") or 1216)
     except ValueError:
         sample_max_side = 512
     try:

--- a/runtime/training/phases/optimizer.py
+++ b/runtime/training/phases/optimizer.py
@@ -72,3 +72,7 @@ def run(ctx: TrainingContext) -> None:
     # 学习率调度器：PR-C 通过 schedulers/ plugin registry 派发；"none" 自动返回 None
     from training.schedulers import build_scheduler
     ctx.scheduler = build_scheduler(args, ctx.optimizer, ctx.total_steps)
+
+    # InfoNoise 自适应调度器（total_steps 确定后才能算 N_warm）
+    from training.infonoise import build_info_noise
+    ctx.info_noise = build_info_noise(args, ctx.total_steps)

--- a/runtime/training/sample_runner.py
+++ b/runtime/training/sample_runner.py
@@ -68,7 +68,7 @@ def run_sample(
         )
         img.save(sample_path)
         ctx.emit(f"采样保存: {sample_path.name}")
-        if wandb_key and ctx.wandb_monitor.log_samples:
+        if wandb_key:
             ctx.wandb_monitor.log_image(
                 wandb_key,
                 sample_path,

--- a/studio.bat
+++ b/studio.bat
@@ -4,9 +4,11 @@ REM AnimaStudio Windows shortcut -- forwards to: python -m studio
 REM Usage:
 REM   .\studio.bat                same as: python -m studio run
 REM   .\studio.bat --reinstall    DELETE venv\ and rebuild (studio_data\ kept)
-REM   .\studio.bat dev            frontend + backend dev mode
-REM   .\studio.bat build          build frontend only
-REM   .\studio.bat test           run pytest + vitest
+REM   .\studio.bat dev                      frontend + backend dev mode
+REM   .\studio.bat dev --fe-port 5174       Vite on port 5174
+REM   .\studio.bat dev --port 8766          backend on port 8766
+REM   .\studio.bat build                    build frontend only
+REM   .\studio.bat test                     run pytest + vitest
 REM
 REM Note: PowerShell needs the `.\` prefix; cmd.exe accepts either.
 REM

--- a/studio.bat
+++ b/studio.bat
@@ -2,8 +2,9 @@
 chcp 65001 >nul
 REM AnimaStudio Windows shortcut -- forwards to: python -m studio
 REM Usage:
-REM   .\studio.bat                same as: python -m studio run
-REM   .\studio.bat --reinstall    DELETE venv\ and rebuild (studio_data\ kept)
+REM   .\studio.bat                          same as: python -m studio run
+REM   .\studio.bat --reinstall              DELETE venv\ and rebuild (studio_data\ kept)
+REM   .\studio.bat --torch=cu128            force GPU torch (cu128/cu126/cu124/cu118/cpu)
 REM   .\studio.bat dev                      frontend + backend dev mode
 REM   .\studio.bat dev --fe-port 5174       Vite on port 5174
 REM   .\studio.bat dev --port 8766          backend on port 8766
@@ -26,13 +27,21 @@ set PYTHONIOENCODING=utf-8
 
 REM Parse our flags; collect remaining args to forward to Python.
 set REINSTALL=0
+set TORCH_TAG=
 set PASSTHROUGH=
 :argloop
 if "%~1"=="" goto argdone
 if /i "%~1"=="--reinstall" (
     set REINSTALL=1
 ) else (
-    set PASSTHROUGH=!PASSTHROUGH! %1
+    REM Check for --torch=<tag> prefix
+    set _ARG=%~1
+    if "!_ARG:~0,8!"=="--torch=" (
+        set TORCH_TAG=!_ARG:~8!
+        set PASSTHROUGH=!PASSTHROUGH! --torch !TORCH_TAG!
+    ) else (
+        set PASSTHROUGH=!PASSTHROUGH! %1
+    )
 )
 shift
 goto argloop
@@ -102,14 +111,24 @@ if exist "venv\Scripts\python.exe" (
     REM GPU-aware torch first install (PR-S1a). Without this, requirements.txt's
     REM bare `torch>=2.0.0` makes pip pull the CPU wheel. Installing CUDA torch
     REM from PyTorch's index FIRST satisfies the constraint, pip won't replace.
-    set TORCH_INDEX=
-    for /f "delims=" %%i in ('!PYTHON! tools\select_torch_index.py 2^>nul') do set TORCH_INDEX=%%i
-    if defined TORCH_INDEX (
-        echo [studio] setup: NVIDIA GPU detected; installing torch from !TORCH_INDEX!
+    REM --torch=<tag> overrides auto-detection (useful on CPU-only rentals).
+    if defined TORCH_TAG (
+        set TORCH_INDEX=https://download.pytorch.org/whl/!TORCH_TAG!
+        echo [studio] setup: --torch=!TORCH_TAG! specified; installing torch from !TORCH_INDEX!
         !PYTHON! -m pip install torch torchvision --index-url !TORCH_INDEX!
         if errorlevel 1 (
-            echo [studio] setup: CUDA torch install failed; will fall back to PyPI default in requirements.txt
-            echo [studio] setup: you can fix manually later via Studio Settings ^> PyTorch ^> Reinstall
+            echo [studio] setup: forced torch install failed; will fall back to PyPI default in requirements.txt
+        )
+    ) else (
+        set TORCH_INDEX=
+        for /f "delims=" %%i in ('!PYTHON! tools\select_torch_index.py 2^>nul') do set TORCH_INDEX=%%i
+        if defined TORCH_INDEX (
+            echo [studio] setup: NVIDIA GPU detected; installing torch from !TORCH_INDEX!
+            !PYTHON! -m pip install torch torchvision --index-url !TORCH_INDEX!
+            if errorlevel 1 (
+                echo [studio] setup: CUDA torch install failed; will fall back to PyPI default in requirements.txt
+                echo [studio] setup: you can fix manually later via Studio Settings ^> PyTorch ^> Reinstall
+            )
         )
     )
 

--- a/studio.sh
+++ b/studio.sh
@@ -3,13 +3,19 @@
 # Usage:
 #   ./studio.sh [--mirror] [--reinstall] [subcommand]
 #
-#   --mirror     Use Tencent pip mirror during first-run setup.
-#                Without this flag, official PyPI is tried first; the mirror is
-#                used as a fallback if the official source fails.
+#   --mirror          Use Tencent pip mirror during first-run setup.
+#                     Without this flag, official PyPI is tried first; the mirror is
+#                     used as a fallback if the official source fails.
 #
-#   --reinstall  DELETE venv/ and rebuild from scratch (studio_data/ kept).
-#                Use when venv is broken beyond repair (dep conflict / corrupt
-#                wheels / etc). Asks for confirmation.
+#   --reinstall       DELETE venv/ and rebuild from scratch (studio_data/ kept).
+#                     Use when venv is broken beyond repair (dep conflict / corrupt
+#                     wheels / etc). Asks for confirmation.
+#
+#   --torch=<tag>     Force a specific PyTorch CUDA wheel on first-run venv setup
+#                     AND (via Python cli) reinstall if the current torch differs.
+#                     Tags: cu128 cu126 cu124 cu118 cpu
+#                     Use this on CPU-only rentals when you want GPU torch pre-installed
+#                     for a later GPU machine.  Example: ./studio.sh --torch=cu128
 #
 #   subcommand: run (default) | dev | build | test
 #
@@ -18,12 +24,14 @@
 #     --host <H>      bind host (default 127.0.0.1)
 #     --no-browser    do not auto-open browser
 #     --no-build      skip frontend rebuild check
+#     --torch <tag>   force torch CUDA tag (cu128/cu126/cu124/cu118/cpu)
 #
 #   dev subcommand flags:
 #     --port <N>      backend uvicorn port (default 8765)
 #     --fe-port <N>   frontend Vite dev server port (default 5173)
 #     --host <H>      bind host (default 127.0.0.1)
 #     --no-browser    do not auto-open browser
+#     --torch <tag>   force torch CUDA tag (cu128/cu126/cu124/cu118/cpu)
 #
 # Safe to run with either ./studio.sh or `bash studio.sh`.
 # Avoid `source studio.sh` -- not needed (we call venv python directly).
@@ -43,11 +51,14 @@ export PYTHONIOENCODING=utf-8
 # Parse our flags; collect remaining args to forward to Python.
 _USE_MIRROR=0
 _REINSTALL=0
+_TORCH_TAG=""
 _PASSTHROUGH=()
 for _arg in "$@"; do
     case "$_arg" in
         --mirror)    _USE_MIRROR=1 ;;
         --reinstall) _REINSTALL=1 ;;
+        --torch=*)   _TORCH_TAG="${_arg#--torch=}"
+                     _PASSTHROUGH+=("--torch" "$_TORCH_TAG") ;;
         *)           _PASSTHROUGH+=("$_arg") ;;
     esac
 done
@@ -125,12 +136,21 @@ else
     # bare `torch>=2.0.0` makes pip pull the CPU wheel from PyPI default. By
     # installing torch from PyTorch's CUDA index FIRST, the requirements.txt
     # constraint is already satisfied and pip won't replace it.
-    _TORCH_INDEX="$("$PYTHON" tools/select_torch_index.py 2>/dev/null || true)"
-    if [ -n "$_TORCH_INDEX" ]; then
-        echo "[studio] setup: NVIDIA GPU detected; installing torch from $_TORCH_INDEX"
-        if ! "$PYTHON" -m pip install torch torchvision --index-url "$_TORCH_INDEX"; then
-            echo "[studio] setup: CUDA torch install failed; will fall back to PyPI default in requirements.txt"
-            echo "[studio] setup: you can fix manually later via Studio Settings > PyTorch > Reinstall"
+    # --torch=<tag> overrides auto-detection (useful on CPU-only rentals).
+    if [ -n "$_TORCH_TAG" ]; then
+        _TORCH_INDEX="https://download.pytorch.org/whl/$_TORCH_TAG"
+        echo "[studio] setup: --torch=$_TORCH_TAG specified; installing torch from $_TORCH_INDEX"
+        if ! _pip_install torch torchvision --index-url "$_TORCH_INDEX"; then
+            echo "[studio] setup: forced torch install failed; will fall back to PyPI default in requirements.txt"
+        fi
+    else
+        _TORCH_INDEX="$("$PYTHON" tools/select_torch_index.py 2>/dev/null || true)"
+        if [ -n "$_TORCH_INDEX" ]; then
+            echo "[studio] setup: NVIDIA GPU detected; installing torch from $_TORCH_INDEX"
+            if ! "$PYTHON" -m pip install torch torchvision --index-url "$_TORCH_INDEX"; then
+                echo "[studio] setup: CUDA torch install failed; will fall back to PyPI default in requirements.txt"
+                echo "[studio] setup: you can fix manually later via Studio Settings > PyTorch > Reinstall"
+            fi
         fi
     fi
 

--- a/studio.sh
+++ b/studio.sh
@@ -13,6 +13,18 @@
 #
 #   subcommand: run (default) | dev | build | test
 #
+#   run subcommand flags:
+#     --port <N>      backend uvicorn port (default 8765)
+#     --host <H>      bind host (default 127.0.0.1)
+#     --no-browser    do not auto-open browser
+#     --no-build      skip frontend rebuild check
+#
+#   dev subcommand flags:
+#     --port <N>      backend uvicorn port (default 8765)
+#     --fe-port <N>   frontend Vite dev server port (default 5173)
+#     --host <H>      bind host (default 127.0.0.1)
+#     --no-browser    do not auto-open browser
+#
 # Safe to run with either ./studio.sh or `bash studio.sh`.
 # Avoid `source studio.sh` -- not needed (we call venv python directly).
 #

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -746,10 +746,14 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: Optional[list[str]] = None) -> int:
     parser = build_parser()
-    args = parser.parse_args(argv)
-    if not getattr(args, "cmd", None):
-        # 默认 run
-        args = parser.parse_args(["run", *(argv or [])])
+    args_list = list(argv) if argv is not None else sys.argv[1:]
+    # 没有子命令时默认 run（如 studio.sh --port 6006 → run --port 6006）。
+    # 找第一个不以 '-' 开头的参数，判断是否是已知子命令；不是则插入 run。
+    _subcmds = {'run', 'dev', 'build', 'test'}
+    _first_pos = next((a for a in args_list if not a.startswith('-')), None)
+    if _first_pos not in _subcmds:
+        args_list = ['run'] + args_list
+    args = parser.parse_args(args_list)
     return args.func(args)
 
 

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -613,7 +613,8 @@ def cmd_run(args: argparse.Namespace) -> int:
                 rc = cmd_build(args)
                 if rc != 0:
                     return rc
-        _apply_pending_install()
+        if not getattr(args, 'skip_pending', False):
+            _apply_pending_install()
         _check_torch_cuda()
         _try_enable_flash_attn()
         _bootstrap_onnxruntime()
@@ -657,7 +658,8 @@ def cmd_dev(args: argparse.Namespace) -> int:
     rc = npm_install_if_missing(npm)
     if rc != 0:
         return rc
-    _apply_pending_install()
+    if not getattr(args, 'skip_pending', False):
+        _apply_pending_install()
     _check_torch_cuda()
     _try_enable_flash_attn()
     _bootstrap_onnxruntime()
@@ -723,6 +725,8 @@ def build_parser() -> argparse.ArgumentParser:
                        help="即使 dist 不存在也不自动 build")
     p_run.add_argument("--no-browser", action="store_true",
                        help="启动后不自动打开浏览器")
+    p_run.add_argument("--skip-pending", action="store_true",
+                       help="跳过 pending pip 安装（torch 重装等），直接启动")
     p_run.set_defaults(func=cmd_run)
 
     p_dev = sub.add_parser("dev", help="前后端开发模式")
@@ -733,6 +737,8 @@ def build_parser() -> argparse.ArgumentParser:
                        help="前端 Vite 开发服务器端口（默认 5173）")
     p_dev.add_argument("--no-browser", action="store_true",
                        help="启动后不自动打开浏览器")
+    p_dev.add_argument("--skip-pending", action="store_true",
+                       help="跳过 pending pip 安装（torch 重装等），直接启动")
     p_dev.set_defaults(func=cmd_dev)
 
     p_build = sub.add_parser("build", help="仅构建前端")

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -571,6 +571,32 @@ def _apply_update_pending() -> None:
         )
 
 
+def _maybe_force_torch(args: argparse.Namespace) -> int:
+    """--torch <tag> 指定时，检查当前安装是否匹配；不匹配则立即重装（流式输出）。
+    仅在 launcher 启动期调一次，重装完由 restart 机制加载新 torch。"""
+    tag = getattr(args, 'torch', None)
+    if not tag:
+        return 0
+    from studio.services import torch_setup  # noqa: PLC0415
+    current = torch_setup.detect_torch()
+    current_build = current.get('cuda_build') or ('未安装' if not current.get('installed') else 'unknown')
+    if current.get('installed') and current.get('cuda_build') == tag:
+        print(f"[studio] torch 已是 {tag}，跳过重装")
+        return 0
+    print(f"[studio] --torch {tag} 指定（当前: {current_build}），开始重装...")
+    print("[studio] 提示：按 Ctrl+C 可跳过")
+    try:
+        res = torch_setup.reinstall(tag, stream=True)
+        print(f"[studio] torch 重装完成: {res.get('version')} ({res.get('tag')})")
+        return 0
+    except KeyboardInterrupt:
+        print("\n[studio] 用户中断，跳过 torch 重装", file=sys.stderr)
+        return 0
+    except RuntimeError as exc:
+        print(f"[studio] torch 重装失败: {exc}", file=sys.stderr)
+        return 1
+
+
 def cmd_run(args: argparse.Namespace) -> int:
     """`run` 主循环。
 
@@ -588,6 +614,10 @@ def cmd_run(args: argparse.Namespace) -> int:
     `/api/health` 自动 reconnect），不重复弹新窗口。
     """
     opened_browser = False
+    # --torch 强制重装（仅首次，不在 restart 循环里重复）
+    rc = _maybe_force_torch(args)
+    if rc != 0:
+        return rc
     # PR-D：快照启动期 installer 文件 sha256；server 退出后重算，变化则
     # 退出码 42 让 wrapper 整体 exec 自己。
     startup_installer = _installer_hashes()
@@ -648,6 +678,9 @@ def cmd_run(args: argparse.Namespace) -> int:
 
 
 def cmd_dev(args: argparse.Namespace) -> int:
+    rc = _maybe_force_torch(args)
+    if rc != 0:
+        return rc
     rc = _ensure_python_deps()
     if rc != 0:
         return rc
@@ -727,6 +760,9 @@ def build_parser() -> argparse.ArgumentParser:
                        help="启动后不自动打开浏览器")
     p_run.add_argument("--skip-pending", action="store_true",
                        help="跳过 pending pip 安装（torch 重装等），直接启动")
+    p_run.add_argument("--torch", metavar="TAG",
+                       help="强制指定 torch CUDA 版本（cu128/cu126/cu124/cu118/cpu），"
+                            "与当前不符时自动重装。CPU 租赁机预装 GPU torch 时使用。")
     p_run.set_defaults(func=cmd_run)
 
     p_dev = sub.add_parser("dev", help="前后端开发模式")
@@ -739,6 +775,8 @@ def build_parser() -> argparse.ArgumentParser:
                        help="启动后不自动打开浏览器")
     p_dev.add_argument("--skip-pending", action="store_true",
                        help="跳过 pending pip 安装（torch 重装等），直接启动")
+    p_dev.add_argument("--torch", metavar="TAG",
+                       help="强制指定 torch CUDA 版本（cu128/cu126/cu124/cu118/cpu）")
     p_dev.set_defaults(func=cmd_dev)
 
     p_build = sub.add_parser("build", help="仅构建前端")

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -664,7 +664,7 @@ def cmd_dev(args: argparse.Namespace) -> int:
 
     pg = ProcGroup()
     try:
-        pg.spawn("frontend", [npm, "run", "dev"], cwd=WEB_DIR)
+        pg.spawn("frontend", [npm, "run", "dev", "--", "--port", str(args.fe_port)], cwd=WEB_DIR)
         pg.spawn(
             "backend",
             [
@@ -676,7 +676,7 @@ def cmd_dev(args: argparse.Namespace) -> int:
                 "--reload",
             ],
         )
-        frontend_url = "http://127.0.0.1:5173/studio/"
+        frontend_url = f"http://127.0.0.1:{args.fe_port}/studio/"
         print(
             f"[studio] frontend → {frontend_url}  "
             f"backend → http://{args.host}:{args.port}/studio/"
@@ -727,7 +727,10 @@ def build_parser() -> argparse.ArgumentParser:
 
     p_dev = sub.add_parser("dev", help="前后端开发模式")
     p_dev.add_argument("--host", default="127.0.0.1")
-    p_dev.add_argument("--port", type=int, default=8765)
+    p_dev.add_argument("--port", type=int, default=8765,
+                       help="后端 uvicorn 端口（默认 8765）")
+    p_dev.add_argument("--fe-port", type=int, default=5173,
+                       help="前端 Vite 开发服务器端口（默认 5173）")
     p_dev.add_argument("--no-browser", action="store_true",
                        help="启动后不自动打开浏览器")
     p_dev.set_defaults(func=cmd_dev)

--- a/studio/curation.py
+++ b/studio/curation.py
@@ -45,7 +45,7 @@ def _validate_folder(name: str) -> None:
 
 
 def _validate_filename(name: str) -> None:
-    if not _FILE_PATTERN.fullmatch(name) or ".." in name:
+    if not _FILE_PATTERN.fullmatch(name):
         raise CurationError(f"非法文件名: {name!r}")
 
 

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -165,7 +165,7 @@ class TrainingConfig(BaseModel):
     cache_latents: bool = Field(
         True,
         description="缓存 VAE latent 加速训练",
-        json_schema_extra=_meta("caption"),
+        json_schema_extra=_meta("system"),
     )
 
     # ------------------------------------------------------------------- LoRA
@@ -336,82 +336,82 @@ class TrainingConfig(BaseModel):
     kv_trim: bool = Field(
         False,
         description="【性能】Cross-attention KV trim：按实际 token 数裁到最近 bucket（64/128/256/512），减少 padding 计算量",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("system"),
     )
     noise_offset: float = Field(
         0.0, ge=0.0, le=0.2,
         description="【噪声增强】低频偏移强度，缓解亮度均值偏差（0=禁用，推荐 0.05-0.1）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("noise_schedule"),
     )
     pyramid_noise_iters: int = Field(
         0, ge=0, le=6,
         description="【噪声增强】多尺度噪声叠加层数（0=禁用；2-3 帮助全局光照构图学习）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("noise_schedule"),
     )
     pyramid_noise_discount: float = Field(
         0.35, ge=0.1, le=0.9,
         description="【噪声增强】金字塔每层衰减系数（仅 pyramid_noise_iters > 0）",
-        json_schema_extra=_meta("training", show_when="pyramid_noise_iters!=0"),
+        json_schema_extra=_meta("noise_schedule", show_when="pyramid_noise_iters!=0"),
     )
     timestep_sampling: Literal["logit_normal", "uniform", "logit_normal_low", "mode"] = Field(
         "logit_normal",
         description="【时间步采样】分布（logit_normal 为 SD3/Anima 默认）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("noise_schedule"),
     )
     timestep_shift: float = Field(
         3.0, ge=0.1, le=10.0,
         description="【时间步采样】logit-normal / mode shift（>1 偏向高噪声端，<1 偏向细节端）",
-        json_schema_extra=_meta("training", show_when="timestep_sampling!=uniform"),
+        json_schema_extra=_meta("noise_schedule", show_when="timestep_sampling!=uniform"),
     )
     infonoise_enabled: bool = Field(
         False,
         description="【InfoNoise】启用自适应时间步采样（基于 I-MMSE 信息量，自动聚焦有效训练区间）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("noise_schedule"),
     )
     infonoise_K: int = Field(
         64, ge=16, le=256,
         description="【InfoNoise】log-σ bin 数量",
-        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
     )
     infonoise_N_warm: int = Field(
         5000, ge=100,
         description="【InfoNoise】热身步数（热身期用 baseline logit-normal）",
-        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
     )
     infonoise_M: int = Field(
         100, ge=10,
         description="【InfoNoise】schedule 刷新周期（每 M 步重算一次采样分布）",
-        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
     )
     infonoise_B: int = Field(
         256, ge=32,
         description="【InfoNoise】每 bin 的 FIFO buffer 容量",
-        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
     )
     infonoise_beta: float = Field(
         0.9, ge=0.1, le=0.999,
         description="【InfoNoise】EMA 平滑率",
-        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
     )
     infonoise_N_min: int = Field(
         50, ge=1,
         description="【InfoNoise】触发刷新所需的每 bin 最小样本数",
-        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
     )
     loss_weighting: Literal["none", "min_snr", "detail_inv_t", "cosmap"] = Field(
         "none",
         description="【损失加权】方案（min_snr 推荐；detail_inv_t 细节强化；cosmap SD3 风格）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("noise_schedule"),
     )
     min_snr_gamma: float = Field(
         5.0, ge=0.1, le=20.0,
         description="【损失加权】Min-SNR gamma 值（仅 loss_weighting=min_snr）",
-        json_schema_extra=_meta("training", show_when="loss_weighting==min_snr"),
+        json_schema_extra=_meta("noise_schedule", show_when="loss_weighting==min_snr"),
     )
     weight_cap_ratio: float = Field(
         0.0, ge=0.0, le=50.0,
         description="【损失加权】Batch 内权重 max/min 比上限（0=禁用；小 batch+Prodigy 建议 5）",
-        json_schema_extra=_meta("training", show_when="loss_weighting!=none"),
+        json_schema_extra=_meta("noise_schedule", show_when="loss_weighting!=none"),
     )
     grad_clip_max_norm: float = Field(
         0.0, ge=0.0,
@@ -421,22 +421,22 @@ class TrainingConfig(BaseModel):
     mixed_precision: Literal["bf16", "fp16", "no"] = Field(
         "bf16",
         description="混合精度",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("system"),
     )
     grad_checkpoint: bool = Field(
         True,
         description="梯度检查点（省显存）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("system"),
     )
     attention_backend: AttentionBackend = Field(
         "flash_attn",
         description="Attention backend：none（PyTorch SDPA）/ xformers / Flash Attention（5090 推荐 flash_attn）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("system"),
     )
     num_workers: int = Field(
         0, ge=0,
         description="数据加载线程（Windows 必须 0）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("system"),
     )
 
     @model_validator(mode="before")
@@ -835,8 +835,10 @@ GROUP_ORDER: list[tuple[str, str, bool]] = [
     ("model", "模型路径", False),
     ("dataset", "数据集", False),
     ("caption", "Caption 处理", False),
-    ("lora", "LoRA / LoKr", False),
+    ("lora", "网络设置", False),
     ("training", "训练参数", False),
+    ("noise_schedule", "噪声与调度", False),
+    ("system", "系统与性能", False),
     ("output", "输出与保存", False),
     ("sample", "采样", False),
     ("monitor", "监控与进度", False),

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -231,6 +231,11 @@ class TrainingConfig(BaseModel):
         description="批次大小",
         json_schema_extra=_meta("training"),
     )
+    grad_checkpoint: bool = Field(
+        True,
+        description="梯度检查点（省显存，约增加 1/3 计算量）",
+        json_schema_extra=_meta("training"),
+    )
     grad_accum: int = Field(
         4, ge=1,
         description="梯度累积步数（有效 batch = batch_size × grad_accum）",
@@ -434,11 +439,7 @@ class TrainingConfig(BaseModel):
         description="混合精度",
         json_schema_extra=_meta("system"),
     )
-    grad_checkpoint: bool = Field(
-        True,
-        description="梯度检查点（省显存）",
-        json_schema_extra=_meta("system"),
-    )
+
     attention_backend: AttentionBackend = Field(
         "flash_attn",
         description="Attention backend：none（PyTorch SDPA）/ xformers / Flash Attention（5090 推荐 flash_attn）",

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -390,8 +390,8 @@ class TrainingConfig(BaseModel):
         json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     infonoise_N_warm: int = Field(
-        5000, ge=100,
-        description="【InfoNoise】热身步数（热身期用 baseline logit-normal）",
+        0, ge=0,
+        description="【InfoNoise】热身步数（0 = 自动，取总步数的 20%，最少 200 步）",
         json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     infonoise_M: int = Field(

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -363,6 +363,41 @@ class TrainingConfig(BaseModel):
         description="【时间步采样】logit-normal / mode shift（>1 偏向高噪声端，<1 偏向细节端）",
         json_schema_extra=_meta("training", show_when="timestep_sampling!=uniform"),
     )
+    infonoise_enabled: bool = Field(
+        False,
+        description="【InfoNoise】启用自适应时间步采样（基于 I-MMSE 信息量，自动聚焦有效训练区间）",
+        json_schema_extra=_meta("training"),
+    )
+    infonoise_K: int = Field(
+        64, ge=16, le=256,
+        description="【InfoNoise】log-σ bin 数量",
+        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+    )
+    infonoise_N_warm: int = Field(
+        5000, ge=100,
+        description="【InfoNoise】热身步数（热身期用 baseline logit-normal）",
+        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+    )
+    infonoise_M: int = Field(
+        100, ge=10,
+        description="【InfoNoise】schedule 刷新周期（每 M 步重算一次采样分布）",
+        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+    )
+    infonoise_B: int = Field(
+        256, ge=32,
+        description="【InfoNoise】每 bin 的 FIFO buffer 容量",
+        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+    )
+    infonoise_beta: float = Field(
+        0.9, ge=0.1, le=0.999,
+        description="【InfoNoise】EMA 平滑率",
+        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+    )
+    infonoise_N_min: int = Field(
+        50, ge=1,
+        description="【InfoNoise】触发刷新所需的每 bin 最小样本数",
+        json_schema_extra=_meta("training", show_when="infonoise_enabled==true"),
+    )
     loss_weighting: Literal["none", "min_snr", "detail_inv_t", "cosmap"] = Field(
         "none",
         description="【损失加权】方案（min_snr 推荐；detail_inv_t 细节强化；cosmap SD3 风格）",

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -192,27 +192,27 @@ class TrainingConfig(BaseModel):
     lora_dora: bool = Field(
         False,
         description="DoRA：方向/幅度分离训练，社区共识收敛更稳",
-        json_schema_extra=_meta("lora"),
+        json_schema_extra=_meta("lora", advanced=True),
     )
     lora_rs: bool = Field(
         False,
         description="rs-LoRA：scale=α/√r 而非 α/r，高 rank（>32）训练更稳",
-        json_schema_extra=_meta("lora"),
+        json_schema_extra=_meta("lora", advanced=True),
     )
     lora_dropout: float = Field(
         0.0, ge=0.0, le=1.0,
         description="LoRA 输入 dropout（0 关闭）",
-        json_schema_extra=_meta("lora"),
+        json_schema_extra=_meta("lora", advanced=True),
     )
     lora_rank_dropout: float = Field(
         0.0, ge=0.0, le=1.0,
         description="rank 维 dropout（防过拟合，对小数据集效果好）",
-        json_schema_extra=_meta("lora"),
+        json_schema_extra=_meta("lora", advanced=True),
     )
     lora_module_dropout: float = Field(
         0.0, ge=0.0, le=1.0,
         description="层级 stochastic depth（整层级别随机跳过）",
-        json_schema_extra=_meta("lora"),
+        json_schema_extra=_meta("lora", advanced=True),
     )
 
     # ------------------------------------------------------------------ 训练
@@ -253,17 +253,17 @@ class TrainingConfig(BaseModel):
     lr_scheduler_t0: int = Field(
         500, ge=1,
         description="cosine_with_restart 首次周期",
-        json_schema_extra=_meta("training", show_when="lr_scheduler==cosine_with_restart"),
+        json_schema_extra=_meta("training", show_when="lr_scheduler==cosine_with_restart", advanced=True),
     )
     lr_scheduler_t_mult: float = Field(
         2.0, ge=1.0,
         description="cosine_with_restart 周期倍数",
-        json_schema_extra=_meta("training", show_when="lr_scheduler==cosine_with_restart"),
+        json_schema_extra=_meta("training", show_when="lr_scheduler==cosine_with_restart", advanced=True),
     )
     lr_scheduler_eta_min: float = Field(
         1e-6, ge=0.0,
         description="最小学习率",
-        json_schema_extra=_meta("training", show_when="lr_scheduler!=none"),
+        json_schema_extra=_meta("training", show_when="lr_scheduler!=none", advanced=True),
     )
     optimizer_type: Literal["adamw", "prodigy", "prodigy_plus_schedulefree"] = Field(
         "adamw",
@@ -278,7 +278,7 @@ class TrainingConfig(BaseModel):
     prodigy_safeguard_warmup: bool = Field(
         True,
         description="Prodigy warmup 期间保护 d 增长",
-        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy"),
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy", advanced=True),
     )
     # ---------------- ProdigyPlusScheduleFree (PPSF) 专属字段 ----------------
     # 选 PPSF 时 lr_scheduler 必须为 none（Schedule-Free 不需要 scheduler，
@@ -291,112 +291,123 @@ class TrainingConfig(BaseModel):
     ppsf_prodigy_steps: int = Field(
         0, ge=0,
         description="PPSF 在第 N 步后冻结 d（0=训练全程不冻结，建议为总步数 1/4 到 1/2）",
-        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree", advanced=True),
     )
     ppsf_beta1: float = Field(
         0.9, ge=0.0, le=1.0,
         description="PPSF Adam β1（PPSF 默认 0.9）",
-        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree", advanced=True),
     )
     ppsf_beta2: float = Field(
         0.99, ge=0.0, le=1.0,
         description="PPSF Adam β2（PPSF 默认 0.99，比 AdamW 默认 0.999 更适合小 epoch）",
-        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree", advanced=True),
     )
     ppsf_split_groups: bool = Field(
         True,
         description="PPSF 按 param group 分别估计 d（推荐开启）",
-        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree", advanced=True),
     )
     ppsf_split_groups_mean: bool = Field(
         False,
         description="PPSF split_groups 启用时取各组 d 均值（LoRA 多 param group 建议关闭）",
-        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree", advanced=True),
     )
     ppsf_use_speed: bool = Field(
         False,
         description="PPSF 加速模式（实验性，可能引入不稳定）",
-        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree", advanced=True),
     )
     ppsf_fused_back_pass: bool = Field(
         False,
         description="PPSF 与 fused backward 集成（显存吃紧时开，可显著降显存）",
-        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree", advanced=True),
     )
     ppsf_use_stableadamw: bool = Field(
         True,
         description="PPSF 用 stable AdamW 归一化（推荐开启）",
-        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree"),
+        json_schema_extra=_meta("training", show_when="optimizer_type==prodigy_plus_schedulefree", advanced=True),
     )
     weight_decay: float = Field(
         0.0, ge=0.0,
         description="权重衰减（0=禁用）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("training", advanced=True),
     )
     kv_trim: bool = Field(
         False,
         description="【性能】Cross-attention KV trim：按实际 token 数裁到最近 bucket（64/128/256/512），减少 padding 计算量",
-        json_schema_extra=_meta("system"),
+        json_schema_extra=_meta("system", advanced=True),
     )
     noise_offset: float = Field(
         0.0, ge=0.0, le=0.2,
         description="【噪声增强】低频偏移强度，缓解亮度均值偏差（0=禁用，推荐 0.05-0.1）",
-        json_schema_extra=_meta("noise_schedule"),
+        json_schema_extra=_meta("noise_schedule", advanced=True),
     )
     pyramid_noise_iters: int = Field(
         0, ge=0, le=6,
         description="【噪声增强】多尺度噪声叠加层数（0=禁用；2-3 帮助全局光照构图学习）",
-        json_schema_extra=_meta("noise_schedule"),
+        json_schema_extra=_meta("noise_schedule", advanced=True),
     )
     pyramid_noise_discount: float = Field(
         0.35, ge=0.1, le=0.9,
         description="【噪声增强】金字塔每层衰减系数（仅 pyramid_noise_iters > 0）",
-        json_schema_extra=_meta("noise_schedule", show_when="pyramid_noise_iters!=0"),
+        json_schema_extra=_meta("noise_schedule", show_when="pyramid_noise_iters!=0", advanced=True),
     )
     timestep_sampling: Literal["logit_normal", "uniform", "logit_normal_low", "mode"] = Field(
         "logit_normal",
         description="【时间步采样】分布（logit_normal 为 SD3/Anima 默认）",
-        json_schema_extra=_meta("noise_schedule"),
+        json_schema_extra=_meta(
+            "noise_schedule",
+            disable_when="infonoise_enabled==true",
+            disable_hint="InfoNoise 接管采样",
+            advanced=True,
+        ),
     )
     timestep_shift: float = Field(
         3.0, ge=0.1, le=10.0,
         description="【时间步采样】logit-normal / mode shift（>1 偏向高噪声端，<1 偏向细节端）",
-        json_schema_extra=_meta("noise_schedule", show_when="timestep_sampling!=uniform"),
+        json_schema_extra=_meta(
+            "noise_schedule",
+            show_when="timestep_sampling!=uniform",
+            alt_description="【InfoNoise 热身期】InfoNoise 开启时作为热身阶段的 baseline shift，正式阶段由自适应 CDF 接管",
+            alt_description_when="infonoise_enabled==true",
+            advanced=True,
+        ),
     )
     infonoise_enabled: bool = Field(
         False,
         description="【InfoNoise】启用自适应时间步采样（基于 I-MMSE 信息量，自动聚焦有效训练区间）",
-        json_schema_extra=_meta("noise_schedule"),
+        json_schema_extra=_meta("noise_schedule", advanced=True),
     )
     infonoise_K: int = Field(
         64, ge=16, le=256,
         description="【InfoNoise】log-σ bin 数量",
-        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     infonoise_N_warm: int = Field(
         5000, ge=100,
         description="【InfoNoise】热身步数（热身期用 baseline logit-normal）",
-        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     infonoise_M: int = Field(
         100, ge=10,
         description="【InfoNoise】schedule 刷新周期（每 M 步重算一次采样分布）",
-        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     infonoise_B: int = Field(
         256, ge=32,
         description="【InfoNoise】每 bin 的 FIFO buffer 容量",
-        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     infonoise_beta: float = Field(
         0.9, ge=0.1, le=0.999,
         description="【InfoNoise】EMA 平滑率",
-        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     infonoise_N_min: int = Field(
         50, ge=1,
         description="【InfoNoise】触发刷新所需的每 bin 最小样本数",
-        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true"),
+        json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     loss_weighting: Literal["none", "min_snr", "detail_inv_t", "cosmap"] = Field(
         "none",
@@ -406,17 +417,17 @@ class TrainingConfig(BaseModel):
     min_snr_gamma: float = Field(
         5.0, ge=0.1, le=20.0,
         description="【损失加权】Min-SNR gamma 值（仅 loss_weighting=min_snr）",
-        json_schema_extra=_meta("noise_schedule", show_when="loss_weighting==min_snr"),
+        json_schema_extra=_meta("noise_schedule", show_when="loss_weighting==min_snr", advanced=True),
     )
     weight_cap_ratio: float = Field(
         0.0, ge=0.0, le=50.0,
         description="【损失加权】Batch 内权重 max/min 比上限（0=禁用；小 batch+Prodigy 建议 5）",
-        json_schema_extra=_meta("noise_schedule", show_when="loss_weighting!=none"),
+        json_schema_extra=_meta("noise_schedule", show_when="loss_weighting!=none", advanced=True),
     )
     grad_clip_max_norm: float = Field(
         0.0, ge=0.0,
         description="梯度裁剪最大范数（0=禁用）",
-        json_schema_extra=_meta("training"),
+        json_schema_extra=_meta("training", advanced=True),
     )
     mixed_precision: Literal["bf16", "fp16", "no"] = Field(
         "bf16",
@@ -436,7 +447,7 @@ class TrainingConfig(BaseModel):
     num_workers: int = Field(
         0, ge=0,
         description="数据加载线程（Windows 必须 0）",
-        json_schema_extra=_meta("system"),
+        json_schema_extra=_meta("system", advanced=True),
     )
 
     @model_validator(mode="before")
@@ -467,18 +478,23 @@ class TrainingConfig(BaseModel):
         json_schema_extra=_meta("output"),
     )
     save_every: int = Field(
-        0, ge=0,
+        2, ge=0,
         description="每 N epoch 保存（0=禁用）",
         json_schema_extra=_meta("output"),
     )
     save_every_steps: int = Field(
-        500, ge=0,
-        description="每 N step 保存（推荐）",
+        0, ge=0,
+        description="每 N step 保存（0=禁用）",
         json_schema_extra=_meta("output"),
     )
     save_state_every: int = Field(
-        1000, ge=0,
-        description="每 N step 保存完整训练状态（断点续训）",
+        0, ge=0,
+        description="每 N step 保存完整训练状态（断点续训，0=禁用）",
+        json_schema_extra=_meta("output"),
+    )
+    save_state_every_epochs: int = Field(
+        0, ge=0,
+        description="每 N epoch 保存完整训练状态（断点续训，0=禁用；与 save_state_every 取先到者）",
         json_schema_extra=_meta("output"),
     )
     seed: int = Field(
@@ -499,7 +515,7 @@ class TrainingConfig(BaseModel):
 
     # -------------------------------------------------------------------- 采样
     sample_every: int = Field(
-        5, ge=0,
+        2, ge=0,
         description="每 N epoch 采样（0=禁用）",
         json_schema_extra=_meta("sample"),
     )

--- a/studio/server.py
+++ b/studio/server.py
@@ -1092,7 +1092,7 @@ def project_thumb(
     """
     if bucket != "download":
         raise HTTPException(400, "PP2 仅支持 bucket=download")
-    if "/" in name or "\\" in name or ".." in name or not name:
+    if "/" in name or "\\" in name or not name:
         raise HTTPException(400, "invalid name")
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
@@ -1710,9 +1710,9 @@ def list_captions_endpoint(
 def get_caption_endpoint(
     pid: int, vid: int, folder: str, filename: str
 ) -> dict[str, Any]:
-    if "/" in filename or "\\" in filename or ".." in filename:
+    if "/" in filename or "\\" in filename:
         raise HTTPException(400, "invalid filename")
-    if "/" in folder or "\\" in folder or ".." in folder:
+    if "/" in folder or "\\" in folder:
         raise HTTPException(400, "invalid folder")
     _, _, train = _version_train_dir_or_404(pid, vid)
     try:
@@ -1725,9 +1725,9 @@ def get_caption_endpoint(
 def put_caption_endpoint(
     pid: int, vid: int, folder: str, filename: str, body: CaptionEdit
 ) -> dict[str, Any]:
-    if "/" in filename or "\\" in filename or ".." in filename:
+    if "/" in filename or "\\" in filename:
         raise HTTPException(400, "invalid filename")
-    if "/" in folder or "\\" in folder or ".." in folder:
+    if "/" in folder or "\\" in folder:
         raise HTTPException(400, "invalid folder")
     _, _, train = _version_train_dir_or_404(pid, vid)
     try:
@@ -2245,7 +2245,7 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
     直接返回 bytes。LRU / 客户端断连清理在 commit 11 加 —— 在那之前 cache
     跟着 supervisor finalize 释放（一 task 一组 entry，task 终止时全清）。
     """
-    if "/" in filename or "\\" in filename or ".." in filename:
+    if "/" in filename or "\\" in filename:
         raise HTTPException(400, "invalid filename")
     if not filename.lower().endswith(".png"):
         raise HTTPException(400, "only .png supported")
@@ -2461,7 +2461,7 @@ def version_thumb(
 ) -> FileResponse:
     if bucket not in {"train", "reg", "samples"}:
         raise HTTPException(400, f"非法 bucket: {bucket}")
-    if "/" in name or "\\" in name or ".." in name or not name:
+    if "/" in name or "\\" in name or not name:
         raise HTTPException(400, "invalid name")
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
@@ -2808,7 +2808,7 @@ def download_task_outputs_zip(
 def download_task_output(task_id: int, filename: str) -> FileResponse:
     """下载 output 目录下的指定文件。`Content-Disposition: attachment` 让
     浏览器走「保存」对话框而不是 inline 渲染。"""
-    if "/" in filename or "\\" in filename or ".." in filename or not filename:
+    if "/" in filename or "\\" in filename or not filename:
         raise HTTPException(400, "invalid filename")
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
@@ -2908,7 +2908,7 @@ def browse_dir(path: str = "") -> dict[str, Any]:
 @app.get("/api/datasets/thumbnail")
 def get_dataset_thumbnail(folder: str, name: str) -> FileResponse:
     """返回 dataset 缩略图（实际是原图，前端用 CSS 缩放）。"""
-    if ".." in folder or ".." in name or "\\" in name or "/" in name:
+    if "\\" in name or "/" in name:
         raise HTTPException(400, "invalid path component")
     p = (Path(folder) / name).resolve()
     # 保证落在 repo 内（防止任意磁盘读取）
@@ -2980,7 +2980,7 @@ def get_sample(
     不给 → 返回原图。两种都走 _thumb_response 的弱 etag + no-cache，浏览器
     304 命中即可，避免「重启窗口期失败响应被永久缓存」问题。
     """
-    if "/" in filename or "\\" in filename or ".." in filename:
+    if "/" in filename or "\\" in filename:
         raise HTTPException(400, "invalid filename")
 
     resolved: Optional[Path] = None

--- a/studio/services/caption_snapshot.py
+++ b/studio/services/caption_snapshot.py
@@ -89,7 +89,7 @@ def list_snapshots(version_dir: Path) -> list[dict[str, Any]]:
 
 
 def _resolve_snapshot(version_dir: Path, sid: str) -> Path:
-    if "/" in sid or "\\" in sid or ".." in sid or not sid:
+    if "/" in sid or "\\" in sid or not sid:
         raise SnapshotError(f"非法 id: {sid}")
     p = snapshot_root(version_dir) / f"{sid}.zip"
     if not p.exists():

--- a/studio/services/pending_install.py
+++ b/studio/services/pending_install.py
@@ -72,10 +72,15 @@ def apply_pending() -> None:
     if kind == "torch":
         target = pending.get("target", "auto")
         print(f"[studio] 检测到 pending torch 重装请求 (target={target})，开始安装...")
+        print("[studio] 提示：按 Ctrl+C 可跳过本次安装（marker 保留，下次启动重试）")
         # 延迟 import：torch_setup -> onnxruntime_setup 链触发的副作用全留到此刻
         from . import torch_setup  # noqa: PLC0415
         try:
-            res = torch_setup.reinstall(target)
+            res = torch_setup.reinstall(target, stream=True)
+        except KeyboardInterrupt:
+            print("\n[studio] 用户中断 torch 重装，跳过。marker 保留，下次启动会重试。",
+                  file=sys.stderr)
+            return  # 不 clear_pending，下次启动继续尝试
         except RuntimeError as exc:
             print(f"[studio] torch 重装失败: {exc}", file=sys.stderr)
             print("[studio] marker 保留，下次启动会重试", file=sys.stderr)

--- a/studio/services/torch_setup.py
+++ b/studio/services/torch_setup.py
@@ -158,14 +158,19 @@ def current_status() -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _pip(args: list[str], timeout: int = 1800) -> tuple[int, str]:
+def _pip(args: list[str], timeout: int = 1800, stream: bool = False) -> tuple[int, str]:
     """跑 `<sys.executable> -m pip <args>`；返回 (rc, combined_output)。
 
     timeout 默认 30 分钟 —— torch + cuda 依赖打包后 ~3 GB，慢网下一小时也可能。
+    stream=True：输出直接透传到终端（launch 场景用），不捕获，返回空字符串。
+    stream=False（默认）：捕获并返回文本（API 端点 / 日志用）。
     """
     cmd = [sys.executable, "-m", "pip", *args]
     logger.info("[torch_setup] %s", " ".join(cmd))
     try:
+        if stream:
+            rc = subprocess.call(cmd, timeout=timeout)
+            return rc, ""
         out = subprocess.run(
             cmd,
             capture_output=True,
@@ -224,7 +229,7 @@ def _cleanup_zombie_dirs() -> list[str]:
     return cleaned
 
 
-def reinstall(target: str = "auto") -> dict[str, Any]:
+def reinstall(target: str = "auto", stream: bool = False) -> dict[str, Any]:
     """卸装 torch + torchvision，按 target 重装。
 
     target: "auto" | "cu128" | "cu126" | "cu124" | "cu118" | "cpu"
@@ -248,7 +253,7 @@ def reinstall(target: str = "auto") -> dict[str, Any]:
 
     # 第二步：卸装 torch + torchvision（user-installed flash_attn / xformers 等不动，
     # 跟 torch ABI 强绑定，但卸装 torch 不会自动卸它们 —— 用户重启后再 enable / 重装）
-    rc1, log1 = _pip(["uninstall", "-y", "torch", "torchvision"])
+    rc1, log1 = _pip(["uninstall", "-y", "torch", "torchvision"], stream=stream)
 
     # 卸装后再清一次僵尸目录（pip 卸装失败也可能留 `~`-prefix 残留）
     cleaned += _cleanup_zombie_dirs()
@@ -257,7 +262,7 @@ def reinstall(target: str = "auto") -> dict[str, Any]:
     install_args = ["install", "torch", "torchvision"]
     if index_url:
         install_args += ["--index-url", index_url]
-    rc2, log2 = _pip(install_args)
+    rc2, log2 = _pip(install_args, stream=stream)
     if rc2 != 0:
         raise RuntimeError(f"安装 torch ({tag}) 失败（rc={rc2}）:\n{log2}")
 

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -118,7 +118,6 @@ export interface WandBConfig {
   entity: string
   base_url: string
   mode: 'online' | 'offline' | 'disabled'
-  log_samples: boolean
   /** 上传前缩到最长边像素，默认 512 */
   sample_max_side: number
   /** step 节流：>0 时只在 global_step % N == 0 上传，0 = 不额外节流 */

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -42,6 +42,12 @@ export interface SchemaProperty {
   disable_when?: string
   /** disable_when 触发时显示的提示徽章文本。 */
   disable_hint?: string
+  /** 条件说明文字：当 alt_description_when 表达式为真时，替换 description 显示。 */
+  alt_description?: string
+  /** 触发 alt_description 的条件表达式，语法同 show_when。 */
+  alt_description_when?: string
+  /** 高级模式专属字段，简单模式下隐藏。 */
+  advanced?: boolean
   /** 后端打了 hidden=True 的字段：值仍随 ConfigData 透传 / 保存，但 SchemaForm
    * 不渲染。用于「该字段对当前用户群无意义但 schema 必须保留」的兜底场景。 */
   hidden?: boolean

--- a/studio/web/src/components/Field.tsx
+++ b/studio/web/src/components/Field.tsx
@@ -16,6 +16,8 @@ interface Props {
    * 与 disabled 解耦：可以让字段保持可编辑只挂个徽章作信息提示，也可以
    * 配合 disabled 来表达「这字段被自动填且不让你改」。 */
   hint?: string
+  /** 覆盖 prop.description 的说明文字（用于条件上下文描述）。 */
+  descriptionOverride?: string
 }
 
 // input 覆盖 .input 默认值（更紧凑；背景用 canvas 而不是 surface）
@@ -32,11 +34,11 @@ const FieldHint = ({ text }: { text: string }) => (
 
 /** 单个表单字段，按 control kind 分发渲染。 */
 export default function Field({
-  name, prop, value, onChange, disabled = false, hint,
+  name, prop, value, onChange, disabled = false, hint, descriptionOverride,
 }: Props) {
   const kind = controlKind(prop)
   const label = fieldLabel(name)
-  const help = prop.description
+  const help = descriptionOverride ?? prop.description
   const hintText = hint ?? (disabled ? '自动 · 项目控制' : null)
   const hintNode = hintText ? <FieldHint text={hintText} /> : null
   void name

--- a/studio/web/src/components/SchemaForm.tsx
+++ b/studio/web/src/components/SchemaForm.tsx
@@ -14,6 +14,8 @@ interface Props {
   /** 字段不 disabled 但要挂个徽章（如「自动 · 项目设置」表示项目预填了，
    * 但仍允许用户修改）。优先级：disabledHints > autoHints。 */
   autoHints?: Record<string, string>
+  /** false（默认）= 简单模式，隐藏 advanced=true 的字段。 */
+  advancedMode?: boolean
 }
 
 /**
@@ -21,7 +23,7 @@ interface Props {
  * show_when 用 evalShowWhen 做条件显示，依赖当前 values。
  */
 export default function SchemaForm({
-  schema, values, onChange, disabledFields, disabledHints, autoHints,
+  schema, values, onChange, disabledFields, disabledHints, autoHints, advancedMode = false,
 }: Props) {
   const disabledSet = new Set(disabledFields ?? [])
   const dHints = disabledHints ?? {}
@@ -65,6 +67,7 @@ export default function SchemaForm({
   const buckets = new Map<string, string[]>()
   for (const [name, prop] of Object.entries(props)) {
     if (prop.hidden) continue
+    if (prop.advanced && !advancedMode) continue
     const g = prop.group ?? 'misc'
     if (!buckets.has(g)) buckets.set(g, [])
     buckets.get(g)!.push(name)
@@ -110,6 +113,12 @@ export default function SchemaForm({
                     : conditionallyDisabled
                       ? prop.disable_hint
                       : aHints[name]
+                  const descriptionOverride =
+                    prop.alt_description_when &&
+                    prop.alt_description &&
+                    evalShowWhen(prop.alt_description_when, values)
+                      ? prop.alt_description
+                      : undefined
                   return (
                     <Field
                       key={name}
@@ -119,6 +128,7 @@ export default function SchemaForm({
                       onChange={(v) => setField(name, v)}
                       disabled={isDisabled}
                       hint={hint}
+                      descriptionOverride={descriptionOverride}
                     />
                   )
                 })}

--- a/studio/web/src/components/Sidebar.tsx
+++ b/studio/web/src/components/Sidebar.tsx
@@ -229,8 +229,8 @@ function ProjectStepperNav({ pid, activeVid, currentStep, version, collapsed }: 
   }
 
   const linkCls = (active: boolean) => [
-    'flex w-full items-center gap-2.5 rounded-md text-sm no-underline transition-colors',
-    collapsed ? 'py-[7px] px-0 justify-center' : 'py-[7px] px-3 justify-start',
+    'flex items-center gap-2.5 rounded-md text-sm no-underline transition-colors',
+    collapsed ? 'py-2 px-0 justify-center' : 'py-2 px-3 justify-start',
     active ? 'bg-surface text-fg-primary font-semibold shadow-sm' : 'text-fg-secondary font-normal hover:bg-overlay',
   ].join(' ')
 
@@ -379,7 +379,7 @@ export default function Sidebar() {
       </div>
 
       {/* main nav */}
-      <nav className={`flex-1 flex flex-col gap-0.5 overflow-y-auto ${collapsed ? 'px-1.5 py-2.5' : 'px-2.5 py-3.5'}`}>
+      <nav className={`flex-1 flex flex-col gap-0.5 overflow-hidden ${collapsed ? 'px-2 py-2.5' : 'px-2 py-3.5'}`}>
         <NavItem to="/" label="项目" icon={I.folder} active={!inProject && location.pathname === '/'} collapsed={collapsed} />
         <NavItem to="/queue" label="队列" icon={I.queue} active={isMain('/queue')} collapsed={collapsed} />
         <NavItem to="/tools/generate" label="测试" icon={I.image} active={isMain('/tools/generate')} collapsed={collapsed} />

--- a/studio/web/src/components/Sidebar.tsx
+++ b/studio/web/src/components/Sidebar.tsx
@@ -91,7 +91,7 @@ function NavItem({ to, label, icon, active, collapsed }: {
       to={to}
       title={collapsed ? label : undefined}
       className={[
-        'flex items-center gap-2.5 rounded-md text-sm no-underline transition-colors relative',
+        'flex w-full items-center gap-2.5 rounded-md text-sm no-underline transition-colors relative',
         collapsed ? 'py-[9px] px-0 justify-center' : 'py-2 px-3 justify-start',
         active
           ? 'bg-surface text-fg-primary font-semibold shadow-sm'
@@ -229,7 +229,7 @@ function ProjectStepperNav({ pid, activeVid, currentStep, version, collapsed }: 
   }
 
   const linkCls = (active: boolean) => [
-    'flex items-center gap-2.5 rounded-md text-sm no-underline transition-colors',
+    'flex w-full items-center gap-2.5 rounded-md text-sm no-underline transition-colors',
     collapsed ? 'py-[7px] px-0 justify-center' : 'py-[7px] px-3 justify-start',
     active ? 'bg-surface text-fg-primary font-semibold shadow-sm' : 'text-fg-secondary font-normal hover:bg-overlay',
   ].join(' ')

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -66,12 +66,12 @@ export default function TrainPage() {
   const [pickerOpen, setPickerOpen] = useState(false)
   const [pickerSearch, setPickerSearch] = useState('')
   const [advancedMode, setAdvancedMode] = useState(() =>
-    localStorage.getItem('train_advanced_mode') === 'true'
+    localStorage.getItem('advanced_mode') === 'true'
   )
   const toggleAdvancedMode = () => {
     setAdvancedMode(v => {
       const next = !v
-      localStorage.setItem('train_advanced_mode', String(next))
+      localStorage.setItem('advanced_mode', String(next))
       return next
     })
   }

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -65,6 +65,16 @@ export default function TrainPage() {
   // 预设 picker（dropdown 模式，与 Presets 页一致）
   const [pickerOpen, setPickerOpen] = useState(false)
   const [pickerSearch, setPickerSearch] = useState('')
+  const [advancedMode, setAdvancedMode] = useState(() =>
+    localStorage.getItem('train_advanced_mode') === 'true'
+  )
+  const toggleAdvancedMode = () => {
+    setAdvancedMode(v => {
+      const next = !v
+      localStorage.setItem('train_advanced_mode', String(next))
+      return next
+    })
+  }
   const pickerAnchorRef = useRef<HTMLButtonElement | null>(null)
   const pickerPopRef = useRef<HTMLDivElement | null>(null)
 
@@ -630,6 +640,24 @@ export default function TrainPage() {
               </div>
             ) : config ? (
               <section className="flex-1 min-h-0 overflow-y-auto pr-1">
+                <div className="flex justify-end mb-2">
+                  <div className="inline-flex rounded-md border border-subtle overflow-hidden text-xs">
+                    <button
+                      type="button"
+                      onClick={() => !advancedMode || toggleAdvancedMode()}
+                      className={`px-3 py-1 transition-colors ${!advancedMode ? 'bg-accent text-white' : 'bg-surface text-fg-secondary hover:bg-subtle'}`}
+                    >
+                      简单
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => advancedMode || toggleAdvancedMode()}
+                      className={`px-3 py-1 transition-colors ${advancedMode ? 'bg-accent text-white' : 'bg-surface text-fg-secondary hover:bg-subtle'}`}
+                    >
+                      高级
+                    </button>
+                  </div>
+                </div>
                 <SchemaForm
                   schema={schema}
                   values={config}
@@ -637,6 +665,7 @@ export default function TrainPage() {
                   disabledFields={disabledFields}
                   disabledHints={disabledHints}
                   autoHints={autoHints}
+                  advancedMode={advancedMode}
                 />
               </section>
             ) : (

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -79,6 +79,16 @@ export default function PresetsPage() {
   const [pickerOpen, setPickerOpen] = useState(false)
   const [pickerSearch, setPickerSearch] = useState('')
   const [tomlOpen, setTomlOpen] = useState(false)
+  const [advancedMode, setAdvancedMode] = useState(() =>
+    localStorage.getItem('advanced_mode') === 'true'
+  )
+  const toggleAdvancedMode = () => {
+    setAdvancedMode(v => {
+      const next = !v
+      localStorage.setItem('advanced_mode', String(next))
+      return next
+    })
+  }
   const pickerAnchorRef = useRef<HTMLButtonElement | null>(null)
   const pickerPopRef = useRef<HTMLDivElement | null>(null)
   const newNameInputRef = useRef<HTMLInputElement | null>(null)
@@ -544,11 +554,29 @@ export default function PresetsPage() {
               <div className="flex items-center gap-2 mb-2.5">
                 <span className="inline-block w-1.5 h-1.5 rounded-full bg-fg-tertiary shrink-0" />
                 <span className="caption uppercase tracking-[0.06em] text-xs">训练参数</span>
+                <span className="flex-1" />
+                <div className="inline-flex rounded-md border border-subtle overflow-hidden text-xs">
+                  <button
+                    type="button"
+                    onClick={() => advancedMode && toggleAdvancedMode()}
+                    className={`px-3 py-1 transition-colors ${!advancedMode ? 'bg-accent text-white' : 'bg-surface text-fg-secondary hover:bg-subtle'}`}
+                  >
+                    简单
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => !advancedMode && toggleAdvancedMode()}
+                    className={`px-3 py-1 transition-colors ${advancedMode ? 'bg-accent text-white' : 'bg-surface text-fg-secondary hover:bg-subtle'}`}
+                  >
+                    高级
+                  </button>
+                </div>
               </div>
               <SchemaForm
                 schema={schema}
                 values={config}
                 onChange={setConfig}
+                advancedMode={advancedMode}
               />
             </section>
           )}

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -28,7 +28,6 @@ const initialServerState = {
     entity: '',
     base_url: '',
     mode: 'online',
-    log_samples: false,
     sample_max_side: 512,
     sample_every_n_steps: 0,
   },

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -28,7 +28,7 @@ const initialServerState = {
     entity: '',
     base_url: '',
     mode: 'online',
-    sample_max_side: 512,
+    sample_max_side: 1216,
     sample_every_n_steps: 0,
   },
   llm_tagger: {

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -176,7 +176,6 @@ const EMPTY: Secrets = {
     entity: '',
     base_url: '',
     mode: 'online',
-    log_samples: false,
     sample_max_side: 512,
     sample_every_n_steps: 0,
   },
@@ -886,17 +885,8 @@ export default function SettingsPage() {
               <option value="disabled">disabled</option>
             </select>
           </SettingsField>
-          <SettingsField
-            label="记录采样图"
-            helpTooltip={
-              <p>开启后训练采样图会上传到 <code>wandb.ai</code> 公网；私有 IP / NSFW 数据集请保持关闭。</p>
-            }
-          >
-            <Bool value={draft.wandb.log_samples} onChange={(v) => update('wandb', 'log_samples', v)} />
-          </SettingsField>
         </div>
-        {draft.wandb.log_samples && (
-          <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-2 gap-3">
             <SettingsField
               label="采样图最长边"
               helpTooltip={<p>上传前缩到此像素。原图常 2K+，512 已够 wandb 浏览。</p>}

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -176,7 +176,7 @@ const EMPTY: Secrets = {
     entity: '',
     base_url: '',
     mode: 'online',
-    sample_max_side: 512,
+    sample_max_side: 1216,
     sample_every_n_steps: 0,
   },
   modelscope: { token: '' },
@@ -889,14 +889,14 @@ export default function SettingsPage() {
         <div className="grid grid-cols-2 gap-3">
             <SettingsField
               label="采样图最长边"
-              helpTooltip={<p>上传前缩到此像素。原图常 2K+，512 已够 wandb 浏览。</p>}
+              helpTooltip={<p>上传前缩到此像素。原图常 2K+，1216 已够 wandb 浏览。</p>}
             >
               <input
                 type="number"
                 min={64}
                 step={64}
                 value={draft.wandb.sample_max_side}
-                onChange={(e) => update('wandb', 'sample_max_side', Math.max(64, parseInt(e.target.value) || 512))}
+                onChange={(e) => update('wandb', 'sample_max_side', Math.max(64, parseInt(e.target.value) || 1216))}
                 className={textInputClass}
               />
             </SettingsField>
@@ -916,7 +916,6 @@ export default function SettingsPage() {
               />
             </SettingsField>
           </div>
-        )}
       </SettingsSection>
       </>)}
 

--- a/studio/web/vite.config.ts
+++ b/studio/web/vite.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     emptyOutDir: true,
+    chunkSizeWarningLimit: 700,
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Summary

### Training

- **InfoNoise adaptive timestep sampler** (`runtime/training/infonoise.py`)  
  Based on the I-MMSE identity (d/dσ H[x0|xσ] = mmse/σ³): tracks per-bin denoising MSE via FIFO buffers + EMA, builds an inverse-CDF sampler that concentrates draws on the informative noise window. Falls back to logit-normal baseline during warm-up. Integrated into ADR 0003 structure (new `training/infonoise.py`, wired via `TrainingContext.info_noise` and `phases/optimizer.py`).
  - `infonoise_N_warm = 0` auto-computes as `max(200, total_steps × 20%)` — fixes the hardcoded 5000-step warmup exceeding short runs
  - Seven `infonoise_*` config fields, all disabled by default (zero impact on existing runs)

- **wandb metrics improvements**
  - Remove redundant `train/epoch` from per-step log (step axis is sufficient)
  - Add `train/loss_epoch` (epoch-average loss) + `train/epoch` logged once at epoch boundary
  - Sample images now always sent to wandb when enabled (removed `log_samples` gate)

- **`wandb` promoted to required dependency** (was optional comment in requirements.txt)

### UI / Schema

- **Simple / Advanced mode toggle** on both the Train page and Presets page, synced via shared `localStorage` key `advanced_mode`. 35 fields are hidden in simple mode (dropouts, scheduler tuning, PPSF knobs, noise schedule details, etc.)
- **Schema group reorganization**: new `noise_schedule` group (noise offset, pyramid noise, timestep sampling, InfoNoise, loss weighting); `kv_trim` / `mixed_precision` / `attention_backend` / `num_workers` moved to `system` group
- **`grad_checkpoint` moved** to training group, positioned above `grad_accum`
- **Context-sensitive field descriptions**: `timestep_shift` shows warm-up context when InfoNoise is active; `timestep_sampling` disabled with hint when InfoNoise is enabled
- **Save defaults fixed**: `save_every` → 2, `save_every_steps` → 0, `sample_every` → 2, `save_state_every` → 0; new `save_state_every_epochs` field
- **Sidebar nav fix**: `overflow-hidden` + unified `px-2` removes the ~10px scrollbar-gutter slot that caused icons to appear left-shifted in collapsed state

### CLI / Launcher

- **`--torch <tag>` flag** (`studio.sh` / `studio.bat` / `cli.py`): forces a specific CUDA torch wheel (`cu128`/`cu126`/`cu124`/`cu118`/`cpu`) — useful on CPU-only rental machines where GPU torch can't auto-detect. Skippable with Ctrl+C. Passes through `--skip-pending` to bypass pending-install on restart.
- **`--fe-port` flag** for `dev` subcommand: sets the Vite dev server port (default 5173)
- **Default subcommand fix**: `studio.sh --port 6006` no longer fails with `invalid choice: '6006'` — unknown positional args now correctly default to `run` subcommand
- **Streaming pip output** + graceful Ctrl+C during pending torch install

## Test plan

- [x] Train a short run (< 1000 steps) with `infonoise_enabled: true` — confirm N_warm auto-computes correctly and sampler activates after warmup
- [ ] Train with `infonoise_enabled: false` (default) — confirm zero behavior change vs baseline
- [x] Toggle simple/advanced on Train page and Presets page — confirm state syncs across both pages
- [x] `./studio.sh --port 6006` — confirm starts without argparse error
- [ ] `./studio.sh --torch cu128` on a CPU-only machine — confirm torch reinstall triggers and is skippable with Ctrl+C
- [ ] Check wandb dashboard: per-step log should not have `epoch` key; epoch boundary should emit `loss_epoch` + `epoch`; sample images should appear regardless of `log_samples` setting
