### PR TITLE
fix(ui): improve generate and queue workflows

### DIFF
--- a/studio/server.py
+++ b/studio/server.py
@@ -2254,7 +2254,11 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
     data = generate_cache.get_image(task_id, filename)
     if data is None:
         raise HTTPException(404)
-    return Response(content=data, media_type="image/png")
+    return Response(
+        content=data,
+        media_type="image/png",
+        headers={"Cache-Control": "no-store"},
+    )
 
 
 @app.delete("/api/projects/{pid}/versions/{vid}/reg")

--- a/studio/web/src/components/BulkActionBar.tsx
+++ b/studio/web/src/components/BulkActionBar.tsx
@@ -177,7 +177,7 @@ export default function BulkActionBar({
 
       {/* Hint row */}
       <div className="text-fg-tertiary text-[11px]">
-        alt+点击 = 查看大图并编辑 · 普通点击 = 多选
+        点击图片 = 查看大图并编辑 · 勾选 = 多选 · Shift/Ctrl+点击 = 快速多选
       </div>
 
       {/* Popover row */}

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -124,10 +124,11 @@ export default function QueuePage() {
   }, [tasks])
 
   // 当前 running 任务的 id，给 monitor 进度条 / 状态卡片用。
-  const runningTaskId = useMemo(
-    () => tasks.find((t) => t.status === 'running')?.id ?? null,
+  const runningTask = useMemo(
+    () => tasks.find((t) => t.status === 'running') ?? null,
     [tasks],
   )
+  const runningTaskId = runningTask?.id ?? null
   // monitor 进度走 useMonitorProgress hook (PR #37 增量协议)：runningTaskId
   // 切换时 hook 自动清状态 + 重拉 /api/state 冷启动；不需要本组件再写清理逻辑。
   const { state: monitor } = useMonitorProgress(runningTaskId)
@@ -164,6 +165,25 @@ export default function QueuePage() {
 
   const hasRunning = useMemo(() => tasks.some(t => t.status === 'running'), [tasks])
 
+  const pauseRunning = async () => {
+    if (!runningTask) return
+    const ok = await confirm(
+      `暂停当前任务 #${runningTask.id}？会向后台发送取消信号，任务会在安全点停止。`,
+      { tone: 'warn', okText: '暂停任务' },
+    )
+    if (!ok) return
+    setBusy(true)
+    try {
+      await api.cancelTask(runningTask.id)
+      toast('已发送暂停信号', 'success')
+      await reload()
+    } catch (e) {
+      toast(String(e), 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
   return (
     <StepShell
       idx={-1}
@@ -173,8 +193,13 @@ export default function QueuePage() {
         <>
           <button onClick={clearDone} disabled={busy} className="btn btn-ghost btn-sm">清理已完成</button>
           {hasRunning && (
-            <button className="btn btn-secondary btn-sm text-warn border-warn">
-              暂停队列
+            <button
+              onClick={() => void pauseRunning()}
+              disabled={busy || !runningTask}
+              className="btn btn-secondary btn-sm text-warn border-warn"
+              title="发送取消信号，让当前运行任务停止"
+            >
+              暂停当前任务
             </button>
           )}
           <button

--- a/studio/web/src/pages/project/Overview.tsx
+++ b/studio/web/src/pages/project/Overview.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useMemo, useState } from 'react'
 import { useNavigate, useOutletContext } from 'react-router-dom'
-import { api, type ProjectDetail, type Version } from '../../api/client'
+import { api, type ProjectDetail, type Task, type Version } from '../../api/client'
 import PageHeader from '../../components/PageHeader'
 import StageBadge from '../../components/StageBadge'
 import { useToast } from '../../components/Toast'
@@ -178,6 +179,20 @@ export default function ProjectOverview() {
   const { project, activeVersion, reload, onCreateVersion, creatingVersionBusy } = useOutletContext<Ctx>()
   const navigate = useNavigate()
   const { toast } = useToast()
+  const [relatedTasks, setRelatedTasks] = useState<Task[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    void api.listQueue()
+      .then((items) => {
+        if (cancelled) return
+        setRelatedTasks(items.filter((t) => t.project_id === project.id))
+      })
+      .catch(() => {
+        if (!cancelled) setRelatedTasks([])
+      })
+    return () => { cancelled = true }
+  }, [project.id])
 
   const handleActivate = async (v: Version) => {
     try {
@@ -223,6 +238,15 @@ export default function ProjectOverview() {
   ]
 
   const steps = deriveTimeline(project, activeVersion)
+
+  const latestOutputTaskByVersion = useMemo(() => {
+    const out = new Map<number, Task>()
+    for (const task of [...relatedTasks].sort((a, b) => b.id - a.id)) {
+      if (task.status !== 'done' || task.version_id == null) continue
+      if (!out.has(task.version_id)) out.set(task.version_id, task)
+    }
+    return out
+  }, [relatedTasks])
 
   const nextStep = steps.find(s => s.status === 'active')
   const nextStepPaths: Record<string, string> = {
@@ -321,6 +345,15 @@ export default function ProjectOverview() {
                     >
                       {isActive ? '打开' : '激活并打开'}
                     </button>
+                    {latestOutputTaskByVersion.has(v.id) && (
+                      <button
+                        className="btn btn-ghost btn-sm ml-2"
+                        onClick={() => navigate(`/queue/${latestOutputTaskByVersion.get(v.id)!.id}#outputs`)}
+                        title="打开该版本最近一次完成任务的 output"
+                      >
+                        查看输出
+                      </button>
+                    )}
                   </div>
                 </div>
               )

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -158,7 +158,6 @@ export default function TagEditPage() {
   }
 
   const handleClick = (key: string, e: React.MouseEvent) => {
-    if (e.altKey) { setActiveKey(key); return }
     const r = applySelection(sel, key, e, filteredKeys, anchor)
     setSel(r.next); setAnchor(r.anchor)
   }
@@ -199,7 +198,13 @@ export default function TagEditPage() {
     } catch (e) { toast(String(e), 'error') }
   }
 
-  const onAfterRestore = async () => { await reloadCache(); await reload() }
+  const onAfterRestore = async () => {
+    await reloadCache()
+    setActiveKey('')
+    setSel(new Set())
+    setAnchor(null)
+    await reload()
+  }
 
   const downloadTrainZip = async () => {
     if (dirty) {
@@ -283,6 +288,8 @@ export default function TagEditPage() {
               selected={sel}
               activeName={activeKey || undefined}
               onSelect={handleClick}
+              onActivate={setActiveKey}
+              clickMode="activate"
               ariaLabel="tag-edit-grid"
               emptyHint={filterTag ? `没有图含「${filterTag}」` : '还没有图。请先在筛选和打标步骤完成操作。'}
             />

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -598,7 +598,7 @@ export default function PresetsPage() {
 function SkeletonGroups() {
   const rows = [5, 6, 4, 5]
   return (
-    <div className="flex flex-col gap-3">
+    <div className="flex flex-col gap-3 animate-pulse" role="status" aria-label="加载预设配置中">
       {rows.map((r, gi) => (
         <div key={gi} className="flex flex-col gap-2">
           <div className="h-3 w-24 rounded-sm bg-sunken opacity-60" />
@@ -612,6 +612,7 @@ function SkeletonGroups() {
           </div>
         </div>
       ))}
+      <span className="sr-only">加载预设配置中...</span>
     </div>
   )
 }

--- a/studio/web/src/pages/tools/generate/FullscreenViewer.tsx
+++ b/studio/web/src/pages/tools/generate/FullscreenViewer.tsx
@@ -8,19 +8,46 @@ import { useEffect } from 'react'
  */
 export default function FullscreenViewer({
   src, alt, caption, onClose,
+  hasPrev, hasNext, hasUp, hasDown,
+  onPrev, onNext, onUp, onDown,
+  shortcutHint,
 }: {
   src: string
   alt?: string
   caption?: string
   onClose: () => void
+  hasPrev?: boolean
+  hasNext?: boolean
+  hasUp?: boolean
+  hasDown?: boolean
+  onPrev?: () => void
+  onNext?: () => void
+  onUp?: () => void
+  onDown?: () => void
+  shortcutHint?: string
 }) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        onClose()
+      } else if (e.key === 'ArrowLeft' && hasPrev && onPrev) {
+        e.preventDefault()
+        onPrev()
+      } else if (e.key === 'ArrowRight' && hasNext && onNext) {
+        e.preventDefault()
+        onNext()
+      } else if (e.key === 'ArrowUp' && hasUp && onUp) {
+        e.preventDefault()
+        onUp()
+      } else if (e.key === 'ArrowDown' && hasDown && onDown) {
+        e.preventDefault()
+        onDown()
+      }
     }
     document.addEventListener('keydown', onKey)
     return () => document.removeEventListener('keydown', onKey)
-  }, [onClose])
+  }, [hasDown, hasNext, hasPrev, hasUp, onClose, onDown, onNext, onPrev, onUp])
 
   return (
     <div
@@ -35,6 +62,50 @@ export default function FullscreenViewer({
       }}
     >
       <div className="flex flex-col items-center gap-2" onClick={(e) => e.stopPropagation()}>
+        {hasUp && onUp && (
+          <button
+            type="button"
+            onClick={onUp}
+            className="absolute top-4 left-1/2 -translate-x-1/2 z-10 rounded bg-black/45 px-4 py-2 text-slate-300 hover:text-white hover:bg-black/65 text-2xl"
+            aria-label="上一行"
+            title="上一行"
+          >
+            ↑
+          </button>
+        )}
+        {hasPrev && onPrev && (
+          <button
+            type="button"
+            onClick={onPrev}
+            className="absolute left-4 top-1/2 -translate-y-1/2 z-10 rounded bg-black/45 px-4 py-3 text-slate-300 hover:text-white hover:bg-black/65 text-4xl"
+            aria-label="左一格"
+            title="左一格"
+          >
+            ‹
+          </button>
+        )}
+        {hasNext && onNext && (
+          <button
+            type="button"
+            onClick={onNext}
+            className="absolute right-4 top-1/2 -translate-y-1/2 z-10 rounded bg-black/45 px-4 py-3 text-slate-300 hover:text-white hover:bg-black/65 text-4xl"
+            aria-label="右一格"
+            title="右一格"
+          >
+            ›
+          </button>
+        )}
+        {hasDown && onDown && (
+          <button
+            type="button"
+            onClick={onDown}
+            className="absolute bottom-12 left-1/2 -translate-x-1/2 z-10 rounded bg-black/45 px-4 py-2 text-slate-300 hover:text-white hover:bg-black/65 text-2xl"
+            aria-label="下一行"
+            title="下一行"
+          >
+            ↓
+          </button>
+        )}
         <img
           src={src}
           alt={alt}
@@ -51,7 +122,7 @@ export default function FullscreenViewer({
           </div>
         )}
         <div className="text-2xs text-fg-tertiary">
-          ESC / 点击遮罩关闭 · 在新窗口打开请按右键
+          {shortcutHint ?? 'ESC / 点击遮罩关闭 · 在新窗口打开请按右键'}
         </div>
       </div>
     </div>

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.test.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
 import InlineLoraPicker, { projectAbbr } from './InlineLoraPicker'
@@ -38,6 +38,8 @@ describe('projectAbbr', () => {
 })
 
 describe('InlineLoraPicker', () => {
+  const rows = () => within(screen.getByTestId('inline-lora-list'))
+
   function renderPicker(overrides: Partial<{
     projectLoras: ProjectLora[]
     selectedPaths: Set<string>
@@ -63,13 +65,26 @@ describe('InlineLoraPicker', () => {
     expect(screen.getByText(/已选 0 \/ 3/)).toBeInTheDocument()
   })
 
-  it('groups versions by project title', () => {
+  it('shows project and version labels in each row', () => {
     renderPicker()
-    // 项目名作为 caption uppercase 显示（出现 2 次：组头 + cute_chibi 的 2 行 + noir 的 1 行）
-    // 用更稳的断言：每个 version 都渲染了
-    expect(screen.getByText(/cute_chibi \/ v3/)).toBeInTheDocument()
-    expect(screen.getByText(/cute_chibi \/ v2/)).toBeInTheDocument()
-    expect(screen.getByText(/noir_portrait \/ v1/)).toBeInTheDocument()
+    expect(rows().getByText(/cute_chibi \/ v3/)).toBeInTheDocument()
+    expect(rows().getByText(/cute_chibi \/ v2/)).toBeInTheDocument()
+    expect(rows().getByText(/noir_portrait \/ v1/)).toBeInTheDocument()
+  })
+
+  it('filters with separate project and version dropdowns', async () => {
+    const user = userEvent.setup()
+    renderPicker()
+
+    await user.selectOptions(screen.getByLabelText('筛选项目'), '1')
+    expect(rows().getByText(/cute_chibi \/ v3/)).toBeInTheDocument()
+    expect(rows().getByText(/cute_chibi \/ v2/)).toBeInTheDocument()
+    expect(rows().queryByText(/noir_portrait \/ v1/)).not.toBeInTheDocument()
+
+    await user.selectOptions(screen.getByLabelText('筛选版本'), '1:12')
+    expect(rows().queryByText(/cute_chibi \/ v3/)).not.toBeInTheDocument()
+    expect(rows().getByText(/cute_chibi \/ v2/)).toBeInTheDocument()
+    expect(screen.getByText(/已选 0 \/ 1/)).toBeInTheDocument()
   })
 
   it('shows 训练中 badge for training-stage versions', () => {
@@ -81,7 +96,7 @@ describe('InlineLoraPicker', () => {
     renderPicker({
       selectedPaths: new Set(['/loras/cute_chibi/v3.safetensors']),
     })
-    const addedBtn = screen.getByText(/cute_chibi \/ v3/).closest('button')!
+    const addedBtn = rows().getByText(/cute_chibi \/ v3/).closest('button')!
     // 没传 onRemove → multi-select off → button disabled
     expect(addedBtn).toBeDisabled()
     expect(addedBtn.textContent).toContain('✓')
@@ -90,7 +105,7 @@ describe('InlineLoraPicker', () => {
   it('calls onPick with path when a version is clicked', async () => {
     const user = userEvent.setup()
     const { onPick } = renderPicker()
-    const btn = screen.getByText(/noir_portrait \/ v1/).closest('button')!
+    const btn = rows().getByText(/noir_portrait \/ v1/).closest('button')!
     await user.click(btn)
     expect(onPick).toHaveBeenCalledWith('/loras/noir/v1.safetensors')
   })
@@ -100,7 +115,7 @@ describe('InlineLoraPicker', () => {
     const { onPick } = renderPicker({
       selectedPaths: new Set(['/loras/cute_chibi/v3.safetensors']),
     })
-    const btn = screen.getByText(/cute_chibi \/ v3/).closest('button')!
+    const btn = rows().getByText(/cute_chibi \/ v3/).closest('button')!
     await user.click(btn)
     expect(onPick).not.toHaveBeenCalled()
   })
@@ -111,8 +126,8 @@ describe('InlineLoraPicker', () => {
     const search = screen.getByPlaceholderText('搜索项目 / 版本 / 文件名…')
     await user.type(search, 'noir')
     // cute_chibi 的版本应该消失
-    expect(screen.queryByText(/cute_chibi \/ v3/)).not.toBeInTheDocument()
-    expect(screen.getByText(/noir_portrait \/ v1/)).toBeInTheDocument()
+    expect(rows().queryByText(/cute_chibi \/ v3/)).not.toBeInTheDocument()
+    expect(rows().getByText(/noir_portrait \/ v1/)).toBeInTheDocument()
     // count 更新（改成 已选 0/总）
     expect(screen.getByText(/已选 0 \/ 1/)).toBeInTheDocument()
   })
@@ -122,9 +137,9 @@ describe('InlineLoraPicker', () => {
     renderPicker()
     const search = screen.getByPlaceholderText('搜索项目 / 版本 / 文件名…')
     await user.type(search, 'v3')
-    expect(screen.getByText(/cute_chibi \/ v3/)).toBeInTheDocument()
-    expect(screen.queryByText(/cute_chibi \/ v2/)).not.toBeInTheDocument()
-    expect(screen.queryByText(/noir_portrait \/ v1/)).not.toBeInTheDocument()
+    expect(rows().getByText(/cute_chibi \/ v3/)).toBeInTheDocument()
+    expect(rows().queryByText(/cute_chibi \/ v2/)).not.toBeInTheDocument()
+    expect(rows().queryByText(/noir_portrait \/ v1/)).not.toBeInTheDocument()
   })
 
   it('shows empty hint when no matches', async () => {

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { ProjectLora } from './types'
 import { ckptStemFromPath } from './xy'
 
@@ -38,17 +38,45 @@ export default function InlineLoraPicker({
   onPickExternal: () => void
 }) {
   const [search, setSearch] = useState('')
+  const [projectId, setProjectId] = useState<string>('all')
+  const [versionKey, setVersionKey] = useState<string>('all')
+
+  const projects = useMemo(() => {
+    const seen = new Map<number, string>()
+    for (const l of projectLoras) {
+      if (!seen.has(l.projectId)) seen.set(l.projectId, l.projectTitle)
+    }
+    return Array.from(seen.entries()).map(([id, title]) => ({ id, title }))
+  }, [projectLoras])
+
+  const versions = useMemo(() => {
+    const seen = new Map<string, ProjectLora>()
+    for (const l of projectLoras) {
+      if (projectId !== 'all' && l.projectId !== Number(projectId)) continue
+      const key = `${l.projectId}:${l.versionId}`
+      if (!seen.has(key)) seen.set(key, l)
+    }
+    return Array.from(seen.entries()).map(([key, l]) => ({ key, item: l }))
+  }, [projectId, projectLoras])
+
+  useEffect(() => {
+    if (versionKey === 'all') return
+    if (!versions.some((v) => v.key === versionKey)) setVersionKey('all')
+  }, [versionKey, versions])
 
   const filtered = useMemo(() => {
     const q = search.trim().toLowerCase()
-    if (!q) return projectLoras
-    return projectLoras.filter(
-      (l) =>
+    return projectLoras.filter((l) => {
+      if (projectId !== 'all' && l.projectId !== Number(projectId)) return false
+      if (versionKey !== 'all' && `${l.projectId}:${l.versionId}` !== versionKey) return false
+      if (!q) return true
+      return (
         l.projectTitle.toLowerCase().includes(q) ||
         l.versionLabel.toLowerCase().includes(q) ||
         ckptStemFromPath(l.path).toLowerCase().includes(q)
-    )
-  }, [projectLoras, search])
+      )
+    })
+  }, [projectId, projectLoras, search, versionKey])
 
   const selectedCount = selectedPaths.size
 
@@ -57,11 +85,43 @@ export default function InlineLoraPicker({
       className="rounded-md border border-subtle bg-overlay p-2.5 flex flex-col gap-2"
       data-testid="inline-lora-picker"
     >
-      {/* header: 搜索 + 计数 + 一键清空 + 外部文件 + 关闭 */}
-      <div className="flex items-center gap-2">
+      {/* header: project/version filters + search + actions */}
+      <div className="flex items-center gap-2 flex-wrap">
+        <select
+          className="input text-xs"
+          value={projectId}
+          onChange={(e) => {
+            setProjectId(e.target.value)
+            setVersionKey('all')
+          }}
+          aria-label="筛选项目"
+          style={{ width: 132 }}
+        >
+          <option value="all">全部项目</option>
+          {projects.map((p) => (
+            <option key={p.id} value={p.id}>{p.title}</option>
+          ))}
+        </select>
+        <select
+          className="input text-xs"
+          value={versionKey}
+          onChange={(e) => setVersionKey(e.target.value)}
+          aria-label="筛选版本"
+          disabled={versions.length === 0}
+          style={{ width: 150 }}
+        >
+          <option value="all">全部版本</option>
+          {versions.map(({ key, item }) => (
+            <option key={key} value={key}>
+              {projectId === 'all'
+                ? `${item.projectTitle} / ${item.versionLabel}`
+                : item.versionLabel}
+            </option>
+          ))}
+        </select>
         <input
           type="text"
-          className="input flex-1 text-xs"
+          className="input flex-1 text-xs min-w-[160px]"
           placeholder="搜索项目 / 版本 / 文件名…"
           value={search}
           onChange={(e) => setSearch(e.target.value)}
@@ -97,7 +157,11 @@ export default function InlineLoraPicker({
       </div>
 
       {/* 列表：扁平，每行一个 LoRA */}
-      <div className="flex flex-col gap-px overflow-y-auto" style={{ maxHeight: 360 }}>
+      <div
+        className="flex flex-col gap-px overflow-y-auto"
+        style={{ maxHeight: 360 }}
+        data-testid="inline-lora-list"
+      >
         {filtered.map((l) => {
           const added = selectedPaths.has(l.path)
           const stem = ckptStemFromPath(l.path)

--- a/studio/web/src/pages/tools/generate/PreviewXYGrid.test.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewXYGrid.test.tsx
@@ -113,4 +113,26 @@ describe('PreviewXYGrid', () => {
     expect(buttons[0]?.className).toContain('border-accent')
     expect(buttons[1]?.className).not.toContain('border-accent')
   })
+
+  it('navigates fullscreen cells with arrow keys', async () => {
+    const user = userEvent.setup()
+    const samples: Sample[] = [
+      makeSample(0, 0, 20, 3.0),
+      makeSample(1, 0, 25, 3.0),
+      makeSample(0, 1, 20, 5.0),
+      makeSample(1, 1, 25, 5.0),
+    ]
+    render(
+      <PreviewXYGrid samples={samples} taskId={99} xDraft={xDraft} yDraft={yDraft} />
+    )
+
+    await user.dblClick(screen.getAllByRole('img')[0])
+    expect(screen.getByText(/步数=20 .* CFG Scale=3/)).toBeInTheDocument()
+
+    await user.keyboard('{ArrowRight}')
+    expect(screen.getByText(/步数=25 .* CFG Scale=3/)).toBeInTheDocument()
+
+    await user.keyboard('{ArrowDown}')
+    expect(screen.getByText(/步数=25 .* CFG Scale=5/)).toBeInTheDocument()
+  })
 })

--- a/studio/web/src/pages/tools/generate/PreviewXYGrid.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewXYGrid.tsx
@@ -161,6 +161,20 @@ export default function PreviewXYGrid({
     return m
   }, [samples])
 
+  const fullscreenNeighbors = useMemo(() => {
+    if (fullscreenIdx == null) return null
+    const sample = samples[fullscreenIdx]
+    if (!sample?.xy) return null
+    const at = (dx: number, dy: number): number | null =>
+      cellIndex.get(`${sample.xy!.yi + dy}_${sample.xy!.xi + dx}`) ?? null
+    return {
+      left: at(-1, 0),
+      right: at(1, 0),
+      up: at(0, -1),
+      down: at(0, 1),
+    }
+  }, [cellIndex, fullscreenIdx, samples])
+
   const selSet = new Set(selectedIndices ?? [])
 
   // grid 列：固定 cellW（zoom 调它），yDraft 时左侧多一列 axis label。
@@ -265,6 +279,23 @@ export default function PreviewXYGrid({
             alt={fn}
             caption={captionParts.join(' · ')}
             onClose={() => setFullscreenIdx(null)}
+            hasPrev={fullscreenNeighbors?.left != null}
+            hasNext={fullscreenNeighbors?.right != null}
+            hasUp={fullscreenNeighbors?.up != null}
+            hasDown={fullscreenNeighbors?.down != null}
+            onPrev={() => {
+              if (fullscreenNeighbors?.left != null) setFullscreenIdx(fullscreenNeighbors.left)
+            }}
+            onNext={() => {
+              if (fullscreenNeighbors?.right != null) setFullscreenIdx(fullscreenNeighbors.right)
+            }}
+            onUp={() => {
+              if (fullscreenNeighbors?.up != null) setFullscreenIdx(fullscreenNeighbors.up)
+            }}
+            onDown={() => {
+              if (fullscreenNeighbors?.down != null) setFullscreenIdx(fullscreenNeighbors.down)
+            }}
+            shortcutHint="←/→/↑/↓ 切换单元格 · ESC / 点击遮罩关闭"
           />
         )
       })()}

--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
@@ -1,6 +1,17 @@
 import { useEffect, useMemo, useState } from 'react'
 import { api, type CaptionEntry, type ProjectSummary } from '../../../api/client'
 
+const LAST_PROJECT_KEY = 'anima.generate.promptDataset.projectId'
+const LAST_VERSION_KEY = 'anima.generate.promptDataset.versionId'
+
+function readStoredNumber(key: string): number | null {
+  if (typeof window === 'undefined') return null
+  const raw = window.localStorage.getItem(key)
+  if (!raw) return null
+  const n = Number(raw)
+  return Number.isFinite(n) ? n : null
+}
+
 /** 从训练集 caption 里选一条，把 tags 拿到生成 prompt 里。
  *
  * 流程：选项目 → 选版本 → 列 captions → 单选 → 「追加」/「替换」。
@@ -28,7 +39,13 @@ export default function PromptFromDatasetPicker({
   // 1. 拉项目列表
   useEffect(() => {
     void api.listProjects()
-      .then(setProjects)
+      .then((items) => {
+        setProjects(items)
+        const storedPid = readStoredNumber(LAST_PROJECT_KEY)
+        if (storedPid != null && items.some((p) => p.id === storedPid)) {
+          setPid(storedPid)
+        }
+      })
       .catch((e) => setError(String(e)))
   }, [])
 
@@ -39,11 +56,23 @@ export default function PromptFromDatasetPicker({
       .then((p) => {
         const vs = p.versions.map((v) => ({ id: v.id, label: v.label }))
         setVersions(vs)
-        if (vs.length > 0) setVid(vs[0].id)
+        const storedVid = readStoredNumber(LAST_VERSION_KEY)
+        if (storedVid != null && vs.some((v) => v.id === storedVid)) setVid(storedVid)
+        else if (vs.length > 0) setVid(vs[0].id)
         else setVid(null)
       })
       .catch((e) => setError(String(e)))
   }, [pid])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (pid != null) window.localStorage.setItem(LAST_PROJECT_KEY, String(pid))
+  }, [pid])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    if (vid != null) window.localStorage.setItem(LAST_VERSION_KEY, String(vid))
+  }, [vid])
 
   // 3. 选版本后拉 captions
   useEffect(() => {
@@ -168,13 +197,13 @@ export default function PromptFromDatasetPicker({
               onClick={() => { onReplace(selected.tags); onClose() }}
               className="btn btn-ghost btn-sm text-xs"
             >
-              替换 prompt
+              替换当前提示词
             </button>
             <button
               onClick={() => { onAppend(selected.tags); onClose() }}
               className="btn btn-primary btn-sm text-xs"
             >
-              追加到末尾
+              追加到当前提示词
             </button>
           </div>
         </>

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -56,6 +56,20 @@ def test_health_returns_ok(client: TestClient) -> None:
     assert body["version"] == server.app.version
 
 
+def test_generate_sample_response_is_not_browser_cached(client: TestClient) -> None:
+    from studio.services import generate_cache
+
+    generate_cache.clear_all()
+    try:
+        generate_cache.cache_image(7, "sample.png", b"PNG")
+        resp = client.get("/api/generate/7/sample/sample.png")
+        assert resp.status_code == 200
+        assert resp.content == b"PNG"
+        assert resp.headers["cache-control"] == "no-store"
+    finally:
+        generate_cache.clear_all()
+
+
 # ---------------------------------------------------------------------------
 # /api/state
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- Add XY fullscreen cell navigation, keyboard shortcuts, and no-store generated sample responses.
- Add project/version LoRA filters and remember dataset prompt selection.
- Wire queue pause/output links, tag-edit activation behavior, and loading semantics.

Tests:
- npm run test -- InlineLoraPicker.test.tsx PreviewXYGrid.test.tsx ImageGrid.test.tsx
- npm run build
- venv TestClient check for /api/generate/{task_id}/sample/{filename} Cache-Control: no-store

Note:
- python -m pytest tests/test_studio_server.py could not run in the current system/venv env because project deps such as psutil/pytest were missing; the endpoint was verified with the existing venv TestClient instead.