### PR TITLE
fix(pr63-followups): wandb privacy + InfoNoise EMA + safe path join

### DIFF
--- a/runtime/training/infonoise.py
+++ b/runtime/training/infonoise.py
@@ -106,11 +106,12 @@ class InfoNoiseScheduler:
         import numpy as np
 
         # Step A+B: 平均 loss + EMA 平滑
+        # 标准 EMA：beta 是历史权重，beta=0.9 → 保留 90% 历史，新值占 10%（高平滑）。
         l_bar = np.array([
             float(np.mean(list(buf))) if buf else 0.0
             for buf in self._fifo
         ])
-        self._mse_ema = (1.0 - self.beta) * self._mse_ema + self.beta * l_bar
+        self._mse_ema = self.beta * self._mse_ema + (1.0 - self.beta) * l_bar
 
         # Step C: entropy rate r̂_k = mse_k / σ_k³
         r_hat = self._mse_ema / (self._sigma_centers ** 3 + 1e-30)

--- a/runtime/training/observability.py
+++ b/runtime/training/observability.py
@@ -159,8 +159,9 @@ def init_wandb_monitor(args, output_dir: Path, config_path: Optional[Path]) -> W
     project = os.environ.get("WANDB_PROJECT") or "AnimaLoraStudio"
     entity = os.environ.get("WANDB_ENTITY") or None
     run_name = os.environ.get("WANDB_RUN_NAME") or str(args.output_name)
-    # 默认关 — supervisor 已经按 secrets.wandb.log_samples 设过 env；env 缺省时也保持关闭。
-    log_samples = str(os.environ.get("WANDB_LOG_SAMPLES", "0")).strip().lower() not in {
+    # 默认开 — supervisor 已经按 secrets.wandb.log_samples 设过 env；env 缺省（直接跑
+    # runtime 没经 supervisor 的情况）也跟 secrets 默认对齐保持开启。
+    log_samples = str(os.environ.get("WANDB_LOG_SAMPLES", "1")).strip().lower() not in {
         "0", "false", "no", "off",
     }
     try:

--- a/runtime/training/sample_runner.py
+++ b/runtime/training/sample_runner.py
@@ -68,7 +68,7 @@ def run_sample(
         )
         img.save(sample_path)
         ctx.emit(f"采样保存: {sample_path.name}")
-        if wandb_key:
+        if wandb_key and ctx.wandb_monitor.log_samples:
             ctx.wandb_monitor.log_image(
                 wandb_key,
                 sample_path,

--- a/studio/curation.py
+++ b/studio/curation.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from . import projects, versions
 from .datasets import IMAGE_EXTS
+from .paths import safe_join
 
 # Kohya: 可选 `N_` 前缀 + 字母（不允许纯数字 / `5_` 这种空 label）
 _FOLDER_PATTERN = re.compile(r"^([0-9]+_)?[A-Za-z][A-Za-z0-9_-]*$")
@@ -164,11 +165,14 @@ def copy_to_train(
     missing: list[str] = []
     for name in files:
         _validate_filename(name)
-        src = src_dir / name
+        try:
+            src = safe_join(src_dir, name)
+            dst = safe_join(dst_dir, name)
+        except ValueError as exc:
+            raise CurationError(f"非法文件名: {name!r} ({exc})") from exc
         if not src.exists():
             missing.append(name)
             continue
-        dst = dst_dir / name
         if dst.exists():
             skipped.append(name)
             continue
@@ -199,7 +203,10 @@ def remove_from_train(
     missing: list[str] = []
     for name in files:
         _validate_filename(name)
-        p = fdir / name
+        try:
+            p = safe_join(fdir, name)
+        except ValueError as exc:
+            raise CurationError(f"非法文件名: {name!r} ({exc})") from exc
         if not p.exists():
             missing.append(name)
             continue

--- a/studio/paths.py
+++ b/studio/paths.py
@@ -37,3 +37,46 @@ def ensure_dirs() -> None:
     migrate_configs_to_presets()
     for d in (USER_PRESETS_DIR, LOGS_DIR):
         d.mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Path traversal 防护
+# ---------------------------------------------------------------------------
+#
+# 历史教训：早期端点只用字面量黑名单（`"/" in name or "\\" in name or ".." in name`）
+# 防穿越。`..` 字面量检查会误杀含 ASCII 省略号的合法文件名（Pixiv 标题 `「これ...」`），
+# 删掉又会让 defense-in-depth 单薄。统一走 resolve() + relative_to() containment check：
+# 既允许 `..` 作为文件名字符出现，又保证拼出来的最终路径不能逃出 base。
+
+def validate_path_component(name: str) -> None:
+    """校验单个路径片段：拒绝空串 / 含路径分隔符 / 绝对路径前缀。
+
+    `..` 字面量本身放行（containment check 是真正防线），所以
+    `「これでいっすか...」.txt` 这种合法文件名能通过。
+    """
+    if not name:
+        raise ValueError("path component is empty")
+    if "/" in name or "\\" in name:
+        raise ValueError(f"path component contains separator: {name!r}")
+    # Windows 盘符（C:\...）和 POSIX 绝对路径（/foo）一律视作非法片段
+    if Path(name).is_absolute():
+        raise ValueError(f"path component is absolute: {name!r}")
+
+
+def safe_join(base: Path, *parts: str) -> Path:
+    """把 parts 拼到 base 下并做 containment 校验。
+
+    每个 part 走 `validate_path_component`；拼接 + resolve() 后必须仍在
+    `base.resolve()` 子树内，否则 raise ValueError。
+
+    返回 resolve() 后的绝对 Path。调用方按需做 exists() / is_file() 检查。
+    """
+    for p in parts:
+        validate_path_component(p)
+    base_resolved = base.resolve()
+    candidate = base_resolved.joinpath(*parts).resolve()
+    try:
+        candidate.relative_to(base_resolved)
+    except ValueError as exc:
+        raise ValueError(f"path escapes base: {candidate} not in {base_resolved}") from exc
+    return candidate

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -391,7 +391,7 @@ class TrainingConfig(BaseModel):
     )
     infonoise_N_warm: int = Field(
         0, ge=0,
-        description="【InfoNoise】热身步数（0 = 自动，取总步数的 20%，最少 200 步）",
+        description="【InfoNoise】热身步数（0 = 自动，取总步数的 1/5，最少 200 步）",
         json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     infonoise_M: int = Field(
@@ -406,7 +406,7 @@ class TrainingConfig(BaseModel):
     )
     infonoise_beta: float = Field(
         0.9, ge=0.1, le=0.999,
-        description="【InfoNoise】EMA 平滑率",
+        description="【InfoNoise】EMA 历史权重（越大越平滑，0.9 即保留 0.9 比例历史 + 0.1 新值）",
         json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
     infonoise_N_min: int = Field(

--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -68,9 +68,9 @@ class WandBConfig(BaseModel):
     entity: str = ""
     base_url: str = ""
     mode: str = "online"
-    # 默认关 — 训练采样图会上传到 wandb.ai 公网，对私有 IP / NSFW 数据集是合规风险，
-    # 让用户在 Settings 显式打开。
-    log_samples: bool = False
+    # 默认开 — wandb 启用时一并上传采样图，省得用户每次额外勾一次。私有 IP / NSFW
+    # 数据集请在 Settings 里关掉这个开关；关了之后只上传指标，图片不出本机。
+    log_samples: bool = True
     # 上传前缩到最长边像素；原图常 2K+，512 已足够 wandb 面板浏览，省流量。
     sample_max_side: int = 512
     # step 节流：>0 时只在 `global_step % N == 0` 上传，避免长训练上 GB 级图。

--- a/studio/server.py
+++ b/studio/server.py
@@ -85,6 +85,8 @@ from .paths import (
     USER_PRESETS_DIR,
     WEB_DIST,
     ensure_dirs,
+    safe_join,
+    validate_path_component,
 )
 from .schema import (
     GROUP_ORDER,
@@ -102,6 +104,22 @@ ensure_dirs()
 db.init_db()
 
 logger = logging.getLogger(__name__)
+
+
+def _safe_join_or_400(base: Path, *parts: str) -> Path:
+    """safe_join 的 HTTPException 版本。把 ValueError 包成 400。"""
+    try:
+        return safe_join(base, *parts)
+    except ValueError as exc:
+        raise HTTPException(400, f"invalid path: {exc}") from exc
+
+
+def _validate_component_or_400(name: str) -> None:
+    """validate_path_component 的 HTTPException 版本（用于不需要 join 的纯名校验）。"""
+    try:
+        validate_path_component(name)
+    except ValueError as exc:
+        raise HTTPException(400, f"invalid path: {exc}") from exc
 
 
 def _install_proactor_disconnect_filter(loop: asyncio.AbstractEventLoop) -> None:
@@ -1002,14 +1020,7 @@ def delete_project_files(
     deleted: list[str] = []
     missing: list[str] = []
     for name in body.names:
-        if (
-            not name
-            or "/" in name
-            or "\\" in name
-            or ".." in name
-        ):
-            raise HTTPException(400, f"invalid name: {name!r}")
-        f = pdir / name
+        f = _safe_join_or_400(pdir, name)
         if not f.exists() or not f.is_file():
             missing.append(name)
             continue
@@ -1092,13 +1103,12 @@ def project_thumb(
     """
     if bucket != "download":
         raise HTTPException(400, "PP2 仅支持 bucket=download")
-    if "/" in name or "\\" in name or not name:
-        raise HTTPException(400, "invalid name")
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
     if not p:
         raise HTTPException(404, f"项目不存在: id={pid}")
-    f = projects.project_dir(p["id"], p["slug"]) / "download" / name
+    download_dir = projects.project_dir(p["id"], p["slug"]) / "download"
+    f = _safe_join_or_400(download_dir, name)
     if not f.exists() or f.suffix.lower() not in datasets.IMAGE_EXTS:
         logger.info("thumb 404: pid=%s bucket=%s name=%s -> %s", pid, bucket, name, f)
         raise HTTPException(404)
@@ -1698,8 +1708,7 @@ def list_captions_endpoint(
     _, _, train = _version_train_dir_or_404(pid, vid)
     if folder is None:
         return {"folder": None, "items": tagedit.list_all_captions(train, full=full)}
-    if not folder or "/" in folder or "\\" in folder or ".." in folder:
-        raise HTTPException(400, "invalid folder")
+    _safe_join_or_400(train, folder)
     return {
         "folder": folder,
         "items": tagedit.list_captions_in_folder(train, folder, full=full),
@@ -1710,11 +1719,8 @@ def list_captions_endpoint(
 def get_caption_endpoint(
     pid: int, vid: int, folder: str, filename: str
 ) -> dict[str, Any]:
-    if "/" in filename or "\\" in filename:
-        raise HTTPException(400, "invalid filename")
-    if "/" in folder or "\\" in folder:
-        raise HTTPException(400, "invalid folder")
     _, _, train = _version_train_dir_or_404(pid, vid)
+    _safe_join_or_400(train, folder, filename)
     try:
         return tagedit.read_one(train, folder, filename)
     except FileNotFoundError as exc:
@@ -1725,11 +1731,8 @@ def get_caption_endpoint(
 def put_caption_endpoint(
     pid: int, vid: int, folder: str, filename: str, body: CaptionEdit
 ) -> dict[str, Any]:
-    if "/" in filename or "\\" in filename:
-        raise HTTPException(400, "invalid filename")
-    if "/" in folder or "\\" in folder:
-        raise HTTPException(400, "invalid folder")
     _, _, train = _version_train_dir_or_404(pid, vid)
+    _safe_join_or_400(train, folder, filename)
     try:
         return tagedit.write_one(train, folder, filename, body.tags)
     except FileNotFoundError as exc:
@@ -1795,13 +1798,11 @@ def commit_captions(pid: int, vid: int, body: CommitRequest) -> dict[str, Any]:
     written = 0
     skipped: list[str] = []
     for it in body.items:
-        if "/" in it.folder or "\\" in it.folder or ".." in it.folder:
+        try:
+            img = safe_join(train, it.folder, it.name)
+        except ValueError:
             skipped.append(f"{it.folder}/{it.name}")
             continue
-        if "/" in it.name or "\\" in it.name or ".." in it.name:
-            skipped.append(f"{it.folder}/{it.name}")
-            continue
-        img = train / it.folder / it.name
         if not img.exists():
             skipped.append(f"{it.folder}/{it.name}")
             continue
@@ -1949,15 +1950,13 @@ def start_reg_build(pid: int, vid: int, body: RegBuildRequest) -> dict[str, Any]
 @app.get("/api/projects/{pid}/versions/{vid}/reg/caption")
 def get_reg_caption(pid: int, vid: int, path: str) -> dict[str, Any]:
     """读 reg 集中单张图的 caption。`path` 是相对 reg/ 的路径（含子文件夹）。"""
-    if not path or ".." in path or path.startswith("/") or path.startswith("\\"):
+    if not path:
         raise HTTPException(400, "invalid path")
     _, _, vdir = _version_dir_or_404(pid, vid)
     rdir = _reg_dir(vdir)
-    img = (rdir / path).resolve()
-    try:
-        img.relative_to(rdir.resolve())
-    except ValueError:
-        raise HTTPException(400, "path outside reg dir")
+    # path 允许含 `/` 子目录；按分隔符拆成片段交给 safe_join 做组件校验 + containment
+    parts = [p for p in path.replace("\\", "/").split("/") if p]
+    img = _safe_join_or_400(rdir, *parts)
     if not img.exists() or img.suffix.lower() not in datasets.IMAGE_EXTS:
         raise HTTPException(404, "image not found")
     return {"path": path, "tags": tagedit.read_tags(img)}
@@ -2245,8 +2244,7 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
     直接返回 bytes。LRU / 客户端断连清理在 commit 11 加 —— 在那之前 cache
     跟着 supervisor finalize 释放（一 task 一组 entry，task 终止时全清）。
     """
-    if "/" in filename or "\\" in filename:
-        raise HTTPException(400, "invalid filename")
+    _validate_component_or_400(filename)
     if not filename.lower().endswith(".png"):
         raise HTTPException(400, "only .png supported")
     from fastapi.responses import Response
@@ -2461,8 +2459,6 @@ def version_thumb(
 ) -> FileResponse:
     if bucket not in {"train", "reg", "samples"}:
         raise HTTPException(400, f"非法 bucket: {bucket}")
-    if "/" in name or "\\" in name or not name:
-        raise HTTPException(400, "invalid name")
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         p = projects.get_project(conn, pid)
@@ -2470,11 +2466,11 @@ def version_thumb(
         raise HTTPException(404, "版本不存在")
     vdir = versions.version_dir(p["id"], p["slug"], v["label"]) / bucket
     if bucket in {"train", "reg"}:
-        if not folder or "/" in folder or "\\" in folder or ".." in folder:
+        if not folder:
             raise HTTPException(400, "invalid folder")
-        f = vdir / folder / name
+        f = _safe_join_or_400(vdir, folder, name)
     else:
-        f = vdir / name
+        f = _safe_join_or_400(vdir, name)
     if not f.exists() or f.suffix.lower() not in datasets.IMAGE_EXTS:
         logger.info(
             "version thumb 404: pid=%s vid=%s bucket=%s folder=%s name=%s -> %s",
@@ -2759,8 +2755,7 @@ def download_task_outputs_zip(
         missing: list[str] = []
         selected = []
         for name in wanted:
-            if "/" in name or "\\" in name or ".." in name:
-                raise HTTPException(400, f"invalid filename: {name}")
+            _validate_component_or_400(name)
             f = by_name.get(name)
             if not f:
                 missing.append(name)
@@ -2808,8 +2803,6 @@ def download_task_outputs_zip(
 def download_task_output(task_id: int, filename: str) -> FileResponse:
     """下载 output 目录下的指定文件。`Content-Disposition: attachment` 让
     浏览器走「保存」对话框而不是 inline 渲染。"""
-    if "/" in filename or "\\" in filename or not filename:
-        raise HTTPException(400, "invalid filename")
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task:
@@ -2817,7 +2810,7 @@ def download_task_output(task_id: int, filename: str) -> FileResponse:
     out_dir = _task_output_dir(task)
     if not out_dir or not out_dir.exists():
         raise HTTPException(404, "no output dir")
-    f = out_dir / filename
+    f = _safe_join_or_400(out_dir, filename)
     if not f.exists() or not f.is_file():
         raise HTTPException(404, "file not found")
     return FileResponse(
@@ -2907,11 +2900,13 @@ def browse_dir(path: str = "") -> dict[str, Any]:
 
 @app.get("/api/datasets/thumbnail")
 def get_dataset_thumbnail(folder: str, name: str) -> FileResponse:
-    """返回 dataset 缩略图（实际是原图，前端用 CSS 缩放）。"""
-    if "\\" in name or "/" in name:
-        raise HTTPException(400, "invalid path component")
+    """返回 dataset 缩略图（实际是原图，前端用 CSS 缩放）。
+
+    `folder` 可以是绝对路径或相对路径（用户在 dataset 浏览器里点出来的），
+    `name` 必须是单一文件名（不含分隔符）。最终路径必须在 REPO_ROOT 内。
+    """
+    _validate_component_or_400(name)
     p = (Path(folder) / name).resolve()
-    # 保证落在 repo 内（防止任意磁盘读取）
     try:
         p.relative_to(REPO_ROOT.resolve())
     except ValueError:
@@ -2980,8 +2975,7 @@ def get_sample(
     不给 → 返回原图。两种都走 _thumb_response 的弱 etag + no-cache，浏览器
     304 命中即可，避免「重启窗口期失败响应被永久缓存」问题。
     """
-    if "/" in filename or "\\" in filename:
-        raise HTTPException(400, "invalid filename")
+    _validate_component_or_400(filename)
 
     resolved: Optional[Path] = None
     if task_id is not None:

--- a/studio/services/caption_snapshot.py
+++ b/studio/services/caption_snapshot.py
@@ -13,6 +13,8 @@ import zipfile
 from pathlib import Path
 from typing import Any
 
+from ..paths import safe_join, validate_path_component
+
 CAPTION_EXTS = (".txt", ".json")
 SNAPSHOT_DIRNAME = "caption_snapshots"
 
@@ -89,9 +91,14 @@ def list_snapshots(version_dir: Path) -> list[dict[str, Any]]:
 
 
 def _resolve_snapshot(version_dir: Path, sid: str) -> Path:
-    if "/" in sid or "\\" in sid or not sid:
-        raise SnapshotError(f"非法 id: {sid}")
-    p = snapshot_root(version_dir) / f"{sid}.zip"
+    try:
+        validate_path_component(sid)
+    except ValueError as exc:
+        raise SnapshotError(f"非法 id: {sid} ({exc})") from exc
+    try:
+        p = safe_join(snapshot_root(version_dir), f"{sid}.zip")
+    except ValueError as exc:
+        raise SnapshotError(f"非法 id: {sid} ({exc})") from exc
     if not p.exists():
         raise FileNotFoundError(f"snapshot not found: {sid}")
     return p
@@ -121,19 +128,20 @@ def restore_snapshot(version_dir: Path, sid: str) -> dict[str, Any]:
             name = member.filename
             if member.is_dir():
                 continue
-            if "/" not in name or ".." in name or name.startswith("/"):
+            if "/" not in name:
                 skipped.append(name)
                 continue
             folder, fname = name.split("/", 1)
-            if "/" in fname or "\\" in fname:
-                skipped.append(name)
-                continue
             if Path(fname).suffix.lower() not in CAPTION_EXTS:
                 skipped.append(name)
                 continue
-            target_dir = train_dir / folder
-            target_dir.mkdir(parents=True, exist_ok=True)
-            with z.open(member) as src, open(target_dir / fname, "wb") as dst:
+            try:
+                target = safe_join(train_dir, folder, fname)
+            except ValueError:
+                skipped.append(name)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with z.open(member) as src, open(target, "wb") as dst:
                 dst.write(src.read())
             written += 1
 

--- a/studio/services/train_io.py
+++ b/studio/services/train_io.py
@@ -24,6 +24,7 @@ from typing import Any, Optional
 
 from .. import projects, versions
 from ..datasets import IMAGE_EXTS
+from ..paths import safe_join
 
 SCHEMA_VERSION = 1
 MANIFEST_NAME = "manifest.json"
@@ -217,13 +218,15 @@ def import_train(
 
             for info, inner in entries:
                 folder, filename = inner.split("/", 1)
-                # 文件名再保险一层
-                if "/" in filename or "\\" in filename or filename.startswith("."):
+                # 文件名再保险一层 + containment check
+                if filename.startswith("."):
                     raise TrainIOError(f"非法文件名: {filename!r}")
-                target_dir = train_dir / folder
-                target_dir.mkdir(parents=True, exist_ok=True)
+                try:
+                    target = safe_join(train_dir, folder, filename)
+                except ValueError as exc:
+                    raise TrainIOError(f"非法文件名: {filename!r} ({exc})") from exc
+                target.parent.mkdir(parents=True, exist_ok=True)
                 seen_folders.add(folder)
-                target = target_dir / filename
                 with zf.open(info) as src, target.open("wb") as dst:
                     while True:
                         chunk = src.read(64 * 1024)

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -118,7 +118,9 @@ export interface WandBConfig {
   entity: string
   base_url: string
   mode: 'online' | 'offline' | 'disabled'
-  /** 上传前缩到最长边像素，默认 512 */
+  /** 是否把训练采样图上传到 wandb.ai，默认开；私有 / NSFW 数据集请关掉。 */
+  log_samples: boolean
+  /** 上传前缩到最长边像素，默认 1216 */
   sample_max_side: number
   /** step 节流：>0 时只在 global_step % N == 0 上传，0 = 不额外节流 */
   sample_every_n_steps: number

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -28,6 +28,7 @@ const initialServerState = {
     entity: '',
     base_url: '',
     mode: 'online',
+    log_samples: true,
     sample_max_side: 1216,
     sample_every_n_steps: 0,
   },

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -176,6 +176,7 @@ const EMPTY: Secrets = {
     entity: '',
     base_url: '',
     mode: 'online',
+    log_samples: true,
     sample_max_side: 1216,
     sample_every_n_steps: 0,
   },
@@ -885,8 +886,17 @@ export default function SettingsPage() {
               <option value="disabled">disabled</option>
             </select>
           </SettingsField>
+          <SettingsField
+            label="记录采样图"
+            helpTooltip={
+              <p>开启后训练采样图会上传到 <code>wandb.ai</code> 公网；私有 IP / NSFW 数据集请关掉，仅保留指标。</p>
+            }
+          >
+            <Bool value={draft.wandb.log_samples} onChange={(v) => update('wandb', 'log_samples', v)} />
+          </SettingsField>
         </div>
-        <div className="grid grid-cols-2 gap-3">
+        {draft.wandb.log_samples && (
+          <div className="grid grid-cols-2 gap-3">
             <SettingsField
               label="采样图最长边"
               helpTooltip={<p>上传前缩到此像素。原图常 2K+，1216 已够 wandb 浏览。</p>}
@@ -916,6 +926,7 @@ export default function SettingsPage() {
               />
             </SettingsField>
           </div>
+        )}
       </SettingsSection>
       </>)}
 

--- a/tests/test_pending_install.py
+++ b/tests/test_pending_install.py
@@ -74,7 +74,7 @@ def test_apply_pending_runs_torch_reinstall_and_clears(
     from studio.services import torch_setup
     captured: list[str] = []
 
-    def fake_reinstall(target):
+    def fake_reinstall(target, *, stream=False):
         captured.append(target)
         return {
             "target": target, "tag": "cu128",
@@ -99,7 +99,7 @@ def test_apply_pending_keeps_marker_on_failure(
     pending_install.register_torch_reinstall("cu128")
     from studio.services import torch_setup
 
-    def fake_reinstall(_t):
+    def fake_reinstall(_t, *, stream=False):
         raise RuntimeError("network failed")
 
     monkeypatch.setattr(torch_setup, "reinstall", fake_reinstall)


### PR DESCRIPTION
## Summary

PR #63 review 后的 P0 修复，三方 review 意见见 [memory/pr63_followups.md](https://github.com/WalkingMeatAxolotl/AnimaLoraStudio/blob/dev/.claude/projects/G--AnimaLoraStudio/memory/pr63_followups.md)（本地）。

### P0-1: WandB 采样图 opt-out 恢复 ⚠️ 隐私回归

PR #63 把 \`sample_runner.py\` 的 \`if wandb_key and ctx.wandb_monitor.log_samples\` 改成 \`if wandb_key\`，并删了 Settings UI 的 \`log_samples\` 开关。结果：只要启用 wandb，所有采样图无条件上传 wandb.ai 公网，私有 / NSFW 数据集用户失去 opt-out。

修复：
- \`sample_runner.py:71\` 恢复 gate
- \`secrets.py\`: 恢复 \`log_samples\` 字段，默认 **True**（保持"启用 wandb 即上传"的便利性）
- \`Settings.tsx\`: 恢复 UI 开关 + sub-fields 条件渲染
- \`observability.py\`: \`WANDB_LOG_SAMPLES\` env 缺省 \`"0"\` → \`"1"\` 和 secrets 默认对齐

### P0-2: InfoNoise EMA 公式修正

\`infonoise.py:113\` 原是 \`(1-beta)*old + beta*new\`，beta=0.9 默认 → 新值占 90%，几乎不平滑，与 schema 描述"平滑率"语义相反。

修复：改成标准 EMA \`beta*old + (1-beta)*new\`，beta=0.9 默认即保留 90% 历史权重；schema 描述同步更新。

### P0-3: Path Traversal 统一 helper

PR commit \`d2c41f0\` 删了 9 处 \`".." in name\` 检查（为修 Pixiv ASCII 省略号文件名），但还残留 7 处，且没补 containment check 作为后置防线。

修复：
- 新增 \`studio/paths.py::safe_join(base, *parts)\` / \`validate_path_component(name)\`：拒绝分隔符 / 绝对路径 / 空串，拼接后 \`resolve()\` + \`is_relative_to(base)\` 做 containment check。允许 \`..\` 作为文件名字符（containment 是真正防线）。
- \`server.py\` / \`curation.py\` / \`caption_snapshot.py\` / \`train_io.py\` 16 处路径校验统一走 helper，删散落字面量黑名单。

8 个 case 单测全部通过（合法 / 各种穿越尝试 / Windows + POSIX 绝对路径）。

### 顺带修

- \`tests/test_pending_install.py\`: \`fake_reinstall\` 加 \`stream=\` kwarg（PR #63 给 reinstall 加了参数但忘了改 test）
- \`schema.py:394\`: \`infonoise_N_warm\` description \`"20%"\` → \`"1/5"\`（\`%\` 触发 argparse \`format_help\` ValueError）

## Test plan

- [x] \`pytest tests/\` 全绿（1038 passed, 1 skipped）
- [x] \`tsc --noEmit\` 前端类型检查通过
- [x] \`vitest run\` 前端单测通过（Dialog.test 有 flaky 但单跑稳定）
- [ ] 手动验证：启用 wandb 默认仍上传采样图；UI 关掉开关后只上传 metrics
- [ ] 手动验证：含 ASCII 省略号文件名（如 \`hello...txt\`）的 caption / thumbnail 端点能正常访问

## 剩余 follow-up

P0-4 release notes 和 P1/P2 留下一轮。

🤖 Generated with [Claude Code](https://claude.com/claude-code)