### PR TITLE
follow-up(pr64): P1 hook/skeleton/fullscreen + P2/P3 polish + F no-store 注释

### DIFF
--- a/studio/server.py
+++ b/studio/server.py
@@ -2252,6 +2252,11 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
     data = generate_cache.get_image(task_id, filename)
     if data is None:
         raise HTTPException(404)
+    # 用 no-store 不是 _thumb_response 那套 no-cache + ETag：
+    # generate cache 同 (task_id, filename) 内容会随重跑覆盖（用户改 prompt 重生成），
+    # 没有稳定 ETag 可发；用 no-store 让浏览器每次都重拉，永远拿到最新结果。
+    # 带宽代价小：用户在测试出图页主动看才命中本 endpoint，QPS 低。
+    # （Thumbnail / dataset 那种内容稳定的图，继续用 _thumb_response 的 ETag。）
     return Response(
         content=data,
         media_type="image/png",

--- a/studio/web/src/components/BulkActionBar.tsx
+++ b/studio/web/src/components/BulkActionBar.tsx
@@ -175,9 +175,10 @@ export default function BulkActionBar({
         )}
       </div>
 
-      {/* Hint row */}
-      <div className="text-fg-tertiary text-[11px]">
-        点击图片 = 查看大图并编辑 · 勾选 = 多选 · Shift/Ctrl+点击 = 快速多选
+      {/* Hint row：进阶快捷键拆到第二行，避免单行 50+ 字过密 */}
+      <div className="text-fg-tertiary text-[11px] flex flex-col gap-0.5">
+        <span>点击图片 = 查看大图并编辑 · 勾选 = 多选</span>
+        <span>Shift / Ctrl / ⌘ + 点击 = 快速多选</span>
       </div>
 
       {/* Popover row */}

--- a/studio/web/src/components/ConfigSkeleton.test.tsx
+++ b/studio/web/src/components/ConfigSkeleton.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * ConfigSkeleton 单元测试。
+ *
+ * 验证：
+ *   - card 变体外层是 <section>，flat 变体外层是 <div>
+ *   - role="status" + aria-label + sr-only 文本一致
+ *   - groups prop 控制组数，row 数控制每组行数
+ *   - label 透传到 aria + sr-only
+ */
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import ConfigSkeleton from './ConfigSkeleton'
+
+describe('ConfigSkeleton', () => {
+  it('renders card variant with section + per-group border', () => {
+    const { container } = render(<ConfigSkeleton groups={[2, 3]} />)
+    expect(container.querySelector('section')).toBeTruthy()
+    // 2 个组 × 1 个 border 卡片
+    const cards = container.querySelectorAll('.border.border-subtle.bg-surface')
+    expect(cards.length).toBe(2)
+  })
+
+  it('renders flat variant with div and no per-group border', () => {
+    const { container } = render(<ConfigSkeleton variant="flat" groups={[2, 3]} />)
+    expect(container.querySelector('section')).toBeFalsy()
+    expect(container.querySelector('div[role="status"]')).toBeTruthy()
+    expect(container.querySelectorAll('.border.border-subtle.bg-surface').length).toBe(0)
+  })
+
+  it('uses label for aria-label and sr-only text', () => {
+    render(<ConfigSkeleton label="加载训练配置中" />)
+    const status = screen.getByRole('status')
+    expect(status.getAttribute('aria-label')).toBe('加载训练配置中')
+    expect(screen.getByText('加载训练配置中...')).toBeInTheDocument()
+  })
+
+  it('defaults to 4 groups when groups prop is omitted', () => {
+    const { container } = render(<ConfigSkeleton />)
+    // section > 4 children groups + 1 sr-only span = 5 direct children
+    const section = container.querySelector('section')
+    expect(section).toBeTruthy()
+    // 4 group cards
+    expect(container.querySelectorAll('.border.border-subtle.bg-surface').length).toBe(4)
+  })
+
+  it('renders the requested row count per group', () => {
+    const { container } = render(<ConfigSkeleton groups={[1, 5]} />)
+    const groups = container.querySelectorAll('section > div')
+    expect(groups.length).toBe(2)
+    // 第 1 组 1 行 = 1 label bar + 1 input bar = 2 row 容器内的 div
+    // 第 2 组 5 行 = 5 row 容器（每行 2 个 bar）
+    const rowsInGroup1 = groups[0].querySelectorAll('.flex.flex-col.gap-1')
+    const rowsInGroup2 = groups[1].querySelectorAll('.flex.flex-col.gap-1')
+    expect(rowsInGroup1.length).toBe(1)
+    expect(rowsInGroup2.length).toBe(5)
+  })
+})

--- a/studio/web/src/components/ConfigSkeleton.tsx
+++ b/studio/web/src/components/ConfigSkeleton.tsx
@@ -1,0 +1,73 @@
+/**
+ * ConfigSkeleton — Schema 表单的加载骨架。
+ *
+ * 抽自 Train.tsx 的 `ConfigSkeleton` 和 Presets.tsx 的 `SkeletonGroups`。两边
+ * 结构（N 组 × M 行的"label bar + input bar"）几乎一致，只是外观风格不同：
+ *   - Train 页：每组带 border + bg-surface 卡片，沉浸感强（variant='card'）
+ *   - Presets 页：扁平展开节省空间（variant='flat'）
+ *
+ * 顺带修 Designer P2 提到的 a11y 问题：role="status" 放外层在卸载时不会播报
+ * "加载完成"。这里 sr-only 文本保留，但本组件返回时 caller 应保证只在
+ * `loading === true` 期间挂载它（卸载 = 隐式表示加载完成），调用方页面如果
+ * 要"加载完成"播报应在页面顶层挂一个独立的 aria-live region。
+ */
+
+interface ConfigSkeletonProps {
+  /** sr-only / aria-label 文本，默认 "加载配置中" */
+  label?: string
+  /** 各组的行数，默认 [5, 6, 4, 5] */
+  groups?: number[]
+  /** 'card' = 每组带卡片边框（Train 风格）；'flat' = 扁平（Presets 风格）。默认 'card' */
+  variant?: 'card' | 'flat'
+}
+
+const DEFAULT_GROUPS = [5, 6, 4, 5]
+
+export default function ConfigSkeleton({
+  label = '加载配置中',
+  groups = DEFAULT_GROUPS,
+  variant = 'card',
+}: ConfigSkeletonProps) {
+  const isCard = variant === 'card'
+  const Wrapper = isCard ? 'section' : 'div'
+  const wrapperClass = isCard
+    ? 'flex-1 min-h-0 overflow-y-auto pr-1 space-y-3'
+    : 'flex flex-col gap-3 animate-pulse'
+  const groupClass = isCard
+    ? 'animate-pulse rounded-md border border-subtle bg-surface p-3.5'
+    : 'flex flex-col gap-2'
+  const titleBarClass = isCard
+    ? 'h-3.5 w-32 rounded-sm bg-sunken mb-2.5'
+    : 'h-3 w-24 rounded-sm bg-sunken opacity-60'
+  const rowsContainerClass = isCard
+    ? 'flex flex-col gap-2'
+    : 'flex flex-col gap-1.5'
+  const rowClass = isCard
+    ? 'flex flex-col gap-1'
+    : 'flex flex-col gap-0.5'
+  const labelBarClass = isCard
+    ? 'h-2.5 w-24 rounded-sm bg-sunken opacity-70'
+    : 'h-2 w-20 rounded-sm bg-sunken opacity-50'
+  const inputBarClass = isCard
+    ? 'h-7 rounded-sm bg-canvas border border-subtle'
+    : 'h-[26px] rounded-sm border border-subtle bg-canvas'
+
+  return (
+    <Wrapper className={wrapperClass} role="status" aria-label={label}>
+      {groups.map((rows, gi) => (
+        <div key={gi} className={groupClass}>
+          <div className={titleBarClass} />
+          <div className={rowsContainerClass}>
+            {Array.from({ length: rows }).map((_, ri) => (
+              <div key={ri} className={rowClass}>
+                <div className={labelBarClass} />
+                <div className={inputBarClass} />
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+      <span className="sr-only">{label}...</span>
+    </Wrapper>
+  )
+}

--- a/studio/web/src/lib/useLocalStorageState.test.ts
+++ b/studio/web/src/lib/useLocalStorageState.test.ts
@@ -1,0 +1,93 @@
+/**
+ * useLocalStorageState 单元测试。
+ *
+ * 覆盖：
+ *   - 初值：localStorage 没值用 default；有值用解析后的值
+ *   - setter：写 localStorage 同步更新 state
+ *   - 函数式 setter
+ *   - 'storage' 事件跨 tab 同步：新值同步进 state、null（其他 tab 删除）回 default
+ *   - parse 失败 fallback 到 default
+ */
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { useLocalStorageState } from './useLocalStorageState'
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+describe('useLocalStorageState', () => {
+  it('returns defaultValue when storage is empty', () => {
+    const { result } = renderHook(() => useLocalStorageState('k', 42))
+    expect(result.current[0]).toBe(42)
+  })
+
+  it('reads existing stored value at mount', () => {
+    window.localStorage.setItem('k', JSON.stringify('hello'))
+    const { result } = renderHook(() => useLocalStorageState('k', 'default'))
+    expect(result.current[0]).toBe('hello')
+  })
+
+  it('writes to localStorage on setValue', () => {
+    const { result } = renderHook(() => useLocalStorageState<number>('k', 1))
+    act(() => result.current[1](7))
+    expect(result.current[0]).toBe(7)
+    expect(window.localStorage.getItem('k')).toBe('7')
+  })
+
+  it('supports functional updater', () => {
+    const { result } = renderHook(() => useLocalStorageState<number>('k', 10))
+    act(() => result.current[1]((prev) => prev + 5))
+    expect(result.current[0]).toBe(15)
+  })
+
+  it('syncs from storage event (other tab wrote new value)', () => {
+    const { result } = renderHook(() => useLocalStorageState('k', 'a'))
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: 'k', newValue: JSON.stringify('b') }),
+      )
+    })
+    expect(result.current[0]).toBe('b')
+  })
+
+  it('reverts to default when storage event signals delete (newValue=null)', () => {
+    window.localStorage.setItem('k', JSON.stringify('x'))
+    const { result } = renderHook(() => useLocalStorageState('k', 'fallback'))
+    expect(result.current[0]).toBe('x')
+    act(() => {
+      window.dispatchEvent(new StorageEvent('storage', { key: 'k', newValue: null }))
+    })
+    expect(result.current[0]).toBe('fallback')
+  })
+
+  it('ignores storage event for unrelated keys', () => {
+    const { result } = renderHook(() => useLocalStorageState('k', 'a'))
+    act(() => {
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: 'other', newValue: JSON.stringify('b') }),
+      )
+    })
+    expect(result.current[0]).toBe('a')
+  })
+
+  it('falls back to default when stored value is unparsable', () => {
+    window.localStorage.setItem('k', '{not json')
+    const { result } = renderHook(() => useLocalStorageState('k', 'fallback'))
+    expect(result.current[0]).toBe('fallback')
+  })
+
+  it('works with object values', () => {
+    type Pref = { mode: 'dark' | 'light'; size: number }
+    const { result } = renderHook(() =>
+      useLocalStorageState<Pref>('k', { mode: 'light', size: 12 }),
+    )
+    act(() => result.current[1]({ mode: 'dark', size: 14 }))
+    expect(result.current[0]).toEqual({ mode: 'dark', size: 14 })
+    expect(JSON.parse(window.localStorage.getItem('k')!)).toEqual({
+      mode: 'dark',
+      size: 14,
+    })
+  })
+})

--- a/studio/web/src/lib/useLocalStorageState.ts
+++ b/studio/web/src/lib/useLocalStorageState.ts
@@ -1,0 +1,74 @@
+/**
+ * useLocalStorageState — 通用 localStorage 持久化 state hook。
+ *
+ * 项目里此前散落 4+ 处手搓 localStorage 读写 (preset-helpers / Settings /
+ * Regularization / Curation / PromptFromDatasetPicker)；签名分歧导致后续
+ * 不好统一加 cross-tab sync / SSR 守护。本 hook 是统一入口。
+ *
+ * 行为：
+ *   - mount 时从 localStorage 读初值，没读到用 defaultValue
+ *   - setValue(v) 立即写回 localStorage
+ *   - 监听 'storage' 事件做跨 tab 同步（参考 useAdvancedMode）
+ *   - SSR 安全：typeof window === 'undefined' 时静默用 default
+ *   - JSON.stringify / JSON.parse 序列化；parse 失败用 default
+ *
+ * 命名约定：key 用 `studio:scope:field` 前缀（参考 useAdvancedMode 的
+ * `studio:advanced_mode`），避免和其他 web app / 老版本冲突。
+ */
+import { useCallback, useEffect, useState } from 'react'
+
+export function useLocalStorageState<T>(
+  key: string,
+  defaultValue: T,
+): [T, (v: T | ((prev: T) => T)) => void] {
+  const [value, setValue] = useState<T>(() => readPersisted(key, defaultValue))
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const handler = (e: StorageEvent) => {
+      if (e.key !== key) return
+      if (e.newValue === null) {
+        setValue(defaultValue)
+        return
+      }
+      try {
+        setValue(JSON.parse(e.newValue) as T)
+      } catch {
+        // 其他 tab 写了非 JSON 值（外部脚本？）→ 忽略，本 tab 保留当前值
+      }
+    }
+    window.addEventListener('storage', handler)
+    return () => window.removeEventListener('storage', handler)
+  }, [key, defaultValue])
+
+  const update = useCallback(
+    (next: T | ((prev: T) => T)) => {
+      setValue((prev) => {
+        const resolved =
+          typeof next === 'function' ? (next as (p: T) => T)(prev) : next
+        if (typeof window !== 'undefined') {
+          try {
+            window.localStorage.setItem(key, JSON.stringify(resolved))
+          } catch {
+            // quota exceeded / private mode → 静默；state 仍在内存里有效
+          }
+        }
+        return resolved
+      })
+    },
+    [key],
+  )
+
+  return [value, update]
+}
+
+function readPersisted<T>(key: string, defaultValue: T): T {
+  if (typeof window === 'undefined') return defaultValue
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (raw === null) return defaultValue
+    return JSON.parse(raw) as T
+  } catch {
+    return defaultValue
+  }
+}

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -163,7 +163,8 @@ export default function QueuePage() {
     return `已运行 ${fmtDurationShort(elapsed)}`
   }, [])
 
-  const hasRunning = useMemo(() => tasks.some(t => t.status === 'running'), [tasks])
+  // 用 runningTask 派生比 tasks.some 再扫一遍便宜（runningTask 已经 memo 过）
+  const hasRunning = runningTask !== null
 
   // 后端只有 per-task cancel，没有 queue-level pause。"暂停" 语义会让用户误以为
   // 可以恢复，但 cancelTask 是 terminal cancel（task 进 canceled 状态，重启从 0
@@ -200,7 +201,7 @@ export default function QueuePage() {
           {hasRunning && (
             <button
               onClick={() => void cancelRunning()}
-              disabled={busy || !runningTask}
+              disabled={busy}
               className="btn btn-secondary btn-sm text-warn border-warn"
               title="发送取消信号，让当前运行任务停止"
             >

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -203,6 +203,10 @@ export default function TagEditPage() {
     setActiveKey('')
     setSel(new Set())
     setAnchor(null)
+    // P2：restore 后清 filterTag。restore 是大改动，旧 filter tag 在新结果里可能
+    // 已不存在 → 显示空网格让用户困惑。一并 reset 让用户看到完整 restore 结果，
+    // 想再过滤可以重选。
+    setFilterTag('')
     await reload()
   }
 

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -10,6 +10,7 @@ import {
   type Version,
   type VersionConfigResponse,
 } from '../../../api/client'
+import ConfigSkeleton from '../../../components/ConfigSkeleton'
 import { useDialog } from '../../../components/Dialog'
 import SchemaForm from '../../../components/SchemaForm'
 import StepShell from '../../../components/StepShell'
@@ -625,7 +626,7 @@ export default function TrainPage() {
                 </div>
               </section>
             ) : configResp === null || !schema ? (
-              <ConfigSkeleton />
+              <ConfigSkeleton label="加载训练配置中" />
             ) : !configResp.has_config ? (
               <div className="flex-1 flex items-center justify-center text-fg-tertiary text-sm rounded-md border border-dashed border-dim">
                 请从上方预设卡片选择一个，复制进当前 version 后即可编辑配置。
@@ -661,7 +662,7 @@ export default function TrainPage() {
                 />
               </section>
             ) : (
-              <ConfigSkeleton />
+              <ConfigSkeleton label="加载训练配置中" />
             )}
           </div>
 
@@ -871,36 +872,5 @@ function Row({
         fontWeight: bold ? 700 : 500,
       }}>{value}</span>
     </div>
-  )
-}
-
-
-function ConfigSkeleton() {
-  // 一个分组卡片：标题条 + 4-6 行字段（label + input 灰条）
-  const groups = [5, 6, 4, 5]
-  return (
-    <section
-      className="flex-1 min-h-0 overflow-y-auto pr-1 space-y-3"
-      role="status"
-      aria-label="加载训练配置中"
-    >
-      {groups.map((rows, gi) => (
-        <div
-          key={gi}
-          className="animate-pulse rounded-md border border-subtle bg-surface p-3.5"
-        >
-          <div className="h-3.5 w-32 rounded-sm bg-sunken mb-2.5" />
-          <div className="flex flex-col gap-2">
-            {Array.from({ length: rows }).map((_, ri) => (
-              <div key={ri} className="flex flex-col gap-1">
-                <div className="h-2.5 w-24 rounded-sm bg-sunken opacity-70" />
-                <div className="h-7 rounded-sm bg-canvas border border-subtle" />
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
-      <span className="sr-only">加载训练配置中...</span>
-    </section>
   )
 }

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -5,6 +5,7 @@ import {
   type PresetSummary,
   type SchemaResponse,
 } from '../../api/client'
+import ConfigSkeleton from '../../components/ConfigSkeleton'
 import { useDialog } from '../../components/Dialog'
 import SchemaForm from '../../components/SchemaForm'
 import { useToast } from '../../components/Toast'
@@ -539,7 +540,7 @@ export default function PresetsPage() {
           {/* schema 表单 */}
           {!schema || !config ? (
             <div className="h-[200px] rounded-md border border-subtle bg-surface p-3.5">
-              <SkeletonGroups />
+              <ConfigSkeleton variant="flat" label="加载预设配置中" />
             </div>
           ) : (
             <section className="rounded-md border border-subtle bg-surface px-3.5 py-2.5">
@@ -614,25 +615,3 @@ export default function PresetsPage() {
   )
 }
 
-// ── Schema 加载骨架 ──
-function SkeletonGroups() {
-  const rows = [5, 6, 4, 5]
-  return (
-    <div className="flex flex-col gap-3 animate-pulse" role="status" aria-label="加载预设配置中">
-      {rows.map((r, gi) => (
-        <div key={gi} className="flex flex-col gap-2">
-          <div className="h-3 w-24 rounded-sm bg-sunken opacity-60" />
-          <div className="flex flex-col gap-1.5">
-            {Array.from({ length: r }).map((_, ri) => (
-              <div key={ri} className="flex flex-col gap-0.5">
-                <div className="h-2 w-20 rounded-sm bg-sunken opacity-50" />
-                <div className="h-[26px] rounded-sm border border-subtle bg-canvas" />
-              </div>
-            ))}
-          </div>
-        </div>
-      ))}
-      <span className="sr-only">加载预设配置中...</span>
-    </div>
-  )
-}

--- a/studio/web/src/pages/tools/generate/FullscreenViewer.tsx
+++ b/studio/web/src/pages/tools/generate/FullscreenViewer.tsx
@@ -1,10 +1,12 @@
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
 /** 全屏图片 modal：双击 grid cell / cell action 触发。
  *
  * - 背景半透明遮罩，居中显示原图（object-contain）
  * - ESC / 点击遮罩关闭
  * - 不开新窗口（之前是 window.open，频繁评测时切换 tab 麻烦）
+ * - 方向键 + 屏上箭头切换邻居（PR #64 + P1-G）：caller 喂 hasX / onX；
+ *   shortcutHint 不传时按当前可用方向动态拼接（避免在单行 / 单列 / 角落格上撒谎）
  */
 export default function FullscreenViewer({
   src, alt, caption, onClose,
@@ -28,6 +30,13 @@ export default function FullscreenViewer({
 }) {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // P3：方向键在 input / textarea / contenteditable 内不抢焦点，
+      // 当前组件不带这些元素，纯防御性（未来加 caption 编辑时也安全）
+      const t = e.target as HTMLElement | null
+      if (t) {
+        const tag = t.tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || t.isContentEditable) return
+      }
       if (e.key === 'Escape') {
         e.preventDefault()
         onClose()
@@ -49,6 +58,17 @@ export default function FullscreenViewer({
     return () => document.removeEventListener('keydown', onKey)
   }, [hasDown, hasNext, hasPrev, hasUp, onClose, onDown, onNext, onPrev, onUp])
 
+  const computedHint = useMemo(() => {
+    if (shortcutHint) return shortcutHint
+    const dirs: string[] = []
+    if (hasPrev) dirs.push('←')
+    if (hasNext) dirs.push('→')
+    if (hasUp) dirs.push('↑')
+    if (hasDown) dirs.push('↓')
+    const nav = dirs.length > 0 ? `${dirs.join(' / ')} 切换 · ` : ''
+    return `${nav}ESC / 点击遮罩关闭`
+  }, [shortcutHint, hasPrev, hasNext, hasUp, hasDown])
+
   return (
     <div
       onClick={onClose}
@@ -67,8 +87,8 @@ export default function FullscreenViewer({
             type="button"
             onClick={onUp}
             className="absolute top-4 left-1/2 -translate-x-1/2 z-10 rounded bg-black/45 px-4 py-2 text-slate-300 hover:text-white hover:bg-black/65 text-2xl"
-            aria-label="上一行"
-            title="上一行"
+            aria-label="上一格"
+            title="上一格"
           >
             ↑
           </button>
@@ -100,8 +120,8 @@ export default function FullscreenViewer({
             type="button"
             onClick={onDown}
             className="absolute bottom-12 left-1/2 -translate-x-1/2 z-10 rounded bg-black/45 px-4 py-2 text-slate-300 hover:text-white hover:bg-black/65 text-2xl"
-            aria-label="下一行"
-            title="下一行"
+            aria-label="下一格"
+            title="下一格"
           >
             ↓
           </button>
@@ -122,7 +142,7 @@ export default function FullscreenViewer({
           </div>
         )}
         <div className="text-2xs text-fg-tertiary">
-          {shortcutHint ?? 'ESC / 点击遮罩关闭 · 在新窗口打开请按右键'}
+          {computedHint}
         </div>
       </div>
     </div>

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
@@ -59,6 +59,9 @@ export default function InlineLoraPicker({
     return Array.from(seen.entries()).map(([key, l]) => ({ key, item: l }))
   }, [projectId, projectLoras])
 
+  // versions 变化（切项目 / 上游 projectLoras 增减）时，若当前 versionKey 不再
+  // 出现在新 versions 中，回退到 'all'。切项目时 onChange 已显式 reset，这条 effect
+  // 是 projectLoras 列表外部变化（新增 / 删除 LoRA）的兜底，保留两路是有意为之。
   useEffect(() => {
     if (versionKey === 'all') return
     if (!versions.some((v) => v.key === versionKey)) setVersionKey('all')
@@ -85,40 +88,10 @@ export default function InlineLoraPicker({
       className="rounded-md border border-subtle bg-overlay p-2.5 flex flex-col gap-2"
       data-testid="inline-lora-picker"
     >
-      {/* header: project/version filters + search + actions */}
-      <div className="flex items-center gap-2 flex-wrap">
-        <select
-          className="input text-xs"
-          value={projectId}
-          onChange={(e) => {
-            setProjectId(e.target.value)
-            setVersionKey('all')
-          }}
-          aria-label="筛选项目"
-          style={{ width: 132 }}
-        >
-          <option value="all">全部项目</option>
-          {projects.map((p) => (
-            <option key={p.id} value={p.id}>{p.title}</option>
-          ))}
-        </select>
-        <select
-          className="input text-xs"
-          value={versionKey}
-          onChange={(e) => setVersionKey(e.target.value)}
-          aria-label="筛选版本"
-          disabled={versions.length === 0}
-          style={{ width: 150 }}
-        >
-          <option value="all">全部版本</option>
-          {versions.map(({ key, item }) => (
-            <option key={key} value={key}>
-              {projectId === 'all'
-                ? `${item.projectTitle} / ${item.versionLabel}`
-                : item.versionLabel}
-            </option>
-          ))}
-        </select>
+      {/* 两行布局（P1-H）：第 1 行 = 搜索 + 操作；第 2 行 = 项目 / 版本筛选。
+          原来挤一行 7 个元素在 picker 宽 < 600px 时 wrap 成 2-3 行视觉零散。
+          项目数 ≤ 1 时直接隐藏筛选行（dropdown 无意义）。 */}
+      <div className="flex items-center gap-2">
         <input
           type="text"
           className="input flex-1 text-xs min-w-[160px]"
@@ -155,6 +128,42 @@ export default function InlineLoraPicker({
           ×
         </button>
       </div>
+      {projects.length > 1 && (
+        <div className="flex items-center gap-2">
+          <select
+            className="input text-xs"
+            value={projectId}
+            onChange={(e) => {
+              setProjectId(e.target.value)
+              setVersionKey('all')
+            }}
+            aria-label="筛选项目"
+            style={{ width: 132 }}
+          >
+            <option value="all">全部项目</option>
+            {projects.map((p) => (
+              <option key={p.id} value={p.id}>{p.title}</option>
+            ))}
+          </select>
+          <select
+            className="input text-xs"
+            value={versionKey}
+            onChange={(e) => setVersionKey(e.target.value)}
+            aria-label="筛选版本"
+            disabled={versions.length === 0}
+            style={{ width: 150 }}
+          >
+            <option value="all">全部版本</option>
+            {versions.map(({ key, item }) => (
+              <option key={key} value={key}>
+                {projectId === 'all'
+                  ? `${item.projectTitle} / ${item.versionLabel}`
+                  : item.versionLabel}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       {/* 列表：扁平，每行一个 LoRA */}
       <div

--- a/studio/web/src/pages/tools/generate/PreviewCompare.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewCompare.tsx
@@ -32,7 +32,8 @@ export default function PreviewCompare({
   const [aIdx, bIdx] = selectedIndices
   const sampleA = samples[aIdx]
   const sampleB = samples[bIdx]
-  const [fullscreenSrc, setFullscreenSrc] = useState<{ url: string; caption: string } | null>(null)
+  // P1-G：全屏时按 side 记，让 ←/→ 在 A 和 B 之间切换（不只是被动看一张）
+  const [fullscreenSide, setFullscreenSide] = useState<'A' | 'B' | null>(null)
 
   if (!sampleA || !sampleB) {
     return (
@@ -78,7 +79,7 @@ export default function PreviewCompare({
               <span className="font-mono text-fg-tertiary truncate">{caption}</span>
             </div>
             <button
-              onDoubleClick={() => setFullscreenSrc({ url, caption })}
+              onDoubleClick={() => setFullscreenSide(side)}
               className="flex-1 min-h-0 flex items-center justify-center bg-sunken rounded-md border border-subtle p-0 cursor-zoom-in"
               title="双击全屏"
             >
@@ -92,11 +93,17 @@ export default function PreviewCompare({
           </div>
         ))}
       </div>
-      {fullscreenSrc && (
+      {fullscreenSide && (
         <FullscreenViewer
-          src={fullscreenSrc.url}
-          caption={fullscreenSrc.caption}
-          onClose={() => setFullscreenSrc(null)}
+          src={fullscreenSide === 'A' ? urlA : urlB}
+          caption={fullscreenSide === 'A' ? captionA : captionB}
+          onClose={() => setFullscreenSide(null)}
+          // A 和 B 都存在（早退分支已保证）→ ←/→ 都可走
+          hasPrev
+          hasNext
+          onPrev={() => setFullscreenSide((s) => (s === 'B' ? 'A' : 'B'))}
+          onNext={() => setFullscreenSide((s) => (s === 'A' ? 'B' : 'A'))}
+          shortcutHint={`← / → 切换 ${fullscreenSide === 'A' ? 'A→B' : 'B→A'} · ESC 关闭`}
         />
       )}
     </div>

--- a/studio/web/src/pages/tools/generate/PreviewXYGrid.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewXYGrid.tsx
@@ -295,7 +295,8 @@ export default function PreviewXYGrid({
             onDown={() => {
               if (fullscreenNeighbors?.down != null) setFullscreenIdx(fullscreenNeighbors.down)
             }}
-            shortcutHint="←/→/↑/↓ 切换单元格 · ESC / 点击遮罩关闭"
+            // shortcutHint 不传 → FullscreenViewer 按 hasX 动态拼接（单行 /
+            // 单列 / 角落格上不显示无效方向）
           />
         )
       })()}

--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
@@ -1,15 +1,24 @@
 import { useEffect, useMemo, useState } from 'react'
 import { api, type CaptionEntry, type ProjectSummary } from '../../../api/client'
+import { useLocalStorageState } from '../../../lib/useLocalStorageState'
 
-const LAST_PROJECT_KEY = 'anima.generate.promptDataset.projectId'
-const LAST_VERSION_KEY = 'anima.generate.promptDataset.versionId'
+// 命名前缀对齐 useAdvancedMode 的 `studio:` 约定（PR #66 P1-4）。旧的
+// `anima.generate.promptDataset.*` key 在 mount 时 migrate 一次后丢弃。
+const LAST_PROJECT_KEY = 'studio:generate:promptDataset:projectId'
+const LAST_VERSION_KEY = 'studio:generate:promptDataset:versionId'
+const LEGACY_PROJECT_KEY = 'anima.generate.promptDataset.projectId'
+const LEGACY_VERSION_KEY = 'anima.generate.promptDataset.versionId'
 
-function readStoredNumber(key: string): number | null {
-  if (typeof window === 'undefined') return null
-  const raw = window.localStorage.getItem(key)
-  if (!raw) return null
+function migrateLegacyKey(legacyKey: string, newKey: string): void {
+  if (typeof window === 'undefined') return
+  if (window.localStorage.getItem(newKey) !== null) return
+  const raw = window.localStorage.getItem(legacyKey)
+  if (raw === null) return
   const n = Number(raw)
-  return Number.isFinite(n) ? n : null
+  if (Number.isFinite(n)) {
+    window.localStorage.setItem(newKey, JSON.stringify(n))
+  }
+  window.localStorage.removeItem(legacyKey)
 }
 
 /** 从训练集 caption 里选一条，把 tags 拿到生成 prompt 里。
@@ -26,9 +35,16 @@ export default function PromptFromDatasetPicker({
   onReplace: (tags: string[]) => void
   onClose: () => void
 }) {
+  // 一次性 migrate 旧 anima.* key 到 studio: 命名（PR #66 P1-4 约定）；module 顶部
+  // 调用即可，没必要进 useEffect —— 没读 / 写 React state 副作用，只动 localStorage。
+  if (typeof window !== 'undefined') {
+    migrateLegacyKey(LEGACY_PROJECT_KEY, LAST_PROJECT_KEY)
+    migrateLegacyKey(LEGACY_VERSION_KEY, LAST_VERSION_KEY)
+  }
+
   const [projects, setProjects] = useState<ProjectSummary[]>([])
-  const [pid, setPid] = useState<number | null>(null)
-  const [vid, setVid] = useState<number | null>(null)
+  const [pid, setPid] = useLocalStorageState<number | null>(LAST_PROJECT_KEY, null)
+  const [vid, setVid] = useLocalStorageState<number | null>(LAST_VERSION_KEY, null)
   const [versions, setVersions] = useState<Array<{ id: number; label: string }>>([])
   const [captions, setCaptions] = useState<CaptionEntry[]>([])
   const [loading, setLoading] = useState(false)
@@ -36,43 +52,32 @@ export default function PromptFromDatasetPicker({
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [search, setSearch] = useState('')
 
-  // 1. 拉项目列表
+  // 1. 拉项目列表；若上次记的 pid 在新项目列表中不存在则清掉避免幽灵选择
   useEffect(() => {
     void api.listProjects()
       .then((items) => {
         setProjects(items)
-        const storedPid = readStoredNumber(LAST_PROJECT_KEY)
-        if (storedPid != null && items.some((p) => p.id === storedPid)) {
-          setPid(storedPid)
-        }
+        if (pid != null && !items.some((p) => p.id === pid)) setPid(null)
       })
       .catch((e) => setError(String(e)))
+    // pid 进依赖会触发反复拉项目；mount 一次就够
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // 2. 选项目后拉版本列表
+  // 2. 选项目后拉版本列表；优先复用 vid（如果该版本在新项目里仍存在）
   useEffect(() => {
     if (!pid) { setVersions([]); setVid(null); return }
     void api.getProject(pid)
       .then((p) => {
         const vs = p.versions.map((v) => ({ id: v.id, label: v.label }))
         setVersions(vs)
-        const storedVid = readStoredNumber(LAST_VERSION_KEY)
-        if (storedVid != null && vs.some((v) => v.id === storedVid)) setVid(storedVid)
-        else if (vs.length > 0) setVid(vs[0].id)
-        else setVid(null)
+        if (vid != null && vs.some((v) => v.id === vid)) return  // 旧 vid 仍在 → 保留
+        setVid(vs.length > 0 ? vs[0].id : null)
       })
       .catch((e) => setError(String(e)))
+    // 同上：vid 只在 effect 内部读，不进依赖
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pid])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    if (pid != null) window.localStorage.setItem(LAST_PROJECT_KEY, String(pid))
-  }, [pid])
-
-  useEffect(() => {
-    if (typeof window === 'undefined') return
-    if (vid != null) window.localStorage.setItem(LAST_VERSION_KEY, String(vid))
-  }, [vid])
 
   // 3. 选版本后拉 captions
   useEffect(() => {


### PR DESCRIPTION
## Summary

PR #64 review 时三方（dev / designer / pm）给出的 P1 / P2 / P3 follow-up 一起做。P0 已合在 \`f64da1f\`。

4 个 commit：

### 1. \`8a0287b\` P1-E: useLocalStorageState 通用 hook + PromptFromDatasetPicker 迁移

- 项目里此前 8 处文件手搓 localStorage，签名分歧，无 cross-tab sync 也无 SSR 守护
- 新 hook：泛型 T + JSON 序列化 + 'storage' 事件跨 tab 同步 + SSR 安全 + quota 静默
- PromptFromDatasetPicker 迁到新 hook + 命名前缀 \`anima.\` → \`studio:\`（对齐 useAdvancedMode）
- 旧 key 一次性 migrate 后删除，老用户记忆不丢
- 其他 7 处 ad-hoc localStorage 保持不动，避免 scope creep
- 单测 9 个

### 2. \`f92fc1a\` P1-I: 抽 ConfigSkeleton 公共组件复用 Train + Presets

- Train.tsx 已有 ConfigSkeleton（card 风格），PR #64 又在 Presets.tsx 写了几乎逐字相同的 SkeletonGroups（flat 风格）
- 统一成 \`components/ConfigSkeleton.tsx\` 提供 variant 'card' | 'flat' + label prop
- 视觉零回归，class 完全保留
- 单测 5 个覆盖两种变体 + label + groups

### 3. \`962de87\` P1-G: FullscreenViewer 动态 hint + 统一 aria + PreviewCompare 接 ←→

- shortcutHint 默认按 hasX 动态拼接，单行 / 单列 / 角落格不再撒谎承诺 4 方向
- aria-label \`左一格 / 上一行\` 混用 → 统一成 \`上/下/左/右一格\`
- PreviewCompare 双图对比模式 fullscreen 后 ←→ 切 A↔B（之前只能 ESC）
- P3 防御：方向键在 INPUT / TEXTAREA / contenteditable 内不抢焦点

### 4. \`a118b88\` P1-H + P2/P3 + F

- **P1-H**：InlineLoraPicker header 拆 2 行（搜索/操作 + project/version dropdowns），projects ≤ 1 时直接隐藏 dropdown 行
- **P2**：Queue 删多余 \`tasks.some\` + 取消按钮 dead code；InlineLoraPicker versionKey 双路 reset 加注释；BulkActionBar hint 拆两行 + Mac ⌘；TagEdit onAfterRestore 加清 filterTag
- **F**：server.py no-store 加原因注释（vs _thumb_response 的 no-cache + ETag）

## 跳过的 P1 / P2 / P3

- **P1-E 部分**：Designer 提的 "跨项目幻觉" visual feedback（顶部加 \"来自项目: X / v3\"）— picker dropdown 自身已显示选中项目，UX 决策延后
- **TagEdit 行为变更 release notes**（P3）— 不在代码改动范畴，0.7.1 release 时手动加
- **测试缺失**（P3）— repo culture 问题，不在本 PR 修

## Test plan

- [x] \`npm test\` 全套 151/151（其中 14 个本 PR 新增：useLocalStorageState 9 + ConfigSkeleton 5）
- [x] \`npm run build\` lint + tsc + vite 全过
- [x] \`pytest tests/test_studio_server.py\` 53/53
- [ ] 手测 Generate 页 PromptDatasetPicker 旧 key migration（旧 \`anima.\` key 自动转 \`studio:\`）
- [ ] 手测 InlineLoraPicker 单项目 / 多项目下 dropdown 行可见性
- [ ] 手测 PreviewCompare 双图全屏 ← → 切 A↔B
- [ ] 手测 XY grid 边缘 cell fullscreen hint 只显示可走方向

参考 \`memory/pr64_followups.md\` P1/P2/P3 清单。

🤖 Generated with [Claude Code](https://claude.com/claude-code)