### PR TITLE
fix(tag-edit): scope bulk edits to filtered images

### DIFF
--- a/studio/web/src/components/BulkActionBar.test.tsx
+++ b/studio/web/src/components/BulkActionBar.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import BulkActionBar from './BulkActionBar'
+import { ToastProvider } from './Toast'
+
+const cache = new Map<string, string[]>([
+  ['a.png', ['cat', 'solo']],
+  ['b.png', ['cat']],
+  ['c.png', ['dog']],
+])
+
+function renderBar(overrides: Partial<ComponentProps<typeof BulkActionBar>> = {}) {
+  const onApply = vi.fn()
+  const props: ComponentProps<typeof BulkActionBar> = {
+    cache,
+    selectedKeys: [],
+    onApply,
+    tagSuggestions: ['cat', 'dog', 'solo', 'warm'],
+    filterTag: 'cat',
+    onFilterTagChange: vi.fn(),
+    filteredKeys: ['a.png', 'b.png'],
+    totalCount: 3,
+    filteredCount: 2,
+    onSelectAll: vi.fn(),
+    onClearSelection: vi.fn(),
+    ...overrides,
+  }
+  render(
+    <ToastProvider>
+      <BulkActionBar {...props} />
+    </ToastProvider>,
+  )
+  return { onApply }
+}
+
+describe('BulkActionBar', () => {
+  it('can apply a bulk operation to the current filtered result without touching hidden images', async () => {
+    const user = userEvent.setup()
+    const { onApply } = renderBar()
+
+    await user.selectOptions(screen.getByRole('combobox'), 'filtered')
+    await user.click(screen.getByRole('button', { name: '+ 加 tag' }))
+    await user.type(screen.getByPlaceholderText('tag1, tag2 (逗号分隔)'), 'warm')
+    await user.click(screen.getByRole('button', { name: '执行' }))
+
+    expect(onApply).toHaveBeenCalledOnce()
+    const updates = onApply.mock.calls[0][0] as Map<string, string[]>
+    expect([...updates.keys()].sort()).toEqual(['a.png', 'b.png'])
+    expect(updates.get('a.png')).toEqual(['warm', 'cat', 'solo'])
+    expect(updates.get('b.png')).toEqual(['warm', 'cat'])
+    expect(updates.has('c.png')).toBe(false)
+  })
+
+  it('keeps selected scope disabled until a visible image is selected', () => {
+    renderBar({ selectedKeys: [] })
+    expect(screen.getByRole('button', { name: '+ 加 tag' })).toBeDisabled()
+  })
+})

--- a/studio/web/src/components/BulkActionBar.tsx
+++ b/studio/web/src/components/BulkActionBar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import TagAutocomplete from './TagAutocomplete'
 import { useToast } from './Toast'
 
-type ScopeKind = 'selected' | 'all'
+type ScopeKind = 'selected' | 'filtered' | 'all'
 type Op = 'add' | 'remove' | 'replace' | 'dedupe'
 
 interface Props {
@@ -15,6 +15,7 @@ interface Props {
   // filter/select controls (moved from sidebar)
   filterTag: string
   onFilterTagChange: (v: string) => void
+  filteredKeys: string[]
   totalCount: number
   filteredCount: number
   onSelectAll: () => void
@@ -23,7 +24,7 @@ interface Props {
 export default function BulkActionBar({
   cache, selectedKeys, onApply,
   tagSuggestions = [], defaultScope = 'selected', onClearSelection,
-  filterTag, onFilterTagChange, totalCount, filteredCount, onSelectAll,
+  filterTag, onFilterTagChange, filteredKeys, totalCount, filteredCount, onSelectAll,
 }: Props) {
   const { toast } = useToast()
   const [openOp, setOpenOp] = useState<Op | null>(null)
@@ -37,16 +38,27 @@ export default function BulkActionBar({
     setOpenOp(null); setTagsInput(''); setOldTag(''); setNewTag('')
   }
 
-  const targetKeys = (): string[] =>
-    scope === 'selected' ? selectedKeys : Array.from(cache.keys())
+  const targetKeys = (): string[] => {
+    if (scope === 'selected') return selectedKeys
+    if (scope === 'filtered') return filteredKeys
+    return Array.from(cache.keys())
+  }
 
   const parseTags = (raw: string): string[] =>
     raw.split(/[,，\n]/).map((t) => t.trim()).filter(Boolean)
 
   const apply = (op: Op) => {
     const keys = targetKeys()
-    if (scope === 'selected' && keys.length === 0) {
-      toast('当前没有选中文件', 'error'); return
+    if (keys.length === 0) {
+      toast(
+        scope === 'selected'
+          ? '当前没有选中文件'
+          : scope === 'filtered'
+            ? '当前筛选结果为空'
+            : '当前没有图片',
+        'error',
+      )
+      return
     }
     const updates = new Map<string, string[]>()
 
@@ -97,7 +109,13 @@ export default function BulkActionBar({
   }
 
   const isSelected = scope === 'selected'
-  const opDisabled = isSelected && selectedKeys.length === 0
+  const opDisabled =
+    (isSelected && selectedKeys.length === 0) ||
+    (scope === 'filtered' && filteredKeys.length === 0) ||
+    (scope === 'all' && cache.size === 0)
+  const filteredScopeLabel = filterTag
+    ? `当前筛选（${filteredCount}）`
+    : `当前列表（${filteredCount}）`
 
   return (
     <div className="rounded-md border border-subtle bg-surface px-3 py-2 flex flex-col gap-1.5 text-xs shrink-0">
@@ -153,7 +171,8 @@ export default function BulkActionBar({
           style={{ fontSize: 'var(--t-xs)', padding: '2px 8px' }}
         >
           <option value="selected">当前选中（{selectedKeys.length}）</option>
-          <option value="all">全部图片</option>
+          <option value="filtered" disabled={filteredCount === 0}>{filteredScopeLabel}</option>
+          <option value="all">全部图片（{totalCount}）</option>
         </select>
 
         <span className="text-dim">|</span>

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -334,6 +334,7 @@ export default function TagEditPage() {
             onClearSelection={() => setSel(new Set())}
             filterTag={filterTag}
             onFilterTagChange={setFilterTag}
+            filteredKeys={filteredKeys}
             totalCount={keys.length}
             filteredCount={filteredKeys.length}
             onSelectAll={() => setSel(new Set(filteredKeys))}


### PR DESCRIPTION
## 截图

![标签批量编辑范围下拉](https://litter.catbox.moe/6wbiko.png)

## 改了什么功能

- 在标签编辑页的批量操作栏里新增「当前筛选 / 当前列表」范围。
- 批量加 tag、删 tag、replace、dedupe 现在可以直接作用于当前可见结果，不需要先手动全选。
- 「当前选中」「当前筛选 / 当前列表」「全部图片」三个范围都带计数，降低误操作成本。
- 新增 `BulkActionBar` 回归测试，确保筛选范围批量编辑不会改到隐藏图片。

## 为什么要改

原来的过滤和批量编辑是反直觉的：用户先用 tag 过滤出一批图片后，批量范围只有「当前选中」和「全部图片」。如果选「全部图片」，会改到筛选外的隐藏图片；如果选「当前选中」，又必须额外点一次全选。这个 PR 把“我正在看的这批图”变成明确范围，减少额外步骤，也避免误伤不可见图片。

## 使用场景

- 标签统计里发现某个 tag 需要统一替换，先过滤出含该 tag 的图片，再把范围切到「当前筛选」执行 replace。
- 筛出一组图片后统一追加触发词或质量词，不需要先勾选每张图。
- 过滤结果为空时批量按钮会禁用，避免对空结果执行操作。

## 实际使用复测

这次按真实使用路径重新走了一遍，不只验证按钮状态：

1. 本机临时创建一个测试 project/version，放入两张训练图：
   - `alpha.png`: `cat, shared, alpha_only`
   - `beta.png`: `dog, shared, beta_only`
2. 打开 `/studio/projects/{pid}/v/{vid}/edit`，确认默认「当前选中（0）」时批量按钮禁用。
3. 在「搜索 tag（精确）」输入 `cat`，列表只剩 `alpha.png`，计数显示 `1/2`，范围出现「当前筛选（1）」。
4. 切到「当前筛选（1）」后，不勾选图片，直接执行 `+ 加 tag`，添加 `tmp_pr71_scope`。
5. 页面提示 `add 完成（1 张待保存）`，打开单图编辑确认：
   - `alpha.png` 出现 `tmp_pr71_scope`
   - `beta.png` 仍只有 `dog/shared/beta_only`，没有 `tmp_pr71_scope`
6. 保存后用后端 API 和磁盘 caption 文件确认：
   - `alpha.txt` 写入 `tmp_pr71_scope, cat, shared, alpha_only`
   - `beta.txt` 保持 `dog, shared, beta_only`
7. 临时测试 project 和回收站目录已清理，仓库没有留下额外文件改动。

## 测试

- `npm run test -- BulkActionBar.test.tsx ImageGrid.test.tsx`
- `npm run build`
- 浏览器检查：打开标签编辑页，按上面的真实路径验证筛选范围只作用于当前可见结果。

## 备注

浏览器巡检时看到一个既有的 `ProjectsPage` 嵌套 button 的 React warning，这个不属于本 PR，后续单独拆。