### PR TITLE
feat(train): detail_inv_t loss weighting 上下限可配置

### DIFF
--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -138,6 +138,8 @@ def run(ctx: TrainingContext) -> None:
                         scheme=lw_scheme,
                         min_snr_gamma=float(getattr(args, "min_snr_gamma", 5.0) or 5.0),
                         weight_cap_ratio=float(getattr(args, "weight_cap_ratio", 0.0) or 0.0),
+                        detail_inv_t_min=float(getattr(args, "detail_inv_t_min", 1.0) or 1.0),
+                        detail_inv_t_max=float(getattr(args, "detail_inv_t_max", 5.0) or 5.0),
                     ).to(device=ctx.device, dtype=torch.float32)
                     loss_per_sample = loss_per_sample * lw.view(-1, *([1] * (loss_per_sample.dim() - 1)))
                 loss = loss_per_sample.mean()

--- a/runtime/training/loss_weighting.py
+++ b/runtime/training/loss_weighting.py
@@ -19,16 +19,23 @@ def compute_loss_weight(
     scheme: str = "none",
     min_snr_gamma: float = 5.0,
     weight_cap_ratio: float = 0.0,
+    detail_inv_t_min: float = 1.0,
+    detail_inv_t_max: float = 5.0,
 ) -> torch.Tensor:
     """返回每样本 loss 权重 (B,)，Flow Matching CONST 调度下：SNR(t) = ((1-t)/t)^2。
 
     scheme:
       none          — 全 1，与原始行为一致
       min_snr       — w = min(gamma/SNR, 1)，下调高 SNR 简单步（推荐基础款）
-      detail_inv_t  — w = 1/t clamp [1,5]，温和细节强化，小 batch + Prodigy 友好
+      detail_inv_t  — w = 1/t clamp [detail_inv_t_min, detail_inv_t_max]，
+                      温和细节强化，小 batch + Prodigy 友好；默认 [1,5]
       cosmap        — SD3 cosmap weighting，中间 t 更均匀（max/min ≈ 1.81×）
 
     weight_cap_ratio — batch 内 max/min 比上限（0=禁用），防单样本主导破坏 Prodigy d 估计
+    detail_inv_t_min/max — detail_inv_t 加权曲线的下/上限。
+                           默认 [1, 5]：t=1 时 w=1，t=0.2 时 w=5（被 clamp）。
+                           降 max（如 3）→ 雾蒙蒙/低饱和画风更稳；
+                           升 max（如 8）→ 细节学得更激进但 Prodigy d 估计易被单样本主导。
     """
     scheme = (scheme or "none").lower()
     if scheme == "none":
@@ -41,7 +48,11 @@ def compute_loss_weight(
         snr = ((1 - t_c) / t_c) ** 2
         w = torch.minimum(torch.tensor(float(min_snr_gamma), device=t.device) / snr, torch.ones_like(t_c))
     elif scheme == "detail_inv_t":
-        w = (1.0 / t_c).clamp(min=1.0, max=5.0)
+        lo = float(detail_inv_t_min)
+        hi = float(detail_inv_t_max)
+        if lo > hi:
+            lo, hi = hi, lo
+        w = (1.0 / t_c).clamp(min=lo, max=hi)
     elif scheme == "cosmap":
         bot = (1 - 2 * t_c + 2 * t_c ** 2).clamp(min=eps)
         w = 2.0 / (math.pi * bot)

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -429,6 +429,16 @@ class TrainingConfig(BaseModel):
         description="【损失加权】Batch 内权重 max/min 比上限（0=禁用；小 batch+Prodigy 建议 5）",
         json_schema_extra=_meta("noise_schedule", show_when="loss_weighting!=none", advanced=True),
     )
+    detail_inv_t_min: float = Field(
+        1.0, ge=0.1, le=20.0,
+        description="【损失加权】detail_inv_t 权重下限（默认 1.0；升至 1.5 可让高 t 步也被略微加权）",
+        json_schema_extra=_meta("noise_schedule", show_when="loss_weighting==detail_inv_t", advanced=True),
+    )
+    detail_inv_t_max: float = Field(
+        5.0, ge=0.1, le=50.0,
+        description="【损失加权】detail_inv_t 权重上限（默认 5.0；雾蒙蒙画风建议降到 3，激进细节可升到 8）",
+        json_schema_extra=_meta("noise_schedule", show_when="loss_weighting==detail_inv_t", advanced=True),
+    )
     grad_clip_max_norm: float = Field(
         0.0, ge=0.0,
         description="梯度裁剪最大范数（0=禁用）",

--- a/tests/test_loss_weighting.py
+++ b/tests/test_loss_weighting.py
@@ -1,0 +1,116 @@
+"""loss_weighting 单元测试。
+
+主要覆盖：
+- detail_inv_t 默认 clamp 范围 [1, 5] —— 防 PR 把默认行为改坏
+- detail_inv_t_min/max 自定义边界生效（PR：参数化原本写死的上下限）
+- min > max 时 swap 后正常工作，不崩溃
+- 新参数只影响 detail_inv_t，不影响 min_snr / cosmap / none
+
+其他 scheme（min_snr 公式 / cosmap 公式 / weight_cap_ratio）不在本 PR 范围内重测。
+"""
+from __future__ import annotations
+
+import torch
+
+from training.loss_weighting import compute_loss_weight
+
+
+# ---------------------------------------------------------------------------
+# detail_inv_t 默认行为回归
+# ---------------------------------------------------------------------------
+
+
+def test_detail_inv_t_default_matches_legacy_clamp():
+    """默认参数下，clamp 行为应等价于历史 hardcode [1, 5]：
+        t=0.5  → 1/t=2     → 未 clamp → w=2
+        t=0.1  → 1/t=10    → 触上界 → w=5
+        t=0.9  → 1/t≈1.11  → 未 clamp
+        t=0.999→ 1/t≈1.001 → 未 clamp（默认下界 1.0 在 t∈(0,1) 下几乎不生效）
+    """
+    t = torch.tensor([0.5, 0.1, 0.9, 0.999])
+    w = compute_loss_weight(t, scheme="detail_inv_t")
+    expected = torch.tensor([2.0, 5.0, 1.0 / 0.9, 1.0 / 0.999])
+    torch.testing.assert_close(w, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_detail_inv_t_extreme_low_t_clamps_to_max():
+    """t 趋近 0 时 1/t 爆炸，必须被 max 截住（默认 5）。"""
+    t = torch.tensor([1e-5, 1e-3, 0.0])  # 0.0 会被 eps 处理
+    w = compute_loss_weight(t, scheme="detail_inv_t")
+    assert torch.all(w <= 5.0 + 1e-6)
+    assert torch.all(w == 5.0)
+
+
+# ---------------------------------------------------------------------------
+# 自定义 min/max 生效
+# ---------------------------------------------------------------------------
+
+
+def test_detail_inv_t_custom_max_hazy_profile():
+    """雾蒙蒙画风用 [1, 3]：t=0.1 应该 clamp 到 3 而不是 5。"""
+    t = torch.tensor([0.5, 0.1, 0.9])
+    w = compute_loss_weight(t, scheme="detail_inv_t", detail_inv_t_min=1.0, detail_inv_t_max=3.0)
+    expected = torch.tensor([2.0, 3.0, 1.0 / 0.9])
+    torch.testing.assert_close(w, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_detail_inv_t_custom_max_aggressive_profile():
+    """激进风用 [1, 8]：t=0.1 应该 clamp 到 8。"""
+    t = torch.tensor([0.5, 0.1, 0.05])
+    w = compute_loss_weight(t, scheme="detail_inv_t", detail_inv_t_min=1.0, detail_inv_t_max=8.0)
+    # t=0.05 → 1/t=20 → clamp 到 8
+    expected = torch.tensor([2.0, 8.0, 8.0])
+    torch.testing.assert_close(w, expected, rtol=1e-4, atol=1e-4)
+
+
+def test_detail_inv_t_custom_min_lifts_high_t():
+    """提高下限到 1.5：t=0.9 (1/t≈1.11) 应被抬到 1.5。"""
+    t = torch.tensor([0.9, 0.999])
+    w = compute_loss_weight(t, scheme="detail_inv_t", detail_inv_t_min=1.5, detail_inv_t_max=5.0)
+    assert torch.all(w >= 1.5 - 1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 边界 / 健壮性
+# ---------------------------------------------------------------------------
+
+
+def test_detail_inv_t_min_above_max_is_swapped():
+    """误配 min > max 时函数内部 swap，不崩溃且产出有意义结果。"""
+    t = torch.tensor([0.1, 0.5, 0.9])
+    w_swap = compute_loss_weight(t, scheme="detail_inv_t", detail_inv_t_min=5.0, detail_inv_t_max=1.0)
+    w_normal = compute_loss_weight(t, scheme="detail_inv_t", detail_inv_t_min=1.0, detail_inv_t_max=5.0)
+    torch.testing.assert_close(w_swap, w_normal)
+
+
+def test_detail_inv_t_min_equals_max_collapses_to_constant():
+    """min == max 时 clamp 把所有权重压成一个常数。"""
+    t = torch.tensor([0.05, 0.5, 0.95])
+    w = compute_loss_weight(t, scheme="detail_inv_t", detail_inv_t_min=2.5, detail_inv_t_max=2.5)
+    expected = torch.full_like(t, 2.5)
+    torch.testing.assert_close(w, expected)
+
+
+# ---------------------------------------------------------------------------
+# 不影响其他 scheme
+# ---------------------------------------------------------------------------
+
+
+def test_detail_inv_t_bounds_do_not_affect_min_snr():
+    t = torch.tensor([0.1, 0.5, 0.9])
+    w_a = compute_loss_weight(t, scheme="min_snr", detail_inv_t_min=99.0, detail_inv_t_max=0.5)
+    w_b = compute_loss_weight(t, scheme="min_snr")
+    torch.testing.assert_close(w_a, w_b)
+
+
+def test_detail_inv_t_bounds_do_not_affect_cosmap():
+    t = torch.tensor([0.1, 0.5, 0.9])
+    w_a = compute_loss_weight(t, scheme="cosmap", detail_inv_t_min=99.0, detail_inv_t_max=0.5)
+    w_b = compute_loss_weight(t, scheme="cosmap")
+    torch.testing.assert_close(w_a, w_b)
+
+
+def test_detail_inv_t_bounds_do_not_affect_none():
+    t = torch.tensor([0.1, 0.5, 0.9])
+    w = compute_loss_weight(t, scheme="none", detail_inv_t_min=99.0, detail_inv_t_max=0.5)
+    torch.testing.assert_close(w, torch.ones_like(t))


### PR DESCRIPTION
## 背景 / 动机

`loss_weighting=detail_inv_t` 的 clamp 范围当前在 `loss_weighting.py` 写死 `[1, 5]`，没法在 YAML / WebUI 里调。实际训练里两条边界都有调参需求：

- **雾蒙蒙 / 低饱和画风**：把 max 降到 3，把"低 t 反复学"的偏置减半，缓解低对比图的细节溶解
- **高对比 / 硬朗画风**：维持默认 [1, 5]
- **激进细节**：把 max 升到 8（Prodigy 的 d 估计需注意单样本主导风险）

## 改动概要

- `runtime/training/loss_weighting.py`:`compute_loss_weight()` 新增 `detail_inv_t_min=1.0` / `detail_inv_t_max=5.0` 两参；clamp 范围从 hardcode 改为参数化；min>max 时内部 swap 容错
- `runtime/training/loop.py`:caller 显式传新参，沿用 `getattr(args, ..., default) or default` 风格
- `studio/schema.py`:在 `weight_cap_ratio` 后加两个 `Field`，`show_when="loss_weighting==detail_inv_t"` + `advanced=True` + `group=noise_schedule`。前端 SchemaForm 自动渲染
- `tests/test_loss_weighting.py`:新建，10 个用例覆盖默认行为回归 / 自定义边界（hazy/aggressive）/ min>max swap / min=max 退化 / 不影响其他 scheme

## 默认行为

所有现有 YAML / 已存 preset 的 `loss_weighting=detail_inv_t` 行为**零变化**:新参默认 `[1.0, 5.0]` 等价历史 hardcode.

## ADR 0003 一致性

ADR 0003 L113 "loss_weighting 不引入 schema 字段" 的描述已被 `min_snr_gamma` / `weight_cap_ratio` 默认松动;本 PR 延续同一惯例,未升级 `loss_weighting.py` 成 plugin subfolder.

## 测试

本地用 ComfyUI 自带 python (3.10.11 + torch 2.7.0+cu128 + pydantic 2.11.4):

tests/test_loss_weighting.py 10/10 PASS（新增）
tests/test_anima_train_migration.py PASS
tests/test_plugin_registry.py PASS
tests/test_argparse_bridge.py PASS（含 schema → CLI 衍生回归）
tests/test_infonoise.py PASS

合计 58 passed, 4 skipped, 0 failed
