### PR TITLE
feat(train): mixed_uniform timestep 采样模式 + schedule_shift 后置偏移

### DIFF
--- a/runtime/training/timestep_samplers/baseline.py
+++ b/runtime/training/timestep_samplers/baseline.py
@@ -1,7 +1,8 @@
 """Baseline timestep 采样器：包装 training.timestep_sampling.sample_t。
 
 非自适应；record / maybe_refresh 是 no-op。
-覆盖 4 种 mode：logit_normal / uniform / logit_normal_low / mode。
+覆盖 6 种 mode：logit_normal / uniform / logit_normal_low / mode /
+mixed_uniform_low / mixed_uniform_logit。
 """
 
 from __future__ import annotations
@@ -14,12 +15,27 @@ from training.timestep_sampling import sample_t
 class BaselineTimestepSampler:
     """sample_t 的 thin wrapper，使它符合 TimestepSamplerProtocol。"""
 
-    def __init__(self, mode: str = "logit_normal", shift: float = 3.0):
+    def __init__(
+        self,
+        mode: str = "logit_normal",
+        shift: float = 3.0,
+        mix_low_prob: float = 0.0,
+        schedule_shift: float = 1.0,
+    ):
         self.mode = mode
         self.shift = shift
+        self.mix_low_prob = mix_low_prob
+        self.schedule_shift = schedule_shift
 
     def sample(self, bs: int, device) -> torch.Tensor:
-        return sample_t(bs, device, mode=self.mode, shift=self.shift)
+        return sample_t(
+            bs,
+            device,
+            mode=self.mode,
+            shift=self.shift,
+            mix_low_prob=self.mix_low_prob,
+            schedule_shift=self.schedule_shift,
+        )
 
     def record(self, t: torch.Tensor, raw_mse: torch.Tensor) -> None:
         return None
@@ -28,7 +44,13 @@ class BaselineTimestepSampler:
         return None
 
     def status(self) -> dict:
-        return {"kind": "baseline", "mode": self.mode, "shift": self.shift}
+        return {
+            "kind": "baseline",
+            "mode": self.mode,
+            "shift": self.shift,
+            "mix_low_prob": self.mix_low_prob,
+            "schedule_shift": self.schedule_shift,
+        }
 
 
 def build(args, total_steps) -> BaselineTimestepSampler:
@@ -36,4 +58,6 @@ def build(args, total_steps) -> BaselineTimestepSampler:
     return BaselineTimestepSampler(
         mode=str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal"),
         shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
+        mix_low_prob=float(getattr(args, "timestep_mix_low_prob", 0.0) or 0.0),
+        schedule_shift=float(getattr(args, "schedule_shift", 1.0) or 1.0),
     )

--- a/runtime/training/timestep_samplers/infonoise.py
+++ b/runtime/training/timestep_samplers/infonoise.py
@@ -43,6 +43,8 @@ class InfoNoiseScheduler:
         N_min: int = 50,
         baseline_shift: float = 3.0,
         baseline_mode: str = "logit_normal",
+        baseline_mix_low_prob: float = 0.0,
+        baseline_schedule_shift: float = 1.0,
     ):
         self.K = K
         self.N_warm = N_warm
@@ -54,6 +56,8 @@ class InfoNoiseScheduler:
         self.N_min = N_min
         self.baseline_shift = baseline_shift
         self.baseline_mode = baseline_mode
+        self.baseline_mix_low_prob = baseline_mix_low_prob
+        self.baseline_schedule_shift = baseline_schedule_shift
         self._internal_step = 0
 
         sigma_min = t_min / (1.0 - t_min)
@@ -90,7 +94,14 @@ class InfoNoiseScheduler:
         # 而不是写死 logit_normal_shift。复用 training.timestep_sampling.sample_t
         # 避免分叉两份分布逻辑。
         from training.timestep_sampling import sample_t
-        return sample_t(bs, device, mode=self.baseline_mode, shift=self.baseline_shift)
+        return sample_t(
+            bs,
+            device,
+            mode=self.baseline_mode,
+            shift=self.baseline_shift,
+            mix_low_prob=self.baseline_mix_low_prob,
+            schedule_shift=self.baseline_schedule_shift,
+        )
 
     def record(self, t: torch.Tensor, raw_mse: torch.Tensor):
         """记录 per-sample 原始 MSE（不含任何 loss weight）到对应 bin。"""
@@ -209,6 +220,8 @@ def build(args, total_steps: Optional[int]) -> InfoNoiseScheduler:
         N_min=int(getattr(args, "infonoise_N_min", 50) or 50),
         baseline_shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
         baseline_mode=str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal"),
+        baseline_mix_low_prob=float(getattr(args, "timestep_mix_low_prob", 0.0) or 0.0),
+        baseline_schedule_shift=float(getattr(args, "schedule_shift", 1.0) or 1.0),
     )
     logger.info(
         f"InfoNoise 已启用：K={scheduler.K}, N_warm={scheduler.N_warm}, "

--- a/runtime/training/timestep_sampling.py
+++ b/runtime/training/timestep_sampling.py
@@ -12,32 +12,71 @@ from __future__ import annotations
 import torch
 
 
-def sample_t(bs, device, mode: str = "logit_normal", shift: float = 3.0) -> torch.Tensor:
+def sample_t(
+    bs,
+    device,
+    mode: str = "logit_normal",
+    shift: float = 3.0,
+    mix_low_prob: float = 0.0,
+    schedule_shift: float = 1.0,
+) -> torch.Tensor:
     """采样 Flow Matching 时间步 t ∈ (0, 1)。
 
     mode:
-      logit_normal      — SD3/Anima 默认，偏向中间 t；shift>1 推向高噪声端
-      uniform           — 均匀采样，对细节端和结构端覆盖更均衡
-      logit_normal_low  — logit-normal 反向 shift，偏向低噪声/细节端
-      mode              — SD3 mode-distribution，集中在某个 sigma 附近
+      logit_normal       — SD3/Anima 默认，偏向中间 t；shift>1 推向高噪声端
+      uniform            — 均匀采样，对细节端和结构端覆盖更均衡
+      logit_normal_low   — logit-normal 反向 shift，偏向低噪声/细节端
+      mode               — SD3 mode-distribution，集中在某个 sigma 附近
+      mixed_uniform_low  — 每样本独立按 mix_low_prob 概率走 logit_normal_low，
+                           其余走 uniform；细节端强化但保留 uniform 覆盖度
+      mixed_uniform_logit— 同上但偏置端走 logit_normal（标准），适合不想偏低 t 的场景
+
+    mix_low_prob — mixed_* mode 下走偏置端的样本比例（默认 0 = 全 uniform）
+    schedule_shift — 采样完成后对 t 做的额外 σ schedule 偏移（默认 1.0 = 无 shift）；
+                     公式 t' = (t * s) / (1 + (s - 1) * t)；与 logit-normal 内部 shift 不同：
+                     timestep_shift 作用于 sigmoid 后的 u 值，schedule_shift 作用于最终 t
     """
     mode = (mode or "logit_normal").lower()
-    u = torch.sigmoid(torch.randn(bs, device=device))
 
     if mode == "uniform":
-        return torch.rand(bs, device=device).clamp(1e-4, 1 - 1e-4)
+        t = torch.rand(bs, device=device).clamp(1e-4, 1 - 1e-4)
+        return _apply_schedule_shift(t, schedule_shift)
+
+    if mode in ("mixed_uniform_low", "mixed_uniform_logit"):
+        p = max(0.0, min(1.0, float(mix_low_prob)))
+        use_biased = torch.rand(bs, device=device) < p
+        t_uniform = torch.rand(bs, device=device).clamp(1e-4, 1 - 1e-4)
+        biased_mode = "logit_normal_low" if mode == "mixed_uniform_low" else "logit_normal"
+        # 递归调用基础 mode 采样偏置端（不再传 mix_low_prob 避免循环；不在内部再做 schedule_shift，
+        # 留到最后统一应用）
+        t_biased = sample_t(bs, device, mode=biased_mode, shift=shift, mix_low_prob=0.0, schedule_shift=1.0)
+        t = torch.where(use_biased, t_biased, t_uniform)
+        return _apply_schedule_shift(t, schedule_shift)
+
+    u = torch.sigmoid(torch.randn(bs, device=device))
 
     if mode == "logit_normal_low":
         s = max(float(shift), 1e-4)
         u = (u * (1.0 / s)) / (1 + (1.0 / s - 1) * u)
-        return u.clamp(1e-4, 1 - 1e-4)
+        return _apply_schedule_shift(u.clamp(1e-4, 1 - 1e-4), schedule_shift)
 
     if mode == "mode":
         s = float(shift)
         u = 1 - u - s * (torch.cos(torch.pi * 0.5 * u) ** 2 - 1 + u)
-        return u.clamp(1e-4, 1 - 1e-4)
+        return _apply_schedule_shift(u.clamp(1e-4, 1 - 1e-4), schedule_shift)
 
     # logit_normal（默认）+ shift
     s = float(shift)
     u = (u * s) / (1 + (s - 1) * u)
-    return u.clamp(1e-4, 1 - 1e-4)
+    return _apply_schedule_shift(u.clamp(1e-4, 1 - 1e-4), schedule_shift)
+
+
+def _apply_schedule_shift(t: torch.Tensor, schedule_shift: float) -> torch.Tensor:
+    """对采样后的 t 做额外 σ schedule 偏移：t' = (t * s) / (1 + (s - 1) * t)。
+
+    s == 1.0 时恒等映射（默认行为不变）。s > 1 推向高噪声端；s < 1 偏低噪声端。
+    """
+    s = float(schedule_shift)
+    if s == 1.0:
+        return t
+    return ((t * s) / (1 + (s - 1) * t)).clamp(1e-4, 1 - 1e-4)

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -358,9 +358,16 @@ class TrainingConfig(BaseModel):
         description="【噪声增强】金字塔每层衰减系数（仅 pyramid_noise_iters > 0）",
         json_schema_extra=_meta("noise_schedule", show_when="pyramid_noise_iters!=0", advanced=True),
     )
-    timestep_sampling: Literal["logit_normal", "uniform", "logit_normal_low", "mode"] = Field(
+    timestep_sampling: Literal[
         "logit_normal",
-        description="【时间步采样】分布（logit_normal 为 SD3/Anima 默认）",
+        "uniform",
+        "logit_normal_low",
+        "mode",
+        "mixed_uniform_low",
+        "mixed_uniform_logit",
+    ] = Field(
+        "logit_normal",
+        description="【时间步采样】分布（logit_normal 为 SD3/Anima 默认；mixed_* 模式混合 uniform 与偏置端，按 timestep_mix_low_prob 控制比例）",
         json_schema_extra=_meta(
             "noise_schedule",
             alt_description="【时间步采样】分布；InfoNoise 启用时作为热身期 baseline，正式阶段由自适应 CDF 接管",
@@ -375,6 +382,27 @@ class TrainingConfig(BaseModel):
             "noise_schedule",
             show_when="timestep_sampling!=uniform",
             alt_description="【InfoNoise 热身期】InfoNoise 开启时作为热身阶段的 baseline shift，正式阶段由自适应 CDF 接管",
+            alt_description_when="infonoise_enabled==true",
+            advanced=True,
+        ),
+    )
+    timestep_mix_low_prob: float = Field(
+        0.0, ge=0.0, le=1.0,
+        description="【时间步采样】mixed_* 模式下走偏置端的样本比例（0 = 全 uniform；典型 0.15-0.30）",
+        json_schema_extra=_meta(
+            "noise_schedule",
+            show_when="timestep_sampling!=uniform",
+            alt_description="【InfoNoise 热身期】InfoNoise 开启 + mixed_* baseline 时，热身阶段混合比例；正式阶段由自适应 CDF 接管",
+            alt_description_when="infonoise_enabled==true",
+            advanced=True,
+        ),
+    )
+    schedule_shift: float = Field(
+        1.0, ge=0.1, le=10.0,
+        description="【时间步采样】采样后对 t 做的额外 σ schedule 偏移（1.0 = 无偏移；与 timestep_shift 不同：后者作用于 logit-normal 内部，前者作用于最终 t）",
+        json_schema_extra=_meta(
+            "noise_schedule",
+            alt_description="【InfoNoise 热身期】InfoNoise 开启时仅热身期生效；正式阶段由自适应 CDF 接管",
             alt_description_when="infonoise_enabled==true",
             advanced=True,
         ),

--- a/tests/test_timestep_sampling.py
+++ b/tests/test_timestep_sampling.py
@@ -1,0 +1,259 @@
+"""timestep_sampling 单元测试。
+
+主要覆盖：
+- 4 个原 mode 在默认 mix_low_prob=0/schedule_shift=1.0 下行为不变（防回归）
+- 2 个新 mode（mixed_uniform_low / mixed_uniform_logit）p=0/p=1/部分混合三种情形
+- schedule_shift 公式数学正确 + 1.0 时恒等 + >1 推高均值
+- BaselineTimestepSampler 接收+透传新参 + build() 读 args
+- InfoNoise build() 读新参 + baseline 走 sample_t 时透传
+
+随机性大的用大 batch (>=4096) + 统计性 assertion 避免 flakiness。
+"""
+from __future__ import annotations
+
+import torch
+
+from training.timestep_sampling import _apply_schedule_shift, sample_t
+from training.timestep_samplers.baseline import BaselineTimestepSampler
+from training.timestep_samplers.baseline import build as build_baseline
+from training.timestep_samplers.infonoise import InfoNoiseScheduler
+from training.timestep_samplers.infonoise import build as build_infonoise
+
+
+# ---------------------------------------------------------------------------
+# schedule_shift 数学
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_shift_identity_when_one():
+    t = torch.tensor([0.1, 0.3, 0.5, 0.7, 0.9])
+    out = _apply_schedule_shift(t, 1.0)
+    torch.testing.assert_close(out, t)
+
+
+def test_schedule_shift_formula_matches_spec():
+    """t' = (t * s) / (1 + (s-1)*t); s=2, t=0.5 → 1/1.5 = 2/3"""
+    t = torch.tensor([0.5])
+    out = _apply_schedule_shift(t, 2.0)
+    torch.testing.assert_close(out, torch.tensor([2.0 / 3.0]), rtol=1e-5, atol=1e-5)
+
+
+def test_schedule_shift_clamps_to_open_interval():
+    """t∈(0,1) 后经 shift 也应保持 (0, 1) 开区间（clamp 到 [eps, 1-eps]）。"""
+    t = torch.tensor([1e-5, 0.5, 1 - 1e-5])
+    out = _apply_schedule_shift(t, 5.0)
+    assert (out > 0).all() and (out < 1).all()
+
+
+# ---------------------------------------------------------------------------
+# 默认行为回归（4 个原 mode 在新参默认值下统计上等价于历史）
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_logit_normal_shift_pushes_high():
+    """shift=3 logit_normal 应推向高 t（mean > 0.5）。"""
+    torch.manual_seed(0)
+    t = sample_t(4096, "cpu", mode="logit_normal", shift=3.0)
+    assert t.mean().item() > 0.55
+    assert (t > 0).all() and (t < 1).all()
+
+
+def test_legacy_uniform_mean_half():
+    torch.manual_seed(0)
+    t = sample_t(4096, "cpu", mode="uniform")
+    assert abs(t.mean().item() - 0.5) < 0.05
+
+
+def test_legacy_logit_normal_low_pushes_low():
+    """logit_normal_low 反向 shift 应偏向低 t（mean < 0.5）。"""
+    torch.manual_seed(0)
+    t = sample_t(4096, "cpu", mode="logit_normal_low", shift=3.0)
+    assert t.mean().item() < 0.45
+
+
+def test_legacy_mode_outputs_in_range():
+    torch.manual_seed(0)
+    t = sample_t(4096, "cpu", mode="mode", shift=3.0)
+    assert (t > 0).all() and (t < 1).all()
+
+
+# ---------------------------------------------------------------------------
+# mixed_uniform_low
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_uniform_low_p_zero_is_pure_uniform():
+    """p=0 时不取偏置端，分布等价于 uniform（mean≈0.5）。"""
+    torch.manual_seed(0)
+    t = sample_t(4096, "cpu", mode="mixed_uniform_low", mix_low_prob=0.0)
+    assert abs(t.mean().item() - 0.5) < 0.05
+
+
+def test_mixed_uniform_low_p_one_matches_logit_normal_low_distribution():
+    """p=1 时所有样本走 logit_normal_low，分布偏低 t，mean 跟 pure logit_normal_low 接近。"""
+    torch.manual_seed(0)
+    t_mixed = sample_t(8192, "cpu", mode="mixed_uniform_low", shift=3.0, mix_low_prob=1.0)
+    torch.manual_seed(0)
+    t_pure = sample_t(8192, "cpu", mode="logit_normal_low", shift=3.0)
+    # 两者均值都应该 < 0.5 且接近
+    assert t_mixed.mean().item() < 0.45
+    assert t_pure.mean().item() < 0.45
+    assert abs(t_mixed.mean().item() - t_pure.mean().item()) < 0.03
+
+
+def test_mixed_uniform_low_partial_interpolates():
+    """p=0.3 时均值应该介于 pure uniform (0.5) 和 pure low 之间。"""
+    torch.manual_seed(0)
+    t_mixed = sample_t(8192, "cpu", mode="mixed_uniform_low", shift=3.0, mix_low_prob=0.3)
+    torch.manual_seed(0)
+    t_pure_low = sample_t(8192, "cpu", mode="logit_normal_low", shift=3.0)
+    low_mean = t_pure_low.mean().item()
+    # 介于 pure low (e.g. 0.25) 和 uniform (0.5) 之间
+    assert low_mean < t_mixed.mean().item() < 0.5
+
+
+# ---------------------------------------------------------------------------
+# mixed_uniform_logit
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_uniform_logit_p_one_matches_logit_normal_distribution():
+    """p=1 时分布跟 pure logit_normal（shift=3）接近，mean 都 > 0.5。"""
+    torch.manual_seed(0)
+    t_mixed = sample_t(8192, "cpu", mode="mixed_uniform_logit", shift=3.0, mix_low_prob=1.0)
+    torch.manual_seed(0)
+    t_pure = sample_t(8192, "cpu", mode="logit_normal", shift=3.0)
+    assert t_mixed.mean().item() > 0.55
+    assert abs(t_mixed.mean().item() - t_pure.mean().item()) < 0.03
+
+
+def test_mixed_uniform_logit_partial_pulls_toward_high():
+    """shift=3 偏置端推高 t；p=0.3 应让均值略 > 0.5。"""
+    torch.manual_seed(0)
+    t = sample_t(8192, "cpu", mode="mixed_uniform_logit", shift=3.0, mix_low_prob=0.3)
+    assert t.mean().item() > 0.5
+
+
+# ---------------------------------------------------------------------------
+# schedule_shift 跟分布混合
+# ---------------------------------------------------------------------------
+
+
+def test_schedule_shift_high_value_raises_mean():
+    """schedule_shift > 1 推高 mean。"""
+    torch.manual_seed(0)
+    t_base = sample_t(4096, "cpu", mode="uniform", schedule_shift=1.0)
+    torch.manual_seed(0)
+    t_high = sample_t(4096, "cpu", mode="uniform", schedule_shift=3.0)
+    assert t_high.mean().item() > t_base.mean().item() + 0.05
+
+
+def test_schedule_shift_applies_to_mixed_mode():
+    """mixed_uniform_low + schedule_shift=2 输出应推高（覆盖偏低端原本的均值）。"""
+    torch.manual_seed(0)
+    t = sample_t(4096, "cpu", mode="mixed_uniform_low", shift=3.0, mix_low_prob=1.0, schedule_shift=3.0)
+    # 即使是 mixed_uniform_low (本应偏低)，schedule_shift=3 也应把均值推回 > 0.4
+    assert t.mean().item() > 0.4
+
+
+# ---------------------------------------------------------------------------
+# BaselineTimestepSampler 集成
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_sampler_accepts_new_params():
+    s = BaselineTimestepSampler(
+        mode="mixed_uniform_low",
+        shift=3.0,
+        mix_low_prob=0.5,
+        schedule_shift=1.5,
+    )
+    t = s.sample(64, "cpu")
+    assert t.shape == (64,)
+    assert (t > 0).all() and (t < 1).all()
+    status = s.status()
+    assert status["mode"] == "mixed_uniform_low"
+    assert status["mix_low_prob"] == 0.5
+    assert status["schedule_shift"] == 1.5
+
+
+def test_baseline_build_reads_new_args():
+    """build() 从 args 读取新参。"""
+    class Args:
+        timestep_sampling = "mixed_uniform_low"
+        timestep_shift = 2.0
+        timestep_mix_low_prob = 0.25
+        schedule_shift = 1.12
+
+    s = build_baseline(Args(), total_steps=1000)
+    assert s.mode == "mixed_uniform_low"
+    assert s.mix_low_prob == 0.25
+    assert s.schedule_shift == 1.12
+
+
+def test_baseline_build_backward_compatible_with_missing_new_args():
+    """旧 args namespace 缺新参时，build() 应回落到默认值（getattr 默认）。"""
+    class OldArgs:
+        timestep_sampling = "logit_normal"
+        timestep_shift = 3.0
+        # 缺 timestep_mix_low_prob / schedule_shift
+
+    s = build_baseline(OldArgs(), total_steps=1000)
+    assert s.mix_low_prob == 0.0
+    assert s.schedule_shift == 1.0
+
+
+def test_baseline_sampler_default_args_unchanged():
+    """无显式传参时跟历史 BaselineTimestepSampler() 行为等价（mix_low_prob=0, schedule_shift=1）。"""
+    s = BaselineTimestepSampler()
+    assert s.mix_low_prob == 0.0
+    assert s.schedule_shift == 1.0
+    t = s.sample(128, "cpu")
+    # 默认 mode=logit_normal shift=3 → mean > 0.5
+    assert t.mean().item() > 0.5
+
+
+# ---------------------------------------------------------------------------
+# InfoNoise 兼容
+# ---------------------------------------------------------------------------
+
+
+def test_infonoise_build_reads_new_args():
+    class Args:
+        timestep_sampling = "mixed_uniform_low"
+        timestep_shift = 3.0
+        timestep_mix_low_prob = 0.2
+        schedule_shift = 1.5
+        infonoise_K = 32
+        infonoise_N_warm = 0  # auto
+        infonoise_M = 50
+        infonoise_B = 128
+        infonoise_beta = 0.9
+        infonoise_N_min = 10
+
+    s = build_infonoise(Args(), total_steps=500)
+    assert s.baseline_mode == "mixed_uniform_low"
+    assert s.baseline_mix_low_prob == 0.2
+    assert s.baseline_schedule_shift == 1.5
+
+
+def test_infonoise_warmup_sample_uses_new_params():
+    """CDF 未就绪时 sample 走 _sample_baseline，应该正确透传新参（不崩溃，输出合法 t）。"""
+    s = InfoNoiseScheduler(
+        K=32, N_warm=100, M=10, B=10, N_min=1,
+        baseline_mode="mixed_uniform_low",
+        baseline_shift=3.0,
+        baseline_mix_low_prob=0.5,
+        baseline_schedule_shift=1.0,
+    )
+    assert s._cdf_values is None
+    t = s.sample(128, "cpu")
+    assert t.shape == (128,)
+    assert (t > 0).all() and (t < 1).all()
+
+
+def test_infonoise_default_baseline_params_unchanged():
+    """InfoNoiseScheduler 无显式 baseline_mix_low_prob/schedule_shift 时回落到默认。"""
+    s = InfoNoiseScheduler(K=32, N_warm=100, M=10, B=10, N_min=1)
+    assert s.baseline_mix_low_prob == 0.0
+    assert s.baseline_schedule_shift == 1.0


### PR DESCRIPTION
## 背景 / 动机

实际训练里有两类经常用到的 timestep 调参需求当前没办法在 schema 表达：

1. **混合采样**：在 uniform 全覆盖基础上按一定比例混入 `logit_normal_low` / `logit_normal` 的偏置端分布。`mixed_uniform_low` 在我们小圈子的成功配置里默认 `mix_low_prob=0.24`，比 pure uniform 多学一些细节端但又保留结构端覆盖度。
2. **后置 σ schedule shift**：跟 `timestep_shift`（logit-normal 内部 shift）不同，是在采样**完成后**对 t 做一次额外的 `t' = (t·s) / (1 + (s-1)·t)` 偏移。我们在 1536 训练里用 1.12 取得了比单纯调 `timestep_shift` 更稳的结果。

合并提交因为两条都是 `timestep_sampling.py` 的小幅参数化扩展、性质极相似，分两个 PR 会重复折腾相同的 caller / schema / 测试结构。

## 改动概要

- `runtime/training/timestep_sampling.py`:`sample_t()` 新增两个 mode (`mixed_uniform_low` / `mixed_uniform_logit`) + 两个参数 (`mix_low_prob` / `schedule_shift`);抽出 `_apply_schedule_shift()` helper 在所有 mode 末尾统一应用
- `runtime/training/timestep_samplers/baseline.py`:`BaselineTimestepSampler.__init__` 接收新参数 + `sample()` 透传 + `build()` 从 args 读 + `status()` 上报
- `runtime/training/timestep_samplers/infonoise.py`:`InfoNoiseScheduler.__init__` 加 `baseline_mix_low_prob` / `baseline_schedule_shift` 两个 baseline 透传字段 + `_sample_baseline()` 透传 + `build()` 从 args 读;**EMA / CDF / refresh 逻辑零变动**(论文敏感区不触)
- `studio/schema.py`:
  - `timestep_sampling` Literal 加两个枚举值
  - 新增 `timestep_mix_low_prob: float = 0.0` 字段,`show_when="timestep_sampling!=uniform"`
  - 新增 `schedule_shift: float = 1.0` 字段
  - 沿用现有 `alt_description_when="infonoise_enabled==true"` 双描述机制,InfoNoise 启用时前端切换文案说明"仅热身期生效"
- `tests/test_timestep_sampling.py`:新建,19 个用例覆盖 schedule_shift 数学公式 / 4 原 mode 默认行为回归 / mixed 模式 p=0/p=1/部分混合 / Baseline + InfoNoise 接口透传

## 默认行为

`timestep_mix_low_prob=0.0` + `schedule_shift=1.0` 默认值下,4 个原 mode 的输出**完全等价于历史 sample_t**(`_apply_schedule_shift` 的 `s==1.0` 短路返回原 t)。InfoNoise 在新 args 下 baseline 透传新参,但默认值不影响 warmup 期分布,正式阶段由自适应 CDF 完全接管,亦无变化。

## ADR 0003 一致性

延续 `timestep_sampling.py` 单文件多 if 分支 + schema 标量字段的现有惯例(ADR 0003 L113「不引入 schema 字段」描述已被 `timestep_shift` 默认松动)。新模式没引入"枚举值带专属字段",不需要升级 plugin subfolder。

## show_when 表达式语法

仓库现有 `show_when` 全是 `field==value` / `field!=value` 单条件,没看到复合表达式。`timestep_mix_low_prob` 严格意义上只在 `mixed_uniform_low` / `mixed_uniform_logit` 两个 mode 下生效,但单条件 `show_when` 没法精确表达"两个值"——选了 `timestep_sampling!=uniform` 跟现有 `timestep_shift` 对齐(`logit_normal` / `mode` 下显示但值被忽略,UI 上 advanced 折起,无明显误导)。如想精确控制,需要扩展前端表达式引擎,放在后续 follow-up。

## 测试
tests/test_timestep_sampling.py 19/19 PASS（新增）
tests/test_infonoise.py 16/16 PASS（关键回归：EMA 公式 + warmup baseline + 4 mode）
tests/test_argparse_bridge.py 19/19 PASS（schema → CLI 派生回归）
tests/test_plugin_registry.py PASS
tests/test_anima_train_migration.py PASS

合计 79 passed, 4 skipped, 0 failed