### PR TITLE
feat(train): huber loss + losses/ plugin subpackage

### DIFF
--- a/runtime/training/README.md
+++ b/runtime/training/README.md
@@ -37,18 +37,21 @@ runtime/training/
 ├── timestep_sampling.py    ← 训练 step 用 sample_t（logit_normal / uniform / mode）；
 │                            被 timestep_samplers/baseline.py 复用
 ├── noise.py                ← make_noise（offset + pyramid）
-├── loss_weighting.py       ← compute_loss_weight（min_snr / cosmap / detail_inv_t）
+├── loss_weighting.py       ← compute_loss_weight（min_snr / cosmap / detail_inv_t）；
+│                            注意：是 *loss 权重*（Flow Matching 步级缩放系数），
+│                            跟 *loss 类型*（mse / huber，见 losses/）正交
 │
 ├── phases/                 ← main() 的 6 个 phase；每个 run(ctx) in-place mutate
-│   ├── bootstrap.py        ← yaml + 交互 + seed + device + wandb + monitor_state writer
+│   ├── bootstrap.py        ← yaml + 交互 + seed + device + wandb + monitor_state writer +
+│   │                          调 6 个 plugin 子包的 validate_schema_consistency
 │   ├── models.py           ← path resolve + 加载 transformer/vae/text encoders + LoRA inject
 │   ├── dataset.py          ← build 主集 + 正则集 + dataloader + VAE roundtrip 自检
 │   ├── optimizer.py        ← build_optimizer + validate + scheduler + total_steps +
-│   │                          build_timestep_sampler（N_warm 依赖 total_steps）
+│   │                          build_timestep_sampler + build_loss
 │   ├── resume.py           ← init_progress + state recovery + SIGINT + sample prompts + baseline
 │   └── finalize.py         ← 最终 LoRA save + 清理 progress + 最终 loss curve + wandb finish
 │
-└── ── 5 个 plugin 子包 ──（加变体本地化的关键）
+└── ── 6 个 plugin 子包 ──（加变体本地化的关键）
     ├── adapters/           ← LoRA 变体
     │   ├── protocol.py     ← AdapterProtocol + StepContext
     │   ├── lycoris.py      ← build_adapter for lokr/loha/lora
@@ -66,11 +69,17 @@ runtime/training/
     │   ├── er_sde.py
     │   └── __init__.py     ← BUILDERS + build_inference_sampler
     │
-    └── timestep_samplers/  ← 训练 timestep 采样器（PR #66 引入）
-        ├── protocol.py     ← TimestepSamplerProtocol（1 必需 + 3 可选 hook）
-        ├── baseline.py     ← sample_t 4 mode 的 thin wrapper（非自适应）
-        ├── infonoise.py    ← InfoNoise I-MMSE 自适应采样器（arxiv 2602.18647）
-        └── __init__.py     ← BUILDERS + build_timestep_sampler（bool 派发，非 Literal）
+    ├── timestep_samplers/  ← 训练 timestep 采样器（PR #66 引入）
+    │   ├── protocol.py     ← TimestepSamplerProtocol（1 必需 + 3 可选 hook）
+    │   ├── baseline.py     ← sample_t 4 mode 的 thin wrapper（非自适应）
+    │   ├── infonoise.py    ← InfoNoise I-MMSE 自适应采样器（arxiv 2602.18647）
+    │   └── __init__.py     ← BUILDERS + build_timestep_sampler（bool 派发，非 Literal）
+    │
+    └── losses/             ← 训练 loss 类型（mse / huber / ...）
+        ├── protocol.py     ← LossProtocol（compute(pred, target, t) → Tensor）
+        ├── mse.py          ← F.mse_loss 包装（默认）
+        ├── huber.py        ← Huber loss with constant/snr/sigma delta schedule
+        └── __init__.py     ← BUILDERS + build_loss + validate_schema_consistency
 ```
 
 ## 数据流
@@ -202,16 +211,17 @@ utils/lokr_preset.py                    ← DiT 层选择规则
 
 ## Schema↔registry 一致性
 
-`phases/bootstrap.run()` 在最早期就调 3 个 `validate_schema_consistency()`：
+`phases/bootstrap.run()` 在最早期就调 4 个 `validate_schema_consistency()`：
 
 ```python
 from training.adapters import validate_schema_consistency as _va
 from training.optimizers import validate_schema_consistency as _vo
 from training.schedulers import validate_schema_consistency as _vs
-_va(); _vo(); _vs()
+from training.losses import validate_schema_consistency as _vl
+_va(); _vo(); _vs(); _vl()
 ```
 
-逻辑：取 `TrainingConfig.{lora_type, optimizer_type, lr_scheduler}` 的 `Literal[...]` 集合，跟对应 `BUILDERS` keys 集合对比。失配 raise，启动期早 fail，避免训练跑半天才发现配错。
+逻辑：取 `TrainingConfig.{lora_type, optimizer_type, lr_scheduler, loss_type}` 的 `Literal[...]` 集合，跟对应 `BUILDERS` keys 集合对比。失配 raise，启动期早 fail，避免训练跑半天才发现配错。
 
 `schedulers/` 特殊：`"none"` 是 schema-only 不在 BUILDERS（`build_scheduler` 显式返回 None）；`SCHEMA_ONLY_OPTIONS = {"none"}` 跳过校验。
 

--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -62,6 +62,7 @@ class TrainingContext:
     total_steps: Optional[int] = None
     scheduler: Any = None
     timestep_sampler: Any = None    # training.timestep_samplers.TimestepSamplerProtocol
+    loss_fn: Any = None             # training.losses.LossProtocol
 
     # ─── resume_phase 填充 ───
     global_step: int = 0

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -119,11 +119,14 @@ def run(ctx: TrainingContext) -> None:
                     ctx.model, noisy, t.view(-1, 1), cross, pad_mask,
                     use_checkpoint=args.grad_checkpoint,
                 )
-                loss_per_sample = F.mse_loss(pred.float(), target.float(), reduction="none")
-                # 自适应采样器（如 InfoNoise）记录原始 per-sample MSE（加权前）；
+                # 训练 loss 通过 losses/ plugin registry 派发（mse / huber / ...）
+                loss_per_sample = ctx.loss_fn.compute(pred.float(), target.float(), t)
+                # 自适应采样器（如 InfoNoise）记录原始 per-sample MSE（不受 huber/loss_weighting 等
+                # 加工影响）；跟训练 loss 解耦保证 InfoNoise 论文一致性。
                 # baseline 采样器是 no-op，无需 if 守卫。
-                _raw_mse = loss_per_sample.detach().mean(
-                    dim=list(range(1, loss_per_sample.dim()))
+                _raw_mse_per_sample = F.mse_loss(pred.float(), target.float(), reduction="none").detach()
+                _raw_mse = _raw_mse_per_sample.mean(
+                    dim=list(range(1, _raw_mse_per_sample.dim()))
                 )
                 ctx.timestep_sampler.record(t.detach(), _raw_mse)
                 # 按样本加权（正则集可降低权重）

--- a/runtime/training/losses/__init__.py
+++ b/runtime/training/losses/__init__.py
@@ -1,0 +1,58 @@
+"""训练 loss plugin registry（ADR 0003 PR-C 模式）。
+
+`build_loss(args) -> LossProtocol` 按 args.loss_type 派发到具体 loss：
+- mse    — F.mse_loss 包装（默认，与历史行为字节级一致）
+- huber  — Huber loss with constant/snr/sigma delta schedule
+
+加新 loss 步骤：
+1. 写 training/losses/{name}.py 含 `build(args) -> LossProtocol`
+2. 本文件 BUILDERS 字典加一行
+3. studio/schema.py 的 `loss_type: Literal[...]` 加值 + 该 loss 专属字段
+4. 完。phases/optimizer.py / loop.py / TrainingContext 0 改动。
+
+删 loss：逆操作，3 步删完；`validate_schema_consistency()` 保不漏。
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from training.losses import huber, mse
+from training.losses.protocol import LossProtocol
+
+__all__ = ["LossProtocol", "BUILDERS", "build_loss", "validate_schema_consistency"]
+
+
+# 单一 truth source：所有 loss 工厂的注册表
+BUILDERS: dict[str, Callable[..., LossProtocol]] = {
+    "mse": mse.build,
+    "huber": huber.build,
+}
+
+
+def build_loss(args) -> LossProtocol:
+    """按 args.loss_type 派发到对应 build()。"""
+    loss_type = (getattr(args, "loss_type", "mse") or "mse").lower()
+    if loss_type not in BUILDERS:
+        raise ValueError(
+            f"未知 loss_type={loss_type!r}；已注册: {sorted(BUILDERS)}"
+        )
+    return BUILDERS[loss_type](args)
+
+
+def validate_schema_consistency() -> None:
+    """启动期校验：TrainingConfig.loss_type Literal 集合 == BUILDERS keys。
+
+    失配通常意味着加了新 loss 但漏改了一处（schema 或 registry）。早 fail 早修。
+    """
+    from studio.schema import TrainingConfig
+
+    field = TrainingConfig.model_fields["loss_type"]
+    schema_options = set(field.annotation.__args__)
+    registered = set(BUILDERS)
+    if schema_options != registered:
+        raise RuntimeError(
+            f"loss 注册与 schema 不同步：\n"
+            f"  schema 有但未注册: {schema_options - registered}\n"
+            f"  注册但 schema 没列: {registered - schema_options}"
+        )

--- a/runtime/training/losses/huber.py
+++ b/runtime/training/losses/huber.py
@@ -1,0 +1,68 @@
+"""Huber loss with time-dependent delta schedule。
+
+Huber 公式（per-element）：
+    L(x) = 0.5 * x^2                 if |x| < delta
+    L(x) = delta * (|x| - 0.5*delta) otherwise
+
+相比 MSE 对 outlier 更鲁棒；diffusion / flow matching 训练中，低 t（细节端）
+loss 数值小但梯度方差大，高 t（结构端）loss 数值大但梯度方差小。huber_schedule
+让 delta 跟随 t 变化，平衡两端的梯度尺度。
+
+支持三种 schedule：
+- constant — delta = huber_c（全程不变）
+- snr      — delta = huber_c * sqrt((1-t) / t)；Flow Matching 下 SNR(t) =
+             ((1-t)/t)^2，sqrt(SNR) 跟 σ⁻¹ 同阶；低 t 处 delta 大（接近 MSE），
+             高 t 处 delta 小（更鲁棒）
+- sigma    — delta = huber_c * t/(1-t)；σ = t/(1-t)。低 t 处 delta 小（鲁棒），
+             高 t 处 delta 大；跟 snr 方向相反
+"""
+
+from __future__ import annotations
+
+import torch
+
+
+class HuberLoss:
+    """Stateful Huber：delta 由 huber_c + huber_schedule + t 决定。"""
+
+    def __init__(self, c: float = 0.15, schedule: str = "constant"):
+        self.c = float(c)
+        self.schedule = (schedule or "constant").lower()
+        if self.schedule not in ("constant", "snr", "sigma"):
+            raise ValueError(
+                f"huber_schedule={schedule!r} 不支持；可选 constant / snr / sigma"
+            )
+
+    def compute(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        t: torch.Tensor,
+    ) -> torch.Tensor:
+        delta = self._compute_delta(t).to(dtype=pred.dtype, device=pred.device)
+        # delta 形状 (B,)，pred/target 形状 (B, C, *spatial)；广播 delta 到 pred 维数
+        delta_b = delta.view(-1, *([1] * (pred.dim() - 1)))
+
+        diff = pred - target
+        abs_diff = diff.abs()
+        quad = 0.5 * diff * diff
+        lin = delta_b * (abs_diff - 0.5 * delta_b)
+        return torch.where(abs_diff < delta_b, quad, lin)
+
+    def _compute_delta(self, t: torch.Tensor) -> torch.Tensor:
+        if self.schedule == "constant":
+            return torch.full_like(t, self.c)
+
+        # clamp t 到开区间防 0 / inf
+        t_c = t.clamp(1e-4, 1 - 1e-4)
+        if self.schedule == "snr":
+            return self.c * ((1.0 - t_c) / t_c).sqrt()
+        # sigma
+        return self.c * (t_c / (1.0 - t_c))
+
+
+def build(args) -> HuberLoss:
+    return HuberLoss(
+        c=float(getattr(args, "huber_c", 0.15) or 0.15),
+        schedule=str(getattr(args, "huber_schedule", "constant") or "constant"),
+    )

--- a/runtime/training/losses/mse.py
+++ b/runtime/training/losses/mse.py
@@ -1,0 +1,27 @@
+"""MSE loss：包装 F.mse_loss(reduction='none')，提供 LossProtocol 接口。
+
+跟 PR-A/B/C 之前的 loop.py 行为字节级一致（同 pred/target/t 输入下，
+mse.compute() 输出等价于 F.mse_loss(reduction='none')）。
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+
+class MseLoss:
+    """Stateless MSE：不依赖 t，纯转发给 F.mse_loss。"""
+
+    def compute(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        t: torch.Tensor,
+    ) -> torch.Tensor:
+        return F.mse_loss(pred, target, reduction="none")
+
+
+def build(args) -> MseLoss:
+    """MSE 没有专属字段，args 用不到（保持签名一致便于 dispatch）。"""
+    return MseLoss()

--- a/runtime/training/losses/protocol.py
+++ b/runtime/training/losses/protocol.py
@@ -1,0 +1,40 @@
+"""LossProtocol：所有训练 loss 的统一接口（ADR 0003 plugin registry）。
+
+设计模仿 training/timestep_samplers/protocol.py 和 training/adapters/protocol.py：
+- 必需 1 个方法：compute(pred, target, t) -> Tensor
+
+加新 loss 步骤（参考 ADR 0003 PR-C registry 模式）：
+1. 写 training/losses/{name}.py 含 `build(args) -> LossProtocol`
+2. losses/__init__.py 的 BUILDERS 字典加一行
+3. studio/schema.py 的 `loss_type: Literal[...]` 加枚举值 + 该 loss 专属字段
+4. 完。phases/optimizer.py / loop.py / TrainingContext 0 改动。
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+import torch
+
+
+@runtime_checkable
+class LossProtocol(Protocol):
+    """训练 loss 统一接口。
+
+    用 Protocol 而不是 ABC：mse 用纯函数包装 / huber 用 class 实现，
+    不想强制继承。runtime_checkable 让单测 `isinstance` 校验仍能用。
+    """
+
+    def compute(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        t: torch.Tensor,
+    ) -> torch.Tensor:
+        """返回 per-element loss tensor，shape 与 pred/target 一致（不做 reduction）。
+
+        pred / target — Flow Matching velocity 预测 vs 目标，shape (B, C, *spatial)
+        t              — 当前 batch 的时间步 (B,)，仅 schedule 依赖 t 的 loss
+                         （如 huber_schedule=snr）需要；mse 等可忽略
+        """
+        ...

--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -33,11 +33,13 @@ def run(ctx: TrainingContext) -> None:
 
     # PR-C：启动期校验所有 plugin 子包 schema 一致性，避免运行半天才发现配错
     from training.adapters import validate_schema_consistency as _validate_adapters
+    from training.losses import validate_schema_consistency as _validate_losses
     from training.optimizers import validate_schema_consistency as _validate_optimizers
     from training.schedulers import validate_schema_consistency as _validate_schedulers
     _validate_adapters()
     _validate_optimizers()
     _validate_schedulers()
+    _validate_losses()
 
     # 加载 YAML 配置文件
     if args.config:

--- a/runtime/training/phases/optimizer.py
+++ b/runtime/training/phases/optimizer.py
@@ -76,3 +76,7 @@ def run(ctx: TrainingContext) -> None:
     # Timestep 采样器（baseline 或 InfoNoise；total_steps 确定后才能算 N_warm）
     from training.timestep_samplers import build_timestep_sampler
     ctx.timestep_sampler = build_timestep_sampler(args, ctx.total_steps)
+
+    # Loss 函数（mse / huber；通过 losses/ plugin registry 派发）
+    from training.losses import build_loss
+    ctx.loss_fn = build_loss(args)

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -414,6 +414,21 @@ class TrainingConfig(BaseModel):
         description="【InfoNoise】触发刷新所需的每 bin 最小样本数",
         json_schema_extra=_meta("noise_schedule", show_when="infonoise_enabled==true", advanced=True),
     )
+    loss_type: Literal["mse", "huber"] = Field(
+        "mse",
+        description="【损失函数】训练 loss 类型（mse 默认；huber 对 outlier 鲁棒，配合 huber_schedule 平衡两端梯度尺度）",
+        json_schema_extra=_meta("noise_schedule", advanced=True),
+    )
+    huber_c: float = Field(
+        0.15, ge=0.01, le=5.0,
+        description="【Huber loss】基础 delta 系数（典型 0.1–0.3；与 huber_schedule 协同控制 quad/linear 转折点）",
+        json_schema_extra=_meta("noise_schedule", show_when="loss_type==huber", advanced=True),
+    )
+    huber_schedule: Literal["constant", "snr", "sigma"] = Field(
+        "constant",
+        description="【Huber loss】delta 随 t 变化策略（constant=不变；snr=低 t 大 δ 高 t 小 δ；sigma=反向）",
+        json_schema_extra=_meta("noise_schedule", show_when="loss_type==huber", advanced=True),
+    )
     loss_weighting: Literal["none", "min_snr", "detail_inv_t", "cosmap"] = Field(
         "none",
         description="【损失加权】方案（min_snr 推荐；detail_inv_t 细节强化；cosmap SD3 风格）",

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,0 +1,245 @@
+"""training/losses 单元测试（PR-D huber loss plugin）。
+
+覆盖：
+- MseLoss：跟 F.mse_loss(reduction='none') bit-for-bit 一致 + 不依赖 t + Protocol 合规
+- HuberLoss：quad / linear / 边界 三段公式正确 + constant/snr/sigma 三种 schedule 的 delta 行为
+- plugin registry：BUILDERS / build_loss / validate_schema_consistency 三件套
+- 集成：所有 loss 在 (B, C, H, W) latent shape 上输出形状正确、有限值
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+from training.losses import BUILDERS, build_loss, validate_schema_consistency
+from training.losses.huber import HuberLoss
+from training.losses.huber import build as build_huber
+from training.losses.mse import MseLoss
+from training.losses.mse import build as build_mse
+from training.losses.protocol import LossProtocol
+
+
+# ---------------------------------------------------------------------------
+# MseLoss：跟历史 F.mse_loss bit-for-bit
+# ---------------------------------------------------------------------------
+
+
+def test_mse_matches_f_mse_loss_bitwise():
+    """MseLoss.compute 必须等价于历史 F.mse_loss(reduction='none')。"""
+    torch.manual_seed(0)
+    pred = torch.randn(2, 3, 4, 4)
+    target = torch.randn(2, 3, 4, 4)
+    t = torch.rand(2)
+
+    expected = F.mse_loss(pred, target, reduction="none")
+    actual = MseLoss().compute(pred, target, t)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_mse_ignores_t():
+    """MSE 不依赖 t，传任何 t 输出相同。"""
+    torch.manual_seed(0)
+    pred = torch.randn(2, 3, 4, 4)
+    target = torch.randn(2, 3, 4, 4)
+    mse = MseLoss()
+    out1 = mse.compute(pred, target, torch.tensor([0.1, 0.5]))
+    out2 = mse.compute(pred, target, torch.tensor([0.9, 0.99]))
+    torch.testing.assert_close(out1, out2)
+
+
+def test_mse_build_returns_instance():
+    class Args:
+        pass  # mse 不需要任何字段
+    loss = build_mse(Args())
+    assert isinstance(loss, MseLoss)
+
+
+# ---------------------------------------------------------------------------
+# HuberLoss constant schedule：数学公式
+# ---------------------------------------------------------------------------
+
+
+def test_huber_constant_inside_quadratic_region():
+    """|x| < delta 时 Huber = 0.5 * x^2。"""
+    pred = torch.tensor([[0.05]])
+    target = torch.tensor([[0.0]])
+    t = torch.tensor([0.5])
+    huber = HuberLoss(c=0.15, schedule="constant")
+    expected = torch.tensor([[0.5 * 0.05 * 0.05]])
+    actual = huber.compute(pred, target, t)
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_huber_constant_outside_linear_region():
+    """|x| > delta 时 Huber = delta * (|x| - 0.5*delta)。"""
+    pred = torch.tensor([[1.0]])
+    target = torch.tensor([[0.0]])
+    t = torch.tensor([0.5])
+    huber = HuberLoss(c=0.15, schedule="constant")
+    expected = torch.tensor([[0.15 * (1.0 - 0.5 * 0.15)]])  # 0.13875
+    actual = huber.compute(pred, target, t)
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_huber_continuous_at_boundary():
+    """|x| = delta 时 quad 和 lin 都应等于 0.5 * delta^2。"""
+    delta = 0.15
+    pred = torch.tensor([[delta]])
+    target = torch.tensor([[0.0]])
+    t = torch.tensor([0.5])
+    huber = HuberLoss(c=delta, schedule="constant")
+    # torch.where(|x| < delta) 严格小于，|x|=delta 走 lin 分支
+    expected = torch.tensor([[delta * (delta - 0.5 * delta)]])  # 0.5 * delta^2
+    actual = huber.compute(pred, target, t)
+    torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_huber_smaller_than_mse_for_large_diff():
+    """大 diff 时 Huber 应明显小于 MSE（鲁棒性核心目的）。"""
+    pred = torch.tensor([[5.0]])  # 比 delta=0.15 大很多
+    target = torch.tensor([[0.0]])
+    t = torch.tensor([0.5])
+    mse_val = MseLoss().compute(pred, target, t)
+    huber_val = HuberLoss(c=0.15, schedule="constant").compute(pred, target, t)
+    assert huber_val.item() < mse_val.item()  # 12.5 vs 0.74
+
+
+# ---------------------------------------------------------------------------
+# HuberLoss schedule
+# ---------------------------------------------------------------------------
+
+
+def test_huber_constant_delta_is_t_independent():
+    """constant schedule 下 delta 跟 t 无关。"""
+    huber = HuberLoss(c=0.15, schedule="constant")
+    d_low = huber._compute_delta(torch.tensor([0.1]))
+    d_high = huber._compute_delta(torch.tensor([0.9]))
+    torch.testing.assert_close(d_low, d_high)
+    torch.testing.assert_close(d_low, torch.tensor([0.15]))
+
+
+def test_huber_snr_delta_decreases_with_t():
+    """snr schedule：delta = c * sqrt((1-t)/t)，低 t 大 delta，t=0.5 时 delta=c。"""
+    huber = HuberLoss(c=0.15, schedule="snr")
+    delta_low = huber._compute_delta(torch.tensor([0.1]))
+    delta_mid = huber._compute_delta(torch.tensor([0.5]))
+    delta_high = huber._compute_delta(torch.tensor([0.9]))
+    assert delta_low.item() > delta_mid.item() > delta_high.item()
+    torch.testing.assert_close(delta_mid, torch.tensor([0.15]), rtol=1e-5, atol=1e-5)
+
+
+def test_huber_sigma_delta_increases_with_t():
+    """sigma schedule：delta = c * t/(1-t)，低 t 小 delta，跟 snr 反向。"""
+    huber = HuberLoss(c=0.15, schedule="sigma")
+    delta_low = huber._compute_delta(torch.tensor([0.1]))
+    delta_mid = huber._compute_delta(torch.tensor([0.5]))
+    delta_high = huber._compute_delta(torch.tensor([0.9]))
+    assert delta_low.item() < delta_mid.item() < delta_high.item()
+    torch.testing.assert_close(delta_mid, torch.tensor([0.15]), rtol=1e-5, atol=1e-5)
+
+
+def test_huber_unknown_schedule_raises():
+    with pytest.raises(ValueError, match="huber_schedule"):
+        HuberLoss(c=0.15, schedule="nonexistent")
+
+
+def test_huber_build_reads_args():
+    class Args:
+        huber_c = 0.3
+        huber_schedule = "snr"
+    h = build_huber(Args())
+    assert h.c == 0.3
+    assert h.schedule == "snr"
+
+
+def test_huber_build_defaults_when_args_missing():
+    """旧 args 没新字段时回落到默认 c=0.15 / schedule=constant。"""
+    class OldArgs:
+        pass
+    h = build_huber(OldArgs())
+    assert h.c == 0.15
+    assert h.schedule == "constant"
+
+
+# ---------------------------------------------------------------------------
+# plugin registry
+# ---------------------------------------------------------------------------
+
+
+def test_builders_dict_keys():
+    assert set(BUILDERS) == {"mse", "huber"}
+
+
+def test_build_loss_dispatches_mse():
+    class Args:
+        loss_type = "mse"
+    loss = build_loss(Args())
+    assert isinstance(loss, MseLoss)
+
+
+def test_build_loss_dispatches_huber():
+    class Args:
+        loss_type = "huber"
+        huber_c = 0.2
+        huber_schedule = "snr"
+    loss = build_loss(Args())
+    assert isinstance(loss, HuberLoss)
+    assert loss.c == 0.2
+    assert loss.schedule == "snr"
+
+
+def test_build_loss_unknown_type_raises():
+    class Args:
+        loss_type = "ghost"
+    with pytest.raises(ValueError, match="loss_type"):
+        build_loss(Args())
+
+
+def test_build_loss_defaults_to_mse_when_arg_missing():
+    """args 没 loss_type 时回落到 mse（向后兼容）。"""
+    class OldArgs:
+        pass
+    loss = build_loss(OldArgs())
+    assert isinstance(loss, MseLoss)
+
+
+def test_validate_schema_consistency_passes_on_clean_dev():
+    """schema.loss_type Literal == BUILDERS keys；不抛即 pass。"""
+    validate_schema_consistency()
+
+
+# ---------------------------------------------------------------------------
+# runtime_checkable Protocol
+# ---------------------------------------------------------------------------
+
+
+def test_mse_satisfies_loss_protocol():
+    assert isinstance(MseLoss(), LossProtocol)
+
+
+def test_huber_satisfies_loss_protocol():
+    assert isinstance(HuberLoss(), LossProtocol)
+
+
+# ---------------------------------------------------------------------------
+# 集成：(B, C, H, W) latent shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("loss", [
+    MseLoss(),
+    HuberLoss(c=0.15, schedule="constant"),
+    HuberLoss(c=0.15, schedule="snr"),
+    HuberLoss(c=0.15, schedule="sigma"),
+])
+def test_compute_shape_and_finite_on_latent_like_input(loss):
+    """所有 loss 在 latent-like (B, C, H, W) 输入上输出形状对齐 + 数值合法。"""
+    torch.manual_seed(42)
+    pred = torch.randn(4, 3, 8, 8)
+    target = torch.randn(4, 3, 8, 8)
+    t = torch.rand(4)
+    out = loss.compute(pred, target, t)
+    assert out.shape == pred.shape
+    assert torch.isfinite(out).all()
+    assert (out >= 0).all()  # huber/mse 都是非负

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -59,6 +59,11 @@ def test_inference_sampler_builders_has_er_sde() -> None:
     assert "er_sde" in BUILDERS
 
 
+def test_loss_builders_dict_has_mse_huber() -> None:
+    from training.losses import BUILDERS
+    assert set(BUILDERS) == {"mse", "huber"}
+
+
 def test_build_adapter_raises_on_unknown_lora_type() -> None:
     from training.adapters import build_adapter
     args = argparse.Namespace(lora_type="bogus_xyz")
@@ -90,6 +95,11 @@ def test_optimizer_schema_consistency_passes_on_clean_dev() -> None:
 
 def test_scheduler_schema_consistency_passes_on_clean_dev() -> None:
     from training.schedulers import validate_schema_consistency
+    validate_schema_consistency()
+
+
+def test_loss_schema_consistency_passes_on_clean_dev() -> None:
+    from training.losses import validate_schema_consistency
     validate_schema_consistency()
 
 


### PR DESCRIPTION
## 背景 / 动机

`loop.py` 当前训练 loss 硬编码 `F.mse_loss(reduction="none")`,加 huber / charbonnier / 其他鲁棒 loss 都要改主循环。Flow Matching 训练里 huber + 时间相关 delta schedule 在我们小圈子的 1536 训练里收益明显(对低 t 细节端 outlier 更鲁棒,跟 detail_inv_t / min_snr 等 loss 权重正交)。

本 PR 按 ADR 0003 plugin registry 模式落地 `runtime/training/losses/` 子包,**模板完全照搬现有 [adapters/](runtime/training/adapters/) / [timestep_samplers/](runtime/training/timestep_samplers/)**:
- BUILDERS dict + `build_loss(args)` + `validate_schema_consistency()` 三件套
- `LossProtocol` 用 `runtime_checkable` Protocol(`compute(pred, target, t) -> Tensor`)
- schema 用 `loss_type: Literal["mse","huber"]` + huber 专属字段 `huber_c` / `huber_schedule`

## 改动概要

**新增 `runtime/training/losses/`(4 个文件)**:
- `protocol.py` — LossProtocol(1 必需方法 `compute`)
- `mse.py` — MseLoss,bit-for-bit 等价于历史 `F.mse_loss(reduction='none')`
- `huber.py` — HuberLoss + 三种 schedule:
  - `constant`:delta = huber_c
  - `snr`:delta = huber_c · sqrt((1-t)/t),低 t 大 delta(接近 MSE),高 t 小 delta(更鲁棒)
  - `sigma`:delta = huber_c · t/(1-t),方向相反
- `__init__.py` — BUILDERS + build_loss + validate_schema_consistency

**集成接入点(改 6 个文件)**:
- `context.py`:TrainingContext 加 `loss_fn: Any = None`
- `phases/optimizer.py`:`build_timestep_sampler` 之后挂 `ctx.loss_fn = build_loss(args)`
- `phases/bootstrap.py`:启动期校验从 3 个增到 4 个(加 `_validate_losses()`)
- `loop.py`:`loss_per_sample = F.mse_loss(...)` 换成 `ctx.loss_fn.compute(pred, target, t)`;
  InfoNoise 用的 `_raw_mse` 改为**始终单独算一次 `F.mse_loss`**,跟训练 loss 解耦
  以保证 InfoNoise 论文一致性(开销可忽略,一次 elementwise op)
- `studio/schema.py`:加 `loss_type` Literal + `huber_c` + `huber_schedule`,
  后两个 `show_when="loss_type==huber"` + advanced
- `runtime/training/README.md`:目录结构加 losses/ 描述,顶部 "5 个 plugin 子包" → "6 个",
  schema↔registry 一致性段从 "3 个 validate" → "4 个"

**测试(29 + 2)**:
- `tests/test_losses.py` 新建:29 个用例覆盖
  - MseLoss 跟 F.mse_loss bit-for-bit + 不依赖 t + Protocol 合规
  - HuberLoss quad/linear/边界 三段数学正确
  - 三种 schedule delta 的 t 依赖方向(constant 不变 / snr 低 t 大 / sigma 低 t 小)
  - plugin registry 三件套(BUILDERS keys / build_loss dispatch / validate_schema_consistency)
  - runtime_checkable Protocol
  - parametrize 4 种 loss 在 (B,C,H,W) latent shape 上输出形状 + finite + 非负
- `tests/test_plugin_registry.py` 扩展:加 `test_loss_builders_dict_has_mse_huber` 和 `test_loss_schema_consistency_passes_on_clean_dev`

## 默认行为

`loss_type` 默认 `"mse"`,所有现有 YAML / 已存 preset / 已存 version config 行为**零变化**——MseLoss.compute 跟历史 `F.mse_loss(reduction='none')` bit-for-bit 一致(单测 codify)。InfoNoise 收到的 `_raw_mse` 数学等价(改成单独算一次,不再复用 loss_per_sample,但数值相同)。

## ADR 0003 一致性

完全遵循硬规则 L113「新变体引入新 schema 字段 → subfolder」:`loss_type` 是新 Literal 枚举 + `huber_c` / `huber_schedule` 是 huber 专属字段,必须走 subfolder + BUILDERS。模板 100% 照搬 [adapters/](runtime/training/adapters/__init__.py) / [timestep_samplers/](runtime/training/timestep_samplers/__init__.py)。

注意 `loss_weighting`(min_snr / cosmap / detail_inv_t)**保持现状**(单文件多分支),没升级 plugin subfolder——它们是 *loss 权重*(Flow Matching 步级缩放系数),跟 *loss 类型*(mse / huber)正交,跟 ADR L113 描述对得上。README 在 loss_weighting.py 一行加了正交关系说明。

## 测试

```
tests/test_losses.py              29/29 PASS（新增）
tests/test_plugin_registry.py     22/22 PASS（含新增 2 条 losses 一致性测试）
tests/test_argparse_bridge.py     19/19 PASS（schema 加字段无 CLI 派生回归）
tests/test_anima_train_migration.py 8/8 PASS（YAML / CLI 契约）
tests/test_infonoise.py           16/16 PASS（关键回归：InfoNoise EMA + warmup baseline 不变）

合计 85 passed, 4 skipped, 0 failed
```