### PR TITLE
chore: post-PR#77 cleanup（UI 文案 + 删回收站 + 删队列伪清理）

### DIFF
--- a/studio/projects.py
+++ b/studio/projects.py
@@ -4,8 +4,8 @@ Project 是 Pipeline 的最外层容器：每次 LoRA 训练对应一个 project
 包含 download/ 和若干 versions/。slug 一旦生成就不可改（路径锚点）；
 title 和 note 可改。
 
-软删：目录搬到 `studio_data/_trash/projects/{slug}/`，db 行真实删除
-（CASCADE 删 versions / project_jobs）。配 `empty_trash()` 物理清理。
+删除：直接 rmtree 项目目录 + DELETE db 行（CASCADE 清 versions /
+project_jobs）。无回收站、不可恢复 —— UI 层 confirm 提示用户。
 """
 from __future__ import annotations
 
@@ -20,7 +20,6 @@ from typing import Any, Iterable, Optional
 from .paths import STUDIO_DATA
 
 PROJECTS_DIR = STUDIO_DATA / "projects"
-TRASH_DIR = STUDIO_DATA / "_trash" / "projects"
 
 VALID_STAGES: frozenset[str] = frozenset({
     "created", "downloading", "preprocessing", "curating", "tagging",
@@ -163,33 +162,14 @@ def update_project(
     return p
 
 
-def soft_delete_project(conn: sqlite3.Connection, project_id: int) -> None:
-    """目录搬到 `_trash/`，db 行删除（CASCADE 清掉 versions/project_jobs）。"""
+def delete_project(conn: sqlite3.Connection, project_id: int) -> None:
+    """rmtree 项目目录 + DELETE db 行（CASCADE 清掉 versions/project_jobs）。不可恢复。"""
     p = _must_get(conn, project_id)
     src = project_dir(p["id"], p["slug"])
     if src.exists():
-        TRASH_DIR.mkdir(parents=True, exist_ok=True)
-        # 冲突时加时间戳后缀
-        dst = TRASH_DIR / f"{p['id']}-{p['slug']}"
-        if dst.exists():
-            dst = TRASH_DIR / f"{p['id']}-{p['slug']}-{int(time.time())}"
-        shutil.move(str(src), str(dst))
+        shutil.rmtree(src, ignore_errors=True)
     conn.execute("DELETE FROM projects WHERE id = ?", (project_id,))
     conn.commit()
-
-
-def empty_trash() -> int:
-    """物理删除 `_trash/projects/` 下所有内容；返回删掉的项目目录数。"""
-    if not TRASH_DIR.exists():
-        return 0
-    n = 0
-    for child in list(TRASH_DIR.iterdir()):
-        if child.is_dir():
-            shutil.rmtree(child, ignore_errors=True)
-            n += 1
-        else:
-            child.unlink(missing_ok=True)
-    return n
 
 
 # ---------------------------------------------------------------------------

--- a/studio/server.py
+++ b/studio/server.py
@@ -689,15 +689,10 @@ def patch_project_endpoint(pid: int, body: ProjectUpdate) -> dict[str, Any]:
 def delete_project_endpoint(pid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         try:
-            projects.soft_delete_project(conn, pid)
+            projects.delete_project(conn, pid)
         except projects.ProjectError as exc:
             raise HTTPException(_project_err_code(exc), str(exc)) from exc
     return {"deleted": pid}
-
-
-@app.post("/api/projects/_trash/empty")
-def empty_trash_endpoint() -> dict[str, Any]:
-    return {"removed": projects.empty_trash()}
 
 
 # Versions ------------------------------------------------------------------

--- a/studio/versions.py
+++ b/studio/versions.py
@@ -4,7 +4,7 @@ Version 是 Pipeline 的「实验单元」：每个 version 独立维护 train/ 
 output/ samples/ 与 monitor_state.json。label 由用户起（baseline /
 high-lr 这种语义名），同 project 内唯一，且不可改（路径锚点）。
 
-软删：目录搬到 `_trash/projects/{slug}/versions/{label}/`，db 行删除。
+删除：直接 rmtree version 目录 + DELETE db 行。不可恢复。
 若被删的是 active version，自动 reassign 到「最新创建的剩余 version」。
 """
 from __future__ import annotations
@@ -390,22 +390,13 @@ def update_version(
 
 
 def delete_version(conn: sqlite3.Connection, version_id: int) -> None:
-    """目录搬到 _trash；db 删行；若是 active 自动 reassign。"""
+    """rmtree version 目录 + DELETE db 行；若是 active 自动 reassign。不可恢复。"""
     v = _must_get(conn, version_id)
     p = projects.get_project(conn, v["project_id"])
     if p:
         src = version_dir(p["id"], p["slug"], v["label"])
         if src.exists():
-            trash = (
-                projects.TRASH_DIR
-                / f"{p['id']}-{p['slug']}"
-                / "versions"
-                / v["label"]
-            )
-            if trash.exists():
-                trash = trash.with_name(f"{v['label']}-{int(time.time())}")
-            trash.parent.mkdir(parents=True, exist_ok=True)
-            shutil.move(str(src), str(trash))
+            shutil.rmtree(src, ignore_errors=True)
 
         if p.get("active_version_id") == version_id:
             # 选剩下里 created_at 最新的；都没了就清空

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1216,8 +1216,6 @@ export const api = {
     }),
   deleteProject: (pid: number) =>
     req<{ deleted: number }>(`/api/projects/${pid}`, { method: 'DELETE' }),
-  emptyTrash: () =>
-    req<{ removed: number }>('/api/projects/_trash/empty', { method: 'POST' }),
 
   listVersions: (pid: number) =>
     req<{ items: Version[] }>(`/api/projects/${pid}/versions`).then(

--- a/studio/web/src/components/ProjectStepper.tsx
+++ b/studio/web/src/components/ProjectStepper.tsx
@@ -9,11 +9,11 @@ interface Step {
 
 const STEPS: Step[] = [
   { key: 'download', label: '① 下载', scope: 'project' },
-  { key: 'preprocess', label: '② 预处理', scope: 'project' },
+  { key: 'preprocess', label: '② 预处理（可选）', scope: 'project' },
   { key: 'curate', label: '③ 筛选', scope: 'version' },
   { key: 'tag', label: '④ 打标', scope: 'version' },
   { key: 'edit', label: '⑤ 标签编辑', scope: 'version' },
-  { key: 'reg', label: '⑥ 正则集', scope: 'version' },
+  { key: 'reg', label: '⑥ 正则集（可选）', scope: 'version' },
   { key: 'train', label: '⑦ 训练', scope: 'version' },
 ]
 

--- a/studio/web/src/components/Sidebar.tsx
+++ b/studio/web/src/components/Sidebar.tsx
@@ -158,7 +158,7 @@ function VersionPanel({ collapsed }: { collapsed: boolean }) {
               {isActive && project.versions.length > 1 && (
                 <button
                   onClick={() => onDeleteVersion(v.id)}
-                  title="删除此版本（移到回收站）"
+                  title="删除此版本（不可恢复）"
                   className="px-[5px] py-0.5 text-fg-tertiary text-xs bg-transparent border-none cursor-pointer rounded-sm hover:text-err transition-colors shrink-0"
                 >
                   ×
@@ -194,11 +194,11 @@ function VersionPanel({ collapsed }: { collapsed: boolean }) {
 // ── project stepper nav ────────────────────────────────────────────────────
 const STEPS = [
   { key: 'download',   label: '下载',     idx: '1', icon: I.download, scope: 'project' as const },
-  { key: 'preprocess', label: '预处理',   idx: '2', icon: I.upscale,  scope: 'project' as const },
+  { key: 'preprocess', label: '预处理（可选）', idx: '2', icon: I.upscale,  scope: 'project' as const },
   { key: 'curate',     label: '筛选',     idx: '3', icon: I.filter,   scope: 'version' as const },
   { key: 'tag',        label: '打标',     idx: '4', icon: I.tag,      scope: 'version' as const },
   { key: 'edit',       label: '标签编辑', idx: '5', icon: I.edit,     scope: 'version' as const },
-  { key: 'reg',        label: '正则集',   idx: '6', icon: I.reg,      scope: 'version' as const },
+  { key: 'reg',        label: '正则集（可选）', idx: '6', icon: I.reg,      scope: 'version' as const },
   { key: 'train',      label: '训练',     idx: '7', icon: I.train,    scope: 'version' as const },
 ]
 

--- a/studio/web/src/components/VersionTabs.tsx
+++ b/studio/web/src/components/VersionTabs.tsx
@@ -62,7 +62,7 @@ export default function VersionTabs({
                 onClick={() => onDelete(v.id)}
                 className="text-[10px] text-fg-tertiary hover:text-err px-1"
                 aria-label={`删除版本 ${v.label}`}
-                title="删除该版本（移到回收站）"
+                title="删除该版本（不可恢复）"
               >
                 ×
               </button>

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -77,10 +77,13 @@ export default function ProjectsPage() {
   const handleDelete = async (p: ProjectSummary, e: React.MouseEvent) => {
     e.preventDefault()
     e.stopPropagation()
-    if (!(await confirm(`移到回收站？\n${p.title} (${p.slug})`, { tone: 'warn', okText: '移到回收站' }))) return
+    if (!(await confirm(
+      `删除项目「${p.title}」(${p.slug})？\n包括所有版本、数据集、训练产物，此操作不可恢复。`,
+      { tone: 'danger', okText: '删除' },
+    ))) return
     try {
       await api.deleteProject(p.id)
-      toast(`已移到回收站: ${p.title}`, 'success')
+      toast(`已删除: ${p.title}`, 'success')
       await refresh()
     } catch (err) {
       toast(String(err), 'error')
@@ -105,16 +108,6 @@ export default function ProjectsPage() {
     }
   }
 
-  const handleEmptyTrash = async () => {
-    if (!(await confirm('物理删除所有回收站项目？此操作不可恢复。', { tone: 'danger', okText: '清空回收站' }))) return
-    try {
-      const r = await api.emptyTrash()
-      toast(`清空了 ${r.removed} 个项目`, 'success')
-    } catch (e) {
-      toast(String(e), 'error')
-    }
-  }
-
   const openProject = (p: ProjectSummary) => {
     navigate(`/projects/${p.id}`)
   }
@@ -126,13 +119,6 @@ export default function ProjectsPage() {
         subtitle="每个项目对应一个 LoRA 训练目标 — 角色、风格或概念。新建一个项目开始流水线。"
         actions={
           <>
-            <button
-              className="btn btn-ghost btn-sm"
-              onClick={handleEmptyTrash}
-              title="物理删除回收站"
-            >
-              清空回收站
-            </button>
             <input
               ref={fileInputRef}
               type="file"
@@ -261,7 +247,7 @@ function ProjectCard({
         <button
           onClick={onDelete}
           className="bg-transparent border-none px-1.5 py-0.5 rounded-sm text-fg-tertiary text-xs cursor-pointer"
-          title="移到回收站"
+          title="删除项目（不可恢复）"
         >
           ×
         </button>

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -133,19 +133,6 @@ export default function QueuePage() {
   // 切换时 hook 自动清状态 + 重拉 /api/state 冷启动；不需要本组件再写清理逻辑。
   const { state: monitor } = useMonitorProgress(runningTaskId)
 
-  const clearDone = async () => {
-    const done = tasks.filter((t) => t.status === 'done')
-    if (done.length === 0) { toast('没有已完成的任务', 'success'); return }
-    if (!(await confirm(`删除 ${done.length} 个已完成任务？`, { tone: 'danger', okText: '删除' }))) return
-    setBusy(true)
-    try {
-      for (const t of done) await api.deleteTask(t.id)
-      toast(`已清理 ${done.length} 个任务`, 'success')
-      await reload()
-    } catch (e) { toast(String(e), 'error') }
-    finally { setBusy(false) }
-  }
-
   const sorted = useMemo(() => [...tasks].sort((a, b) => b.id - a.id), [tasks])
 
   const prevCount = useCallback((taskId: number): number => {
@@ -197,7 +184,6 @@ export default function QueuePage() {
       subtitle="同一时刻仅运行一个任务 · 完成后自动启动下一个"
       actions={
         <>
-          <button onClick={clearDone} disabled={busy} className="btn btn-ghost btn-sm">清理已完成</button>
           {hasRunning && (
             <button
               onClick={() => void cancelRunning()}

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -83,7 +83,7 @@ export default function ProjectLayout() {
     if (!projectRef.current) return
     const v = projectRef.current.versions.find((x) => x.id === vid)
     if (!v) return
-    if (!(await confirm(`删除版本 ${v.label}？目录将移到回收站。`, { tone: 'warn', okText: '删版本' }))) return
+    if (!(await confirm(`删除版本「${v.label}」？包括 train/reg/output/samples，此操作不可恢复。`, { tone: 'danger', okText: '删除' }))) return
     const pid = projectRef.current.id
     try {
       await api.deleteVersion(pid, vid)

--- a/studio/web/src/pages/project/steps/Preprocess.tsx
+++ b/studio/web/src/pages/project/steps/Preprocess.tsx
@@ -980,17 +980,6 @@ function PreprocessSidebar({
           tile 越大显存占用越高；OOM 时降到 128/192。
         </p>
       </div>
-
-      <div className="rounded-md border border-subtle bg-surface px-3 py-2.5">
-        <h3 className="caption flex items-center gap-1.5">
-          <span className="inline-block w-1.5 h-1.5 rounded-full shrink-0 bg-warn opacity-60" />
-          下一步
-        </h3>
-        <p className="text-xs text-fg-secondary leading-snug">
-          预处理是可选阶段——跳过的图筛选页会用原图，已处理的图自动用预处理副本。
-          ADR 0004：用户只看到一份图。
-        </p>
-      </div>
     </div>
   )
 }

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
@@ -146,10 +146,11 @@ export default function InlineLoraPicker(props: Props) {
   const [internalWeight, setInternalWeight] = useState<number>(
     isSingle ? props.weight : (props.mode === 'multi' ? props.defaultWeight ?? 1.0 : 1.0)
   )
-  // single 模式 weight 跟着 props 走
+  // single 模式 weight 跟着 props 走；multi 模式 singleWeight 恒为 0，不会触发同步
+  const singleWeight = isSingle ? props.weight : 0
   useEffect(() => {
-    if (isSingle) setInternalWeight(props.weight)
-  }, [isSingle, isSingle ? props.weight : 0])
+    if (isSingle) setInternalWeight(singleWeight)
+  }, [isSingle, singleWeight])
 
   const currentVersion = versions.find((v) => v.id === vid)
 

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -14,7 +14,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     with db.connection_for(dbfile) as conn:
         p = projects.create_project(conn, title="P")

--- a/tests/test_curation_endpoints.py
+++ b/tests/test_curation_endpoints.py
@@ -14,7 +14,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
     return {"db": dbfile}

--- a/tests/test_download_endpoints.py
+++ b/tests/test_download_endpoints.py
@@ -14,7 +14,6 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)

--- a/tests/test_lora_ckpt_scan.py
+++ b/tests/test_lora_ckpt_scan.py
@@ -168,12 +168,11 @@ def project_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """建 fake DB + 项目 + 3 个 version，落产出文件，返回 (dbfile, project)。
 
     复用 test_versions.py 的 isolation 模式：monkeypatch projects 模块的
-    PROJECTS_DIR / TRASH_DIR + db.STUDIO_DB。
+    PROJECTS_DIR + db.STUDIO_DB。
     """
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash" / "projects")
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
 
     with db.connection_for(dbfile) as conn:

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -20,7 +20,6 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     db.init_db(dbfile)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
     with db.connection_for(dbfile) as conn:
         p = projects.create_project(conn, title="PP")

--- a/tests/test_preprocess_endpoints.py
+++ b/tests/test_preprocess_endpoints.py
@@ -18,7 +18,6 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)

--- a/tests/test_project_endpoints.py
+++ b/tests/test_project_endpoints.py
@@ -14,9 +14,7 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     pdir = tmp_path / "projects"
-    tdir = tmp_path / "_trash" / "projects"
     monkeypatch.setattr(projects, "PROJECTS_DIR", pdir)
-    monkeypatch.setattr(projects, "TRASH_DIR", tdir)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
     return {"db": dbfile}
@@ -87,15 +85,13 @@ def test_patch_updates_note_and_stage(client: TestClient) -> None:
     assert body["stage"] == "curating"
 
 
-def test_delete_moves_to_trash_and_empty_trash(client: TestClient) -> None:
+def test_delete_removes_dir(client: TestClient) -> None:
     p = client.post("/api/projects", json={"title": "ToDel"}).json()
     pdir = projects.project_dir(p["id"], p["slug"])
     assert pdir.exists()
     assert client.delete(f"/api/projects/{p['id']}").status_code == 200
     assert client.get(f"/api/projects/{p['id']}").status_code == 404
     assert not pdir.exists()
-    r = client.post("/api/projects/_trash/empty").json()
-    assert r["removed"] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_project_jobs.py
+++ b/tests/test_project_jobs.py
@@ -14,7 +14,6 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     db.init_db(dbfile)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
     # 建一个父 project，FK 才能成立
     with db.connection_for(dbfile) as conn:

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -1,4 +1,4 @@
-"""PP1 — projects.py: slug 唯一性、目录创建、软删、empty_trash。"""
+"""PP1 — projects.py: slug 唯一性、目录创建、硬删除。"""
 from __future__ import annotations
 
 from pathlib import Path
@@ -13,11 +13,9 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     pdir = tmp_path / "projects"
-    tdir = tmp_path / "_trash" / "projects"
     monkeypatch.setattr(projects, "PROJECTS_DIR", pdir)
-    monkeypatch.setattr(projects, "TRASH_DIR", tdir)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
-    return {"db": dbfile, "projects_dir": pdir, "trash_dir": tdir}
+    return {"db": dbfile, "projects_dir": pdir}
 
 
 # ---------------------------------------------------------------------------
@@ -113,29 +111,17 @@ def test_update_rejects_invalid_stage(isolated) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_soft_delete_moves_to_trash_and_removes_row(isolated) -> None:
+def test_delete_removes_dir_and_row(isolated) -> None:
     with db.connection_for(isolated["db"]) as conn:
         p = projects.create_project(conn, title="ToDel")
         pid = p["id"]
-        projects.soft_delete_project(conn, pid)
+        projects.delete_project(conn, pid)
         assert projects.get_project(conn, pid) is None
     src = projects.project_dir(pid, p["slug"])
     assert not src.exists()
-    trash_dst = isolated["trash_dir"] / f"{pid}-{p['slug']}"
-    assert trash_dst.exists()
 
 
-def test_empty_trash(isolated) -> None:
-    with db.connection_for(isolated["db"]) as conn:
-        p = projects.create_project(conn, title="X")
-        projects.soft_delete_project(conn, p["id"])
-    n = projects.empty_trash()
-    assert n == 1
-    # 再调一次安全
-    assert projects.empty_trash() == 0
-
-
-def test_soft_delete_missing_raises(isolated) -> None:
+def test_delete_missing_raises(isolated) -> None:
     with db.connection_for(isolated["db"]) as conn:
         with pytest.raises(projects.ProjectError, match="不存在"):
-            projects.soft_delete_project(conn, 9999)
+            projects.delete_project(conn, 9999)

--- a/tests/test_reg_build_worker.py
+++ b/tests/test_reg_build_worker.py
@@ -42,7 +42,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     db.init_db(dbfile)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
     monkeypatch.setattr(secrets, "SECRETS_FILE", tmp_path / "secrets.json")
 

--- a/tests/test_reg_endpoints.py
+++ b/tests/test_reg_endpoints.py
@@ -18,7 +18,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -382,7 +382,6 @@ def test_finalize_version_writes_output_lora_path(env, tmp_path, monkeypatch) ->
     from studio import projects, versions
 
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
 
     # 建 project + version + 假 lora_final.safetensors
     with db.connection_for(env["db"]) as conn:

--- a/tests/test_supervisor_jobs.py
+++ b/tests/test_supervisor_jobs.py
@@ -17,7 +17,6 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     db.init_db(dbfile)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
     return {"db": dbfile, "logs": tmp_path / "logs"}
 

--- a/tests/test_tag_endpoints.py
+++ b/tests/test_tag_endpoints.py
@@ -17,7 +17,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)

--- a/tests/test_tag_worker.py
+++ b/tests/test_tag_worker.py
@@ -66,7 +66,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     db.init_db(dbfile)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
     # tag_worker 内部 import 用的是 studio.services.tagger.get_tagger；
     # 接受 overrides=... 的新签名（由 PP4 后续 wd14 per-job 覆盖功能引入）。

--- a/tests/test_train_endpoints.py
+++ b/tests/test_train_endpoints.py
@@ -17,7 +17,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     presets_dir = tmp_path / "presets"
     presets_dir.mkdir()
     from studio import presets_io

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -22,9 +22,7 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     pdir = tmp_path / "projects"
-    tdir = tmp_path / "_trash" / "projects"
     monkeypatch.setattr(projects, "PROJECTS_DIR", pdir)
-    monkeypatch.setattr(projects, "TRASH_DIR", tdir)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     return {"db": dbfile, "tmp": tmp_path}
 

--- a/tests/test_version_config.py
+++ b/tests/test_version_config.py
@@ -16,7 +16,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     db.init_db(dbfile)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(projects, "TRASH_DIR", tmp_path / "_trash")
     # 全局 preset 池
     presets_dir = tmp_path / "presets"
     presets_dir.mkdir()

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -13,9 +13,7 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     pdir = tmp_path / "projects"
-    tdir = tmp_path / "_trash" / "projects"
     monkeypatch.setattr(projects, "PROJECTS_DIR", pdir)
-    monkeypatch.setattr(projects, "TRASH_DIR", tdir)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     return {"db": dbfile}
 
@@ -238,7 +236,7 @@ def test_delete_last_version_clears_active(isolated) -> None:
     assert p2 and p2["active_version_id"] is None
 
 
-def test_delete_moves_dir_to_trash(isolated) -> None:
+def test_delete_removes_dir(isolated) -> None:
     p = _new_project(isolated)
     with db.connection_for(isolated["db"]) as conn:
         v = versions.create_version(conn, project_id=p["id"], label="baseline")
@@ -246,13 +244,6 @@ def test_delete_moves_dir_to_trash(isolated) -> None:
         assert src.exists()
         versions.delete_version(conn, v["id"])
     assert not src.exists()
-    trash = (
-        projects.TRASH_DIR
-        / f"{p['id']}-{p['slug']}"
-        / "versions"
-        / "baseline"
-    )
-    assert trash.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
本分支汇集 PR #77 合并后的几项小清理，分三个主题。

## A. UI 文案微调

- **Preprocess** 删除多余的「下一步」section —— ADR 0004 内容（单 manifest）已经吸收掉，此处赘述
- **Sidebar / ProjectStepper STEPS**: 「预处理」「正则集」加「（可选）」标签，让用户清楚知道这两步可跳
- **Version 删除文案**: 「移到回收站」→「不可恢复」(Sidebar / VersionTabs / Layout)

## B. 删除「回收站」假象（讨论后选 A：直接硬删）

**原状的问题**:
- 软删把目录搬到 `studio_data/_trash/`，但**没有恢复 UI** —— grep 全 repo 无 `restoreProject`
- **不自动清理** —— server 启动只清 generate tempdir，不动 `_trash/`
- 唯一触发清理是用户手动点「清空回收站」按钮
- 结果：UI 视角等同硬删（项目消失、无法恢复），却 silently 在磁盘上累积孤儿目录

**改动**:
- `studio/projects.py`: 删 `TRASH_DIR` + `empty_trash`；`soft_delete_project` → `delete_project`（rmtree）
- `studio/versions.py`: `delete_version` 改 rmtree
- `studio/server.py`: 删 `/api/projects/_trash/empty` 端点
- 前端: 删 `emptyTrash` API + 「清空回收站」按钮 + `handleEmptyTrash` handler
- Projects 删除 confirm: 「删除项目「X」(slug)？包括所有版本、数据集、训练产物，此操作不可恢复。」(`tone: danger`)
- 19 个 tests fixture 清理 `TRASH_DIR` setattr + 4 个测试改名/断言（`test_soft_delete_*` → `test_delete_*`）

## C. 删队列「清理已完成」按钮

**原状的问题**:
- 只删 `tasks` 表的 `done` 行（KB 级），**不动 logs/{id}.log**（MB 级）
- output 是 per-version 目录，跟 task row 无关 —— 用户可能误以为按钮会丢 output（UX 焦虑）
- 漏了 `failed` / `canceled` 状态（也算 terminal）
- 清的不是问题（磁盘 log），问题的不清

**改动**: 删 `clearDone` handler + 按钮。视觉嘈杂的真解决方案（filter/折叠/分组）后续单独做。

## 同时包含的 lint fix（commit f172adb）

消除 `InlineLoraPicker.tsx:152` 的两条 react-hooks/exhaustive-deps warning（ternary 抽到 `singleWeight` 派生变量后，deps 数组只剩简单标识符）。

## 验证

- `npx tsc --noEmit` ✓
- `npx eslint src` ✓ 0 warning（含修复的两条）
- `npx vitest run` ✓ 159/159
- `python -m pytest tests/{test_projects,test_versions,test_curation,test_preprocess,test_lora_ckpt_scan,test_train_io,test_version_config}.py` ✓ 95/95
- (test_*_endpoints.py 因本地 env 缺 fastapi 跳过，但 fixture 改动平移自非 endpoint 测试，逻辑一致)

## Test plan

- [ ] 项目页面: × 删除一个项目 → confirm 文案显示「不可恢复」(red danger) → 确认后磁盘目录确实没了
- [ ] 项目页面: 顶上不再有「清空回收站」按钮
- [ ] 预处理页面: 右侧不再有「下一步」box（删了 ADR 0004 解释那段）
- [ ] Sidebar: 步骤列表显示「② 预处理（可选）」「⑥ 正则集（可选）」
- [ ] 版本切换: 删除版本 confirm 文案显示「不可恢复」
- [ ] 队列页面: 顶上不再有「清理已完成」按钮（导出/导入/刷新仍在）
- [ ] 生成页面: LoRA picker（受控单选 + 权重 slider）工作正常 —— 验证 useEffect 改写没影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)