### PR TITLE
feat(presets): 端到端 yaml 文件 I/O 替代手写 parser + JSON 导出

### DIFF
--- a/studio/presets_io.py
+++ b/studio/presets_io.py
@@ -35,6 +35,36 @@ def _preset_path(name: str, base: Path | None = None) -> Path:
     return (base or USER_PRESETS_DIR) / f"{name}.yaml"
 
 
+def preset_path(name: str, base: Path | None = None) -> Path:
+    """公开版 `_preset_path`，给端到端文件下载用（server 不要碰 _ 私有 helper）。"""
+    return _preset_path(name, base)
+
+
+def parse_preset_bytes(raw: bytes, filename: str) -> tuple[dict[str, Any], str]:
+    """解析 .yaml/.yml/.json 上传内容 + pydantic 校验，返回 (config_dict, suggested_name)。
+
+    不写盘 —— caller 决定最终落盘名字（前端 confirm flow 让用户改名再保存）。
+    yaml.safe_load 是 JSON 的 superset，所以 .json 文件也能直接吃。
+    """
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise PresetError(f"文件不是 UTF-8: {exc}") from exc
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        raise PresetError(f"YAML/JSON 解析失败: {exc}") from exc
+    if not isinstance(data, dict):
+        raise PresetError("预设格式错误（顶层不是 mapping）")
+    try:
+        cfg = TrainingConfig.model_validate(data)
+    except ValidationError as exc:
+        raise PresetError(f"预设校验失败: {exc}") from exc
+    stem = re.sub(r"\.(ya?ml|json)$", "", filename, flags=re.I)
+    suggested = re.sub(r"[^A-Za-z0-9_-]+", "-", stem).strip("-") or "imported"
+    return cfg.model_dump(mode="python"), suggested
+
+
 def list_presets(base: Path | None = None) -> list[dict[str, Any]]:
     """返回 `[{name, path, updated_at}]`，按修改时间倒序。"""
     base = base or USER_PRESETS_DIR

--- a/studio/server.py
+++ b/studio/server.py
@@ -419,6 +419,33 @@ def duplicate_preset_endpoint(name: str, body: DuplicateRequest) -> dict[str, st
     return {"name": body.new_name, "path": str(path)}
 
 
+@app.get("/api/presets/{name}/download")
+def download_preset(name: str) -> FileResponse:
+    """端到端文件 I/O：直接返回 `studio_data/presets/{name}.yaml` 原文件。"""
+    try:
+        path = presets_io.preset_path(name)
+    except presets_io.PresetError as exc:
+        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+    if not path.exists():
+        raise HTTPException(status_code=404, detail=f"预设不存在: {name}")
+    return FileResponse(path, media_type="application/yaml", filename=f"{name}.yaml")
+
+
+@app.post("/api/presets/import")
+async def import_preset(file: UploadFile = File(...)) -> dict[str, Any]:
+    """接 .yaml/.yml/.json 上传 → 解析 + schema 校验 → 返回 config + suggested_name。
+
+    不写盘 —— 让前端 draftSeed flow 拿 config + suggested 进新建模式，
+    用户确认名字 + 编辑后再走 PUT /api/presets/{name}。
+    """
+    raw = await file.read()
+    try:
+        config, suggested = presets_io.parse_preset_bytes(raw, file.filename or "")
+    except presets_io.PresetError as exc:
+        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+    return {"config": config, "suggested_name": suggested}
+
+
 def _err_code(exc: presets_io.PresetError) -> int:
     """PresetError → HTTP 状态码：'不存在' → 404，名字非法/已存在 → 400，其它 → 422。"""
     msg = str(exc)

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1119,6 +1119,23 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ new_name: newName }),
     }),
+  /** 端到端文件上传：把 .yaml/.yml/.json 文件给后端 yaml + pydantic 校验，
+   *  返回 config + suggested_name，前端走 draftSeed flow 让用户改名 + 编辑后保存。
+   *  绕过 req() 的 JSON header，让浏览器自加 multipart boundary。 */
+  importPreset: async (file: File): Promise<{ config: ConfigData; suggested_name: string }> => {
+    const fd = new FormData()
+    fd.append('file', file, file.name)
+    const resp = await fetch('/api/presets/import', { method: 'POST', body: fd })
+    if (!resp.ok) {
+      let detail = `${resp.status} ${resp.statusText}`
+      try {
+        const body = await resp.json()
+        if (body?.detail) detail = body.detail
+      } catch { /* ignore */ }
+      throw new Error(detail)
+    }
+    return (await resp.json()) as { config: ConfigData; suggested_name: string }
+  },
 
   // 兼容别名：PP0 之前叫 listConfigs / getConfig / ...。保留一段时间。
   listConfigs: () =>

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -259,33 +259,22 @@ export default function PresetsPage() {
     }).catch((e) => toast(String(e), 'error')).finally(() => setBusy(false))
   }
 
+  // 端到端文件 I/O：直接拿磁盘上的 `studio_data/presets/{name}.yaml` 流。
+  // 走 <a download> 而非 fetch + blob，让浏览器使用原生下载机制。
   const handleExport = () => {
-    if (!config || !selected) return
-    const blob = new Blob([JSON.stringify(config, null, 2)], { type: 'application/json' })
-    const url = URL.createObjectURL(blob)
+    if (!selected) return
     const a = document.createElement('a')
-    a.href = url; a.download = `${selected}.json`; a.click()
-    setTimeout(() => URL.revokeObjectURL(url), 1000)
+    a.href = `/api/presets/${encodeURIComponent(selected)}/download`
+    a.download = `${selected}.yaml`
+    a.click()
   }
 
-  // 「导入」：解析后切到新建模式预填，让用户在表单里改 + 输名字 + 看 schema 确认。
-  // 不再用 window.prompt 直接保存——跟新建走同一条路径。
+  // 「导入」：上传文件给后端做 yaml + pydantic 校验，拿回 config + suggested_name；
+  // 切到新建模式预填，让用户在表单里改 + 输名字 + 看 schema 确认。
   const handleImportFile = async (f: File) => {
     try {
-      const text = await f.text()
-      let data: ConfigData
-      if (f.name.endsWith('.json')) {
-        data = JSON.parse(text)
-      } else {
-        // 简单 YAML（仅 key: value 行）
-        data = {}
-        for (const line of text.split('\n')) {
-          const m = line.match(/^([a-zA-Z_]\w*)\s*:\s*(.+)/)
-          if (m) data[m[1]] = m[2].trim()
-        }
-      }
-      const suggested = f.name.replace(/\.(json|ya?ml)$/i, '').replace(/[^A-Za-z0-9_\-]/g, '-')
-      draftSeedRef.current = { config: data, desc: '', name: suggested }
+      const { config: data, suggested_name } = await api.importPreset(f)
+      draftSeedRef.current = { config: data, desc: '', name: suggested_name }
       setSelected(null)
       toast('已加载，确认无误后点保存', 'success')
     } catch (e) { toast(String(e), 'error') }
@@ -368,7 +357,7 @@ export default function PresetsPage() {
               复制副本
             </button>
             <button onClick={handleExport} disabled={busy || !config} className="btn btn-ghost btn-sm">
-              导出 JSON
+              导出 YAML
             </button>
             <button onClick={handleDelete} disabled={busy} className="btn btn-ghost btn-sm" style={{ color: 'var(--err)' }}>
               删除

--- a/tests/test_presets_io.py
+++ b/tests/test_presets_io.py
@@ -80,3 +80,71 @@ def test_duplicate_conflict(presets_dir: Path) -> None:
     presets_io.write_preset("b", _payload())
     with pytest.raises(presets_io.PresetError, match="已存在"):
         presets_io.duplicate_preset("a", "b")
+
+
+# ---------------------------------------------------------------------------
+# parse_preset_bytes（端到端文件导入用）
+# ---------------------------------------------------------------------------
+
+
+def test_parse_yaml_returns_config_and_suggested_name() -> None:
+    import yaml
+    payload = _payload()
+    payload["epochs"] = 12
+    raw = yaml.safe_dump(payload, allow_unicode=True).encode("utf-8")
+    config, suggested = presets_io.parse_preset_bytes(raw, "my-run.yaml")
+    assert config["epochs"] == 12
+    assert suggested == "my-run"
+
+
+def test_parse_json_works_via_yaml_superset() -> None:
+    """yaml.safe_load 同时吃 JSON —— 旧 .json 导出能直接导入回来。"""
+    import json
+    raw = json.dumps(_payload()).encode("utf-8")
+    config, suggested = presets_io.parse_preset_bytes(raw, "old.json")
+    assert config["lora_type"] == "lokr"
+    assert suggested == "old"
+
+
+def test_parse_rejects_unknown_field() -> None:
+    import yaml
+    bad = _payload()
+    bad["nonexistent_field"] = 123
+    raw = yaml.safe_dump(bad).encode("utf-8")
+    with pytest.raises(presets_io.PresetError, match="校验失败"):
+        presets_io.parse_preset_bytes(raw, "bad.yaml")
+
+
+def test_parse_rejects_non_mapping() -> None:
+    # 顶层是 list 不是 dict
+    raw = b"- foo\n- bar\n"
+    with pytest.raises(presets_io.PresetError, match="不是 mapping"):
+        presets_io.parse_preset_bytes(raw, "list.yaml")
+
+
+def test_parse_rejects_invalid_utf8() -> None:
+    raw = b"\xff\xfe\x00\x00bogus"
+    with pytest.raises(presets_io.PresetError, match="UTF-8"):
+        presets_io.parse_preset_bytes(raw, "binary.yaml")
+
+
+def test_parse_sanitizes_suggested_name() -> None:
+    """文件名带空格 / 中文 / 特殊字符 → suggested 走 [A-Za-z0-9_-] 白名单。"""
+    import yaml
+    raw = yaml.safe_dump(_payload()).encode("utf-8")
+    _, suggested = presets_io.parse_preset_bytes(raw, "我的 preset (v2).yaml")
+    assert all(c.isalnum() or c in "_-" for c in suggested)
+    assert "v2" in suggested
+
+
+def test_parse_empty_filename_fallback() -> None:
+    import yaml
+    raw = yaml.safe_dump(_payload()).encode("utf-8")
+    _, suggested = presets_io.parse_preset_bytes(raw, "")
+    assert suggested == "imported"
+
+
+def test_preset_path_is_public_alias() -> None:
+    assert presets_io.preset_path("foo").name == "foo.yaml"
+    with pytest.raises(presets_io.PresetError, match="非法预设名"):
+        presets_io.preset_path("bad/name")

--- a/tests/test_studio_configs.py
+++ b/tests/test_studio_configs.py
@@ -168,6 +168,95 @@ def test_yaml_on_disk_is_human_readable(client: TestClient, presets_dir: Path) -
 
 
 # ---------------------------------------------------------------------------
+# 端到端文件 I/O: /api/presets/{name}/download + /api/presets/import
+# ---------------------------------------------------------------------------
+
+
+def test_download_returns_raw_yaml(client: TestClient, presets_dir: Path) -> None:
+    """下载端点字节级一致：磁盘上 yaml 文件原封不动透传给客户端。"""
+    client.put("/api/presets/dl", json=_payload())
+    on_disk = (presets_dir / "dl.yaml").read_bytes()
+
+    resp = client.get("/api/presets/dl/download")
+    assert resp.status_code == 200
+    assert resp.content == on_disk
+    assert resp.headers["content-type"].startswith("application/yaml")
+    assert 'filename="dl.yaml"' in resp.headers["content-disposition"]
+
+
+def test_download_missing(client: TestClient) -> None:
+    assert client.get("/api/presets/ghost/download").status_code == 404
+
+
+def test_download_invalid_name(client: TestClient) -> None:
+    assert client.get("/api/presets/has..dot/download").status_code in (400, 422)
+
+
+def test_import_yaml_roundtrip(client: TestClient, presets_dir: Path) -> None:
+    """上传 yaml → 拿回 config + suggested_name；不写盘。"""
+    payload = _payload()
+    payload["epochs"] = 9
+    yaml_bytes = yaml.safe_dump(payload, allow_unicode=True).encode("utf-8")
+
+    resp = client.post(
+        "/api/presets/import",
+        files={"file": ("my-run.yaml", yaml_bytes, "application/yaml")},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["config"]["epochs"] == 9
+    assert body["suggested_name"] == "my-run"
+    # 不写盘：磁盘上不该多出 my-run.yaml
+    assert not (presets_dir / "my-run.yaml").exists()
+
+
+def test_import_json_also_works(client: TestClient) -> None:
+    """yaml.safe_load 是 JSON superset，旧的 .json 导出也能直接 import。"""
+    import json as json_mod
+    payload = _payload()
+    payload["epochs"] = 3
+    resp = client.post(
+        "/api/presets/import",
+        files={"file": ("legacy.json", json_mod.dumps(payload).encode(), "application/json")},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["config"]["epochs"] == 3
+
+
+def test_import_rejects_unknown_field(client: TestClient) -> None:
+    bad = _payload()
+    bad["nonexistent_field"] = 123
+    yaml_bytes = yaml.safe_dump(bad).encode("utf-8")
+    resp = client.post(
+        "/api/presets/import",
+        files={"file": ("bad.yaml", yaml_bytes, "application/yaml")},
+    )
+    assert resp.status_code == 422
+
+
+def test_import_rejects_malformed_yaml(client: TestClient) -> None:
+    resp = client.post(
+        "/api/presets/import",
+        files={"file": ("trash.yaml", b"this: : not yaml\n  invalid", "application/yaml")},
+    )
+    assert resp.status_code in (400, 422)
+
+
+def test_import_sanitizes_suggested_name(client: TestClient) -> None:
+    """文件名带空格 / 中文 / 特殊字符 → suggested_name 走 [A-Za-z0-9_-] 白名单。"""
+    yaml_bytes = yaml.safe_dump(_payload()).encode("utf-8")
+    resp = client.post(
+        "/api/presets/import",
+        files={"file": ("我的 preset (v2).yaml", yaml_bytes, "application/yaml")},
+    )
+    assert resp.status_code == 200
+    suggested = resp.json()["suggested_name"]
+    # 白名单：[A-Za-z0-9_-]+，非匹配字符压成 '-'，首尾 strip
+    assert all(c.isalnum() or c in "_-" for c in suggested)
+    assert "v2" in suggested
+
+
+# ---------------------------------------------------------------------------
 # /api/configs/* 兼容（308 redirect → /api/presets/*）
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
切换预设导入 / 导出的传输模型：从前端手写 YAML parser + JSON 文件，改为后端 send/receive 原生 yaml 文件，前端零格式翻译。

## 现状的问题

- **格式错位**: 后端落盘是 `studio_data/presets/{name}.yaml`（`presets_io.py` 用 `yaml.safe_dump`），但前端导出却是 JSON
- **手写 YAML parser 是地雷**: `Presets.tsx:282` 只有 4 行 mini parser，只能解 `key: value` 单行 scalar — 遇到 `sample_prompts: [a, b]` / `timestep_samplers` 这种 list / nested / quoted 字段就静默丢字段
- **不匹配 [[feedback_authoring_time_normalize]]**: 用户偏好"结构化 yaml + 工具校验"，当前却需要 runtime 解析 free-form 文本

## 改动

### 后端

- `studio/presets_io.py`:
  - 公开 `preset_path()`（薄壳调 `_preset_path`），让 server 能拿到磁盘路径
  - 新加 `parse_preset_bytes(raw, filename) → (config_dict, suggested_name)`: UTF-8 解码 + `yaml.safe_load` + pydantic validate + 文件名 sanitize
- `studio/server.py`:
  - `GET /api/presets/{name}/download` → `FileResponse` 直接透传 yaml 文件（字节级一致）
  - `POST /api/presets/import` → multipart `UploadFile`，校验后返回 `{config, suggested_name}`，**不写盘** —— 让前端 draftSeed flow 拿去预填，用户改名 + 编辑后再走 PUT

### 前端

- `client.ts`: 加 `importPreset(file: File)`，绕过 `req()` 的 JSON header 走 FormData
- `Presets.tsx`:
  - `handleExport` 改 `<a href="/api/presets/{name}/download" download>` 触发原生下载，从 `fetch + Blob.createObjectURL` 退出
  - `handleImportFile` 改用 `api.importPreset(f)`，**删手写 YAML parser**
  - 按钮文案: 「导出 JSON」→「导出 YAML」

## 设计要点

- **yaml.safe_load 是 JSON 的 superset** —— 旧的 `.json` 导出文件也能直接 import 回来，零兼容包袱
- **schema 真相只在后端** (pydantic) —— 前端不维护 yaml parser / dumper 副本；今后字段变了零前端同步
- **端到端字节一致** —— 用户能拷贝 `studio_data/presets/foo.yaml` 改改再导回，工作流完整闭环（匹配 authoring-time-normalize）
- **错误信息单一来源** —— 校验错都从 `PresetError` 经 `_err_code` 返 HTTP 状态码，文案不分散

## 验证

- ✅ `pytest tests/test_presets_io.py` 16/16（含 8 个 `parse_preset_bytes` unit 测试：roundtrip / json superset / unknown field / non-mapping / invalid utf-8 / sanitized name / empty filename fallback / preset_path 公开校验）
- ✅ `tsc --noEmit` 0 error
- ✅ `eslint src` 0 warning
- ✅ `vitest run` 159/159
- ⏳ `test_studio_configs.py` 加 7 个端点 test（download 字节级一致 / download missing 404 / download invalid name / import yaml roundtrip / import json works / import unknown field / import malformed / import sanitize name） — 本地 env 缺 fastapi，待 CI 跑

## Test plan

- [ ] 工具 → 预设页面：选一个 preset → 点「导出 YAML」 → 浏览器下载 `{name}.yaml` —— 内容跟 `studio_data/presets/{name}.yaml` 字节一致
- [ ] 点「导入」选刚才导出的 yaml → 切到新建模式，suggested_name 是文件名（去后缀）
- [ ] 导入文件名带空格 / 中文（"我的 preset.yaml"）→ suggested 被 sanitize 为 `我的-preset` 这种 ASCII（实际中文也被压成 `-`，看测试 expectation）
- [ ] 导入残废的 yaml（`bad: : not yaml`）→ 错误 toast 显示后端 PresetError 详情
- [ ] 导入旧的 `.json` 导出（任意之前的预设导出）→ 仍能正确解析（yaml.safe_load 吃 JSON superset）
- [ ] 高级工作流：直接编辑 `studio_data/presets/{name}.yaml`，存盘后 → 重启 / 刷新页面 → 改动在 UI 里生效（这不是新行为但本 PR 让它"看起来对头"）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
