### PR TITLE
polish(settings): 版本面板单视图 + 通道偏好 toggle + 文案脱离 git 词汇 (ADR 0005)

### DIFF
--- a/docs/adr/0005-update-channel-as-preference.md
+++ b/docs/adr/0005-update-channel-as-preference.md
@@ -1,0 +1,158 @@
+# 0005 — 更新通道（master / dev）作为用户视图偏好，与 git 工作树状态解耦
+
+**状态**：Accepted
+**日期**：2026-05-16
+**决策者**：@WalkingMeatAxolotl
+
+## 背景
+
+ADR 0002（webui 自更新）落地后，Settings → 系统 → 版本面板有两个长期暗坑，在
+v0.8.0 release 直后被触发：
+
+### 现象
+
+用户做了 v0.8.0 release（dev → master + PR merge + 打 tag）后，本地 master
+还没 `git pull`。打开版本面板看到：
+
+| UI 元素 | 显示 | 用户解读 |
+|---|---|---|
+| master 卡「你在这里」 | 我在 master | branch 名 = master |
+| master 卡 `v0.8.0` | 我装的是 v0.8.0 | `__version__` 字符串 |
+| master 卡「↑落后 2 commits」 | 我落后了 | git `rev-list --count` |
+| dev 卡「HEAD f6f202b」 | dev 顶端是这个 | 远端 |
+| dev 卡列表「● 当前」 | 我装的就是这个 | commit hash 比较 |
+| 「切到 dev (f6f202b)」按钮 | 可以切 | onDev=false |
+| `v0.8.0 → v0.8.0` 箭头 | 升级前后版本号一样？ |  |
+
+点「切到 dev (f6f202b)」 → preview 出现 → 确认 → 重启 → UI **没有变化**，
+仍然显示「master · 你在这里」。
+
+### 两个根因
+
+1. **UI 用 git 词汇而不是产品语言**。
+   - `commits_ahead` 直接从后端 `git rev-list --count` 出来，前端原样显示
+     「↑落后 N commits」。
+   - 但用户视角的"落后"只有一个维度：版本号。版本号 v0.8.0 == v0.8.0 时根本
+     不存在"落后"。`__version__` 字符串与 commit hash 是两套独立维度，UI 把
+     两套维度混着展示就产生了 `v0.8.0 → v0.8.0` + 「落后 2 commits」的矛盾。
+
+2. **"通道"概念绑死在 git 工作树状态上**。
+   - 「我在哪个通道」判定 = `git rev-parse --abbrev-ref HEAD`（branch 名）
+   - 「切换通道」实现 = `git reset --hard <ref>`（不动 branch 名）
+   - 两个机制大多数场景下"凑巧"能用：dev 通常比 master 领先，reset 后 commit
+     hash 变了，UI 看上去就"动了"。
+   - **release 直后例外**：本地 commit `f6f202b` 已经 == origin/dev HEAD（release
+     commit 本身在 dev 上做），切到 dev 是 no-op，branch 名也不变 → UI 永远
+     卡在「master · 你在这里」。
+
+更深的：UI 把 master 卡 + dev 卡**并排同屏**渲染，本应互斥的两个通道在视觉上
+变成两张同时活着的卡，让用户陷入「我究竟在哪个通道」的矛盾解读。
+
+## 决策
+
+**通道是用户视图偏好，不是 git 工作树状态**：
+
+1. **用户偏好持久化为 `system.update_channel`**（`"stable"` / `"dev"`），存
+   `secrets.json`。**切 toggle 不触发任何 git 操作**，纯 UI 视图切换。
+2. **真正"切到 dev HEAD" / "更新到 vX.Y.Z" / "回滚"是独立按钮**，跟通道偏好
+   解耦 —— 用户可以"订阅 dev 通道做研发"但暂时"装着稳定版"。
+3. **同屏只展示当前选中通道的卡片**（不再 master + dev 并排）。
+4. **后端引入「装了什么」分类 `installed_kind`**（`stable` / `dev` / `custom`），
+   按 commit hash 比对推断，**取代前端依赖 `branch` 字段做产品判断**。
+5. **前端文案只用版本号 / 状态语言**，不出现 `commits` / `sha` / `branch` 等
+   git 词汇。"落后 N commits" → "有新稳定版 vX.Y.Z" / "已是最新" / dev 通道
+   改"N 项新更新"。
+
+### 后端 API 形态
+
+`VersionInfo`（`/api/system/version`）：
+
+```python
+@dataclass
+class VersionInfo:
+    version: str
+    commit: str
+    commit_short: str
+    commit_time_iso: str
+    branch: str              # debug 用，前端不再做产品判断
+    tag: Optional[str]
+    is_dirty: bool
+    # ---- ADR 0005 ----
+    installed_kind: str      # "stable" / "dev" / "custom"
+    installed_label: str     # "v0.8.0" / "dev @ f6f202b · 2026-05-16" / "自定义（feat/foo @ a1b2c3d）"
+    stable_version: Optional[str]  # "vX.Y.Z" 仅 stable 时填
+```
+
+分类规则（优先级）：
+
+1. HEAD 命中 `vX.Y.Z` release tag → `stable`
+2. `__version__` 匹某 vX.Y.Z tag 且当前 commit 与 tag commit 的 **tree 一致** →
+   `stable`（覆盖 release 直后 release commit 在 dev、tag 在 merge commit 的场景）
+3. commit == `origin/dev` HEAD → `dev`
+4. else → `custom`（feature branch / detached）
+
+`UpdateCheckResult`（`/api/system/update_check`）：
+
+```python
+@dataclass
+class UpdateCheckResult:
+    channel: str
+    current_commit: str
+    latest_commit: str
+    commits_ahead: int       # 内部 debug 保留
+    has_update: bool         # 兼容字段 = (state == "update_available")
+    latest_tag: Optional[str]
+    checked_at: float
+    # ---- ADR 0005 ----
+    state: str               # "up_to_date" / "update_available" / "ahead" / "detached"
+    installed_version: Optional[str]
+    latest_version: Optional[str]
+    behind_count: int        # 给前端用的"N 项更新"数字
+    error: Optional[str]
+```
+
+state 推断：
+- **master 通道**：版本号优先（`installed_version == latest_version` → up_to_date），
+  没版本号（custom / dev）回落到 commit 比较
+- **dev 通道**：直接 commit hash 比较 + ahead/behind 计数
+
+### 前端
+
+- `formatMasterStateText(check)` / `formatDevStateText(check)`：纯函数把 state
+  + check 数据 → 用户可读文案
+- `shouldShowMasterUpdateButton(check)`：state=update_available 且有 latest_version
+- `isDevSwitchButtonDisabled(check)`：state=up_to_date → disabled
+- toggle 视觉切换走 `<button role="radio">`，写 `secrets.json` 但**不**调
+  `/api/system/update`
+
+### 迁移
+
+旧 `system.show_dev_channel`：保留 pydantic 字段做兼容；
+`_migrate_legacy_schema` 一次性映射 `show_dev_channel=true → update_channel="dev"`，
+前端 PATCH 时同时写两个字段保持旧版本回滚兼容。
+
+## 后果
+
+### 正面
+
+- release 直后用户的版本面板能正确显示「已是最新 v0.8.0」+「与 dev HEAD 一致」，
+  不再有"落后 2 commits"+「切到 dev 没反应」的矛盾
+- UI 文案彻底脱离 git 词汇，对非 git 用户更友好
+- 「装了什么」与「订阅哪条通道」解耦后，未来支持"装稳定版但跟 dev 看预览"等
+  灵活组合时不需要再改架构
+
+### 负面 / 待评估
+
+- `installed_kind=stable` 判定靠 `git diff --quiet` tree 比较，每次 `current_version()`
+  会多 1-2 个 git 调用。release 后短期内本地 tag 没 fetch 全时可能误判为 custom，
+  靠下次 `check_update` fetch tag 后自动纠正
+- 后端 `commits_ahead` / `has_update` 字段保留作兼容，但前端不再读 —— 任何外部
+  脚本读这俩字段的还能跑，可逐步迁移
+
+## 不在范围
+
+- "切到此 commit"（点 dev 列表里旧 commit 切过去）保留，但属于 dev 通道展开
+  区里的二级操作
+- 自动检查 + Topbar 红点维持 ADR 0002 的"只看 master"决定，不因通道偏好改
+- 完整翻译 Settings 页里其他地方的 git 词汇（譬如 secrets 里 wandb 同步状态）
+  不在此 ADR 范围

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,6 +10,7 @@
 | 0002 | [Webui 内自更新（flag + shell wrapper loop）](0002-webui-self-update.md) | Proposed | 2026-05-12 |
 | 0003 | [anima_train.py 模块化重构（plugin 边界 + adapter hook protocol）](0003-anima-train-refactor.md) | Proposed | 2026-05-14 |
 | 0004 | [预处理状态用单 manifest 替代「双 bucket + per-image sidecar」](0004-preprocess-manifest.md) | Accepted | 2026-05-15 |
+| 0005 | [更新通道作为用户视图偏好，与 git 工作树状态解耦](0005-update-channel-as-preference.md) | Accepted | 2026-05-16 |
 
 ## 状态值
 

--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -395,14 +395,18 @@ class GenerateConfig(BaseModel):
 
 
 class SystemConfig(BaseModel):
-    """系统级偏好（ADR 0002 / PR-D）。
+    """系统级偏好（ADR 0002 / 0005）。
 
-    - `show_dev_channel`：Settings 高级里勾选"显示开发版更新"后变 True。
-      开启时 UI 暴露"手动检查 dev"+"更新到 dev"按钮；自动检查仍只 fetch
-      master，Topbar badge 永不亮 dev（避免开发者被 dev commit 持续骚扰）。
-      默认 False —— 绝大多数用户看到的是只 master 的简化界面。
+    - `update_channel`：用户订阅哪条更新轨道。"stable"（默认）= 只看稳定版
+      更新提示；"dev" = 看 dev 通道（最近 commit 时间线、可切到 dev HEAD）。
+      这是**用户视图偏好**，与 git 工作树状态解耦 —— 切 toggle 不触发任何
+      git 操作；真正"切到 dev HEAD" / "更新到 vX.Y.Z" 是单独按钮。
+    - `show_dev_channel`：deprecated，由 `_migrate_legacy_schema` 一次性迁移成
+      `update_channel`（true → "dev"，false → "stable"），保留字段以便旧
+      secrets.json 读取时 pydantic 不报错；新代码不要再用。
     """
-    show_dev_channel: bool = False
+    update_channel: str = "stable"  # "stable" / "dev"
+    show_dev_channel: bool = False  # deprecated, 仅作迁移源
 
 
 class Secrets(BaseModel):
@@ -520,9 +524,17 @@ def _migrate_legacy_schema(raw: dict[str, Any]) -> dict[str, Any]:
     4. JoyCaptionConfig.base_url / model / prompt_template → 写入 joycaption preset
        （base_url/model 直接覆盖；prompt_template 非默认时建 `user_joycaption`）
     5. 删 raw["joycaption"] 字段
+    6. system.show_dev_channel=true → system.update_channel="dev"（ADR 0005）
 
     幂等：新 schema（llm_tagger 含 current_preset / presets）直接返回。
     """
+    # 6. system 通道偏好一次性迁移（无论后面 llm_tagger path 怎么走都先做）
+    sys_raw = raw.get("system")
+    if isinstance(sys_raw, dict):
+        # 新字段已显式设过 → 不覆盖（幂等）
+        if "update_channel" not in sys_raw and sys_raw.get("show_dev_channel") is True:
+            sys_raw["update_channel"] = "dev"
+
     llm_old = raw.get("llm_tagger")
     if not isinstance(llm_old, dict):
         # 不存在 llm_tagger 字段：可能是更老的 secrets.json；交给 pydantic 用默认值

--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -53,26 +53,43 @@ GIT_PULL_TIMEOUT = 120.0
 # ----- 数据类型 -----------------------------------------------------------
 @dataclass
 class VersionInfo:
-    """当前仓库 git 状态。"""
+    """当前仓库 git 状态 + 产品视角的"装了什么"分类。
+
+    产品 UI 应使用 `installed_kind` / `installed_label`，不要依赖 `branch`。
+    切换通道走 `git reset --hard`，不改 branch 名 —— branch 字段只做 debug。
+    """
     version: str               # studio.__version__ (0.6.0)
     commit: str                # 完整 sha
     commit_short: str          # 前 8 位
     commit_time_iso: str       # ISO8601
-    branch: str                # master / dev / detached
+    branch: str                # master / dev / detached / feature-name（debug 用）
     tag: Optional[str]         # HEAD 上的 tag（仅 exact match），无则 None
     is_dirty: bool             # working tree 有未提交改动
+    # ---- 产品 UI 用的「装了什么」分类（前端唯一应该看的字段）----
+    installed_kind: str        # "stable" / "dev" / "custom"
+    installed_label: str       # 用户可读："v0.8.0" / "dev @ f6f202b · 2026-05-16" / "自定义（feat/foo @ a1b2c3d）"
+    stable_version: Optional[str]  # "vX.Y.Z" 形式，仅 installed_kind=stable 时填；用于版本号比对
 
 
 @dataclass
 class UpdateCheckResult:
-    """git fetch + 比对结果。"""
+    """git fetch + 比对结果。
+
+    前端应使用 `state` + `installed_version` / `latest_version` / `behind_count`，
+    不要依赖 `commits_ahead`（git 词汇）/ `has_update`（兼容字段）。
+    """
     channel: str               # master / dev
     current_commit: str
     latest_commit: str
-    commits_ahead: int         # local 落后 remote 多少 commit
-    has_update: bool
+    commits_ahead: int         # 内部 debug：local 落后 remote 多少 commit
+    has_update: bool           # 兼容字段 = (state == "update_available")
     latest_tag: Optional[str]  # remote 最新 tag（仅 master 通道有）
     checked_at: float          # epoch
+    # ---- 产品 UI 用的状态机 ----
+    state: str = "up_to_date"  # "up_to_date" / "update_available" / "ahead" / "detached"
+    installed_version: Optional[str] = None  # 当前装的稳定版 tag (vX.Y.Z)，仅 stable 时填
+    latest_version: Optional[str] = None     # 远端最新稳定版 tag（master 通道）
+    behind_count: int = 0      # 前端文案"N 项更新"用（= commits_ahead，但语义更清楚）
     error: Optional[str] = None  # fetch 失败时填
 
 
@@ -127,6 +144,11 @@ def _git(*args: str, timeout: float = 15.0) -> tuple[int, str, str]:
         return 1, "", str(exc)
 
 
+# 稳定版 tag 形如 v0.8.0。HEAD 命中这种 tag 就归类 stable。
+# 第四段（如 v0.8.0-rc1）暂时不在版本面板的"稳定版"语义里，先归 custom。
+_RELEASE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
 # ----- 公开 API -----------------------------------------------------------
 def current_version() -> VersionInfo:
     """读当前仓库状态。git 不可用时返回占位值（不抛）。"""
@@ -149,6 +171,15 @@ def current_version() -> VersionInfo:
     rc, status, _ = _git("status", "--porcelain", "--untracked-files=no")
     is_dirty = rc == 0 and bool(status)
 
+    installed_kind, installed_label, stable_version = _classify_install(
+        commit=commit,
+        exact_tag=exact_tag,
+        branch=branch,
+        short=short,
+        commit_time_iso=ctime_iso,
+        is_dirty=is_dirty,
+    )
+
     return VersionInfo(
         version=__version__,
         commit=commit,
@@ -157,7 +188,69 @@ def current_version() -> VersionInfo:
         branch=branch,
         tag=exact_tag,
         is_dirty=is_dirty,
+        installed_kind=installed_kind,
+        installed_label=installed_label,
+        stable_version=stable_version,
     )
+
+
+def _classify_install(
+    *,
+    commit: str,
+    exact_tag: Optional[str],
+    branch: str,
+    short: str,
+    commit_time_iso: str,
+    is_dirty: bool,
+) -> tuple[str, str, Optional[str]]:
+    """推断 (installed_kind, installed_label, stable_version)。
+
+    优先级：
+    1. HEAD 命中 vX.Y.Z release tag → stable（最常见的稳定版情形）
+    2. `__version__` 匹 vX.Y.Z tag 且当前 commit 与 tag commit 的 tree 一致 → stable
+       覆盖 "release commit 在 dev 上，tag 打在 master 的 merge commit 上" 这种
+       release 直后场景（两个 commit 内容相同，用户语义上装的就是稳定版）
+    3. commit == origin/dev HEAD → dev
+    4. else → custom（feature branch / detached / 任意 commit）
+
+    返回三元组：
+    - installed_kind / installed_label：给前端做 UI 文案的
+    - stable_version：仅 stable 时为 "vX.Y.Z"，否则 None；后端做版本号比对用
+
+    label 是给用户看的字符串；dirty 时追加"· 未提交修改"。
+    """
+    dirty_suffix = " · 未提交修改" if is_dirty else ""
+
+    # 1. HEAD 命中 release tag
+    if exact_tag and _RELEASE_TAG_RE.match(exact_tag):
+        return "stable", f"{exact_tag}{dirty_suffix}", exact_tag
+
+    if commit and commit != "unknown":
+        # 2. __version__ 字符串匹 release tag 且 tree 一致
+        version_tag = f"v{__version__}"
+        if _RELEASE_TAG_RE.match(version_tag):
+            rc, tag_commit, _ = _git("rev-parse", f"{version_tag}^{{commit}}")
+            if rc == 0 and tag_commit:
+                if tag_commit == commit:
+                    # 极少触发（exact_tag 应已捕获），保险起见
+                    return "stable", f"{version_tag}{dirty_suffix}", version_tag
+                # tree 一致 = 文件内容完全相同（merge / cherry-pick 常见）
+                rc_diff, _, _ = _git("diff", "--quiet", commit, tag_commit)
+                if rc_diff == 0:
+                    return "stable", f"{version_tag}{dirty_suffix}", version_tag
+
+        # 3. commit == origin/dev HEAD
+        rc, dev_head, _ = _git("rev-parse", "origin/dev")
+        if rc == 0 and dev_head and commit == dev_head:
+            date_part = ""
+            if commit_time_iso:
+                date_part = f" · {commit_time_iso[:16].replace('T', ' ')}"
+            return "dev", f"dev @ {short}{date_part}{dirty_suffix}", None
+
+    # 4. custom
+    if not branch or branch == "detached":
+        return "custom", f"自定义（@ {short}）{dirty_suffix}", None
+    return "custom", f"自定义（{branch} @ {short}）{dirty_suffix}", None
 
 
 def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheckResult:
@@ -165,6 +258,13 @@ def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheck
 
     channel 仅接受 'master' / 'dev'。Master 走 24h 缓存（cache 写到磁盘）；
     dev 不写缓存（开发者主动检查，避免污染 master 的"有更新"信号）。
+
+    输出走 state 状态机（up_to_date / update_available / ahead / detached）。
+    state 推断：
+    - master 通道：优先比较 installed_version vs latest_version（版本号语义），
+      没有版本号（installed_kind != stable）时回落到 commit 比较
+    - dev 通道：直接比较 commit hash；commits_ahead>0 → update_available；
+      =0 但 sha 不一致 → ahead（你超前）或 detached
     """
     if channel not in ("master", "dev"):
         raise ValueError(f"invalid channel: {channel}")
@@ -175,13 +275,16 @@ def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheck
             return cached
 
     cur = current_version()
+    checked_at = time.time()
 
     rc, _, stderr = _git("fetch", "origin", channel, timeout=GIT_FETCH_TIMEOUT)
     if rc != 0:
         return UpdateCheckResult(
             channel=channel, current_commit=cur.commit, latest_commit="",
             commits_ahead=0, has_update=False, latest_tag=None,
-            checked_at=time.time(), error=f"git fetch failed: {stderr[:200]}",
+            checked_at=checked_at, state="detached", behind_count=0,
+            installed_version=None, latest_version=None,
+            error=f"git fetch failed: {stderr[:200]}",
         )
 
     rc, latest, _ = _git("rev-parse", f"origin/{channel}")
@@ -189,27 +292,73 @@ def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheck
         return UpdateCheckResult(
             channel=channel, current_commit=cur.commit, latest_commit="",
             commits_ahead=0, has_update=False, latest_tag=None,
-            checked_at=time.time(), error=f"git rev-parse origin/{channel} failed",
+            checked_at=checked_at, state="detached", behind_count=0,
+            installed_version=None, latest_version=None,
+            error=f"git rev-parse origin/{channel} failed",
         )
 
-    rc, ahead_str, _ = _git("rev-list", "--count", f"HEAD..origin/{channel}")
-    commits_ahead = int(ahead_str) if rc == 0 and ahead_str.isdigit() else 0
-    has_update = commits_ahead > 0 and cur.commit != latest
+    # commit 计数 —— behind = origin 比本地多多少；ahead = 本地比 origin 多多少
+    rc, behind_str, _ = _git("rev-list", "--count", f"HEAD..origin/{channel}")
+    behind = int(behind_str) if rc == 0 and behind_str.isdigit() else 0
+    rc, ahead_str, _ = _git("rev-list", "--count", f"origin/{channel}..HEAD")
+    ahead = int(ahead_str) if rc == 0 and ahead_str.isdigit() else 0
 
     latest_tag: Optional[str] = None
-    if channel == "master" and has_update:
-        rc, tag, _ = _git("describe", "--tags", "--abbrev=0", latest)
+    latest_version: Optional[str] = None
+    rc, tag_at_remote, _ = _git("describe", "--tags", "--exact-match", latest)
+    if rc == 0:
+        latest_tag = tag_at_remote
+        if _RELEASE_TAG_RE.match(tag_at_remote):
+            latest_version = tag_at_remote
+    if not latest_tag:
+        # describe 精确匹配失败 → fallback：取最近 reachable tag（保留兼容）
+        rc, tag_near, _ = _git("describe", "--tags", "--abbrev=0", latest)
         if rc == 0:
-            latest_tag = tag
+            latest_tag = tag_near
+            if channel == "master" and _RELEASE_TAG_RE.match(tag_near):
+                latest_version = tag_near
+
+    installed_version = cur.stable_version
+
+    # ---- 状态机推断 ----
+    if channel == "master":
+        # 版本号优先：版本号相同（已是最新稳定版）→ up_to_date
+        if installed_version and latest_version and installed_version == latest_version:
+            state = "up_to_date"
+        elif installed_version and latest_version and installed_version != latest_version:
+            # 装了稳定版且远端有更新稳定版 → 提示更新
+            state = "update_available"
+        elif cur.commit == latest:
+            # 没装 stable（custom / dev）但 commit 与 origin/master 完全一致
+            state = "up_to_date"
+        elif behind > 0:
+            state = "update_available"
+        elif ahead > 0:
+            state = "ahead"
+        else:
+            state = "detached"
+    else:  # dev
+        if cur.commit == latest:
+            state = "up_to_date"
+        elif behind > 0:
+            state = "update_available"
+        elif ahead > 0:
+            state = "ahead"
+        else:
+            state = "detached"
 
     result = UpdateCheckResult(
         channel=channel,
         current_commit=cur.commit,
         latest_commit=latest,
-        commits_ahead=commits_ahead,
-        has_update=has_update,
+        commits_ahead=behind,
+        has_update=(state == "update_available"),
         latest_tag=latest_tag,
-        checked_at=time.time(),
+        checked_at=checked_at,
+        state=state,
+        installed_version=installed_version,
+        latest_version=latest_version,
+        behind_count=behind,
     )
 
     if channel == "master":

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -344,9 +344,13 @@ export interface GenerateSecretsConfig {
   attention_backend: AttentionBackend
 }
 
-/** 系统级偏好（ADR 0002 / PR-D）。show_dev_channel 开启后 Settings 暴露 dev
- *  通道按钮（手动检查 / 更新到 dev）；自动检查 + Topbar badge 仍然只看 master。 */
+/** 系统级偏好（ADR 0002 / 0005）。update_channel 是用户视图偏好（"stable" /
+ *  "dev"），与 git 工作树状态解耦：toggle 切换不触发 git 操作，仅改 UI 展示
+ *  的通道；真正"切到 dev HEAD" / "更新到 vX.Y.Z" 是单独按钮。
+ *  show_dev_channel 是 deprecated 字段（pydantic 兼容），新代码用 update_channel。 */
 export interface SystemPrefsConfig {
+  update_channel: 'stable' | 'dev'
+  /** @deprecated use update_channel */
   show_dev_channel: boolean
 }
 
@@ -1859,20 +1863,45 @@ export interface SystemVersion {
   commit: string
   commit_short: string
   commit_time_iso: string
+  /** @deprecated UI 用 installed_kind / installed_label；branch 仅 debug */
   branch: string
   tag: string | null
   is_dirty: boolean
+  /** 产品视角的"装了什么"分类（ADR 0005）。
+   *  - stable：HEAD 命中 vX.Y.Z release tag，或 __version__ 匹某 release tag 且 tree 一致
+   *  - dev：commit == origin/dev HEAD
+   *  - custom：feature branch / detached / 未识别 commit */
+  installed_kind: 'stable' | 'dev' | 'custom'
+  /** 用户可读 label，如 "v0.8.0" / "dev @ f6f202b · 2026-05-16" / "自定义（feat/foo @ a1b2c3d）"。
+   *  dirty 时追加 "· 未提交修改" */
+  installed_label: string
+  /** "vX.Y.Z" 形式，仅 installed_kind=stable 时填；前端做版本号比对用 */
+  stable_version: string | null
 }
 
 export interface SystemUpdateCheck {
   channel: 'master' | 'dev'
   current_commit: string
   latest_commit: string
+  /** @deprecated 前端用 behind_count；commits_ahead 是 git 词汇 */
   commits_ahead: number
+  /** @deprecated 前端用 state；has_update = (state === 'update_available') */
   has_update: boolean
   latest_tag: string | null
   checked_at: number
   error: string | null
+  /** 状态机（ADR 0005）。
+   *  - up_to_date：已是最新（版本号 / commit 一致）
+   *  - update_available：远端有更新
+   *  - ahead：本地领先远端（罕见，常见于回滚后又抢跑）
+   *  - detached：当前 commit 不在 channel 历史上（feature branch / 离群） */
+  state: 'up_to_date' | 'update_available' | 'ahead' | 'detached'
+  /** 当前装的稳定版（master 通道）："vX.Y.Z" / null（没装 stable） */
+  installed_version: string | null
+  /** 远端最新稳定版（master 通道）："vX.Y.Z" / null（远端没 tag / dev 通道） */
+  latest_version: string | null
+  /** 前端文案"N 项更新"用（= commits_ahead，但语义更清楚） */
+  behind_count: number
 }
 
 /** PR-C — 最近一次 update 的结构化结果。

--- a/studio/web/src/lib/versionPanel.test.ts
+++ b/studio/web/src/lib/versionPanel.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import type { SystemUpdateCheck } from '../api/client'
+import {
+  formatDevStateText,
+  formatMasterStateText,
+  isDevSwitchButtonDisabled,
+  shouldShowMasterUpdateButton,
+} from './versionPanel'
+
+/** 构造一个 check 对象（必填字段填默认值，便于按需 override）。 */
+function mkCheck(over: Partial<SystemUpdateCheck>): SystemUpdateCheck {
+  return {
+    channel: 'master',
+    current_commit: '',
+    latest_commit: '',
+    commits_ahead: 0,
+    has_update: false,
+    latest_tag: null,
+    checked_at: 0,
+    error: null,
+    state: 'up_to_date',
+    installed_version: null,
+    latest_version: null,
+    behind_count: 0,
+    ...over,
+  }
+}
+
+describe('formatMasterStateText (ADR 0005)', () => {
+  it('null check → 未检查', () => {
+    expect(formatMasterStateText(null)).toBe('未检查')
+  })
+
+  it('up_to_date + latest_version → 已是最新 vX.Y.Z', () => {
+    expect(formatMasterStateText(mkCheck({ state: 'up_to_date', latest_version: 'v0.8.0' })))
+      .toBe('已是最新 v0.8.0')
+  })
+
+  it('up_to_date 无 latest_version → 已是最新', () => {
+    expect(formatMasterStateText(mkCheck({ state: 'up_to_date' }))).toBe('已是最新')
+  })
+
+  it('update_available 显示目标版本号', () => {
+    expect(formatMasterStateText(mkCheck({
+      state: 'update_available', latest_version: 'v0.9.0',
+    }))).toBe('有新稳定版 v0.9.0')
+  })
+
+  it('update_available fallback 到 latest_tag', () => {
+    expect(formatMasterStateText(mkCheck({
+      state: 'update_available', latest_version: null, latest_tag: 'v0.9.0-rc1',
+    }))).toBe('有新稳定版 v0.9.0-rc1')
+  })
+
+  it('ahead → 本地领先稳定版（不暴露 commit 词汇）', () => {
+    expect(formatMasterStateText(mkCheck({ state: 'ahead' }))).toBe('本地领先稳定版')
+  })
+
+  it('detached → 当前 commit 不在稳定版历史上', () => {
+    expect(formatMasterStateText(mkCheck({ state: 'detached' })))
+      .toBe('当前 commit 不在稳定版历史上')
+  })
+
+  it('不出现 git 词汇：commits / sha / branch', () => {
+    const samples = [
+      formatMasterStateText(mkCheck({ state: 'up_to_date', latest_version: 'v0.8.0' })),
+      formatMasterStateText(mkCheck({ state: 'update_available', latest_version: 'v0.9.0' })),
+      formatMasterStateText(mkCheck({ state: 'ahead' })),
+    ]
+    for (const s of samples) {
+      expect(s).not.toMatch(/commits?/i)
+      expect(s).not.toMatch(/\bsha\b/i)
+      expect(s).not.toMatch(/branch/i)
+    }
+  })
+})
+
+describe('formatDevStateText (ADR 0005)', () => {
+  it('null check → 未抓取', () => {
+    expect(formatDevStateText(null)).toBe('未抓取')
+  })
+
+  it('up_to_date → 与 dev HEAD 一致', () => {
+    expect(formatDevStateText(mkCheck({ channel: 'dev', state: 'up_to_date' })))
+      .toBe('与 dev HEAD 一致')
+  })
+
+  it('update_available with behind_count=3 → 有 3 项新更新', () => {
+    expect(formatDevStateText(mkCheck({
+      channel: 'dev', state: 'update_available', behind_count: 3,
+    }))).toBe('有 3 项新更新')
+  })
+
+  it('update_available with behind_count=0 → 有新更新', () => {
+    expect(formatDevStateText(mkCheck({
+      channel: 'dev', state: 'update_available', behind_count: 0,
+    }))).toBe('有新更新')
+  })
+
+  it('ahead → 本地领先 dev HEAD', () => {
+    expect(formatDevStateText(mkCheck({ channel: 'dev', state: 'ahead' })))
+      .toBe('本地领先 dev HEAD')
+  })
+
+  it('不出现 "commits" 字眼（dev 通道改"项更新"）', () => {
+    const s = formatDevStateText(mkCheck({
+      channel: 'dev', state: 'update_available', behind_count: 5,
+    }))
+    expect(s).not.toMatch(/commits?/i)
+    expect(s).toContain('项新更新')
+  })
+})
+
+describe('shouldShowMasterUpdateButton', () => {
+  it('null check → false', () => {
+    expect(shouldShowMasterUpdateButton(null)).toBe(false)
+  })
+
+  it('up_to_date → false（已是最新，不显示更新按钮）', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'up_to_date', latest_version: 'v0.8.0',
+    }))).toBe(false)
+  })
+
+  it('update_available + latest_version → true', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'update_available', latest_version: 'v0.9.0',
+    }))).toBe(true)
+  })
+
+  it('update_available 但无目标版本号 → false（防止显示空目标按钮）', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'update_available', latest_version: null, latest_tag: null,
+    }))).toBe(false)
+  })
+
+  it('ahead / detached → false（不暗示用户能"更新到自己"）', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'ahead' }))).toBe(false)
+    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'detached' }))).toBe(false)
+  })
+})
+
+describe('isDevSwitchButtonDisabled (release 直后场景 regression)', () => {
+  it('up_to_date → disabled（当前 commit 已等于 dev HEAD，切是 no-op）', () => {
+    expect(isDevSwitchButtonDisabled(mkCheck({
+      channel: 'dev', state: 'up_to_date',
+    }))).toBe(true)
+  })
+
+  it('update_available → 可点', () => {
+    expect(isDevSwitchButtonDisabled(mkCheck({
+      channel: 'dev', state: 'update_available', behind_count: 2,
+    }))).toBe(false)
+  })
+
+  it('null check → 可点（用户没抓取过，按钮要能触发抓取 + 切换）', () => {
+    expect(isDevSwitchButtonDisabled(null)).toBe(false)
+  })
+})

--- a/studio/web/src/lib/versionPanel.ts
+++ b/studio/web/src/lib/versionPanel.ts
@@ -1,0 +1,60 @@
+/** 版本面板文案 mapping（ADR 0005）。
+ *
+ * 把"check.state + version/check 数据 → 用户可读文案"的逻辑抽出来，
+ * 与 React 组件解耦便于单测。所有文案**只用版本号 / 状态语言**，
+ * 不出现 commits / sha / branch 等 git 词汇。
+ */
+import type { SystemUpdateCheck } from '../api/client'
+
+/** master（稳定版）通道的状态行文案。
+ *
+ * 优先级：
+ * - up_to_date：已是最新 vX.Y.Z（latest_version 有就拼版本号，没就裸"已是最新"）
+ * - update_available：有新稳定版 vX.Y.Z
+ * - ahead：本地领先稳定版（罕见，回滚 / 抢跑）
+ * - detached：当前 commit 不在稳定版历史上（feature branch）
+ * - check=null：未检查
+ */
+export function formatMasterStateText(check: SystemUpdateCheck | null): string {
+  if (!check) return '未检查'
+  if (check.state === 'up_to_date') {
+    return check.latest_version ? `已是最新 ${check.latest_version}` : '已是最新'
+  }
+  if (check.state === 'update_available') {
+    const target = check.latest_version ?? check.latest_tag ?? check.latest_commit?.slice(0, 8) ?? ''
+    return target ? `有新稳定版 ${target}` : '有新稳定版'
+  }
+  if (check.state === 'ahead') return '本地领先稳定版'
+  return '当前 commit 不在稳定版历史上'
+}
+
+/** dev（开发版）通道的状态行文案。
+ *
+ * dev 没有版本号语义（滚动），所以"N 项新更新"是合理表达；不暴露
+ * commits 字眼给用户。
+ */
+export function formatDevStateText(check: SystemUpdateCheck | null): string {
+  if (!check) return '未抓取'
+  if (check.state === 'up_to_date') return '与 dev HEAD 一致'
+  if (check.state === 'update_available') {
+    return check.behind_count > 0 ? `有 ${check.behind_count} 项新更新` : '有新更新'
+  }
+  if (check.state === 'ahead') return '本地领先 dev HEAD'
+  return '当前 commit 不在 dev 历史上'
+}
+
+/** master 通道"更新"按钮是否应该显示（state=update_available 且有目标版本）。 */
+export function shouldShowMasterUpdateButton(check: SystemUpdateCheck | null): boolean {
+  if (!check || check.state !== 'update_available') return false
+  return !!(check.latest_version ?? check.latest_tag)
+}
+
+/** dev 通道"切到 dev HEAD"按钮是否应该 disabled。
+ *
+ * 当 state=up_to_date 时按钮 disabled —— 即便用户的 installed_kind 是
+ * stable，只要 commit 已等于 origin/dev HEAD，切操作就是 no-op，
+ * 该 disabled 避免点了无反应（release 直后场景）。
+ */
+export function isDevSwitchButtonDisabled(check: SystemUpdateCheck | null): boolean {
+  return check?.state === 'up_to_date'
+}

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -29,6 +29,12 @@ import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
 import { useEventStream } from '../../lib/useEventStream'
+import {
+  formatMasterStateText,
+  formatDevStateText,
+  shouldShowMasterUpdateButton,
+  isDevSwitchButtonDisabled,
+} from '../../lib/versionPanel'
 import { applyDensity, applyTheme, getStoredDensity, getStoredTheme, setStoredDensity, setStoredTheme, type Density, type Theme } from '../../lib/theme'
 
 const MASK = '***'
@@ -214,7 +220,7 @@ const EMPTY: Secrets = {
   models: { root: null, selected_anima: '1.0', selected_upscaler: '4x-AnimeSharp' },
   queue: { allow_gpu_during_train: false },
   generate: { preview_every_n_steps: 3, attention_backend: 'auto' },
-  system: { show_dev_channel: false },
+  system: { update_channel: 'stable', show_dev_channel: false },
 }
 
 const textInputClass = 'w-full px-2 py-1 outline-none rounded-sm bg-sunken border border-subtle text-sm text-fg-primary focus:border-accent'
@@ -2625,20 +2631,23 @@ async function pollHealthThenReload(
   onTimeout()
 }
 
-// ── 版本 Section（双通道重设计 — Chunk 1）─────────────────────────────
+// ── 版本 Section（ADR 0005 重设计 — 单视图 + 通道偏好）───────────────
 //
-// 布局：master / dev 两张通道卡并排（dev 隐藏时 master solo）。toggle 行
-// 下移到卡片之后（demoted），不是建议操作；当前在 dev 时强制开 + 锁定。
+// 产品模型：
+// - 通道（channel）是**用户视图偏好**：你想订阅哪条更新轨道（稳定 / 开发）
+// - 与 git 工作树状态**解耦**：切 toggle 不动 git；真正"切到 dev HEAD" /
+//   "更新到 vX.Y.Z" 是单独按钮
+// - 同屏只显示当前选中通道的卡片（不并排）—— 通道是互斥视图，并排会让
+//   用户陷入"我究竟在哪里"的矛盾
+// - 文案语言只有"版本号"+"状态"，绝不出现"commits"/"sha"等 git 词汇
 //
-// 加载时 fetch /api/system/version + /api/system/update_check（master,
-// 走 cache）+ /api/system/update_status + /api/secrets.system。
+// 数据：
+// - version.installed_kind (stable / dev / custom) + installed_label：装了什么
+// - check.state (up_to_date / update_available / ahead / detached)：相对所选
+//   通道的状态
+// - prefs.update_channel：用户偏好（"stable" / "dev"）
 //
 // 自动检查 + Topbar 红点仍然只看 master（ADR 0002 决策）。
-//
-// 状态（chunk 1）：synced / has-update / failed（用现有 .update_status 数据）；
-// 操作按钮"更新到 X" / "切到 X" 仍走现有 dialog 模态。preview / progress /
-// inline-failed 状态机留给 chunk 4。release notes 留给 chunk 2，dev commits
-// 列表留给 chunk 3。
 function VersionSection() {
   const { toast } = useToast()
   // chunk 4：dialog 模态被 inline preview 面板取代，VersionSection 不再用 dialog
@@ -2675,18 +2684,19 @@ function VersionSection() {
     void api.getSecrets().then((s) => setPrefs(s.system)).catch(() => { /* silent */ })
   }, [])
 
-  // chunk 3 — devVisible 第一次转 true 时自动拉一遍 dev_commits + check（用户
-  // 不用先手动按 [抓取 dev] 才看到时间线）。后续 [抓取 dev] 按钮再做刷新。
-  const devVisibleNow = (version?.branch === 'dev') || !!prefs?.show_dev_channel
+  // 选中 dev 通道时自动拉 dev_commits + dev check（用户不用先手动按 [抓取 dev]）。
+  // 即便装的是 stable，用户切到 dev 通道偏好时也要能立刻看到 dev HEAD 信息。
+  const channelPref: 'stable' | 'dev' = prefs?.update_channel ?? 'stable'
+  const showDevView = channelPref === 'dev'
   useEffect(() => {
-    if (!devVisibleNow || devCommits !== null) return
+    if (!showDevView || devCommits !== null) return
     let cancelled = false
     void api.getDevCommits(10).then((r) => { if (!cancelled) setDevCommits(r) }).catch(() => { /* silent */ })
     if (devCheck === null) {
       void api.checkSystemUpdate('dev', true).then((r) => { if (!cancelled) setDevCheck(r) }).catch(() => { /* silent */ })
     }
     return () => { cancelled = true }
-  }, [devVisibleNow, devCommits, devCheck])
+  }, [showDevView, devCommits, devCheck])
 
   const handleCheck = async () => {
     setChecking(true)
@@ -2695,10 +2705,13 @@ function VersionSection() {
       setCheck(r)
       if (r.error) {
         toast(`检查失败: ${r.error}`, 'error')
-      } else if (r.has_update) {
-        toast(`有新版本：${r.latest_tag ?? r.latest_commit.slice(0, 8)}（${r.commits_ahead} commits）`, 'info')
+      } else if (r.state === 'update_available') {
+        const target = r.latest_version ?? r.latest_tag ?? r.latest_commit.slice(0, 8)
+        toast(`有新稳定版：${target}`, 'info')
+      } else if (r.state === 'ahead') {
+        toast('本地领先稳定版（可能由回滚 / 抢跑造成）', 'info')
       } else {
-        toast('已是最新版本', 'success')
+        toast(`已是最新${r.latest_version ? '稳定版 ' + r.latest_version : ''}`, 'success')
       }
     } catch (e) {
       toast(`检查更新失败: ${e}`, 'error')
@@ -2806,17 +2819,23 @@ function VersionSection() {
     }
   }
 
-  // PR-D — dev 通道 toggle 持久化到 secrets.json。乐观更新 + 失败回滚。
-  const handleToggleDevChannel = async (next: boolean) => {
+  // ADR 0005 — 通道偏好持久化到 secrets.json。**不触发任何 git 操作**，
+  // 只是切换 UI 视图。乐观更新 + 失败回滚。
+  const handleSwitchChannel = async (next: 'stable' | 'dev') => {
     const prev = prefs
-    setPrefs((p) => p ? { ...p, show_dev_channel: next } : { show_dev_channel: next })
-    if (!next) setDevCheck(null)        // 关掉时清掉缓存的 dev 检查结果
+    setPrefs((p) => p
+      ? { ...p, update_channel: next }
+      : { update_channel: next, show_dev_channel: next === 'dev' })
+    if (next === 'stable') setDevCheck(null)  // 切回稳定版时清掉 dev 缓存
     try {
-      const updated = await api.updateSecrets({ system: { show_dev_channel: next } })
+      // 同步写 show_dev_channel 字段，保留对老版本回滚兼容
+      const updated = await api.updateSecrets({
+        system: { update_channel: next, show_dev_channel: next === 'dev' },
+      })
       setPrefs(updated.system)
     } catch (e) {
-      setPrefs(prev)                    // 失败回滚 UI
-      toast(`保存失败: ${(e as Error).message ?? e}`, 'error')
+      setPrefs(prev)
+      toast(`保存通道偏好失败: ${(e as Error).message ?? e}`, 'error')
     }
   }
 
@@ -2834,10 +2853,12 @@ function VersionSection() {
         toast(`dev 检查失败: ${check.error}`, 'error')
       } else if (commits.error && !commits.fetched) {
         toast(`dev 抓取部分失败: ${commits.error}`, 'error')
-      } else if (check.has_update) {
-        toast(`dev 通道有 ${check.commits_ahead} commits 新提交`, 'info')
+      } else if (check.state === 'update_available') {
+        toast(`dev 通道有 ${check.behind_count} 项新更新`, 'info')
+      } else if (check.state === 'ahead') {
+        toast('本地领先 dev HEAD（罕见，可能是抢跑）', 'info')
       } else {
-        toast('dev 通道与当前一致', 'success')
+        toast('已与 dev HEAD 一致', 'success')
       }
     } catch (e) {
       toast(`dev 检查失败: ${e}`, 'error')
@@ -2874,21 +2895,20 @@ function VersionSection() {
     })
   }
 
-  // 通道判定 + 派生状态
-  const onDev = version?.branch === 'dev'
-  // dev 卡显示条件：toggle 开了，或者当前已经在 dev（强制可见）
-  const devVisible = onDev || !!prefs?.show_dev_channel
-  const hasUpdate = !!check?.has_update
+  // 派生状态（ADR 0005）：installed_kind / state 取代 branch / has_update
+  const installedIsDevHead = version?.installed_kind === 'dev'
+  const masterHasUpdate = check?.state === 'update_available'
   const hasRollback = !!status?.rollback_target
   // 上次 update 失败 banner（aborted / failed / partial 时显示红色提示）
   const statusBadFailed = !!status && (status.status === 'failed' || status.status === 'aborted' || status.status === 'partial')
 
-  // chunk 2 — 当展示的 tag 变化时拉对应 release notes。展示 tag = hasUpdate
-  // 时为目标 tag（"v0.6.1 · 更新内容"），否则当前 tag（"v0.6.0 · 此版本"）。
-  // CHANGELOG.md 没条目时 found=false，UI 自然 fallback 到占位链接。
-  const displayedTag = hasUpdate
-    ? (check?.latest_tag ?? null)
-    : (version?.tag ?? (version ? `v${version.version}` : null))
+  // release notes 拉对应 tag：stable 通道有更新时展示目标版本，否则展示当前
+  // 已装版本；dev 通道不展示 release notes（dev 是滚动的，没有版本号语义）
+  const displayedTag = showDevView
+    ? null
+    : masterHasUpdate
+      ? (check?.latest_version ?? check?.latest_tag ?? null)
+      : (version?.stable_version ?? version?.tag ?? (version ? `v${version.version}` : null))
   useEffect(() => {
     if (!displayedTag) {
       setReleaseNotes(null)
@@ -2910,67 +2930,78 @@ function VersionSection() {
       headerExtras={
         <InfoButton>
           <ul>
-            <li>自动检查每 24 小时，仅看 master 通道；dev 必须主动触发，不进 Topbar 红点</li>
+            <li>切换通道是改 UI 视图偏好（不动 git）；真正"切到 dev HEAD" / "更新到 vX.Y.Z" 是单独按钮</li>
+            <li>自动检查每 24 小时，仅看稳定版通道；切到开发版通道不进 Topbar 红点</li>
             <li>更新 / 切换底层走 git reset --hard，需要时跑 pip / npm install</li>
             <li>有运行中任务 / 本地工作树脏 → 操作会被 pre-flight 拒绝</li>
-            <li>master 显示 release tag；dev 显示 commit 时间线，可点任意 commit 切换</li>
           </ul>
         </InfoButton>
       }
     >
-      {/* dev toggle 行：搬到 title 下面（独立一行），不再下方"附庸" */}
-      <div className={`vs-dev-toggle-row${devVisible ? ' open' : ''}${onDev ? ' locked' : ''}`}>
-        <div className="vs-lhs">
-          <div
-            className={`vs-sw${devVisible ? ' on' : ''}${onDev ? ' locked' : ''}`}
-            onClick={() => { if (!onDev) void handleToggleDevChannel(!devVisible) }}
-            role="switch"
-            aria-checked={devVisible}
-            aria-disabled={onDev}
-          />
-          <div>
-            <div className="vs-t" style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-              <span>查看 dev 通道（开发版）</span>
-              {onDev && (
-                <span className="vs-lock-pill">
-                  <VersionIcon name="lock" />当前在 dev · 不可关闭
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
+      {/* 顶部：你装的是什么（一行事实状态，与通道偏好解耦） */}
+      <div className="vs-installed-row">
+        <span className="vs-installed-label">你装的：</span>
+        <b className="vs-installed-value">{version?.installed_label ?? '加载中…'}</b>
+        {version?.is_dirty && !version.installed_label.includes('未提交修改') && (
+          <span className="vs-installed-warn">· 本地有改动</span>
+        )}
+      </div>
+
+      {/* 通道偏好：radio toggle（不触发 git） */}
+      <div className="vs-channel-toggle-row">
+        <span className="vs-channel-toggle-label">更新通道：</span>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={channelPref === 'stable'}
+          className={`vs-channel-radio${channelPref === 'stable' ? ' on' : ''}`}
+          onClick={() => { if (channelPref !== 'stable') void handleSwitchChannel('stable') }}
+        >
+          <span className="vs-channel-dot" />稳定版
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={channelPref === 'dev'}
+          className={`vs-channel-radio${channelPref === 'dev' ? ' on' : ''}`}
+          onClick={() => { if (channelPref !== 'dev') void handleSwitchChannel('dev') }}
+        >
+          <span className="vs-channel-dot" />开发版
+        </button>
+        <span className="vs-channel-hint">仅切 UI 视图，不动 git</span>
       </div>
 
       <div className="vs-sec-card">
-        <div className={`vs-channels${devVisible ? ' both' : ''}`}>
-          <MasterCard
-            on={!onDev}
-            solo={!devVisible}
-            version={version}
-            check={check}
-            status={status}
-            hasUpdate={hasUpdate}
-            hasRollback={hasRollback}
-            statusBadFailed={statusBadFailed}
-            releaseNotes={releaseNotes}
-            onShowReleaseNotesDetail={() => setDetailModalOpen(true)}
-            checking={checking}
-            busy={busy}
-            cardState={masterState}
-            pendingTarget={pendingTarget}
-            preflight={preflight}
-            preflightLoading={preflightLoading}
-            onCancelPreview={cancelPreview}
-            onConfirmPreview={confirmPreview}
-            onCheck={handleCheck}
-            onUpdate={handleUpdate}
-            onSwitchToMaster={handleSwitchToMaster}
-            onRollback={handleRollback}
-            onViewLog={handleViewLog}
-          />
-          {devVisible && (
+        <div className="vs-channels">
+          {!showDevView ? (
+            <MasterCard
+              on={true}
+              solo={true}
+              version={version}
+              check={check}
+              status={status}
+              hasUpdate={masterHasUpdate}
+              hasRollback={hasRollback}
+              statusBadFailed={statusBadFailed}
+              releaseNotes={releaseNotes}
+              onShowReleaseNotesDetail={() => setDetailModalOpen(true)}
+              checking={checking}
+              busy={busy}
+              cardState={masterState}
+              pendingTarget={pendingTarget}
+              preflight={preflight}
+              preflightLoading={preflightLoading}
+              onCancelPreview={cancelPreview}
+              onConfirmPreview={confirmPreview}
+              onCheck={handleCheck}
+              onUpdate={handleUpdate}
+              onSwitchToMaster={handleSwitchToMaster}
+              onRollback={handleRollback}
+              onViewLog={handleViewLog}
+            />
+          ) : (
             <DevCard
-              on={onDev}
+              on={installedIsDevHead}
               check={devCheck}
               commits={devCommits}
               currentSha={version?.commit ?? ''}
@@ -3249,15 +3280,20 @@ function MasterReleaseNotes({
 }
 
 function MasterCard(p: MasterCardProps) {
-  const currentTag = p.version?.tag ?? (p.version ? `v${p.version.version}` : '加载中…')
-  const targetTag = p.check?.latest_tag ?? p.check?.latest_commit?.slice(0, 8) ?? ''
-  // chunk 4 — preview / progress 状态优先渲染（替代 chan-body + chan-foot）
+  // 当前装的版本号优先用 stable_version（精确），fallback 到 __version__
+  const currentTag = p.version?.stable_version
+    ?? p.version?.tag
+    ?? (p.version ? `v${p.version.version}` : '加载中…')
+  // 远端最新稳定版（state=update_available 时显示）
+  const targetTag = p.check?.latest_version ?? p.check?.latest_tag ?? ''
+  const stateText = formatMasterStateText(p.check)
+  const showUpdateButton = shouldShowMasterUpdateButton(p.check)
   if (p.cardState === 'preview' && p.pendingTarget && p.pendingTarget.kind === 'master') {
     return (
-      <div className={`vs-chan${p.on ? ' here' : ''}`}>
+      <div className="vs-chan">
         <div className="vs-chan-head">
           <div className="vs-lhs">
-            <span className="vs-name">master · 确认更新</span>
+            <span className="vs-name">稳定版 · 确认更新</span>
             <span className="vs-pill vs-pill-stable"><span className="vs-dot" />稳定</span>
           </div>
           <button className="btn btn-sm btn-ghost" onClick={p.onCancelPreview} disabled={p.busy}>
@@ -3268,7 +3304,6 @@ function MasterCard(p: MasterCardProps) {
           channel="master"
           fromLabel={currentTag}
           toLabel={p.pendingTarget.label}
-          badge={p.check?.has_update ? `+${p.check.commits_ahead} commits` : undefined}
           details={
             <div className="vs-change-block">
               <div className="vs-h">{p.pendingTarget.label} · 更新内容</div>
@@ -3286,10 +3321,10 @@ function MasterCard(p: MasterCardProps) {
   }
   if (p.cardState === 'progress' && p.pendingTarget && p.pendingTarget.kind === 'master') {
     return (
-      <div className={`vs-chan${p.on ? ' here' : ''}`}>
+      <div className="vs-chan">
         <div className="vs-chan-head">
           <div className="vs-lhs">
-            <span className="vs-name">master · 更新中</span>
+            <span className="vs-name">稳定版 · 更新中</span>
             <span className="vs-pill vs-pill-stable"><span className="vs-dot" />稳定</span>
           </div>
         </div>
@@ -3305,16 +3340,13 @@ function MasterCard(p: MasterCardProps) {
     : null
 
   return (
-    <div className={`vs-chan${p.on ? ' here' : ''}`}>
+    <div className="vs-chan">
       <div className="vs-chan-head">
         <div className="vs-lhs">
-          <span className="vs-name">master</span>
+          <span className="vs-name">稳定版</span>
           <span className="vs-pill vs-pill-stable"><span className="vs-dot" />稳定</span>
-          {p.on && <span className="vs-pill vs-pill-here">● 你在这里</span>}
         </div>
-        <div className={`vs-meta${p.hasUpdate ? ' attn' : ''}`}>
-          {p.hasUpdate ? `↑ 落后 ${p.check?.commits_ahead ?? 0} commits` : '已是最新'}
-        </div>
+        <div className={`vs-meta${p.hasUpdate ? ' attn' : ''}`}>{stateText}</div>
       </div>
 
       {p.statusBadFailed && p.status && (
@@ -3362,18 +3394,6 @@ function MasterCard(p: MasterCardProps) {
           </div>
           <div className="vs-ver-meta">
             {releasedAt && <span>发布于 <b>{releasedAt}</b></span>}
-            {p.hasUpdate && (
-              <>
-                {releasedAt && <span className="vs-sep">·</span>}
-                <span>↑ {p.check?.commits_ahead ?? 0} commits</span>
-              </>
-            )}
-            {p.version?.is_dirty && (
-              <>
-                {(releasedAt || p.hasUpdate) && <span className="vs-sep">·</span>}
-                <span style={{ color: 'var(--warn)' }}>本地有改动</span>
-              </>
-            )}
           </div>
           {!p.hasUpdate && p.solo && (
             <div className="vs-ver-tagline">Topbar 红点 + 自动检查仅看此通道。</div>
@@ -3400,14 +3420,17 @@ function MasterCard(p: MasterCardProps) {
           <button onClick={p.onCheck} disabled={p.checking || p.busy} className="btn btn-sm">
             <VersionIcon name="refresh" />{p.checking ? '检查中…' : '检查更新'}
           </button>
-          {p.hasUpdate && p.on && (
+          {/* state=update_available 才显示更新按钮；up_to_date / ahead / detached 不显示
+              （上面 vs-meta 已经把"已是最新 / 本地领先 / 当前不在历史上"说清楚了）*/}
+          {showUpdateButton && (
             <button onClick={p.onUpdate} disabled={p.busy || p.checking} className="btn btn-sm btn-primary">
               {p.busy ? '更新中…' : `更新到 ${targetTag}…`}
             </button>
           )}
-          {!p.on && (
+          {/* 装在非稳定版（dev / custom）时显示"切到最新稳定版"按钮 */}
+          {p.version && p.version.installed_kind !== 'stable' && p.check?.latest_version && (
             <button onClick={p.onSwitchToMaster} disabled={p.busy || p.checking} className="btn btn-sm btn-primary">
-              {p.busy ? '切换中…' : '切到 master'}
+              {p.busy ? '切换中…' : `切到稳定版 ${p.check.latest_version}…`}
             </button>
           )}
         </div>
@@ -3468,18 +3491,18 @@ type DevCardProps = {
 function DevCard(p: DevCardProps) {
   const commits = p.commits?.commits ?? []
   const head = commits[0]?.short_sha ?? p.check?.latest_commit?.slice(0, 8)
-  const ahead = p.check?.commits_ahead ?? 0
   const selectedCommit = p.selectedSha ? commits.find((c) => c.sha === p.selectedSha) ?? null : null
   const fetchError = p.commits?.error ?? p.check?.error
   const currentShortSha = p.currentSha ? p.currentSha.slice(0, 8) : '当前'
-  // chunk 4 — preview / progress 状态优先渲染
+  const stateText = formatDevStateText(p.check)
+  const devSwitchDisabled = isDevSwitchButtonDisabled(p.check)
   if (p.cardState === 'preview' && p.pendingTarget && p.pendingTarget.kind === 'dev') {
     const t = p.pendingTarget
     return (
-      <div className={`vs-chan${p.on ? ' here' : ''}`}>
+      <div className="vs-chan">
         <div className="vs-chan-head">
           <div className="vs-lhs">
-            <span className="vs-name">dev · 确认切换</span>
+            <span className="vs-name">开发版 · 确认切换</span>
             <span className="vs-pill vs-pill-dev"><span className="vs-dot" />开发版</span>
           </div>
           <button className="btn btn-sm btn-ghost" onClick={p.onCancelPreview} disabled={p.busy}>
@@ -3506,7 +3529,7 @@ function DevCard(p: DevCardProps) {
                 </>
               ) : (
                 <div style={{ fontSize: 13, color: 'var(--fg-tertiary)', marginTop: 4 }}>
-                  切到 dev HEAD（git reset --hard origin/dev）
+                  切到 dev HEAD
                 </div>
               )}
             </div>
@@ -3522,10 +3545,10 @@ function DevCard(p: DevCardProps) {
   }
   if (p.cardState === 'progress' && p.pendingTarget && p.pendingTarget.kind === 'dev') {
     return (
-      <div className={`vs-chan${p.on ? ' here' : ''}`}>
+      <div className="vs-chan">
         <div className="vs-chan-head">
           <div className="vs-lhs">
-            <span className="vs-name">dev · 切换中</span>
+            <span className="vs-name">开发版 · 切换中</span>
             <span className="vs-pill vs-pill-dev"><span className="vs-dot" />开发版</span>
           </div>
         </div>
@@ -3535,20 +3558,19 @@ function DevCard(p: DevCardProps) {
   }
 
   return (
-    <div className={`vs-chan${p.on ? ' here' : ''}`}>
+    <div className="vs-chan">
       <div className="vs-chan-head">
         <div className="vs-lhs">
-          <span className="vs-name">dev</span>
+          <span className="vs-name">开发版</span>
           <span className="vs-pill vs-pill-dev"><span className="vs-dot" />开发版</span>
-          {p.on && <span className="vs-pill vs-pill-here">● 你在这里</span>}
         </div>
-        <div className="vs-meta">
+        <div className={`vs-meta${p.check?.state === 'update_available' ? ' attn' : ''}`}>
           {fetchError && !head ? (
             <span style={{ color: 'var(--err)' }}>{fetchError}</span>
           ) : head ? (
             <>
-              HEAD <b style={{ color: 'var(--fg-secondary)', fontWeight: 500 }}>{head}</b>
-              {p.check && (<>{' · '}{ahead === 0 ? '与 master 持平' : `↑ ${ahead}`}</>)}
+              dev HEAD <b style={{ color: 'var(--fg-secondary)', fontWeight: 500 }}>{head}</b>
+              {p.check && <>{' · '}{stateText}</>}
             </>
           ) : (
             <span>未抓取</span>
@@ -3650,15 +3672,18 @@ function DevCard(p: DevCardProps) {
             <button onClick={p.onCheck} disabled={p.checking || p.busy} className="btn btn-sm">
               <VersionIcon name="refresh" />{p.checking ? '抓取中…' : '抓取 dev'}
             </button>
-            {p.on ? (
-              <button disabled className="btn btn-sm">已在 dev HEAD</button>
+            {/* 切按钮 disabled 条件改用 commit 比较（state=up_to_date），不再
+                看 branch / installed_kind —— 因为 release 直后存在"装的是 stable
+                但 commit 恰好等于 dev HEAD"的边界，此时切操作是 no-op */}
+            {devSwitchDisabled ? (
+              <button disabled className="btn btn-sm">已与 dev HEAD 同步</button>
             ) : commits.length > 0 ? (
               <button
                 onClick={p.onSwitchToDev}
                 disabled={p.busy || p.checking}
                 className="btn btn-sm btn-warn"
               >
-                {p.busy ? '切换中…' : `切到 dev${head ? ` (${head})` : ''}`}
+                {p.busy ? '切换中…' : `切到 dev HEAD${head ? ` (${head})` : ''}`}
               </button>
             ) : null}
           </div>

--- a/studio/web/src/styles/version-section.css
+++ b/studio/web/src/styles/version-section.css
@@ -1,24 +1,94 @@
-/* VersionSection 双通道升级面板（ADR 0002 / PR-D 重设计）
+/* VersionSection 单视图升级面板（ADR 0005 重设计）
  *
  * 所有 class 用 vs- 前缀避免与全局 / Tailwind utility 碰撞。
  * 全部走 tokens.css 现有 CSS variable，自动适配 light/dark。
- * 容器宽度响应：container query (sec-card → vs-channels)。
+ *
+ * 产品模型：单视图 + 通道偏好 radio（不再并排双卡，避免"两个通道纠结"问题）
+ * - vs-installed-row：顶部一行展示"装了什么"（installed_label）
+ * - vs-channel-toggle-row：通道偏好 radio（stable / dev，纯 UI 视图）
+ * - vs-channels：当前选中通道的卡片容器（永远单列）
  */
 
-/* ==================== 双卡 grid ==================== */
+/* ==================== 卡片容器（永远单卡） ==================== */
 .vs-channels {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 14px;
 }
-.vs-channels.both {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-}
 .vs-sec-card {
   container-type: inline-size;
 }
-@container (max-width: 760px) {
-  .vs-channels.both { grid-template-columns: minmax(0, 1fr); }
+
+/* ==================== 顶部：你装的是什么 ==================== */
+.vs-installed-row {
+  padding: 10px 12px;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+.vs-installed-label {
+  color: var(--fg-tertiary);
+}
+.vs-installed-value {
+  font-family: var(--font-mono);
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+.vs-installed-warn {
+  color: var(--warn);
+  font-size: 11.5px;
+}
+
+/* ==================== 通道偏好 radio ==================== */
+.vs-channel-toggle-row {
+  padding: 6px 12px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12.5px;
+}
+.vs-channel-toggle-label {
+  color: var(--fg-tertiary);
+}
+.vs-channel-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  font-size: 12.5px;
+  transition: 120ms;
+}
+.vs-channel-radio:hover:not(.on) {
+  background: var(--bg-overlay);
+}
+.vs-channel-radio.on {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.vs-channel-radio .vs-channel-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  background: transparent;
+}
+.vs-channel-radio.on .vs-channel-dot {
+  background: currentColor;
+}
+.vs-channel-hint {
+  margin-left: auto;
+  color: var(--fg-tertiary);
+  font-size: 11px;
+  font-style: italic;
 }
 
 /* ==================== 单卡片 ==================== */
@@ -296,89 +366,8 @@
   font-size: 10.5px;
 }
 
-/* ==================== dev toggle 行（title 下方独立一行） ==================== */
-/* 之前下方双卡之后用 dashed border 表达 "opt-in"；现在搬到 title 下方
-   主流位置，更紧凑、无边框，背景由 .open / .locked 状态决定 */
-.vs-dev-toggle-row {
-  padding: 8px 12px;
-  background: transparent;
-  border-radius: 6px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  justify-content: space-between;
-  flex-wrap: wrap;
-}
-.vs-dev-toggle-row.open {
-  background: var(--bg-sunken);
-}
-.vs-dev-toggle-row.locked {
-  background: var(--bg-sunken);
-}
-.vs-dev-toggle-row .vs-lhs {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
-  flex-wrap: wrap;
-}
-.vs-dev-toggle-row .vs-t {
-  font-size: 12.5px;
-  color: var(--fg-secondary);
-}
-.vs-dev-toggle-row .vs-d {
-  font-size: 11.5px;
-  color: var(--fg-tertiary);
-  margin-top: 2px;
-  max-width: 720px;
-  line-height: 1.5;
-}
-.vs-lock-pill {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  padding: 2px 7px;
-  border-radius: 999px;
-  background: var(--accent-soft);
-  color: var(--accent);
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-/* ==================== switch ==================== */
-.vs-sw {
-  width: 32px;
-  height: 18px;
-  border-radius: 999px;
-  background: var(--bg-overlay);
-  border: 1px solid var(--border-default);
-  position: relative;
-  cursor: pointer;
-  flex-shrink: 0;
-}
-.vs-sw::after {
-  content: "";
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--fg-tertiary);
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  transition: 140ms;
-}
-.vs-sw.on {
-  background: var(--accent-soft);
-  border-color: var(--accent);
-}
-.vs-sw.on::after {
-  background: var(--accent);
-  transform: translateX(14px);
-}
-.vs-sw.locked {
-  cursor: not-allowed;
-  opacity: 0.7;
-}
+/* 旧 .vs-dev-toggle-row / .vs-sw / .vs-lock-pill 已删，由
+   .vs-channel-toggle-row + .vs-channel-radio 取代（ADR 0005）。 */
 
 /* InfoButton ⓘ 弹层（之前的 .vs-info-* 类）已抽到
    components/InfoButton.tsx + styles/info-button.css，所有 .info-btn-*

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -369,38 +369,63 @@ def test_has_gelbooru_credentials(secrets_file: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# PR-D — system.show_dev_channel（dev 通道 toggle 持久化）
+# PR-D / ADR 0005 — system.update_channel（用户视图偏好持久化）
 # ---------------------------------------------------------------------------
 
 
-def test_system_defaults_show_dev_channel_false(secrets_file: Path) -> None:
-    """新装默认 toggle 关 —— 绝大多数用户看简化 UI，不暴露 dev 入口。"""
+def test_system_defaults_update_channel_stable(secrets_file: Path) -> None:
+    """新装默认通道偏好 = stable，绝大多数用户只看稳定版。"""
     s = secrets.load()
-    assert s.system.show_dev_channel is False
+    assert s.system.update_channel == "stable"
+    assert s.system.show_dev_channel is False  # legacy 字段默认也是 False
 
 
-def test_system_show_dev_channel_round_trip(secrets_file: Path) -> None:
-    """update + load 持久化（webui 勾选 toggle 后刷页应保留）。"""
-    secrets.update({"system": {"show_dev_channel": True}})
-    assert secrets.load().system.show_dev_channel is True
-    # 关掉也持久化
-    secrets.update({"system": {"show_dev_channel": False}})
-    assert secrets.load().system.show_dev_channel is False
+def test_system_update_channel_round_trip(secrets_file: Path) -> None:
+    """update + load 持久化（webui 切 toggle 后刷页应保留）。"""
+    secrets.update({"system": {"update_channel": "dev"}})
+    assert secrets.load().system.update_channel == "dev"
+    secrets.update({"system": {"update_channel": "stable"}})
+    assert secrets.load().system.update_channel == "stable"
 
 
 def test_system_legacy_file_without_system_field(secrets_file: Path) -> None:
-    """老 secrets.json 没有 system 字段时，加载用默认值（show_dev_channel=False）。"""
+    """老 secrets.json 没有 system 字段时，加载用默认值 stable。"""
     secrets_file.write_text(
         json.dumps({"gelbooru": {"user_id": "alice"}}),
         encoding="utf-8",
     )
     s = secrets.load()
-    assert s.system.show_dev_channel is False
+    assert s.system.update_channel == "stable"
     assert s.gelbooru.user_id == "alice"  # 其它字段不受影响
 
 
-def test_system_show_dev_channel_in_masked_dict(secrets_file: Path) -> None:
-    """show_dev_channel 不是敏感字段，掩码后应保留原值。"""
-    secrets.update({"system": {"show_dev_channel": True}})
+def test_system_update_channel_in_masked_dict(secrets_file: Path) -> None:
+    """update_channel 不是敏感字段，掩码后应保留原值。"""
+    secrets.update({"system": {"update_channel": "dev"}})
     masked = secrets.to_masked_dict(secrets.load())
-    assert masked["system"]["show_dev_channel"] is True
+    assert masked["system"]["update_channel"] == "dev"
+
+
+def test_system_show_dev_channel_migrated_to_update_channel(
+    secrets_file: Path,
+) -> None:
+    """ADR 0005：老 secrets.json 里 show_dev_channel=true 一次性迁移成
+    update_channel='dev'，让升级用户保留之前的 dev 视图偏好。"""
+    secrets_file.write_text(
+        json.dumps({"system": {"show_dev_channel": True}}),
+        encoding="utf-8",
+    )
+    s = secrets.load()
+    assert s.system.update_channel == "dev"
+
+
+def test_system_show_dev_channel_migration_does_not_overwrite_explicit_pref(
+    secrets_file: Path,
+) -> None:
+    """update_channel 已显式设过 → 迁移函数不覆盖（幂等）。"""
+    secrets_file.write_text(
+        json.dumps({"system": {"show_dev_channel": True, "update_channel": "stable"}}),
+        encoding="utf-8",
+    )
+    s = secrets.load()
+    assert s.system.update_channel == "stable"  # 显式设过不被 legacy 覆盖

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -90,6 +90,8 @@ def test_apply_pending_dirty_tree_aborts(
     fake_version = updater.VersionInfo(
         version="0.0.0", commit="abc", commit_short="abc",
         commit_time_iso="", branch="master", tag=None, is_dirty=True,
+        installed_kind="custom", installed_label="自定义（master @ abc）",
+        stable_version=None,
     )
     monkeypatch.setattr(updater, "current_version", lambda: fake_version)
 
@@ -119,6 +121,8 @@ def test_apply_pending_records_last_version(
     fake_version = updater.VersionInfo(
         version="0.0.0", commit="deadbeef" * 5, commit_short="deadbeef",
         commit_time_iso="", branch="master", tag=None, is_dirty=True,
+        installed_kind="custom", installed_label="自定义（master @ deadbeef）",
+        stable_version=None,
     )
     monkeypatch.setattr(updater, "current_version", lambda: fake_version)
     monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
@@ -212,6 +216,8 @@ def test_check_update_force_skips_cache(
         lambda: updater.VersionInfo(
             version="0.7.0", commit="local_sha", commit_short="local_sh",
             commit_time_iso="", branch="master", tag=None, is_dirty=False,
+            installed_kind="stable", installed_label="v0.7.0",
+            stable_version="v0.7.0",
         ),
     )
 
@@ -281,6 +287,8 @@ def test_apply_pending_writes_aborted_status(
     fake = updater.VersionInfo(
         version="0.0.0", commit="abc", commit_short="abc",
         commit_time_iso="", branch="master", tag=None, is_dirty=True,
+        installed_kind="custom", installed_label="自定义（master @ abc）",
+        stable_version=None,
     )
     monkeypatch.setattr(updater, "current_version", lambda: fake)
     monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
@@ -302,6 +310,8 @@ def test_apply_pending_writes_failed_status_on_fetch_error(
     fake = updater.VersionInfo(
         version="0.0.0", commit="abc", commit_short="abc",
         commit_time_iso="", branch="master", tag=None, is_dirty=False,
+        installed_kind="custom", installed_label="自定义（master @ abc）",
+        stable_version=None,
     )
     monkeypatch.setattr(updater, "current_version", lambda: fake)
     def _fake_git(*args, **kwargs):
@@ -554,3 +564,299 @@ def test_dev_commits_malformed_log_lines_skipped(monkeypatch: pytest.MonkeyPatch
     r = updater.dev_commits(limit=10)
     assert len(r.commits) == 1
     assert r.commits[0].short_sha == "dddddddd"
+
+
+# ---------------------------------------------------------------------------
+# ADR 0005：installed_kind / installed_label 分类
+# ---------------------------------------------------------------------------
+
+
+def test_classify_install_stable_via_exact_tag() -> None:
+    """HEAD 命中 vX.Y.Z release tag → stable + label = tag。"""
+    kind, label, ver = updater._classify_install(
+        commit="a" * 40, exact_tag="v0.8.0", branch="master",
+        short="aaaaaaaa", commit_time_iso="2026-05-16T00:00:00Z",
+        is_dirty=False,
+    )
+    assert kind == "stable"
+    assert label == "v0.8.0"
+    assert ver == "v0.8.0"
+
+
+def test_classify_install_stable_with_dirty_suffix() -> None:
+    kind, label, ver = updater._classify_install(
+        commit="a" * 40, exact_tag="v0.8.0", branch="master",
+        short="aaaaaaaa", commit_time_iso="", is_dirty=True,
+    )
+    assert kind == "stable"
+    assert "未提交修改" in label
+    assert ver == "v0.8.0"
+
+
+def test_classify_install_stable_via_version_tree_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HEAD 没 tag，但 __version__ 匹 vX.Y.Z 且 tree 与 tag commit 一致 → stable。
+
+    覆盖 release 直后场景：本地 commit 是 release commit（在 dev 分支上），
+    tag 打在 master merge commit 上 —— exact_tag 不命中但 tree 一致。
+    """
+    monkeypatch.setattr(updater, "__version__", "0.8.0")
+    def _fake_git(*args, **_kw):
+        # rev-parse v0.8.0^{commit} → 返回 tag commit
+        if args[:2] == ("rev-parse", "v0.8.0^{commit}"):
+            return 0, "merge_commit_sha", ""
+        # diff --quiet release_commit merge_commit → 0 表示 tree 一致
+        if args[:2] == ("diff", "--quiet"):
+            return 0, "", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    kind, label, ver = updater._classify_install(
+        commit="release_commit_sha", exact_tag=None, branch="master",
+        short="release_", commit_time_iso="", is_dirty=False,
+    )
+    assert kind == "stable"
+    assert ver == "v0.8.0"
+
+
+def test_classify_install_dev_when_commit_equals_origin_dev(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """commit == origin/dev HEAD → dev + label 含 sha + 时间。"""
+    monkeypatch.setattr(updater, "__version__", "0.0.0-noversion")  # 强制不匹 stable
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("rev-parse", "v0.0.0-noversion^{commit}"):
+            return 1, "", ""
+        if args[:2] == ("rev-parse", "origin/dev"):
+            return 0, "dev_head_sha", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    kind, label, ver = updater._classify_install(
+        commit="dev_head_sha", exact_tag=None, branch="anything",
+        short="dev_head", commit_time_iso="2026-05-16T19:50:00-05:00",
+        is_dirty=False,
+    )
+    assert kind == "dev"
+    assert "dev @ dev_head" in label
+    assert "2026-05-16 19:50" in label
+    assert ver is None
+
+
+def test_classify_install_custom_on_feature_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """既不命中 release tag 也不在 dev HEAD → custom + label 含 branch + sha。"""
+    monkeypatch.setattr(updater, "__version__", "0.0.0-noversion")
+    monkeypatch.setattr(updater, "_git",
+                        lambda *a, **_k: (1, "", "no plan"))
+
+    kind, label, ver = updater._classify_install(
+        commit="feature_commit", exact_tag=None, branch="feat/something",
+        short="feature_", commit_time_iso="", is_dirty=False,
+    )
+    assert kind == "custom"
+    assert "feat/something" in label
+    assert "feature_" in label
+    assert ver is None
+
+
+def test_classify_install_custom_detached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(updater, "__version__", "0.0.0-noversion")
+    monkeypatch.setattr(updater, "_git",
+                        lambda *a, **_k: (1, "", "no plan"))
+
+    kind, label, ver = updater._classify_install(
+        commit="random_commit", exact_tag=None, branch="detached",
+        short="random__", commit_time_iso="", is_dirty=False,
+    )
+    assert kind == "custom"
+    assert "random__" in label
+    assert "detached" not in label  # detached 时不暴露字面 "detached"，只显示 "（@ sha）"
+    assert ver is None
+
+
+# ---------------------------------------------------------------------------
+# ADR 0005：check_update state 状态机
+# ---------------------------------------------------------------------------
+
+
+def test_check_update_master_up_to_date_same_version(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """master 通道：installed_version == latest_version → state=up_to_date。
+
+    即使 commit 不同（release 后本地是 release commit, 远端是 merge commit），
+    版本号相同就视为已是最新 —— 不再用 commit 词汇糊弄用户。
+    """
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.8.0", commit="release_commit", commit_short="release_",
+            commit_time_iso="", branch="master", tag=None, is_dirty=False,
+            installed_kind="stable", installed_label="v0.8.0",
+            stable_version="v0.8.0",
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/master"):
+            return 0, "merge_commit", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/master"):
+            return 0, "2", ""
+        if args[:3] == ("rev-list", "--count", "origin/master..HEAD"):
+            return 0, "0", ""
+        if args[0] == "describe":
+            return 0, "v0.8.0", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("master", use_cache=False)
+    assert r.state == "up_to_date"
+    assert r.installed_version == "v0.8.0"
+    assert r.latest_version == "v0.8.0"
+    assert r.has_update is False
+
+
+def test_check_update_master_update_available_diff_version(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """master 通道：installed=v0.7.0, latest=v0.8.0 → state=update_available。"""
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.7.0", commit="v070_commit", commit_short="v070_com",
+            commit_time_iso="", branch="master", tag="v0.7.0", is_dirty=False,
+            installed_kind="stable", installed_label="v0.7.0",
+            stable_version="v0.7.0",
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/master"):
+            return 0, "v080_commit", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/master"):
+            return 0, "5", ""
+        if args[:3] == ("rev-list", "--count", "origin/master..HEAD"):
+            return 0, "0", ""
+        if args[0] == "describe":
+            return 0, "v0.8.0", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("master", use_cache=False)
+    assert r.state == "update_available"
+    assert r.installed_version == "v0.7.0"
+    assert r.latest_version == "v0.8.0"
+    assert r.has_update is True
+    assert r.behind_count == 5
+
+
+def test_check_update_dev_up_to_date_when_commit_matches(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dev 通道：当前 commit == origin/dev HEAD → state=up_to_date。"""
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.8.0", commit="dev_tip", commit_short="dev_tip_",
+            commit_time_iso="", branch="dev", tag=None, is_dirty=False,
+            installed_kind="dev", installed_label="dev @ dev_tip_",
+            stable_version=None,
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/dev"):
+            return 0, "dev_tip", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/dev"):
+            return 0, "0", ""
+        if args[:3] == ("rev-list", "--count", "origin/dev..HEAD"):
+            return 0, "0", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("dev", use_cache=False)
+    assert r.state == "up_to_date"
+    assert r.behind_count == 0
+
+
+def test_check_update_dev_update_available_when_behind(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dev 通道：本地落后 origin/dev N commit → state=update_available + behind_count=N。"""
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.8.0", commit="old_dev_commit", commit_short="old_dev_",
+            commit_time_iso="", branch="dev", tag=None, is_dirty=False,
+            installed_kind="custom", installed_label="自定义（dev @ old_dev_）",
+            stable_version=None,
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/dev"):
+            return 0, "new_dev_tip", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/dev"):
+            return 0, "3", ""
+        if args[:3] == ("rev-list", "--count", "origin/dev..HEAD"):
+            return 0, "0", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("dev", use_cache=False)
+    assert r.state == "update_available"
+    assert r.behind_count == 3
+    assert r.has_update is True
+
+
+def test_check_update_dev_ahead_when_local_leads(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dev 通道：本地 commit 领先 origin/dev（罕见，回滚或抢跑） → state=ahead。"""
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.8.0", commit="ahead_commit", commit_short="ahead_co",
+            commit_time_iso="", branch="dev", tag=None, is_dirty=False,
+            installed_kind="custom", installed_label="自定义",
+            stable_version=None,
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/dev"):
+            return 0, "old_remote_tip", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/dev"):
+            return 0, "0", ""
+        if args[:3] == ("rev-list", "--count", "origin/dev..HEAD"):
+            return 0, "2", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("dev", use_cache=False)
+    assert r.state == "ahead"
+
+
+def test_check_update_fetch_error_returns_detached(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fetch 失败 → state=detached + error 字段填，前端不该认为"有更新"。"""
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 128, "", "fatal: network unreachable"
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("master", use_cache=False)
+    assert r.state == "detached"
+    assert r.error is not None


### PR DESCRIPTION
## Summary

修复 v0.8.0 release 直后 Settings → 系统 → 版本面板出现的"通道纠结"+"按钮空操作"问题。核心是把**通道（master / dev）从 git 工作树状态改成用户视图偏好**，并把 UI 文案从 git 词汇全部翻译成版本号 / 状态语言（详见 ADR 0005）。

## 触发场景

v0.8.0 release 后，本地 master 还没 `git pull` 拉远端的 merge commit。打开版本面板：

| UI 元素 | 显示 | 用户解读 |
|---|---|---|
| master 卡「你在这里」 | 我在 master | branch 名 = master |
| master `v0.8.0` | 我装的是 v0.8.0 | `__version__` 字符串 |
| 「↑落后 2 commits」 | 我落后了 | `git rev-list --count` |
| dev 卡列表「● 当前」 | 我装的就是这个 dev commit | commit hash 比较 |
| 「切到 dev (f6f202b)」按钮 | 可以切 | onDev=false |
| `v0.8.0 → v0.8.0` 箭头 | ??? |  |

点切按钮 → preview → 确认 → 重启 → UI **没变化**（reset 目标 == 当前 commit，no-op）。

## 根因

1. **UI 用 git 词汇而不是产品语言**：`commits_ahead` 直接搬到「↑落后 N commits」徽章；用户视角"落后"只有版本号一个维度，版本号相同就不存在"落后"。
2. **"通道"绑死 git 工作树**："我在哪个通道"判定 = branch 名；"切换通道"实现 = `git reset --hard <ref>`。两个机制大多数场景"凑巧"能用，release 直后 commit 已等于目标时切操作 no-op，UI 永远卡住。
3. **双卡并排同屏**：本应互斥的两个通道在视觉上同时活着，配合 4 套不打通的"我在哪里"判据（branch / `__version__` / commit hash / `commits_ahead`），产生自相矛盾的画面。

## 改了什么

### 后端

- `VersionInfo` 加 `installed_kind`（stable / dev / custom）+ `installed_label`（用户可读串）+ `stable_version`，按 commit hash 推断，不依赖 branch 名
  - 关键判定：`__version__` 匹某 vX.Y.Z tag + 当前 commit 与 tag commit **tree 一致** → stable（修 release 直后 release commit 在 dev、tag 打在 merge commit 上的边界）
- `UpdateCheckResult` 加 `state` 状态机（`up_to_date` / `update_available` / `ahead` / `detached`）+ `installed_version` / `latest_version` / `behind_count`；前端不再消费 `commits_ahead`
- `system.update_channel` 入用户偏好（`stable` / `dev`），旧 `show_dev_channel` 一次性迁移；切换 toggle **不触发任何 git 操作**

### 前端

- 版本面板布局重做：删双卡并排；改单视图 + 顶部"你装的：vX.Y.Z"事实行 + radio toggle 通道偏好
- 文案 git → version 翻译：
  - "↑落后 N commits" → 删
  - "v0.8.0 → v0.8.0" → "已是最新 v0.8.0"
  - "v0.7.0 → v0.8.0 ↑5 commits" → "有新稳定版 v0.8.0"
  - dev "↑ N" → "有 N 项新更新"
  - "已在 dev HEAD" disabled 条件改用 `state=up_to_date`（不再看 branch），修按钮空操作
- 文案 / 按钮逻辑抽到 `lib/versionPanel.ts` 纯函数便于单测

### 测试

- 后端：tests/test_updater.py 加 12 测（`_classify_install` 4 路径 + `check_update` state 状态机 6 场景），共 36 → 48 全过
- 后端：tests/test_secrets.py 加 2 测覆盖 `update_channel` 迁移
- 前端：新 `lib/versionPanel.test.ts` 22 测覆盖 4 个公开函数 + 显式断言"不出现 commits / sha / branch 字眼"

### 文档

- ADR 0005（accepted）+ docs/adr/README.md 索引

## Test plan

- [x] 后端 79 / 前端 22 单测全过
- [x] TypeScript `tsc --noEmit` 通过
- [ ] 手动 E2E（reviewer 跑）：
  - [ ] `studio.sh dev` 起前端，进 Settings → 系统 → 版本，**当前 release 直后场景**：应显示「你装的：v0.8.0」+「已是最新 v0.8.0」+「与 dev HEAD 一致」，**任何按钮都不可点**，**没有 commits 字眼**
  - [ ] 切通道偏好 toggle stable ↔ dev：UI 立即切换展开区，**不重启**，刷页保留偏好
  - [ ] 模拟落后稳定版（本地 reset 到 v0.7.0 commit）：应显示「有新稳定版 v0.8.0」+ 「更新到 v0.8.0…」按钮亮起
  - [ ] 模拟落后 dev（切到一个不是 origin/dev HEAD 的 commit）：dev 通道显示「有 N 项新更新」+ 「切到 dev HEAD」按钮亮

## 不在范围

- 翻译 Settings 页其他地方的 git 词汇（譬如 wandb 同步状态）
- 自动检查 + Topbar 红点维持只看 master（ADR 0002 决策）
- `release_notes.yaml` 条目下次发版（0.8.1 / 0.9.0）一起加

🤖 Generated with [Claude Code](https://claude.com/claude-code)
