### PR TITLE
fix(ui): PR #81 E2E 回归 3 个 follow-up（按钮 disabled / 伪箭头 / 双按钮）

### DIFF
--- a/studio/web/src/lib/versionPanel.test.ts
+++ b/studio/web/src/lib/versionPanel.test.ts
@@ -5,6 +5,7 @@ import {
   formatMasterStateText,
   isDevSwitchButtonDisabled,
   shouldShowMasterUpdateButton,
+  shouldShowSwitchToStableButton,
 } from './versionPanel'
 
 /** 构造一个 check 对象（必填字段填默认值，便于按需 override）。 */
@@ -113,30 +114,72 @@ describe('formatDevStateText (ADR 0005)', () => {
 
 describe('shouldShowMasterUpdateButton', () => {
   it('null check → false', () => {
-    expect(shouldShowMasterUpdateButton(null)).toBe(false)
+    expect(shouldShowMasterUpdateButton(null, 'stable')).toBe(false)
   })
 
   it('up_to_date → false（已是最新，不显示更新按钮）', () => {
     expect(shouldShowMasterUpdateButton(mkCheck({
       state: 'up_to_date', latest_version: 'v0.8.0',
-    }))).toBe(false)
+    }), 'stable')).toBe(false)
   })
 
-  it('update_available + latest_version → true', () => {
+  it('update_available + 装 stable + latest_version → true', () => {
     expect(shouldShowMasterUpdateButton(mkCheck({
       state: 'update_available', latest_version: 'v0.9.0',
-    }))).toBe(true)
+    }), 'stable')).toBe(true)
+  })
+
+  it('update_available + 装 dev → false（由"切到稳定版"按钮覆盖，避免双按钮）', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'update_available', latest_version: 'v0.8.0',
+    }), 'dev')).toBe(false)
+  })
+
+  it('update_available + 装 custom → false', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'update_available', latest_version: 'v0.8.0',
+    }), 'custom')).toBe(false)
   })
 
   it('update_available 但无目标版本号 → false（防止显示空目标按钮）', () => {
     expect(shouldShowMasterUpdateButton(mkCheck({
       state: 'update_available', latest_version: null, latest_tag: null,
-    }))).toBe(false)
+    }), 'stable')).toBe(false)
   })
 
   it('ahead / detached → false（不暗示用户能"更新到自己"）', () => {
-    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'ahead' }))).toBe(false)
-    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'detached' }))).toBe(false)
+    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'ahead' }), 'stable')).toBe(false)
+    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'detached' }), 'stable')).toBe(false)
+  })
+})
+
+describe('shouldShowSwitchToStableButton', () => {
+  it('装 stable → false（已经在稳定版了）', () => {
+    expect(shouldShowSwitchToStableButton(mkCheck({
+      state: 'update_available', latest_version: 'v0.9.0',
+    }), 'stable')).toBe(false)
+  })
+
+  it('装 dev + 远端有 latest_version → true', () => {
+    expect(shouldShowSwitchToStableButton(mkCheck({
+      latest_version: 'v0.8.0',
+    }), 'dev')).toBe(true)
+  })
+
+  it('装 custom + 远端有 latest_version → true', () => {
+    expect(shouldShowSwitchToStableButton(mkCheck({
+      latest_version: 'v0.8.0',
+    }), 'custom')).toBe(true)
+  })
+
+  it('装 dev + 远端无 latest_version → false', () => {
+    expect(shouldShowSwitchToStableButton(mkCheck({
+      latest_version: null,
+    }), 'dev')).toBe(false)
+  })
+
+  it('null check → false', () => {
+    expect(shouldShowSwitchToStableButton(null, 'dev')).toBe(false)
   })
 })
 
@@ -153,7 +196,15 @@ describe('isDevSwitchButtonDisabled (release 直后场景 regression)', () => {
     }))).toBe(false)
   })
 
-  it('null check → 可点（用户没抓取过，按钮要能触发抓取 + 切换）', () => {
+  it('null check + installedKind=dev → disabled（fallback，避免按钮看上去可点）', () => {
+    expect(isDevSwitchButtonDisabled(null, 'dev')).toBe(true)
+  })
+
+  it('null check + installedKind=stable → 可点（要能触发抓取 + 切换）', () => {
+    expect(isDevSwitchButtonDisabled(null, 'stable')).toBe(false)
+  })
+
+  it('null check 无 installedKind → 可点', () => {
     expect(isDevSwitchButtonDisabled(null)).toBe(false)
   })
 })

--- a/studio/web/src/lib/versionPanel.ts
+++ b/studio/web/src/lib/versionPanel.ts
@@ -43,18 +43,46 @@ export function formatDevStateText(check: SystemUpdateCheck | null): string {
   return '当前 commit 不在 dev 历史上'
 }
 
-/** master 通道"更新"按钮是否应该显示（state=update_available 且有目标版本）。 */
-export function shouldShowMasterUpdateButton(check: SystemUpdateCheck | null): boolean {
+/** master 通道"更新到 vX.Y.Z"按钮是否应该显示。
+ *
+ * 仅在「装的是 stable + 远端有新稳定版」时显示 —— 装非 stable（dev / custom）
+ * 时由「切到稳定版 vX.Y.Z」按钮覆盖（两个按钮做同一件事，避免同屏显示重复）。
+ */
+export function shouldShowMasterUpdateButton(
+  check: SystemUpdateCheck | null,
+  installedKind: 'stable' | 'dev' | 'custom' | undefined,
+): boolean {
   if (!check || check.state !== 'update_available') return false
+  if (installedKind !== 'stable') return false
   return !!(check.latest_version ?? check.latest_tag)
+}
+
+/** master 通道「切到稳定版 vX.Y.Z」按钮是否应该显示。
+ *
+ * 装非 stable 时显示（切回最新稳定版的入口）。装 stable 时由
+ * `shouldShowMasterUpdateButton` 覆盖。
+ */
+export function shouldShowSwitchToStableButton(
+  check: SystemUpdateCheck | null,
+  installedKind: 'stable' | 'dev' | 'custom' | undefined,
+): boolean {
+  if (!check || installedKind === 'stable') return false
+  return !!check.latest_version
 }
 
 /** dev 通道"切到 dev HEAD"按钮是否应该 disabled。
  *
- * 当 state=up_to_date 时按钮 disabled —— 即便用户的 installed_kind 是
- * stable，只要 commit 已等于 origin/dev HEAD，切操作就是 no-op，
- * 该 disabled 避免点了无反应（release 直后场景）。
+ * 优先看 check.state：state=up_to_date → disabled（commit 已等于 dev HEAD，
+ * 切是 no-op；release 直后场景常见）。
+ *
+ * check 未加载时按 installedKind fallback：装的是 dev tip → disabled
+ * （避免 check 还没 resolve 期间按钮看上去可点但实际 no-op）。
  */
-export function isDevSwitchButtonDisabled(check: SystemUpdateCheck | null): boolean {
-  return check?.state === 'up_to_date'
+export function isDevSwitchButtonDisabled(
+  check: SystemUpdateCheck | null,
+  installedKind?: 'stable' | 'dev' | 'custom',
+): boolean {
+  if (check?.state === 'up_to_date') return true
+  if (!check && installedKind === 'dev') return true
+  return false
 }

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -33,6 +33,7 @@ import {
   formatMasterStateText,
   formatDevStateText,
   shouldShowMasterUpdateButton,
+  shouldShowSwitchToStableButton,
   isDevSwitchButtonDisabled,
 } from '../../lib/versionPanel'
 import { applyDensity, applyTheme, getStoredDensity, getStoredTheme, setStoredDensity, setStoredTheme, type Density, type Theme } from '../../lib/theme'
@@ -2688,15 +2689,22 @@ function VersionSection() {
   // 即便装的是 stable，用户切到 dev 通道偏好时也要能立刻看到 dev HEAD 信息。
   const channelPref: 'stable' | 'dev' = prefs?.update_channel ?? 'stable'
   const showDevView = channelPref === 'dev'
+  // 两个 fetch 拆独立 effect：避免「commits 先 resolve 触发 re-render，
+  // effect 用 devCommits !== null 早 return 跳过 check fetch」race
+  // —— 实测会导致 devCheck 一直 null、"切到 dev HEAD" 按钮不知道
+  // 该 disabled，UI 显示 enabled 但点了 no-op。
   useEffect(() => {
     if (!showDevView || devCommits !== null) return
     let cancelled = false
     void api.getDevCommits(10).then((r) => { if (!cancelled) setDevCommits(r) }).catch(() => { /* silent */ })
-    if (devCheck === null) {
-      void api.checkSystemUpdate('dev', true).then((r) => { if (!cancelled) setDevCheck(r) }).catch(() => { /* silent */ })
-    }
     return () => { cancelled = true }
-  }, [showDevView, devCommits, devCheck])
+  }, [showDevView, devCommits])
+  useEffect(() => {
+    if (!showDevView || devCheck !== null) return
+    let cancelled = false
+    void api.checkSystemUpdate('dev', true).then((r) => { if (!cancelled) setDevCheck(r) }).catch(() => { /* silent */ })
+    return () => { cancelled = true }
+  }, [showDevView, devCheck])
 
   const handleCheck = async () => {
     setChecking(true)
@@ -3005,6 +3013,7 @@ function VersionSection() {
               check={devCheck}
               commits={devCommits}
               currentSha={version?.commit ?? ''}
+              installedKind={version?.installed_kind}
               selectedSha={selectedSha}
               setSelectedSha={setSelectedSha}
               checking={checkingDev}
@@ -3280,14 +3289,18 @@ function MasterReleaseNotes({
 }
 
 function MasterCard(p: MasterCardProps) {
-  // 当前装的版本号优先用 stable_version（精确），fallback 到 __version__
-  const currentTag = p.version?.stable_version
-    ?? p.version?.tag
-    ?? (p.version ? `v${p.version.version}` : '加载中…')
+  // 装的是 stable 时显示当前稳定版号，否则 ver-tag 区不显示 from（"你装的"
+  // 顶部行已经表达了装了什么，避免 "v0.8.0 → v0.8.0" 这种因 __version__
+  // 字符串与目标 tag 字面相同导致的伪箭头）
+  const installedIsStable = p.version?.installed_kind === 'stable'
+  const currentTag = installedIsStable
+    ? (p.version?.stable_version ?? p.version?.tag ?? `v${p.version?.version ?? ''}`)
+    : null
   // 远端最新稳定版（state=update_available 时显示）
   const targetTag = p.check?.latest_version ?? p.check?.latest_tag ?? ''
   const stateText = formatMasterStateText(p.check)
-  const showUpdateButton = shouldShowMasterUpdateButton(p.check)
+  const showUpdateButton = shouldShowMasterUpdateButton(p.check, p.version?.installed_kind)
+  const showSwitchToStableButton = shouldShowSwitchToStableButton(p.check, p.version?.installed_kind)
   if (p.cardState === 'preview' && p.pendingTarget && p.pendingTarget.kind === 'master') {
     return (
       <div className="vs-chan">
@@ -3302,7 +3315,7 @@ function MasterCard(p: MasterCardProps) {
         </div>
         <PreviewPane
           channel="master"
-          fromLabel={currentTag}
+          fromLabel={currentTag ?? p.version?.installed_label ?? '当前'}
           toLabel={p.pendingTarget.label}
           details={
             <div className="vs-change-block">
@@ -3328,7 +3341,7 @@ function MasterCard(p: MasterCardProps) {
             <span className="vs-pill vs-pill-stable"><span className="vs-dot" />稳定</span>
           </div>
         </div>
-        <ProgressPane fromLabel={currentTag} toLabel={p.pendingTarget.label} />
+        <ProgressPane fromLabel={currentTag ?? p.version?.installed_label ?? '当前'} toLabel={p.pendingTarget.label} />
       </div>
     )
   }
@@ -3384,13 +3397,21 @@ function MasterCard(p: MasterCardProps) {
       <div className={`vs-chan-body ${p.solo ? 'solo' : 'split'}`}>
         <div className="vs-ver-block" style={{ flex: p.solo ? '0 0 220px' : 1 }}>
           <div className="vs-ver-tag">
-            {p.hasUpdate && targetTag ? (
+            {/* 装的是 stable 且有新稳定版：显示 from → to 箭头
+                装的是 stable 但已是最新：只显示当前版本号
+                装的不是 stable（dev / custom）：只显示目标稳定版号（如有），
+                  不再显示 "v0.8.0 → v0.8.0" 伪箭头 */}
+            {installedIsStable && p.hasUpdate && targetTag && currentTag !== targetTag ? (
               <>
                 <span className="vs-dim">{currentTag}</span>
                 <span className="vs-arrow">→</span>
                 <span className="vs-target">{targetTag}</span>
               </>
-            ) : currentTag}
+            ) : installedIsStable ? (
+              currentTag
+            ) : targetTag ? (
+              <span className="vs-target">{targetTag}</span>
+            ) : null}
           </div>
           <div className="vs-ver-meta">
             {releasedAt && <span>发布于 <b>{releasedAt}</b></span>}
@@ -3404,7 +3425,7 @@ function MasterCard(p: MasterCardProps) {
 
         <div className="vs-change-block">
           <div className="vs-h">
-            {p.hasUpdate ? `${targetTag} · 更新内容` : `${currentTag} · 此版本`}
+            {p.hasUpdate ? `${targetTag} · 更新内容` : `${targetTag || currentTag || ''} · 此版本`}
           </div>
           <MasterReleaseNotes notes={p.releaseNotes} onShowDetail={p.onShowReleaseNotesDetail} />
         </div>
@@ -3427,10 +3448,12 @@ function MasterCard(p: MasterCardProps) {
               {p.busy ? '更新中…' : `更新到 ${targetTag}…`}
             </button>
           )}
-          {/* 装在非稳定版（dev / custom）时显示"切到最新稳定版"按钮 */}
-          {p.version && p.version.installed_kind !== 'stable' && p.check?.latest_version && (
+          {/* 装在非稳定版（dev / custom）时显示"切到最新稳定版"按钮；
+              与"更新到 X"按钮互斥（shouldShowMasterUpdateButton 内部已按
+              installed_kind 排除了非 stable），避免同屏显示两个做同样事的按钮 */}
+          {showSwitchToStableButton && (
             <button onClick={p.onSwitchToMaster} disabled={p.busy || p.checking} className="btn btn-sm btn-primary">
-              {p.busy ? '切换中…' : `切到稳定版 ${p.check.latest_version}…`}
+              {p.busy ? '切换中…' : `切到稳定版 ${p.check?.latest_version}…`}
             </button>
           )}
         </div>
@@ -3473,6 +3496,7 @@ type DevCardProps = {
   check: SystemUpdateCheck | null
   commits: DevCommitsResult | null
   currentSha: string
+  installedKind: 'stable' | 'dev' | 'custom' | undefined
   selectedSha: string | null
   setSelectedSha: (sha: string | null) => void
   checking: boolean
@@ -3495,7 +3519,9 @@ function DevCard(p: DevCardProps) {
   const fetchError = p.commits?.error ?? p.check?.error
   const currentShortSha = p.currentSha ? p.currentSha.slice(0, 8) : '当前'
   const stateText = formatDevStateText(p.check)
-  const devSwitchDisabled = isDevSwitchButtonDisabled(p.check)
+  // installedKind 用作 check 还没 resolve 期间的 fallback：装 dev tip 时
+  // 按钮 disabled，避免显示可点但点了 no-op
+  const devSwitchDisabled = isDevSwitchButtonDisabled(p.check, p.installedKind)
   if (p.cardState === 'preview' && p.pendingTarget && p.pendingTarget.kind === 'dev') {
     const t = p.pendingTarget
     return (


### PR DESCRIPTION
## Summary

PR #81 合入 dev 后 E2E 验证发现 3 个回归，用一个 commit 修。

## 问题

**1. 「切到 dev HEAD」按钮 disabled 状态错**

切到 dev 通道时按钮显示 enabled（橙色 btn-warn），即便当前 commit == dev HEAD。

根因：`useEffect` 把 `getDevCommits` + `checkSystemUpdate('dev')` 共享一个 cancelled flag。commits 先 resolve 触发 re-render，effect 检测 `devCommits !== null` 早 return，但 cleanup 已经把第一次 effect 的 cancelled=true，导致 check 的 promise resolve 时被丢弃。devCheck 永远是 null → `isDevSwitchButtonDisabled(null)` 返 false → 按钮 enabled。

修：拆成两个独立 effect，commits / check 各自管自己的 cancellation。

**2. 「v0.8.0 → v0.8.0」伪箭头**

装的是 `dev @ 72c04c55`，但稳定版卡显示 `v0.8.0 → v0.8.0` —— `currentTag` fallback 到 `v${__version__}` = "v0.8.0"，targetTag 也是 "v0.8.0"，UI 给出毫无意义的箭头。

修：装非 stable 时 `ver-tag` 区不再显示 from→to 箭头，只显示目标版本号。装 stable 且版本号确实不同时才显示完整箭头。

**3. 「更新到 v0.8.0…」+「切到稳定版 v0.8.0…」双按钮重复**

装非 stable 时这俩按钮同时出现，做同一件事（reset 到 origin/master）。

修：`shouldShowMasterUpdateButton` 加 `installedKind` 参数，装非 stable 时返 false，让「切到稳定版」按钮独占。新加 `shouldShowSwitchToStableButton` helper 表达对称语义。

## 附带

- `isDevSwitchButtonDisabled` 加 `installedKind` 参数：check 未加载时若装的就是 dev tip，按钮也 disabled（avoid 短暂窗口 UI 看上去可点）

## 测试

- vitest `versionPanel.test.ts`：22 → 31，加 5 个 `shouldShowSwitchToStableButton` + 改造 4 个既有测试覆盖新 `installedKind` 参数
- TypeScript `tsc --noEmit` 通过

## Test plan

- [x] 后端无改动，pytest 不需要再跑
- [x] 前端 vitest 31/31 全过
- [ ] 手动 E2E（reviewer 跑）：
  - [ ] release 直后场景，dev 通道：「切到 dev HEAD」按钮 disabled
  - [ ] 装 dev tip 时稳定版通道：ver-tag 只显示目标 vX.Y.Z 不显示伪箭头
  - [ ] 装 dev tip 时稳定版通道：只显示一个「切到稳定版 vX.Y.Z」按钮
  - [ ] 装 stable + 远端有新稳定版：显示「v0.7.0 → v0.8.0」箭头 +「更新到 v0.8.0…」单按钮

🤖 Generated with [Claude Code](https://claude.com/claude-code)
