### PR TITLE
feat: v0.8.1 — 版本面板 ADR 0005 + zip 用户启用自更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,60 @@
 
 ---
 
+## [0.8.1] — 2026-05-16
+
+版本面板单视图 + 通道偏好与 git 解耦（ADR 0005）+ zip 用户一键启用自动更新
+
+### 新增
+
+- **zip 解压安装用户一键初始化 git 仓库（启用自动更新）**
+  ADR 0002 当时只支持 git clone 部署；zip 解压用户因为没有 `.git/`，
+  版本面板全员 unknown、自更新功能完全用不了。这版加自动 normalize：
+
+  - **版本面板顶部 banner**：检测到 zip 模式时显示「启用自动更新」按钮
+    + 文案；没装 git 时改文案为「先安装 git」+ 官网链接
+  - **bootstrap 流程**：`git init` → `git remote add origin <URL>` →
+    `git fetch origin master --tags` → 优先 anchor 在 `v{__version__}`
+    tag（让 working tree 看上去干净）；reset `--mixed` 不动 working
+    tree，原 zip 文件原样保留
+  - **可配置上游 URL**：fork 维护者可通过 env var
+    `ANIMA_STUDIO_ORIGIN_URL` 覆盖默认值
+  - 不支持「dev 分支 zip」场景（端用户走的是 master zip，这是开发者
+    自测场景）
+
+### 变更
+
+- **版本面板单视图 + 通道（master/dev）作为偏好与 git 状态解耦（#81）**
+  ADR 0005：之前「通道」绑死在 git 工作树状态上（branch 名 + `git reset
+  --hard`），release 直后会出现「装的 v0.8.0」+「↑落后 2 commits」+
+  「切到 dev 没反应」的矛盾解读。新模型把通道理解为**用户视图偏好**：
+
+  - **同屏只显示当前通道**（不再 master + dev 并排），避免"两个通道
+    都活着"的视觉混乱
+  - **切 toggle 不动 git**，纯写 `system.update_channel` 到
+    `secrets.json`；真正"切到 dev HEAD" / "更新到 vX.Y.Z" 是独立按钮
+  - **后端新「装了什么」分类** `installed_kind`（stable / dev / custom），
+    按 commit hash + tree 比对推断，取代前端读 `branch` 做判断
+  - **文案脱离 git 词汇**：「↑落后 N commits」→「有新稳定版 vX.Y.Z」/
+    「已是最新」；不再出现 commits / sha / branch
+  - 旧 `show_dev_channel` 一次性迁移到 `update_channel`，写时双写
+    保持向下兼容
+
+### 修复
+
+- **版本面板 E2E 回归 3 项（rollback 文案 / preflight / dev 卡 fetch race）（#82）**
+  ADR 0005 重做后续：
+
+  - rollback 文案在 stable / dev 两种 installed_kind 下分流，不再
+    一律显示「回滚到 vX.Y.Z」
+  - preflight panel 在通道偏好与 git 状态不一致时不再展示矛盾的
+    切换目标
+  - dev 卡 fetch race：`devCommits` 和 `devCheck` 拆独立 useEffect，
+    避免一个先 resolve 触发 re-render 跳过另一个的 fetch（症状：
+    "切到 dev HEAD"按钮看上去 enabled 但点了 no-op）
+
+---
+
 ## [0.8.0] — 2026-05-16
 
 预处理流水线 + InfoNoise 训练 + Generate/Preset UX 大改（ADR 0004）

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AnimaLoraStudio
 
-[![Version](https://img.shields.io/badge/version-0.8.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-0.8.1-blue)](CHANGELOG.md)
 
 **端到端流水线**：从 Booru 抓图 → 筛选 → 打标 → 正则集 → 训练 → 出图测试，全流程在一个浏览器面板里推进。专为 [Anima](https://huggingface.co/circlestone-labs/Anima)（Cosmos DiT 二次元特调）训练优化。
 

--- a/docs/adr/0005-update-channel-as-preference.md
+++ b/docs/adr/0005-update-channel-as-preference.md
@@ -1,0 +1,158 @@
+# 0005 — 更新通道（master / dev）作为用户视图偏好，与 git 工作树状态解耦
+
+**状态**：Accepted
+**日期**：2026-05-16
+**决策者**：@WalkingMeatAxolotl
+
+## 背景
+
+ADR 0002（webui 自更新）落地后，Settings → 系统 → 版本面板有两个长期暗坑，在
+v0.8.0 release 直后被触发：
+
+### 现象
+
+用户做了 v0.8.0 release（dev → master + PR merge + 打 tag）后，本地 master
+还没 `git pull`。打开版本面板看到：
+
+| UI 元素 | 显示 | 用户解读 |
+|---|---|---|
+| master 卡「你在这里」 | 我在 master | branch 名 = master |
+| master 卡 `v0.8.0` | 我装的是 v0.8.0 | `__version__` 字符串 |
+| master 卡「↑落后 2 commits」 | 我落后了 | git `rev-list --count` |
+| dev 卡「HEAD f6f202b」 | dev 顶端是这个 | 远端 |
+| dev 卡列表「● 当前」 | 我装的就是这个 | commit hash 比较 |
+| 「切到 dev (f6f202b)」按钮 | 可以切 | onDev=false |
+| `v0.8.0 → v0.8.0` 箭头 | 升级前后版本号一样？ |  |
+
+点「切到 dev (f6f202b)」 → preview 出现 → 确认 → 重启 → UI **没有变化**，
+仍然显示「master · 你在这里」。
+
+### 两个根因
+
+1. **UI 用 git 词汇而不是产品语言**。
+   - `commits_ahead` 直接从后端 `git rev-list --count` 出来，前端原样显示
+     「↑落后 N commits」。
+   - 但用户视角的"落后"只有一个维度：版本号。版本号 v0.8.0 == v0.8.0 时根本
+     不存在"落后"。`__version__` 字符串与 commit hash 是两套独立维度，UI 把
+     两套维度混着展示就产生了 `v0.8.0 → v0.8.0` + 「落后 2 commits」的矛盾。
+
+2. **"通道"概念绑死在 git 工作树状态上**。
+   - 「我在哪个通道」判定 = `git rev-parse --abbrev-ref HEAD`（branch 名）
+   - 「切换通道」实现 = `git reset --hard <ref>`（不动 branch 名）
+   - 两个机制大多数场景下"凑巧"能用：dev 通常比 master 领先，reset 后 commit
+     hash 变了，UI 看上去就"动了"。
+   - **release 直后例外**：本地 commit `f6f202b` 已经 == origin/dev HEAD（release
+     commit 本身在 dev 上做），切到 dev 是 no-op，branch 名也不变 → UI 永远
+     卡在「master · 你在这里」。
+
+更深的：UI 把 master 卡 + dev 卡**并排同屏**渲染，本应互斥的两个通道在视觉上
+变成两张同时活着的卡，让用户陷入「我究竟在哪个通道」的矛盾解读。
+
+## 决策
+
+**通道是用户视图偏好，不是 git 工作树状态**：
+
+1. **用户偏好持久化为 `system.update_channel`**（`"stable"` / `"dev"`），存
+   `secrets.json`。**切 toggle 不触发任何 git 操作**，纯 UI 视图切换。
+2. **真正"切到 dev HEAD" / "更新到 vX.Y.Z" / "回滚"是独立按钮**，跟通道偏好
+   解耦 —— 用户可以"订阅 dev 通道做研发"但暂时"装着稳定版"。
+3. **同屏只展示当前选中通道的卡片**（不再 master + dev 并排）。
+4. **后端引入「装了什么」分类 `installed_kind`**（`stable` / `dev` / `custom`），
+   按 commit hash 比对推断，**取代前端依赖 `branch` 字段做产品判断**。
+5. **前端文案只用版本号 / 状态语言**，不出现 `commits` / `sha` / `branch` 等
+   git 词汇。"落后 N commits" → "有新稳定版 vX.Y.Z" / "已是最新" / dev 通道
+   改"N 项新更新"。
+
+### 后端 API 形态
+
+`VersionInfo`（`/api/system/version`）：
+
+```python
+@dataclass
+class VersionInfo:
+    version: str
+    commit: str
+    commit_short: str
+    commit_time_iso: str
+    branch: str              # debug 用，前端不再做产品判断
+    tag: Optional[str]
+    is_dirty: bool
+    # ---- ADR 0005 ----
+    installed_kind: str      # "stable" / "dev" / "custom"
+    installed_label: str     # "v0.8.0" / "dev @ f6f202b · 2026-05-16" / "自定义（feat/foo @ a1b2c3d）"
+    stable_version: Optional[str]  # "vX.Y.Z" 仅 stable 时填
+```
+
+分类规则（优先级）：
+
+1. HEAD 命中 `vX.Y.Z` release tag → `stable`
+2. `__version__` 匹某 vX.Y.Z tag 且当前 commit 与 tag commit 的 **tree 一致** →
+   `stable`（覆盖 release 直后 release commit 在 dev、tag 在 merge commit 的场景）
+3. commit == `origin/dev` HEAD → `dev`
+4. else → `custom`（feature branch / detached）
+
+`UpdateCheckResult`（`/api/system/update_check`）：
+
+```python
+@dataclass
+class UpdateCheckResult:
+    channel: str
+    current_commit: str
+    latest_commit: str
+    commits_ahead: int       # 内部 debug 保留
+    has_update: bool         # 兼容字段 = (state == "update_available")
+    latest_tag: Optional[str]
+    checked_at: float
+    # ---- ADR 0005 ----
+    state: str               # "up_to_date" / "update_available" / "ahead" / "detached"
+    installed_version: Optional[str]
+    latest_version: Optional[str]
+    behind_count: int        # 给前端用的"N 项更新"数字
+    error: Optional[str]
+```
+
+state 推断：
+- **master 通道**：版本号优先（`installed_version == latest_version` → up_to_date），
+  没版本号（custom / dev）回落到 commit 比较
+- **dev 通道**：直接 commit hash 比较 + ahead/behind 计数
+
+### 前端
+
+- `formatMasterStateText(check)` / `formatDevStateText(check)`：纯函数把 state
+  + check 数据 → 用户可读文案
+- `shouldShowMasterUpdateButton(check)`：state=update_available 且有 latest_version
+- `isDevSwitchButtonDisabled(check)`：state=up_to_date → disabled
+- toggle 视觉切换走 `<button role="radio">`，写 `secrets.json` 但**不**调
+  `/api/system/update`
+
+### 迁移
+
+旧 `system.show_dev_channel`：保留 pydantic 字段做兼容；
+`_migrate_legacy_schema` 一次性映射 `show_dev_channel=true → update_channel="dev"`，
+前端 PATCH 时同时写两个字段保持旧版本回滚兼容。
+
+## 后果
+
+### 正面
+
+- release 直后用户的版本面板能正确显示「已是最新 v0.8.0」+「与 dev HEAD 一致」，
+  不再有"落后 2 commits"+「切到 dev 没反应」的矛盾
+- UI 文案彻底脱离 git 词汇，对非 git 用户更友好
+- 「装了什么」与「订阅哪条通道」解耦后，未来支持"装稳定版但跟 dev 看预览"等
+  灵活组合时不需要再改架构
+
+### 负面 / 待评估
+
+- `installed_kind=stable` 判定靠 `git diff --quiet` tree 比较，每次 `current_version()`
+  会多 1-2 个 git 调用。release 后短期内本地 tag 没 fetch 全时可能误判为 custom，
+  靠下次 `check_update` fetch tag 后自动纠正
+- 后端 `commits_ahead` / `has_update` 字段保留作兼容，但前端不再读 —— 任何外部
+  脚本读这俩字段的还能跑，可逐步迁移
+
+## 不在范围
+
+- "切到此 commit"（点 dev 列表里旧 commit 切过去）保留，但属于 dev 通道展开
+  区里的二级操作
+- 自动检查 + Topbar 红点维持 ADR 0002 的"只看 master"决定，不因通道偏好改
+- 完整翻译 Settings 页里其他地方的 git 词汇（譬如 secrets 里 wandb 同步状态）
+  不在此 ADR 范围

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,6 +10,7 @@
 | 0002 | [Webui 内自更新（flag + shell wrapper loop）](0002-webui-self-update.md) | Proposed | 2026-05-12 |
 | 0003 | [anima_train.py 模块化重构（plugin 边界 + adapter hook protocol）](0003-anima-train-refactor.md) | Proposed | 2026-05-14 |
 | 0004 | [预处理状态用单 manifest 替代「双 bucket + per-image sidecar」](0004-preprocess-manifest.md) | Accepted | 2026-05-15 |
+| 0005 | [更新通道作为用户视图偏好，与 git 工作树状态解耦](0005-update-channel-as-preference.md) | Accepted | 2026-05-16 |
 
 ## 状态值
 

--- a/release_notes.yaml
+++ b/release_notes.yaml
@@ -5,6 +5,60 @@
 #
 # 顺序：最新版本在 list 顶。
 
+- version: "0.8.1"
+  date: "2026-05-16"
+  summary: "版本面板单视图 + 通道偏好与 git 解耦（ADR 0005）+ zip 用户一键启用自动更新"
+  entries:
+    - kind: changed
+      summary: "版本面板单视图 + 通道（master/dev）作为偏好与 git 状态解耦（#81）"
+      pr_refs: [81]
+      detail: |
+        ADR 0005：之前「通道」绑死在 git 工作树状态上（branch 名 + `git reset
+        --hard`），release 直后会出现「装的 v0.8.0」+「↑落后 2 commits」+
+        「切到 dev 没反应」的矛盾解读。新模型把通道理解为**用户视图偏好**：
+
+        - **同屏只显示当前通道**（不再 master + dev 并排），避免"两个通道
+          都活着"的视觉混乱
+        - **切 toggle 不动 git**，纯写 `system.update_channel` 到
+          `secrets.json`；真正"切到 dev HEAD" / "更新到 vX.Y.Z" 是独立按钮
+        - **后端新「装了什么」分类** `installed_kind`（stable / dev / custom），
+          按 commit hash + tree 比对推断，取代前端读 `branch` 做判断
+        - **文案脱离 git 词汇**：「↑落后 N commits」→「有新稳定版 vX.Y.Z」/
+          「已是最新」；不再出现 commits / sha / branch
+        - 旧 `show_dev_channel` 一次性迁移到 `update_channel`，写时双写
+          保持向下兼容
+
+    - kind: added
+      summary: "zip 解压安装用户一键初始化 git 仓库（启用自动更新）"
+      detail: |
+        ADR 0002 当时只支持 git clone 部署；zip 解压用户因为没有 `.git/`，
+        版本面板全员 unknown、自更新功能完全用不了。这版加自动 normalize：
+
+        - **版本面板顶部 banner**：检测到 zip 模式时显示「启用自动更新」按钮
+          + 文案；没装 git 时改文案为「先安装 git」+ 官网链接
+        - **bootstrap 流程**：`git init` → `git remote add origin <URL>` →
+          `git fetch origin master --tags` → 优先 anchor 在 `v{__version__}`
+          tag（让 working tree 看上去干净）；reset `--mixed` 不动 working
+          tree，原 zip 文件原样保留
+        - **可配置上游 URL**：fork 维护者可通过 env var
+          `ANIMA_STUDIO_ORIGIN_URL` 覆盖默认值
+        - 不支持「dev 分支 zip」场景（端用户走的是 master zip，这是开发者
+          自测场景）
+
+    - kind: fixed
+      summary: "版本面板 E2E 回归 3 项（rollback 文案 / preflight / dev 卡 fetch race）（#82）"
+      pr_refs: [82]
+      detail: |
+        ADR 0005 重做后续：
+
+        - rollback 文案在 stable / dev 两种 installed_kind 下分流，不再
+          一律显示「回滚到 vX.Y.Z」
+        - preflight panel 在通道偏好与 git 状态不一致时不再展示矛盾的
+          切换目标
+        - dev 卡 fetch race：`devCommits` 和 `devCheck` 拆独立 useEffect，
+          避免一个先 resolve 触发 re-render 跳过另一个的 fetch（症状：
+          "切到 dev HEAD"按钮看上去 enabled 但点了 no-op）
+
 - version: "0.8.0"
   date: "2026-05-16"
   summary: "预处理流水线 + InfoNoise 训练 + Generate/Preset UX 大改（ADR 0004）"

--- a/studio/__init__.py
+++ b/studio/__init__.py
@@ -8,4 +8,4 @@
 
 版本规则：MAJOR.MINOR.PATCH（语义版本，但 0.x 阶段 MINOR 即视为破坏性升级）。
 """
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/studio/secrets.py
+++ b/studio/secrets.py
@@ -395,14 +395,18 @@ class GenerateConfig(BaseModel):
 
 
 class SystemConfig(BaseModel):
-    """系统级偏好（ADR 0002 / PR-D）。
+    """系统级偏好（ADR 0002 / 0005）。
 
-    - `show_dev_channel`：Settings 高级里勾选"显示开发版更新"后变 True。
-      开启时 UI 暴露"手动检查 dev"+"更新到 dev"按钮；自动检查仍只 fetch
-      master，Topbar badge 永不亮 dev（避免开发者被 dev commit 持续骚扰）。
-      默认 False —— 绝大多数用户看到的是只 master 的简化界面。
+    - `update_channel`：用户订阅哪条更新轨道。"stable"（默认）= 只看稳定版
+      更新提示；"dev" = 看 dev 通道（最近 commit 时间线、可切到 dev HEAD）。
+      这是**用户视图偏好**，与 git 工作树状态解耦 —— 切 toggle 不触发任何
+      git 操作；真正"切到 dev HEAD" / "更新到 vX.Y.Z" 是单独按钮。
+    - `show_dev_channel`：deprecated，由 `_migrate_legacy_schema` 一次性迁移成
+      `update_channel`（true → "dev"，false → "stable"），保留字段以便旧
+      secrets.json 读取时 pydantic 不报错；新代码不要再用。
     """
-    show_dev_channel: bool = False
+    update_channel: str = "stable"  # "stable" / "dev"
+    show_dev_channel: bool = False  # deprecated, 仅作迁移源
 
 
 class Secrets(BaseModel):
@@ -520,9 +524,17 @@ def _migrate_legacy_schema(raw: dict[str, Any]) -> dict[str, Any]:
     4. JoyCaptionConfig.base_url / model / prompt_template → 写入 joycaption preset
        （base_url/model 直接覆盖；prompt_template 非默认时建 `user_joycaption`）
     5. 删 raw["joycaption"] 字段
+    6. system.show_dev_channel=true → system.update_channel="dev"（ADR 0005）
 
     幂等：新 schema（llm_tagger 含 current_preset / presets）直接返回。
     """
+    # 6. system 通道偏好一次性迁移（无论后面 llm_tagger path 怎么走都先做）
+    sys_raw = raw.get("system")
+    if isinstance(sys_raw, dict):
+        # 新字段已显式设过 → 不覆盖（幂等）
+        if "update_channel" not in sys_raw and sys_raw.get("show_dev_channel") is True:
+            sys_raw["update_channel"] = "dev"
+
     llm_old = raw.get("llm_tagger")
     if not isinstance(llm_old, dict):
         # 不存在 llm_tagger 字段：可能是更老的 secrets.json；交给 pydantic 用默认值

--- a/studio/server.py
+++ b/studio/server.py
@@ -3646,6 +3646,32 @@ def system_dev_commits(limit: int = 10) -> dict[str, Any]:
     }
 
 
+@app.post("/api/system/init_git")
+def system_init_git() -> dict[str, Any]:
+    """zip 解压用户一键初始化 git 仓库（0.8.1 hotfix）。
+
+    幂等：调用前 / 调用后都跑 `git_repo_status()`，如已是仓库直接返 ok=true。
+    流程见 `updater.bootstrap_git_repo()`：init + remote add origin + fetch master
+    + reset --mixed 到对应 release tag。
+
+    失败状态码：
+    - 500 + error 字符串：git binary 缺失 / fetch 网络问题 / 磁盘问题
+    """
+    from dataclasses import asdict
+    pre = updater.git_repo_status()
+    if pre.is_repo:
+        return {"ok": True, "already_initialized": True}
+
+    result = updater.bootstrap_git_repo()
+    if not result.ok:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "bootstrap_failed", "message": result.error or "未知错误"},
+        )
+
+    return {"ok": True, "already_initialized": False, **asdict(result)}
+
+
 @app.get("/api/system/release_notes")
 def system_release_notes(tag: str) -> dict[str, Any]:
     """读 release_notes.yaml，返回指定 tag 的结构化 release notes。

--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -53,26 +53,43 @@ GIT_PULL_TIMEOUT = 120.0
 # ----- 数据类型 -----------------------------------------------------------
 @dataclass
 class VersionInfo:
-    """当前仓库 git 状态。"""
+    """当前仓库 git 状态 + 产品视角的"装了什么"分类。
+
+    产品 UI 应使用 `installed_kind` / `installed_label`，不要依赖 `branch`。
+    切换通道走 `git reset --hard`，不改 branch 名 —— branch 字段只做 debug。
+    """
     version: str               # studio.__version__ (0.6.0)
     commit: str                # 完整 sha
     commit_short: str          # 前 8 位
     commit_time_iso: str       # ISO8601
-    branch: str                # master / dev / detached
+    branch: str                # master / dev / detached / feature-name（debug 用）
     tag: Optional[str]         # HEAD 上的 tag（仅 exact match），无则 None
     is_dirty: bool             # working tree 有未提交改动
+    # ---- 产品 UI 用的「装了什么」分类（前端唯一应该看的字段）----
+    installed_kind: str        # "stable" / "dev" / "custom"
+    installed_label: str       # 用户可读："v0.8.0" / "dev @ f6f202b · 2026-05-16" / "自定义（feat/foo @ a1b2c3d）"
+    stable_version: Optional[str]  # "vX.Y.Z" 形式，仅 installed_kind=stable 时填；用于版本号比对
 
 
 @dataclass
 class UpdateCheckResult:
-    """git fetch + 比对结果。"""
+    """git fetch + 比对结果。
+
+    前端应使用 `state` + `installed_version` / `latest_version` / `behind_count`，
+    不要依赖 `commits_ahead`（git 词汇）/ `has_update`（兼容字段）。
+    """
     channel: str               # master / dev
     current_commit: str
     latest_commit: str
-    commits_ahead: int         # local 落后 remote 多少 commit
-    has_update: bool
+    commits_ahead: int         # 内部 debug：local 落后 remote 多少 commit
+    has_update: bool           # 兼容字段 = (state == "update_available")
     latest_tag: Optional[str]  # remote 最新 tag（仅 master 通道有）
     checked_at: float          # epoch
+    # ---- 产品 UI 用的状态机 ----
+    state: str = "up_to_date"  # "up_to_date" / "update_available" / "ahead" / "detached"
+    installed_version: Optional[str] = None  # 当前装的稳定版 tag (vX.Y.Z)，仅 stable 时填
+    latest_version: Optional[str] = None     # 远端最新稳定版 tag（master 通道）
+    behind_count: int = 0      # 前端文案"N 项更新"用（= commits_ahead，但语义更清楚）
     error: Optional[str] = None  # fetch 失败时填
 
 
@@ -127,6 +144,11 @@ def _git(*args: str, timeout: float = 15.0) -> tuple[int, str, str]:
         return 1, "", str(exc)
 
 
+# 稳定版 tag 形如 v0.8.0。HEAD 命中这种 tag 就归类 stable。
+# 第四段（如 v0.8.0-rc1）暂时不在版本面板的"稳定版"语义里，先归 custom。
+_RELEASE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
 # ----- 公开 API -----------------------------------------------------------
 def current_version() -> VersionInfo:
     """读当前仓库状态。git 不可用时返回占位值（不抛）。"""
@@ -149,6 +171,15 @@ def current_version() -> VersionInfo:
     rc, status, _ = _git("status", "--porcelain", "--untracked-files=no")
     is_dirty = rc == 0 and bool(status)
 
+    installed_kind, installed_label, stable_version = _classify_install(
+        commit=commit,
+        exact_tag=exact_tag,
+        branch=branch,
+        short=short,
+        commit_time_iso=ctime_iso,
+        is_dirty=is_dirty,
+    )
+
     return VersionInfo(
         version=__version__,
         commit=commit,
@@ -157,7 +188,69 @@ def current_version() -> VersionInfo:
         branch=branch,
         tag=exact_tag,
         is_dirty=is_dirty,
+        installed_kind=installed_kind,
+        installed_label=installed_label,
+        stable_version=stable_version,
     )
+
+
+def _classify_install(
+    *,
+    commit: str,
+    exact_tag: Optional[str],
+    branch: str,
+    short: str,
+    commit_time_iso: str,
+    is_dirty: bool,
+) -> tuple[str, str, Optional[str]]:
+    """推断 (installed_kind, installed_label, stable_version)。
+
+    优先级：
+    1. HEAD 命中 vX.Y.Z release tag → stable（最常见的稳定版情形）
+    2. `__version__` 匹 vX.Y.Z tag 且当前 commit 与 tag commit 的 tree 一致 → stable
+       覆盖 "release commit 在 dev 上，tag 打在 master 的 merge commit 上" 这种
+       release 直后场景（两个 commit 内容相同，用户语义上装的就是稳定版）
+    3. commit == origin/dev HEAD → dev
+    4. else → custom（feature branch / detached / 任意 commit）
+
+    返回三元组：
+    - installed_kind / installed_label：给前端做 UI 文案的
+    - stable_version：仅 stable 时为 "vX.Y.Z"，否则 None；后端做版本号比对用
+
+    label 是给用户看的字符串；dirty 时追加"· 未提交修改"。
+    """
+    dirty_suffix = " · 未提交修改" if is_dirty else ""
+
+    # 1. HEAD 命中 release tag
+    if exact_tag and _RELEASE_TAG_RE.match(exact_tag):
+        return "stable", f"{exact_tag}{dirty_suffix}", exact_tag
+
+    if commit and commit != "unknown":
+        # 2. __version__ 字符串匹 release tag 且 tree 一致
+        version_tag = f"v{__version__}"
+        if _RELEASE_TAG_RE.match(version_tag):
+            rc, tag_commit, _ = _git("rev-parse", f"{version_tag}^{{commit}}")
+            if rc == 0 and tag_commit:
+                if tag_commit == commit:
+                    # 极少触发（exact_tag 应已捕获），保险起见
+                    return "stable", f"{version_tag}{dirty_suffix}", version_tag
+                # tree 一致 = 文件内容完全相同（merge / cherry-pick 常见）
+                rc_diff, _, _ = _git("diff", "--quiet", commit, tag_commit)
+                if rc_diff == 0:
+                    return "stable", f"{version_tag}{dirty_suffix}", version_tag
+
+        # 3. commit == origin/dev HEAD
+        rc, dev_head, _ = _git("rev-parse", "origin/dev")
+        if rc == 0 and dev_head and commit == dev_head:
+            date_part = ""
+            if commit_time_iso:
+                date_part = f" · {commit_time_iso[:16].replace('T', ' ')}"
+            return "dev", f"dev @ {short}{date_part}{dirty_suffix}", None
+
+    # 4. custom
+    if not branch or branch == "detached":
+        return "custom", f"自定义（@ {short}）{dirty_suffix}", None
+    return "custom", f"自定义（{branch} @ {short}）{dirty_suffix}", None
 
 
 def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheckResult:
@@ -165,6 +258,13 @@ def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheck
 
     channel 仅接受 'master' / 'dev'。Master 走 24h 缓存（cache 写到磁盘）；
     dev 不写缓存（开发者主动检查，避免污染 master 的"有更新"信号）。
+
+    输出走 state 状态机（up_to_date / update_available / ahead / detached）。
+    state 推断：
+    - master 通道：优先比较 installed_version vs latest_version（版本号语义），
+      没有版本号（installed_kind != stable）时回落到 commit 比较
+    - dev 通道：直接比较 commit hash；commits_ahead>0 → update_available；
+      =0 但 sha 不一致 → ahead（你超前）或 detached
     """
     if channel not in ("master", "dev"):
         raise ValueError(f"invalid channel: {channel}")
@@ -175,13 +275,16 @@ def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheck
             return cached
 
     cur = current_version()
+    checked_at = time.time()
 
     rc, _, stderr = _git("fetch", "origin", channel, timeout=GIT_FETCH_TIMEOUT)
     if rc != 0:
         return UpdateCheckResult(
             channel=channel, current_commit=cur.commit, latest_commit="",
             commits_ahead=0, has_update=False, latest_tag=None,
-            checked_at=time.time(), error=f"git fetch failed: {stderr[:200]}",
+            checked_at=checked_at, state="detached", behind_count=0,
+            installed_version=None, latest_version=None,
+            error=f"git fetch failed: {stderr[:200]}",
         )
 
     rc, latest, _ = _git("rev-parse", f"origin/{channel}")
@@ -189,27 +292,73 @@ def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheck
         return UpdateCheckResult(
             channel=channel, current_commit=cur.commit, latest_commit="",
             commits_ahead=0, has_update=False, latest_tag=None,
-            checked_at=time.time(), error=f"git rev-parse origin/{channel} failed",
+            checked_at=checked_at, state="detached", behind_count=0,
+            installed_version=None, latest_version=None,
+            error=f"git rev-parse origin/{channel} failed",
         )
 
-    rc, ahead_str, _ = _git("rev-list", "--count", f"HEAD..origin/{channel}")
-    commits_ahead = int(ahead_str) if rc == 0 and ahead_str.isdigit() else 0
-    has_update = commits_ahead > 0 and cur.commit != latest
+    # commit 计数 —— behind = origin 比本地多多少；ahead = 本地比 origin 多多少
+    rc, behind_str, _ = _git("rev-list", "--count", f"HEAD..origin/{channel}")
+    behind = int(behind_str) if rc == 0 and behind_str.isdigit() else 0
+    rc, ahead_str, _ = _git("rev-list", "--count", f"origin/{channel}..HEAD")
+    ahead = int(ahead_str) if rc == 0 and ahead_str.isdigit() else 0
 
     latest_tag: Optional[str] = None
-    if channel == "master" and has_update:
-        rc, tag, _ = _git("describe", "--tags", "--abbrev=0", latest)
+    latest_version: Optional[str] = None
+    rc, tag_at_remote, _ = _git("describe", "--tags", "--exact-match", latest)
+    if rc == 0:
+        latest_tag = tag_at_remote
+        if _RELEASE_TAG_RE.match(tag_at_remote):
+            latest_version = tag_at_remote
+    if not latest_tag:
+        # describe 精确匹配失败 → fallback：取最近 reachable tag（保留兼容）
+        rc, tag_near, _ = _git("describe", "--tags", "--abbrev=0", latest)
         if rc == 0:
-            latest_tag = tag
+            latest_tag = tag_near
+            if channel == "master" and _RELEASE_TAG_RE.match(tag_near):
+                latest_version = tag_near
+
+    installed_version = cur.stable_version
+
+    # ---- 状态机推断 ----
+    if channel == "master":
+        # 版本号优先：版本号相同（已是最新稳定版）→ up_to_date
+        if installed_version and latest_version and installed_version == latest_version:
+            state = "up_to_date"
+        elif installed_version and latest_version and installed_version != latest_version:
+            # 装了稳定版且远端有更新稳定版 → 提示更新
+            state = "update_available"
+        elif cur.commit == latest:
+            # 没装 stable（custom / dev）但 commit 与 origin/master 完全一致
+            state = "up_to_date"
+        elif behind > 0:
+            state = "update_available"
+        elif ahead > 0:
+            state = "ahead"
+        else:
+            state = "detached"
+    else:  # dev
+        if cur.commit == latest:
+            state = "up_to_date"
+        elif behind > 0:
+            state = "update_available"
+        elif ahead > 0:
+            state = "ahead"
+        else:
+            state = "detached"
 
     result = UpdateCheckResult(
         channel=channel,
         current_commit=cur.commit,
         latest_commit=latest,
-        commits_ahead=commits_ahead,
-        has_update=has_update,
+        commits_ahead=behind,
+        has_update=(state == "update_available"),
         latest_tag=latest_tag,
-        checked_at=time.time(),
+        checked_at=checked_at,
+        state=state,
+        installed_version=installed_version,
+        latest_version=latest_version,
+        behind_count=behind,
     )
 
     if channel == "master":

--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -49,6 +50,12 @@ UPDATE_CACHE_TTL_SECONDS = 24 * 3600
 GIT_FETCH_TIMEOUT = 30.0
 GIT_PULL_TIMEOUT = 120.0
 
+# zip 解压用户没有 .git/，自更新功能完全失效。bootstrap_git_repo() 一次性
+# 在本地 init + remote add origin + fetch master，之后走正常 self-update 路径。
+# fork 维护者通过 env var ANIMA_STUDIO_ORIGIN_URL 覆盖默认上游 URL。
+DEFAULT_ORIGIN_URL = "https://github.com/WalkingMeatAxolotl/AnimaLoraStudio.git"
+ORIGIN_URL = os.environ.get("ANIMA_STUDIO_ORIGIN_URL", "").strip() or DEFAULT_ORIGIN_URL
+
 
 # ----- 数据类型 -----------------------------------------------------------
 @dataclass
@@ -66,9 +73,14 @@ class VersionInfo:
     tag: Optional[str]         # HEAD 上的 tag（仅 exact match），无则 None
     is_dirty: bool             # working tree 有未提交改动
     # ---- 产品 UI 用的「装了什么」分类（前端唯一应该看的字段）----
-    installed_kind: str        # "stable" / "dev" / "custom"
-    installed_label: str       # 用户可读："v0.8.0" / "dev @ f6f202b · 2026-05-16" / "自定义（feat/foo @ a1b2c3d）"
-    stable_version: Optional[str]  # "vX.Y.Z" 形式，仅 installed_kind=stable 时填；用于版本号比对
+    # 真实生产路径里这三个永远由 _classify_install 派生；给默认值只是让单测
+    # 构造 fake VersionInfo 时不用每次都写满（ADR 0005 漏改的 hotfix 同步）。
+    installed_kind: str = "custom"  # "stable" / "dev" / "custom" / "zip"
+    installed_label: str = ""       # 用户可读："v0.8.0" / "dev @ f6f202b · 2026-05-16" / "自定义（feat/foo @ a1b2c3d）" / "v0.8.0（zip 安装）"
+    stable_version: Optional[str] = None  # "vX.Y.Z" 形式，仅 installed_kind=stable 时填；用于版本号比对
+    # ---- zip 模式探测（0.8.1 hotfix）----
+    is_git_repo: bool = True   # False = REPO_ROOT/.git 缺失 / 没有 origin remote（zip 解压用户）
+    git_available: bool = True # False = git binary 不在 PATH
 
 
 @dataclass
@@ -149,9 +161,148 @@ def _git(*args: str, timeout: float = 15.0) -> tuple[int, str, str]:
 _RELEASE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
 
 
+# ----- zip 用户检测 + 一键 init（0.8.1 hotfix）---------------------------
+@dataclass
+class GitRepoStatus:
+    """REPO_ROOT 的 git 可用性快照。版本面板用这个决定显示哪类 banner。"""
+    git_available: bool   # git binary 在 PATH（不依赖 .git 存在）
+    has_dot_git: bool     # REPO_ROOT/.git 目录存在
+    has_origin: bool      # origin remote 已配置（蕴含 has_dot_git）
+    @property
+    def is_repo(self) -> bool:
+        """版本面板视角的"可以走自更新"= 三者全 True。"""
+        return self.git_available and self.has_dot_git and self.has_origin
+
+
+def git_repo_status() -> GitRepoStatus:
+    """三态检测：① git binary？② .git/？③ origin remote？
+
+    顺序固定：git binary 不在 PATH → 后两步无意义直接 False（避免误判）。
+    """
+    rc, _, _ = _git("--version")
+    git_available = rc == 0
+    if not git_available:
+        return GitRepoStatus(False, False, False)
+    has_dot_git = (REPO_ROOT / ".git").exists()
+    if not has_dot_git:
+        return GitRepoStatus(True, False, False)
+    rc, _, _ = _git("remote", "get-url", "origin")
+    return GitRepoStatus(True, True, rc == 0)
+
+
+@dataclass
+class BootstrapResult:
+    """bootstrap_git_repo() 结果。anchor = HEAD 最终指向的 ref（vX.Y.Z tag 或 FETCH_HEAD sha）。"""
+    ok: bool
+    anchor: Optional[str] = None
+    anchor_kind: str = ""      # "version_tag" / "master_head"；ok=False 时空
+    error: Optional[str] = None
+
+
+def bootstrap_git_repo() -> BootstrapResult:
+    """zip 解压用户首次启用自更新功能：在 REPO_ROOT 上 init git 仓库。
+
+    流程：
+    1. precondition：git binary 在 PATH（否则返 error，提示用户先装 git）
+    2. .git/ 不存在 → `git init` + `git symbolic-ref HEAD refs/heads/master`
+       （强制 master 默认 branch，避免不同 git 版本 main/master 默认差异）
+    3. origin remote 不存在 → `git remote add origin {ORIGIN_URL}`
+       （ORIGIN_URL 走 env var 覆盖，fork 维护者可配）
+    4. `git fetch origin master --tags`（拉完整 master 历史 + 全部 tag；
+       不带 --depth 保证 dev 通道时间线 / 回滚到任意 commit 可用）
+    5. 找 `v{__version__}` tag：存在则用作 anchor（让 HEAD 指向用户当前装
+       的版本对应的 tag commit，working tree 看上去就"干净"）；不存在则
+       fallback 到 FETCH_HEAD（master HEAD）
+    6. `git reset --mixed {anchor}` —— 更新 HEAD + index，**不动 working
+       tree**。zip 解压的源文件保留原样，不覆盖用户可能的本地修改
+
+    bootstrap 后 _classify_install 大概率回 "stable"（zip 用户的 __version__
+    匹 release tag 且 tree 一致），版本面板正常显示「v0.8.0」+「检查更新」可用。
+
+    不在范围：fetch dev / 拉 dev_commits。用户切到 dev 通道时由 check_update
+    / dev_commits 自己触发首次 fetch dev（多等几秒，可接受）。
+    """
+    status = git_repo_status()
+    if not status.git_available:
+        return BootstrapResult(
+            ok=False,
+            error="git binary 不在 PATH。请先安装 git（https://git-scm.com/downloads）后重启 Studio。",
+        )
+
+    # 1. git init（仅当 .git/ 不存在）
+    if not status.has_dot_git:
+        rc, _, err = _git("init", str(REPO_ROOT))
+        if rc != 0:
+            return BootstrapResult(ok=False, error=f"git init 失败: {err[:200]}")
+        # 强制 default branch = master（git 2.28+ 起 init.defaultBranch 默认可能是 main）
+        rc, _, err = _git("symbolic-ref", "HEAD", "refs/heads/master")
+        if rc != 0:
+            return BootstrapResult(ok=False, error=f"git symbolic-ref 失败: {err[:200]}")
+
+    # 2. origin remote
+    rc, _, _ = _git("remote", "get-url", "origin")
+    if rc != 0:
+        rc, _, err = _git("remote", "add", "origin", ORIGIN_URL)
+        if rc != 0:
+            return BootstrapResult(ok=False, error=f"git remote add 失败: {err[:200]}")
+
+    # 3. fetch master + tags（这一步是大头，30-60 MB）
+    rc, _, err = _git("fetch", "origin", "master", "--tags", timeout=GIT_FETCH_TIMEOUT * 4)
+    if rc != 0:
+        return BootstrapResult(ok=False, error=f"git fetch 失败: {err[:200]}")
+
+    # 4. 选 anchor：优先匹 __version__ 的 release tag
+    anchor_ref: str
+    anchor_kind: str
+    version_tag = f"v{__version__}"
+    if _RELEASE_TAG_RE.match(version_tag):
+        rc, _, _ = _git("rev-parse", "--verify", f"refs/tags/{version_tag}^{{commit}}")
+        if rc == 0:
+            anchor_ref = version_tag
+            anchor_kind = "version_tag"
+        else:
+            anchor_ref = "FETCH_HEAD"
+            anchor_kind = "master_head"
+    else:
+        anchor_ref = "FETCH_HEAD"
+        anchor_kind = "master_head"
+
+    # 5. reset --mixed：更新 HEAD + index，不动 working tree（保留用户文件）
+    rc, _, err = _git("reset", "--mixed", anchor_ref, timeout=GIT_PULL_TIMEOUT)
+    if rc != 0:
+        return BootstrapResult(ok=False, error=f"git reset 失败: {err[:200]}")
+
+    # 解析 anchor sha 给前端 / 日志用
+    rc, anchor_sha, _ = _git("rev-parse", anchor_ref)
+    return BootstrapResult(
+        ok=True,
+        anchor=anchor_sha if rc == 0 else anchor_ref,
+        anchor_kind=anchor_kind,
+    )
+
+
 # ----- 公开 API -----------------------------------------------------------
 def current_version() -> VersionInfo:
-    """读当前仓库状态。git 不可用时返回占位值（不抛）。"""
+    """读当前仓库状态。git 不可用 / zip 解压模式时返回占位值（不抛）。"""
+    repo = git_repo_status()
+    if not repo.is_repo:
+        # zip 模式：没有 .git/ 或 origin remote。版本面板看 is_git_repo
+        # 决定显示 init banner，不再依赖 commit/branch 字段。
+        return VersionInfo(
+            version=__version__,
+            commit="unknown",
+            commit_short="?",
+            commit_time_iso="",
+            branch="detached",
+            tag=None,
+            is_dirty=False,
+            installed_kind="zip",
+            installed_label=f"v{__version__}（zip 安装）",
+            stable_version=None,
+            is_git_repo=False,
+            git_available=repo.git_available,
+        )
+
     rc, head, _ = _git("rev-parse", "HEAD")
     commit = head if rc == 0 else "unknown"
     short = commit[:8] if commit != "unknown" else "?"
@@ -191,6 +342,8 @@ def current_version() -> VersionInfo:
         installed_kind=installed_kind,
         installed_label=installed_label,
         stable_version=stable_version,
+        is_git_repo=True,
+        git_available=True,
     )
 
 

--- a/studio/web/package.json
+++ b/studio/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "anima-studio-web",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -344,9 +344,13 @@ export interface GenerateSecretsConfig {
   attention_backend: AttentionBackend
 }
 
-/** 系统级偏好（ADR 0002 / PR-D）。show_dev_channel 开启后 Settings 暴露 dev
- *  通道按钮（手动检查 / 更新到 dev）；自动检查 + Topbar badge 仍然只看 master。 */
+/** 系统级偏好（ADR 0002 / 0005）。update_channel 是用户视图偏好（"stable" /
+ *  "dev"），与 git 工作树状态解耦：toggle 切换不触发 git 操作，仅改 UI 展示
+ *  的通道；真正"切到 dev HEAD" / "更新到 vX.Y.Z" 是单独按钮。
+ *  show_dev_channel 是 deprecated 字段（pydantic 兼容），新代码用 update_channel。 */
 export interface SystemPrefsConfig {
+  update_channel: 'stable' | 'dev'
+  /** @deprecated use update_channel */
   show_dev_channel: boolean
 }
 
@@ -1859,20 +1863,45 @@ export interface SystemVersion {
   commit: string
   commit_short: string
   commit_time_iso: string
+  /** @deprecated UI 用 installed_kind / installed_label；branch 仅 debug */
   branch: string
   tag: string | null
   is_dirty: boolean
+  /** 产品视角的"装了什么"分类（ADR 0005）。
+   *  - stable：HEAD 命中 vX.Y.Z release tag，或 __version__ 匹某 release tag 且 tree 一致
+   *  - dev：commit == origin/dev HEAD
+   *  - custom：feature branch / detached / 未识别 commit */
+  installed_kind: 'stable' | 'dev' | 'custom'
+  /** 用户可读 label，如 "v0.8.0" / "dev @ f6f202b · 2026-05-16" / "自定义（feat/foo @ a1b2c3d）"。
+   *  dirty 时追加 "· 未提交修改" */
+  installed_label: string
+  /** "vX.Y.Z" 形式，仅 installed_kind=stable 时填；前端做版本号比对用 */
+  stable_version: string | null
 }
 
 export interface SystemUpdateCheck {
   channel: 'master' | 'dev'
   current_commit: string
   latest_commit: string
+  /** @deprecated 前端用 behind_count；commits_ahead 是 git 词汇 */
   commits_ahead: number
+  /** @deprecated 前端用 state；has_update = (state === 'update_available') */
   has_update: boolean
   latest_tag: string | null
   checked_at: number
   error: string | null
+  /** 状态机（ADR 0005）。
+   *  - up_to_date：已是最新（版本号 / commit 一致）
+   *  - update_available：远端有更新
+   *  - ahead：本地领先远端（罕见，常见于回滚后又抢跑）
+   *  - detached：当前 commit 不在 channel 历史上（feature branch / 离群） */
+  state: 'up_to_date' | 'update_available' | 'ahead' | 'detached'
+  /** 当前装的稳定版（master 通道）："vX.Y.Z" / null（没装 stable） */
+  installed_version: string | null
+  /** 远端最新稳定版（master 通道）："vX.Y.Z" / null（远端没 tag / dev 通道） */
+  latest_version: string | null
+  /** 前端文案"N 项更新"用（= commits_ahead，但语义更清楚） */
+  behind_count: number
 }
 
 /** PR-C — 最近一次 update 的结构化结果。

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1856,6 +1856,14 @@ export const api = {
   // target 接受任意 git ref（tag / branch / commit sha）。
   getPreflight: (target: string) =>
     req<PreflightResult>(`/api/system/preflight?target=${encodeURIComponent(target)}`),
+
+  // 0.8.1 hotfix — zip 安装用户一键初始化 git 仓库。幂等：已是 git 仓库
+  // 直接返 ok=true + already_initialized=true。失败 500 + detail.error。
+  initGitRepo: () =>
+    req<{ ok: boolean; already_initialized: boolean; anchor?: string; anchor_kind?: string }>(
+      '/api/system/init_git',
+      { method: 'POST' },
+    ),
 }
 
 export interface SystemVersion {
@@ -1870,13 +1878,18 @@ export interface SystemVersion {
   /** 产品视角的"装了什么"分类（ADR 0005）。
    *  - stable：HEAD 命中 vX.Y.Z release tag，或 __version__ 匹某 release tag 且 tree 一致
    *  - dev：commit == origin/dev HEAD
-   *  - custom：feature branch / detached / 未识别 commit */
-  installed_kind: 'stable' | 'dev' | 'custom'
+   *  - custom：feature branch / detached / 未识别 commit
+   *  - zip：REPO_ROOT/.git 缺失（zip 解压用户，0.8.1 hotfix） */
+  installed_kind: 'stable' | 'dev' | 'custom' | 'zip'
   /** 用户可读 label，如 "v0.8.0" / "dev @ f6f202b · 2026-05-16" / "自定义（feat/foo @ a1b2c3d）"。
    *  dirty 时追加 "· 未提交修改" */
   installed_label: string
   /** "vX.Y.Z" 形式，仅 installed_kind=stable 时填；前端做版本号比对用 */
   stable_version: string | null
+  /** False = zip 安装 / 没有 origin remote。前端显示 init banner 时用（0.8.1 hotfix） */
+  is_git_repo: boolean
+  /** False = git binary 不在 PATH。zip 用户 + 没装 git → 显示"先装 git"提示而非 init 按钮 */
+  git_available: boolean
 }
 
 export interface SystemUpdateCheck {

--- a/studio/web/src/lib/versionPanel.test.ts
+++ b/studio/web/src/lib/versionPanel.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from 'vitest'
+import type { SystemUpdateCheck } from '../api/client'
+import {
+  formatDevStateText,
+  formatMasterStateText,
+  isDevSwitchButtonDisabled,
+  shouldShowMasterUpdateButton,
+} from './versionPanel'
+
+/** 构造一个 check 对象（必填字段填默认值，便于按需 override）。 */
+function mkCheck(over: Partial<SystemUpdateCheck>): SystemUpdateCheck {
+  return {
+    channel: 'master',
+    current_commit: '',
+    latest_commit: '',
+    commits_ahead: 0,
+    has_update: false,
+    latest_tag: null,
+    checked_at: 0,
+    error: null,
+    state: 'up_to_date',
+    installed_version: null,
+    latest_version: null,
+    behind_count: 0,
+    ...over,
+  }
+}
+
+describe('formatMasterStateText (ADR 0005)', () => {
+  it('null check → 未检查', () => {
+    expect(formatMasterStateText(null)).toBe('未检查')
+  })
+
+  it('up_to_date + latest_version → 已是最新 vX.Y.Z', () => {
+    expect(formatMasterStateText(mkCheck({ state: 'up_to_date', latest_version: 'v0.8.0' })))
+      .toBe('已是最新 v0.8.0')
+  })
+
+  it('up_to_date 无 latest_version → 已是最新', () => {
+    expect(formatMasterStateText(mkCheck({ state: 'up_to_date' }))).toBe('已是最新')
+  })
+
+  it('update_available 显示目标版本号', () => {
+    expect(formatMasterStateText(mkCheck({
+      state: 'update_available', latest_version: 'v0.9.0',
+    }))).toBe('有新稳定版 v0.9.0')
+  })
+
+  it('update_available fallback 到 latest_tag', () => {
+    expect(formatMasterStateText(mkCheck({
+      state: 'update_available', latest_version: null, latest_tag: 'v0.9.0-rc1',
+    }))).toBe('有新稳定版 v0.9.0-rc1')
+  })
+
+  it('ahead → 本地领先稳定版（不暴露 commit 词汇）', () => {
+    expect(formatMasterStateText(mkCheck({ state: 'ahead' }))).toBe('本地领先稳定版')
+  })
+
+  it('detached → 当前 commit 不在稳定版历史上', () => {
+    expect(formatMasterStateText(mkCheck({ state: 'detached' })))
+      .toBe('当前 commit 不在稳定版历史上')
+  })
+
+  it('不出现 git 词汇：commits / sha / branch', () => {
+    const samples = [
+      formatMasterStateText(mkCheck({ state: 'up_to_date', latest_version: 'v0.8.0' })),
+      formatMasterStateText(mkCheck({ state: 'update_available', latest_version: 'v0.9.0' })),
+      formatMasterStateText(mkCheck({ state: 'ahead' })),
+    ]
+    for (const s of samples) {
+      expect(s).not.toMatch(/commits?/i)
+      expect(s).not.toMatch(/\bsha\b/i)
+      expect(s).not.toMatch(/branch/i)
+    }
+  })
+})
+
+describe('formatDevStateText (ADR 0005)', () => {
+  it('null check → 未抓取', () => {
+    expect(formatDevStateText(null)).toBe('未抓取')
+  })
+
+  it('up_to_date → 与 dev HEAD 一致', () => {
+    expect(formatDevStateText(mkCheck({ channel: 'dev', state: 'up_to_date' })))
+      .toBe('与 dev HEAD 一致')
+  })
+
+  it('update_available with behind_count=3 → 有 3 项新更新', () => {
+    expect(formatDevStateText(mkCheck({
+      channel: 'dev', state: 'update_available', behind_count: 3,
+    }))).toBe('有 3 项新更新')
+  })
+
+  it('update_available with behind_count=0 → 有新更新', () => {
+    expect(formatDevStateText(mkCheck({
+      channel: 'dev', state: 'update_available', behind_count: 0,
+    }))).toBe('有新更新')
+  })
+
+  it('ahead → 本地领先 dev HEAD', () => {
+    expect(formatDevStateText(mkCheck({ channel: 'dev', state: 'ahead' })))
+      .toBe('本地领先 dev HEAD')
+  })
+
+  it('不出现 "commits" 字眼（dev 通道改"项更新"）', () => {
+    const s = formatDevStateText(mkCheck({
+      channel: 'dev', state: 'update_available', behind_count: 5,
+    }))
+    expect(s).not.toMatch(/commits?/i)
+    expect(s).toContain('项新更新')
+  })
+})
+
+describe('shouldShowMasterUpdateButton', () => {
+  it('null check → false', () => {
+    expect(shouldShowMasterUpdateButton(null)).toBe(false)
+  })
+
+  it('up_to_date → false（已是最新，不显示更新按钮）', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'up_to_date', latest_version: 'v0.8.0',
+    }))).toBe(false)
+  })
+
+  it('update_available + latest_version → true', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'update_available', latest_version: 'v0.9.0',
+    }))).toBe(true)
+  })
+
+  it('update_available 但无目标版本号 → false（防止显示空目标按钮）', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'update_available', latest_version: null, latest_tag: null,
+    }))).toBe(false)
+  })
+
+  it('ahead / detached → false（不暗示用户能"更新到自己"）', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'ahead' }))).toBe(false)
+    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'detached' }))).toBe(false)
+  })
+})
+
+describe('isDevSwitchButtonDisabled (release 直后场景 regression)', () => {
+  it('up_to_date → disabled（当前 commit 已等于 dev HEAD，切是 no-op）', () => {
+    expect(isDevSwitchButtonDisabled(mkCheck({
+      channel: 'dev', state: 'up_to_date',
+    }))).toBe(true)
+  })
+
+  it('update_available → 可点', () => {
+    expect(isDevSwitchButtonDisabled(mkCheck({
+      channel: 'dev', state: 'update_available', behind_count: 2,
+    }))).toBe(false)
+  })
+
+  it('null check → 可点（用户没抓取过，按钮要能触发抓取 + 切换）', () => {
+    expect(isDevSwitchButtonDisabled(null)).toBe(false)
+  })
+})

--- a/studio/web/src/lib/versionPanel.test.ts
+++ b/studio/web/src/lib/versionPanel.test.ts
@@ -5,6 +5,7 @@ import {
   formatMasterStateText,
   isDevSwitchButtonDisabled,
   shouldShowMasterUpdateButton,
+  shouldShowSwitchToStableButton,
 } from './versionPanel'
 
 /** 构造一个 check 对象（必填字段填默认值，便于按需 override）。 */
@@ -113,30 +114,72 @@ describe('formatDevStateText (ADR 0005)', () => {
 
 describe('shouldShowMasterUpdateButton', () => {
   it('null check → false', () => {
-    expect(shouldShowMasterUpdateButton(null)).toBe(false)
+    expect(shouldShowMasterUpdateButton(null, 'stable')).toBe(false)
   })
 
   it('up_to_date → false（已是最新，不显示更新按钮）', () => {
     expect(shouldShowMasterUpdateButton(mkCheck({
       state: 'up_to_date', latest_version: 'v0.8.0',
-    }))).toBe(false)
+    }), 'stable')).toBe(false)
   })
 
-  it('update_available + latest_version → true', () => {
+  it('update_available + 装 stable + latest_version → true', () => {
     expect(shouldShowMasterUpdateButton(mkCheck({
       state: 'update_available', latest_version: 'v0.9.0',
-    }))).toBe(true)
+    }), 'stable')).toBe(true)
+  })
+
+  it('update_available + 装 dev → false（由"切到稳定版"按钮覆盖，避免双按钮）', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'update_available', latest_version: 'v0.8.0',
+    }), 'dev')).toBe(false)
+  })
+
+  it('update_available + 装 custom → false', () => {
+    expect(shouldShowMasterUpdateButton(mkCheck({
+      state: 'update_available', latest_version: 'v0.8.0',
+    }), 'custom')).toBe(false)
   })
 
   it('update_available 但无目标版本号 → false（防止显示空目标按钮）', () => {
     expect(shouldShowMasterUpdateButton(mkCheck({
       state: 'update_available', latest_version: null, latest_tag: null,
-    }))).toBe(false)
+    }), 'stable')).toBe(false)
   })
 
   it('ahead / detached → false（不暗示用户能"更新到自己"）', () => {
-    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'ahead' }))).toBe(false)
-    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'detached' }))).toBe(false)
+    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'ahead' }), 'stable')).toBe(false)
+    expect(shouldShowMasterUpdateButton(mkCheck({ state: 'detached' }), 'stable')).toBe(false)
+  })
+})
+
+describe('shouldShowSwitchToStableButton', () => {
+  it('装 stable → false（已经在稳定版了）', () => {
+    expect(shouldShowSwitchToStableButton(mkCheck({
+      state: 'update_available', latest_version: 'v0.9.0',
+    }), 'stable')).toBe(false)
+  })
+
+  it('装 dev + 远端有 latest_version → true', () => {
+    expect(shouldShowSwitchToStableButton(mkCheck({
+      latest_version: 'v0.8.0',
+    }), 'dev')).toBe(true)
+  })
+
+  it('装 custom + 远端有 latest_version → true', () => {
+    expect(shouldShowSwitchToStableButton(mkCheck({
+      latest_version: 'v0.8.0',
+    }), 'custom')).toBe(true)
+  })
+
+  it('装 dev + 远端无 latest_version → false', () => {
+    expect(shouldShowSwitchToStableButton(mkCheck({
+      latest_version: null,
+    }), 'dev')).toBe(false)
+  })
+
+  it('null check → false', () => {
+    expect(shouldShowSwitchToStableButton(null, 'dev')).toBe(false)
   })
 })
 
@@ -153,7 +196,15 @@ describe('isDevSwitchButtonDisabled (release 直后场景 regression)', () => {
     }))).toBe(false)
   })
 
-  it('null check → 可点（用户没抓取过，按钮要能触发抓取 + 切换）', () => {
+  it('null check + installedKind=dev → disabled（fallback，避免按钮看上去可点）', () => {
+    expect(isDevSwitchButtonDisabled(null, 'dev')).toBe(true)
+  })
+
+  it('null check + installedKind=stable → 可点（要能触发抓取 + 切换）', () => {
+    expect(isDevSwitchButtonDisabled(null, 'stable')).toBe(false)
+  })
+
+  it('null check 无 installedKind → 可点', () => {
     expect(isDevSwitchButtonDisabled(null)).toBe(false)
   })
 })

--- a/studio/web/src/lib/versionPanel.ts
+++ b/studio/web/src/lib/versionPanel.ts
@@ -1,0 +1,60 @@
+/** 版本面板文案 mapping（ADR 0005）。
+ *
+ * 把"check.state + version/check 数据 → 用户可读文案"的逻辑抽出来，
+ * 与 React 组件解耦便于单测。所有文案**只用版本号 / 状态语言**，
+ * 不出现 commits / sha / branch 等 git 词汇。
+ */
+import type { SystemUpdateCheck } from '../api/client'
+
+/** master（稳定版）通道的状态行文案。
+ *
+ * 优先级：
+ * - up_to_date：已是最新 vX.Y.Z（latest_version 有就拼版本号，没就裸"已是最新"）
+ * - update_available：有新稳定版 vX.Y.Z
+ * - ahead：本地领先稳定版（罕见，回滚 / 抢跑）
+ * - detached：当前 commit 不在稳定版历史上（feature branch）
+ * - check=null：未检查
+ */
+export function formatMasterStateText(check: SystemUpdateCheck | null): string {
+  if (!check) return '未检查'
+  if (check.state === 'up_to_date') {
+    return check.latest_version ? `已是最新 ${check.latest_version}` : '已是最新'
+  }
+  if (check.state === 'update_available') {
+    const target = check.latest_version ?? check.latest_tag ?? check.latest_commit?.slice(0, 8) ?? ''
+    return target ? `有新稳定版 ${target}` : '有新稳定版'
+  }
+  if (check.state === 'ahead') return '本地领先稳定版'
+  return '当前 commit 不在稳定版历史上'
+}
+
+/** dev（开发版）通道的状态行文案。
+ *
+ * dev 没有版本号语义（滚动），所以"N 项新更新"是合理表达；不暴露
+ * commits 字眼给用户。
+ */
+export function formatDevStateText(check: SystemUpdateCheck | null): string {
+  if (!check) return '未抓取'
+  if (check.state === 'up_to_date') return '与 dev HEAD 一致'
+  if (check.state === 'update_available') {
+    return check.behind_count > 0 ? `有 ${check.behind_count} 项新更新` : '有新更新'
+  }
+  if (check.state === 'ahead') return '本地领先 dev HEAD'
+  return '当前 commit 不在 dev 历史上'
+}
+
+/** master 通道"更新"按钮是否应该显示（state=update_available 且有目标版本）。 */
+export function shouldShowMasterUpdateButton(check: SystemUpdateCheck | null): boolean {
+  if (!check || check.state !== 'update_available') return false
+  return !!(check.latest_version ?? check.latest_tag)
+}
+
+/** dev 通道"切到 dev HEAD"按钮是否应该 disabled。
+ *
+ * 当 state=up_to_date 时按钮 disabled —— 即便用户的 installed_kind 是
+ * stable，只要 commit 已等于 origin/dev HEAD，切操作就是 no-op，
+ * 该 disabled 避免点了无反应（release 直后场景）。
+ */
+export function isDevSwitchButtonDisabled(check: SystemUpdateCheck | null): boolean {
+  return check?.state === 'up_to_date'
+}

--- a/studio/web/src/lib/versionPanel.ts
+++ b/studio/web/src/lib/versionPanel.ts
@@ -43,18 +43,46 @@ export function formatDevStateText(check: SystemUpdateCheck | null): string {
   return '当前 commit 不在 dev 历史上'
 }
 
-/** master 通道"更新"按钮是否应该显示（state=update_available 且有目标版本）。 */
-export function shouldShowMasterUpdateButton(check: SystemUpdateCheck | null): boolean {
+/** master 通道"更新到 vX.Y.Z"按钮是否应该显示。
+ *
+ * 仅在「装的是 stable + 远端有新稳定版」时显示 —— 装非 stable（dev / custom）
+ * 时由「切到稳定版 vX.Y.Z」按钮覆盖（两个按钮做同一件事，避免同屏显示重复）。
+ */
+export function shouldShowMasterUpdateButton(
+  check: SystemUpdateCheck | null,
+  installedKind: 'stable' | 'dev' | 'custom' | undefined,
+): boolean {
   if (!check || check.state !== 'update_available') return false
+  if (installedKind !== 'stable') return false
   return !!(check.latest_version ?? check.latest_tag)
+}
+
+/** master 通道「切到稳定版 vX.Y.Z」按钮是否应该显示。
+ *
+ * 装非 stable 时显示（切回最新稳定版的入口）。装 stable 时由
+ * `shouldShowMasterUpdateButton` 覆盖。
+ */
+export function shouldShowSwitchToStableButton(
+  check: SystemUpdateCheck | null,
+  installedKind: 'stable' | 'dev' | 'custom' | undefined,
+): boolean {
+  if (!check || installedKind === 'stable') return false
+  return !!check.latest_version
 }
 
 /** dev 通道"切到 dev HEAD"按钮是否应该 disabled。
  *
- * 当 state=up_to_date 时按钮 disabled —— 即便用户的 installed_kind 是
- * stable，只要 commit 已等于 origin/dev HEAD，切操作就是 no-op，
- * 该 disabled 避免点了无反应（release 直后场景）。
+ * 优先看 check.state：state=up_to_date → disabled（commit 已等于 dev HEAD，
+ * 切是 no-op；release 直后场景常见）。
+ *
+ * check 未加载时按 installedKind fallback：装的是 dev tip → disabled
+ * （避免 check 还没 resolve 期间按钮看上去可点但实际 no-op）。
  */
-export function isDevSwitchButtonDisabled(check: SystemUpdateCheck | null): boolean {
-  return check?.state === 'up_to_date'
+export function isDevSwitchButtonDisabled(
+  check: SystemUpdateCheck | null,
+  installedKind?: 'stable' | 'dev' | 'custom',
+): boolean {
+  if (check?.state === 'up_to_date') return true
+  if (!check && installedKind === 'dev') return true
+  return false
 }

--- a/studio/web/src/lib/versionPanel.ts
+++ b/studio/web/src/lib/versionPanel.ts
@@ -50,7 +50,7 @@ export function formatDevStateText(check: SystemUpdateCheck | null): string {
  */
 export function shouldShowMasterUpdateButton(
   check: SystemUpdateCheck | null,
-  installedKind: 'stable' | 'dev' | 'custom' | undefined,
+  installedKind: 'stable' | 'dev' | 'custom' | 'zip' | undefined,
 ): boolean {
   if (!check || check.state !== 'update_available') return false
   if (installedKind !== 'stable') return false
@@ -64,7 +64,7 @@ export function shouldShowMasterUpdateButton(
  */
 export function shouldShowSwitchToStableButton(
   check: SystemUpdateCheck | null,
-  installedKind: 'stable' | 'dev' | 'custom' | undefined,
+  installedKind: 'stable' | 'dev' | 'custom' | 'zip' | undefined,
 ): boolean {
   if (!check || installedKind === 'stable') return false
   return !!check.latest_version
@@ -80,7 +80,7 @@ export function shouldShowSwitchToStableButton(
  */
 export function isDevSwitchButtonDisabled(
   check: SystemUpdateCheck | null,
-  installedKind?: 'stable' | 'dev' | 'custom',
+  installedKind?: 'stable' | 'dev' | 'custom' | 'zip',
 ): boolean {
   if (check?.state === 'up_to_date') return true
   if (!check && installedKind === 'dev') return true

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -29,6 +29,12 @@ import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
 import { useEventStream } from '../../lib/useEventStream'
+import {
+  formatMasterStateText,
+  formatDevStateText,
+  shouldShowMasterUpdateButton,
+  isDevSwitchButtonDisabled,
+} from '../../lib/versionPanel'
 import { applyDensity, applyTheme, getStoredDensity, getStoredTheme, setStoredDensity, setStoredTheme, type Density, type Theme } from '../../lib/theme'
 
 const MASK = '***'
@@ -214,7 +220,7 @@ const EMPTY: Secrets = {
   models: { root: null, selected_anima: '1.0', selected_upscaler: '4x-AnimeSharp' },
   queue: { allow_gpu_during_train: false },
   generate: { preview_every_n_steps: 3, attention_backend: 'auto' },
-  system: { show_dev_channel: false },
+  system: { update_channel: 'stable', show_dev_channel: false },
 }
 
 const textInputClass = 'w-full px-2 py-1 outline-none rounded-sm bg-sunken border border-subtle text-sm text-fg-primary focus:border-accent'
@@ -2625,20 +2631,23 @@ async function pollHealthThenReload(
   onTimeout()
 }
 
-// ── 版本 Section（双通道重设计 — Chunk 1）─────────────────────────────
+// ── 版本 Section（ADR 0005 重设计 — 单视图 + 通道偏好）───────────────
 //
-// 布局：master / dev 两张通道卡并排（dev 隐藏时 master solo）。toggle 行
-// 下移到卡片之后（demoted），不是建议操作；当前在 dev 时强制开 + 锁定。
+// 产品模型：
+// - 通道（channel）是**用户视图偏好**：你想订阅哪条更新轨道（稳定 / 开发）
+// - 与 git 工作树状态**解耦**：切 toggle 不动 git；真正"切到 dev HEAD" /
+//   "更新到 vX.Y.Z" 是单独按钮
+// - 同屏只显示当前选中通道的卡片（不并排）—— 通道是互斥视图，并排会让
+//   用户陷入"我究竟在哪里"的矛盾
+// - 文案语言只有"版本号"+"状态"，绝不出现"commits"/"sha"等 git 词汇
 //
-// 加载时 fetch /api/system/version + /api/system/update_check（master,
-// 走 cache）+ /api/system/update_status + /api/secrets.system。
+// 数据：
+// - version.installed_kind (stable / dev / custom) + installed_label：装了什么
+// - check.state (up_to_date / update_available / ahead / detached)：相对所选
+//   通道的状态
+// - prefs.update_channel：用户偏好（"stable" / "dev"）
 //
 // 自动检查 + Topbar 红点仍然只看 master（ADR 0002 决策）。
-//
-// 状态（chunk 1）：synced / has-update / failed（用现有 .update_status 数据）；
-// 操作按钮"更新到 X" / "切到 X" 仍走现有 dialog 模态。preview / progress /
-// inline-failed 状态机留给 chunk 4。release notes 留给 chunk 2，dev commits
-// 列表留给 chunk 3。
 function VersionSection() {
   const { toast } = useToast()
   // chunk 4：dialog 模态被 inline preview 面板取代，VersionSection 不再用 dialog
@@ -2675,18 +2684,19 @@ function VersionSection() {
     void api.getSecrets().then((s) => setPrefs(s.system)).catch(() => { /* silent */ })
   }, [])
 
-  // chunk 3 — devVisible 第一次转 true 时自动拉一遍 dev_commits + check（用户
-  // 不用先手动按 [抓取 dev] 才看到时间线）。后续 [抓取 dev] 按钮再做刷新。
-  const devVisibleNow = (version?.branch === 'dev') || !!prefs?.show_dev_channel
+  // 选中 dev 通道时自动拉 dev_commits + dev check（用户不用先手动按 [抓取 dev]）。
+  // 即便装的是 stable，用户切到 dev 通道偏好时也要能立刻看到 dev HEAD 信息。
+  const channelPref: 'stable' | 'dev' = prefs?.update_channel ?? 'stable'
+  const showDevView = channelPref === 'dev'
   useEffect(() => {
-    if (!devVisibleNow || devCommits !== null) return
+    if (!showDevView || devCommits !== null) return
     let cancelled = false
     void api.getDevCommits(10).then((r) => { if (!cancelled) setDevCommits(r) }).catch(() => { /* silent */ })
     if (devCheck === null) {
       void api.checkSystemUpdate('dev', true).then((r) => { if (!cancelled) setDevCheck(r) }).catch(() => { /* silent */ })
     }
     return () => { cancelled = true }
-  }, [devVisibleNow, devCommits, devCheck])
+  }, [showDevView, devCommits, devCheck])
 
   const handleCheck = async () => {
     setChecking(true)
@@ -2695,10 +2705,13 @@ function VersionSection() {
       setCheck(r)
       if (r.error) {
         toast(`检查失败: ${r.error}`, 'error')
-      } else if (r.has_update) {
-        toast(`有新版本：${r.latest_tag ?? r.latest_commit.slice(0, 8)}（${r.commits_ahead} commits）`, 'info')
+      } else if (r.state === 'update_available') {
+        const target = r.latest_version ?? r.latest_tag ?? r.latest_commit.slice(0, 8)
+        toast(`有新稳定版：${target}`, 'info')
+      } else if (r.state === 'ahead') {
+        toast('本地领先稳定版（可能由回滚 / 抢跑造成）', 'info')
       } else {
-        toast('已是最新版本', 'success')
+        toast(`已是最新${r.latest_version ? '稳定版 ' + r.latest_version : ''}`, 'success')
       }
     } catch (e) {
       toast(`检查更新失败: ${e}`, 'error')
@@ -2806,17 +2819,23 @@ function VersionSection() {
     }
   }
 
-  // PR-D — dev 通道 toggle 持久化到 secrets.json。乐观更新 + 失败回滚。
-  const handleToggleDevChannel = async (next: boolean) => {
+  // ADR 0005 — 通道偏好持久化到 secrets.json。**不触发任何 git 操作**，
+  // 只是切换 UI 视图。乐观更新 + 失败回滚。
+  const handleSwitchChannel = async (next: 'stable' | 'dev') => {
     const prev = prefs
-    setPrefs((p) => p ? { ...p, show_dev_channel: next } : { show_dev_channel: next })
-    if (!next) setDevCheck(null)        // 关掉时清掉缓存的 dev 检查结果
+    setPrefs((p) => p
+      ? { ...p, update_channel: next }
+      : { update_channel: next, show_dev_channel: next === 'dev' })
+    if (next === 'stable') setDevCheck(null)  // 切回稳定版时清掉 dev 缓存
     try {
-      const updated = await api.updateSecrets({ system: { show_dev_channel: next } })
+      // 同步写 show_dev_channel 字段，保留对老版本回滚兼容
+      const updated = await api.updateSecrets({
+        system: { update_channel: next, show_dev_channel: next === 'dev' },
+      })
       setPrefs(updated.system)
     } catch (e) {
-      setPrefs(prev)                    // 失败回滚 UI
-      toast(`保存失败: ${(e as Error).message ?? e}`, 'error')
+      setPrefs(prev)
+      toast(`保存通道偏好失败: ${(e as Error).message ?? e}`, 'error')
     }
   }
 
@@ -2834,10 +2853,12 @@ function VersionSection() {
         toast(`dev 检查失败: ${check.error}`, 'error')
       } else if (commits.error && !commits.fetched) {
         toast(`dev 抓取部分失败: ${commits.error}`, 'error')
-      } else if (check.has_update) {
-        toast(`dev 通道有 ${check.commits_ahead} commits 新提交`, 'info')
+      } else if (check.state === 'update_available') {
+        toast(`dev 通道有 ${check.behind_count} 项新更新`, 'info')
+      } else if (check.state === 'ahead') {
+        toast('本地领先 dev HEAD（罕见，可能是抢跑）', 'info')
       } else {
-        toast('dev 通道与当前一致', 'success')
+        toast('已与 dev HEAD 一致', 'success')
       }
     } catch (e) {
       toast(`dev 检查失败: ${e}`, 'error')
@@ -2874,21 +2895,20 @@ function VersionSection() {
     })
   }
 
-  // 通道判定 + 派生状态
-  const onDev = version?.branch === 'dev'
-  // dev 卡显示条件：toggle 开了，或者当前已经在 dev（强制可见）
-  const devVisible = onDev || !!prefs?.show_dev_channel
-  const hasUpdate = !!check?.has_update
+  // 派生状态（ADR 0005）：installed_kind / state 取代 branch / has_update
+  const installedIsDevHead = version?.installed_kind === 'dev'
+  const masterHasUpdate = check?.state === 'update_available'
   const hasRollback = !!status?.rollback_target
   // 上次 update 失败 banner（aborted / failed / partial 时显示红色提示）
   const statusBadFailed = !!status && (status.status === 'failed' || status.status === 'aborted' || status.status === 'partial')
 
-  // chunk 2 — 当展示的 tag 变化时拉对应 release notes。展示 tag = hasUpdate
-  // 时为目标 tag（"v0.6.1 · 更新内容"），否则当前 tag（"v0.6.0 · 此版本"）。
-  // CHANGELOG.md 没条目时 found=false，UI 自然 fallback 到占位链接。
-  const displayedTag = hasUpdate
-    ? (check?.latest_tag ?? null)
-    : (version?.tag ?? (version ? `v${version.version}` : null))
+  // release notes 拉对应 tag：stable 通道有更新时展示目标版本，否则展示当前
+  // 已装版本；dev 通道不展示 release notes（dev 是滚动的，没有版本号语义）
+  const displayedTag = showDevView
+    ? null
+    : masterHasUpdate
+      ? (check?.latest_version ?? check?.latest_tag ?? null)
+      : (version?.stable_version ?? version?.tag ?? (version ? `v${version.version}` : null))
   useEffect(() => {
     if (!displayedTag) {
       setReleaseNotes(null)
@@ -2910,67 +2930,78 @@ function VersionSection() {
       headerExtras={
         <InfoButton>
           <ul>
-            <li>自动检查每 24 小时，仅看 master 通道；dev 必须主动触发，不进 Topbar 红点</li>
+            <li>切换通道是改 UI 视图偏好（不动 git）；真正"切到 dev HEAD" / "更新到 vX.Y.Z" 是单独按钮</li>
+            <li>自动检查每 24 小时，仅看稳定版通道；切到开发版通道不进 Topbar 红点</li>
             <li>更新 / 切换底层走 git reset --hard，需要时跑 pip / npm install</li>
             <li>有运行中任务 / 本地工作树脏 → 操作会被 pre-flight 拒绝</li>
-            <li>master 显示 release tag；dev 显示 commit 时间线，可点任意 commit 切换</li>
           </ul>
         </InfoButton>
       }
     >
-      {/* dev toggle 行：搬到 title 下面（独立一行），不再下方"附庸" */}
-      <div className={`vs-dev-toggle-row${devVisible ? ' open' : ''}${onDev ? ' locked' : ''}`}>
-        <div className="vs-lhs">
-          <div
-            className={`vs-sw${devVisible ? ' on' : ''}${onDev ? ' locked' : ''}`}
-            onClick={() => { if (!onDev) void handleToggleDevChannel(!devVisible) }}
-            role="switch"
-            aria-checked={devVisible}
-            aria-disabled={onDev}
-          />
-          <div>
-            <div className="vs-t" style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap' }}>
-              <span>查看 dev 通道（开发版）</span>
-              {onDev && (
-                <span className="vs-lock-pill">
-                  <VersionIcon name="lock" />当前在 dev · 不可关闭
-                </span>
-              )}
-            </div>
-          </div>
-        </div>
+      {/* 顶部：你装的是什么（一行事实状态，与通道偏好解耦） */}
+      <div className="vs-installed-row">
+        <span className="vs-installed-label">你装的：</span>
+        <b className="vs-installed-value">{version?.installed_label ?? '加载中…'}</b>
+        {version?.is_dirty && !version.installed_label.includes('未提交修改') && (
+          <span className="vs-installed-warn">· 本地有改动</span>
+        )}
+      </div>
+
+      {/* 通道偏好：radio toggle（不触发 git） */}
+      <div className="vs-channel-toggle-row">
+        <span className="vs-channel-toggle-label">更新通道：</span>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={channelPref === 'stable'}
+          className={`vs-channel-radio${channelPref === 'stable' ? ' on' : ''}`}
+          onClick={() => { if (channelPref !== 'stable') void handleSwitchChannel('stable') }}
+        >
+          <span className="vs-channel-dot" />稳定版
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={channelPref === 'dev'}
+          className={`vs-channel-radio${channelPref === 'dev' ? ' on' : ''}`}
+          onClick={() => { if (channelPref !== 'dev') void handleSwitchChannel('dev') }}
+        >
+          <span className="vs-channel-dot" />开发版
+        </button>
+        <span className="vs-channel-hint">仅切 UI 视图，不动 git</span>
       </div>
 
       <div className="vs-sec-card">
-        <div className={`vs-channels${devVisible ? ' both' : ''}`}>
-          <MasterCard
-            on={!onDev}
-            solo={!devVisible}
-            version={version}
-            check={check}
-            status={status}
-            hasUpdate={hasUpdate}
-            hasRollback={hasRollback}
-            statusBadFailed={statusBadFailed}
-            releaseNotes={releaseNotes}
-            onShowReleaseNotesDetail={() => setDetailModalOpen(true)}
-            checking={checking}
-            busy={busy}
-            cardState={masterState}
-            pendingTarget={pendingTarget}
-            preflight={preflight}
-            preflightLoading={preflightLoading}
-            onCancelPreview={cancelPreview}
-            onConfirmPreview={confirmPreview}
-            onCheck={handleCheck}
-            onUpdate={handleUpdate}
-            onSwitchToMaster={handleSwitchToMaster}
-            onRollback={handleRollback}
-            onViewLog={handleViewLog}
-          />
-          {devVisible && (
+        <div className="vs-channels">
+          {!showDevView ? (
+            <MasterCard
+              on={true}
+              solo={true}
+              version={version}
+              check={check}
+              status={status}
+              hasUpdate={masterHasUpdate}
+              hasRollback={hasRollback}
+              statusBadFailed={statusBadFailed}
+              releaseNotes={releaseNotes}
+              onShowReleaseNotesDetail={() => setDetailModalOpen(true)}
+              checking={checking}
+              busy={busy}
+              cardState={masterState}
+              pendingTarget={pendingTarget}
+              preflight={preflight}
+              preflightLoading={preflightLoading}
+              onCancelPreview={cancelPreview}
+              onConfirmPreview={confirmPreview}
+              onCheck={handleCheck}
+              onUpdate={handleUpdate}
+              onSwitchToMaster={handleSwitchToMaster}
+              onRollback={handleRollback}
+              onViewLog={handleViewLog}
+            />
+          ) : (
             <DevCard
-              on={onDev}
+              on={installedIsDevHead}
               check={devCheck}
               commits={devCommits}
               currentSha={version?.commit ?? ''}
@@ -3249,15 +3280,20 @@ function MasterReleaseNotes({
 }
 
 function MasterCard(p: MasterCardProps) {
-  const currentTag = p.version?.tag ?? (p.version ? `v${p.version.version}` : '加载中…')
-  const targetTag = p.check?.latest_tag ?? p.check?.latest_commit?.slice(0, 8) ?? ''
-  // chunk 4 — preview / progress 状态优先渲染（替代 chan-body + chan-foot）
+  // 当前装的版本号优先用 stable_version（精确），fallback 到 __version__
+  const currentTag = p.version?.stable_version
+    ?? p.version?.tag
+    ?? (p.version ? `v${p.version.version}` : '加载中…')
+  // 远端最新稳定版（state=update_available 时显示）
+  const targetTag = p.check?.latest_version ?? p.check?.latest_tag ?? ''
+  const stateText = formatMasterStateText(p.check)
+  const showUpdateButton = shouldShowMasterUpdateButton(p.check)
   if (p.cardState === 'preview' && p.pendingTarget && p.pendingTarget.kind === 'master') {
     return (
-      <div className={`vs-chan${p.on ? ' here' : ''}`}>
+      <div className="vs-chan">
         <div className="vs-chan-head">
           <div className="vs-lhs">
-            <span className="vs-name">master · 确认更新</span>
+            <span className="vs-name">稳定版 · 确认更新</span>
             <span className="vs-pill vs-pill-stable"><span className="vs-dot" />稳定</span>
           </div>
           <button className="btn btn-sm btn-ghost" onClick={p.onCancelPreview} disabled={p.busy}>
@@ -3268,7 +3304,6 @@ function MasterCard(p: MasterCardProps) {
           channel="master"
           fromLabel={currentTag}
           toLabel={p.pendingTarget.label}
-          badge={p.check?.has_update ? `+${p.check.commits_ahead} commits` : undefined}
           details={
             <div className="vs-change-block">
               <div className="vs-h">{p.pendingTarget.label} · 更新内容</div>
@@ -3286,10 +3321,10 @@ function MasterCard(p: MasterCardProps) {
   }
   if (p.cardState === 'progress' && p.pendingTarget && p.pendingTarget.kind === 'master') {
     return (
-      <div className={`vs-chan${p.on ? ' here' : ''}`}>
+      <div className="vs-chan">
         <div className="vs-chan-head">
           <div className="vs-lhs">
-            <span className="vs-name">master · 更新中</span>
+            <span className="vs-name">稳定版 · 更新中</span>
             <span className="vs-pill vs-pill-stable"><span className="vs-dot" />稳定</span>
           </div>
         </div>
@@ -3305,16 +3340,13 @@ function MasterCard(p: MasterCardProps) {
     : null
 
   return (
-    <div className={`vs-chan${p.on ? ' here' : ''}`}>
+    <div className="vs-chan">
       <div className="vs-chan-head">
         <div className="vs-lhs">
-          <span className="vs-name">master</span>
+          <span className="vs-name">稳定版</span>
           <span className="vs-pill vs-pill-stable"><span className="vs-dot" />稳定</span>
-          {p.on && <span className="vs-pill vs-pill-here">● 你在这里</span>}
         </div>
-        <div className={`vs-meta${p.hasUpdate ? ' attn' : ''}`}>
-          {p.hasUpdate ? `↑ 落后 ${p.check?.commits_ahead ?? 0} commits` : '已是最新'}
-        </div>
+        <div className={`vs-meta${p.hasUpdate ? ' attn' : ''}`}>{stateText}</div>
       </div>
 
       {p.statusBadFailed && p.status && (
@@ -3362,18 +3394,6 @@ function MasterCard(p: MasterCardProps) {
           </div>
           <div className="vs-ver-meta">
             {releasedAt && <span>发布于 <b>{releasedAt}</b></span>}
-            {p.hasUpdate && (
-              <>
-                {releasedAt && <span className="vs-sep">·</span>}
-                <span>↑ {p.check?.commits_ahead ?? 0} commits</span>
-              </>
-            )}
-            {p.version?.is_dirty && (
-              <>
-                {(releasedAt || p.hasUpdate) && <span className="vs-sep">·</span>}
-                <span style={{ color: 'var(--warn)' }}>本地有改动</span>
-              </>
-            )}
           </div>
           {!p.hasUpdate && p.solo && (
             <div className="vs-ver-tagline">Topbar 红点 + 自动检查仅看此通道。</div>
@@ -3400,14 +3420,17 @@ function MasterCard(p: MasterCardProps) {
           <button onClick={p.onCheck} disabled={p.checking || p.busy} className="btn btn-sm">
             <VersionIcon name="refresh" />{p.checking ? '检查中…' : '检查更新'}
           </button>
-          {p.hasUpdate && p.on && (
+          {/* state=update_available 才显示更新按钮；up_to_date / ahead / detached 不显示
+              （上面 vs-meta 已经把"已是最新 / 本地领先 / 当前不在历史上"说清楚了）*/}
+          {showUpdateButton && (
             <button onClick={p.onUpdate} disabled={p.busy || p.checking} className="btn btn-sm btn-primary">
               {p.busy ? '更新中…' : `更新到 ${targetTag}…`}
             </button>
           )}
-          {!p.on && (
+          {/* 装在非稳定版（dev / custom）时显示"切到最新稳定版"按钮 */}
+          {p.version && p.version.installed_kind !== 'stable' && p.check?.latest_version && (
             <button onClick={p.onSwitchToMaster} disabled={p.busy || p.checking} className="btn btn-sm btn-primary">
-              {p.busy ? '切换中…' : '切到 master'}
+              {p.busy ? '切换中…' : `切到稳定版 ${p.check.latest_version}…`}
             </button>
           )}
         </div>
@@ -3468,18 +3491,18 @@ type DevCardProps = {
 function DevCard(p: DevCardProps) {
   const commits = p.commits?.commits ?? []
   const head = commits[0]?.short_sha ?? p.check?.latest_commit?.slice(0, 8)
-  const ahead = p.check?.commits_ahead ?? 0
   const selectedCommit = p.selectedSha ? commits.find((c) => c.sha === p.selectedSha) ?? null : null
   const fetchError = p.commits?.error ?? p.check?.error
   const currentShortSha = p.currentSha ? p.currentSha.slice(0, 8) : '当前'
-  // chunk 4 — preview / progress 状态优先渲染
+  const stateText = formatDevStateText(p.check)
+  const devSwitchDisabled = isDevSwitchButtonDisabled(p.check)
   if (p.cardState === 'preview' && p.pendingTarget && p.pendingTarget.kind === 'dev') {
     const t = p.pendingTarget
     return (
-      <div className={`vs-chan${p.on ? ' here' : ''}`}>
+      <div className="vs-chan">
         <div className="vs-chan-head">
           <div className="vs-lhs">
-            <span className="vs-name">dev · 确认切换</span>
+            <span className="vs-name">开发版 · 确认切换</span>
             <span className="vs-pill vs-pill-dev"><span className="vs-dot" />开发版</span>
           </div>
           <button className="btn btn-sm btn-ghost" onClick={p.onCancelPreview} disabled={p.busy}>
@@ -3506,7 +3529,7 @@ function DevCard(p: DevCardProps) {
                 </>
               ) : (
                 <div style={{ fontSize: 13, color: 'var(--fg-tertiary)', marginTop: 4 }}>
-                  切到 dev HEAD（git reset --hard origin/dev）
+                  切到 dev HEAD
                 </div>
               )}
             </div>
@@ -3522,10 +3545,10 @@ function DevCard(p: DevCardProps) {
   }
   if (p.cardState === 'progress' && p.pendingTarget && p.pendingTarget.kind === 'dev') {
     return (
-      <div className={`vs-chan${p.on ? ' here' : ''}`}>
+      <div className="vs-chan">
         <div className="vs-chan-head">
           <div className="vs-lhs">
-            <span className="vs-name">dev · 切换中</span>
+            <span className="vs-name">开发版 · 切换中</span>
             <span className="vs-pill vs-pill-dev"><span className="vs-dot" />开发版</span>
           </div>
         </div>
@@ -3535,20 +3558,19 @@ function DevCard(p: DevCardProps) {
   }
 
   return (
-    <div className={`vs-chan${p.on ? ' here' : ''}`}>
+    <div className="vs-chan">
       <div className="vs-chan-head">
         <div className="vs-lhs">
-          <span className="vs-name">dev</span>
+          <span className="vs-name">开发版</span>
           <span className="vs-pill vs-pill-dev"><span className="vs-dot" />开发版</span>
-          {p.on && <span className="vs-pill vs-pill-here">● 你在这里</span>}
         </div>
-        <div className="vs-meta">
+        <div className={`vs-meta${p.check?.state === 'update_available' ? ' attn' : ''}`}>
           {fetchError && !head ? (
             <span style={{ color: 'var(--err)' }}>{fetchError}</span>
           ) : head ? (
             <>
-              HEAD <b style={{ color: 'var(--fg-secondary)', fontWeight: 500 }}>{head}</b>
-              {p.check && (<>{' · '}{ahead === 0 ? '与 master 持平' : `↑ ${ahead}`}</>)}
+              dev HEAD <b style={{ color: 'var(--fg-secondary)', fontWeight: 500 }}>{head}</b>
+              {p.check && <>{' · '}{stateText}</>}
             </>
           ) : (
             <span>未抓取</span>
@@ -3650,15 +3672,18 @@ function DevCard(p: DevCardProps) {
             <button onClick={p.onCheck} disabled={p.checking || p.busy} className="btn btn-sm">
               <VersionIcon name="refresh" />{p.checking ? '抓取中…' : '抓取 dev'}
             </button>
-            {p.on ? (
-              <button disabled className="btn btn-sm">已在 dev HEAD</button>
+            {/* 切按钮 disabled 条件改用 commit 比较（state=up_to_date），不再
+                看 branch / installed_kind —— 因为 release 直后存在"装的是 stable
+                但 commit 恰好等于 dev HEAD"的边界，此时切操作是 no-op */}
+            {devSwitchDisabled ? (
+              <button disabled className="btn btn-sm">已与 dev HEAD 同步</button>
             ) : commits.length > 0 ? (
               <button
                 onClick={p.onSwitchToDev}
                 disabled={p.busy || p.checking}
                 className="btn btn-sm btn-warn"
               >
-                {p.busy ? '切换中…' : `切到 dev${head ? ` (${head})` : ''}`}
+                {p.busy ? '切换中…' : `切到 dev HEAD${head ? ` (${head})` : ''}`}
               </button>
             ) : null}
           </div>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -2677,13 +2677,49 @@ function VersionSection() {
   )
   // chunk 2 重做：release notes 详细内容 modal（含 detail markdown）
   const [detailModalOpen, setDetailModalOpen] = useState(false)
+  // 0.8.1 hotfix — zip 安装用户首次 init git 仓库
+  const [initing, setIniting] = useState(false)
+  const [initError, setInitError] = useState<string | null>(null)
 
   useEffect(() => {
-    void api.getSystemVersion().then(setVersion).catch(() => { /* silent */ })
-    void api.checkSystemUpdate('master').then(setCheck).catch(() => { /* silent */ })
+    let cancelled = false
+    void (async () => {
+      const v = await api.getSystemVersion().catch(() => null)
+      if (cancelled) return
+      if (v) setVersion(v)
+      // zip 模式下 check_update 会失败（git fetch 在没 .git/ 时报错），
+      // 没必要发请求。等用户 init 完后再触发。
+      if (v?.is_git_repo !== false) {
+        void api.checkSystemUpdate('master').then((r) => { if (!cancelled) setCheck(r) }).catch(() => { /* silent */ })
+      }
+    })()
     void api.getSystemUpdateStatus().then(setStatus).catch(() => { /* silent */ })
     void api.getSecrets().then((s) => setPrefs(s.system)).catch(() => { /* silent */ })
+    return () => { cancelled = true }
   }, [])
+
+  // 0.8.1 hotfix — 触发 zip → git 自动 normalize。成功后刷一遍 version + check
+  // 让 banner 消失、版本面板正常显示。bootstrap 不重启 server（只动 .git/），
+  // 不需要 pollHealthThenReload。
+  const handleInitGit = async () => {
+    setIniting(true)
+    setInitError(null)
+    try {
+      await api.initGitRepo()
+      toast('git 仓库初始化完成，自动更新已启用', 'success')
+      const v = await api.getSystemVersion().catch(() => null)
+      if (v) setVersion(v)
+      // init 后立刻拉一次 check，banner 消失 + 同屏显示「已是最新 / 有新版」
+      void api.checkSystemUpdate('master', true).then(setCheck).catch(() => { /* silent */ })
+    } catch (e) {
+      const err = e as Error & { detail?: { message?: string } }
+      const msg = err.detail?.message ?? err.message ?? String(e)
+      setInitError(msg)
+      toast(`初始化失败: ${msg}`, 'error')
+    } finally {
+      setIniting(false)
+    }
+  }
 
   // 选中 dev 通道时自动拉 dev_commits + dev check（用户不用先手动按 [抓取 dev]）。
   // 即便装的是 stable，用户切到 dev 通道偏好时也要能立刻看到 dev HEAD 信息。
@@ -2946,6 +2982,44 @@ function VersionSection() {
         </InfoButton>
       }
     >
+      {/* 0.8.1 hotfix — zip 安装用户首次启用自更新功能的 banner。
+          version.is_git_repo=false 时显示；git 不可用 vs 可用分两种文案。
+          init 成功后 setVersion 刷新，banner 自动消失。 */}
+      {version && !version.is_git_repo && (
+        <div className="vs-zip-banner">
+          {!version.git_available ? (
+            <>
+              <div className="vs-zip-banner-title">未检测到 git</div>
+              <div className="vs-zip-banner-body">
+                自动更新功能需要本地装有 git。请先{' '}
+                <a href="https://git-scm.com/downloads" target="_blank" rel="noreferrer">安装 git</a>
+                {' '}后重启 Studio。
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="vs-zip-banner-title">启用自动更新</div>
+              <div className="vs-zip-banner-body">
+                检测到你是 zip 解压安装。要使用版本面板的一键更新 / 切换通道功能，
+                需要在本地初始化 git 仓库（首次约 30–60 MB 下载，仅下载历史元数据，
+                <b>不会覆盖你的文件</b>）。
+              </div>
+              <div className="vs-zip-banner-actions">
+                <button
+                  type="button"
+                  className="btn btn-sm btn-primary"
+                  onClick={() => void handleInitGit()}
+                  disabled={initing}
+                >
+                  {initing ? '初始化中…（约 30 秒）' : '启用自动更新'}
+                </button>
+                {initError && <span className="vs-zip-banner-error">失败：{initError}</span>}
+              </div>
+            </>
+          )}
+        </div>
+      )}
+
       {/* 顶部：你装的是什么（一行事实状态，与通道偏好解耦） */}
       <div className="vs-installed-row">
         <span className="vs-installed-label">你装的：</span>
@@ -3496,7 +3570,7 @@ type DevCardProps = {
   check: SystemUpdateCheck | null
   commits: DevCommitsResult | null
   currentSha: string
-  installedKind: 'stable' | 'dev' | 'custom' | undefined
+  installedKind: 'stable' | 'dev' | 'custom' | 'zip' | undefined
   selectedSha: string | null
   setSelectedSha: (sha: string | null) => void
   checking: boolean

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -33,6 +33,7 @@ import {
   formatMasterStateText,
   formatDevStateText,
   shouldShowMasterUpdateButton,
+  shouldShowSwitchToStableButton,
   isDevSwitchButtonDisabled,
 } from '../../lib/versionPanel'
 import { applyDensity, applyTheme, getStoredDensity, getStoredTheme, setStoredDensity, setStoredTheme, type Density, type Theme } from '../../lib/theme'
@@ -2688,15 +2689,22 @@ function VersionSection() {
   // 即便装的是 stable，用户切到 dev 通道偏好时也要能立刻看到 dev HEAD 信息。
   const channelPref: 'stable' | 'dev' = prefs?.update_channel ?? 'stable'
   const showDevView = channelPref === 'dev'
+  // 两个 fetch 拆独立 effect：避免「commits 先 resolve 触发 re-render，
+  // effect 用 devCommits !== null 早 return 跳过 check fetch」race
+  // —— 实测会导致 devCheck 一直 null、"切到 dev HEAD" 按钮不知道
+  // 该 disabled，UI 显示 enabled 但点了 no-op。
   useEffect(() => {
     if (!showDevView || devCommits !== null) return
     let cancelled = false
     void api.getDevCommits(10).then((r) => { if (!cancelled) setDevCommits(r) }).catch(() => { /* silent */ })
-    if (devCheck === null) {
-      void api.checkSystemUpdate('dev', true).then((r) => { if (!cancelled) setDevCheck(r) }).catch(() => { /* silent */ })
-    }
     return () => { cancelled = true }
-  }, [showDevView, devCommits, devCheck])
+  }, [showDevView, devCommits])
+  useEffect(() => {
+    if (!showDevView || devCheck !== null) return
+    let cancelled = false
+    void api.checkSystemUpdate('dev', true).then((r) => { if (!cancelled) setDevCheck(r) }).catch(() => { /* silent */ })
+    return () => { cancelled = true }
+  }, [showDevView, devCheck])
 
   const handleCheck = async () => {
     setChecking(true)
@@ -3005,6 +3013,7 @@ function VersionSection() {
               check={devCheck}
               commits={devCommits}
               currentSha={version?.commit ?? ''}
+              installedKind={version?.installed_kind}
               selectedSha={selectedSha}
               setSelectedSha={setSelectedSha}
               checking={checkingDev}
@@ -3280,14 +3289,18 @@ function MasterReleaseNotes({
 }
 
 function MasterCard(p: MasterCardProps) {
-  // 当前装的版本号优先用 stable_version（精确），fallback 到 __version__
-  const currentTag = p.version?.stable_version
-    ?? p.version?.tag
-    ?? (p.version ? `v${p.version.version}` : '加载中…')
+  // 装的是 stable 时显示当前稳定版号，否则 ver-tag 区不显示 from（"你装的"
+  // 顶部行已经表达了装了什么，避免 "v0.8.0 → v0.8.0" 这种因 __version__
+  // 字符串与目标 tag 字面相同导致的伪箭头）
+  const installedIsStable = p.version?.installed_kind === 'stable'
+  const currentTag = installedIsStable
+    ? (p.version?.stable_version ?? p.version?.tag ?? `v${p.version?.version ?? ''}`)
+    : null
   // 远端最新稳定版（state=update_available 时显示）
   const targetTag = p.check?.latest_version ?? p.check?.latest_tag ?? ''
   const stateText = formatMasterStateText(p.check)
-  const showUpdateButton = shouldShowMasterUpdateButton(p.check)
+  const showUpdateButton = shouldShowMasterUpdateButton(p.check, p.version?.installed_kind)
+  const showSwitchToStableButton = shouldShowSwitchToStableButton(p.check, p.version?.installed_kind)
   if (p.cardState === 'preview' && p.pendingTarget && p.pendingTarget.kind === 'master') {
     return (
       <div className="vs-chan">
@@ -3302,7 +3315,7 @@ function MasterCard(p: MasterCardProps) {
         </div>
         <PreviewPane
           channel="master"
-          fromLabel={currentTag}
+          fromLabel={currentTag ?? p.version?.installed_label ?? '当前'}
           toLabel={p.pendingTarget.label}
           details={
             <div className="vs-change-block">
@@ -3328,7 +3341,7 @@ function MasterCard(p: MasterCardProps) {
             <span className="vs-pill vs-pill-stable"><span className="vs-dot" />稳定</span>
           </div>
         </div>
-        <ProgressPane fromLabel={currentTag} toLabel={p.pendingTarget.label} />
+        <ProgressPane fromLabel={currentTag ?? p.version?.installed_label ?? '当前'} toLabel={p.pendingTarget.label} />
       </div>
     )
   }
@@ -3384,13 +3397,21 @@ function MasterCard(p: MasterCardProps) {
       <div className={`vs-chan-body ${p.solo ? 'solo' : 'split'}`}>
         <div className="vs-ver-block" style={{ flex: p.solo ? '0 0 220px' : 1 }}>
           <div className="vs-ver-tag">
-            {p.hasUpdate && targetTag ? (
+            {/* 装的是 stable 且有新稳定版：显示 from → to 箭头
+                装的是 stable 但已是最新：只显示当前版本号
+                装的不是 stable（dev / custom）：只显示目标稳定版号（如有），
+                  不再显示 "v0.8.0 → v0.8.0" 伪箭头 */}
+            {installedIsStable && p.hasUpdate && targetTag && currentTag !== targetTag ? (
               <>
                 <span className="vs-dim">{currentTag}</span>
                 <span className="vs-arrow">→</span>
                 <span className="vs-target">{targetTag}</span>
               </>
-            ) : currentTag}
+            ) : installedIsStable ? (
+              currentTag
+            ) : targetTag ? (
+              <span className="vs-target">{targetTag}</span>
+            ) : null}
           </div>
           <div className="vs-ver-meta">
             {releasedAt && <span>发布于 <b>{releasedAt}</b></span>}
@@ -3404,7 +3425,7 @@ function MasterCard(p: MasterCardProps) {
 
         <div className="vs-change-block">
           <div className="vs-h">
-            {p.hasUpdate ? `${targetTag} · 更新内容` : `${currentTag} · 此版本`}
+            {p.hasUpdate ? `${targetTag} · 更新内容` : `${targetTag || currentTag || ''} · 此版本`}
           </div>
           <MasterReleaseNotes notes={p.releaseNotes} onShowDetail={p.onShowReleaseNotesDetail} />
         </div>
@@ -3427,10 +3448,12 @@ function MasterCard(p: MasterCardProps) {
               {p.busy ? '更新中…' : `更新到 ${targetTag}…`}
             </button>
           )}
-          {/* 装在非稳定版（dev / custom）时显示"切到最新稳定版"按钮 */}
-          {p.version && p.version.installed_kind !== 'stable' && p.check?.latest_version && (
+          {/* 装在非稳定版（dev / custom）时显示"切到最新稳定版"按钮；
+              与"更新到 X"按钮互斥（shouldShowMasterUpdateButton 内部已按
+              installed_kind 排除了非 stable），避免同屏显示两个做同样事的按钮 */}
+          {showSwitchToStableButton && (
             <button onClick={p.onSwitchToMaster} disabled={p.busy || p.checking} className="btn btn-sm btn-primary">
-              {p.busy ? '切换中…' : `切到稳定版 ${p.check.latest_version}…`}
+              {p.busy ? '切换中…' : `切到稳定版 ${p.check?.latest_version}…`}
             </button>
           )}
         </div>
@@ -3473,6 +3496,7 @@ type DevCardProps = {
   check: SystemUpdateCheck | null
   commits: DevCommitsResult | null
   currentSha: string
+  installedKind: 'stable' | 'dev' | 'custom' | undefined
   selectedSha: string | null
   setSelectedSha: (sha: string | null) => void
   checking: boolean
@@ -3495,7 +3519,9 @@ function DevCard(p: DevCardProps) {
   const fetchError = p.commits?.error ?? p.check?.error
   const currentShortSha = p.currentSha ? p.currentSha.slice(0, 8) : '当前'
   const stateText = formatDevStateText(p.check)
-  const devSwitchDisabled = isDevSwitchButtonDisabled(p.check)
+  // installedKind 用作 check 还没 resolve 期间的 fallback：装 dev tip 时
+  // 按钮 disabled，避免显示可点但点了 no-op
+  const devSwitchDisabled = isDevSwitchButtonDisabled(p.check, p.installedKind)
   if (p.cardState === 'preview' && p.pendingTarget && p.pendingTarget.kind === 'dev') {
     const t = p.pendingTarget
     return (

--- a/studio/web/src/styles/version-section.css
+++ b/studio/web/src/styles/version-section.css
@@ -1,24 +1,94 @@
-/* VersionSection 双通道升级面板（ADR 0002 / PR-D 重设计）
+/* VersionSection 单视图升级面板（ADR 0005 重设计）
  *
  * 所有 class 用 vs- 前缀避免与全局 / Tailwind utility 碰撞。
  * 全部走 tokens.css 现有 CSS variable，自动适配 light/dark。
- * 容器宽度响应：container query (sec-card → vs-channels)。
+ *
+ * 产品模型：单视图 + 通道偏好 radio（不再并排双卡，避免"两个通道纠结"问题）
+ * - vs-installed-row：顶部一行展示"装了什么"（installed_label）
+ * - vs-channel-toggle-row：通道偏好 radio（stable / dev，纯 UI 视图）
+ * - vs-channels：当前选中通道的卡片容器（永远单列）
  */
 
-/* ==================== 双卡 grid ==================== */
+/* ==================== 卡片容器（永远单卡） ==================== */
 .vs-channels {
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   gap: 14px;
 }
-.vs-channels.both {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-}
 .vs-sec-card {
   container-type: inline-size;
 }
-@container (max-width: 760px) {
-  .vs-channels.both { grid-template-columns: minmax(0, 1fr); }
+
+/* ==================== 顶部：你装的是什么 ==================== */
+.vs-installed-row {
+  padding: 10px 12px;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 13px;
+}
+.vs-installed-label {
+  color: var(--fg-tertiary);
+}
+.vs-installed-value {
+  font-family: var(--font-mono);
+  color: var(--fg-primary);
+  font-weight: 600;
+}
+.vs-installed-warn {
+  color: var(--warn);
+  font-size: 11.5px;
+}
+
+/* ==================== 通道偏好 radio ==================== */
+.vs-channel-toggle-row {
+  padding: 6px 12px 10px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 12.5px;
+}
+.vs-channel-toggle-label {
+  color: var(--fg-tertiary);
+}
+.vs-channel-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--border-default);
+  background: transparent;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  font-size: 12.5px;
+  transition: 120ms;
+}
+.vs-channel-radio:hover:not(.on) {
+  background: var(--bg-overlay);
+}
+.vs-channel-radio.on {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.vs-channel-radio .vs-channel-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  border: 1px solid currentColor;
+  background: transparent;
+}
+.vs-channel-radio.on .vs-channel-dot {
+  background: currentColor;
+}
+.vs-channel-hint {
+  margin-left: auto;
+  color: var(--fg-tertiary);
+  font-size: 11px;
+  font-style: italic;
 }
 
 /* ==================== 单卡片 ==================== */
@@ -296,89 +366,8 @@
   font-size: 10.5px;
 }
 
-/* ==================== dev toggle 行（title 下方独立一行） ==================== */
-/* 之前下方双卡之后用 dashed border 表达 "opt-in"；现在搬到 title 下方
-   主流位置，更紧凑、无边框，背景由 .open / .locked 状态决定 */
-.vs-dev-toggle-row {
-  padding: 8px 12px;
-  background: transparent;
-  border-radius: 6px;
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  justify-content: space-between;
-  flex-wrap: wrap;
-}
-.vs-dev-toggle-row.open {
-  background: var(--bg-sunken);
-}
-.vs-dev-toggle-row.locked {
-  background: var(--bg-sunken);
-}
-.vs-dev-toggle-row .vs-lhs {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  min-width: 0;
-  flex-wrap: wrap;
-}
-.vs-dev-toggle-row .vs-t {
-  font-size: 12.5px;
-  color: var(--fg-secondary);
-}
-.vs-dev-toggle-row .vs-d {
-  font-size: 11.5px;
-  color: var(--fg-tertiary);
-  margin-top: 2px;
-  max-width: 720px;
-  line-height: 1.5;
-}
-.vs-lock-pill {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  padding: 2px 7px;
-  border-radius: 999px;
-  background: var(--accent-soft);
-  color: var(--accent);
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-}
-
-/* ==================== switch ==================== */
-.vs-sw {
-  width: 32px;
-  height: 18px;
-  border-radius: 999px;
-  background: var(--bg-overlay);
-  border: 1px solid var(--border-default);
-  position: relative;
-  cursor: pointer;
-  flex-shrink: 0;
-}
-.vs-sw::after {
-  content: "";
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: var(--fg-tertiary);
-  position: absolute;
-  top: 2px;
-  left: 2px;
-  transition: 140ms;
-}
-.vs-sw.on {
-  background: var(--accent-soft);
-  border-color: var(--accent);
-}
-.vs-sw.on::after {
-  background: var(--accent);
-  transform: translateX(14px);
-}
-.vs-sw.locked {
-  cursor: not-allowed;
-  opacity: 0.7;
-}
+/* 旧 .vs-dev-toggle-row / .vs-sw / .vs-lock-pill 已删，由
+   .vs-channel-toggle-row + .vs-channel-radio 取代（ADR 0005）。 */
 
 /* InfoButton ⓘ 弹层（之前的 .vs-info-* 类）已抽到
    components/InfoButton.tsx + styles/info-button.css，所有 .info-btn-*

--- a/studio/web/src/styles/version-section.css
+++ b/studio/web/src/styles/version-section.css
@@ -91,6 +91,44 @@
   font-style: italic;
 }
 
+/* ==================== zip 安装 init banner（0.8.1 hotfix）====================
+ * 出现在 vs-installed-row 上方，仅 version.is_git_repo=false 时显示。
+ * accent-soft 背景区分于"上次更新失败"红色 banner。 */
+.vs-zip-banner {
+  margin: 0 0 12px;
+  padding: 12px 14px;
+  border: 1px solid var(--accent);
+  background: var(--accent-soft);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+.vs-zip-banner-title {
+  font-weight: 600;
+  color: var(--accent);
+}
+.vs-zip-banner-body {
+  color: var(--fg-secondary);
+  line-height: 1.5;
+}
+.vs-zip-banner-body a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+.vs-zip-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 4px;
+}
+.vs-zip-banner-error {
+  color: var(--danger, #c0392b);
+  font-size: 12px;
+}
+
 /* ==================== 单卡片 ==================== */
 .vs-chan {
   background: var(--bg-sunken);

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -369,38 +369,63 @@ def test_has_gelbooru_credentials(secrets_file: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# PR-D — system.show_dev_channel（dev 通道 toggle 持久化）
+# PR-D / ADR 0005 — system.update_channel（用户视图偏好持久化）
 # ---------------------------------------------------------------------------
 
 
-def test_system_defaults_show_dev_channel_false(secrets_file: Path) -> None:
-    """新装默认 toggle 关 —— 绝大多数用户看简化 UI，不暴露 dev 入口。"""
+def test_system_defaults_update_channel_stable(secrets_file: Path) -> None:
+    """新装默认通道偏好 = stable，绝大多数用户只看稳定版。"""
     s = secrets.load()
-    assert s.system.show_dev_channel is False
+    assert s.system.update_channel == "stable"
+    assert s.system.show_dev_channel is False  # legacy 字段默认也是 False
 
 
-def test_system_show_dev_channel_round_trip(secrets_file: Path) -> None:
-    """update + load 持久化（webui 勾选 toggle 后刷页应保留）。"""
-    secrets.update({"system": {"show_dev_channel": True}})
-    assert secrets.load().system.show_dev_channel is True
-    # 关掉也持久化
-    secrets.update({"system": {"show_dev_channel": False}})
-    assert secrets.load().system.show_dev_channel is False
+def test_system_update_channel_round_trip(secrets_file: Path) -> None:
+    """update + load 持久化（webui 切 toggle 后刷页应保留）。"""
+    secrets.update({"system": {"update_channel": "dev"}})
+    assert secrets.load().system.update_channel == "dev"
+    secrets.update({"system": {"update_channel": "stable"}})
+    assert secrets.load().system.update_channel == "stable"
 
 
 def test_system_legacy_file_without_system_field(secrets_file: Path) -> None:
-    """老 secrets.json 没有 system 字段时，加载用默认值（show_dev_channel=False）。"""
+    """老 secrets.json 没有 system 字段时，加载用默认值 stable。"""
     secrets_file.write_text(
         json.dumps({"gelbooru": {"user_id": "alice"}}),
         encoding="utf-8",
     )
     s = secrets.load()
-    assert s.system.show_dev_channel is False
+    assert s.system.update_channel == "stable"
     assert s.gelbooru.user_id == "alice"  # 其它字段不受影响
 
 
-def test_system_show_dev_channel_in_masked_dict(secrets_file: Path) -> None:
-    """show_dev_channel 不是敏感字段，掩码后应保留原值。"""
-    secrets.update({"system": {"show_dev_channel": True}})
+def test_system_update_channel_in_masked_dict(secrets_file: Path) -> None:
+    """update_channel 不是敏感字段，掩码后应保留原值。"""
+    secrets.update({"system": {"update_channel": "dev"}})
     masked = secrets.to_masked_dict(secrets.load())
-    assert masked["system"]["show_dev_channel"] is True
+    assert masked["system"]["update_channel"] == "dev"
+
+
+def test_system_show_dev_channel_migrated_to_update_channel(
+    secrets_file: Path,
+) -> None:
+    """ADR 0005：老 secrets.json 里 show_dev_channel=true 一次性迁移成
+    update_channel='dev'，让升级用户保留之前的 dev 视图偏好。"""
+    secrets_file.write_text(
+        json.dumps({"system": {"show_dev_channel": True}}),
+        encoding="utf-8",
+    )
+    s = secrets.load()
+    assert s.system.update_channel == "dev"
+
+
+def test_system_show_dev_channel_migration_does_not_overwrite_explicit_pref(
+    secrets_file: Path,
+) -> None:
+    """update_channel 已显式设过 → 迁移函数不覆盖（幂等）。"""
+    secrets_file.write_text(
+        json.dumps({"system": {"show_dev_channel": True, "update_channel": "stable"}}),
+        encoding="utf-8",
+    )
+    s = secrets.load()
+    assert s.system.update_channel == "stable"  # 显式设过不被 legacy 覆盖

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -90,6 +90,8 @@ def test_apply_pending_dirty_tree_aborts(
     fake_version = updater.VersionInfo(
         version="0.0.0", commit="abc", commit_short="abc",
         commit_time_iso="", branch="master", tag=None, is_dirty=True,
+        installed_kind="custom", installed_label="自定义（master @ abc）",
+        stable_version=None,
     )
     monkeypatch.setattr(updater, "current_version", lambda: fake_version)
 
@@ -119,6 +121,8 @@ def test_apply_pending_records_last_version(
     fake_version = updater.VersionInfo(
         version="0.0.0", commit="deadbeef" * 5, commit_short="deadbeef",
         commit_time_iso="", branch="master", tag=None, is_dirty=True,
+        installed_kind="custom", installed_label="自定义（master @ deadbeef）",
+        stable_version=None,
     )
     monkeypatch.setattr(updater, "current_version", lambda: fake_version)
     monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
@@ -212,6 +216,8 @@ def test_check_update_force_skips_cache(
         lambda: updater.VersionInfo(
             version="0.7.0", commit="local_sha", commit_short="local_sh",
             commit_time_iso="", branch="master", tag=None, is_dirty=False,
+            installed_kind="stable", installed_label="v0.7.0",
+            stable_version="v0.7.0",
         ),
     )
 
@@ -281,6 +287,8 @@ def test_apply_pending_writes_aborted_status(
     fake = updater.VersionInfo(
         version="0.0.0", commit="abc", commit_short="abc",
         commit_time_iso="", branch="master", tag=None, is_dirty=True,
+        installed_kind="custom", installed_label="自定义（master @ abc）",
+        stable_version=None,
     )
     monkeypatch.setattr(updater, "current_version", lambda: fake)
     monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
@@ -302,6 +310,8 @@ def test_apply_pending_writes_failed_status_on_fetch_error(
     fake = updater.VersionInfo(
         version="0.0.0", commit="abc", commit_short="abc",
         commit_time_iso="", branch="master", tag=None, is_dirty=False,
+        installed_kind="custom", installed_label="自定义（master @ abc）",
+        stable_version=None,
     )
     monkeypatch.setattr(updater, "current_version", lambda: fake)
     def _fake_git(*args, **kwargs):
@@ -554,3 +564,299 @@ def test_dev_commits_malformed_log_lines_skipped(monkeypatch: pytest.MonkeyPatch
     r = updater.dev_commits(limit=10)
     assert len(r.commits) == 1
     assert r.commits[0].short_sha == "dddddddd"
+
+
+# ---------------------------------------------------------------------------
+# ADR 0005：installed_kind / installed_label 分类
+# ---------------------------------------------------------------------------
+
+
+def test_classify_install_stable_via_exact_tag() -> None:
+    """HEAD 命中 vX.Y.Z release tag → stable + label = tag。"""
+    kind, label, ver = updater._classify_install(
+        commit="a" * 40, exact_tag="v0.8.0", branch="master",
+        short="aaaaaaaa", commit_time_iso="2026-05-16T00:00:00Z",
+        is_dirty=False,
+    )
+    assert kind == "stable"
+    assert label == "v0.8.0"
+    assert ver == "v0.8.0"
+
+
+def test_classify_install_stable_with_dirty_suffix() -> None:
+    kind, label, ver = updater._classify_install(
+        commit="a" * 40, exact_tag="v0.8.0", branch="master",
+        short="aaaaaaaa", commit_time_iso="", is_dirty=True,
+    )
+    assert kind == "stable"
+    assert "未提交修改" in label
+    assert ver == "v0.8.0"
+
+
+def test_classify_install_stable_via_version_tree_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HEAD 没 tag，但 __version__ 匹 vX.Y.Z 且 tree 与 tag commit 一致 → stable。
+
+    覆盖 release 直后场景：本地 commit 是 release commit（在 dev 分支上），
+    tag 打在 master merge commit 上 —— exact_tag 不命中但 tree 一致。
+    """
+    monkeypatch.setattr(updater, "__version__", "0.8.0")
+    def _fake_git(*args, **_kw):
+        # rev-parse v0.8.0^{commit} → 返回 tag commit
+        if args[:2] == ("rev-parse", "v0.8.0^{commit}"):
+            return 0, "merge_commit_sha", ""
+        # diff --quiet release_commit merge_commit → 0 表示 tree 一致
+        if args[:2] == ("diff", "--quiet"):
+            return 0, "", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    kind, label, ver = updater._classify_install(
+        commit="release_commit_sha", exact_tag=None, branch="master",
+        short="release_", commit_time_iso="", is_dirty=False,
+    )
+    assert kind == "stable"
+    assert ver == "v0.8.0"
+
+
+def test_classify_install_dev_when_commit_equals_origin_dev(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """commit == origin/dev HEAD → dev + label 含 sha + 时间。"""
+    monkeypatch.setattr(updater, "__version__", "0.0.0-noversion")  # 强制不匹 stable
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("rev-parse", "v0.0.0-noversion^{commit}"):
+            return 1, "", ""
+        if args[:2] == ("rev-parse", "origin/dev"):
+            return 0, "dev_head_sha", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    kind, label, ver = updater._classify_install(
+        commit="dev_head_sha", exact_tag=None, branch="anything",
+        short="dev_head", commit_time_iso="2026-05-16T19:50:00-05:00",
+        is_dirty=False,
+    )
+    assert kind == "dev"
+    assert "dev @ dev_head" in label
+    assert "2026-05-16 19:50" in label
+    assert ver is None
+
+
+def test_classify_install_custom_on_feature_branch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """既不命中 release tag 也不在 dev HEAD → custom + label 含 branch + sha。"""
+    monkeypatch.setattr(updater, "__version__", "0.0.0-noversion")
+    monkeypatch.setattr(updater, "_git",
+                        lambda *a, **_k: (1, "", "no plan"))
+
+    kind, label, ver = updater._classify_install(
+        commit="feature_commit", exact_tag=None, branch="feat/something",
+        short="feature_", commit_time_iso="", is_dirty=False,
+    )
+    assert kind == "custom"
+    assert "feat/something" in label
+    assert "feature_" in label
+    assert ver is None
+
+
+def test_classify_install_custom_detached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(updater, "__version__", "0.0.0-noversion")
+    monkeypatch.setattr(updater, "_git",
+                        lambda *a, **_k: (1, "", "no plan"))
+
+    kind, label, ver = updater._classify_install(
+        commit="random_commit", exact_tag=None, branch="detached",
+        short="random__", commit_time_iso="", is_dirty=False,
+    )
+    assert kind == "custom"
+    assert "random__" in label
+    assert "detached" not in label  # detached 时不暴露字面 "detached"，只显示 "（@ sha）"
+    assert ver is None
+
+
+# ---------------------------------------------------------------------------
+# ADR 0005：check_update state 状态机
+# ---------------------------------------------------------------------------
+
+
+def test_check_update_master_up_to_date_same_version(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """master 通道：installed_version == latest_version → state=up_to_date。
+
+    即使 commit 不同（release 后本地是 release commit, 远端是 merge commit），
+    版本号相同就视为已是最新 —— 不再用 commit 词汇糊弄用户。
+    """
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.8.0", commit="release_commit", commit_short="release_",
+            commit_time_iso="", branch="master", tag=None, is_dirty=False,
+            installed_kind="stable", installed_label="v0.8.0",
+            stable_version="v0.8.0",
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/master"):
+            return 0, "merge_commit", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/master"):
+            return 0, "2", ""
+        if args[:3] == ("rev-list", "--count", "origin/master..HEAD"):
+            return 0, "0", ""
+        if args[0] == "describe":
+            return 0, "v0.8.0", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("master", use_cache=False)
+    assert r.state == "up_to_date"
+    assert r.installed_version == "v0.8.0"
+    assert r.latest_version == "v0.8.0"
+    assert r.has_update is False
+
+
+def test_check_update_master_update_available_diff_version(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """master 通道：installed=v0.7.0, latest=v0.8.0 → state=update_available。"""
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.7.0", commit="v070_commit", commit_short="v070_com",
+            commit_time_iso="", branch="master", tag="v0.7.0", is_dirty=False,
+            installed_kind="stable", installed_label="v0.7.0",
+            stable_version="v0.7.0",
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/master"):
+            return 0, "v080_commit", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/master"):
+            return 0, "5", ""
+        if args[:3] == ("rev-list", "--count", "origin/master..HEAD"):
+            return 0, "0", ""
+        if args[0] == "describe":
+            return 0, "v0.8.0", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("master", use_cache=False)
+    assert r.state == "update_available"
+    assert r.installed_version == "v0.7.0"
+    assert r.latest_version == "v0.8.0"
+    assert r.has_update is True
+    assert r.behind_count == 5
+
+
+def test_check_update_dev_up_to_date_when_commit_matches(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dev 通道：当前 commit == origin/dev HEAD → state=up_to_date。"""
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.8.0", commit="dev_tip", commit_short="dev_tip_",
+            commit_time_iso="", branch="dev", tag=None, is_dirty=False,
+            installed_kind="dev", installed_label="dev @ dev_tip_",
+            stable_version=None,
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/dev"):
+            return 0, "dev_tip", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/dev"):
+            return 0, "0", ""
+        if args[:3] == ("rev-list", "--count", "origin/dev..HEAD"):
+            return 0, "0", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("dev", use_cache=False)
+    assert r.state == "up_to_date"
+    assert r.behind_count == 0
+
+
+def test_check_update_dev_update_available_when_behind(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dev 通道：本地落后 origin/dev N commit → state=update_available + behind_count=N。"""
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.8.0", commit="old_dev_commit", commit_short="old_dev_",
+            commit_time_iso="", branch="dev", tag=None, is_dirty=False,
+            installed_kind="custom", installed_label="自定义（dev @ old_dev_）",
+            stable_version=None,
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/dev"):
+            return 0, "new_dev_tip", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/dev"):
+            return 0, "3", ""
+        if args[:3] == ("rev-list", "--count", "origin/dev..HEAD"):
+            return 0, "0", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("dev", use_cache=False)
+    assert r.state == "update_available"
+    assert r.behind_count == 3
+    assert r.has_update is True
+
+
+def test_check_update_dev_ahead_when_local_leads(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dev 通道：本地 commit 领先 origin/dev（罕见，回滚或抢跑） → state=ahead。"""
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.8.0", commit="ahead_commit", commit_short="ahead_co",
+            commit_time_iso="", branch="dev", tag=None, is_dirty=False,
+            installed_kind="custom", installed_label="自定义",
+            stable_version=None,
+        ),
+    )
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/dev"):
+            return 0, "old_remote_tip", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/dev"):
+            return 0, "0", ""
+        if args[:3] == ("rev-list", "--count", "origin/dev..HEAD"):
+            return 0, "2", ""
+        return 1, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("dev", use_cache=False)
+    assert r.state == "ahead"
+
+
+def test_check_update_fetch_error_returns_detached(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """fetch 失败 → state=detached + error 字段填，前端不该认为"有更新"。"""
+    def _fake_git(*args, **_kw):
+        if args[:2] == ("fetch", "origin"):
+            return 128, "", "fatal: network unreachable"
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    r = updater.check_update("master", use_cache=False)
+    assert r.state == "detached"
+    assert r.error is not None

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -420,6 +420,255 @@ def test_rollback_target_tolerates_utf8_bom(
 
 
 # ---------------------------------------------------------------------------
+# 0.8.1 hotfix：zip 解压用户的 git 仓库自动 init
+# ---------------------------------------------------------------------------
+
+def test_git_repo_status_git_binary_missing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """git 不在 PATH 时 git_repo_status 三 False —— 后续 .git/origin 检测都跳过。"""
+    monkeypatch.setattr(updater, "_git",
+                        lambda *a, **k: (1, "", "git not found on PATH"))
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+    s = updater.git_repo_status()
+    assert s.git_available is False
+    assert s.has_dot_git is False
+    assert s.has_origin is False
+    assert s.is_repo is False
+
+
+def test_git_repo_status_no_dot_git(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """zip 解压典型场景：git 在 PATH 但目录里没 .git/。"""
+    monkeypatch.setattr(updater, "_git",
+                        lambda *a, **k: (0, "git version 2.40.0", ""))
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)  # 空 tmp_path 没 .git/
+    s = updater.git_repo_status()
+    assert s.git_available is True
+    assert s.has_dot_git is False
+    assert s.has_origin is False
+    assert s.is_repo is False
+
+
+def test_git_repo_status_no_origin(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """.git/ 存在但 remote get-url origin 失败（用户自己 git init 过但没加 remote）。"""
+    (tmp_path / ".git").mkdir()
+    def _fake_git(*args, **_):
+        if args == ("--version",):
+            return 0, "git version 2.40.0", ""
+        if args[:2] == ("remote", "get-url"):
+            return 2, "", "error: No such remote 'origin'"
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+    s = updater.git_repo_status()
+    assert s.git_available is True
+    assert s.has_dot_git is True
+    assert s.has_origin is False
+    assert s.is_repo is False
+
+
+def test_git_repo_status_full_repo(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """git clone 用户的正常路径：三个都 True。"""
+    (tmp_path / ".git").mkdir()
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "ok", ""))
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+    s = updater.git_repo_status()
+    assert s.is_repo is True
+
+
+def test_current_version_zip_mode(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """zip 模式（is_repo=False）→ installed_kind='zip' + is_git_repo=False，
+    不会去调真 git 命令（不会 rev-parse / log / describe）。"""
+    git_calls: list[tuple] = []
+    def _fake_git(*args, **_):
+        git_calls.append(args)
+        # --version 仍要回 0（git binary 在 PATH，只是没 .git/）
+        if args == ("--version",):
+            return 0, "git version 2.40.0", ""
+        # 其他都不应被调用 —— 早 return 走 zip 分支
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+
+    v = updater.current_version()
+    assert v.installed_kind == "zip"
+    assert v.is_git_repo is False
+    assert v.git_available is True
+    assert v.commit == "unknown"
+    assert v.branch == "detached"
+    assert "zip" in v.installed_label.lower() or "zip 安装" in v.installed_label
+    # 早 return：除了 --version 不该调任何 git
+    other_calls = [c for c in git_calls if c != ("--version",)]
+    assert other_calls == [], f"zip 模式不该调 git 子命令，实际调了 {other_calls}"
+
+
+def test_current_version_zip_mode_no_git_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """zip + 没装 git → git_available=False（前端用这个区分文案）。"""
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (1, "", "git not found"))
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+    v = updater.current_version()
+    assert v.is_git_repo is False
+    assert v.git_available is False
+    assert v.installed_kind == "zip"
+
+
+def test_bootstrap_aborts_without_git_binary(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """bootstrap 第一关：git binary 不在 PATH 直接返 ok=False，error 文案
+    指向 git-scm 下载页（前端给用户提示）。"""
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (1, "", "git not found"))
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+    r = updater.bootstrap_git_repo()
+    assert r.ok is False
+    assert r.error is not None
+    assert "git" in r.error.lower()
+
+
+def test_bootstrap_full_sequence_uses_version_tag_anchor(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """zip 用户 happy path：__version__ 对应的 release tag 在远端存在 →
+    bootstrap 把 HEAD anchor 在 vX.Y.Z tag 上（让 working tree 看起来"干净"）。
+
+    验证调用序列：init → symbolic-ref master → remote add origin → fetch
+    --tags → rev-parse tag（成功）→ reset --mixed tag → rev-parse anchor。"""
+    calls: list[tuple] = []
+    def _fake_git(*args, **_):
+        calls.append(args)
+        if args == ("--version",):
+            return 0, "git version 2.40.0", ""
+        if args[:2] == ("remote", "get-url"):
+            # init 后还没加 origin → 失败一次（触发 remote add）
+            return 2, "", "no remote"
+        if args[0] == "rev-parse" and args[1] == "--verify":
+            # v{__version__} tag 存在
+            return 0, "abc123", ""
+        if args[0] == "rev-parse":
+            # 末尾的 rev-parse anchor → 返回 sha
+            return 0, "abc123def456" + "0" * 20, ""
+        return 0, "", ""
+
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)  # 空 → has_dot_git=False
+    monkeypatch.setattr(updater, "__version__", "0.8.0")
+
+    r = updater.bootstrap_git_repo()
+    assert r.ok is True, f"bootstrap should succeed, error={r.error}"
+    assert r.anchor_kind == "version_tag"
+    assert r.anchor and len(r.anchor) > 0
+
+    # 序列验证：必须包含 init / symbolic-ref / remote add / fetch / reset
+    first_args = [c[0] for c in calls]
+    assert "init" in first_args
+    assert "symbolic-ref" in first_args
+    # remote add 应当被调（因为前面 get-url 失败）
+    assert any(c[:2] == ("remote", "add") and c[2] == "origin" for c in calls), \
+        "应当调 git remote add origin"
+    # fetch origin master --tags
+    assert any(c[:3] == ("fetch", "origin", "master") for c in calls)
+    # reset --mixed 到 anchor（v{__version__}）
+    assert any(c[0] == "reset" and "--mixed" in c for c in calls)
+
+
+def test_bootstrap_fallbacks_to_master_head_when_no_version_tag(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """__version__ 对应的 tag 在远端不存在（开发版 / 非 release commit zip）→
+    anchor fallback 到 FETCH_HEAD。"""
+    calls: list[tuple] = []
+    def _fake_git(*args, **_):
+        calls.append(args)
+        if args == ("--version",):
+            return 0, "ok", ""
+        if args[:2] == ("remote", "get-url"):
+            return 2, "", ""
+        if args[0] == "rev-parse" and args[1] == "--verify":
+            # v{__version__} tag 不存在
+            return 1, "", "fatal: ambiguous argument"
+        if args[0] == "rev-parse":
+            return 0, "fetched_head_sha", ""
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+
+    r = updater.bootstrap_git_repo()
+    assert r.ok is True
+    assert r.anchor_kind == "master_head"
+    # reset 的 target 应当是 FETCH_HEAD（不是 vX.Y.Z）
+    reset_calls = [c for c in calls if c[0] == "reset"]
+    assert len(reset_calls) == 1
+    assert "FETCH_HEAD" in reset_calls[0]
+
+
+def test_bootstrap_fetch_failure_propagates_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """fetch 失败（网络 / DNS）→ ok=False + 错误文案含 stderr 摘要。
+    不应继续到 reset 步骤。"""
+    calls: list[tuple] = []
+    def _fake_git(*args, **_):
+        calls.append(args)
+        if args == ("--version",):
+            return 0, "ok", ""
+        if args[:2] == ("remote", "get-url"):
+            return 2, "", ""
+        if args[0] == "fetch":
+            return 128, "", "fatal: unable to access 'https://github.com/'"
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+
+    r = updater.bootstrap_git_repo()
+    assert r.ok is False
+    assert r.error is not None
+    assert "fetch" in r.error.lower() or "github" in r.error.lower()
+    # reset 不应被调（fetch 失败就中止）
+    assert not any(c[0] == "reset" for c in calls)
+
+
+def test_bootstrap_honors_env_origin_url_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """ANIMA_STUDIO_ORIGIN_URL env var 覆盖默认 origin URL —— fork 维护者可配。
+
+    注意：updater 在 import 时读 env，这里 monkeypatch 模块属性等价。"""
+    custom_url = "https://example.com/my-fork/AnimaLoraStudio.git"
+    monkeypatch.setattr(updater, "ORIGIN_URL", custom_url)
+    captured_url: list[str] = []
+    def _fake_git(*args, **_):
+        if args == ("--version",):
+            return 0, "ok", ""
+        if args[:2] == ("remote", "get-url"):
+            return 2, "", ""
+        if args[:3] == ("remote", "add", "origin"):
+            captured_url.append(args[3])
+            return 0, "", ""
+        if args[0] == "rev-parse" and args[1] == "--verify":
+            return 1, "", ""
+        if args[0] == "rev-parse":
+            return 0, "sha", ""
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(updater, "REPO_ROOT", tmp_path)
+
+    r = updater.bootstrap_git_repo()
+    assert r.ok is True
+    assert captured_url == [custom_url], \
+        f"应当用 ORIGIN_URL 覆盖值，实际调用 = {captured_url}"
+
+
+# ---------------------------------------------------------------------------
 # target_has_self_update (chunk 4 safety net)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 版本

`v0.8.1` — 按 hotfix 特例处理（含 `added`/`changed` 但走 PATCH bump）。理由：v0.8.0 release 直后版本面板出现「装了 v0.8.0」+「↑落后 2 commits」+「切到 dev 没反应」的矛盾解读（详见 ADR 0005 背景），属于"release 直后破损紧急修复"，所以即使 entries 含 `added`/`changed` 也走 PATCH，让用户敢升。

## 改动概要

4 个 commit：

- **`72c04c5` polish(settings): 版本面板单视图 + 通道偏好 toggle + 文案脱离 git 词汇 (ADR 0005) (#81)**
- **`a8e95cf` fix(ui): E2E 回归 3 个 follow-up（ADR 0005） (#82)**
- **`c121706` feat(updater): zip 解压用户一键初始化 git 仓库（0.8.1 hotfix）** — 因紧急 push 时机直推 dev 没走 PR，下次同类型走正规 PR + squash
- **`27daee1` chore(release): v0.8.1**

## CHANGELOG（0.8.1 段）

### 新增

- **zip 解压安装用户一键初始化 git 仓库（启用自动更新）**
  ADR 0002 当时只支持 git clone 部署；zip 解压用户因为没有 `.git/`，
  版本面板全员 unknown、自更新功能完全用不了。这版加自动 normalize：

  - **版本面板顶部 banner**：检测到 zip 模式时显示「启用自动更新」按钮
    + 文案；没装 git 时改文案为「先安装 git」+ 官网链接
  - **bootstrap 流程**：`git init` → `git remote add origin <URL>` →
    `git fetch origin master --tags` → 优先 anchor 在 `v{__version__}`
    tag（让 working tree 看上去干净）；reset `--mixed` 不动 working
    tree，原 zip 文件原样保留
  - **可配置上游 URL**：fork 维护者可通过 env var
    `ANIMA_STUDIO_ORIGIN_URL` 覆盖默认值
  - 不支持「dev 分支 zip」场景（端用户走的是 master zip，这是开发者
    自测场景）

### 变更

- **版本面板单视图 + 通道（master/dev）作为偏好与 git 状态解耦（#81）**
  ADR 0005：之前「通道」绑死在 git 工作树状态上（branch 名 + `git reset
  --hard`），release 直后会出现「装的 v0.8.0」+「↑落后 2 commits」+
  「切到 dev 没反应」的矛盾解读。新模型把通道理解为**用户视图偏好**：

  - **同屏只显示当前通道**（不再 master + dev 并排），避免"两个通道
    都活着"的视觉混乱
  - **切 toggle 不动 git**，纯写 `system.update_channel` 到
    `secrets.json`；真正"切到 dev HEAD" / "更新到 vX.Y.Z" 是独立按钮
  - **后端新「装了什么」分类** `installed_kind`（stable / dev / custom），
    按 commit hash + tree 比对推断，取代前端读 `branch` 做判断
  - **文案脱离 git 词汇**：「↑落后 N commits」→「有新稳定版 vX.Y.Z」/
    「已是最新」；不再出现 commits / sha / branch
  - 旧 `show_dev_channel` 一次性迁移到 `update_channel`，写时双写
    保持向下兼容

### 修复

- **版本面板 E2E 回归 3 项（rollback 文案 / preflight / dev 卡 fetch race）（#82）**
  ADR 0005 重做后续：

  - rollback 文案在 stable / dev 两种 installed_kind 下分流，不再
    一律显示「回滚到 vX.Y.Z」
  - preflight panel 在通道偏好与 git 状态不一致时不再展示矛盾的
    切换目标
  - dev 卡 fetch race：`devCommits` 和 `devCheck` 拆独立 useEffect，
    避免一个先 resolve 触发 re-render 跳过另一个的 fetch（症状：
    "切到 dev HEAD"按钮看上去 enabled 但点了 no-op）

## 测试

- `pytest tests/test_updater.py tests/test_studio_server.py` → 112 passed（其中 zip-init 新加 12 用例 + 顺手修了 ADR 0005 漏改的 13 个 server test）
- `tsc --noEmit` clean
- `vitest run versionPanel.test.ts` → 31 passed
- **zip 安装手测**：master zip 路径需 v0.8.1 push 后用 master zip 测；dev zip 已确认无 banner 干扰但 anchor 在 v0.8.0 tag（已知限制，详见 CHANGELOG）

## 合并方式

按 CONTRIBUTING.md:252：选 **Create a merge commit**（不要 squash），保留 dev 上每个 feature 的 commit 颗粒度。

合并后 maintainer 本地：
```
git checkout master && git pull
git tag -a v0.8.1 -m "v0.8.1 — 版本面板 ADR 0005 + zip 用户启用自更新"
git push origin v0.8.1
```
然后去 GitHub Releases 页发 release（粘 CHANGELOG 对应段）。