### PR TITLE
fix(updater): zip bootstrap 用 reset --hard 强制对齐 working tree

### DIFF
--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -211,13 +211,22 @@ def bootstrap_git_repo() -> BootstrapResult:
     4. `git fetch origin master --tags`（拉完整 master 历史 + 全部 tag；
        不带 --depth 保证 dev 通道时间线 / 回滚到任意 commit 可用）
     5. 找 `v{__version__}` tag：存在则用作 anchor（让 HEAD 指向用户当前装
-       的版本对应的 tag commit，working tree 看上去就"干净"）；不存在则
-       fallback 到 FETCH_HEAD（master HEAD）
-    6. `git reset --mixed {anchor}` —— 更新 HEAD + index，**不动 working
-       tree**。zip 解压的源文件保留原样，不覆盖用户可能的本地修改
+       的版本对应的 tag commit，working tree 完全对齐）；不存在则 fallback
+       到 FETCH_HEAD（master HEAD）
+    6. `git reset --hard {anchor}` —— 同时更新 HEAD / index / working tree，
+       强制对齐到 anchor 的 tree。注意**会覆盖用户在 zip 目录里的所有修改**
+       （npm install 自动改的 package-lock.json、用户手动 tweak 的配置等）。
 
-    bootstrap 后 _classify_install 大概率回 "stable"（zip 用户的 __version__
-    匹 release tag 且 tree 一致），版本面板正常显示「v0.8.0」+「检查更新」可用。
+    为什么 `--hard` 不是 `--mixed`：
+    - 早期版本用 `--mixed` 想保留用户文件，但 Windows 上 `studio.bat run`
+      启动期会跑 npm install 改 package-lock.json，导致 init 完就 dirty →
+      pre-flight 卡更新 → 用户无法触发自更新（v0.8.1 实测撞到）
+    - zip 用户场景下，"启用自动更新"的潜台词就是"对齐到上游稳定版"，强制
+      覆盖比保留本地随机改动更符合期望
+    - banner 文案对此显式提示
+
+    bootstrap 后 _classify_install 回 "stable"（HEAD == v{__version__} tag
+    commit），版本面板正常显示「v0.8.0」+「检查更新」可用 + working tree clean。
 
     不在范围：fetch dev / 拉 dev_commits。用户切到 dev 通道时由 check_update
     / dev_commits 自己触发首次 fetch dev（多等几秒，可接受）。
@@ -267,8 +276,10 @@ def bootstrap_git_repo() -> BootstrapResult:
         anchor_ref = "FETCH_HEAD"
         anchor_kind = "master_head"
 
-    # 5. reset --mixed：更新 HEAD + index，不动 working tree（保留用户文件）
-    rc, _, err = _git("reset", "--mixed", anchor_ref, timeout=GIT_PULL_TIMEOUT)
+    # 5. reset --hard：HEAD + index + working tree 全部对齐到 anchor。
+    # 会覆盖 zip 目录里 npm install 改过的 lockfile / 用户手动的本地 tweak；
+    # 这是 zip 用户"启用自动更新"的预期行为（banner 文案显式提示）。
+    rc, _, err = _git("reset", "--hard", anchor_ref, timeout=GIT_PULL_TIMEOUT)
     if rc != 0:
         return BootstrapResult(ok=False, error=f"git reset 失败: {err[:200]}")
 

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -3001,8 +3001,10 @@ function VersionSection() {
               <div className="vs-zip-banner-title">启用自动更新</div>
               <div className="vs-zip-banner-body">
                 检测到你是 zip 解压安装。要使用版本面板的一键更新 / 切换通道功能，
-                需要在本地初始化 git 仓库（首次约 30–60 MB 下载，仅下载历史元数据，
-                <b>不会覆盖你的文件</b>）。
+                需要在本地初始化 git 仓库（首次约 30–60 MB 下载历史元数据）。
+                本地源码会同步到上游 <b>v{version.stable_version?.replace(/^v/, '') ?? version.version}</b>
+                ，<b>你在 zip 目录里的本地修改会被覆盖</b>
+                （npm 自动生成的 lockfile / 自定义配置等都会重置到上游版本）。
               </div>
               <div className="vs-zip-banner-actions">
                 <button

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -542,7 +542,7 @@ def test_bootstrap_full_sequence_uses_version_tag_anchor(
     bootstrap 把 HEAD anchor 在 vX.Y.Z tag 上（让 working tree 看起来"干净"）。
 
     验证调用序列：init → symbolic-ref master → remote add origin → fetch
-    --tags → rev-parse tag（成功）→ reset --mixed tag → rev-parse anchor。"""
+    --tags → rev-parse tag（成功）→ reset --hard tag → rev-parse anchor。"""
     calls: list[tuple] = []
     def _fake_git(*args, **_):
         calls.append(args)
@@ -577,8 +577,12 @@ def test_bootstrap_full_sequence_uses_version_tag_anchor(
         "应当调 git remote add origin"
     # fetch origin master --tags
     assert any(c[:3] == ("fetch", "origin", "master") for c in calls)
-    # reset --mixed 到 anchor（v{__version__}）
-    assert any(c[0] == "reset" and "--mixed" in c for c in calls)
+    # reset --hard 到 anchor（v{__version__}）—— 强制对齐 working tree，
+    # 避免 npm install 等启动期修改导致 init 完就 dirty
+    assert any(c[0] == "reset" and "--hard" in c for c in calls)
+    # 反向断言：绝不能用 --mixed（会保留 working tree，撞 v0.8.1 实测 bug）
+    assert not any(c[0] == "reset" and "--mixed" in c for c in calls), \
+        "bootstrap 必须用 --hard 强制对齐 working tree（v0.8.1 用 --mixed 撞过 dirty bug）"
 
 
 def test_bootstrap_fallbacks_to_master_head_when_no_version_tag(
@@ -635,6 +639,86 @@ def test_bootstrap_fetch_failure_propagates_error(
     assert "fetch" in r.error.lower() or "github" in r.error.lower()
     # reset 不应被调（fetch 失败就中止）
     assert not any(c[0] == "reset" for c in calls)
+
+
+def test_bootstrap_happy_path_leaves_clean_working_tree(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """端到端回归：真起 file:// 本地 origin + 模拟 zip 解压目录（含 npm
+    自动改过的文件），bootstrap 完后 `git status --porcelain` 应当为空。
+
+    v0.8.1 撞过的 bug：bootstrap 用 `--mixed`，npm install 改过 package-lock.json
+    后 init 完就 dirty → pre-flight 卡更新。换 `--hard` 后 working tree 强制
+    对齐到 anchor，npm 改动被覆盖，状态干净。
+
+    没装 git 直接 skip（CI 上一般有 git；个别隔离环境可能没）。"""
+    import shutil
+    import subprocess
+
+    if not shutil.which("git"):
+        pytest.skip("git binary 不在 PATH，跳过端到端 bootstrap 测试")
+
+    def _run(*args: str, cwd: Path) -> None:
+        """在 cwd 下跑 git，失败抛 AssertionError 带 stderr。"""
+        proc = subprocess.run(
+            ["git", *args], cwd=str(cwd), capture_output=True, text=True, timeout=30,
+        )
+        assert proc.returncode == 0, f"git {' '.join(args)} 失败:\n{proc.stderr}"
+
+    # ---- 1. 起一个本地 bare repo 作为 origin ----
+    origin_dir = tmp_path / "origin.git"
+    origin_dir.mkdir()
+    _run("init", "--bare", "--initial-branch=master", ".", cwd=origin_dir)
+
+    # ---- 2. 起一个 working repo，commit + tag v9.9.9，push 到 origin ----
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    _run("init", "--initial-branch=master", ".", cwd=src_dir)
+    _run("config", "user.email", "test@example.com", cwd=src_dir)
+    _run("config", "user.name", "Test", cwd=src_dir)
+    # commit 一些"上游"文件
+    (src_dir / "README.md").write_text("upstream readme\n", encoding="utf-8")
+    (src_dir / "package-lock.json").write_text('{"upstream": true}\n', encoding="utf-8")
+    _run("add", "-A", cwd=src_dir)
+    _run("commit", "-m", "release v9.9.9", cwd=src_dir)
+    _run("tag", "v9.9.9", cwd=src_dir)
+    _run("remote", "add", "origin", str(origin_dir), cwd=src_dir)
+    _run("push", "origin", "master", "--tags", cwd=src_dir)
+
+    # ---- 3. 模拟 zip 解压：把 src/ 内容（不含 .git/）拷到 zip_dir ----
+    zip_dir = tmp_path / "zip"
+    zip_dir.mkdir()
+    for f in src_dir.iterdir():
+        if f.name == ".git":
+            continue
+        shutil.copy(f, zip_dir / f.name)
+
+    # ---- 4. 模拟 npm install 改过 package-lock.json（v0.8.1 bug 触发点）----
+    (zip_dir / "package-lock.json").write_text(
+        '{"upstream": true, "npm_local_modification": "different"}\n',
+        encoding="utf-8",
+    )
+
+    # ---- 5. monkeypatch updater 指向这个模拟环境，跑 bootstrap ----
+    monkeypatch.setattr(updater, "REPO_ROOT", zip_dir)
+    monkeypatch.setattr(updater, "ORIGIN_URL", str(origin_dir))
+    monkeypatch.setattr(updater, "__version__", "9.9.9")  # 匹配 tag
+
+    result = updater.bootstrap_git_repo()
+    assert result.ok is True, f"bootstrap 失败: {result.error}"
+    assert result.anchor_kind == "version_tag", "应当 anchor 在 v9.9.9 tag"
+
+    # ---- 6. 关键断言：working tree 完全干净（不含 untracked）----
+    proc = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=str(zip_dir), capture_output=True, text=True, timeout=10,
+    )
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == "", \
+        f"bootstrap 完应当 clean，实际 status:\n{proc.stdout}"
+
+    # ---- 7. package-lock.json 被强制覆盖回上游版本（npm 改动丢了）----
+    assert (zip_dir / "package-lock.json").read_text(encoding="utf-8") == '{"upstream": true}\n'
 
 
 def test_bootstrap_honors_env_origin_url_override(


### PR DESCRIPTION
## 背景

v0.8.1 上线后实测：zip 用户解压后跑过 `studio.bat run`，npm install 会改 `studio/web/package-lock.json` 几行（依赖元数据 / 平台特定字段）。当时 bootstrap 用 `--mixed` 想保留 working tree，结果 init 完就 dirty → 版本面板 pre-flight 卡更新 → 用户拿不到"启用自动更新"的实际收益。

## 改动

- **`updater.bootstrap_git_repo`**：`git reset --mixed` → `git reset --hard`。HEAD / index / working tree 全部强制对齐到 anchor (`v{__version__}` tag 或 FETCH_HEAD)。代价：覆盖 zip 目录里的本地修改。zip 用户场景下"启用自动更新"的潜台词就是"对齐到上游稳定版"，强制覆盖比保留随机改动符合预期
- **Settings.tsx banner 文案**：从「不会覆盖你的文件」改成「本地源码会同步到上游 v{X.Y.Z}，zip 目录里的本地修改会被覆盖（npm lockfile / 自定义配置等都会重置）」—— 显式提示
- **测试**：现有 `--mixed` 断言改 `--hard` + 加反向断言禁回退；新增端到端 happy-path 回归测试（起 file:// 本地 origin + 模拟 zip 解压目录含 npm 风格本地修改 → bootstrap → 验证 `git status --porcelain` 为空 + 被改文件回到上游内容）

## 测试

- `pytest tests/test_updater.py` → 60 passed（含新加 happy-path）
- `tsc --noEmit` clean
- v0.8.1 手测路径（reproduce 步骤）：
  1. 下载 [AnimaLoraStudio-0.8.1.zip](https://github.com/WalkingMeatAxolotl/AnimaLoraStudio/archive/refs/tags/v0.8.1.zip) 解压
  2. 跑 `studio.bat run` 一次（让 npm install 改 package-lock.json）
  3. 打开版本面板 → 点「启用自动更新」
  4. **预期（这版前）**：init 完 banner 消失但「你装的：v0.8.1 · 未提交修改」+ pre-flight 卡所有更新
  5. **预期（这版后）**：init 完干净，可以正常用所有按钮

## 不在范围

- 版本号不 bump（按 maintainer 指示：问题不大，zip 用户也不会用 dev，下次正常 release 一起带走 PATCH bump）
- 没改 release_notes.yaml