### PR TITLE
refactor(train): schedule_shift → timestep_schedule_shift 字段重命名

### DIFF
--- a/runtime/training/timestep_samplers/baseline.py
+++ b/runtime/training/timestep_samplers/baseline.py
@@ -20,12 +20,12 @@ class BaselineTimestepSampler:
         mode: str = "logit_normal",
         shift: float = 3.0,
         mix_low_prob: float = 0.0,
-        schedule_shift: float = 1.0,
+        timestep_schedule_shift: float = 1.0,
     ):
         self.mode = mode
         self.shift = shift
         self.mix_low_prob = mix_low_prob
-        self.schedule_shift = schedule_shift
+        self.timestep_schedule_shift = timestep_schedule_shift
 
     def sample(self, bs: int, device) -> torch.Tensor:
         return sample_t(
@@ -34,7 +34,7 @@ class BaselineTimestepSampler:
             mode=self.mode,
             shift=self.shift,
             mix_low_prob=self.mix_low_prob,
-            schedule_shift=self.schedule_shift,
+            timestep_schedule_shift=self.timestep_schedule_shift,
         )
 
     def record(self, t: torch.Tensor, raw_mse: torch.Tensor) -> None:
@@ -49,7 +49,7 @@ class BaselineTimestepSampler:
             "mode": self.mode,
             "shift": self.shift,
             "mix_low_prob": self.mix_low_prob,
-            "schedule_shift": self.schedule_shift,
+            "timestep_schedule_shift": self.timestep_schedule_shift,
         }
 
 
@@ -59,5 +59,5 @@ def build(args, total_steps) -> BaselineTimestepSampler:
         mode=str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal"),
         shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
         mix_low_prob=float(getattr(args, "timestep_mix_low_prob", 0.0) or 0.0),
-        schedule_shift=float(getattr(args, "schedule_shift", 1.0) or 1.0),
+        timestep_schedule_shift=float(getattr(args, "timestep_schedule_shift", 1.0) or 1.0),
     )

--- a/runtime/training/timestep_samplers/infonoise.py
+++ b/runtime/training/timestep_samplers/infonoise.py
@@ -44,7 +44,7 @@ class InfoNoiseScheduler:
         baseline_shift: float = 3.0,
         baseline_mode: str = "logit_normal",
         baseline_mix_low_prob: float = 0.0,
-        baseline_schedule_shift: float = 1.0,
+        baseline_timestep_schedule_shift: float = 1.0,
     ):
         self.K = K
         self.N_warm = N_warm
@@ -57,7 +57,7 @@ class InfoNoiseScheduler:
         self.baseline_shift = baseline_shift
         self.baseline_mode = baseline_mode
         self.baseline_mix_low_prob = baseline_mix_low_prob
-        self.baseline_schedule_shift = baseline_schedule_shift
+        self.baseline_timestep_schedule_shift = baseline_timestep_schedule_shift
         self._internal_step = 0
 
         sigma_min = t_min / (1.0 - t_min)
@@ -100,7 +100,7 @@ class InfoNoiseScheduler:
             mode=self.baseline_mode,
             shift=self.baseline_shift,
             mix_low_prob=self.baseline_mix_low_prob,
-            schedule_shift=self.baseline_schedule_shift,
+            timestep_schedule_shift=self.baseline_timestep_schedule_shift,
         )
 
     def record(self, t: torch.Tensor, raw_mse: torch.Tensor):
@@ -221,7 +221,7 @@ def build(args, total_steps: Optional[int]) -> InfoNoiseScheduler:
         baseline_shift=float(getattr(args, "timestep_shift", 3.0) or 3.0),
         baseline_mode=str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal"),
         baseline_mix_low_prob=float(getattr(args, "timestep_mix_low_prob", 0.0) or 0.0),
-        baseline_schedule_shift=float(getattr(args, "schedule_shift", 1.0) or 1.0),
+        baseline_timestep_schedule_shift=float(getattr(args, "timestep_schedule_shift", 1.0) or 1.0),
     )
     logger.info(
         f"InfoNoise 已启用：K={scheduler.K}, N_warm={scheduler.N_warm}, "

--- a/runtime/training/timestep_sampling.py
+++ b/runtime/training/timestep_sampling.py
@@ -18,7 +18,7 @@ def sample_t(
     mode: str = "logit_normal",
     shift: float = 3.0,
     mix_low_prob: float = 0.0,
-    schedule_shift: float = 1.0,
+    timestep_schedule_shift: float = 1.0,
 ) -> torch.Tensor:
     """采样 Flow Matching 时间步 t ∈ (0, 1)。
 
@@ -32,51 +32,53 @@ def sample_t(
       mixed_uniform_logit— 同上但偏置端走 logit_normal（标准），适合不想偏低 t 的场景
 
     mix_low_prob — mixed_* mode 下走偏置端的样本比例（默认 0 = 全 uniform）
-    schedule_shift — 采样完成后对 t 做的额外 σ schedule 偏移（默认 1.0 = 无 shift）；
-                     公式 t' = (t * s) / (1 + (s - 1) * t)；与 logit-normal 内部 shift 不同：
-                     timestep_shift 作用于 sigmoid 后的 u 值，schedule_shift 作用于最终 t
+    timestep_schedule_shift — 采样完成后对 t 做的额外 σ schedule 偏移（默认 1.0 = 无 shift）；
+                     公式 t' = (t * s) / (1 + (s - 1) * t)（SD3/FLUX shifted schedule，
+                     Möbius 变换）；与 timestep_shift 不同：后者作用于 logit-normal 内部
+                     的 sigmoid 后 u 值，前者作用于最终 t
     """
     mode = (mode or "logit_normal").lower()
 
     if mode == "uniform":
         t = torch.rand(bs, device=device).clamp(1e-4, 1 - 1e-4)
-        return _apply_schedule_shift(t, schedule_shift)
+        return _apply_timestep_schedule_shift(t, timestep_schedule_shift)
 
     if mode in ("mixed_uniform_low", "mixed_uniform_logit"):
         p = max(0.0, min(1.0, float(mix_low_prob)))
         use_biased = torch.rand(bs, device=device) < p
         t_uniform = torch.rand(bs, device=device).clamp(1e-4, 1 - 1e-4)
         biased_mode = "logit_normal_low" if mode == "mixed_uniform_low" else "logit_normal"
-        # 递归调用基础 mode 采样偏置端（不再传 mix_low_prob 避免循环；不在内部再做 schedule_shift，
+        # 递归调用基础 mode 采样偏置端（不再传 mix_low_prob 避免循环；不在内部再做 schedule shift，
         # 留到最后统一应用）
-        t_biased = sample_t(bs, device, mode=biased_mode, shift=shift, mix_low_prob=0.0, schedule_shift=1.0)
+        t_biased = sample_t(bs, device, mode=biased_mode, shift=shift, mix_low_prob=0.0, timestep_schedule_shift=1.0)
         t = torch.where(use_biased, t_biased, t_uniform)
-        return _apply_schedule_shift(t, schedule_shift)
+        return _apply_timestep_schedule_shift(t, timestep_schedule_shift)
 
     u = torch.sigmoid(torch.randn(bs, device=device))
 
     if mode == "logit_normal_low":
         s = max(float(shift), 1e-4)
         u = (u * (1.0 / s)) / (1 + (1.0 / s - 1) * u)
-        return _apply_schedule_shift(u.clamp(1e-4, 1 - 1e-4), schedule_shift)
+        return _apply_timestep_schedule_shift(u.clamp(1e-4, 1 - 1e-4), timestep_schedule_shift)
 
     if mode == "mode":
         s = float(shift)
         u = 1 - u - s * (torch.cos(torch.pi * 0.5 * u) ** 2 - 1 + u)
-        return _apply_schedule_shift(u.clamp(1e-4, 1 - 1e-4), schedule_shift)
+        return _apply_timestep_schedule_shift(u.clamp(1e-4, 1 - 1e-4), timestep_schedule_shift)
 
     # logit_normal（默认）+ shift
     s = float(shift)
     u = (u * s) / (1 + (s - 1) * u)
-    return _apply_schedule_shift(u.clamp(1e-4, 1 - 1e-4), schedule_shift)
+    return _apply_timestep_schedule_shift(u.clamp(1e-4, 1 - 1e-4), timestep_schedule_shift)
 
 
-def _apply_schedule_shift(t: torch.Tensor, schedule_shift: float) -> torch.Tensor:
+def _apply_timestep_schedule_shift(t: torch.Tensor, timestep_schedule_shift: float) -> torch.Tensor:
     """对采样后的 t 做额外 σ schedule 偏移：t' = (t * s) / (1 + (s - 1) * t)。
 
-    s == 1.0 时恒等映射（默认行为不变）。s > 1 推向高噪声端；s < 1 偏低噪声端。
+    SD3/FLUX shifted schedule 的 Möbius 变换；s == 1.0 时恒等映射（默认行为不变）。
+    s > 1 推向高噪声端；s < 1 偏低噪声端。
     """
-    s = float(schedule_shift)
+    s = float(timestep_schedule_shift)
     if s == 1.0:
         return t
     return ((t * s) / (1 + (s - 1) * t)).clamp(1e-4, 1 - 1e-4)

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -397,7 +397,7 @@ class TrainingConfig(BaseModel):
             advanced=True,
         ),
     )
-    schedule_shift: float = Field(
+    timestep_schedule_shift: float = Field(
         1.0, ge=0.1, le=10.0,
         description="【时间步采样】采样后对 t 做的额外 σ schedule 偏移（1.0 = 无偏移；与 timestep_shift 不同：后者作用于 logit-normal 内部，前者作用于最终 t）",
         json_schema_extra=_meta(

--- a/tests/test_timestep_sampling.py
+++ b/tests/test_timestep_sampling.py
@@ -1,9 +1,9 @@
 """timestep_sampling 单元测试。
 
 主要覆盖：
-- 4 个原 mode 在默认 mix_low_prob=0/schedule_shift=1.0 下行为不变（防回归）
+- 4 个原 mode 在默认 mix_low_prob=0/timestep_schedule_shift=1.0 下行为不变（防回归）
 - 2 个新 mode（mixed_uniform_low / mixed_uniform_logit）p=0/p=1/部分混合三种情形
-- schedule_shift 公式数学正确 + 1.0 时恒等 + >1 推高均值
+- timestep_schedule_shift 公式数学正确 + 1.0 时恒等 + >1 推高均值
 - BaselineTimestepSampler 接收+透传新参 + build() 读 args
 - InfoNoise build() 读新参 + baseline 走 sample_t 时透传
 
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import torch
 
-from training.timestep_sampling import _apply_schedule_shift, sample_t
+from training.timestep_sampling import _apply_timestep_schedule_shift, sample_t
 from training.timestep_samplers.baseline import BaselineTimestepSampler
 from training.timestep_samplers.baseline import build as build_baseline
 from training.timestep_samplers.infonoise import InfoNoiseScheduler
@@ -21,27 +21,27 @@ from training.timestep_samplers.infonoise import build as build_infonoise
 
 
 # ---------------------------------------------------------------------------
-# schedule_shift 数学
+# timestep_schedule_shift 数学
 # ---------------------------------------------------------------------------
 
 
-def test_schedule_shift_identity_when_one():
+def test_timestep_schedule_shift_identity_when_one():
     t = torch.tensor([0.1, 0.3, 0.5, 0.7, 0.9])
-    out = _apply_schedule_shift(t, 1.0)
+    out = _apply_timestep_schedule_shift(t, 1.0)
     torch.testing.assert_close(out, t)
 
 
-def test_schedule_shift_formula_matches_spec():
+def test_timestep_schedule_shift_formula_matches_spec():
     """t' = (t * s) / (1 + (s-1)*t); s=2, t=0.5 → 1/1.5 = 2/3"""
     t = torch.tensor([0.5])
-    out = _apply_schedule_shift(t, 2.0)
+    out = _apply_timestep_schedule_shift(t, 2.0)
     torch.testing.assert_close(out, torch.tensor([2.0 / 3.0]), rtol=1e-5, atol=1e-5)
 
 
-def test_schedule_shift_clamps_to_open_interval():
+def test_timestep_schedule_shift_clamps_to_open_interval():
     """t∈(0,1) 后经 shift 也应保持 (0, 1) 开区间（clamp 到 [eps, 1-eps]）。"""
     t = torch.tensor([1e-5, 0.5, 1 - 1e-5])
-    out = _apply_schedule_shift(t, 5.0)
+    out = _apply_timestep_schedule_shift(t, 5.0)
     assert (out > 0).all() and (out < 1).all()
 
 
@@ -135,24 +135,24 @@ def test_mixed_uniform_logit_partial_pulls_toward_high():
 
 
 # ---------------------------------------------------------------------------
-# schedule_shift 跟分布混合
+# timestep_schedule_shift 跟分布混合
 # ---------------------------------------------------------------------------
 
 
-def test_schedule_shift_high_value_raises_mean():
-    """schedule_shift > 1 推高 mean。"""
+def test_timestep_schedule_shift_high_value_raises_mean():
+    """timestep_schedule_shift > 1 推高 mean。"""
     torch.manual_seed(0)
-    t_base = sample_t(4096, "cpu", mode="uniform", schedule_shift=1.0)
+    t_base = sample_t(4096, "cpu", mode="uniform", timestep_schedule_shift=1.0)
     torch.manual_seed(0)
-    t_high = sample_t(4096, "cpu", mode="uniform", schedule_shift=3.0)
+    t_high = sample_t(4096, "cpu", mode="uniform", timestep_schedule_shift=3.0)
     assert t_high.mean().item() > t_base.mean().item() + 0.05
 
 
-def test_schedule_shift_applies_to_mixed_mode():
-    """mixed_uniform_low + schedule_shift=2 输出应推高（覆盖偏低端原本的均值）。"""
+def test_timestep_schedule_shift_applies_to_mixed_mode():
+    """mixed_uniform_low + timestep_schedule_shift=2 输出应推高（覆盖偏低端原本的均值）。"""
     torch.manual_seed(0)
-    t = sample_t(4096, "cpu", mode="mixed_uniform_low", shift=3.0, mix_low_prob=1.0, schedule_shift=3.0)
-    # 即使是 mixed_uniform_low (本应偏低)，schedule_shift=3 也应把均值推回 > 0.4
+    t = sample_t(4096, "cpu", mode="mixed_uniform_low", shift=3.0, mix_low_prob=1.0, timestep_schedule_shift=3.0)
+    # 即使是 mixed_uniform_low (本应偏低)，timestep_schedule_shift=3 也应把均值推回 > 0.4
     assert t.mean().item() > 0.4
 
 
@@ -166,7 +166,7 @@ def test_baseline_sampler_accepts_new_params():
         mode="mixed_uniform_low",
         shift=3.0,
         mix_low_prob=0.5,
-        schedule_shift=1.5,
+        timestep_schedule_shift=1.5,
     )
     t = s.sample(64, "cpu")
     assert t.shape == (64,)
@@ -174,7 +174,7 @@ def test_baseline_sampler_accepts_new_params():
     status = s.status()
     assert status["mode"] == "mixed_uniform_low"
     assert status["mix_low_prob"] == 0.5
-    assert status["schedule_shift"] == 1.5
+    assert status["timestep_schedule_shift"] == 1.5
 
 
 def test_baseline_build_reads_new_args():
@@ -183,12 +183,12 @@ def test_baseline_build_reads_new_args():
         timestep_sampling = "mixed_uniform_low"
         timestep_shift = 2.0
         timestep_mix_low_prob = 0.25
-        schedule_shift = 1.12
+        timestep_schedule_shift = 1.12
 
     s = build_baseline(Args(), total_steps=1000)
     assert s.mode == "mixed_uniform_low"
     assert s.mix_low_prob == 0.25
-    assert s.schedule_shift == 1.12
+    assert s.timestep_schedule_shift == 1.12
 
 
 def test_baseline_build_backward_compatible_with_missing_new_args():
@@ -196,18 +196,18 @@ def test_baseline_build_backward_compatible_with_missing_new_args():
     class OldArgs:
         timestep_sampling = "logit_normal"
         timestep_shift = 3.0
-        # 缺 timestep_mix_low_prob / schedule_shift
+        # 缺 timestep_mix_low_prob / timestep_schedule_shift
 
     s = build_baseline(OldArgs(), total_steps=1000)
     assert s.mix_low_prob == 0.0
-    assert s.schedule_shift == 1.0
+    assert s.timestep_schedule_shift == 1.0
 
 
 def test_baseline_sampler_default_args_unchanged():
-    """无显式传参时跟历史 BaselineTimestepSampler() 行为等价（mix_low_prob=0, schedule_shift=1）。"""
+    """无显式传参时跟历史 BaselineTimestepSampler() 行为等价（mix_low_prob=0, timestep_schedule_shift=1）。"""
     s = BaselineTimestepSampler()
     assert s.mix_low_prob == 0.0
-    assert s.schedule_shift == 1.0
+    assert s.timestep_schedule_shift == 1.0
     t = s.sample(128, "cpu")
     # 默认 mode=logit_normal shift=3 → mean > 0.5
     assert t.mean().item() > 0.5
@@ -223,7 +223,7 @@ def test_infonoise_build_reads_new_args():
         timestep_sampling = "mixed_uniform_low"
         timestep_shift = 3.0
         timestep_mix_low_prob = 0.2
-        schedule_shift = 1.5
+        timestep_schedule_shift = 1.5
         infonoise_K = 32
         infonoise_N_warm = 0  # auto
         infonoise_M = 50
@@ -234,7 +234,7 @@ def test_infonoise_build_reads_new_args():
     s = build_infonoise(Args(), total_steps=500)
     assert s.baseline_mode == "mixed_uniform_low"
     assert s.baseline_mix_low_prob == 0.2
-    assert s.baseline_schedule_shift == 1.5
+    assert s.baseline_timestep_schedule_shift == 1.5
 
 
 def test_infonoise_warmup_sample_uses_new_params():
@@ -244,7 +244,7 @@ def test_infonoise_warmup_sample_uses_new_params():
         baseline_mode="mixed_uniform_low",
         baseline_shift=3.0,
         baseline_mix_low_prob=0.5,
-        baseline_schedule_shift=1.0,
+        baseline_timestep_schedule_shift=1.0,
     )
     assert s._cdf_values is None
     t = s.sample(128, "cpu")
@@ -253,7 +253,7 @@ def test_infonoise_warmup_sample_uses_new_params():
 
 
 def test_infonoise_default_baseline_params_unchanged():
-    """InfoNoiseScheduler 无显式 baseline_mix_low_prob/schedule_shift 时回落到默认。"""
+    """InfoNoiseScheduler 无显式 baseline_mix_low_prob/timestep_schedule_shift 时回落到默认。"""
     s = InfoNoiseScheduler(K=32, N_warm=100, M=10, B=10, N_min=1)
     assert s.baseline_mix_low_prob == 0.0
-    assert s.baseline_schedule_shift == 1.0
+    assert s.baseline_timestep_schedule_shift == 1.0


### PR DESCRIPTION
## Summary

PR #73 字段命名不一致的合后立刻修正。`schedule_shift` 不带 `timestep_` 前缀，跟兄弟字段 `timestep_sampling` / `timestep_shift` / `timestep_mix_low_prob` 一族不对齐。

**时间窗口正在关闭**：PR #73 合并 ~24h，preset / yaml 仍未引用本字段，重命名零成本；晚改一周就成永久 API，再改要走 deprecation cycle。

## 变动

- `studio/schema.py` 字段名 `schedule_shift` → `timestep_schedule_shift`
- `runtime/training/timestep_sampling.py` `sample_t` 参数 + helper `_apply_timestep_schedule_shift` 函数名 + docstring
- `runtime/training/timestep_samplers/baseline.py` `BaselineTimestepSampler.timestep_schedule_shift` attr + `status()` key + `getattr(args, ...)` bridge
- `runtime/training/timestep_samplers/infonoise.py` `baseline_timestep_schedule_shift` attr + bridge
- `tests/test_timestep_sampling.py` 全量替换

顺手在 `_apply_timestep_schedule_shift` docstring 补 SD3/FLUX shifted schedule（Möbius 变换）引用——这是另一条 #73 follow-up。

## 数值兼容性

`timestep_schedule_shift=1.0` 默认下 `_apply_timestep_schedule_shift` 走 `if s == 1.0: return t` short-circuit，行为跟旧 `schedule_shift=1.0` bit-for-bit 一致。

## Test plan

- [x] `tests/test_timestep_sampling.py` 21 passed
- [x] `tests/test_loss_weighting.py` / `tests/test_plugin_registry.py` / `tests/test_losses.py` 共 58 passed
- [x] 全套 1243 测试通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)