### PR TITLE
fix(train): SqrtZ3 三 PR follow-ups（②~⑥ 合后必修）

### DIFF
--- a/runtime/training/loss_weighting.py
+++ b/runtime/training/loss_weighting.py
@@ -2,9 +2,10 @@
 
 抽自原 runtime/anima_train.py L1898-1937（ADR 0003 PR-A）。
 
-各 scheme 共享同一签名 (t, gamma, cap) -> (B,)，不引入 schema 字段（用
-schema.loss_weighting: str），所以一文件多 if 分支即可，不需要 plugin
-subfolder。
+各 scheme 共享 compute_loss_weight 入口；scheme-specific 参数（如
+detail_inv_t_min/max）通过 keyword arg 透传。当前 scheme 总数较少仍用
+单文件多 if 分支；若未来 scheme 数量增长 / scheme-specific 字段进一步
+扩张，应迁移到 plugin 模式（参考 runtime/training/losses/）。
 """
 
 from __future__ import annotations

--- a/runtime/training/losses/__init__.py
+++ b/runtime/training/losses/__init__.py
@@ -2,7 +2,7 @@
 
 `build_loss(args) -> LossProtocol` 按 args.loss_type 派发到具体 loss：
 - mse    — F.mse_loss 包装（默认，与历史行为字节级一致）
-- huber  — Huber loss with constant/snr/sigma delta schedule
+- huber  — Huber loss with constant delta（EDM/Karras 标准做法）
 
 加新 loss 步骤：
 1. 写 training/losses/{name}.py 含 `build(args) -> LossProtocol`

--- a/runtime/training/losses/huber.py
+++ b/runtime/training/losses/huber.py
@@ -1,20 +1,15 @@
-"""Huber loss with time-dependent delta schedule。
+"""Huber loss（constant delta）。
 
 Huber 公式（per-element）：
     L(x) = 0.5 * x^2                 if |x| < delta
     L(x) = delta * (|x| - 0.5*delta) otherwise
 
-相比 MSE 对 outlier 更鲁棒；diffusion / flow matching 训练中，低 t（细节端）
-loss 数值小但梯度方差大，高 t（结构端）loss 数值大但梯度方差小。huber_schedule
-让 delta 跟随 t 变化，平衡两端的梯度尺度。
+相比 MSE 对 outlier 更鲁棒，缓解极端 sample 的梯度爆炸。EDM/Karras /
+kohya-ss 等主流 trainer 都用 constant δ。
 
-支持三种 schedule：
-- constant — delta = huber_c（全程不变）
-- snr      — delta = huber_c * sqrt((1-t) / t)；Flow Matching 下 SNR(t) =
-             ((1-t)/t)^2，sqrt(SNR) 跟 σ⁻¹ 同阶；低 t 处 delta 大（接近 MSE），
-             高 t 处 delta 小（更鲁棒）
-- sigma    — delta = huber_c * t/(1-t)；σ = t/(1-t)。低 t 处 delta 小（鲁棒），
-             高 t 处 delta 大；跟 snr 方向相反
+**若未来要引入 t-dependent δ schedule，必须附 (a) 论文 DOI / (b) 上游
+trainer 实现链接 / (c) 本项目自跑 ablation 数据**——参考
+[[feedback_verify_paper_before_fixing_algo]]（P0-2 EMA 翻转事故同根）。
 """
 
 from __future__ import annotations
@@ -23,46 +18,25 @@ import torch
 
 
 class HuberLoss:
-    """Stateful Huber：delta 由 huber_c + huber_schedule + t 决定。"""
+    """Huber loss with constant delta（per-element，reduction='none'）。"""
 
-    def __init__(self, c: float = 0.15, schedule: str = "constant"):
+    def __init__(self, c: float = 0.15):
         self.c = float(c)
-        self.schedule = (schedule or "constant").lower()
-        if self.schedule not in ("constant", "snr", "sigma"):
-            raise ValueError(
-                f"huber_schedule={schedule!r} 不支持；可选 constant / snr / sigma"
-            )
 
     def compute(
         self,
         pred: torch.Tensor,
         target: torch.Tensor,
-        t: torch.Tensor,
+        t: torch.Tensor,  # noqa: ARG002 — LossProtocol 一致性，constant huber 不使用
     ) -> torch.Tensor:
-        delta = self._compute_delta(t).to(dtype=pred.dtype, device=pred.device)
-        # delta 形状 (B,)，pred/target 形状 (B, C, *spatial)；广播 delta 到 pred 维数
-        delta_b = delta.view(-1, *([1] * (pred.dim() - 1)))
-
         diff = pred - target
         abs_diff = diff.abs()
         quad = 0.5 * diff * diff
-        lin = delta_b * (abs_diff - 0.5 * delta_b)
-        return torch.where(abs_diff < delta_b, quad, lin)
-
-    def _compute_delta(self, t: torch.Tensor) -> torch.Tensor:
-        if self.schedule == "constant":
-            return torch.full_like(t, self.c)
-
-        # clamp t 到开区间防 0 / inf
-        t_c = t.clamp(1e-4, 1 - 1e-4)
-        if self.schedule == "snr":
-            return self.c * ((1.0 - t_c) / t_c).sqrt()
-        # sigma
-        return self.c * (t_c / (1.0 - t_c))
+        lin = self.c * (abs_diff - 0.5 * self.c)
+        return torch.where(abs_diff < self.c, quad, lin)
 
 
 def build(args) -> HuberLoss:
     return HuberLoss(
         c=float(getattr(args, "huber_c", 0.15) or 0.15),
-        schedule=str(getattr(args, "huber_schedule", "constant") or "constant"),
     )

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -444,17 +444,12 @@ class TrainingConfig(BaseModel):
     )
     loss_type: Literal["mse", "huber"] = Field(
         "mse",
-        description="【损失函数】训练 loss 类型（mse 默认；huber 对 outlier 鲁棒，配合 huber_schedule 平衡两端梯度尺度）",
-        json_schema_extra=_meta("noise_schedule", advanced=True),
+        description="【损失函数】训练 loss 类型（mse 默认；huber 对 outlier 鲁棒）",
+        json_schema_extra=_meta("noise_schedule"),
     )
     huber_c: float = Field(
         0.15, ge=0.01, le=5.0,
-        description="【Huber loss】基础 delta 系数（典型 0.1–0.3；与 huber_schedule 协同控制 quad/linear 转折点）",
-        json_schema_extra=_meta("noise_schedule", show_when="loss_type==huber", advanced=True),
-    )
-    huber_schedule: Literal["constant", "snr", "sigma"] = Field(
-        "constant",
-        description="【Huber loss】delta 随 t 变化策略（constant=不变；snr=低 t 大 δ 高 t 小 δ；sigma=反向）",
+        description="【Huber loss】delta 系数（典型 0.1–0.3；控制 quad/linear 转折点，|x|<δ 走二次，|x|≥δ 走线性）",
         json_schema_extra=_meta("noise_schedule", show_when="loss_type==huber", advanced=True),
     )
     loss_weighting: Literal["none", "min_snr", "detail_inv_t", "cosmap"] = Field(
@@ -473,8 +468,8 @@ class TrainingConfig(BaseModel):
         json_schema_extra=_meta("noise_schedule", show_when="loss_weighting!=none", advanced=True),
     )
     detail_inv_t_min: float = Field(
-        1.0, ge=0.1, le=20.0,
-        description="【损失加权】detail_inv_t 权重下限（默认 1.0；升至 1.5 可让高 t 步也被略微加权）",
+        1.0, ge=1.0, le=20.0,
+        description="【损失加权】detail_inv_t 权重下限（默认 1.0；升至 1.5 可让高 t 步也被略微加权；<1.0 因 1/t>1 恒成立故无效）",
         json_schema_extra=_meta("noise_schedule", show_when="loss_weighting==detail_inv_t", advanced=True),
     )
     detail_inv_t_max: float = Field(

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -2,7 +2,7 @@
 
 覆盖：
 - MseLoss：跟 F.mse_loss(reduction='none') bit-for-bit 一致 + 不依赖 t + Protocol 合规
-- HuberLoss：quad / linear / 边界 三段公式正确 + constant/snr/sigma 三种 schedule 的 delta 行为
+- HuberLoss：quad / linear / 边界 三段公式正确（constant delta）
 - plugin registry：BUILDERS / build_loss / validate_schema_consistency 三件套
 - 集成：所有 loss 在 (B, C, H, W) latent shape 上输出形状正确、有限值
 """
@@ -60,23 +60,23 @@ def test_mse_build_returns_instance():
 # ---------------------------------------------------------------------------
 
 
-def test_huber_constant_inside_quadratic_region():
+def test_huber_inside_quadratic_region():
     """|x| < delta 时 Huber = 0.5 * x^2。"""
     pred = torch.tensor([[0.05]])
     target = torch.tensor([[0.0]])
     t = torch.tensor([0.5])
-    huber = HuberLoss(c=0.15, schedule="constant")
+    huber = HuberLoss(c=0.15)
     expected = torch.tensor([[0.5 * 0.05 * 0.05]])
     actual = huber.compute(pred, target, t)
     torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
 
 
-def test_huber_constant_outside_linear_region():
+def test_huber_outside_linear_region():
     """|x| > delta 时 Huber = delta * (|x| - 0.5*delta)。"""
     pred = torch.tensor([[1.0]])
     target = torch.tensor([[0.0]])
     t = torch.tensor([0.5])
-    huber = HuberLoss(c=0.15, schedule="constant")
+    huber = HuberLoss(c=0.15)
     expected = torch.tensor([[0.15 * (1.0 - 0.5 * 0.15)]])  # 0.13875
     actual = huber.compute(pred, target, t)
     torch.testing.assert_close(actual, expected, rtol=1e-5, atol=1e-5)
@@ -88,7 +88,7 @@ def test_huber_continuous_at_boundary():
     pred = torch.tensor([[delta]])
     target = torch.tensor([[0.0]])
     t = torch.tensor([0.5])
-    huber = HuberLoss(c=delta, schedule="constant")
+    huber = HuberLoss(c=delta)
     # torch.where(|x| < delta) 严格小于，|x|=delta 走 lin 分支
     expected = torch.tensor([[delta * (delta - 0.5 * delta)]])  # 0.5 * delta^2
     actual = huber.compute(pred, target, t)
@@ -101,65 +101,34 @@ def test_huber_smaller_than_mse_for_large_diff():
     target = torch.tensor([[0.0]])
     t = torch.tensor([0.5])
     mse_val = MseLoss().compute(pred, target, t)
-    huber_val = HuberLoss(c=0.15, schedule="constant").compute(pred, target, t)
+    huber_val = HuberLoss(c=0.15).compute(pred, target, t)
     assert huber_val.item() < mse_val.item()  # 12.5 vs 0.74
 
 
-# ---------------------------------------------------------------------------
-# HuberLoss schedule
-# ---------------------------------------------------------------------------
-
-
-def test_huber_constant_delta_is_t_independent():
-    """constant schedule 下 delta 跟 t 无关。"""
-    huber = HuberLoss(c=0.15, schedule="constant")
-    d_low = huber._compute_delta(torch.tensor([0.1]))
-    d_high = huber._compute_delta(torch.tensor([0.9]))
-    torch.testing.assert_close(d_low, d_high)
-    torch.testing.assert_close(d_low, torch.tensor([0.15]))
-
-
-def test_huber_snr_delta_decreases_with_t():
-    """snr schedule：delta = c * sqrt((1-t)/t)，低 t 大 delta，t=0.5 时 delta=c。"""
-    huber = HuberLoss(c=0.15, schedule="snr")
-    delta_low = huber._compute_delta(torch.tensor([0.1]))
-    delta_mid = huber._compute_delta(torch.tensor([0.5]))
-    delta_high = huber._compute_delta(torch.tensor([0.9]))
-    assert delta_low.item() > delta_mid.item() > delta_high.item()
-    torch.testing.assert_close(delta_mid, torch.tensor([0.15]), rtol=1e-5, atol=1e-5)
-
-
-def test_huber_sigma_delta_increases_with_t():
-    """sigma schedule：delta = c * t/(1-t)，低 t 小 delta，跟 snr 反向。"""
-    huber = HuberLoss(c=0.15, schedule="sigma")
-    delta_low = huber._compute_delta(torch.tensor([0.1]))
-    delta_mid = huber._compute_delta(torch.tensor([0.5]))
-    delta_high = huber._compute_delta(torch.tensor([0.9]))
-    assert delta_low.item() < delta_mid.item() < delta_high.item()
-    torch.testing.assert_close(delta_mid, torch.tensor([0.15]), rtol=1e-5, atol=1e-5)
-
-
-def test_huber_unknown_schedule_raises():
-    with pytest.raises(ValueError, match="huber_schedule"):
-        HuberLoss(c=0.15, schedule="nonexistent")
+def test_huber_t_independent():
+    """constant delta 下 huber 输出与 t 无关。"""
+    huber = HuberLoss(c=0.15)
+    torch.manual_seed(0)
+    pred = torch.randn(2, 3, 4, 4)
+    target = torch.randn(2, 3, 4, 4)
+    out1 = huber.compute(pred, target, torch.tensor([0.1, 0.5]))
+    out2 = huber.compute(pred, target, torch.tensor([0.9, 0.99]))
+    torch.testing.assert_close(out1, out2)
 
 
 def test_huber_build_reads_args():
     class Args:
         huber_c = 0.3
-        huber_schedule = "snr"
     h = build_huber(Args())
     assert h.c == 0.3
-    assert h.schedule == "snr"
 
 
 def test_huber_build_defaults_when_args_missing():
-    """旧 args 没新字段时回落到默认 c=0.15 / schedule=constant。"""
+    """旧 args 没新字段时回落到默认 c=0.15。"""
     class OldArgs:
         pass
     h = build_huber(OldArgs())
     assert h.c == 0.15
-    assert h.schedule == "constant"
 
 
 # ---------------------------------------------------------------------------
@@ -182,11 +151,9 @@ def test_build_loss_dispatches_huber():
     class Args:
         loss_type = "huber"
         huber_c = 0.2
-        huber_schedule = "snr"
     loss = build_loss(Args())
     assert isinstance(loss, HuberLoss)
     assert loss.c == 0.2
-    assert loss.schedule == "snr"
 
 
 def test_build_loss_unknown_type_raises():
@@ -229,9 +196,7 @@ def test_huber_satisfies_loss_protocol():
 
 @pytest.mark.parametrize("loss", [
     MseLoss(),
-    HuberLoss(c=0.15, schedule="constant"),
-    HuberLoss(c=0.15, schedule="snr"),
-    HuberLoss(c=0.15, schedule="sigma"),
+    HuberLoss(c=0.15),
 ])
 def test_compute_shape_and_finite_on_latent_like_input(loss):
     """所有 loss 在 latent-like (B, C, H, W) 输入上输出形状对齐 + 数值合法。"""
@@ -243,3 +208,51 @@ def test_compute_shape_and_finite_on_latent_like_input(loss):
     assert out.shape == pred.shape
     assert torch.isfinite(out).all()
     assert (out >= 0).all()  # huber/mse 都是非负
+
+
+# ---------------------------------------------------------------------------
+# InfoNoise × loss_type 解耦集成测试
+# ---------------------------------------------------------------------------
+
+
+def test_infonoise_raw_mse_decoupled_from_loss_type():
+    """codify PR #75 loop.py:122-131 的核心解耦：启用 huber 时 InfoNoise 仍收到纯 MSE。
+
+    防止未来重构 loop.py 把 _raw_mse 复用 ctx.loss_fn.compute 抢算力，从而违反
+    InfoNoise paper 的 I-MMSE 假设。参考 [[feedback_verify_paper_before_fixing_algo]]
+    （P0-2 EMA 翻转事故同根：对外部算法的"小聪明"必须先 verify 论文）。
+    """
+    from training.timestep_samplers.infonoise import InfoNoiseScheduler
+
+    torch.manual_seed(0)
+    pred = torch.randn(4, 4, 8, 8)
+    target = torch.randn(4, 4, 8, 8)
+    t = torch.rand(4).clamp(1e-3, 1 - 1e-3)
+
+    # 复现 loop.py:122-131 的两路计算：
+    # (1) 训练 loss 走 loss_fn（这里取 huber，跟 MSE 数值必然不同）
+    huber = HuberLoss(c=0.15)
+    loss_per_sample = huber.compute(pred.float(), target.float(), t)
+    huber_per_sample = loss_per_sample.mean(dim=list(range(1, loss_per_sample.dim())))
+
+    # (2) raw_mse 给 InfoNoise — 必须用 F.mse_loss 而不是 loss_fn
+    raw_mse_per_sample = F.mse_loss(pred.float(), target.float(), reduction="none").detach()
+    raw_mse = raw_mse_per_sample.mean(dim=list(range(1, raw_mse_per_sample.dim())))
+
+    # 预检：huber 跟 MSE 数值在这组随机输入上必然不同（差异大于 1e-3）
+    assert not torch.allclose(raw_mse, huber_per_sample, rtol=1e-2), (
+        "测试无效：huber 输出跟 MSE 太接近，重写测试或换更极端 c。"
+    )
+
+    # 核心断言：raw_mse 路径输出 == MseLoss 输出（即与 loss_fn 类型无关）
+    mse_reference = MseLoss().compute(pred.float(), target.float(), t)
+    mse_per_sample = mse_reference.mean(dim=list(range(1, mse_reference.dim())))
+    torch.testing.assert_close(raw_mse, mse_per_sample)
+
+    # 用真正 InfoNoiseScheduler 验证 record() 接受这个 raw_mse 不崩
+    scheduler = InfoNoiseScheduler(K=16, N_warm=10, M=5, B=10, N_min=1)
+    scheduler.record(t.detach(), raw_mse)
+    assert scheduler._internal_step == 1
+    # 验证记录到的总样本数 == batch size（每个 bin 之和）
+    total_recorded = sum(len(buf) for buf in scheduler._fifo)
+    assert total_recorded == 4


### PR DESCRIPTION
## Summary

PR #72 / #73 / #75 review 标的合后必修 6 项里的 5 条（① schedule_shift 字段重命名见 PR-A，单独走）。所有改动都是合前 review 标了"阻塞"但未在合并时处置的项。

## ② loss_type 去 advanced=True

`schema.py` 把 `loss_type` 的 `advanced=True` 删掉。原因：simple UI 用户原本看不到 huber 入口，导致 PR #75 huber 路径对 simple 模式是死代码。同位置兄弟字段 `loss_weighting` 本来就不是 advanced。

## ③ detail_inv_t_min ge=0.1 → ge=1.0

`(1/t_c).clamp(min=X)` 中 `1/t_c` 在 `t∈(0,1)` 时恒 > 1，下限 < 1.0 是配置死区（用户填 0.5 跟填 1.0 完全一样）。描述补 "<1.0 因 1/t>1 恒成立故无效"。

## ④ loss_weighting.py 文件头 docstring 修订

PR #72 引入了 `detail_inv_t_min` / `_max` 两个 schema 字段，破坏了原 docstring 的两条架构声明（"共享同一签名 (t, gamma, cap)"、"不引入 schema 字段"）。改为承认 scheme-specific 参数 + 留 plugin 化扩展 hook（参考 `runtime/training/losses/`）。

## ⑤ 删 huber.py 的 snr / sigma δ schedule

**问题** —— PR #75 引入的 `snr` / `sigma` schedule：

1. **数学退化**：`huber_c` 上限 5.0，t→1e-4 时 `δ = 5.0 · √((1-t)/t) ≈ 500`。huber 全程在二次区，等于关掉 huber 退化为 MSE。
2. **无 paper / trainer 出处**：作者称 "based on FM SNR" 但 SNR 是 loss weighting 公式不是 δ schedule。EDM/Karras / kohya-ss 主流 trainer 都用 constant δ。
3. **触 [[feedback_verify_paper_before_fixing_algo]]** —— P0-2 EMA 翻转事故同根。

**改动**：`HuberLoss` 简化为单 constant δ（去 `schedule` 参数），`schema.py` 删 `huber_schedule` 字段，`tests/test_losses.py` 删 snr/sigma 测试。docstring 留扩展 hook：未来引入 t-dependent δ 必须附 (a) 论文 DOI / (b) 上游 trainer 实现 / (c) 本项目自跑 ablation。

## ⑥ test_infonoise_raw_mse_decoupled_from_loss_type

新增集成测试，codify PR #75 `loop.py:122-131` 核心解耦语义：启用 huber 时 InfoNoise.record 收到的 raw_mse 必须等于 `F.mse_loss` 而非 `ctx.loss_fn.compute`。

防未来重构合并这两路计算（"为啥不复用 loss_fn 省一次 forward"）导致 InfoNoise paper-sensitive 区违反 I-MMSE 假设。

## 数值兼容性

所有改动默认值下与历史 bit-for-bit 一致：
- `loss_type=mse`（默认）走 `MseLoss.compute` 内部就是 `F.mse_loss`，有 `test_mse_matches_f_mse_loss_bitwise` codify
- `detail_inv_t_min=1.0`（默认）等价旧硬编码
- `huber_schedule` 字段删除但默认就是 `constant`，删除等于"用户什么都没填" → 无差异
- 旧 yaml preset 不需要任何改动

## Test plan

- [x] `tests/test_losses.py` 23 passed
- [x] `tests/test_loss_weighting.py` 14 passed
- [x] `tests/test_plugin_registry.py` 10 passed
- [x] `tests/test_timestep_sampling.py` 21 passed
- [x] 全套 1243 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)