### PR TITLE
fix(train): SqrtZ3 三 PR 二轮 follow-ups（A-R 共 14 项）

### DIFF
--- a/docs/user-guide/training-tips.md
+++ b/docs/user-guide/training-tips.md
@@ -103,9 +103,19 @@ Flow Matching 训练里每个 step 要从 `(0, 1)` 区间采一个 `t` 来构造
 | `uniform` | 均匀采样，覆盖结构端到细节端 | 想让模型对所有 noise level 同样关注 |
 | `logit_normal_low` | logit-normal 反向 shift，偏向低噪声/细节端 | 细节强化、风格 LoRA |
 | `mode` | SD3 mode-distribution，集中在某个 sigma 附近 | 论文实验复现 |
+| `mixed_uniform_low` | 每样本独立按 `timestep_mix_low_prob` 概率走 `logit_normal_low`，其余走 uniform | 想细节强化但保留 uniform 覆盖度 |
+| `mixed_uniform_logit` | 同上但偏置端走 `logit_normal` | 想轻度推高噪声但保留 uniform 覆盖度 |
 
 **`timestep_shift`**：仅 `logit_normal` / `mode` 用。`>1` 偏向高噪声（结构端），`<1` 偏向
 细节端。默认 `3.0` 是 SD3 经验值。
+
+**`timestep_mix_low_prob`**：仅 `mixed_uniform_*` 用，其他 mode 忽略。`0` = 全 uniform，
+`1` = 全偏置端；典型 `0.15-0.30`。
+
+**`timestep_schedule_shift`**：作用于**最终 t**（采样完成后再做一次 SD3/FLUX shifted
+schedule 偏移，公式 `t' = (t·s) / (1 + (s-1)·t)`，Möbius 变换）；跟 `timestep_shift`
+不同：后者作用于 logit-normal 内部的 sigmoid 后 u 值。默认 `1.0` 是恒等。`>1` 整体
+推向高噪声端；`<1` 偏低噪声端。可跟任意 mode 叠加。
 
 ### Loss Weighting（损失加权）
 
@@ -116,8 +126,28 @@ Flow Matching 训练里每个 step 要从 `(0, 1)` 区间采一个 `t` 来构造
 |------|------|----------|
 | `none` | 默认，纯 MSE | — |
 | `min_snr` | **强烈推荐**。SD3 论文方案，缓解 t→1 端的 loss 主导 | `min_snr_gamma` 默认 5.0，可在 3.0~7.0 调 |
-| `detail_inv_t` | 细节强化，损失 ∝ 1/(t+ε) | 慎用，可能让训练发散 |
+| `detail_inv_t` | 细节强化，损失 ∝ 1/(t+ε)，clamp 到 `[detail_inv_t_min, detail_inv_t_max]` | 默认 `[1, 5]` 跟历史一致；雾蒙蒙/低饱和画风建议 `max=3`，激进细节 `max=8` |
 | `cosmap` | SD3 风格 cosine mapping | 实验性 |
+
+**`detail_inv_t_min` / `detail_inv_t_max`**：detail_inv_t 加权曲线的下/上限（默认 `1` / `5`）。
+- `detail_inv_t_min` 必须 ≥ `1.0`——因为 `1/t` 在 `t∈(0,1)` 时恒 > 1，下限 < 1.0 是配置死区。
+- `detail_inv_t_min > detail_inv_t_max` 时启动期 schema 校验直接报错（fail-fast）。
+- 升 `max` 让低 t（细节端）权重更激进，但 Prodigy 用户注意：单样本权重过大易主导 `d` 估计，
+  建议同时开 `weight_cap_ratio=5`。
+
+### Loss 函数（0.8.x 新增）
+
+`loss_type` 默认 `mse`（与历史 bit-for-bit 一致）。可选 `huber`：
+
+| 字段 | 默认 | 说明 |
+|------|------|------|
+| `loss_type` | `mse` | 选 `huber` 对 outlier 鲁棒，缓解极端 sample 的梯度爆炸 |
+| `huber_c` | `0.15` | huber δ 系数（仅 `loss_type=huber`）；典型 `0.1–0.3`，控制 quad/linear 转折点 |
+
+**何时用 huber**：训练时偶发 NaN / loss 跳变剧烈、或数据集有少量极端 sample 时。
+EDM/Karras 论文里 δ=0.15 是常用经验值。
+
+**注意**：启用 huber 后 InfoNoise 仍收到纯 MSE（解耦设计），所以两者可同时开。
 
 ### InfoNoise 自适应采样器（0.7.1 新增）
 

--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -17,9 +17,12 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 import torch
+
+if TYPE_CHECKING:
+    from training.losses.protocol import LossProtocol
 
 
 @dataclass
@@ -62,7 +65,7 @@ class TrainingContext:
     total_steps: Optional[int] = None
     scheduler: Any = None
     timestep_sampler: Any = None    # training.timestep_samplers.TimestepSamplerProtocol
-    loss_fn: Any = None             # training.losses.LossProtocol
+    loss_fn: Optional["LossProtocol"] = None
 
     # ─── resume_phase 填充 ───
     global_step: int = 0

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -124,10 +124,12 @@ def run(ctx: TrainingContext) -> None:
                 # 自适应采样器（如 InfoNoise）记录原始 per-sample MSE（不受 huber/loss_weighting 等
                 # 加工影响）；跟训练 loss 解耦保证 InfoNoise 论文一致性。
                 # baseline 采样器是 no-op，无需 if 守卫。
-                _raw_mse_per_sample = F.mse_loss(pred.float(), target.float(), reduction="none").detach()
-                _raw_mse = _raw_mse_per_sample.mean(
-                    dim=list(range(1, _raw_mse_per_sample.dim()))
-                )
+                # 用 no_grad 避免构造 autograd 元数据（比 .detach() 少一份 grad_fn 开销）。
+                with torch.no_grad():
+                    _raw_mse_per_sample = F.mse_loss(pred.float(), target.float(), reduction="none")
+                    _raw_mse = _raw_mse_per_sample.mean(
+                        dim=list(range(1, _raw_mse_per_sample.dim()))
+                    )
                 ctx.timestep_sampler.record(t.detach(), _raw_mse)
                 # 按样本加权（正则集可降低权重）
                 if "loss_weight" in batch:

--- a/runtime/training/loss_weighting.py
+++ b/runtime/training/loss_weighting.py
@@ -49,11 +49,8 @@ def compute_loss_weight(
         snr = ((1 - t_c) / t_c) ** 2
         w = torch.minimum(torch.tensor(float(min_snr_gamma), device=t.device) / snr, torch.ones_like(t_c))
     elif scheme == "detail_inv_t":
-        lo = float(detail_inv_t_min)
-        hi = float(detail_inv_t_max)
-        if lo > hi:
-            lo, hi = hi, lo
-        w = (1.0 / t_c).clamp(min=lo, max=hi)
+        # min/max 已由 TrainingConfig.model_validator 校验过 min <= max，此处直接用
+        w = (1.0 / t_c).clamp(min=float(detail_inv_t_min), max=float(detail_inv_t_max))
     elif scheme == "cosmap":
         bot = (1 - 2 * t_c + 2 * t_c ** 2).clamp(min=eps)
         w = 2.0 / (math.pi * bot)

--- a/runtime/training/losses/protocol.py
+++ b/runtime/training/losses/protocol.py
@@ -23,6 +23,12 @@ class LossProtocol(Protocol):
 
     用 Protocol 而不是 ABC：mse 用纯函数包装 / huber 用 class 实现，
     不想强制继承。runtime_checkable 让单测 `isinstance` 校验仍能用。
+
+    **签名稳定性约定**：当前 compute(pred, target, t) 是 v1 签名。未来若引入
+    LPIPS / SNR-aware / classifier-free guidance 等需要额外上下文的 loss，
+    会以 keyword-only `*, ctx=None` 形式追加（向后兼容；不传时旧实现继续工作）。
+    新写的 loss 实现建议提前预留 `def compute(self, pred, target, t, *, ctx=None)`
+    签名以避免未来 break；调用方（loop.py）目前不传 ctx，传时机另行公告。
     """
 
     def compute(
@@ -34,7 +40,7 @@ class LossProtocol(Protocol):
         """返回 per-element loss tensor，shape 与 pred/target 一致（不做 reduction）。
 
         pred / target — Flow Matching velocity 预测 vs 目标，shape (B, C, *spatial)
-        t              — 当前 batch 的时间步 (B,)，仅 schedule 依赖 t 的 loss
-                         （如 huber_schedule=snr）需要；mse 等可忽略
+        t              — 当前 batch 的时间步 (B,)，仅 t-dependent loss 需要；
+                         mse / constant-δ huber 可忽略
         """
         ...

--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -80,6 +80,12 @@ def run(ctx: TrainingContext) -> None:
     ctx.sample_dir.mkdir(exist_ok=True)
     ctx.wandb_monitor = init_wandb_monitor(args, ctx.output_dir, ctx.config_path)
 
+    # Loss 函数（mse / huber；通过 losses/ plugin registry 派发）
+    # 不依赖 total_steps，跟 timestep_sampler/scheduler 不同；放 bootstrap 而非
+    # optimizer phase 避免架构错位。
+    from training.losses import build_loss
+    ctx.loss_fn = build_loss(args)
+
     # 训练监控状态写入（PP6.1）：永远开启，文件路径优先来自 --monitor-state-file，
     # 否则落到 output_dir/monitor_state.json。Studio 前端通过 /api/state?task_id=
     # 读这个文件，不再启动训练侧 HTTP server（Studio 自己是 monitor）。

--- a/runtime/training/phases/optimizer.py
+++ b/runtime/training/phases/optimizer.py
@@ -76,7 +76,3 @@ def run(ctx: TrainingContext) -> None:
     # Timestep 采样器（baseline 或 InfoNoise；total_steps 确定后才能算 N_warm）
     from training.timestep_samplers import build_timestep_sampler
     ctx.timestep_sampler = build_timestep_sampler(args, ctx.total_steps)
-
-    # Loss 函数（mse / huber；通过 losses/ plugin registry 派发）
-    from training.losses import build_loss
-    ctx.loss_fn = build_loss(args)

--- a/runtime/training/timestep_samplers/infonoise.py
+++ b/runtime/training/timestep_samplers/infonoise.py
@@ -226,6 +226,8 @@ def build(args, total_steps: Optional[int]) -> InfoNoiseScheduler:
     logger.info(
         f"InfoNoise 已启用：K={scheduler.K}, N_warm={scheduler.N_warm}, "
         f"M={scheduler.M}, B={scheduler.B}, beta={scheduler.beta}, "
-        f"baseline={scheduler.baseline_mode}(shift={scheduler.baseline_shift})"
+        f"baseline={scheduler.baseline_mode}(shift={scheduler.baseline_shift}, "
+        f"mix_low_prob={scheduler.baseline_mix_low_prob}, "
+        f"timestep_schedule_shift={scheduler.baseline_timestep_schedule_shift})"
     )
     return scheduler

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -388,7 +388,7 @@ class TrainingConfig(BaseModel):
     )
     timestep_mix_low_prob: float = Field(
         0.0, ge=0.0, le=1.0,
-        description="【时间步采样】mixed_* 模式下走偏置端的样本比例（0 = 全 uniform；典型 0.15-0.30）",
+        description="【时间步采样】mixed_* 模式下走偏置端的样本比例（0 = 全 uniform；典型 0.15-0.30；仅 mixed_uniform_low / mixed_uniform_logit 生效，其他 mode 忽略）",
         json_schema_extra=_meta(
             "noise_schedule",
             show_when="timestep_sampling!=uniform",
@@ -512,6 +512,16 @@ class TrainingConfig(BaseModel):
             raise ValueError(
                 "optimizer_type=prodigy_plus_schedulefree requires lr_scheduler=none "
                 "(Schedule-Free 不需要 scheduler；强行叠加会破坏 averaged weights)."
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_detail_inv_t_range(self) -> "TrainingConfig":
+        """detail_inv_t 加权曲线的 min 必须 <= max；fail-fast 取代历史的静默 swap。"""
+        if self.detail_inv_t_min > self.detail_inv_t_max:
+            raise ValueError(
+                f"detail_inv_t_min ({self.detail_inv_t_min}) 不能大于 "
+                f"detail_inv_t_max ({self.detail_inv_t_max})。"
             )
         return self
 

--- a/tests/test_argparse_bridge.py
+++ b/tests/test_argparse_bridge.py
@@ -216,3 +216,51 @@ def test_training_config_yaml_ppsf() -> None:
     assert args.ppsf_beta2 == 0.99
     assert args.ppsf_prodigy_steps == 1000
     assert args.ppsf_use_stableadamw is True
+
+
+# ---------------------------------------------------------------------------
+# SqrtZ3 三 PR 新增字段：bridge 自动生成 CLI flag 验证
+# ---------------------------------------------------------------------------
+
+
+def test_training_config_emits_detail_inv_t_flags() -> None:
+    """PR #72 引入 detail_inv_t_min/max；bridge 应自动生成 --detail-inv-t-min/--max。"""
+    parser = bridge.build_parser(TrainingConfig)
+    ns = parser.parse_args([
+        "--detail-inv-t-min", "1.5",
+        "--detail-inv-t-max", "8.0",
+    ])
+    assert ns.detail_inv_t_min == 1.5
+    assert ns.detail_inv_t_max == 8.0
+
+
+def test_training_config_emits_timestep_mix_low_prob_flag() -> None:
+    """PR #73 引入 timestep_mix_low_prob；bridge 应自动生成 --timestep-mix-low-prob。"""
+    parser = bridge.build_parser(TrainingConfig)
+    ns = parser.parse_args(["--timestep-mix-low-prob", "0.25"])
+    assert ns.timestep_mix_low_prob == 0.25
+
+
+def test_training_config_emits_timestep_schedule_shift_flag() -> None:
+    """PR #73 引入 timestep_schedule_shift（PR-A 重命名后名）；bridge 应自动生成
+    --timestep-schedule-shift。"""
+    parser = bridge.build_parser(TrainingConfig)
+    ns = parser.parse_args(["--timestep-schedule-shift", "1.5"])
+    assert ns.timestep_schedule_shift == 1.5
+
+
+def test_training_config_emits_mixed_uniform_modes() -> None:
+    """PR #73 引入两个新 mode；Literal choices 应被 bridge 接受。"""
+    parser = bridge.build_parser(TrainingConfig)
+    ns_low = parser.parse_args(["--timestep-sampling", "mixed_uniform_low"])
+    assert ns_low.timestep_sampling == "mixed_uniform_low"
+    ns_logit = parser.parse_args(["--timestep-sampling", "mixed_uniform_logit"])
+    assert ns_logit.timestep_sampling == "mixed_uniform_logit"
+
+
+def test_training_config_emits_loss_type_and_huber_flags() -> None:
+    """PR #75 引入 loss_type / huber_c；bridge 应自动生成 --loss-type / --huber-c。"""
+    parser = bridge.build_parser(TrainingConfig)
+    ns = parser.parse_args(["--loss-type", "huber", "--huber-c", "0.2"])
+    assert ns.loss_type == "huber"
+    assert ns.huber_c == 0.2

--- a/tests/test_loss_weighting.py
+++ b/tests/test_loss_weighting.py
@@ -3,15 +3,19 @@
 主要覆盖：
 - detail_inv_t 默认 clamp 范围 [1, 5] —— 防 PR 把默认行为改坏
 - detail_inv_t_min/max 自定义边界生效（PR：参数化原本写死的上下限）
-- min > max 时 swap 后正常工作，不崩溃
+- min > max 由 schema validator fail-fast 拒绝（替代历史的静默 swap）
 - 新参数只影响 detail_inv_t，不影响 min_snr / cosmap / none
+- weight_cap_ratio × detail_inv_t 联合作用（cap 在 detail_inv_t clamp 后再生效）
 
-其他 scheme（min_snr 公式 / cosmap 公式 / weight_cap_ratio）不在本 PR 范围内重测。
+其他 scheme（min_snr 公式 / cosmap 公式）不在本 PR 范围内重测。
 """
 from __future__ import annotations
 
+import pytest
 import torch
+from pydantic import ValidationError
 
+from studio.schema import TrainingConfig
 from training.loss_weighting import compute_loss_weight
 
 
@@ -75,16 +79,8 @@ def test_detail_inv_t_custom_min_lifts_high_t():
 # ---------------------------------------------------------------------------
 
 
-def test_detail_inv_t_min_above_max_is_swapped():
-    """误配 min > max 时函数内部 swap，不崩溃且产出有意义结果。"""
-    t = torch.tensor([0.1, 0.5, 0.9])
-    w_swap = compute_loss_weight(t, scheme="detail_inv_t", detail_inv_t_min=5.0, detail_inv_t_max=1.0)
-    w_normal = compute_loss_weight(t, scheme="detail_inv_t", detail_inv_t_min=1.0, detail_inv_t_max=5.0)
-    torch.testing.assert_close(w_swap, w_normal)
-
-
 def test_detail_inv_t_min_equals_max_collapses_to_constant():
-    """min == max 时 clamp 把所有权重压成一个常数。"""
+    """min == max 时 clamp 把所有权重压成一个常数（合法用例，schema 允许 min <= max）。"""
     t = torch.tensor([0.05, 0.5, 0.95])
     w = compute_loss_weight(t, scheme="detail_inv_t", detail_inv_t_min=2.5, detail_inv_t_max=2.5)
     expected = torch.full_like(t, 2.5)
@@ -114,3 +110,87 @@ def test_detail_inv_t_bounds_do_not_affect_none():
     t = torch.tensor([0.1, 0.5, 0.9])
     w = compute_loss_weight(t, scheme="none", detail_inv_t_min=99.0, detail_inv_t_max=0.5)
     torch.testing.assert_close(w, torch.ones_like(t))
+
+
+# ---------------------------------------------------------------------------
+# Schema validator：边界 fail-fast（替代历史 swap）
+# ---------------------------------------------------------------------------
+
+
+def _minimal_cfg(**overrides) -> dict:
+    """构造能通过 schema 必填校验的最小 dict（detail_inv_t 字段默认值已在 schema 里）。"""
+    base = {
+        "data_dir": "./dataset",
+        "transformer_path": "x.safetensors",
+        "vae_path": "x.safetensors",
+        "text_encoder_path": "x",
+        "t5_tokenizer_path": "x",
+    }
+    base.update(overrides)
+    return base
+
+
+def test_schema_rejects_detail_inv_t_min_above_max():
+    """min > max 在 schema validator 直接抛错（替代 compute_loss_weight 内的 swap）。"""
+    with pytest.raises(ValidationError, match="detail_inv_t_min"):
+        TrainingConfig(**_minimal_cfg(detail_inv_t_min=5.0, detail_inv_t_max=1.0))
+
+
+def test_schema_rejects_detail_inv_t_min_below_one():
+    """PR #72 follow-up：detail_inv_t_min < 1.0 是死区，schema ge=1.0 拒绝。"""
+    with pytest.raises(ValidationError):
+        TrainingConfig(**_minimal_cfg(detail_inv_t_min=0.5))
+
+
+def test_schema_rejects_detail_inv_t_min_zero():
+    """边界：完全 0 也应被拒（ge=1.0）。"""
+    with pytest.raises(ValidationError):
+        TrainingConfig(**_minimal_cfg(detail_inv_t_min=0.0))
+
+
+def test_schema_rejects_detail_inv_t_min_above_upper_bound():
+    """边界上界：detail_inv_t_min 上限是 20，21 应被拒。"""
+    with pytest.raises(ValidationError):
+        TrainingConfig(**_minimal_cfg(detail_inv_t_min=21.0))
+
+
+def test_schema_rejects_detail_inv_t_max_above_upper_bound():
+    """边界上界：detail_inv_t_max 上限是 50，51 应被拒。"""
+    with pytest.raises(ValidationError):
+        TrainingConfig(**_minimal_cfg(detail_inv_t_max=51.0))
+
+
+def test_schema_rejects_weight_cap_ratio_above_upper_bound():
+    """边界上界：weight_cap_ratio 上限是 50，51 应被拒。"""
+    with pytest.raises(ValidationError):
+        TrainingConfig(**_minimal_cfg(weight_cap_ratio=51.0))
+
+
+def test_schema_accepts_min_equals_max():
+    """min == max 是合法配置（清单的边界值），不应触发 validator。"""
+    cfg = TrainingConfig(**_minimal_cfg(detail_inv_t_min=3.0, detail_inv_t_max=3.0))
+    assert cfg.detail_inv_t_min == 3.0 and cfg.detail_inv_t_max == 3.0
+
+
+# ---------------------------------------------------------------------------
+# weight_cap_ratio × detail_inv_t_* 联合作用
+# ---------------------------------------------------------------------------
+
+
+def test_weight_cap_constrains_detail_inv_t_spread():
+    """detail_inv_t 默认 [1, 5] 时 max/min 比 5；开 weight_cap_ratio=2 应把 max 压到 min*2。"""
+    # t=[0.1, 0.5, 0.9] → 1/t clamp=[5, 2, 1.111]，max/min=4.5
+    # 加 cap=2 → max 应被压到 min*2=2.222（其中 min=1.111）
+    t = torch.tensor([0.1, 0.5, 0.9])
+    w = compute_loss_weight(t, scheme="detail_inv_t", weight_cap_ratio=2.0)
+    w_min = float(w.min())
+    w_max = float(w.max())
+    assert w_max <= w_min * 2.0 + 1e-5, f"max/min={w_max/w_min:.3f} > cap 2.0"
+
+
+def test_weight_cap_disabled_preserves_detail_inv_t_spread():
+    """cap=0（禁用）时 detail_inv_t 完整 [1, 5] 跨度都保留。"""
+    t = torch.tensor([0.1, 0.5, 0.9])
+    w_no_cap = compute_loss_weight(t, scheme="detail_inv_t", weight_cap_ratio=0.0)
+    # max 应该达到 5（来自 t=0.1）
+    assert abs(float(w_no_cap.max()) - 5.0) < 1e-4

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -26,7 +26,13 @@ from training.losses.protocol import LossProtocol
 
 
 def test_mse_matches_f_mse_loss_bitwise():
-    """MseLoss.compute 必须等价于历史 F.mse_loss(reduction='none')。"""
+    """MseLoss.compute 必须 bit-for-bit 等价于历史 F.mse_loss(reduction='none')。
+
+    用 torch.equal（严格逐 byte 比较）而不是 assert_close（默认 rtol=1.3e-6）——
+    PR #75 docstring 反复声明 "bit-for-bit" 语义，必须 codify 这条不变式。
+    若未来 MseLoss 内部重排 ops 引入 numerically equivalent 但 byte-different 实现，
+    本测试会失败，提醒重新评估 "bit-for-bit" 承诺。
+    """
     torch.manual_seed(0)
     pred = torch.randn(2, 3, 4, 4)
     target = torch.randn(2, 3, 4, 4)
@@ -34,7 +40,7 @@ def test_mse_matches_f_mse_loss_bitwise():
 
     expected = F.mse_loss(pred, target, reduction="none")
     actual = MseLoss().compute(pred, target, t)
-    torch.testing.assert_close(actual, expected)
+    assert torch.equal(actual, expected)
 
 
 def test_mse_ignores_t():
@@ -213,6 +219,82 @@ def test_compute_shape_and_finite_on_latent_like_input(loss):
 # ---------------------------------------------------------------------------
 # InfoNoise × loss_type 解耦集成测试
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# HuberLoss dtype / shape edge cases
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16, torch.float16])
+def test_huber_handles_low_precision_dtypes(dtype):
+    """bf16 / fp16 下 huber 必须不崩溃、输出 dtype 一致、数值合法。
+
+    huber.py:50 用 `torch.where(abs_diff < delta_b, quad, lin)`，要求 abs_diff /
+    delta_b 跟 pred 同 dtype。若未来重构把 delta cast 写错（如保留 fp32 比较），
+    autocast 下会出现 dtype mismatch 或 silent 截断。
+    """
+    torch.manual_seed(0)
+    pred = torch.randn(2, 3, 4, 4, dtype=dtype)
+    target = torch.randn(2, 3, 4, 4, dtype=dtype)
+    t = torch.rand(2)
+    huber = HuberLoss(c=0.15)
+    out = huber.compute(pred, target, t)
+    assert out.dtype == dtype
+    assert torch.isfinite(out).all()
+    assert (out >= 0).all()
+
+
+def test_huber_handles_5d_input_shape():
+    """huber.py:43 `delta.view(-1, *([1] * (pred.dim() - 1)))` 应能处理任意 pred.dim()。
+
+    复现 video latent 场景：pred shape (B, C, T, H, W) 是 5D。delta_b 必须能广播到 5D。
+    """
+    torch.manual_seed(0)
+    pred = torch.randn(2, 4, 3, 8, 8)  # (B, C, T, H, W) 5D
+    target = torch.randn(2, 4, 3, 8, 8)
+    t = torch.rand(2)
+    huber = HuberLoss(c=0.15)
+    out = huber.compute(pred, target, t)
+    assert out.shape == pred.shape
+    assert torch.isfinite(out).all()
+
+
+def test_huber_handles_3d_input_shape():
+    """3D 输入（如 sequence-style latent）也应工作。"""
+    torch.manual_seed(0)
+    pred = torch.randn(4, 16, 32)
+    target = torch.randn(4, 16, 32)
+    t = torch.rand(4)
+    huber = HuberLoss(c=0.15)
+    out = huber.compute(pred, target, t)
+    assert out.shape == pred.shape
+
+
+# ---------------------------------------------------------------------------
+# validate_schema_consistency 失配检测
+# ---------------------------------------------------------------------------
+
+
+def test_validate_schema_consistency_detects_extra_builder(monkeypatch):
+    """BUILDERS 多了个 schema 没列的 key 时，consistency check 必须抛错。"""
+    from training.losses import BUILDERS as ORIG_BUILDERS
+
+    fake_builders = dict(ORIG_BUILDERS)
+    fake_builders["ghost"] = lambda args: None  # schema 没这选项
+    monkeypatch.setattr("training.losses.BUILDERS", fake_builders)
+    with pytest.raises(RuntimeError, match="loss 注册与 schema 不同步"):
+        validate_schema_consistency()
+
+
+def test_validate_schema_consistency_detects_missing_builder(monkeypatch):
+    """BUILDERS 少了 schema Literal 里的 key 时，consistency check 必须抛错。"""
+    from training.losses import BUILDERS as ORIG_BUILDERS
+
+    fake_builders = {k: v for k, v in ORIG_BUILDERS.items() if k != "huber"}
+    monkeypatch.setattr("training.losses.BUILDERS", fake_builders)
+    with pytest.raises(RuntimeError, match="loss 注册与 schema 不同步"):
+        validate_schema_consistency()
 
 
 def test_infonoise_raw_mse_decoupled_from_loss_type():

--- a/tests/test_timestep_sampling.py
+++ b/tests/test_timestep_sampling.py
@@ -257,3 +257,52 @@ def test_infonoise_default_baseline_params_unchanged():
     s = InfoNoiseScheduler(K=32, N_warm=100, M=10, B=10, N_min=1)
     assert s.baseline_mix_low_prob == 0.0
     assert s.baseline_timestep_schedule_shift == 1.0
+
+
+def test_infonoise_cdf_path_ignores_baseline_timestep_schedule_shift():
+    """codify PR #73 核心声明：CDF 就绪后正式阶段不读 baseline_timestep_schedule_shift。
+
+    InfoNoise 是 paper-sensitive 区（I-MMSE 假设依赖自适应 CDF）。baseline shift
+    只在 warmup 路径 (_cdf_values is None) 生效；正式阶段必须无视该字段，否则
+    违反论文采样分布。若未来重构把 baseline shift 误用到 CDF 路径，本测试 detect。
+
+    参考 [[feedback_verify_paper_before_fixing_algo]]——P0-2 EMA 翻转事故同根。
+    """
+    import numpy as np
+
+    # 两个 scheduler 用极端不同的 baseline shift（1.0 vs 5.0）
+    s1 = InfoNoiseScheduler(K=16, N_warm=100, M=5, B=10, N_min=1,
+                            baseline_timestep_schedule_shift=1.0)
+    s2 = InfoNoiseScheduler(K=16, N_warm=100, M=5, B=10, N_min=1,
+                            baseline_timestep_schedule_shift=5.0)
+    # 手动 set 完全相同的 CDF（强制走正式阶段路径）
+    cdf = np.linspace(0.0, 1.0, 17)
+    s1._cdf_values = cdf
+    s2._cdf_values = cdf
+    # 正式阶段采样：CDF 路径用 np.interp + torch.rand，跟 baseline shift 无关
+    # 同种子 + 同 CDF → 输出 bit-for-bit 一致
+    torch.manual_seed(42)
+    t1 = s1.sample(2048, "cpu")
+    torch.manual_seed(42)
+    t2 = s2.sample(2048, "cpu")
+    torch.testing.assert_close(t1, t2, rtol=0, atol=0)
+
+
+def test_infonoise_warmup_path_respects_baseline_timestep_schedule_shift():
+    """对偶检查：warmup 路径（_cdf_values is None）确实读 baseline shift，统计上有差异。
+
+    跟上面 test_infonoise_cdf_path_ignores_* 配对——保两条路径各司其职。
+    """
+    s1 = InfoNoiseScheduler(K=16, N_warm=100, M=5, B=10, N_min=1,
+                            baseline_mode="uniform",
+                            baseline_timestep_schedule_shift=1.0)
+    s2 = InfoNoiseScheduler(K=16, N_warm=100, M=5, B=10, N_min=1,
+                            baseline_mode="uniform",
+                            baseline_timestep_schedule_shift=5.0)
+    assert s1._cdf_values is None and s2._cdf_values is None
+    torch.manual_seed(0)
+    t1 = s1.sample(4096, "cpu")
+    torch.manual_seed(0)
+    t2 = s2.sample(4096, "cpu")
+    # baseline_uniform + shift=5 应推高均值（Möbius 变换 s>1 推向高噪声端）
+    assert t2.mean().item() > t1.mean().item() + 0.1


### PR DESCRIPTION
## Summary

PR #85 / #86 合并后清掉 [memory/sqrtz3_pr72_73_75_followups](https://github.com/.../) 里剩余的 14 项 follow-ups。默认值零变更（bit-for-bit）；1265 passed。

按重要度分四档：

### 档一：同级优先级回归测试

- **A**: `test_infonoise_cdf_path_ignores_baseline_timestep_schedule_shift` + 配对的 warmup 路径测试。codify PR #73 的核心声明——CDF 就绪后正式阶段不读 baseline shift。跟 PR #86 的 ⑥ 是平行关系（⑥ 守 huber × InfoNoise 解耦，A 守 schedule_shift × CDF 解耦）。

### 档二：轻量修订（5 条）

- **B**: `timestep_mix_low_prob` description 补 "仅 mixed_uniform_* 生效"——show_when 表达不准的低成本补救。
- **C**: InfoNoise build log 补打 `mix_low_prob` / `timestep_schedule_shift`——可观测性缺口。
- **D**: `test_mse_matches_f_mse_loss_bitwise`: `assert_close` → `torch.equal`，严格 codify "bit-for-bit" 语义。
- **E**: `context.py` `loss_fn: Any` → `Optional[LossProtocol]`（TYPE_CHECKING 避循环 import）。
- **F**: `loop.py` `_raw_mse` 用 `torch.no_grad` 替代 `.detach()`——少一份 grad_fn 元数据。

### 档三：中等改动（3 条）

- **G**: schema `_validate_detail_inv_t_range` model_validator——`min > max` 启动期 fail-fast 替代 `loss_weighting.py` 内的静默 swap。
- **H**: `build_loss` 从 `phases/optimizer.py` 挪到 `phases/bootstrap.py`——loss 不依赖 `total_steps`，piggyback optimizer phase 是架构错位。
- **I**: `LossProtocol` docstring 标注 v1 签名 + 未来 keyword-only `ctx` 扩展约定（不动签名，零 break）。

### 档四：文档 + 测试加固（J-R）

- **J+K**: `training-tips.md` 补三段：mixed_uniform_* / detail_inv_t_min/max / 0.8.x huber。
- **L**: argparse_bridge: 5 个测试覆盖 PR #72/#73/#75 全部新字段。
- **M**: schema validator 反向用例（边界 < 1.0 / 0 / > 20 / > 50 / min > max）。
- **N**: `weight_cap × detail_inv_t` 联合测试。
- **O**: huber bf16/fp16/fp32 dtype 测试。
- **P**: huber 5D / 3D 输入 shape edge case。
- **R**: `validate_schema_consistency` monkeypatch（extra/missing builder 两方向）。

## 兼容性

- 数值：所有改动默认值下行为 bit-for-bit 一致（已有 `test_mse_matches_f_mse_loss_bitwise` 严格化版本守护）。
- API：`schedule_shift` 字段 PR #85 已重命名；本 PR 不再动字段名。
- Schema 新增 validator 只在 `detail_inv_t_min > detail_inv_t_max` 时 raise——默认值 `(1.0, 5.0)` 通过。

## Test plan

- [x] 全套 1265 测试通过
- [x] 新增 22 个测试（A 2 个 / D 1 严格化 / L 5 / M 7 / N 2 / O 3 / P 2 / R 2）
- [x] 默认值跑通：旧 yaml preset 无需任何改动

🤖 Generated with [Claude Code](https://claude.com/claude-code)