### PR TITLE
fix(i18n): 首次启动语言选择改 modal，去掉 CLI prompt + 后端端点

### DIFF
--- a/studio.bat
+++ b/studio.bat
@@ -107,25 +107,6 @@ if exist "venv\Scripts\python.exe" (
     !BOOTSTRAP_PY! -m venv venv || (echo studio.bat: failed to create venv 1>&2 & goto :fail)
     set PYTHON=venv\Scripts\python.exe
 
-    REM Language selection -- only on fresh install, skip if already saved.
-    if not exist studio_data mkdir studio_data
-    if not exist studio_data\studio_lang (
-        echo.
-        echo   Welcome to AnimaLoraStudio!
-        echo   ================================
-        echo   1^) English
-        echo   2^) Chinese ^(Zhongwen^)
-        set /p LANG_CHOICE="  Select language [1/2, default 2]: "
-        if /i "!LANG_CHOICE!"=="1" (
-            set STUDIO_LANG=en
-        ) else (
-            set STUDIO_LANG=zh
-        )
-        echo !STUDIO_LANG!>studio_data\studio_lang
-        echo [studio] Language set to: !STUDIO_LANG!
-        echo.
-    )
-
     !PYTHON! -m pip install --upgrade pip -i https://mirrors.cloud.tencent.com/pypi/simple/ || (echo studio.bat: failed to upgrade pip 1>&2 & goto :fail)
 
     REM GPU-aware torch first install (PR-S1a). Without this, requirements.txt's

--- a/studio.sh
+++ b/studio.sh
@@ -131,25 +131,6 @@ else
     "$BOOTSTRAP_PY" -m venv venv || { echo "studio.sh: failed to create venv" >&2; exit 1; }
     PYTHON="venv/bin/python"
 
-    # Language selection — only on fresh install, skip if already saved.
-    mkdir -p studio_data
-    if [ ! -f "studio_data/studio_lang" ]; then
-        echo ""
-        echo "  Welcome to AnimaLoraStudio!"
-        echo "  ================================"
-        echo "  1) English"
-        echo "  2) Chinese (Zhongwen / Zhong wen)"
-        printf "  Select language [1/2, default 2]: "
-        read -r _lang_choice
-        case "$_lang_choice" in
-            1) _STUDIO_LANG="en" ;;
-            *) _STUDIO_LANG="zh" ;;
-        esac
-        echo "$_STUDIO_LANG" > "studio_data/studio_lang"
-        echo "[studio] Language set to: $_STUDIO_LANG"
-        echo ""
-    fi
-
     _pip_install --upgrade pip || { echo "studio.sh: failed to upgrade pip" >&2; exit 1; }
 
     # GPU-aware torch first install (PR-S1a). Without this, requirements.txt's

--- a/studio/server.py
+++ b/studio/server.py
@@ -3446,17 +3446,6 @@ def system_version() -> dict[str, Any]:
     return asdict(updater.current_version())
 
 
-@app.get("/api/system/lang")
-def get_system_lang() -> dict[str, Any]:
-    """Return the language preference written by the startup script on first run."""
-    lang_file = STUDIO_DATA / "studio_lang"
-    if lang_file.exists():
-        lang = lang_file.read_text(encoding="utf-8").strip()
-        if lang in ("en", "zh"):
-            return {"lang": lang}
-    return {"lang": None}
-
-
 @app.get("/api/system/update_check")
 def system_update_check(channel: str = "master", force: bool = False) -> dict[str, Any]:
     """git fetch + 比对。master 通道用 24h cache（force=true 强制重 fetch）；

--- a/studio/web/src/components/FirstRunLangModal.test.tsx
+++ b/studio/web/src/components/FirstRunLangModal.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * FirstRunLangModal 单元测试。
+ *
+ * 验证：
+ *   - localStorage 没值时弹 modal
+ *   - localStorage 有值时不渲染（一次性）
+ *   - 点 English / 中文 卡片各自写 localStorage + 调 i18n.changeLanguage + 关 modal
+ *   - navigator.language 命中 zh 时 zh 卡片初始聚焦；否则 en 卡片初始聚焦
+ */
+import { fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const changeLanguage = vi.fn().mockResolvedValue(undefined)
+vi.mock('../i18n', () => ({
+  __esModule: true,
+  default: { changeLanguage: (lang: string) => changeLanguage(lang) },
+  getStoredLang: () => localStorage.getItem('studio.lang'),
+  setStoredLang: (lang: string) => localStorage.setItem('studio.lang', lang),
+}))
+
+import { FirstRunLangModal } from './FirstRunLangModal'
+
+describe('FirstRunLangModal', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    changeLanguage.mockClear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders when localStorage has no stored language', () => {
+    render(<FirstRunLangModal />)
+    expect(screen.getByTestId('first-run-lang-modal')).toBeInTheDocument()
+    expect(screen.getByTestId('first-run-lang-en')).toBeInTheDocument()
+    expect(screen.getByTestId('first-run-lang-zh')).toBeInTheDocument()
+  })
+
+  it('does not render when localStorage already has a stored language', () => {
+    localStorage.setItem('studio.lang', 'en')
+    render(<FirstRunLangModal />)
+    expect(screen.queryByTestId('first-run-lang-modal')).toBeNull()
+  })
+
+  it('clicking English writes localStorage, calls changeLanguage, and dismisses', () => {
+    render(<FirstRunLangModal />)
+    fireEvent.click(screen.getByTestId('first-run-lang-en'))
+    expect(localStorage.getItem('studio.lang')).toBe('en')
+    expect(changeLanguage).toHaveBeenCalledWith('en')
+    expect(screen.queryByTestId('first-run-lang-modal')).toBeNull()
+  })
+
+  it('clicking 中文 writes localStorage, calls changeLanguage, and dismisses', () => {
+    render(<FirstRunLangModal />)
+    fireEvent.click(screen.getByTestId('first-run-lang-zh'))
+    expect(localStorage.getItem('studio.lang')).toBe('zh')
+    expect(changeLanguage).toHaveBeenCalledWith('zh')
+    expect(screen.queryByTestId('first-run-lang-modal')).toBeNull()
+  })
+
+  it('initial keyboard focus lands on the zh card when navigator.language is zh-CN', () => {
+    vi.stubGlobal('navigator', { ...navigator, language: 'zh-CN' })
+    render(<FirstRunLangModal />)
+    expect(document.activeElement).toBe(screen.getByTestId('first-run-lang-zh'))
+    vi.unstubAllGlobals()
+  })
+
+  it('initial keyboard focus lands on the en card when navigator.language is en-US', () => {
+    vi.stubGlobal('navigator', { ...navigator, language: 'en-US' })
+    render(<FirstRunLangModal />)
+    expect(document.activeElement).toBe(screen.getByTestId('first-run-lang-en'))
+    vi.unstubAllGlobals()
+  })
+})

--- a/studio/web/src/components/FirstRunLangModal.tsx
+++ b/studio/web/src/components/FirstRunLangModal.tsx
@@ -45,11 +45,11 @@ export function FirstRunLangModal() {
       aria-modal="true"
       aria-labelledby="first-run-lang-title"
       // 不可绕过：不监听 Esc，不监听点击遮罩。这是 onboarding 不是 Dialog。
-      // 用 bg-canvas 全不透明遮罩，给「splash」感而非「弹窗叠在内容上」。
-      className="fixed inset-0 z-50 flex items-center justify-center bg-canvas"
+      // 暗色半透明幕布 + 高斯模糊，把底层 App 推到背景；window 仍是普通尺寸卡片。
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-md"
       data-testid="first-run-lang-modal"
     >
-      <div className="w-[90%] max-w-[520px] flex flex-col gap-6 p-8">
+      <div className="w-[90%] max-w-[480px] flex flex-col gap-6 p-8 bg-elevated border border-dim rounded-lg shadow-xl">
         <h1
           id="first-run-lang-title"
           className="m-0 text-center text-2xl font-semibold text-fg-primary"

--- a/studio/web/src/components/FirstRunLangModal.tsx
+++ b/studio/web/src/components/FirstRunLangModal.tsx
@@ -1,0 +1,94 @@
+// FirstRunLangModal —— localStorage 没存过 studio.lang 时弹一次的语言选择。
+// 设计动机：onboarding 第一帧的身份级选择，强制二选一、不可绕过、不预选高亮，
+// 替代 PR #76 那个塞在 studio.bat/sh 里的 CLI prompt（触达率低 + ASCII 受限 +
+// 无法预览要选的语言长什么样）。
+import { useEffect, useRef, useState } from 'react'
+import i18n, { getStoredLang, setStoredLang } from '../i18n'
+
+type Lang = 'en' | 'zh'
+
+const STORAGE_KEY = 'studio.lang'
+
+function detectPreferredLang(): Lang {
+  try {
+    const navLang = (navigator.language || '').toLowerCase()
+    if (navLang.startsWith('zh')) return 'zh'
+    return 'en'
+  } catch {
+    return 'zh'
+  }
+}
+
+export function FirstRunLangModal() {
+  // 用 lazy initializer 在 mount 时只读一次 localStorage，避免 SSR / hydration 抖动。
+  const [open, setOpen] = useState<boolean>(() => getStoredLang() === null)
+  const preferred = useRef<Lang>(detectPreferredLang())
+  const focusRef = useRef<HTMLButtonElement | null>(null)
+
+  // 进入时把键盘焦点落到「检测到的」那张卡——A11y 友好（键盘用户敲 Enter 直接确认
+  // 检测语言），视觉上两张卡仍然对等。
+  useEffect(() => {
+    if (open) focusRef.current?.focus()
+  }, [open])
+
+  if (!open) return null
+
+  const handlePick = (lang: Lang) => {
+    setStoredLang(lang)
+    void i18n.changeLanguage(lang)
+    setOpen(false)
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="first-run-lang-title"
+      // 不可绕过：不监听 Esc，不监听点击遮罩。这是 onboarding 不是 Dialog。
+      // 用 bg-canvas 全不透明遮罩，给「splash」感而非「弹窗叠在内容上」。
+      className="fixed inset-0 z-50 flex items-center justify-center bg-canvas"
+      data-testid="first-run-lang-modal"
+    >
+      <div className="w-[90%] max-w-[520px] flex flex-col gap-6 p-8">
+        <h1
+          id="first-run-lang-title"
+          className="m-0 text-center text-2xl font-semibold text-fg-primary"
+        >
+          Welcome · 欢迎
+        </h1>
+
+        <div className="grid grid-cols-2 gap-4">
+          <button
+            ref={preferred.current === 'en' ? focusRef : undefined}
+            type="button"
+            onClick={() => handlePick('en')}
+            className="flex flex-col gap-2 items-center justify-center px-6 py-8 rounded-lg border border-dim bg-surface hover:border-accent hover:bg-accent-soft transition-colors cursor-pointer"
+            data-testid="first-run-lang-en"
+          >
+            <span className="text-xl font-semibold text-fg-primary">English</span>
+            <span className="text-xs text-fg-tertiary">Train your LoRA</span>
+          </button>
+
+          <button
+            ref={preferred.current === 'zh' ? focusRef : undefined}
+            type="button"
+            onClick={() => handlePick('zh')}
+            className="flex flex-col gap-2 items-center justify-center px-6 py-8 rounded-lg border border-dim bg-surface hover:border-accent hover:bg-accent-soft transition-colors cursor-pointer"
+            data-testid="first-run-lang-zh"
+          >
+            <span className="text-xl font-semibold text-fg-primary">中文</span>
+            <span className="text-xs text-fg-tertiary">训练你的 LoRA</span>
+          </button>
+        </div>
+
+        <p className="m-0 text-center text-xs text-fg-tertiary leading-relaxed">
+          You can change this anytime in Settings · 之后可以在设置中切换
+        </p>
+      </div>
+    </div>
+  )
+}
+
+// 测试用：清掉 localStorage，让 modal 在 dev console 里手动复现。
+// 生产代码不引用。
+export const __STORAGE_KEY = STORAGE_KEY

--- a/studio/web/src/main.tsx
+++ b/studio/web/src/main.tsx
@@ -3,45 +3,23 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import { DialogProvider } from './components/Dialog'
 import { ErrorBoundary } from './components/ErrorBoundary'
+import { FirstRunLangModal } from './components/FirstRunLangModal'
 import { ToastProvider } from './components/Toast'
 import { initTheme } from './lib/theme'
 import './i18n'
-import i18n, { getStoredLang, setStoredLang } from './i18n'
 import './index.css'
 
 initTheme()
 
-function mount() {
-  ReactDOM.createRoot(document.getElementById('root')!).render(
-    <React.StrictMode>
-      <ErrorBoundary>
-        <ToastProvider>
-          <DialogProvider>
-            <App />
-          </DialogProvider>
-        </ToastProvider>
-      </ErrorBoundary>
-    </React.StrictMode>,
-  )
-}
-
-async function bootstrap() {
-  // If user already has a stored preference, skip the API check entirely.
-  if (!getStoredLang()) {
-    try {
-      const res = await fetch('/api/system/lang')
-      if (res.ok) {
-        const data = (await res.json()) as { lang: string | null }
-        if (data.lang === 'en' || data.lang === 'zh') {
-          setStoredLang(data.lang)
-          await i18n.changeLanguage(data.lang)
-        }
-      }
-    } catch {
-      // ignore — default zh applies
-    }
-  }
-  mount()
-}
-
-void bootstrap()
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <ErrorBoundary>
+      <ToastProvider>
+        <DialogProvider>
+          <FirstRunLangModal />
+          <App />
+        </DialogProvider>
+      </ToastProvider>
+    </ErrorBoundary>
+  </React.StrictMode>,
+)


### PR DESCRIPTION
## Summary

PR #76 的 follow-up：把首次启动的语言选择从 CLI prompt 改成前端 modal，砍掉相关后端端点和 main.tsx 的 async fetch 联动。

**为什么**

PR #76 用三层联动做首次语言选择：

1. `studio.bat` / `studio.sh` fresh install 时弹 `Select language [1/2, default 2]:`
2. 写到 `studio_data/studio_lang` 文件
3. `GET /api/system/lang` 暴露给前端
4. `main.tsx` bootstrap 异步 fetch 这个端点 → 写 localStorage → 延迟 mount

这个方案有几个问题：

- **CLI 表面承载不住**：cmd.exe 默认 codepage 显示不了汉字，被迫把"中文"写成 `Chinese (Zhongwen / Zhong wen)` —— 当承载媒介连选项本身都渲染不出来时，这就是错误的位置
- **救不了真正的目标用户**：愿意读 bash prompt 的人本身就偏开发者 / 中文用户。真正会被中文 UI 劝退的英语用户最容易没看清就 Enter 跳过 default 2
- **触达率低**：只在 fresh install 跑 `studio.bat/sh` 时触发一次。打包 zip、Docker 镜像、朋友传的安装包、清环境重装都绕过
- **阻塞脚本化安装**：CI / 无人值守部署会卡在 prompt
- **持久化两层、单向同步**：后端 `studio_data/studio_lang` 文件 + 前端 localStorage，后续切换只动 localStorage，两边可能不一致

## 方案

砍掉 CLI prompt + 后端端点 + main.tsx 异步 bootstrap，换成前端 modal：

- **触发**：`localStorage['studio.lang']` 为 null 时自动弹出，否则永不渲染
- **强制选择**：不监听 Esc，不监听遮罩点击。这是 onboarding 不是 Dialog
- **视觉对等**：两张卡 "English / 中文"，不预选高亮，每张卡下方用各自语言写一句副标题（让用户看到那门语言长什么样再选）
- **A11y**：键盘焦点初始落到 `navigator.language` 命中的那张（敲 Enter 直接确认检测语言），但视觉不引导
- **写入**：选完 `setStoredLang(lang)` + `i18n.changeLanguage(lang)`，关闭 modal，永不再弹
- **后续切换**：仍走 Settings → 显示 → 语言（PR #76 已加，保留不动）

## 改动一览

**砍**

- `studio.bat:108-127` / `studio.sh:132-150`：fresh install 语言菜单整块（含为它专门提前 mkdir 的 `studio_data` 目录）
- `studio/server.py:3449-3457`：\`GET /api/system/lang\` 端点
- `studio/web/src/main.tsx`：bootstrap async wrapper + \`/api/system/lang\` fetch，退回到同步 \`ReactDOM.render\`

**加**

- `studio/web/src/components/FirstRunLangModal.tsx` —— modal 组件
- `studio/web/src/components/FirstRunLangModal.test.tsx` —— 6 个 vitest（渲染条件 / 两种点击路径 / 焦点初始位置 zh+en）

## 持久化模型变化

| | 改前 | 改后 |
|---|---|---|
| 后端 | \`studio_data/studio_lang\` 文件 | （无） |
| 前端 | localStorage \`studio.lang\` | localStorage \`studio.lang\`（唯一真相源） |
| 同步 | 后端→前端，仅首次启动 localStorage 空时拉一次 | 不需要 |

存量用户的 \`studio_data/studio_lang\` 文件不再被读取，残留无害不主动清理（避免写迁移代码 + 权限担忧）。

## 终端用户体验变化

**fresh install**：venv 创建 → pip install 之间不再有阻塞 prompt，安静直通。整个流程变成无人值守可脚本化。

**已装机用户**：完全无感。已有 localStorage 值的不会弹 modal。

**清 localStorage 重进**：会被 modal 多问一次（之前会去后端文件取老选择），3 秒选择，可接受。

## Test plan

- [x] \`npx vitest run src/components/FirstRunLangModal.test.tsx\` — 6/6 通过
- [x] \`npx tsc --noEmit\` — 无错误
- [x] \`venv/Scripts/python.exe -m pytest tests/test_studio_configs.py tests/test_updater.py tests/test_studio_cli.py\` — 112/112 通过
- [x] 全量 vitest 与 origin/dev baseline 对比：相同的 28 个 pre-existing 失败（PR #76 留下的 i18n 测试问题，跟本 PR 无关）
- [ ] 手测：清 localStorage，刷新页面，确认 modal 弹出 + 两路点击都正确
- [ ] 手测：选完后刷新，确认 modal 不再弹
- [ ] 手测：进 Settings → 显示 → 语言切换，确认仍正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)