### PR TITLE
fix(release): 0.8.2 release notes yaml 结构错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,92 @@
 
 hotfix：预设系统脱钩 redesign + hf-mirror 暂不可用 + 新建预设预览补齐项目路径
 
+### 变更
+
+- **预设跟 version 完全脱钩；version yaml 是 first-class「项目专属配置」**
+  发现整个训练页预设系统的 mental model 是坏的：
+  - picker 顶部「预设 X · 已自定义」标签永远显示「已自定义」，即使
+    用户没改任何字段 —— 因为 fork 时 default_paths_for_new_version
+    把 4 个全局模型路径注入成绝对路径，跟全局预设 yaml 里的相对
+    路径 diff 永远存在。`stripProjectFields` 只剥了 6 个项目特定
+    字段，漏了 4 个模型字段
+  - fork 之后 version yaml 跟全局预设其实是脱钩的，但 UI 假装一直
+    绑定，导致用户对「换预设」「保存」语义混乱
+  - fork 后 `onForkPreset` / `saveNewPreset` 没调父级 `reload()`
+    刷新 `activeVersion`，picker 顶部标签停在旧预设名上，用户以为
+    fork 没生效（实际后端已写）
+
+  改成「version yaml = 项目专属配置」语义：
+
+  - **picker 顶部 button**：has_config=True 显示「项目专属配置」，
+    has_config=False 显示「未配置 — 选预设作为起点」。不再展示
+    来源预设名 + 「· 已自定义」标签
+  - **picker 列表卡片**：去掉 active 高亮（没有「当前绑定」概念了），
+    全部卡片视觉一致；副标题改为「重置为此预设」/「以此预设为起点」
+  - **confirm 文案**：从「换预设会覆盖当前 version 的配置」改成
+    「重置为预设 X 的配置？当前 version 的所有自定义内容会丢失」，
+    okText 改「重置」
+  - **删整套 baseline diff 逻辑**：`presetBaselineRef` /
+    `refreshPresetBaseline` / `stripProjectFields` / `customized`
+    全部移除，连带相关 useEffect
+  - **fork / saveNewPreset 之后调 reload()**：刷父级 activeVersion，
+    否则 picker 顶部跟主表单内容跟实际 yaml 脱节，需要 F5 才能看到
+  - `versions.config_name` db 字段保留作为 audit trail（informational
+    only），不再有 UI 用途
+
+### 修复
+
+- **新建预设预览表单补齐项目路径（reg_data_dir / data_dir / 模型路径等）**
+  训练页「+ 新建预设」预览表单之前一律展示 schema 默认值
+  （`reg_data_dir=None`、`data_dir=./dataset`、相对模型路径），即使
+  项目已跑过 reg build、Settings 已配好模型，用户在预览里仍看到一片
+  相对路径 / 空白，误以为「fork 后不会自动带项目目录」。实际上
+  `fork_preset_for_version` 后端**早已**注入这些值到 version
+  config（实测验证），只是预览看不到，UX 误导。
+
+  - **后端**：`GET /api/projects/{pid}/versions/{vid}/config` 在
+    `has_config=False` 分支新增 `project_specific_defaults` —— 合并
+    `project_specific_overrides()` + `default_paths_for_new_version()`，
+    含 reg/meta.json 检测结果
+  - **前端 startCreatePreset**：用 `project_specific_defaults` 覆盖
+    schema 默认，预览表单初始化即显示「fork 后会得到的值」（含 reg
+    目录 / 训练目录 / 输出目录 / 绝对模型路径）
+  - **前端预览表单**：与主表单一致挂 `disabledFields`（全局模型路径
+    灰显「自动 · 全局设置」）+ `autoHints`（项目特定字段标
+    「自动 · 项目设置」）+ `advancedMode`
+  - **前端 saveNewPreset**：savePreset 前过滤项目特定字段 + 全局模型
+    路径清回 schema 默认，全局预设池不带项目 / 机器数据（fork 时
+    后端会再注入，version config 仍正确）。与
+    `services/presets.py:save_version_config_as_preset` 的清理逻辑对齐
+
+- **HF 模型下载默认源从 hf-mirror.com 切回 huggingface.co 官方**
+  实测发现 `hf-mirror.com` 在所有已测 `huggingface_hub` 版本
+  （0.25 / 0.30 / 0.34 / 1.14）下下载均失败 —— hub 客户端
+  从 HEAD 响应里读不到 `commit_hash`，抛 `FileMetadataError:
+  Distant resource does not seem to be on huggingface.co`。
+  curl 跟 redirect 拿 bytes 没问题，说明 mirror 服务本身活着，
+  但 hub 期望的元数据 header 在 redirect 链里丢了 —— 怀疑是
+  mirror 服务端近期改动。这不是上游回归（0.25 requests 时代
+  也挂），且锁旧版 hub 会破 transformers 5.x。
+
+  - **默认 endpoint 改空串**（= huggingface_hub 默认 = 直连
+    `huggingface.co`）：`studio/secrets.py`、Settings.tsx、
+    Settings.test.tsx mock 同步
+  - **Settings UI 隐藏 `hf-mirror.com` preset**：endpoint 字段
+    本身仍接受任意 URL，用户可通过「自定义 URL」粘贴 hf-mirror
+    继续试，或切到 ModelScope
+  - **复查 doc**：`docs/todo/hf-mirror-recheck.md` 记录现象、
+    根因、复测命令、上游 PR #4071 跟踪点、复活后逆向回滚清单。
+    建议 2 周一次复查
+  - 默认 endpoint 字段类型 / 接受范围未变，已配置过自定义
+    endpoint 的用户不受影响
+
+---
+
+## [0.8.1] — 2026-05-16
+
+版本面板单视图 + 通道偏好与 git 解耦（ADR 0005）+ zip 用户一键启用自动更新
+
 ### 新增
 
 - **zip 解压安装用户一键初始化 git 仓库（启用自动更新）**

--- a/release_notes.yaml
+++ b/release_notes.yaml
@@ -92,6 +92,9 @@
           endpoint 的用户不受影响
 
 
+- version: "0.8.1"
+  date: "2026-05-16"
+  summary: "版本面板单视图 + 通道偏好与 git 解耦（ADR 0005）+ zip 用户一键启用自动更新"
   entries:
     - kind: changed
       summary: "版本面板单视图 + 通道（master/dev）作为偏好与 git 状态解耦（#81）"


### PR DESCRIPTION
## Summary

0.8.2 hotfix PR #90 合并到 master 后才发现 `release_notes.yaml` 结构错误：

- 0.8.1 的 entries 被错误嵌入 0.8.2 block 内（同一 mapping 出现两次 `entries:` 字段，YAML 解析时后者覆盖前者）
- 结果 `CHANGELOG.md` v0.8.2 段显示的是 0.8.1 的内容（zip git init / 版本面板 ADR 0005 / E2E 回归 #82），完全不对
- 0.8.1 整个 version block 在 yaml 里消失

根因：PR #90 早期 commit (39c5290) 用 Edit 工具改 yaml 顶部时只替换了 0.8.1 的 `version/date/summary` 三行，没让 0.8.1 残留的 entries 另开一个 version block。

## 修复

补 0.8.1 的 version block header（version/date/summary）让它正确成为独立 version，然后 `render-changelog` 重写 CHANGELOG。

修复后 v0.8.2 段显示正确的 3 条内容（预设系统脱钩 / hf-mirror / 新建预设预览补齐），0.8.1 block 也恢复。

## 为啥 hotfix

GitHub Release v0.8.2 还没打 tag —— 必须在这个修复合进 master 之后才能 tag + create release，否则 release notes 会复制到错的内容。

## Merge

按 hotfix 流程 squash-and-merge 进 master。合并后 push tag v0.8.2 + create GitHub Release（用修复后的 CHANGELOG v0.8.2 段做 body）。