### PR TITLE
fix(web): UI polish 一组小修（i18n / 保存按钮 / api_key 自动填充 / XY picker 即时生效 等）

### DIFF
--- a/studio/web/package-lock.json
+++ b/studio/web/package-lock.json
@@ -11,8 +11,10 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "i18next": "^26.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-i18next": "^17.0.8",
         "react-router-dom": "^6.26.2"
       },
       "devDependencies": {
@@ -313,7 +315,6 @@
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3524,6 +3525,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -3550,6 +3560,34 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
+      "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://www.locize.com/i18next"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.locize.com"
+        }
+      ],
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/iconv-lite": {
@@ -4496,6 +4534,33 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.8.tgz",
+      "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "html-parse-stringify": "^3.0.1",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "i18next": ">= 26.2.0",
+        "react": ">= 16.8.0",
+        "typescript": "^5 || ^6"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -5132,7 +5197,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5205,6 +5270,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -5361,6 +5435,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/studio/web/src/components/LLMTaggerWorkspace.tsx
+++ b/studio/web/src/components/LLMTaggerWorkspace.tsx
@@ -956,6 +956,10 @@ function SensitiveInput({ value, serverValue, onChange }: {
       value={masked ? '' : value}
       placeholder={serverValue === MASK ? t('llmWorkspace.secretSavedPlaceholder') : ''}
       onChange={(e) => onChange(e.target.value || MASK)}
+      autoComplete="new-password"
+      data-lpignore="true"
+      data-1p-ignore
+      data-form-type="other"
       style={inputStyle}
     />
   )

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -29,6 +29,7 @@
     "open": "Open",
     "export": "Export",
     "import": "Import",
+    "download": "Download",
     "refresh": "Refresh",
     "execute": "Execute",
     "create": "Create",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -29,6 +29,7 @@
     "open": "打开",
     "export": "导出",
     "import": "导入",
+    "download": "下载",
     "refresh": "刷新",
     "execute": "执行",
     "create": "创建",

--- a/studio/web/src/pages/project/steps/Download.tsx
+++ b/studio/web/src/pages/project/steps/Download.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link, useOutletContext } from 'react-router-dom'
+import { useOutletContext } from 'react-router-dom'
 import {
   api,
   type DownloadFile,
@@ -174,11 +174,6 @@ export default function DownloadPage() {
       idx={1}
       title={t('steps.download.title')}
       subtitle={t('steps.download.subtitle')}
-      actions={
-        <Link to="/tools/settings" className="btn btn-ghost btn-sm">
-          {t('nav.settings')}
-        </Link>
-      }
     >
     <div className="flex flex-col h-full gap-3 min-h-0">
 

--- a/studio/web/src/pages/project/steps/Preprocess.tsx
+++ b/studio/web/src/pages/project/steps/Preprocess.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link, useOutletContext } from 'react-router-dom'
+import { useOutletContext } from 'react-router-dom'
 import {
   api,
   type Job,
@@ -336,11 +336,6 @@ export default function PreprocessPage() {
       idx={2}
       title={t('steps.preprocess.title')}
       subtitle={t('steps.preprocess.subtitle')}
-      actions={
-        <Link to="/tools/settings" className="btn btn-ghost btn-sm">
-          {t('nav.settings')}
-        </Link>
-      }
     >
       <div className="flex flex-col h-full gap-3 min-h-0">
         <div className="grid gap-3 flex-1 min-h-0" style={{ gridTemplateColumns: '1fr 260px' }}>

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -113,10 +113,8 @@ export default function PresetsPage() {
   // ── 选 preset 切换 ──
   // 新建模式（selected=null）：优先用 draftSeed（来自「复制副本」/「导入」），
   // 没种子就用 schema 默认值。draftSeed 是一次性的，消费后清空。
-  // modelPathDefaults 加进 deps：进程启动时 useEffect 可能先于 fetch 跑（用 schema
-  // 相对默认初始化），fetch 完成后 modelPathDefaults 到达，重跑一次覆盖成绝对。
-  // 只在 selected===null（新建模式）且没有 draftSeed 时生效；用户编辑过的 config
-  // 不会被此 effect 覆盖，因为 draftSeed 已消费。
+  // modelPathDefaults 在此处只读初值快照、不进 deps：异步晚到的情况由下面那个
+  // 带「用户没改过」guard 的 useEffect 覆盖，避免重入这里把用户编辑清掉。
   useEffect(() => {
     if (!selected) {
       const seed = draftSeedRef.current
@@ -157,6 +155,8 @@ export default function PresetsPage() {
       toast(t('presets.loadFailed', { error: e }), 'error')
       setSelected(null)
     })
+    // modelPathDefaults 故意排除：late-arrival 由下一个 useEffect 处理
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selected, schema, descriptions, t, toast])
 
   // modelPathDefaults 异步拉取，可能晚于主 init useEffect 到达。新建模式下

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -558,7 +558,7 @@ export default function SettingsPage() {
           <button
             onClick={save}
             disabled={!dirty || saving}
-            className="btn btn-primary btn-sm"
+            className={dirty ? 'btn btn-primary btn-sm' : 'btn btn-secondary btn-sm'}
           >
             {saving ? t('common.saving') : t('common.save')}
           </button>
@@ -582,6 +582,10 @@ export default function SettingsPage() {
             type="text"
             value={draft.gelbooru.user_id}
             onChange={(e) => update('gelbooru', 'user_id', e.target.value)}
+            autoComplete="off"
+            data-lpignore="true"
+            data-1p-ignore
+            data-form-type="other"
             className={textInputClass}                                  />
         </SettingsField>
         <SettingsField label="api_key">
@@ -609,6 +613,10 @@ export default function SettingsPage() {
             value={draft.danbooru.username}
             onChange={(e) => update('danbooru', 'username', e.target.value)}
             placeholder={t('settings.danbooruUsernamePlaceholder')}
+            autoComplete="off"
+            data-lpignore="true"
+            data-1p-ignore
+            data-form-type="other"
             className={textInputClass}                                  />
         </SettingsField>
         <SettingsField label="api_key">
@@ -1178,6 +1186,10 @@ function SensitiveInput({ value, serverValue, onChange }: {
       value={masked ? '' : value}
       placeholder={serverValue === MASK ? t('settings.sensitiveSavedPlaceholder') : ''}
       onChange={(e) => onChange(e.target.value || MASK)}
+      autoComplete="new-password"
+      data-lpignore="true"
+      data-1p-ignore
+      data-form-type="other"
       className={textInputClass}                />
   )
 }

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
@@ -38,11 +38,18 @@ interface MultiModeProps extends CommonProps {
   mode?: 'multi'
   /** 已被 caller 选过的 path（其他 LoRA 槽 / 其他 axis 占用），在 list 标 ✓ 禁用 */
   existingPaths?: Set<string>
-  /** 「添加 N 个」commit 回调；之后 onClose 由 picker 自动触发 */
+  /** chip 切换 / 权重 / pid-vid 变更回调。
+   *
+   * - 普通 multi 模式：用户点「添加 N 个」commit 时触发，picker 自动 onClose
+   * - live 模式：每次 chip toggle / 权重变 / pid-vid 切都立即触发（不依赖 commit 按钮）
+   */
   onPick: (picks: PickedLora[], weight: number) => void
   /** XY 轴绑定下应 hide 权重（轴卡片自己有 lora_scale 控制） */
   showWeight?: boolean
   defaultWeight?: number
+  /** 即时生效：每次 chip toggle 都 onPick，不再渲染「添加 N 个」commit footer。
+   *  用于 XY 轴卡片这种「picker 常驻、用户期望所见即所得」的场景。 */
+  live?: boolean
   value?: never
   weight?: never
   onChange?: never
@@ -136,12 +143,6 @@ export default function InlineLoraPicker(props: Props) {
     )
   }, [ckpts, search])
 
-  // multi 模式的当前会话选中（single 模式不用，受控走 props.value）
-  const [picked, setPicked] = useState<Set<string>>(new Set())
-  useEffect(() => {
-    if (!isSingle) setPicked(new Set())  // pid/vid 切换时清空
-  }, [pid, vid, isSingle])
-
   // 权重：single 模式受控；multi 模式内部状态
   const [internalWeight, setInternalWeight] = useState<number>(
     isSingle ? props.weight : (props.mode === 'multi' ? props.defaultWeight ?? 1.0 : 1.0)
@@ -151,6 +152,20 @@ export default function InlineLoraPicker(props: Props) {
   useEffect(() => {
     if (isSingle) setInternalWeight(singleWeight)
   }, [isSingle, singleWeight])
+
+  // multi 模式的当前会话选中（single 模式不用，受控走 props.value）
+  const [picked, setPicked] = useState<Set<string>>(new Set())
+  const isLive = !isSingle && (props as MultiModeProps).live === true
+  useEffect(() => {
+    if (isSingle) return
+    setPicked(new Set())  // pid/vid 切换时清空 UI 选中
+    // live 模式：pid/vid 切了把 axis 也清掉（新版本下旧 path 已无意义）；
+    // 初始 mount 也会跑一次，但此时 draft.raw 通常已是空，commit 空集合即 no-op。
+    if (isLive) {
+      (props as MultiModeProps).onPick([], internalWeight)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pid, vid, isSingle])
 
   const currentVersion = versions.find((v) => v.id === vid)
 
@@ -175,6 +190,13 @@ export default function InlineLoraPicker(props: Props) {
     setPicked((s) => {
       const next = new Set(s)
       if (next.has(c.path)) next.delete(c.path); else next.add(c.path)
+      // live 模式：每次 chip toggle 都即时 commit，不等用户点「添加 N 个」
+      if (isLive && pid !== null && vid !== null) {
+        const picks: PickedLora[] = Array.from(next).map((path) => ({
+          path, projectId: pid, versionId: vid,
+        }))
+        ;(props as MultiModeProps).onPick(picks, internalWeight)
+      }
       return next
     })
   }
@@ -184,6 +206,12 @@ export default function InlineLoraPicker(props: Props) {
       props.onChange(props.value, w)
     } else {
       setInternalWeight(w)
+      if (isLive && pid !== null && vid !== null && picked.size > 0) {
+        const picks: PickedLora[] = Array.from(picked).map((path) => ({
+          path, projectId: pid, versionId: vid,
+        }))
+        ;(props as MultiModeProps).onPick(picks, w)
+      }
     }
   }
 
@@ -366,8 +394,8 @@ export default function InlineLoraPicker(props: Props) {
         </div>
       )}
 
-      {/* multi 模式：commit footer */}
-      {!isSingle && picked.size > 0 && (
+      {/* multi 模式：commit footer（live 模式下不渲染，chip 即所见即所得） */}
+      {!isSingle && !isLive && picked.size > 0 && (
         <div className="flex items-center gap-2 justify-end">
           <span className="text-2xs text-fg-tertiary mr-auto">已选 {picked.size}</span>
           <button

--- a/studio/web/src/pages/tools/generate/SidebarXYAxes.tsx
+++ b/studio/web/src/pages/tools/generate/SidebarXYAxes.tsx
@@ -33,7 +33,12 @@ function AxisLoraCkptPicker({
   const [externalOpen, setExternalOpen] = useState(false)
 
   const commitPicks = (picks: { path: string; projectId: number | null; versionId: number | null }[]) => {
-    if (picks.length === 0) return
+    if (picks.length === 0) {
+      // live 模式下，picker 把所有 chip 反选 / 切换 pid/vid 都会送空集合过来 →
+      // 清掉 axis 绑定。loras[] 里之前那条 entry 不动（picker 可能复用它）。
+      onDraftChange({ ...draft, loraIndex: null, raw: '' })
+      return
+    }
     const pid = picks[0].projectId
     const vid = picks[0].versionId
     // 在 loras[] 里找已绑过这个 (pid, vid) 的槽
@@ -88,11 +93,12 @@ function AxisLoraCkptPicker({
       )}
       <InlineLoraPicker
         mode="multi"
+        live
         projectLoras={projectLoras}
         existingPaths={new Set()}
         showWeight={false}
         onPick={commitPicks}
-        onClose={() => { /* 多选 commit 后 picker 自动 close —— 但这里是常驻在 axis card 里，nothing to close */ }}
+        onClose={() => { /* 常驻在 axis card 里，nothing to close */ }}
         onPickExternal={() => setExternalOpen(true)}
       />
       {externalOpen && (


### PR DESCRIPTION
## Summary

一批从测试反馈里捞出来的小问题，集中处理：

- **i18n 漏键**：Settings 自定义放大器下载按钮直接漏 `common.download` 字串 → 补 zh/en `common.download`
- **设置保存按钮 dirty 着色**：之前一直橙色，靠 `disabled` 区分弱。改成 `btn-secondary` 灰 / `btn-primary` 橙 切换，跟 `SaveBar.tsx` 同款约定
- **api_key 浏览器自动填充触发 dirty**：`SensitiveInput`（Settings + LLMTaggerWorkspace）和配对的 `username` / `user_id` 加 `autoComplete=\"new-password\"` / `\"off\"` + `data-lpignore` / `data-1p-ignore` / `data-form-type=other`，让 Chrome / 1P / LP 别注入值
- **项目 step header 「设置」按钮**：Download / Preprocess 的 header `actions` 删掉重复入口（顶栏侧边栏已有）
- **Presets.tsx exhaustive-deps lint warning**：主 init `useEffect` 的 `modelPathDefaults` 故意排除（late-arrival 由下面那个带「用户没改过」guard 的 effect 处理），补 `eslint-disable` + 改掉上面过时的「加进 deps」注释
- **XY 轴 LoRA picker 即时生效**：`InlineLoraPicker` 加 `live?: boolean`，chip toggle / 权重变 / pid-vid 切换都即时 `onPick`，picker 常驻在 axis card 里时不再渲染「添加 N 个」commit footer。`AxisLoraCkptPicker.commitPicks` 处理空 picks（清 `draft.raw` + `loraIndex`，loras[] 槽保留可复用）
- **lockfile sync**：`package.json` 已有的 i18next / react-i18next deps 同步到 `package-lock.json`

非 live 的现有 multi 模式调用（如果未来还有）不受影响。`InlineLoraPicker` 现有 19 个单测全通过。

## Test plan

- [ ] Settings 页：自定义下载按钮显示「下载」（zh）/「Download」（en）
- [ ] Settings 页：进入页面保存按钮灰色；改任意字段后变橙色
- [ ] Settings 页：打开 Gelbooru / Danbooru / WandB 区块，api_key 字段 Chrome 自动填充被压制（不会自动注入 → 保存按钮保持灰）
- [ ] 项目页 Download / Preprocess header 右上角不再有「设置」按钮
- [ ] Presets 页：`npm run lint` 无 `react-hooks/exhaustive-deps` 警告
- [ ] Generate 页 XY 轴 = LoRA：chip 点一下就生效（看到摘要 / 网格立刻刷新），不需要点「添加 N 个」；点已选 chip 反选也即时；切版本下拉后旧选清空

🤖 Generated with [Claude Code](https://claude.com/claude-code)