### PR TITLE
chore(spike): 验证 ADR 0006 方案 A — Windows 信号链路通

### DIFF
--- a/docs/design/queue-pause-spike-report.md
+++ b/docs/design/queue-pause-spike-report.md
@@ -1,0 +1,125 @@
+# Queue 暂停信号链路 Spike 报告
+
+**日期**：2026-05-18
+**ADR**：[0006-queue-pause-resume](../adr/0006-queue-pause-resume.md)
+**Spike 脚本**：[`tools/spike/`](../../tools/spike/)
+
+## 结论
+
+**ADR §候选方案 A（信号通道 + 复用 handle_interrupt）可行**，主线进 PR-1。
+方案 B（sentinel 文件 IPC）回归 parking lot。
+
+## 跑了什么
+
+在 Windows 11 上 spawn 一个模拟训练子进程，按 ADR §后端代码方向把整条信号链
+端到端跑通：
+
+```
+parent (supervisor 模拟)             child (training 模拟)
+─────────────────────────            ─────────────────────────
+Popen(CREATE_NEW_PROCESS_GROUP)
+                          ──spawn──▶ signal.signal(SIGBREAK, h)
+                                     signal.signal(SIGINT, h)
+                                     emit __EVENT__:train_loop_started
+                                     fake step loop (step += 1 / 0.5s)
+sleep 3s
+proc.send_signal(CTRL_BREAK_EVENT)
+                          ──CTRL_BREAK──▶
+                                     handler triggered (sig=21)
+                                     fake_save_training_state(.pt)
+                                     fake_write_config_snapshot(.json)
+                                     emit __EVENT__:pause_state
+                                     sys.exit(0)
+stdout reader:
+  parse __EVENT__:pause_state ◀─────
+proc.wait() → rc=0
+validate 6 个检查
+```
+
+## 6 项验证结果（两次连跑都全过）
+
+| # | 检查 | 结果 |
+|---|------|------|
+| 1 | `CTRL_BREAK_EVENT` 送达 `CREATE_NEW_PROCESS_GROUP` 子进程组 | PASS |
+| 2 | `signal.signal(SIGBREAK, handler)` 捕获信号 | PASS（handler 收到 sig=21）|
+| 3 | handler 完整跑完 save + emit + `sys.exit(0)` | PASS（rc=0）|
+| 4 | parent 读到 `__EVENT__:pause_state` 并解析 payload | PASS |
+| 5（附）| pause `.pt` + `.config.json` 各一份落盘 | PASS |
+| 6（附）| `__EVENT__:train_loop_started` 事件能用作 `is_pausable` 信号 | PASS |
+
+**关键数字**：发信号 → 子进程退出耗时 **0.62 s**（含 0.5 s fake IO sleep）。
+真训练 state 几十~几百 MB，落盘 IO 是大头，但 spike 验证的是信号路径而不是
+IO 性能。
+
+## 关键发现
+
+### Python Windows 信号映射
+
+`CTRL_BREAK_EVENT`（OS 层）→ `SIGBREAK`（Python 信号常量值 `21`）。
+**不是 SIGINT**——Python Windows docs 明确指 `CTRL_C_EVENT` 才映射 SIGINT，
+但 `CREATE_NEW_PROCESS_GROUP` 子进程组收不到 `CTRL_C_EVENT`，只收
+`CTRL_BREAK_EVENT`。所以 ADR §`runtime/training/phases/resume.py` 的"Windows
+额外注册 SIGBREAK handler"是必须的，不是可选优化。
+
+### subprocess.Popen + stdout=PIPE 经 line buffering
+
+要在 parent 用 `for raw in proc.stdout:` 实时收事件，必须：
+- 子进程侧：`PYTHONUNBUFFERED=1` 环境 + `print(..., flush=True)` 双保险。
+- 父进程侧：`bufsize=0` 关闭 parent 端的 readahead 缓冲。
+
+只设一边事件会延迟到几 KB stdout 攒满才看到——spike 第一版没设 bufsize=0
+时，event 行延迟到子进程退出后才出现，差点误判为"事件没发出来"。
+
+### Parent stdout 自身编码
+
+跟主项目无关的小坑：Windows shell 默认 codepage（cp936 / cp932）encode 中文
+print 会抛 `UnicodeEncodeError`。`env["PYTHONIOENCODING"] = "utf-8"` 只对
+**子进程**生效，parent 自己得 `sys.stdout.reconfigure(encoding="utf-8")`。
+real supervisor 走的是 `stdout=log_fp`（文件），不打 console，不会遇到。
+
+## 对落地的影响
+
+### 直接采纳
+
+- ADR §`runtime/training/phases/resume.py` 在 Windows 上**必须**额外注册
+  `signal.SIGBREAK`，不能只靠 SIGINT。
+- ADR §`studio/supervisor.py` `_send_pause_signal` 在 Windows 上发
+  `CTRL_BREAK_EVENT`、POSIX 发 `SIGINT`——跟 spike 一致。
+- ADR §`runtime/training/context.py` `handle_interrupt` 完成 save 后 emit
+  `__EVENT__:pause_state` 是必要的——parent 不能光靠 `rc=0` 判断 paused，
+  必须看到事件行（rc 在 Windows wrapper 改写场景下不可靠）。
+- ADR §Cancel 在 Windows 改 `taskkill /T /F`：信号通道**真的**被 pause 独占
+  了，这条决策落地。
+
+### 不需要兜底方案 B
+
+方案 B（sentinel 文件 IPC）在三方 review 里作为 spike 失败的兜底保留。
+spike 通过 → 方案 B 不进 PR-1 ~ PR-5，留在 ADR §候选方案作为历史决策痕迹。
+如果未来 Windows 行为变化或新平台失效，再回头考虑。
+
+### 仍需 PR-3 集成测覆盖
+
+spike 用 **fake** save（500ms sleep + 几十 KB 文件）跑通了。真 case 几十~
+几百 MB optimizer state + wandb finish + monitor flush，整个 handler 跑
+3 ~ 10 秒不奇怪。ADR §4.3 暂停过程 modal 30s 超时阈值的合理性、IO 慢盘 /
+SSD 写满 / antivirus 锁文件等边界 case，必须在 PR-3 端到端集成测里覆盖，
+不在 spike scope 内。
+
+## 复现
+
+```bash
+git checkout chore/queue-pause-signal-spike
+python tools/spike/pause_signal_parent.py
+```
+
+预期：6 项 PASS + `结论: 全部通过 — ADR 方案 A 可行` + `rc=0`。
+
+## Spike 脚本生命周期
+
+PR-0 合入 dev 后留作"曾经验证过方案 A 可行"的可执行证据。下面任一时机
+触发 cleanup PR 删除 `tools/spike/`：
+
+- ADR 0006 全套 PR（PR-1 ~ PR-5）合入并生产验证。
+- 或本报告结论翻转（方案 A 在真实链路上不稳）。
+
+本报告独立留存，不随脚本删除——脚本是"怎么验"，报告是"验过了 & 结论"。

--- a/tools/spike/README.md
+++ b/tools/spike/README.md
@@ -1,0 +1,72 @@
+# Queue 暂停信号链路 Spike
+
+ADR 0006 PR-0 的验证脚本。**临时性质，验证完会随 cleanup PR 删除。**
+
+## 这是什么
+
+ADR 0006 决定走「信号通道 + 复用 handle_interrupt」（方案 A）。落地前要
+先在 Windows 上验证整条信号链路：
+
+```
+supervisor.proc.send_signal(CTRL_BREAK_EVENT)
+    ↓
+[Windows: 子进程组收到]
+    ↓
+Python signal.signal(SIGBREAK, handler) 捕获
+    ↓
+handler 跑完 save_training_state + write snapshot + emit __EVENT__:pause_state
+    ↓
+sys.exit(0)
+    ↓
+supervisor stdout reader 读到事件行 → _finish_slot 标 paused
+```
+
+链路里任何一步通不了 → 整个方案 A 报废，要回退到方案 B（sentinel 文件 IPC）。
+
+## 跑法
+
+```bash
+python tools/spike/pause_signal_parent.py
+```
+
+不要直接跑 `pause_signal_child.py`——它依赖 parent 发的信号才有意义。
+
+跑完控制台会打印一份验证报告（6 项检查），退出码 0 = 全过、非 0 = 至少一项
+失败。
+
+`tmp/spike_state/` 是 spike 输出目录（fake .pt + config snapshot），每次跑
+parent 会先清空。
+
+## 验证项（对应 ADR §Spike 必做）
+
+| # | 检查 | 通过判据 |
+|---|------|---------|
+| 1 | CTRL_BREAK_EVENT 送达 CREATE_NEW_PROCESS_GROUP 子进程组 | parent 收到 `__EVENT__:pause_state` |
+| 2 | `signal.signal(SIGBREAK, handler)` 捕获 | 子进程 stdout 出现 "handler 触发" 行 |
+| 3 | handler 完整 save + sys.exit(0) | 子进程 stdout 出现 "handler 完成" + `rc=0` |
+| 4 | parent 解析 `__EVENT__:pause_state` payload | payload 含 `state_path` 字段 |
+| 5（附加）| pause `.pt` + `.config.json` 各一份落盘 | `tmp/spike_state/state/task_42/` 下文件存在 |
+| 6（附加）| `__EVENT__:train_loop_started` 事件 | parent 收到 → 验证 ADR §8.1 `is_pausable` 信号 |
+
+## 设计意图
+
+- **不依赖项目代码**：spike 是黑盒验证 OS + Python 信号语义，不 import
+  `runtime.training.*` / `studio.supervisor`，免得验证结果被项目代码引入的状态
+  污染。
+- **mirror 真实参数**：`CREATE_NEW_PROCESS_GROUP` / `PYTHONUNBUFFERED=1` /
+  stdout=PIPE+stderr=STDOUT 跟 `studio/supervisor.py:_popen` 对齐。
+- **不模拟体积**：fake `.pt` 是几十 KB 字节，真训练 state 几十~几百 MB。
+  spike 只测信号路径通不通，IO 耗时只 sleep 0.5s 模拟。
+- **不依赖 GPU**：跑得起 python 解释器就行。
+
+## 删除时机
+
+PR-0 合入 dev 后留作"曾经验证过方案 A 可行"的快照证据。下面两个时机
+任一发生时整个 `tools/spike/` 目录可以 cleanup PR 删除：
+
+- ADR 0006 整体落地完成（PR-1 ~ PR-5 全部合入），方案 A 已生产验证。
+- 或 spike 报告显示方案 A 失败，ADR 决策修订走方案 B。
+
+验证报告（看了 `python tools/spike/pause_signal_parent.py` 输出 + 决策结果）
+会落到 `docs/design/queue-pause-spike-report.md`，跟脚本独立——脚本删后
+报告留存。

--- a/tools/spike/pause_signal_child.py
+++ b/tools/spike/pause_signal_child.py
@@ -1,0 +1,104 @@
+"""Spike 子进程：模拟训练循环 + SIGBREAK/SIGINT handler。
+
+跑法：由 pause_signal_parent.py spawn，不要单独跑（信号靠 parent 发）。
+
+模拟的是 ADR 0006 §后端代码方向 / runtime/training 那条链路：
+  - 主循环 = train_loop（每秒 step += 1，print 到 stdout）
+  - handler = TrainingContext.handle_interrupt：保 state（fake .pt + .config.json）+
+    emit __EVENT__:pause_state + sys.exit(0)
+
+stdout 用 supervisor 的 __EVENT__ 协议（详见 studio/supervisor.py:49 _EVENT_MARKER）。
+"""
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+
+# 模拟 TrainingContext 的状态
+STATE = {
+    "global_step": 0,
+    "task_id": int(os.environ.get("LORA_TASK_ID", "9999")),
+    "interrupted": False,
+    "output_dir": Path(os.environ.get("SPIKE_OUTPUT_DIR", "tmp/spike_state")).resolve(),
+}
+
+
+def emit_event(event_type: str, payload: dict) -> None:
+    """Mirror supervisor.py:49 的 __EVENT__ 协议。"""
+    print(f"__EVENT__:{event_type}:{json.dumps(payload, ensure_ascii=False)}", flush=True)
+
+
+def fake_save_training_state(state_path: Path) -> None:
+    """模拟 runtime/training/state.py save_training_state 的写盘耗时 + 体积。"""
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    # 真 save_training_state 写 optimizer + model + monitor 通常几十~几百 MB；
+    # spike 不模拟体积，只验证文件写出来 + 信号路径通即可。
+    state_path.write_bytes(b"FAKE_TRAINING_STATE_BLOB" * 1024)
+    time.sleep(0.5)  # 模拟 IO 耗时
+
+
+def fake_write_config_snapshot(config_path: Path, step: int) -> None:
+    """模拟 ADR §5.7 config snapshot：把 args 全 freeze 成 JSON。"""
+    snapshot = {
+        "args": {"lr": 1e-4, "optimizer": "AdamW", "batch_size": 4, "max_train_steps": 1000},
+        "dataset": {"resolution": 1024, "caption_extension": ".txt"},
+        "output": {"output_dir": str(STATE["output_dir"]), "output_name": "spike_test"},
+        "seed": 42,
+        "global_step_at_pause": step,
+    }
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(snapshot, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def handle_interrupt(sig, frame) -> None:
+    """Mirror runtime/training/context.py:109 handle_interrupt + ADR §后端代码方向。"""
+    if STATE["interrupted"]:
+        print(f"[child] 二次信号 sig={sig}，强退", flush=True)
+        sys.exit(1)
+    STATE["interrupted"] = True
+    step = STATE["global_step"]
+    print(f"[child] handler 触发: sig={sig} step={step}", flush=True)
+
+    state_dir = STATE["output_dir"] / "state" / f"task_{STATE['task_id']}"
+    state_path = state_dir / f"pause_step_{step}.pt"
+    config_path = state_dir / f"pause_step_{step}.config.json"
+
+    print(f"[child] 写 state: {state_path}", flush=True)
+    fake_save_training_state(state_path)
+    print(f"[child] 写 config snapshot: {config_path}", flush=True)
+    fake_write_config_snapshot(config_path, step)
+
+    emit_event("pause_state", {
+        "state_path": str(state_path),
+        "config_path": str(config_path),
+        "step": step,
+    })
+    print(f"[child] handler 完成，sys.exit(0)", flush=True)
+    sys.exit(0)
+
+
+def main() -> None:
+    if os.name == "nt":
+        signal.signal(signal.SIGBREAK, handle_interrupt)
+        print(f"[child] 注册 SIGBREAK handler (Windows, pid={os.getpid()})", flush=True)
+    signal.signal(signal.SIGINT, handle_interrupt)
+    print(f"[child] 注册 SIGINT handler (pid={os.getpid()})", flush=True)
+
+    emit_event("train_loop_started", {"task_id": STATE["task_id"]})
+
+    max_steps = int(os.environ.get("SPIKE_MAX_STEPS", "100"))
+    while STATE["global_step"] < max_steps:
+        STATE["global_step"] += 1
+        print(f"[child] step {STATE['global_step']}/{max_steps}", flush=True)
+        time.sleep(0.5)
+
+    print(f"[child] 训练正常结束 (走到 max_steps)", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/spike/pause_signal_parent.py
+++ b/tools/spike/pause_signal_parent.py
@@ -1,0 +1,211 @@
+"""Spike 父进程：模拟 supervisor 发暂停信号 + 读 stdout 事件。
+
+跑法：
+    python tools/spike/pause_signal_parent.py
+
+验证 ADR 0006 §Spike 必做的 4 项：
+  1. supervisor 端 proc.send_signal(CTRL_BREAK_EVENT) 能否送达
+     CREATE_NEW_PROCESS_GROUP 子进程组。
+  2. 子进程 signal.signal(SIGBREAK, handler) 能否捕获。
+  3. handler 能否完整跑完 save + write snapshot 后 sys.exit(0)。
+  4. supervisor 端能否正确读到子进程 stdout 上的 __EVENT__:pause_state
+     行后才走 _finish_slot 标 paused。
+
+退出码 0 = 全 4 项通过。非 0 = 至少一项失败，详见报告。
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import signal
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# Windows 下 shell 默认 codepage（cp936 / cp932）无法 encode 中文 print。
+# child 用 env PYTHONIOENCODING=utf-8 兜过去了，parent 自己也得 reconfigure。
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="backslashreplace")  # type: ignore[union-attr]
+if hasattr(sys.stderr, "reconfigure"):
+    sys.stderr.reconfigure(encoding="utf-8", errors="backslashreplace")  # type: ignore[union-attr]
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHILD_SCRIPT = Path(__file__).parent / "pause_signal_child.py"
+OUTPUT_DIR = REPO_ROOT / "tmp" / "spike_state"
+EVENT_MARKER = "__EVENT__:"
+
+
+@dataclass
+class Capture:
+    """收集子进程的事件 + stdout 行。"""
+    events: list[dict] = field(default_factory=list)
+    lines: list[str] = field(default_factory=list)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+    def add_line(self, line: str) -> None:
+        with self.lock:
+            self.lines.append(line)
+            if line.startswith(EVENT_MARKER):
+                rest = line[len(EVENT_MARKER):]
+                try:
+                    evt_type, payload_str = rest.split(":", 1)
+                    payload = json.loads(payload_str) if payload_str else {}
+                    self.events.append({"type": evt_type, **payload})
+                except (ValueError, json.JSONDecodeError) as e:
+                    print(f"[parent] WARN 事件解析失败: {line!r}: {e}", flush=True)
+
+    def has_event(self, evt_type: str) -> bool:
+        with self.lock:
+            return any(e["type"] == evt_type for e in self.events)
+
+    def find_event(self, evt_type: str) -> Optional[dict]:
+        with self.lock:
+            for e in self.events:
+                if e["type"] == evt_type:
+                    return e
+        return None
+
+
+def reader_thread(proc: subprocess.Popen, capture: Capture) -> None:
+    """Mirror supervisor 的 _on_line：逐行读 stdout，识别 __EVENT__ 标记。"""
+    assert proc.stdout is not None
+    for raw in proc.stdout:
+        line = raw.decode("utf-8", errors="backslashreplace").rstrip("\r\n")
+        capture.add_line(line)
+        print(f"  [child stdout] {line}", flush=True)
+
+
+def send_pause_signal(proc: subprocess.Popen) -> None:
+    """Mirror ADR §后端代码方向 _send_pause_signal：
+      Windows: CTRL_BREAK_EVENT；POSIX: SIGINT。
+    """
+    if os.name == "nt":
+        print(f"[parent] 发 CTRL_BREAK_EVENT 给子进程组 pid={proc.pid}", flush=True)
+        proc.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
+    else:
+        print(f"[parent] 发 SIGINT 给子进程 pid={proc.pid}", flush=True)
+        proc.send_signal(signal.SIGINT)
+
+
+def run_spike() -> int:
+    if OUTPUT_DIR.exists():
+        shutil.rmtree(OUTPUT_DIR)
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "utf-8"
+    env["PYTHONUTF8"] = "1"
+    env["PYTHONUNBUFFERED"] = "1"
+    env["LORA_TASK_ID"] = "42"
+    env["SPIKE_OUTPUT_DIR"] = str(OUTPUT_DIR)
+    env["SPIKE_MAX_STEPS"] = "100"
+
+    creationflags = 0
+    if os.name == "nt":
+        creationflags = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+
+    print(f"[parent] 起 child: {CHILD_SCRIPT}", flush=True)
+    print(f"[parent] OS={os.name}, creationflags={creationflags}", flush=True)
+    print(f"[parent] OUTPUT_DIR={OUTPUT_DIR}", flush=True)
+
+    started_at = time.time()
+    proc = subprocess.Popen(
+        [sys.executable, "-u", str(CHILD_SCRIPT)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        cwd=str(REPO_ROOT),
+        creationflags=creationflags,
+        env=env,
+        bufsize=0,
+    )
+
+    capture = Capture()
+    reader = threading.Thread(target=reader_thread, args=(proc, capture), daemon=True)
+    reader.start()
+
+    # 等子进程跑几步再发信号，模拟 "用户点暂停" 的时机
+    time.sleep(3.0)
+
+    signal_sent_at = time.time()
+    send_pause_signal(proc)
+
+    try:
+        rc = proc.wait(timeout=30.0)
+    except subprocess.TimeoutExpired:
+        print(f"[parent] 子进程 30s 内未退出，强杀", flush=True)
+        proc.kill()
+        rc = proc.wait()
+
+    finished_at = time.time()
+    reader.join(timeout=2.0)
+
+    # ---- 验证报告 ----------------------------------------------------------
+
+    print()
+    print("=" * 70)
+    print("Spike 验证报告 (ADR 0006 §Spike 必做)")
+    print("=" * 70)
+    print(f"  os={os.name}  child pid={proc.pid}  rc={rc}")
+    print(f"  子进程总耗时: {finished_at - started_at:.2f}s")
+    print(f"  发信号 → 退出: {finished_at - signal_sent_at:.2f}s")
+    print()
+
+    checks = []
+
+    # 1. 信号送达 = handler 跑了 = 收到 pause_state 事件（间接证据）
+    has_pause_state = capture.has_event("pause_state")
+    checks.append(("1. CTRL_BREAK_EVENT 送达 CREATE_NEW_PROCESS_GROUP 子进程", has_pause_state))
+
+    # 2. SIGBREAK handler 注册成功 → 信号被自定义 handler 捕获（不是默认 abort）。
+    # 间接证据：handler 输出 "[child] handler 触发" 行
+    handler_triggered = any("handler 触发" in ln for ln in capture.lines)
+    checks.append(("2. signal.signal(SIGBREAK, handler) 捕获 (handler 触发)", handler_triggered))
+
+    # 3. handler 完整跑完 + sys.exit(0)
+    handler_complete = any("handler 完成" in ln for ln in capture.lines) and rc == 0
+    checks.append(("3. handler 完整 save + emit + sys.exit(0) (rc=0)", handler_complete))
+
+    # 4. parent 读到 __EVENT__:pause_state 行，并能解析 payload
+    pause_evt = capture.find_event("pause_state")
+    parent_got_event = pause_evt is not None and "state_path" in (pause_evt or {})
+    checks.append(("4. parent 读到 __EVENT__:pause_state + 解析 payload", parent_got_event))
+
+    # 附加验证：pause 文件落盘
+    state_files = list(OUTPUT_DIR.rglob("pause_step_*.pt")) if OUTPUT_DIR.exists() else []
+    config_files = list(OUTPUT_DIR.rglob("pause_step_*.config.json")) if OUTPUT_DIR.exists() else []
+    files_ok = len(state_files) == 1 and len(config_files) == 1
+    checks.append(("5. pause .pt + .config.json 各一份落盘 (附加)", files_ok))
+
+    # train_loop_started 事件也验证一下
+    has_loop_started = capture.has_event("train_loop_started")
+    checks.append(("6. 收到 train_loop_started 事件 (is_pausable 信号)", has_loop_started))
+
+    all_pass = True
+    for label, ok in checks:
+        mark = "[PASS]" if ok else "[FAIL]"
+        if not ok:
+            all_pass = False
+        print(f"  {mark} {label}")
+    print()
+
+    if pause_evt:
+        print(f"  pause_state payload: {json.dumps(pause_evt, ensure_ascii=False, indent=2)}")
+    print(f"  state files: {[str(p.relative_to(OUTPUT_DIR)) for p in state_files]}")
+    print(f"  config files: {[str(p.relative_to(OUTPUT_DIR)) for p in config_files]}")
+    print()
+    print("=" * 70)
+    print(f"结论: {'全部通过 — ADR 方案 A 可行' if all_pass else '至少一项失败 — 需回退方案 B 或 debug'}")
+    print("=" * 70)
+
+    return 0 if all_pass else 1
+
+
+if __name__ == "__main__":
+    sys.exit(run_spike())


### PR DESCRIPTION
## 背景

ADR 0006 §候选方案 A 决定走「信号通道 + 复用 handle_interrupt」。落地前
ADR §Spike 必做要求先在 Windows 上验证整条链路：

```
supervisor.send_signal(CTRL_BREAK_EVENT)
    ↓
[CREATE_NEW_PROCESS_GROUP 子进程组]
    ↓
signal.signal(SIGBREAK, handler) 捕获
    ↓
handler save + emit __EVENT__:pause_state + sys.exit(0)
    ↓
supervisor stdout reader 解析事件 → _finish_slot 标 paused
```

任一步通不了 → 整个方案 A 报废，要回退到方案 B（sentinel 文件 IPC）。

## 依赖

**必须先合 #95（docs(adr): 0006 queue 任务暂停 / 恢复 + 队列挂起 / 恢复调度）**——
本 PR 引用了 ADR 0006 + design doc 的路径。合并顺序：

1. 先合 #95（docs only，纯 ADR）
2. 再合本 PR（chore/spike，纯 tools/spike/ + design report）

#95 不合的话，本 PR 里 spike report 的 ADR 链接会 404，但脚本本身能跑。

## 改动概要

- `tools/spike/pause_signal_parent.py` — supervisor 模拟（Popen +
  CREATE_NEW_PROCESS_GROUP + 读 stdout 事件 + 发 CTRL_BREAK_EVENT）
- `tools/spike/pause_signal_child.py` — training 子进程模拟
  （SIGBREAK handler + fake save + emit `__EVENT__:pause_state`）
- `tools/spike/README.md` — spike 用途 + 6 项验证项 + 删除时机
- `docs/design/queue-pause-spike-report.md` — 复盘 + 对 PR-1 落地的影响

## 测试方式

```bash
python tools/spike/pause_signal_parent.py
```

跑两次结果一致（pid 不同但 PASS 项 + 时长 0.62s 一致）。详细输出 + 6 项
检查见报告。

## 结论摘要

**方案 A 可行**，PR-1 ~ PR-5 主线走方案 A。方案 B 回归 ADR §候选方案
作历史决策痕迹。

关键发现写到报告：
- Windows 信号映射：`CTRL_BREAK_EVENT` → `SIGBREAK`（sig=21），**不是
  SIGINT**。ADR §`runtime/training/phases/resume.py` 必须额外注册
  SIGBREAK，不是可选优化。
- `subprocess.Popen` 实时收事件：子进程 `PYTHONUNBUFFERED=1` + 父进程
  `bufsize=0` 双保险，少一个事件行就会延迟到几 KB stdout buffer 攒满。
- ADR §Cancel 在 Windows 改 `taskkill /T /F` 决策落地（信号通道被 pause
  独占了）。

## Spike 脚本生命周期

- 合入 dev 后留作"曾验证过方案 A 可行"的可执行证据。
- ADR 0006 全套 PR（PR-1 ~ PR-5）合入 + 生产验证后，由 cleanup PR 删
  `tools/spike/`（报告留存）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)