### PR TITLE
fix(train): state 文件按 task_id 隔离，避免同 version 多 task 互覆盖

### DIFF
--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -37,6 +37,10 @@ class TrainingContext:
     sample_dir: Optional[Path] = None
     wandb_monitor: Any = None         # observability.WandBMonitor
     monitor_server: Optional[bool] = None  # 旧名兼容：True=monitor_state.json 写入活跃
+    # supervisor 启动训练时通过 env LORA_TASK_ID 注入 queue task id；CLI 直接跑
+    # 时 env 不存在 → None → state_dir() fallback 到 task_unknown 子目录。
+    # 注意：跟 progress bar 的 task_id 字段（line ~80）是两回事，故意起不同名字。
+    lora_task_id: Optional[int] = None
 
     # ─── models_phase 填充 ───
     repo_root: Optional[Path] = None
@@ -84,6 +88,19 @@ class TrainingContext:
 
     # ─── 共用方法 ───
 
+    def state_dir(self) -> Path:
+        """周期 save / handle_interrupt 写 state 的目录，per-task 隔离。
+
+        ADR 0006 §5.3：同一 version 下多 task 跑 state 文件互相覆盖是 latent
+        bug，加 task_id 子目录隔离。env LORA_TASK_ID 没设（CLI 直接跑）时
+        fallback 到 task_unknown/。
+        """
+        assert self.output_dir is not None, "state_dir() called before bootstrap_phase"
+        tid = self.lora_task_id if self.lora_task_id is not None else "unknown"
+        d = self.output_dir / "state" / f"task_{tid}"
+        d.mkdir(parents=True, exist_ok=True)
+        return d
+
     def emit(self, msg: str) -> None:
         """打印一条 user-facing 消息，按当前进度显示模式分流。
 
@@ -121,7 +138,7 @@ class TrainingContext:
             sys.exit(1)
         self.interrupted = True
         self.emit("\n检测到 Ctrl+C，正在保存训练状态...")
-        state_path = self.output_dir / f"training_state_step{self.global_step}.pt"
+        state_path = self.state_dir() / f"training_state_step{self.global_step}.pt"
         monitor_data = None
         if self.monitor_server:
             try:

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -270,7 +270,7 @@ def run(ctx: TrainingContext) -> None:
                 # 定期保存训练状态（断点续训）
                 save_state_every = getattr(args, "save_state_every", 0)
                 if save_state_every > 0 and ctx.global_step % save_state_every == 0:
-                    state_path = ctx.output_dir / f"training_state_step{ctx.global_step}.pt"
+                    state_path = ctx.state_dir() / f"training_state_step{ctx.global_step}.pt"
                     # 获取监控面板数据用于恢复 loss 曲线
                     monitor_data = None
                     if ctx.monitor_server:
@@ -329,7 +329,7 @@ def run(ctx: TrainingContext) -> None:
             # 定期保存训练状态（epoch 版）
             save_state_every_epochs = int(getattr(args, "save_state_every_epochs", 0) or 0)
             if save_state_every_epochs > 0 and ctx.current_epoch % save_state_every_epochs == 0:
-                state_path = ctx.output_dir / f"training_state_epoch{ctx.current_epoch}.pt"
+                state_path = ctx.state_dir() / f"training_state_epoch{ctx.current_epoch}.pt"
                 monitor_data = None
                 if ctx.monitor_server:
                     try:

--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import random
 from pathlib import Path
 
@@ -78,6 +79,14 @@ def run(ctx: TrainingContext) -> None:
     ctx.output_dir.mkdir(parents=True, exist_ok=True)
     ctx.sample_dir = ctx.output_dir / "samples"
     ctx.sample_dir.mkdir(exist_ok=True)
+    # supervisor 启动训练时通过 env LORA_TASK_ID 注入 queue task id（ADR 0006）。
+    # 用于 ctx.state_dir() 计算 per-task state 子目录；env 不存在时 fallback unknown。
+    _env_tid = os.environ.get("LORA_TASK_ID")
+    if _env_tid:
+        try:
+            ctx.lora_task_id = int(_env_tid)
+        except ValueError:
+            logger.warning(f"LORA_TASK_ID={_env_tid!r} 不是 int，按 unknown 处理")
     ctx.wandb_monitor = init_wandb_monitor(args, ctx.output_dir, ctx.config_path)
 
     # Loss 函数（mse / huber；通过 losses/ plugin registry 派发）

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -540,7 +540,9 @@ class Supervisor:
         log_fp = open(log_path, "wb")
 
         cmd = self._cmd_builder(task, cfg_path)
-        proc = self._popen(cmd, log_fp)
+        # ADR 0006 PR-1：LORA_TASK_ID 注入让训练子进程把 state 文件写到
+        # output_dir/state/task_<TID>/ 子目录，避免同 version 多 task 互覆盖。
+        proc = self._popen(cmd, log_fp, extra_env={"LORA_TASK_ID": str(task["id"])})
 
         slot.proc = proc
         slot.kind = "task"
@@ -904,7 +906,12 @@ class Supervisor:
         })
 
     # ---- 子进程通用 -----------------------------------------------------------
-    def _popen(self, cmd: list[str], log_fp: Any) -> subprocess.Popen:
+    def _popen(
+        self,
+        cmd: list[str],
+        log_fp: Any,
+        extra_env: Optional[dict[str, str]] = None,
+    ) -> subprocess.Popen:
         creationflags = 0
         if os.name == "nt":
             creationflags = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
@@ -940,6 +947,8 @@ class Supervisor:
                     env.setdefault("WANDB_BASE_URL", wandb_cfg.base_url)
         except Exception:
             logger.exception("failed to load wandb settings")
+        if extra_env:
+            env.update(extra_env)
         return subprocess.Popen(
             cmd,
             stdout=log_fp,

--- a/studio/versions.py
+++ b/studio/versions.py
@@ -118,37 +118,66 @@ def list_lora_ckpts(vdir: Path) -> list[dict[str, Any]]:
     return items
 
 
+_STATE_FILE_RE = re.compile(r"training_state_(step|epoch)(\d+)\.pt$")
+
+
 def list_state_ckpts(vdir: Path) -> list[dict[str, Any]]:
-    """扫 versions/{label}/output/training_state_step*.pt，列所有断点续训状态文件。
+    """扫 version output/ 下所有断点续训 state 文件。
 
-    anima_train 输出命名约定（runtime/anima_train.py:2218, 2441）：
-      - training_state_step{N}.pt   （optimizer / RNG / loss 历史的完整 state）
+    扫描两个位置（ADR 0006 PR-1 路径迁移）：
+      - 旧路径：``output/training_state_step{N}.pt``（pre-PR-1 残留）
+      - 新路径：``output/state/task_<TID>/training_state_step{N}.pt``（PR-1+）
 
-    返回 [{step, label, path, mtime}]，按 step 降序（最新在前）。
-    给 Train 页的「从断点续训」picker 用。
+    两种粒度都看（PR-1 顺手修扫描漏 epoch 的旧 bug）：
+      - step  →  ``training_state_step{N}.pt``    label "step N"
+      - epoch →  ``training_state_epoch{N}.pt``   label "epoch N"
+
+    pause 文件（PR-2+ 的 ``pause_step_<N>.pt``）**不在此列**——picker 不应
+    暴露 pause 中间态。命名前缀天然过滤。
+
+    返回 [{step, label, path, mtime}]，step 降序，epoch 单独按 step（int 部分）
+    降序排在 step 项前后；UI 按 mtime/step 自己排即可。
     """
     output_dir = vdir / "output"
     if not output_dir.exists():
         return []
     items: list[dict[str, Any]] = []
-    for f in output_dir.glob("training_state_step*.pt"):
+    seen: set[str] = set()
+    # 同一相对路径不要进两次（理论上不会撞，但 glob 重叠 + symlink 兜底）。
+    candidates: list[Path] = []
+    candidates.extend(output_dir.glob("training_state_*.pt"))
+    state_root = output_dir / "state"
+    if state_root.exists():
+        candidates.extend(state_root.glob("task_*/training_state_*.pt"))
+    for f in candidates:
         if not f.is_file():
             continue
-        m = re.search(r"training_state_step(\d+)\.pt$", f.name)
+        m = _STATE_FILE_RE.search(f.name)
         if not m:
             continue
-        step = int(m.group(1))
+        key = str(f.resolve())
+        if key in seen:
+            continue
+        seen.add(key)
+        kind = m.group(1)  # "step" or "epoch"
+        n = int(m.group(2))
         try:
             mtime = f.stat().st_mtime
         except OSError:
             mtime = 0.0
         items.append({
-            "step": step,
-            "label": f"step {step}",
+            "step": n if kind == "step" else 0,
+            "label": f"{kind} {n}",
             "path": str(f),
             "mtime": mtime,
+            "_kind": kind,  # 内部排序用，返回前剥掉
+            "_n": n,
         })
-    items.sort(key=lambda x: -x["step"])
+    # 先 step 段（按 step 降序），后 epoch 段（按 epoch 降序）。
+    items.sort(key=lambda x: (0 if x["_kind"] == "step" else 1, -x["_n"]))
+    for it in items:
+        it.pop("_kind", None)
+        it.pop("_n", None)
     return items
 
 

--- a/tests/test_lora_ckpt_scan.py
+++ b/tests/test_lora_ckpt_scan.py
@@ -115,7 +115,9 @@ def test_mixed_kinds_other_after_step_epoch(vdir: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# list_state_ckpts —— 断点续训 picker 用，只扫 training_state_step*.pt
+# list_state_ckpts —— 断点续训 picker 用
+# ADR 0006 PR-1：扫描 output/ 顶层（旧）+ output/state/task_*/（新）双位置，
+# 同时覆盖 training_state_step*.pt（旧 bug 顺手修：也扫 epoch）。
 # ---------------------------------------------------------------------------
 
 
@@ -156,6 +158,98 @@ def test_state_ckpts_path_is_string(vdir: Path) -> None:
     items = list_state_ckpts(vdir)
     assert items[0]["path"].endswith("training_state_step42.pt")
     assert "mtime" in items[0]
+
+
+# ---- ADR 0006 PR-1: per-task 子目录路径 + epoch 顺手修 ---------------------
+
+
+def test_state_ckpts_scans_new_per_task_subdir(vdir: Path) -> None:
+    """PR-1 新路径 output/state/task_<TID>/ 也要扫到。"""
+    out = vdir / "output"
+    task_dir = out / "state" / "task_42"
+    task_dir.mkdir(parents=True)
+    (task_dir / "training_state_step100.pt").touch()
+    (task_dir / "training_state_step500.pt").touch()
+
+    items = list_state_ckpts(vdir)
+    steps = [it["step"] for it in items]
+    assert steps == [500, 100]
+    # path 应该是子目录下的，不是顶层
+    assert "task_42" in items[0]["path"]
+
+
+def test_state_ckpts_old_and_new_paths_both_scanned(vdir: Path) -> None:
+    """老用户已存在的顶层 .pt + 新跑的子目录 .pt 都能看到（向后兼容）。"""
+    out = vdir / "output"
+    (out / "training_state_step100.pt").touch()  # 老路径
+    task_dir = out / "state" / "task_7"
+    task_dir.mkdir(parents=True)
+    (task_dir / "training_state_step500.pt").touch()  # 新路径
+
+    items = list_state_ckpts(vdir)
+    steps = sorted(it["step"] for it in items)
+    assert steps == [100, 500]
+
+
+def test_state_ckpts_multi_task_isolated(vdir: Path) -> None:
+    """ADR §5.3：同 version 多 task 跑，state 文件按 task_id 隔离。"""
+    out = vdir / "output"
+    for tid, steps in [(1, [500, 1000]), (2, [200])]:
+        td = out / "state" / f"task_{tid}"
+        td.mkdir(parents=True)
+        for s in steps:
+            (td / f"training_state_step{s}.pt").touch()
+
+    items = list_state_ckpts(vdir)
+    # 全部 3 个文件都该被扫到
+    assert len(items) == 3
+    # 不同 task 的同 step 文件不会互相覆盖
+    paths = [it["path"] for it in items]
+    assert any("task_1" in p and "step500" in p for p in paths)
+    assert any("task_1" in p and "step1000" in p for p in paths)
+    assert any("task_2" in p and "step200" in p for p in paths)
+
+
+def test_state_ckpts_dedup_when_path_matches(vdir: Path) -> None:
+    """同一文件不会被两次 glob 重复入列。"""
+    out = vdir / "output"
+    # 文件在新位置；旧 glob 不会扫到——但加测试防 regression
+    task_dir = out / "state" / "task_3"
+    task_dir.mkdir(parents=True)
+    (task_dir / "training_state_step10.pt").touch()
+    items = list_state_ckpts(vdir)
+    assert len(items) == 1
+
+
+def test_state_ckpts_includes_epoch_state(vdir: Path) -> None:
+    """顺手修旧 bug：epoch 版 state 之前 picker 看不到，现在能看到。"""
+    out = vdir / "output"
+    (out / "training_state_step100.pt").touch()
+    (out / "training_state_epoch5.pt").touch()
+    (out / "training_state_epoch3.pt").touch()
+
+    items = list_state_ckpts(vdir)
+    labels = [it["label"] for it in items]
+    # step 在前（降序），epoch 在后（降序）
+    assert labels == ["step 100", "epoch 5", "epoch 3"]
+
+
+def test_state_ckpts_pause_files_not_included(vdir: Path) -> None:
+    """PR-2+ 引入的 pause_step_<N>.pt 文件不应混进 picker 列表。
+
+    本 PR (PR-1) 还没写 pause 文件，但提前验证 _STATE_FILE_RE 不匹配
+    pause_ 前缀，避免 PR-2 时反向回归。
+    """
+    out = vdir / "output"
+    task_dir = out / "state" / "task_9"
+    task_dir.mkdir(parents=True)
+    (task_dir / "training_state_step100.pt").touch()
+    (task_dir / "pause_step_200.pt").touch()       # PR-2+ 命名
+    (task_dir / "pause_step_200.config.json").touch()
+
+    items = list_state_ckpts(vdir)
+    assert len(items) == 1
+    assert items[0]["step"] == 100
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

ADR 0006 PR-1 — latent bug 前置修。把训练 state 文件迁到 per-task 子目录，
铺地基让 PR-2 的 pause/resume 能可靠 attach 到具体 task。

**今天的 bug**：`save_state_every` / `save_state_every_epochs` 写盘路径不带
task_id，同一 version 下连跑两个 task 互相**静默覆盖**。`handle_interrupt`
（Ctrl+C save）也同问题。

## 改动概要

### 写入路径

| 文件 | 旧路径 | 新路径 |
|------|--------|--------|
| `save_state_every` (step) | `output_dir/training_state_step{N}.pt` | `output_dir/state/task_<TID>/training_state_step{N}.pt` |
| `save_state_every_epochs` (epoch) | `output_dir/training_state_epoch{N}.pt` | `output_dir/state/task_<TID>/training_state_epoch{N}.pt` |
| `handle_interrupt` (Ctrl+C) | `output_dir/training_state_step{N}.pt` | `output_dir/state/task_<TID>/training_state_step{N}.pt` |

`<TID>` 由 supervisor 启动训练时通过 env `LORA_TASK_ID` 注入；CLI 直接
跑（无 env）时 fallback 到 `task_unknown/`。文件名故意不动，PR-2 才换
`pause_step_` / `step_` 命名。

### 扫描路径（ResumeFieldPicker 兼容新+旧）

`studio/versions.py:list_state_ckpts` 同时 glob 旧 + 新两个位置 + dedup。
老用户硬盘上现存的 .pt 不丢、picker 里继续能选。

### 顺手修扫描漏 epoch 的旧 bug

list_state_ckpts 之前只扫 `training_state_step*.pt`，epoch state 看不到。
改成 step + epoch 都扫，label 区分。step 段降序在前，epoch 段降序在后。

### LORA_TASK_ID 注入

- \`studio/supervisor.py:_popen\` 加 \`extra_env\` 可选参数
- \`_spawn_task\` 调用时传 \`{\"LORA_TASK_ID\": str(task[\"id\"])}\`
- generate / tagger / data worker 不传 → 不受影响

### TrainingContext 新字段 + helper

- \`lora_task_id: Optional[int] = None\`（故意跟 progress 用的 task_id 不撞名）
- \`state_dir() -> Path\`：返回 \`output_dir/state/task_<TID>/\`，mkdir 兜底

## 测试

\`tests/test_lora_ckpt_scan.py\` 新增 6 case：
- per-task 子目录扫描
- 新 + 旧路径双扫描（兼容性 = 老用户文件不丢）
- 多 task 同 version 不互覆盖（latent bug 直接回归测）
- dedup 防 glob 重叠
- epoch state 现在能扫到
- \`pause_step_*.pt\` 文件不会误进 picker（前向防 PR-2 回归）

旧 \`test_state_ckpts_scans_step_desc\` 行为不变，picker 排序 API 兼容。

跑了 \`tests/test_lora_ckpt_scan.py + tests/test_versions.py\` 全 35 项 PASS。
其他测试套件因本地 dev env 缺 fastapi/torch/lycoris-lora 跑不起来，但都
不涉及 PR-1 touch 的代码。

## 已知 follow-up（不在本 PR scope）

\`GET /api/queue/{tid}/outputs\` 用 \`out_dir.iterdir()\` 只扫顶层一层，PR-1
后周期 save 进了子目录 → outputs UI 暂时看不到 state .pt（LoRA .safetensors
还在顶层不受影响，state .pt 通过 ResumeFieldPicker 仍可见）。是否让
outputs API 递归扫子目录留 follow-up。

## 不在本 PR

- pause 文件 / \`pause_\` 前缀（PR-2）
- handle_interrupt emit \`__EVENT__:pause_state\`（PR-2）
- supervisor \`_Slot\` pause 字段 / pause API（PR-2/3）

## 风险

- **现有用户的 \`save_state_every\` 工作流**：新跑写新路径、老 .pt 不动。
  picker 都能看到。手动 \`--resume-state <path>\` 用绝对路径调用不变。
- **同时跑 PR-1 与 ADR 0006 后续 PR**：PR-2 会在本 PR 的 \`state_dir()\` 基础
  上加 \`pause_step_\` 前缀文件，相互依赖但不撞。
- **migration 不破坏**：完全向后兼容，无需 db migration / 文件迁移脚本。

Refs: ADR 0006 §\`runtime/training/loop.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)