### PR TITLE
feat(queue): pause / queue-hold 后端骨架（ADR 0006 PR-2，flag off）

### DIFF
--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -124,12 +124,28 @@ class TrainingContext:
         return prompt
 
     def handle_interrupt(self, sig, frame) -> None:
-        """Ctrl+C 信号处理：保存 state + LoRA + finish wandb，然后退出。
+        """Pause / Ctrl+C 信号处理：保存 state + config snapshot + LoRA + emit event。
 
-        重复触发（已 interrupted 状态再来一次 Ctrl+C）= 强退。
+        信号来源：
+          - CLI Ctrl+C：POSIX SIGINT / Windows SIGBREAK（由 resume phase 注册）
+          - Supervisor pause：Windows CTRL_BREAK_EVENT / POSIX SIGINT（ADR §`_send_pause_signal`）
+
+        两条入口共用本 handler，触发同一条保 state 链路：
+          1. 写 pause_step_<N>.pt（state_dir 由 PR-1 决定 per-task 子目录）
+          2. 写 pause_step_<N>.config.json（ADR §5.7 config snapshot）
+          3. emit __EVENT__:pause_state（supervisor 识别 → 标 paused）
+          4. sys.exit(0)
+
+        重复触发（已 interrupted 状态再来一次）= 强退。
         """
         # 延迟 import 避免循环依赖（state.py / observability.py 间接 import 本模块）
         from training.state import save_training_state
+        from training.snapshot import (
+            build_pause_config_path,
+            build_pause_state_path,
+            emit_event,
+            write_config_snapshot,
+        )
         from train_monitor import get_state
         from utils.optimizer_utils import optimizer_eval_mode
 
@@ -137,14 +153,20 @@ class TrainingContext:
             self.emit("强制退出...")
             sys.exit(1)
         self.interrupted = True
-        self.emit("\n检测到 Ctrl+C，正在保存训练状态...")
-        state_path = self.state_dir() / f"training_state_step{self.global_step}.pt"
+        self.emit("\n检测到暂停信号，正在保存训练状态...")
+        state_dir = self.state_dir()
+        state_path = build_pause_state_path(state_dir, self.global_step)
+        config_path = build_pause_config_path(state_dir, self.global_step)
         monitor_data = None
         if self.monitor_server:
             try:
                 monitor_data = get_state()
             except Exception:
                 pass
+        # Config snapshot 先写 — 体积小、失败概率低；后面 .pt save 万一失败，
+        # supervisor 能从落盘的 config snapshot 判断"开始保存了"，不至于完全
+        # 状态丢失（cancel 兜底走的也是 supervisor 端时序判断）。
+        write_config_snapshot(config_path, self.args, self.sample_prompts)
         # Schedule-Free 系优化器（PPSF）保存前切到 averaged weights — 否则存的是
         # 训练用的 y 而不是真正应该被使用的 x。非 SF 优化器此 ctx 静默 no-op。
         with optimizer_eval_mode(self.optimizer):
@@ -156,5 +178,11 @@ class TrainingContext:
             lora_path = self.output_dir / f"{self.args.output_name}_interrupted_step{self.global_step}.safetensors"
             self.injector.save(lora_path)
         self.wandb_monitor.finish()
-        self.emit(f"已保存！下次使用 --resume-state \"{state_path}\" 继续训练")
+        # emit 在 wandb finish 后 — 让 supervisor 读到事件时一切 IO 已完成。
+        emit_event("pause_state", {
+            "state_path": str(state_path),
+            "config_path": str(config_path),
+            "step": self.global_step,
+        })
+        self.emit(f"已暂停！state 文件: {state_path}")
         sys.exit(0)

--- a/runtime/training/phases/resume.py
+++ b/runtime/training/phases/resume.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import signal
 import time
 from pathlib import Path
@@ -14,6 +15,7 @@ from training.bootstrap import init_progress
 from training.context import TrainingContext
 from training.observability import render_curve_panel
 from training.sample_runner import run_sample
+from training.snapshot import emit_event
 from training.state import load_training_state
 
 
@@ -78,8 +80,18 @@ def run(ctx: TrainingContext) -> None:
             except Exception as e:
                 ctx.emit(f"监控数据恢复失败: {e}")
 
-    # Ctrl+C 信号处理：handle_interrupt 由 TrainingContext 自带
+        # ADR §`_on_line` 识别此事件后清理上次 pause 文件对（PR-3 cmd_builder 接入）。
+        emit_event("resume_state_loaded", {"path": str(args.resume_state)})
+
+    # 信号处理：handle_interrupt 由 TrainingContext 自带，跨平台双绑
+    # （ADR §`runtime/training/phases/resume.py`）：
+    #   POSIX：SIGINT（CLI Ctrl+C / supervisor `os.kill(pid, SIGINT)`）
+    #   Windows：SIGINT 留给 CLI Ctrl+C，SIGBREAK 接 supervisor 发的
+    #     CTRL_BREAK_EVENT（CREATE_NEW_PROCESS_GROUP 子进程组收不到 CTRL_C_EVENT）
     signal.signal(signal.SIGINT, ctx.handle_interrupt)
+    if os.name == "nt":
+        # SIGBREAK 在 POSIX 上不存在；只 Windows 注册
+        signal.signal(signal.SIGBREAK, ctx.handle_interrupt)  # type: ignore[attr-defined]
 
     ctx.current_epoch = ctx.start_epoch
     ctx.model.train()
@@ -111,3 +123,8 @@ def run(ctx: TrainingContext) -> None:
             )
     elif ctx.global_step > 0 and sampling_enabled:
         ctx.emit(f"跳过启动基线采样（从 step {ctx.global_step} 恢复，非 step 0）")
+
+    # ADR §8.1 is_pausable 信号：resume phase 全部跑完 → 训练进入主循环 →
+    # 允许用户暂停。supervisor `_on_line` 收到此事件后 slot.train_loop_started = True
+    # → 通过 SSE 派发 is_pausable=True 解锁 UI 暂停按钮。
+    emit_event("train_loop_started", {"global_step": ctx.global_step})

--- a/runtime/training/snapshot.py
+++ b/runtime/training/snapshot.py
@@ -1,0 +1,101 @@
+"""Pause / resume 用的 state snapshot helpers（ADR 0006 PR-2）。
+
+落地三块：
+
+  - `build_pause_state_path(state_dir, step)`：拼 pause `.pt` 路径
+  - `write_config_snapshot(path, args, sample_prompts)`：把暂停那一刻
+    训练实际在用的全部 args 序列化成 JSON（详见 ADR §5.7）
+  - `emit_event(event_type, payload)`：往 stdout 写 `__EVENT__:...` 行，
+    supervisor `_on_line` 识别并 publish 成 SSE typed event
+
+这三个都没有训练流水线 import，故意独立成 module 让 supervisor / spike
+脚本 / 测试都能复用，避免 context.py 越长越臃肿。
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+# 跟 studio/supervisor.py:49 _EVENT_MARKER 协议对齐；改这个常量 = 跨进程
+# breaking change，所以挪到此模块顶部唯一字面量。
+EVENT_MARKER = "__EVENT__:"
+
+
+def build_pause_state_path(state_dir: Path, step: int) -> Path:
+    """暂停 `.pt` 文件路径（ADR §5.1）。
+
+    `pause_` 前缀跟 PR-1 周期 save 的 `training_state_step<N>.pt` 区分；
+    同名 `.config.json` 是 snapshot（见 `write_config_snapshot`）。
+    """
+    return state_dir / f"pause_step_{step}.pt"
+
+
+def build_pause_config_path(state_dir: Path, step: int) -> Path:
+    """暂停 config snapshot 文件路径（与 state `.pt` 同前缀，`.config.json` 后缀）。"""
+    return state_dir / f"pause_step_{step}.config.json"
+
+
+def _jsonify(value: Any) -> Any:
+    """把 args / sample_prompts 里的对象转成可 json.dump 的形式。
+
+    覆盖范围：Path → str，set → list，其他保持原样。argparse.Namespace
+    本身 vars() 出来都是 primitive + Path，遇到别的类型就 fallback repr()。
+    """
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, (str, int, float, bool)) or value is None:
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_jsonify(v) for v in value]
+    if isinstance(value, set):
+        return sorted(_jsonify(v) for v in value)
+    if isinstance(value, dict):
+        return {str(k): _jsonify(v) for k, v in value.items()}
+    return repr(value)  # 兜底，不抛错
+
+
+def write_config_snapshot(
+    path: Path,
+    args: Any,  # argparse.Namespace 或 dict
+    sample_prompts: list[str] | None = None,
+) -> None:
+    """暂停时把当前训练实际在用的全部参数 freeze 成 JSON（ADR §5.7）。
+
+    Resume 严格用 snapshot 拼新 args，跟用户后续改 config / preset / yaml
+    完全解耦。snapshot 不含 wandb run id（已 finish）和 monitor live state
+    （已 dump 在 `.pt` 内）。
+
+    `sample_prompts` 来自 `ctx.sample_prompts`（运行时状态），不是 args
+    字段，单独传。
+    """
+    if hasattr(args, "__dict__"):
+        args_dict = vars(args)
+    elif isinstance(args, dict):
+        args_dict = args
+    else:
+        args_dict = {"_args_repr": repr(args)}
+
+    payload = {
+        "version": 1,  # 给 future schema migration 留触点
+        "args": {k: _jsonify(v) for k, v in args_dict.items()},
+        "sample_prompts": list(sample_prompts) if sample_prompts else [],
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def emit_event(event_type: str, payload: dict[str, Any] | None = None) -> None:
+    """往 stdout 写 supervisor `__EVENT__:type:json` 协议行。
+
+    flush=True 是关键 — 否则被子进程 stdout buffer 攒到几 KB 才送达，
+    pause 链路 IO 反馈延迟，supervisor `_on_line` 抓不到事件就误判超时。
+    """
+    body = json.dumps(payload or {}, ensure_ascii=False)
+    sys.stdout.write(f"{EVENT_MARKER}{event_type}:{body}\n")
+    sys.stdout.flush()

--- a/studio/db.py
+++ b/studio/db.py
@@ -33,7 +33,8 @@ CREATE INDEX IF NOT EXISTS idx_tasks_queue
     ON tasks(status, priority DESC, created_at ASC);
 """
 
-VALID_STATUSES = {"pending", "running", "done", "failed", "canceled"}
+VALID_STATUSES = {"pending", "running", "done", "failed", "canceled", "paused"}
+# `paused` 不进 terminal —— task 已暂停但可被 resume，不算结束态。
 TERMINAL_STATUSES = {"done", "failed", "canceled"}
 
 
@@ -157,4 +158,31 @@ def reorder(
             "UPDATE tasks SET priority = ? WHERE id = ? AND status = 'pending'",
             (base - i, tid),
         )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# queue_settings —— kv 表，跨重启保留。ADR 0006 PR-2 引入。
+# ---------------------------------------------------------------------------
+
+_QUEUE_HELD_KEY = "queue.held"
+
+
+def get_queue_held(conn: sqlite3.Connection) -> bool:
+    """队列挂起开关（ADR §3.2）。默认 False（未挂起）。"""
+    row = conn.execute(
+        "SELECT value FROM queue_settings WHERE key = ?", (_QUEUE_HELD_KEY,)
+    ).fetchone()
+    if row is None:
+        return False
+    return str(row[0]).lower() == "true"
+
+
+def set_queue_held(conn: sqlite3.Connection, held: bool) -> None:
+    """写挂起开关。值序列化成字面量 "true" / "false"。"""
+    conn.execute(
+        "INSERT INTO queue_settings(key, value) VALUES(?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (_QUEUE_HELD_KEY, "true" if held else "false"),
+    )
     conn.commit()

--- a/studio/migrations/__init__.py
+++ b/studio/migrations/__init__.py
@@ -18,6 +18,7 @@ from ._v2_projects import migrate as _migrate_v2
 from ._v3_monitor_state import migrate as _migrate_v3
 from ._v4_task_config_path import migrate as _migrate_v4
 from ._v5_task_type import migrate as _migrate_v5
+from ._v6_pause_resume import migrate as _migrate_v6
 
 Migration = Callable[[sqlite3.Connection], None]
 
@@ -27,6 +28,7 @@ MIGRATIONS: list[Migration] = [
     _migrate_v3,  # v3: tasks.monitor_state_path（PP6.1 per-version monitor）
     _migrate_v4,  # v4: tasks.config_path（PP6.3 私有 config 路径）
     _migrate_v5,  # v5: tasks.task_type（PR-9 区分 train / reg_ai / generate）
+    _migrate_v6,  # v6: tasks.paused_* 列 + queue_settings 表（ADR 0006 PR-2）
 ]
 
 

--- a/studio/migrations/_v6_pause_resume.py
+++ b/studio/migrations/_v6_pause_resume.py
@@ -1,0 +1,39 @@
+"""v5 → v6: ADR 0006 PR-2 — pause/resume backend 骨架。
+
+加列：
+
+- `paused_state_path`：暂停时 `.pt` 路径（pause_step_<N>.pt）
+- `paused_config_path`：暂停时 config snapshot 路径（pause_step_<N>.config.json）
+- `paused_step`：global_step 快照（picker / UI 提示用）
+- `paused_at`：UNIX 秒，"在 step N 暂停于 …"显示用
+
+加表 `queue_settings`：kv 单行存储，跨重启保留。当前只有一个 key
+`queue.held` (true/false)，dispatcher 看它决定是否跳过本轮调度（ADR §3.2）。
+
+DDL 设计原则：所有 paused_* 列 NULLABLE（task 没暂停过时全 NULL），不需要
+backfill。queue_settings 表全新，老库升上来空表。
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from ._v2_projects import _add_column_if_missing
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    _add_column_if_missing(conn, "tasks", "paused_state_path",
+                           "paused_state_path TEXT")
+    _add_column_if_missing(conn, "tasks", "paused_config_path",
+                           "paused_config_path TEXT")
+    _add_column_if_missing(conn, "tasks", "paused_step",
+                           "paused_step INTEGER")
+    _add_column_if_missing(conn, "tasks", "paused_at",
+                           "paused_at REAL")
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS queue_settings (
+            key   TEXT PRIMARY KEY,
+            value TEXT
+        );
+        """
+    )

--- a/studio/server.py
+++ b/studio/server.py
@@ -2904,6 +2904,77 @@ def cancel_task(task_id: int) -> dict[str, Any]:
     return {"task_id": task_id, "canceled": True}
 
 
+# ---------------------------------------------------------------------------
+# ADR 0006 PR-2 — pause / hold endpoints。Feature flag 默认 off，灰度由 env
+# ENABLE_PAUSE_RESUME=1 打开。Resume endpoint 留 PR-3（cmd_builder 接入后）。
+# ---------------------------------------------------------------------------
+
+_ENABLE_PAUSE_RESUME = os.environ.get("ENABLE_PAUSE_RESUME", "").lower() in (
+    "1", "true", "yes", "on",
+)
+
+
+def _require_pause_resume_enabled() -> None:
+    if not _ENABLE_PAUSE_RESUME:
+        raise HTTPException(
+            503,
+            "pause/resume feature not enabled (set env ENABLE_PAUSE_RESUME=1)",
+        )
+
+
+@app.post("/api/queue/{task_id}/pause")
+def pause_task(task_id: int) -> dict[str, Any]:
+    """暂停 running task（ADR §4.1 / §4.3）。
+
+    异步：立即返回；UI 端 modal 订阅 SSE 看保存进度。supervisor 收到子进程
+    `__EVENT__:pause_state` 后把 status 写为 paused 并 publish task_state_changed。
+    """
+    _require_pause_resume_enabled()
+    ok, reason = _supervisor().pause(task_id)
+    if not ok:
+        # 区分客户端错误（404/409）vs 状态机不允许（409）
+        with db.connection_for() as conn:
+            task = db.get_task(conn, task_id)
+        if not task:
+            raise HTTPException(404, "task not found")
+        raise HTTPException(409, reason or "pause rejected")
+    return {"task_id": task_id, "pause_pending": True}
+
+
+@app.get("/api/queue/hold")
+def get_queue_hold() -> dict[str, Any]:
+    """查看当前队列挂起状态 + 等待恢复调度的 pending task 数（UI banner 用）。"""
+    _require_pause_resume_enabled()
+    with db.connection_for() as conn:
+        held = db.get_queue_held(conn)
+        pending = db.list_tasks(conn, status="pending")
+    return {"held": held, "pending_waiting": len(pending)}
+
+
+@app.post("/api/queue/hold")
+def hold_queue() -> dict[str, Any]:
+    """挂起队列：dispatcher 不再拉新 task。已 running 的不受影响（ADR §3.2）。
+
+    "同时暂停 running task" 由前端 modal 拆成两步：先调本 endpoint，再
+    单独调 `/api/queue/{id}/pause`。后端不做合一操作。
+    """
+    _require_pause_resume_enabled()
+    with db.connection_for() as conn:
+        db.set_queue_held(conn, True)
+    bus.publish({"type": "queue_hold_changed", "held": True})
+    return {"held": True}
+
+
+@app.post("/api/queue/release")
+def release_queue() -> dict[str, Any]:
+    """恢复调度：dispatcher 重新按 priority + created_at 拉 pending。"""
+    _require_pause_resume_enabled()
+    with db.connection_for() as conn:
+        db.set_queue_held(conn, False)
+    bus.publish({"type": "queue_hold_changed", "held": False})
+    return {"held": False}
+
+
 @app.post("/api/queue/{task_id}/retry")
 def retry_task(task_id: int) -> dict[str, Any]:
     """已结束任务重新入队：复制完整训练上下文创建新 task。

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -71,6 +71,19 @@ class _Slot:
     tailer: Optional[LogTailer] = None
     state_poller: Optional[MonitorStatePoller] = None
     cancel_pending: bool = False
+    # ADR 0006 PR-2 pause/resume backend ----------------------------------
+    pause_pending: bool = False
+    # `__EVENT__:pause_state` payload — handle_interrupt 写好 .pt + snapshot 后
+    # 子进程通过 stdout emit；_on_line 抓到后填这三个字段，_finish_slot 据此
+    # 把 task 标 paused。pause_pending=True 但缺这几个字段 → 子进程退出前
+    # 没来得及 emit → 视为 cancel 兜底（ADR §4.3 modal "强制取消保存进度"）。
+    pause_state_path: Optional[str] = None
+    pause_config_path: Optional[str] = None
+    pause_step: Optional[int] = None
+    # ADR §8.1 is_pausable 信号 — resume phase emit `train_loop_started` 后才
+    # 允许暂停。UI 端 SSE 用这个解锁暂停按钮，API 端 defense-in-depth 拒绝
+    # 过早 pause 请求。
+    train_loop_started: bool = False
 
     @property
     def busy(self) -> bool:
@@ -84,6 +97,11 @@ class _Slot:
         self.tailer = None
         self.state_poller = None
         self.cancel_pending = False
+        self.pause_pending = False
+        self.pause_state_path = None
+        self.pause_config_path = None
+        self.pause_step = None
+        self.train_loop_started = False
 
 EventCallback = Callable[[dict[str, Any]], None]
 CmdBuilder = Callable[[dict[str, Any], Path], list[str]]
@@ -268,6 +286,9 @@ class Supervisor:
     def cancel(self, task_id: int) -> bool:
         """取消 task：pending → status=canceled；running → 异步发信号立即返回。
 
+        ADR 0006 PR-2：paused task 也可被取消（"彻底放弃这个 task"），状态从
+        paused 直接改 canceled，并清理对应的 pause 文件对（已不需要了）。
+
         异步路径关键：**不阻塞 web 请求线程**。supervisor 主循环会自然 poll
         proc.poll() 拿到退出码并走 `_finish_slot` 流程，把 status 写为
         canceled。后台 grace timer 在 30s 后还没退就强杀整棵进程树。
@@ -279,6 +300,29 @@ class Supervisor:
             if task["status"] == "pending":
                 db.update_task(
                     conn, task_id, status="canceled", finished_at=time.time()
+                )
+                self._on_event(
+                    {"type": "task_state_changed", "task_id": task_id, "status": "canceled"}
+                )
+                return True
+            if task["status"] == "paused":
+                # 进程已退出，无需发信号 — 直接改 db 状态 + 清 pause 文件对
+                # （ADR §5.5: 离开 paused 状态时一律删 pause 文件）。
+                for col in ("paused_state_path", "paused_config_path"):
+                    p = task.get(col)
+                    if p:
+                        try:
+                            Path(p).unlink(missing_ok=True)
+                        except Exception:
+                            logger.exception("failed to remove pause file %s", p)
+                db.update_task(
+                    conn, task_id,
+                    status="canceled",
+                    finished_at=time.time(),
+                    paused_state_path=None,
+                    paused_config_path=None,
+                    paused_step=None,
+                    paused_at=None,
                 )
                 self._on_event(
                     {"type": "task_state_changed", "task_id": task_id, "status": "canceled"}
@@ -300,6 +344,37 @@ class Supervisor:
                 logger.exception("failed to stop daemon for cancel")
             return True
         return False
+
+    def pause(self, task_id: int) -> tuple[bool, str]:
+        """暂停 running task：发软信号让 handle_interrupt 保 state 后退出。
+
+        返回 (success, reason_if_failed)。
+
+        ADR §8.1 defense-in-depth：API 端调本方法时，UI 应已用 SSE
+        `is_pausable` 字段隐藏暂停按钮；本方法服务端再校验 train_loop_started
+        信号，未就绪 / 状态非 running / task 不存在 → 拒绝。
+
+        非阻塞：调 `_signal_pause_async` 立刻返回。子进程 emit 事件 →
+        `_on_task_log` 更新 slot → 子进程退出 → `_finish_slot` 标 paused。
+        UI 端 modal 订阅 SSE 看进度（ADR §4.3）。
+        """
+        with db.connection_for(self._db_path) as conn:
+            task = db.get_task(conn, task_id)
+        if not task:
+            return False, "task not found"
+        if task["status"] != "running":
+            return False, f"task status is {task['status']!r}, not running"
+        slot = self._find_slot(kind="task", id=task_id)
+        if slot is None:
+            return False, "task not on a slot (generate-on-daemon not supported)"
+        if not slot.train_loop_started:
+            return False, "train loop not started yet, retry after a few seconds"
+        if slot.pause_pending:
+            return False, "pause already pending"
+        if slot.cancel_pending:
+            return False, "task is being canceled"
+        self._signal_pause_async(slot)
+        return True, ""
 
     def cancel_job(self, job_id: int) -> bool:
         """取消 project_job：pending → canceled；running → 异步发信号立即返回。"""
@@ -355,6 +430,9 @@ class Supervisor:
             self._stop.wait(self._poll)
 
     def _reconcile_orphans(self) -> None:
+        # ADR 0006 PR-2 兼容性 note：此处 list_tasks(status="running") 精确按
+        # status 过滤，paused task（status='paused'）天然不进 this loop —
+        # 跨 supervisor 重启的 paused task 保持状态不变（ADR §8.4）。
         with db.connection_for(self._db_path) as conn:
             for t in db.list_tasks(conn, status="running"):
                 logger.info("orphan running task %d → failed", t["id"])
@@ -416,7 +494,12 @@ class Supervisor:
         commit 12：派活前先要求 daemon 让位（unload 释放 VRAM），除非
         secrets.queue.allow_gpu_during_train=true。daemon 在跑 generate
         时不强中断，等下次 tick 它跑完再卸载。
+
+        ADR 0006 PR-2：queue_held=True 时跳过本次派发（ADR §3.2）。已 running
+        的 task 不受影响（继续跑到自然结束/暂停/取消）。
         """
+        if self._queue_held():
+            return
         task = self._next_pending_task_in(("train", "reg_ai"))
         if task is None:
             return
@@ -425,7 +508,13 @@ class Supervisor:
         self._spawn_task(slot, task)
 
     def _dispatch_generate(self) -> None:
-        """commit 9：把 generate pending task 提交给 daemon，daemon idle 时执行。"""
+        """commit 9：把 generate pending task 提交给 daemon，daemon idle 时执行。
+
+        ADR 0006 PR-2：queue_held=True 时跳过（hold 语义全队列覆盖，不区分
+        task type）。
+        """
+        if self._queue_held():
+            return
         with self._daemon_lock:
             if self._daemon_active_task_id is not None:
                 return
@@ -433,6 +522,15 @@ class Supervisor:
         if task is None:
             return
         self._submit_to_daemon(task)
+
+    def _queue_held(self) -> bool:
+        """ADR §3.2 queue hold 开关，跨 supervisor 重启保留（db kv）。"""
+        try:
+            with db.connection_for(self._db_path) as conn:
+                return db.get_queue_held(conn)
+        except Exception:
+            logger.exception("failed to read queue_held")
+            return False  # 读失败默认放行，安全降级
 
     def _maybe_yield_daemon(self) -> bool:
         """commit 12：daemon 占着 GPU 且不许并行 → 触发 unload，调用方应跳过这次派发。
@@ -466,7 +564,12 @@ class Supervisor:
             * 训练正在跑且未开 `allow_gpu_during_train` → 跳过
             * daemon 占着 VRAM 且未开 `allow_gpu_during_train` → 触发 daemon
               让位（_maybe_yield_daemon），跳过等下次 tick
+
+        ADR 0006 PR-2：queue_held=True 时跳过本次派发，包含 download。语义上
+        hold 是"全队列暂停新派活"，不区分 GPU vs IO。
         """
+        if self._queue_held():
+            return
         train_busy = self._train_busy()
         allow_gpu = self._allow_gpu_during_train()
         with db.connection_for(self._db_path) as conn:
@@ -554,6 +657,36 @@ class Supervisor:
         tid = task["id"]
 
         def _on_task_log(line: str) -> None:
+            # ADR 0006 PR-2：训练 worker 通过 __EVENT__: 协议跟 supervisor 通信
+            # （pause_state / train_loop_started / resume_state_loaded）。跟
+            # jobs 的 _on_line 路径对齐 — 之前 task 这条 path 不识别 event marker，
+            # 现在补上。
+            if line.startswith(_EVENT_MARKER):
+                try:
+                    rest = line[len(_EVENT_MARKER):]
+                    evt_type, payload_str = rest.split(":", 1)
+                    import json as _json
+                    payload = _json.loads(payload_str) if payload_str else {}
+                except Exception:
+                    logger.exception("malformed event marker: %r", line[:200])
+                    return  # 不当 log 推
+                # 状态机镜像（ADR §8.1 / §`_on_line`）
+                if evt_type == "pause_state":
+                    slot.pause_state_path = str(payload.get("state_path") or "")
+                    slot.pause_config_path = str(payload.get("config_path") or "")
+                    slot.pause_step = payload.get("step")
+                elif evt_type == "train_loop_started":
+                    slot.train_loop_started = True
+                elif evt_type == "resume_state_loaded":
+                    # PR-3 cmd_builder 接入后用此事件清理上次 pause 文件对。
+                    # PR-2 仅记录，不做副作用。
+                    pass
+                self._on_event({
+                    "type": evt_type,
+                    "task_id": tid,
+                    **payload,
+                })
+                return
             self._on_event({
                 "type": "task_log_appended",
                 "task_id": tid,
@@ -978,7 +1111,14 @@ class Supervisor:
             except Exception:
                 pass
 
-        if slot.cancel_pending:
+        # ADR 0006 PR-2 三元分流（原来是二元 canceled vs done/failed）。
+        # paused 优先级最高 — pause_pending=True 且子进程 emit 了 pause_state
+        # （state_path / config_path 都到位）= 真正成功暂停。
+        # 缺 pause_state_path = 子进程退出前没来得及 emit（IO 慢 / 异常 /
+        # 强 kill）→ 降级 canceled（ADR §4.3 modal "强制取消保存进度" 兜底）。
+        if slot.pause_pending and slot.pause_state_path:
+            status = "paused"
+        elif slot.cancel_pending:
             status = "canceled"
         elif rc == 0:
             status = "done"
@@ -995,6 +1135,11 @@ class Supervisor:
                 }
                 if status == "failed":
                     fields["error_msg"] = f"exit code {rc}"
+                elif status == "paused":
+                    fields["paused_state_path"] = slot.pause_state_path
+                    fields["paused_config_path"] = slot.pause_config_path
+                    fields["paused_step"] = slot.pause_step
+                    fields["paused_at"] = time.time()
                 db.update_task(conn, cid, **fields)
                 # PP6.3：训练成功时回填 version.output_lora_path + 推 stage=done
                 if status == "done":
@@ -1088,13 +1233,53 @@ class Supervisor:
 
     @staticmethod
     def _send_terminate_signal(proc: subprocess.Popen) -> None:
+        """Cancel 软终止信号。
+
+        ADR 0006 PR-2：Windows 不再发 CTRL_BREAK_EVENT — 跟 pause 信号撞
+        （pause 占用 CTRL_BREAK_EVENT），cancel 的语义本来就是硬中断，
+        直接走 taskkill /T /F。POSIX 没这个冲突，继续 SIGTERM。
+
+        `_signal_terminate_async` 后续仍有 grace timer，Windows 上 proc 早就
+        被 taskkill 杀掉了、grace 第一次 poll 就 return；不浪费时间。
+        """
         try:
             if os.name == "nt":
-                proc.send_signal(signal.CTRL_BREAK_EVENT)
+                _kill_process_tree(proc.pid)
             else:
                 proc.terminate()
         except Exception:
             logger.exception("send terminate signal failed")
+
+    @staticmethod
+    def _send_pause_signal(proc: subprocess.Popen) -> None:
+        """Pause 软信号 — 子进程 handle_interrupt 接住保 state。
+
+        Windows：`CTRL_BREAK_EVENT` 送达 CREATE_NEW_PROCESS_GROUP 子进程组，
+        Python 端映射成 SIGBREAK（sig=21），由 resume phase 注册的 handler 捕获。
+        POSIX：`SIGINT` — 跟 SIGTERM 分流，cancel 走 SIGTERM 不撞。
+
+        Spike 报告 docs/design/queue-pause-spike-report.md 验证过链路通。
+        """
+        try:
+            if os.name == "nt":
+                proc.send_signal(signal.CTRL_BREAK_EVENT)  # type: ignore[attr-defined]
+            else:
+                proc.send_signal(signal.SIGINT)
+        except Exception:
+            logger.exception("send pause signal failed")
+
+    def _signal_pause_async(self, slot: _Slot) -> None:
+        """非阻塞：发暂停信号，不带 grace 强杀。
+
+        跟 `_signal_terminate_async` 的关键差别：暂停**不超时降级**。
+        ADR §4.3：30s 阈值由 UI 端 modal 决定下一步（再等 30s / 强制取消
+        保存进度 / 终止任务），supervisor 不主动 kill 进程 — kill 决策由
+        cancel API（用户从 modal 上选择后再调）下达。
+        """
+        if not slot.proc:
+            return
+        slot.pause_pending = True
+        self._send_pause_signal(slot.proc)
 
 
 def _kill_process_tree(pid: int) -> None:

--- a/tests/test_db_pause_resume.py
+++ b/tests/test_db_pause_resume.py
@@ -1,0 +1,149 @@
+"""db.py + migration v6 (ADR 0006 PR-2) — paused 状态、queue_held kv。"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from studio import db
+
+
+@pytest.fixture
+def dbfile(tmp_path: Path) -> Path:
+    p = tmp_path / "studio.db"
+    db.init_db(p)
+    return p
+
+
+# ---- VALID_STATUSES ----------------------------------------------------------
+
+
+def test_paused_in_valid_statuses() -> None:
+    assert "paused" in db.VALID_STATUSES
+
+
+def test_paused_not_terminal() -> None:
+    """paused 可被 resume，不是终态。"""
+    assert "paused" not in db.TERMINAL_STATUSES
+
+
+# ---- migration v6 ------------------------------------------------------------
+
+
+def test_migration_adds_pause_columns(dbfile: Path) -> None:
+    with db.connection_for(dbfile) as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(tasks)")}
+    for col in ("paused_state_path", "paused_config_path", "paused_step", "paused_at"):
+        assert col in cols, f"missing column {col}"
+
+
+def test_migration_creates_queue_settings_table(dbfile: Path) -> None:
+    with db.connection_for(dbfile) as conn:
+        row = conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='queue_settings'"
+        ).fetchone()
+    assert row is not None
+
+
+def test_migration_idempotent_on_existing_db(dbfile: Path) -> None:
+    """重复 init_db 不应失败（migrations 已有 user_version 防重跑）。"""
+    db.init_db(dbfile)  # second time
+    with db.connection_for(dbfile) as conn:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(tasks)")}
+    assert "paused_state_path" in cols
+
+
+def test_pause_columns_nullable_by_default(dbfile: Path) -> None:
+    """新跑 task 默认 paused_* 全 NULL（没暂停过）。"""
+    with db.connection_for(dbfile) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        task = db.get_task(conn, tid)
+    assert task is not None
+    for col in ("paused_state_path", "paused_config_path", "paused_step", "paused_at"):
+        assert task[col] is None
+
+
+# ---- get_queue_held / set_queue_held ----------------------------------------
+
+
+def test_get_queue_held_default_false(dbfile: Path) -> None:
+    with db.connection_for(dbfile) as conn:
+        assert db.get_queue_held(conn) is False
+
+
+def test_set_queue_held_true_then_read(dbfile: Path) -> None:
+    with db.connection_for(dbfile) as conn:
+        db.set_queue_held(conn, True)
+        assert db.get_queue_held(conn) is True
+
+
+def test_set_queue_held_flip(dbfile: Path) -> None:
+    with db.connection_for(dbfile) as conn:
+        db.set_queue_held(conn, True)
+        db.set_queue_held(conn, False)
+        assert db.get_queue_held(conn) is False
+
+
+def test_queue_held_persists_across_connections(dbfile: Path) -> None:
+    """ADR §3.2: 跨 server 重启保留。"""
+    with db.connection_for(dbfile) as conn:
+        db.set_queue_held(conn, True)
+    # 重开 connection 模拟 process 重启
+    with db.connection_for(dbfile) as conn2:
+        assert db.get_queue_held(conn2) is True
+
+
+def test_queue_held_upsert_no_duplicate_rows(dbfile: Path) -> None:
+    """ON CONFLICT 应该 update，不该再插一条。"""
+    with db.connection_for(dbfile) as conn:
+        for _ in range(5):
+            db.set_queue_held(conn, True)
+        row_count = conn.execute(
+            "SELECT COUNT(*) FROM queue_settings WHERE key = 'queue.held'"
+        ).fetchone()[0]
+    assert row_count == 1
+
+
+# ---- update_task 可写 paused 字段 -------------------------------------------
+
+
+def test_update_task_can_set_paused_fields(dbfile: Path) -> None:
+    with db.connection_for(dbfile) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        db.update_task(
+            conn, tid,
+            status="paused",
+            paused_state_path="/x/pause_step_100.pt",
+            paused_config_path="/x/pause_step_100.config.json",
+            paused_step=100,
+            paused_at=1234567890.5,
+        )
+        task = db.get_task(conn, tid)
+    assert task is not None
+    assert task["status"] == "paused"
+    assert task["paused_state_path"] == "/x/pause_step_100.pt"
+    assert task["paused_step"] == 100
+    assert task["paused_at"] == pytest.approx(1234567890.5)
+
+
+def test_paused_task_not_in_pending_or_running_lists(dbfile: Path) -> None:
+    """paused task 不该被 list_tasks(status='pending') 拉到，dispatcher 不会派它。"""
+    with db.connection_for(dbfile) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        db.update_task(conn, tid, status="paused")
+        pending = db.list_tasks(conn, status="pending")
+        running = db.list_tasks(conn, status="running")
+        paused = db.list_tasks(conn, status="paused")
+    assert tid not in [t["id"] for t in pending]
+    assert tid not in [t["id"] for t in running]
+    assert tid in [t["id"] for t in paused]
+
+
+def test_next_pending_skips_paused(dbfile: Path) -> None:
+    with db.connection_for(dbfile) as conn:
+        paused_id = db.create_task(conn, name="paused", config_name="c", priority=100)
+        db.update_task(conn, paused_id, status="paused")
+        pending_id = db.create_task(conn, name="pending", config_name="c", priority=1)
+        nxt = db.next_pending(conn)
+    assert nxt is not None and nxt["id"] == pending_id

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,143 @@
+"""runtime/training/snapshot.py — pause helpers 单测（ADR 0006 PR-2）。"""
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from runtime.training.snapshot import (  # type: ignore[import-not-found]
+    EVENT_MARKER,
+    build_pause_config_path,
+    build_pause_state_path,
+    emit_event,
+    write_config_snapshot,
+    _jsonify,
+)
+
+
+# ---- 路径 build --------------------------------------------------------------
+
+
+def test_build_pause_state_path_uses_pause_prefix() -> None:
+    sd = Path("/x/state/task_42")
+    p = build_pause_state_path(sd, 100)
+    assert p.name == "pause_step_100.pt"
+    assert p.parent == sd
+
+
+def test_build_pause_config_path_pairs_state() -> None:
+    sd = Path("/x/state/task_42")
+    assert build_pause_config_path(sd, 100).name == "pause_step_100.config.json"
+
+
+def test_state_and_config_path_share_stem_step() -> None:
+    """同 step 的 state 和 config 必须在同目录、文件名同前缀。"""
+    sd = Path("/x/state/task_7")
+    state = build_pause_state_path(sd, 500)
+    cfg = build_pause_config_path(sd, 500)
+    assert state.parent == cfg.parent
+    assert state.stem == cfg.stem.split(".")[0]
+
+
+# ---- _jsonify ----------------------------------------------------------------
+
+
+def test_jsonify_path_to_str() -> None:
+    p = Path("a/b/c")
+    assert _jsonify(p) == str(p)
+
+
+def test_jsonify_set_to_sorted_list() -> None:
+    assert _jsonify({3, 1, 2}) == [1, 2, 3]
+
+
+def test_jsonify_nested_dict_with_paths() -> None:
+    out = _jsonify({"k": Path("v"), "n": 1, "ls": [Path("x")]})
+    assert out["k"] == str(Path("v"))
+    assert out["n"] == 1
+    assert out["ls"] == [str(Path("x"))]
+
+
+def test_jsonify_unknown_type_falls_back_to_repr() -> None:
+    class Weird:
+        def __repr__(self) -> str:
+            return "<weird>"
+
+    assert _jsonify(Weird()) == "<weird>"
+
+
+def test_jsonify_none_passes_through() -> None:
+    assert _jsonify(None) is None
+
+
+# ---- write_config_snapshot ---------------------------------------------------
+
+
+def test_write_config_snapshot_serializes_args_namespace(tmp_path: Path) -> None:
+    args = argparse.Namespace(
+        lr=1e-4, optimizer="AdamW", batch_size=4,
+        output_dir=tmp_path,
+        loss_type="mse",
+    )
+    target = tmp_path / "snap.config.json"
+    write_config_snapshot(target, args, ["prompt1", "prompt2"])
+
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert data["version"] == 1
+    assert data["args"]["lr"] == 1e-4
+    assert data["args"]["optimizer"] == "AdamW"
+    assert data["args"]["batch_size"] == 4
+    assert isinstance(data["args"]["output_dir"], str)  # Path → str
+    assert data["sample_prompts"] == ["prompt1", "prompt2"]
+
+
+def test_write_config_snapshot_handles_dict_args(tmp_path: Path) -> None:
+    args = {"lr": 1.0, "name": "test"}
+    target = tmp_path / "snap.json"
+    write_config_snapshot(target, args, None)
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert data["args"]["lr"] == 1.0
+    assert data["sample_prompts"] == []
+
+
+def test_write_config_snapshot_creates_parent_dir(tmp_path: Path) -> None:
+    target = tmp_path / "nested" / "deep" / "snap.json"
+    args = argparse.Namespace(x=1)
+    write_config_snapshot(target, args, [])
+    assert target.exists()
+
+
+def test_write_config_snapshot_utf8_encoding(tmp_path: Path) -> None:
+    args = argparse.Namespace(name="中文_名字", prompt="anime, 1girl")
+    target = tmp_path / "snap.json"
+    write_config_snapshot(target, args, ["1girl，masterpiece"])
+    data = json.loads(target.read_text(encoding="utf-8"))
+    assert data["args"]["name"] == "中文_名字"
+    assert data["sample_prompts"] == ["1girl，masterpiece"]
+
+
+# ---- emit_event --------------------------------------------------------------
+
+
+def test_emit_event_writes_marker_protocol(capsys: pytest.CaptureFixture) -> None:
+    emit_event("pause_state", {"step": 100, "state_path": "/x"})
+    out = capsys.readouterr().out.strip()
+    assert out.startswith(EVENT_MARKER)
+    assert out.startswith(f"{EVENT_MARKER}pause_state:")
+    payload = json.loads(out[len(f"{EVENT_MARKER}pause_state:"):])
+    assert payload == {"step": 100, "state_path": "/x"}
+
+
+def test_emit_event_empty_payload(capsys: pytest.CaptureFixture) -> None:
+    emit_event("train_loop_started")
+    out = capsys.readouterr().out.strip()
+    assert out == f"{EVENT_MARKER}train_loop_started:{{}}"
+
+
+def test_event_marker_constant_matches_supervisor() -> None:
+    """跨进程 IPC 协议字面量；改 = breaking change。"""
+    assert EVENT_MARKER == "__EVENT__:"

--- a/tests/test_supervisor_pause.py
+++ b/tests/test_supervisor_pause.py
@@ -1,0 +1,314 @@
+"""Supervisor pause/_on_task_log/_finish_slot 分流测试（ADR 0006 PR-2）。
+
+写了三层：
+
+1. **`_Slot` reset 行为**：新字段都被 reset 清零。
+2. **`_finish_slot` 三元分流**：直接构造 slot 状态 + 调 _finish_slot，
+   verify status 写 db 的逻辑（pause_pending+state_path → paused；其余照旧）。
+3. **`pause()` 状态机校验**：mock 一个 slot 模拟各种 state combo，
+   verify pause() 返回 (ok, reason) 是否符合预期。
+
+完整的"发信号 → 子进程保 state → 标 paused" e2e 留 spike 脚本验证过；这里
+用 mock proc + 直接构造 slot 字段绕过真子进程，让测试在没 GPU/不能起真训练
+的 CI 环境也能跑。
+"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from studio import db
+from studio.supervisor import _Slot, Supervisor
+
+
+@pytest.fixture
+def env(tmp_path: Path):
+    db_path = tmp_path / "studio.db"
+    db.init_db(db_path)
+    logs = tmp_path / "logs"
+    configs = tmp_path / "configs"
+    logs.mkdir()
+    configs.mkdir()
+    return {"db": db_path, "logs": logs, "configs": configs}
+
+
+def _new_sup(env) -> Supervisor:
+    """构造一个不 start 的 Supervisor — 直接调内部方法测分支。"""
+    return Supervisor(
+        on_event=lambda _: None,
+        cmd_builder=lambda *_: ["echo"],
+        db_path=env["db"],
+        logs_dir=env["logs"],
+        configs_dir=env["configs"],
+        poll_interval=10,
+    )
+
+
+# ---- _Slot 新字段 ------------------------------------------------------------
+
+
+def test_slot_has_pause_fields_with_safe_defaults() -> None:
+    s = _Slot()
+    assert s.pause_pending is False
+    assert s.pause_state_path is None
+    assert s.pause_config_path is None
+    assert s.pause_step is None
+    assert s.train_loop_started is False
+
+
+def test_slot_reset_clears_pause_fields() -> None:
+    s = _Slot()
+    s.pause_pending = True
+    s.pause_state_path = "/x/y.pt"
+    s.pause_config_path = "/x/y.config.json"
+    s.pause_step = 100
+    s.train_loop_started = True
+    s.reset()
+    assert s.pause_pending is False
+    assert s.pause_state_path is None
+    assert s.pause_config_path is None
+    assert s.pause_step is None
+    assert s.train_loop_started is False
+
+
+# ---- _finish_slot 三元分流 --------------------------------------------------
+
+
+def _populate_running(env, **fields) -> int:
+    """db 里新建一个 running 状态的 task，返回 id。"""
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        update = {"status": "running", "started_at": time.time()}
+        update.update(fields)
+        db.update_task(conn, tid, **update)
+    return tid
+
+
+def _make_slot_with_proc(tid: int) -> _Slot:
+    slot = _Slot(name="train")
+    slot.kind = "task"
+    slot.id = tid
+    slot.proc = MagicMock()
+    slot.log_fp = None
+    slot.tailer = None
+    slot.state_poller = None
+    return slot
+
+
+def test_finish_slot_paused_when_pause_pending_and_state_path(env) -> None:
+    """pause_pending=True + pause_state_path 已 set → status='paused'。"""
+    sup = _new_sup(env)
+    tid = _populate_running(env)
+    slot = _make_slot_with_proc(tid)
+    slot.pause_pending = True
+    slot.pause_state_path = str(env["db"].parent / "pause_step_100.pt")
+    slot.pause_config_path = str(env["db"].parent / "pause_step_100.config.json")
+    slot.pause_step = 100
+    # 调 _finish_slot 后 slot.reset() 会清字段，先 snapshot 期望值
+    expected_state = slot.pause_state_path
+    expected_config = slot.pause_config_path
+
+    sup._finish_slot(slot, rc=0)
+
+    with db.connection_for(env["db"]) as conn:
+        task = db.get_task(conn, tid)
+    assert task is not None
+    assert task["status"] == "paused"
+    assert task["paused_state_path"] == expected_state
+    assert task["paused_config_path"] == expected_config
+    assert task["paused_step"] == 100
+    assert task["paused_at"] is not None
+
+
+def test_finish_slot_canceled_when_pause_pending_but_no_state_path(env) -> None:
+    """pause_pending=True 但子进程没 emit pause_state（state_path None）→ 降级 canceled。
+
+    ADR §4.3 modal "强制取消保存进度" 情形。
+    """
+    sup = _new_sup(env)
+    tid = _populate_running(env)
+    slot = _make_slot_with_proc(tid)
+    slot.pause_pending = True
+    slot.cancel_pending = True  # modal 操作把 cancel_pending 也 set 了
+    # pause_state_path 留 None
+
+    sup._finish_slot(slot, rc=0)
+
+    with db.connection_for(env["db"]) as conn:
+        task = db.get_task(conn, tid)
+    assert task is not None
+    assert task["status"] == "canceled"
+
+
+def test_finish_slot_canceled_takes_precedence_over_rc(env) -> None:
+    """cancel_pending=True 优先于 rc — rc=0 也标 canceled。"""
+    sup = _new_sup(env)
+    tid = _populate_running(env)
+    slot = _make_slot_with_proc(tid)
+    slot.cancel_pending = True
+
+    sup._finish_slot(slot, rc=0)
+    assert _read_status(env["db"], tid) == "canceled"
+
+
+def test_finish_slot_done_when_rc_zero(env) -> None:
+    sup = _new_sup(env)
+    tid = _populate_running(env)
+    slot = _make_slot_with_proc(tid)
+
+    sup._finish_slot(slot, rc=0)
+    assert _read_status(env["db"], tid) == "done"
+
+
+def test_finish_slot_failed_when_rc_nonzero(env) -> None:
+    sup = _new_sup(env)
+    tid = _populate_running(env)
+    slot = _make_slot_with_proc(tid)
+
+    sup._finish_slot(slot, rc=7)
+    with db.connection_for(env["db"]) as conn:
+        task = db.get_task(conn, tid)
+    assert task["status"] == "failed"
+    assert task["exit_code"] == 7
+
+
+def _read_status(db_path: Path, tid: int) -> str:
+    with db.connection_for(db_path) as conn:
+        t = db.get_task(conn, tid)
+    return str(t["status"]) if t else ""
+
+
+# ---- pause() 状态机校验 -----------------------------------------------------
+
+
+def test_pause_returns_false_for_unknown_task(env) -> None:
+    sup = _new_sup(env)
+    ok, reason = sup.pause(99999)
+    assert ok is False
+    assert "not found" in reason
+
+
+def test_pause_returns_false_for_pending_task(env) -> None:
+    sup = _new_sup(env)
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+    ok, reason = sup.pause(tid)
+    assert ok is False
+    assert "not running" in reason
+
+
+def test_pause_returns_false_when_train_loop_not_started(env) -> None:
+    """ADR §8.1 defense-in-depth: 未进入 train_loop 不允许 pause。"""
+    sup = _new_sup(env)
+    tid = _populate_running(env)
+    slot = _make_slot_with_proc(tid)
+    slot.train_loop_started = False
+    sup._slots = [slot]
+
+    ok, reason = sup.pause(tid)
+    assert ok is False
+    assert "train loop not started" in reason
+
+
+def test_pause_succeeds_when_train_loop_started(env) -> None:
+    sup = _new_sup(env)
+    tid = _populate_running(env)
+    slot = _make_slot_with_proc(tid)
+    slot.train_loop_started = True
+    sup._slots = [slot]
+
+    ok, _reason = sup.pause(tid)
+    assert ok is True
+    assert slot.pause_pending is True
+    # 确认确实向子进程发过信号
+    slot.proc.send_signal.assert_called_once()
+
+
+def test_pause_rejects_when_already_pausing(env) -> None:
+    sup = _new_sup(env)
+    tid = _populate_running(env)
+    slot = _make_slot_with_proc(tid)
+    slot.train_loop_started = True
+    slot.pause_pending = True
+    sup._slots = [slot]
+
+    ok, reason = sup.pause(tid)
+    assert ok is False
+    assert "already pending" in reason
+
+
+def test_pause_rejects_when_cancel_pending(env) -> None:
+    sup = _new_sup(env)
+    tid = _populate_running(env)
+    slot = _make_slot_with_proc(tid)
+    slot.train_loop_started = True
+    slot.cancel_pending = True
+    sup._slots = [slot]
+
+    ok, reason = sup.pause(tid)
+    assert ok is False
+    assert "canceled" in reason
+
+
+# ---- cancel paused task → canceled ------------------------------------------
+
+
+def test_cancel_paused_task_changes_to_canceled_and_clears_files(env, tmp_path) -> None:
+    """ADR §5.5: paused → canceled 必须删 pause 文件对。"""
+    sup = _new_sup(env)
+    # 准备 paused task + 真实存在的 pause 文件对
+    state_pt = tmp_path / "pause_step_100.pt"
+    state_cfg = tmp_path / "pause_step_100.config.json"
+    state_pt.write_bytes(b"fake")
+    state_cfg.write_text("{}", encoding="utf-8")
+
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        db.update_task(
+            conn, tid,
+            status="paused",
+            paused_state_path=str(state_pt),
+            paused_config_path=str(state_cfg),
+            paused_step=100,
+            paused_at=time.time(),
+        )
+
+    assert sup.cancel(tid) is True
+
+    with db.connection_for(env["db"]) as conn:
+        task = db.get_task(conn, tid)
+    assert task["status"] == "canceled"
+    assert task["paused_state_path"] is None  # 字段清掉
+    assert not state_pt.exists()  # 文件删掉
+    assert not state_cfg.exists()
+
+
+def test_cancel_paused_task_robust_to_missing_files(env) -> None:
+    """文件已被外部删 / 路径无效时 cancel 仍标 canceled，不抛错。"""
+    sup = _new_sup(env)
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        db.update_task(
+            conn, tid,
+            status="paused",
+            paused_state_path="/nonexistent/path.pt",
+            paused_config_path="/nonexistent/path.config.json",
+            paused_step=100,
+        )
+    assert sup.cancel(tid) is True
+    assert _read_status(env["db"], tid) == "canceled"
+
+
+# ---- queue_held dispatch 影响 -----------------------------------------------
+
+
+def test_queue_held_returns_db_value(env) -> None:
+    sup = _new_sup(env)
+    assert sup._queue_held() is False
+    with db.connection_for(env["db"]) as conn:
+        db.set_queue_held(conn, True)
+    assert sup._queue_held() is True


### PR DESCRIPTION
## 背景

ADR 0006 PR-2 — pause / queue-hold 的后端实现。Resume 路径留 PR-3，
前端 UI 留 PR-4。本 PR 全套 endpoint 都被 env feature flag
\`ENABLE_PAUSE_RESUME\` 兜底（默认 off），主线 / 生产环境零影响。

## 信号链路（PR-0 spike 验证过）

\`\`\`
supervisor.pause(tid)
    ↓
_signal_pause_async → _send_pause_signal
    ↓ Windows: CTRL_BREAK_EVENT     POSIX: SIGINT
resume_phase 注册的 SIGBREAK/SIGINT handler 捕获
    ↓
context.handle_interrupt
    - state_dir() / pause_step_<N>.pt  (复用 PR-1 per-task 子目录)
    - write_config_snapshot → pause_step_<N>.config.json
    - emit __EVENT__:pause_state
    - sys.exit(0)
    ↓
supervisor._on_task_log 抓事件 → slot.pause_state_path 等填上
    ↓
proc.poll() → _finish_slot 三元分流 → status='paused'
\`\`\`

## 改动概要

### runtime/training/snapshot.py（新）

把 pause 文件命名 / config snapshot 序列化 / \`__EVENT__:\` 协议 emit
抽到独立模块，让 supervisor、test、未来 spike 都能复用。EVENT_MARKER
常量跟 supervisor.py 跨进程协议对齐。

### runtime/training/context.py

\`handle_interrupt\` 改造：用 PR-1 的 \`state_dir()\` + 新命名 \`pause_step_<N>.pt\` +
同名 \`.config.json\`。落盘后 emit \`__EVENT__:pause_state\` 让 supervisor 感知。
原 LoRA "interrupted" save 行为保留。

### runtime/training/phases/resume.py

- Windows 加 \`signal.signal(SIGBREAK, ctx.handle_interrupt)\`（PR-0 spike
  验证 CREATE_NEW_PROCESS_GROUP 子进程组只收 CTRL_BREAK_EVENT，映射 SIGBREAK）
- resume 完毕 emit \`__EVENT__:train_loop_started\`（ADR §8.1 is_pausable）
- \`load_training_state\` 成功后 emit \`__EVENT__:resume_state_loaded\`
  （PR-3 用此事件清上次 pause 文件对；PR-2 supervisor 仅日志）

### studio/migrations/_v6_pause_resume.py（新）

- tasks 加 4 NULLABLE 列：\`paused_state_path\` / \`paused_config_path\` /
  \`paused_step\` / \`paused_at\`（老库零 backfill）
- 新 \`queue_settings(key, value)\` kv 表（跨重启保留）

### studio/db.py

- \`VALID_STATUSES\` 加 \`'paused'\`，**不**进 \`TERMINAL_STATUSES\`（可被 resume）
- \`get_queue_held\` / \`set_queue_held\`：kv 表 UPSERT 单行存储

### studio/supervisor.py

- \`_Slot\` 加字段：pause_pending / pause_state_path / pause_config_path /
  pause_step / train_loop_started（reset 同步清）
- \`_on_task_log\` 识别 \`__EVENT__:\` 协议（之前只有 \`_spawn_job\` 的 \`_on_line\`
  识别，task 这条路径不识别；现在补上）
- \`pause(task_id)\` → \`(ok, reason)\` 状态机校验（ADR §8.1 defense-in-depth）
- \`_send_pause_signal\` / \`_signal_pause_async\`（不带 grace 强杀；30s 由 UI
  modal 决定下一步，ADR §4.3）
- \`_finish_slot\` **三元分流**：
  - pause_pending+state_path → paused
  - pause_pending+无 state_path → 降级 canceled（ADR §4.3 "强制取消保存进度"）
  - cancel_pending → canceled；rc==0 → done；else failed
- 三个 dispatch path 都检查 \`_queue_held()\`（ADR §3.2 hold 全队列覆盖）
- \`cancel()\` 允许 paused → canceled，同时清 pause 文件对（ADR §5.5）
- \`_send_terminate_signal\` Windows 改 \`taskkill /T /F\`（PR-0 spike 决策：
  CTRL_BREAK_EVENT 独占 pause，cancel 走硬杀）

### studio/server.py

4 个新 endpoint，全部 \`_require_pause_resume_enabled()\` 兜底：

- \`POST /api/queue/{id}/pause\`
- \`GET  /api/queue/hold\` → \`{held, pending_waiting}\`
- \`POST /api/queue/hold\` → publish \`queue_hold_changed\` event
- \`POST /api/queue/release\` → publish \`queue_hold_changed\` event

Resume endpoint 留 PR-3（cmd_builder 改造后再暴露）。

## 测试

新增 3 个 test 文件 (45 cases) + 兼容现有：

- \`test_snapshot.py\` (15): path build / _jsonify Path & set / Namespace
  序列化 / utf-8 / emit_event 协议
- \`test_db_pause_resume.py\` (14): migration v6 / 幂等 / paused 不进终态 /
  next_pending 跳过 paused / kv 持久化
- \`test_supervisor_pause.py\` (16): _Slot reset / _finish_slot 三元分流四
  分支 / pause() 状态机各 reject 路径 / cancel paused 删文件对 +
  robust to missing files / _queue_held()

跑 PR-1 + PR-2 相关 8 个 test 文件 **109/109 PASS**。Pause 信号 e2e
流程已在 PR-0 spike 报告端到端验证过；PR-3 集成测会补 "pause N step →
resume → 验证 global_step 接上 + loss 连续"。

## Feature flag

env \`ENABLE_PAUSE_RESUME=1\` 才解锁四个新 endpoint；未设值 = 默认 off →
endpoint 503。PR-5 改默认值或加 settings UI 控件。

## 不在本 PR

- Resume endpoint + cmd_builder（PR-3）
- 前端 UI / banner / modal / i18n（PR-4）
- 文档 / changelog / 默认开 flag（PR-5）

Refs: ADR 0006 §runtime/training/context.py / §studio/supervisor.py /
§studio/db.py / §studio/server.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)