### PR TITLE
feat(queue): resume 路径 + cmd_builder 接入（ADR 0006 PR-3）

### DIFF
--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import random
@@ -19,6 +20,46 @@ from training.observability import init_wandb_monitor
 
 
 logger = logging.getLogger(__name__)
+
+
+def _maybe_apply_pause_snapshot(args, resume_state_path: Path) -> None:
+    """读 pause snapshot 覆盖 args（ADR 0006 PR-3 / §5.7）。
+
+    args.resume_state = `…/pause_step_<N>.pt` → snapshot = `…/pause_step_<N>.config.json`。
+    snapshot 不存在 → 静默跳过（用户走 ResumeFieldPicker 选周期 save 文件
+    起新 task 的旧路径）。
+
+    覆盖规则：
+    - snapshot["args"] 内所有字段写到 args namespace，**例外**：
+      - `resume_state` 不覆盖（snapshot 记录的是 pause 前的 args，那时 resume_state
+        是空；现在我们才用它续训）
+      - `config` 不覆盖（snapshot 记录的是用户当时的 yaml 路径，用户可能已删/改名）
+    - snapshot["sample_prompts"] → args.sample_prompts（resume_phase 会读这个）
+    """
+    snapshot_path = resume_state_path.with_suffix(".config.json")
+    if not snapshot_path.exists():
+        return  # 不是 pause state，沿用现有 args
+    try:
+        raw = snapshot_path.read_text(encoding="utf-8")
+        snapshot = json.loads(raw)
+    except Exception as exc:
+        logger.warning(
+            f"读取 pause snapshot 失败，沿用现有 args: {snapshot_path} ({exc})"
+        )
+        return
+    if not isinstance(snapshot, dict) or not isinstance(snapshot.get("args"), dict):
+        logger.warning(f"pause snapshot schema 不识别，沿用现有 args: {snapshot_path}")
+        return
+    logger.info(f"加载 pause snapshot 覆盖训练参数: {snapshot_path}")
+    snap_args: dict = snapshot["args"]
+    skipped = {"resume_state", "config"}
+    for k, v in snap_args.items():
+        if k in skipped:
+            continue
+        setattr(args, k, v)
+    sp = snapshot.get("sample_prompts")
+    if isinstance(sp, list):
+        args.sample_prompts = sp
 
 
 def run(ctx: TrainingContext) -> None:
@@ -53,6 +94,17 @@ def run(ctx: TrainingContext) -> None:
 
     # bridge 已为 prefer_json bool 自动产生 --prefer-json / --no-prefer-json，
     # 此处无需再做兼容处理。
+
+    # ADR 0006 PR-3：pause 文件旁边的 .config.json snapshot 覆盖 args。
+    # 触发条件：args.resume_state 指向的 .pt 旁边有同前缀的 .config.json。
+    # 仅 pause 触发的 state 会带 snapshot（PR-2 handle_interrupt 写）；周期
+    # save 没有 snapshot，ResumeFieldPicker 起新 task 走原路径（用户当前
+    # yaml config）。Snapshot freeze 是 ADR §5.7 的核心 — resume 时 task 的
+    # 训练参数严格用暂停那一刻的值，跟用户后续改 version / preset / yaml
+    # 完全解耦。
+    if getattr(args, "resume_state", None):
+        _maybe_apply_pause_snapshot(args, Path(args.resume_state))
+        ctx.args = args
 
     # 交互模式检查
     required = [args.data_dir, args.transformer_path, args.vae_path, args.text_encoder_path]

--- a/studio/server.py
+++ b/studio/server.py
@@ -2975,6 +2975,57 @@ def release_queue() -> dict[str, Any]:
     return {"held": False}
 
 
+@app.post("/api/queue/{task_id}/resume")
+def resume_task(task_id: int) -> dict[str, Any]:
+    """恢复 paused task（ADR 0006 PR-3 / §6 路径 A）。
+
+    流程：
+      1. 校验 status == 'paused' + paused_state_path 文件存在
+      2. task → pending（**保留 paused_* 字段**，cmd_builder 下轮 dispatch 读它）
+      3. supervisor 下次 _tick 自然 pick up，cmd 加 `--resume-state <pt>`，
+         bootstrap_phase 读 sibling .config.json snapshot 覆盖 args
+      4. 子进程 load_training_state 成功后 emit `resume_state_loaded` →
+         supervisor `_clear_pause_artifacts` 清文件对 + db 字段
+
+    文件丢失 → 409（ADR §5.5：引导用户走 ResumeFieldPicker 起新 task）。
+    """
+    _require_pause_resume_enabled()
+    with db.connection_for() as conn:
+        task = db.get_task(conn, task_id)
+        if not task:
+            raise HTTPException(404, "task not found")
+        if task["status"] != "paused":
+            raise HTTPException(
+                409, f"task status is {task['status']!r}, not paused"
+            )
+        state_path = task.get("paused_state_path")
+        config_path = task.get("paused_config_path")
+        if not state_path or not Path(state_path).exists():
+            raise HTTPException(
+                409,
+                f"paused state file missing: {state_path!r}; "
+                f"use ResumeFieldPicker to start a fresh task from another .pt",
+            )
+        if config_path and not Path(config_path).exists():
+            # snapshot 缺失虽然不致命（bootstrap_phase 会沿用 args.config yaml），
+            # 但 resume 语义会漂；按 ADR §5.7 严格 freeze 原则，拒绝继续。
+            raise HTTPException(
+                409,
+                f"paused config snapshot missing: {config_path!r}; "
+                f"cannot guarantee config freeze, refusing to resume",
+            )
+        db.update_task(
+            conn, task_id,
+            status="pending",
+            started_at=None,
+            finished_at=None,
+            exit_code=None,
+            error_msg=None,
+        )
+    bus.publish({"type": "task_state_changed", "task_id": task_id, "status": "pending"})
+    return {"task_id": task_id, "status": "pending"}
+
+
 @app.post("/api/queue/{task_id}/retry")
 def retry_task(task_id: int) -> dict[str, Any]:
     """已结束任务重新入队：复制完整训练上下文创建新 task。

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -135,6 +135,12 @@ def _default_cmd_builder(task: dict[str, Any], config_path: Path) -> list[str]:
     msp = task.get("monitor_state_path")
     if msp:
         cmd.extend(["--monitor-state-file", str(msp)])
+    # ADR 0006 PR-3: paused task 复活 → 注入 --resume-state，让 anima_train
+    # 的 resume_phase 加载 state；旁边的 .config.json snapshot 由 bootstrap_phase
+    # 自动检测并 freeze args（ADR §5.7）。
+    paused_state = task.get("paused_state_path")
+    if paused_state:
+        cmd.extend(["--resume-state", str(paused_state)])
     return cmd
 
 
@@ -305,29 +311,21 @@ class Supervisor:
                     {"type": "task_state_changed", "task_id": task_id, "status": "canceled"}
                 )
                 return True
-            if task["status"] == "paused":
-                # 进程已退出，无需发信号 — 直接改 db 状态 + 清 pause 文件对
-                # （ADR §5.5: 离开 paused 状态时一律删 pause 文件）。
-                for col in ("paused_state_path", "paused_config_path"):
-                    p = task.get(col)
-                    if p:
-                        try:
-                            Path(p).unlink(missing_ok=True)
-                        except Exception:
-                            logger.exception("failed to remove pause file %s", p)
+        if task["status"] == "paused":
+            # 进程已退出，无需发信号 — 复用 _clear_pause_artifacts 删文件 + 清字段，
+            # 再单独写 status=canceled + finished_at（ADR §5.5）。
+            # 故意走 with 块外：_clear_pause_artifacts 内部开自己 conn，避免嵌套。
+            self._clear_pause_artifacts(task_id)
+            with db.connection_for(self._db_path) as conn:
                 db.update_task(
                     conn, task_id,
                     status="canceled",
                     finished_at=time.time(),
-                    paused_state_path=None,
-                    paused_config_path=None,
-                    paused_step=None,
-                    paused_at=None,
                 )
-                self._on_event(
-                    {"type": "task_state_changed", "task_id": task_id, "status": "canceled"}
-                )
-                return True
+            self._on_event(
+                {"type": "task_state_changed", "task_id": task_id, "status": "canceled"}
+            )
+            return True
         if task["status"] == "running":
             slot = self._find_slot(kind="task", id=task_id)
             if slot is not None:
@@ -678,9 +676,10 @@ class Supervisor:
                 elif evt_type == "train_loop_started":
                     slot.train_loop_started = True
                 elif evt_type == "resume_state_loaded":
-                    # PR-3 cmd_builder 接入后用此事件清理上次 pause 文件对。
-                    # PR-2 仅记录，不做副作用。
-                    pass
+                    # ADR §5.5 / PR-3：训练子进程 load_training_state 成功 →
+                    # 旧 pause 文件对已被消费完，删盘 + 清 db 字段，避免下次
+                    # pause 时跟旧文件命名撞 / 让 ResumeFieldPicker 显示 stale 项。
+                    self._clear_pause_artifacts(tid)
                 self._on_event({
                     "type": evt_type,
                     "task_id": tid,
@@ -1280,6 +1279,36 @@ class Supervisor:
             return
         slot.pause_pending = True
         self._send_pause_signal(slot.proc)
+
+    def _clear_pause_artifacts(self, task_id: int) -> None:
+        """删 pause 文件对 + 清 db `paused_*` 字段（ADR §5.5）。
+
+        调用点：
+          - resume_state_loaded 事件（cmd_builder 成功 load 后）
+          - cancel paused → canceled
+          - 删除 paused task（未来 PR）
+
+        故意 **不改 status** — caller 决定要写什么状态。文件 unlink 兜 missing_ok
+        以容忍用户手动删 / 磁盘异常；db update 是 single transaction。
+        """
+        with db.connection_for(self._db_path) as conn:
+            task = db.get_task(conn, task_id)
+            if not task:
+                return
+            for col in ("paused_state_path", "paused_config_path"):
+                p = task.get(col)
+                if p:
+                    try:
+                        Path(p).unlink(missing_ok=True)
+                    except Exception:
+                        logger.exception("failed to remove pause file %s", p)
+            db.update_task(
+                conn, task_id,
+                paused_state_path=None,
+                paused_config_path=None,
+                paused_step=None,
+                paused_at=None,
+            )
 
 
 def _kill_process_tree(pid: int) -> None:

--- a/tests/test_resume_path.py
+++ b/tests/test_resume_path.py
@@ -1,0 +1,385 @@
+"""ADR 0006 PR-3 — resume 路径 + cmd_builder + snapshot 覆盖测试。
+
+不起真子进程；
+  - cmd_builder 单测：构造 task dict 调 `_default_cmd_builder`
+  - bootstrap 覆盖单测：argparse.Namespace + sibling snapshot 落盘 + 调
+    `_maybe_apply_pause_snapshot`
+  - supervisor `_clear_pause_artifacts` 单测：构造 db 状态 + 调 method
+  - server resume endpoint 单测：直接调函数（绕过 fastapi router，因为本
+    dev env 没装 fastapi/test_client）
+
+完整 end-to-end（pause → resume → loss 连续）依赖真训练栈，留给手测 +
+PR-4 集成。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from studio import db
+from studio.supervisor import Supervisor, _default_cmd_builder
+
+
+# ---------------------------------------------------------------------------
+# cmd_builder 加 --resume-state
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_builder_no_resume_when_no_paused_state(tmp_path: Path) -> None:
+    """正常 train task：cmd 里没 --resume-state。"""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("", encoding="utf-8")
+    cmd = _default_cmd_builder({"task_type": "train", "id": 1}, cfg)
+    assert "--resume-state" not in cmd
+
+
+def test_cmd_builder_adds_resume_state_when_paused(tmp_path: Path) -> None:
+    """task 含 paused_state_path → cmd 加 --resume-state <path>。"""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("", encoding="utf-8")
+    pt = tmp_path / "pause_step_100.pt"
+    cmd = _default_cmd_builder(
+        {"task_type": "train", "id": 1, "paused_state_path": str(pt)},
+        cfg,
+    )
+    assert "--resume-state" in cmd
+    idx = cmd.index("--resume-state")
+    assert cmd[idx + 1] == str(pt)
+
+
+def test_cmd_builder_paused_path_works_for_reg_ai(tmp_path: Path) -> None:
+    """reg_ai task 也支持 paused_state_path（虽然 ADR scope 只 train，
+    但 cmd_builder 不区分；reg_ai 信号链路同 train）。"""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("", encoding="utf-8")
+    pt = tmp_path / "pause_step_200.pt"
+    cmd = _default_cmd_builder(
+        {"task_type": "reg_ai", "paused_state_path": str(pt)},
+        cfg,
+    )
+    assert "--resume-state" in cmd
+
+
+def test_cmd_builder_resume_after_monitor_state_file(tmp_path: Path) -> None:
+    """args 顺序：--config / --monitor-state-file / --resume-state。"""
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text("", encoding="utf-8")
+    cmd = _default_cmd_builder(
+        {
+            "task_type": "train",
+            "monitor_state_path": str(tmp_path / "ms.json"),
+            "paused_state_path": str(tmp_path / "p.pt"),
+        },
+        cfg,
+    )
+    assert cmd.index("--config") < cmd.index("--monitor-state-file") < cmd.index("--resume-state")
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_phase: _maybe_apply_pause_snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_overrides_args(tmp_path: Path) -> None:
+    """sibling .config.json 存在 → snapshot 内 args 覆盖 namespace。"""
+    from runtime.training.phases.bootstrap import _maybe_apply_pause_snapshot  # type: ignore[import-not-found]
+
+    pt = tmp_path / "pause_step_100.pt"
+    pt.write_bytes(b"")
+    snap = pt.with_suffix(".config.json")
+    snap.write_text(json.dumps({
+        "version": 1,
+        "args": {"lr": 5e-5, "optimizer": "Lion", "batch_size": 8},
+        "sample_prompts": ["snap_prompt"],
+    }), encoding="utf-8")
+
+    args = argparse.Namespace(lr=1e-4, optimizer="AdamW", batch_size=2, resume_state=str(pt))
+    _maybe_apply_pause_snapshot(args, pt)
+
+    assert args.lr == 5e-5
+    assert args.optimizer == "Lion"
+    assert args.batch_size == 8
+    assert args.sample_prompts == ["snap_prompt"]
+
+
+def test_snapshot_missing_leaves_args_intact(tmp_path: Path) -> None:
+    """sibling 不存在 → args 完全不动（ResumeFieldPicker 起新 task 兼容）。"""
+    from runtime.training.phases.bootstrap import _maybe_apply_pause_snapshot
+
+    pt = tmp_path / "training_state_step42.pt"  # 周期 save 命名，无 snapshot
+    pt.write_bytes(b"")
+
+    args = argparse.Namespace(lr=1e-4, optimizer="AdamW", resume_state=str(pt))
+    _maybe_apply_pause_snapshot(args, pt)
+    assert args.lr == 1e-4
+    assert args.optimizer == "AdamW"
+
+
+def test_snapshot_keeps_resume_state_and_config(tmp_path: Path) -> None:
+    """snapshot 里的 resume_state / config 不该覆盖当前的 — 当前的是
+    supervisor 刚拼好的真路径，snapshot 里的是 pause 那一刻的（已 stale）。"""
+    from runtime.training.phases.bootstrap import _maybe_apply_pause_snapshot
+
+    pt = tmp_path / "pause_step_50.pt"
+    pt.write_bytes(b"")
+    snap = pt.with_suffix(".config.json")
+    snap.write_text(json.dumps({
+        "version": 1,
+        "args": {
+            "lr": 1e-3,
+            "resume_state": "/old/stale/path.pt",
+            "config": "/old/stale.yaml",
+        },
+    }), encoding="utf-8")
+
+    args = argparse.Namespace(
+        lr=1e-4,
+        resume_state=str(pt),
+        config="/current/cfg.yaml",
+    )
+    _maybe_apply_pause_snapshot(args, pt)
+    assert args.lr == 1e-3                # 覆盖
+    assert args.resume_state == str(pt)   # 保留
+    assert args.config == "/current/cfg.yaml"  # 保留
+
+
+def test_snapshot_malformed_falls_back_silently(tmp_path: Path) -> None:
+    """snapshot json 损坏 / schema 错 → warn log，不抛错，args 不动。"""
+    from runtime.training.phases.bootstrap import _maybe_apply_pause_snapshot
+
+    pt = tmp_path / "pause_step_10.pt"
+    pt.write_bytes(b"")
+    snap = pt.with_suffix(".config.json")
+    snap.write_text("not valid json {{{", encoding="utf-8")
+
+    args = argparse.Namespace(lr=1e-4, resume_state=str(pt))
+    _maybe_apply_pause_snapshot(args, pt)
+    assert args.lr == 1e-4
+
+
+def test_snapshot_schema_wrong_falls_back(tmp_path: Path) -> None:
+    from runtime.training.phases.bootstrap import _maybe_apply_pause_snapshot
+
+    pt = tmp_path / "pause_step_10.pt"
+    pt.write_bytes(b"")
+    snap = pt.with_suffix(".config.json")
+    snap.write_text(json.dumps({"args": "not a dict"}), encoding="utf-8")
+
+    args = argparse.Namespace(lr=1e-4, resume_state=str(pt))
+    _maybe_apply_pause_snapshot(args, pt)
+    assert args.lr == 1e-4
+
+
+# ---------------------------------------------------------------------------
+# supervisor._clear_pause_artifacts
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def env(tmp_path: Path):
+    db_path = tmp_path / "studio.db"
+    db.init_db(db_path)
+    logs = tmp_path / "logs"
+    configs = tmp_path / "configs"
+    logs.mkdir()
+    configs.mkdir()
+    return {"db": db_path, "logs": logs, "configs": configs, "root": tmp_path}
+
+
+def _new_sup(env) -> Supervisor:
+    return Supervisor(
+        on_event=lambda _: None,
+        cmd_builder=lambda *_: ["echo"],
+        db_path=env["db"],
+        logs_dir=env["logs"],
+        configs_dir=env["configs"],
+        poll_interval=10,
+    )
+
+
+def test_clear_pause_artifacts_deletes_files_and_clears_db(env) -> None:
+    sup = _new_sup(env)
+    state_pt = env["root"] / "pause_step_100.pt"
+    cfg_json = env["root"] / "pause_step_100.config.json"
+    state_pt.write_bytes(b"fake state")
+    cfg_json.write_text("{}", encoding="utf-8")
+
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        db.update_task(
+            conn, tid,
+            status="running",
+            paused_state_path=str(state_pt),
+            paused_config_path=str(cfg_json),
+            paused_step=100,
+            paused_at=time.time(),
+        )
+
+    sup._clear_pause_artifacts(tid)
+
+    assert not state_pt.exists()
+    assert not cfg_json.exists()
+    with db.connection_for(env["db"]) as conn:
+        task = db.get_task(conn, tid)
+    assert task is not None
+    assert task["paused_state_path"] is None
+    assert task["paused_config_path"] is None
+    assert task["paused_step"] is None
+    assert task["paused_at"] is None
+    # status 不改 — caller 决定
+    assert task["status"] == "running"
+
+
+def test_clear_pause_artifacts_unknown_task_noop(env) -> None:
+    """task 不存在 → 静默返回，不抛错。"""
+    sup = _new_sup(env)
+    sup._clear_pause_artifacts(99999)
+
+
+def test_clear_pause_artifacts_missing_files_robust(env) -> None:
+    """文件已被外部删 → db 字段照样清，不抛错。"""
+    sup = _new_sup(env)
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        db.update_task(
+            conn, tid,
+            paused_state_path="/nonexistent/path.pt",
+            paused_config_path="/nonexistent/path.config.json",
+            paused_step=100,
+        )
+    sup._clear_pause_artifacts(tid)
+    with db.connection_for(env["db"]) as conn:
+        task = db.get_task(conn, tid)
+    assert task["paused_state_path"] is None
+
+
+# ---------------------------------------------------------------------------
+# resume_task endpoint —— 直接调 function（绕开 fastapi router）
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def server_env(env, monkeypatch):
+    """初始化 db.STUDIO_DB monkeypatch 让 server module 用 isolated db。"""
+    # Ensure feature flag is on for tests
+    monkeypatch.setenv("ENABLE_PAUSE_RESUME", "1")
+    # 重导入 server 让 _ENABLE_PAUSE_RESUME 重读 env
+    import importlib
+    if "studio.server" in sys.modules:
+        del sys.modules["studio.server"]
+    # 触发 server 不要起 supervisor / FastAPI client：只 import module
+    monkeypatch.setattr(db, "STUDIO_DB", env["db"])
+    return env
+
+
+def _create_paused_task(env, state_pt: Path, cfg_json: Path) -> int:
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        db.update_task(
+            conn, tid,
+            status="paused",
+            paused_state_path=str(state_pt),
+            paused_config_path=str(cfg_json),
+            paused_step=100,
+            paused_at=time.time(),
+        )
+    return tid
+
+
+def _import_server_module():
+    """每次干净 import server module — 让 _ENABLE_PAUSE_RESUME 读最新 env。"""
+    import importlib
+    if "studio.server" in sys.modules:
+        del sys.modules["studio.server"]
+    try:
+        import studio.server as _s  # type: ignore[import-not-found]
+        return _s
+    except ImportError:
+        pytest.skip("fastapi not installed; cannot import studio.server")
+
+
+def test_resume_endpoint_rejects_when_feature_flag_off(server_env, monkeypatch) -> None:
+    monkeypatch.delenv("ENABLE_PAUSE_RESUME", raising=False)
+    server = _import_server_module()
+    state_pt = server_env["root"] / "pause_step_100.pt"
+    cfg_json = server_env["root"] / "pause_step_100.config.json"
+    state_pt.write_bytes(b"")
+    cfg_json.write_text("{}", encoding="utf-8")
+    tid = _create_paused_task(server_env, state_pt, cfg_json)
+
+    with pytest.raises(server.HTTPException) as exc:
+        server.resume_task(tid)
+    assert exc.value.status_code == 503
+
+
+def test_resume_endpoint_rejects_unknown_task(server_env) -> None:
+    server = _import_server_module()
+    with pytest.raises(server.HTTPException) as exc:
+        server.resume_task(99999)
+    assert exc.value.status_code == 404
+
+
+def test_resume_endpoint_rejects_non_paused(server_env) -> None:
+    server = _import_server_module()
+    with db.connection_for(server_env["db"]) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        # pending status
+    with pytest.raises(server.HTTPException) as exc:
+        server.resume_task(tid)
+    assert exc.value.status_code == 409
+    assert "not paused" in exc.value.detail
+
+
+def test_resume_endpoint_rejects_when_state_file_missing(server_env) -> None:
+    server = _import_server_module()
+    state_pt = server_env["root"] / "pause_step_100.pt"
+    cfg_json = server_env["root"] / "pause_step_100.config.json"
+    cfg_json.write_text("{}", encoding="utf-8")  # state missing, config exists
+    tid = _create_paused_task(server_env, state_pt, cfg_json)
+    with pytest.raises(server.HTTPException) as exc:
+        server.resume_task(tid)
+    assert exc.value.status_code == 409
+    assert "missing" in exc.value.detail
+
+
+def test_resume_endpoint_rejects_when_config_snapshot_missing(server_env) -> None:
+    server = _import_server_module()
+    state_pt = server_env["root"] / "pause_step_100.pt"
+    cfg_json = server_env["root"] / "pause_step_100.config.json"
+    state_pt.write_bytes(b"")  # state exists, config missing
+    tid = _create_paused_task(server_env, state_pt, cfg_json)
+    with pytest.raises(server.HTTPException) as exc:
+        server.resume_task(tid)
+    assert exc.value.status_code == 409
+    assert "snapshot missing" in exc.value.detail
+
+
+def test_resume_endpoint_success_flips_status_keeps_paused_fields(server_env) -> None:
+    server = _import_server_module()
+    state_pt = server_env["root"] / "pause_step_100.pt"
+    cfg_json = server_env["root"] / "pause_step_100.config.json"
+    state_pt.write_bytes(b"")
+    cfg_json.write_text("{}", encoding="utf-8")
+    tid = _create_paused_task(server_env, state_pt, cfg_json)
+
+    result = server.resume_task(tid)
+    assert result["status"] == "pending"
+    assert result["task_id"] == tid
+    # 关键：paused_state_path 等字段保留（cmd_builder 下一轮 dispatch 才能读到）
+    with db.connection_for(server_env["db"]) as conn:
+        task = db.get_task(conn, tid)
+    assert task["status"] == "pending"
+    assert task["paused_state_path"] == str(state_pt)
+    assert task["paused_config_path"] == str(cfg_json)
+    assert task["paused_step"] == 100
+    # finished_at / exit_code / error_msg 都 reset 了（新一轮跑）
+    assert task["finished_at"] is None
+    assert task["exit_code"] is None
+    assert task["error_msg"] is None


### PR DESCRIPTION
## 背景

ADR 0006 PR-3 — paused task 复活闭环。让用户在 UI 上点 "恢复" 后整条
链路跑通：API 改 status → supervisor dispatch → cmd 加 \`--resume-state\` →
bootstrap 读 snapshot 覆盖 args → \`load_training_state\` → emit
\`resume_state_loaded\` → 清旧 pause 文件对。

跟 PR-2 一样 feature flag off — \`ENABLE_PAUSE_RESUME=1\` 才解锁 endpoint。

## 改动

### studio/supervisor.py

- \`_default_cmd_builder\` 检测 \`task.paused_state_path\` 非空 → cmd 追加
  \`--resume-state <pt>\`。\`--config\` 不动（bootstrap_phase 自动识别 sibling
  snapshot）。
- \`_on_task_log\` 收到 \`__EVENT__:resume_state_loaded\` → 调
  \`_clear_pause_artifacts(tid)\`（PR-2 stub 兑现）。
- 新 \`_clear_pause_artifacts(task_id)\` helper：删 \`.pt\` + \`.config.json\` +
  清 db \`paused_*\` 4 字段。**不改 status**（caller 决定）。
- \`cancel()\` paused 分支 refactor 复用新 helper，避免 with 块嵌套 db
  connection。

### runtime/training/phases/bootstrap.py

新 \`_maybe_apply_pause_snapshot(args, resume_state_path)\`：

- args.resume_state 旁边 \`.config.json\` snapshot 存在 → 读 JSON、用
  \`snapshot[\"args\"]\` 覆盖 namespace（snapshot 是 ADR §5.7 的 frozen 真相）
- 例外字段：\`resume_state\` / \`config\` 不覆盖（snapshot 里的是 pause
  时的 stale 值，supervisor 拼的才是当前真路径）
- \`snapshot[\"sample_prompts\"]\` → \`args.sample_prompts\`，resume_phase 现有
  逻辑会读这个恢复多 prompt 轮换
- snapshot 不存在 / json 损坏 / schema 错 → 沿用当前 args（兼容
  ResumeFieldPicker 选周期 save 文件起新 task 的旧路径）

### studio/server.py

新 \`POST /api/queue/{task_id}/resume\`：

- 校验 task.status == 'paused'
- 校验 paused_state_path 文件存在（缺失 → 409 引导走 ResumeFieldPicker
  起新 task，ADR §5.5）
- 校验 paused_config_path snapshot 存在（缺失 → 409，按 §5.7 严格
  freeze 原则拒绝继续）
- task → pending **保留 paused_* 字段**（cmd_builder 下次 dispatch 才能
  读到 --resume-state 路径）
- reset \`finished_at\` / \`exit_code\` / \`error_msg\`（新一轮跑）
- publish \`task_state_changed\`

旧 4 个 endpoint 不动；feature flag 同一份。

## 测试

新增 \`tests/test_resume_path.py\` (18 case)：

- cmd_builder 加 \`--resume-state\` 的几种 case (4)
- bootstrap snapshot 覆盖 / 兼容老路径 / 故意保留 resume_state+config /
  json 损坏 fallback / schema 错 fallback (5)
- \`_clear_pause_artifacts\` 删文件 + 清字段 / 不存在 task / missing files
  robust (3)
- resume_task endpoint 各种 reject（unknown / non-paused / state missing
  / config missing）+ 成功 flip 状态保留字段 (6)

跑 PR-1+PR-2+PR-3 + 兼容 9 个 test 文件 **127/127 PASS**（含 fastapi
test client 端点测试）。

## 不在本 PR

- 前端 UI（PR-4）：调 \`/api/queue/{id}/resume\` + paused 行内 "恢复" 按钮 +
  暂停过程 modal + queue hold banner
- 文档 / changelog / 默认开 flag（PR-5）

## 风险 / 已知限制

- E2E（pause N step → resume → loss 连续）依赖真训练栈，本仓库 dev env
  跑不了完整流程；PR-0 spike 报告 + PR-2 信号链路单测 + 本 PR 路径单测
  组合保证各环节正确。PR-5 灰度时手测一次跨重启 + GPU 真训练 case。
- snapshot freeze 严格：用户改 config 后 resume 会用 pause 时的 config —
  不允许 "暂停后改 config 再 resume"（ADR §8.5）。需要换 config 走
  ResumeFieldPicker fork 新 task。
- ResumeFieldPicker 之前不暴露 pause 文件（PR-1 的 \`_STATE_FILE_RE\` 不
  匹配 \`pause_\` 前缀）；用户想 fork pause state 需要手动选 .pt 路径，
  暂时未做 picker 列出 pause 文件的功能（v2 考虑）。

Refs: ADR 0006 §runtime/training/phases/resume.py / §/api/queue/{id}/resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)