### PR TITLE
feat(queue): ADR 0006 灰度激活 — 删 feature flag + Accepted

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 - **🧩 训练栈可扩展**（v0.7 新）— `runtime/training/` 子包 + 4 个 plugin registry（adapters / optimizers / schedulers / inference_samplers）+ `AdapterProtocol` hook（on_step_begin / regularization_loss / excludes_weight_decay）；加新变体走 3 步（写 build 函数 + 字典加行 + schema Literal）不动 phases / loop（详见 [ADR 0003](docs/adr/0003-anima-train-refactor.md) + [`runtime/training/README.md`](runtime/training/README.md)）
 - **🖼️ 图片预处理流水线**（v0.8 新）— 流水线插入「② 预处理」step：ESRGAN / Real-ESRGAN 等多放大器预设 + ModelScope/HF 双源、智能流水（大图直接 resize 跳过放大模型）、SSE 实时进度。单 manifest 单 grid + 状态徽章（详见 [ADR 0004](docs/adr/0004-preprocess-manifest.md)）
 - **🎲 InfoNoise 自适应训练**（v0.8 新）— 基于 I-MMSE 等价的反 CDF 时间步采样器，把抽样集中在信息量大的噪声窗口；走 `timestep_samplers/` plugin registry，默认关，存量训练零侵入
+- **⏸️ 暂停 / 恢复训练 + 队列挂起**（v0.9 新）— UI 上一键暂停 running task（保 optimizer / step / monitor state + config snapshot），日后点恢复从同一步接续训练；队列挂起开关让 dispatcher 不拉新 pending，过夜 / 维护场景顺手用（详见 [ADR 0006](docs/adr/0006-queue-pause-resume.md)）
 
 ![Studio 训练页](docs/images/studio-train.png)
 

--- a/docs/adr/0006-queue-pause-resume.md
+++ b/docs/adr/0006-queue-pause-resume.md
@@ -1,6 +1,6 @@
 # 0006 — Queue 任务暂停 / 恢复 + 队列挂起 / 恢复调度
 
-**状态**：Proposed
+**状态**：Accepted（PR-1 #97 / PR-2 #98 / PR-3 #99 / PR-4 #100 全部合入 dev；PR-5 删 feature flag 默认开启）
 **日期**：2026-05-18
 **决策者**：@WalkingMeatAxolotl
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,7 +11,7 @@
 | 0003 | [anima_train.py 模块化重构（plugin 边界 + adapter hook protocol）](0003-anima-train-refactor.md) | Proposed | 2026-05-14 |
 | 0004 | [预处理状态用单 manifest 替代「双 bucket + per-image sidecar」](0004-preprocess-manifest.md) | Accepted | 2026-05-15 |
 | 0005 | [更新通道作为用户视图偏好，与 git 工作树状态解耦](0005-update-channel-as-preference.md) | Accepted | 2026-05-16 |
-| 0006 | [Queue 任务暂停 / 恢复 + 队列挂起 / 恢复调度](0006-queue-pause-resume.md) | Proposed | 2026-05-18 |
+| 0006 | [Queue 任务暂停 / 恢复 + 队列挂起 / 恢复调度](0006-queue-pause-resume.md) | Accepted | 2026-05-18 |
 
 ## 状态值
 

--- a/release_notes.yaml
+++ b/release_notes.yaml
@@ -5,6 +5,84 @@
 #
 # 顺序：最新版本在 list 顶。
 
+- version: "0.9.0"
+  date: "2026-05-18"
+  summary: "queue 暂停 / 恢复 + 队列挂起（ADR 0006 一整套）"
+  entries:
+    - kind: added
+      summary: "UI 暂停 / 恢复训练 + 队列挂起调度（ADR 0006，#97 #98 #99 #100）"
+      pr_refs: [97, 98, 99, 100]
+      detail: |
+        Queue / QueueDetail 页加 4 个新交互（详见
+        [ADR 0006](docs/adr/0006-queue-pause-resume.md) 全文 + design doc
+        三轮 review）：
+
+        - **任务暂停**：running task 点暂停 → 保 state（optimizer + RNG +
+          step + monitor + LoRA "interrupted" + wandb finish）+ config
+          snapshot freeze 当前 args → 子进程 exit 0 → task 标 paused。点暂停
+          立刻锁屏 progress modal 全程引导（保存中 / 30s 超时三选一 /
+          失败兜底）
+        - **任务恢复**：paused 行点恢复 → status 回 pending → supervisor
+          下次 dispatch 用 `--resume-state` 拉起，bootstrap_phase 读 sibling
+          config snapshot 覆盖 args（snapshot 是 frozen 真相，跟用户后续改
+          version / preset / yaml 完全解耦） → load_training_state 成功
+          emit `resume_state_loaded` → supervisor 清 pause 文件对
+        - **队列挂起 / 恢复调度**：banner sticky 顶部；挂起 confirmation
+          modal 检测 running task 多问一句 "让它跑完" / "同时暂停"，
+          主按钮文案随 radio 联动
+        - **取消 paused task**：paused 行有 "彻底取消"，删 pause 文件 + 清 db 字段
+
+        信号链路（PR-0 spike 验证过）：supervisor `CTRL_BREAK_EVENT` /
+        POSIX `SIGINT` → 子进程 SIGBREAK / SIGINT handler → handle_interrupt
+        保 state + emit `__EVENT__:pause_state` → supervisor `_finish_slot`
+        三元分流（paused / canceled / done / failed）。
+
+    - kind: changed
+      summary: "周期 save state 文件按 task_id 隔离到 state/task_<TID>/ 子目录（#97）"
+      pr_refs: [97]
+      detail: |
+        `save_state_every` / `save_state_every_epochs` / `handle_interrupt`
+        全部改写到 `output_dir/state/task_<TID>/` 下，不再写 output_dir
+        顶层。同一 version 下连跑多个 task 时再也不会互相覆盖 state 文件
+        （pre-PR-1 的 latent bug）。
+
+        - supervisor 启动 training 时通过 env `LORA_TASK_ID` 注入 task id
+        - CLI 直接跑（无 env）fallback 到 `state/task_unknown/` 子目录
+        - `list_state_ckpts`（ResumeFieldPicker 后端）同时扫旧顶层 + 新
+          子目录，**老用户的现存 .pt 不丢**
+        - 顺手修了 `list_state_ckpts` 之前只扫 step 不扫 epoch 的小 bug
+
+    - kind: changed
+      summary: "cancel 在 Windows 改 taskkill /T /F 硬杀，让 CTRL_BREAK_EVENT 独占 pause（#98）"
+      pr_refs: [98]
+      detail: |
+        cancel 的语义本来就是硬中断（30s grace 几乎都触发强杀），
+        Windows 上 `proc.send_signal(CTRL_BREAK_EVENT)` 那一步实质无用
+        且跟 pause 信号撞。改为直接 `taskkill /T /F`：CTRL_BREAK_EVENT
+        专门留给 pause，信号意图清晰。POSIX 没这个冲突，cancel 继续
+        SIGTERM、pause 走 SIGINT，互不撞。
+
+    - kind: added
+      summary: "task 状态机加 'paused'，paused task 跨 supervisor 重启保留（#98）"
+      pr_refs: [98]
+      detail: |
+        `paused` 不进 TERMINAL_STATUSES — 可被 resume 复活。supervisor
+        启动 reconcile orphan 时按 status='running' 精确过滤，paused 自然
+        不受影响。db migration v6 加 4 个 NULLABLE 列（paused_state_path /
+        paused_config_path / paused_step / paused_at）+ 新 queue_settings
+        kv 表（持久化 queue.held 开关）。老库零 backfill 直接升上来。
+
+    - kind: added
+      summary: "tools/spike/ 信号链路验证脚本（#96）"
+      pr_refs: [96]
+      detail: |
+        合 ADR 之前先验证 Windows 信号链路通：parent.py 模拟 supervisor
+        发 `CTRL_BREAK_EVENT`、child.py 模拟训练子进程注册 SIGBREAK
+        handler。两次连跑 6 项 PASS（发信号 → 子进程退出 0.62s）。
+        报告写在
+        [docs/design/queue-pause-spike-report.md](docs/design/queue-pause-spike-report.md)；
+        ADR 全套合入并稳定后 cleanup PR 删 spike 脚本（报告留存）。
+
 - version: "0.8.2"
   date: "2026-05-17"
   summary: "hotfix：预设系统脱钩 redesign + hf-mirror 暂不可用 + 新建预设预览补齐项目路径"

--- a/studio/server.py
+++ b/studio/server.py
@@ -2919,21 +2919,8 @@ def cancel_task(task_id: int) -> dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
-# ADR 0006 PR-2 — pause / hold endpoints。Feature flag 默认 off，灰度由 env
-# ENABLE_PAUSE_RESUME=1 打开。Resume endpoint 留 PR-3（cmd_builder 接入后）。
+# ADR 0006 — pause / resume / hold endpoints。
 # ---------------------------------------------------------------------------
-
-_ENABLE_PAUSE_RESUME = os.environ.get("ENABLE_PAUSE_RESUME", "").lower() in (
-    "1", "true", "yes", "on",
-)
-
-
-def _require_pause_resume_enabled() -> None:
-    if not _ENABLE_PAUSE_RESUME:
-        raise HTTPException(
-            503,
-            "pause/resume feature not enabled (set env ENABLE_PAUSE_RESUME=1)",
-        )
 
 
 @app.post("/api/queue/{task_id}/pause")
@@ -2943,7 +2930,6 @@ def pause_task(task_id: int) -> dict[str, Any]:
     异步：立即返回；UI 端 modal 订阅 SSE 看保存进度。supervisor 收到子进程
     `__EVENT__:pause_state` 后把 status 写为 paused 并 publish task_state_changed。
     """
-    _require_pause_resume_enabled()
     ok, reason = _supervisor().pause(task_id)
     if not ok:
         # 区分客户端错误（404/409）vs 状态机不允许（409）
@@ -2958,7 +2944,6 @@ def pause_task(task_id: int) -> dict[str, Any]:
 @app.get("/api/queue/hold")
 def get_queue_hold() -> dict[str, Any]:
     """查看当前队列挂起状态 + 等待恢复调度的 pending task 数（UI banner 用）。"""
-    _require_pause_resume_enabled()
     with db.connection_for() as conn:
         held = db.get_queue_held(conn)
         pending = db.list_tasks(conn, status="pending")
@@ -2972,7 +2957,6 @@ def hold_queue() -> dict[str, Any]:
     "同时暂停 running task" 由前端 modal 拆成两步：先调本 endpoint，再
     单独调 `/api/queue/{id}/pause`。后端不做合一操作。
     """
-    _require_pause_resume_enabled()
     with db.connection_for() as conn:
         db.set_queue_held(conn, True)
     bus.publish({"type": "queue_hold_changed", "held": True})
@@ -2982,7 +2966,6 @@ def hold_queue() -> dict[str, Any]:
 @app.post("/api/queue/release")
 def release_queue() -> dict[str, Any]:
     """恢复调度：dispatcher 重新按 priority + created_at 拉 pending。"""
-    _require_pause_resume_enabled()
     with db.connection_for() as conn:
         db.set_queue_held(conn, False)
     bus.publish({"type": "queue_hold_changed", "held": False})
@@ -2991,7 +2974,7 @@ def release_queue() -> dict[str, Any]:
 
 @app.post("/api/queue/{task_id}/resume")
 def resume_task(task_id: int) -> dict[str, Any]:
-    """恢复 paused task（ADR 0006 PR-3 / §6 路径 A）。
+    """恢复 paused task（ADR 0006 §6 路径 A）。
 
     流程：
       1. 校验 status == 'paused' + paused_state_path 文件存在
@@ -3003,7 +2986,6 @@ def resume_task(task_id: int) -> dict[str, Any]:
 
     文件丢失 → 409（ADR §5.5：引导用户走 ResumeFieldPicker 起新 task）。
     """
-    _require_pause_resume_enabled()
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
         if not task:

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1702,8 +1702,9 @@ export const api = {
     }),
   retryTask: (id: number) =>
     req<Task>(`/api/queue/${id}/retry`, { method: 'POST' }),
-  /** ADR 0006 PR-2 — 暂停 running task。返回时 task 还在 running，需订阅 SSE
-   *  task_state_changed 看 status 转 paused。flag off / 状态不对时抛 409/503。 */
+  /** ADR 0006 — 暂停 running task。返回时 task 还在 running，需订阅 SSE
+   *  task_state_changed 看 status 转 paused。状态不对（非 running / train_loop
+   *  未启动）抛 409。 */
   pauseTask: (id: number) =>
     req<{ task_id: number; pause_pending: boolean }>(
       `/api/queue/${id}/pause`,

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -564,8 +564,7 @@
     },
     "resumeFailedMissing": "Pause file is missing — cannot resume. Start a fresh task from another .pt via ResumeFieldPicker.",
     "resumeFailed": "Resume failed: {{reason}}",
-    "pauseFailed": "Pause failed: {{reason}}",
-    "featureDisabled": "Pause / queue-hold not enabled (set ENABLE_PAUSE_RESUME=1 in server env)"
+    "pauseFailed": "Pause failed: {{reason}}"
   },
   "queueDetail": {
     "invalidId": "Invalid task ID",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -564,8 +564,7 @@
     },
     "resumeFailedMissing": "暂停文件已丢失，无法恢复。请通过 ResumeFieldPicker 新建任务从其他 .pt 起。",
     "resumeFailed": "恢复失败：{{reason}}",
-    "pauseFailed": "暂停失败：{{reason}}",
-    "featureDisabled": "暂停 / 队列挂起功能未启用（需 server 环境 ENABLE_PAUSE_RESUME=1）"
+    "pauseFailed": "暂停失败：{{reason}}"
   },
   "queueDetail": {
     "invalidId": "无效任务 ID",

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -97,10 +97,8 @@ export default function QueuePage() {
     paused:    t('status.paused'),
   }
 
-  // ADR 0006 PR-4：feature flag 探测（首次 fetch /api/queue/hold 503 → flag off
-  // → 不显示 hold/pause UI）；探测成功后保留状态用作 banner + holdModal。
+  // ADR 0006：队列挂起状态，banner + holdModal 用。
   const [holdState, setHoldState] = useState<QueueHoldState | null>(null)
-  const [featureEnabled, setFeatureEnabled] = useState<boolean | null>(null)
   const [holdModalOpen, setHoldModalOpen] = useState(false)
   const [pausingTaskId, setPausingTaskId] = useState<number | null>(null)
 
@@ -108,10 +106,8 @@ export default function QueuePage() {
     try {
       const s = await api.getQueueHold()
       setHoldState(s)
-      setFeatureEnabled(true)
     } catch {
-      // 503 / 网络错 → 视作 flag off。state 留 null 让 UI 隐藏控件。
-      setFeatureEnabled(false)
+      // 网络错 / 启动期 supervisor 未就绪 → 静默；下一轮 SSE 触发重试。
       setHoldState(null)
     }
   }, [])
@@ -197,13 +193,7 @@ export default function QueuePage() {
       await api.pauseTask(task.id)
       toast(t('queue.pauseSent'), 'success')
     } catch (e) {
-      const msg = String(e)
-      // 503 = feature flag off
-      if (msg.includes('503')) {
-        toast(t('queue.featureDisabled'), 'error')
-      } else {
-        toast(t('queue.pauseFailed', { reason: msg }), 'error')
-      }
+      toast(t('queue.pauseFailed', { reason: String(e) }), 'error')
       setPausingTaskId(null)
     }
   }
@@ -292,9 +282,9 @@ export default function QueuePage() {
       subtitle={t('queue.description')}
       actions={
         <>
-          {/* ADR 0006 PR-4: 顶部 pause 按钮 — 仅 is_pausable=true 时显示（§8.1）。
+          {/* ADR 0006: 顶部 pause 按钮 — 仅 is_pausable=true 时显示（§8.1）。
               isPausable 来自 server enrich 的 task 字段（supervisor slot.train_loop_started 派生）。 */}
-          {featureEnabled && runningTask?.is_pausable && (
+          {runningTask?.is_pausable && (
             <button
               onClick={() => void pauseTask(runningTask)}
               disabled={busy || pausingTaskId !== null}
@@ -315,7 +305,7 @@ export default function QueuePage() {
               {t('queue.cancelCurrent')}
             </button>
           )}
-          {featureEnabled && holdState && !holdState.held && (
+          {holdState && !holdState.held && (
             <button
               onClick={() => setHoldModalOpen(true)}
               disabled={busy}
@@ -325,7 +315,7 @@ export default function QueuePage() {
               {t('queue.holdQueue')}
             </button>
           )}
-          {featureEnabled && holdState && holdState.held && (
+          {holdState && holdState.held && (
             <button
               onClick={() => void releaseQueue()}
               disabled={busy}
@@ -367,7 +357,7 @@ export default function QueuePage() {
     >
       <div className="flex flex-col gap-2.5">
         {/* ADR §4.1 队列挂起 banner — 仅 held=true 时显示，sticky 顶部。 */}
-        {featureEnabled && holdState?.held && (
+        {holdState?.held && (
           <div
             className="sticky top-0 z-10 px-3.5 py-2.5 rounded-md bg-warn-soft border border-warn text-warn text-xs flex items-center justify-between"
             data-testid="queue-hold-banner"

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -171,9 +171,7 @@ export default function QueueDetailPage() {
       await api.pauseTask(task.id)
       toast(t('queue.pauseSent'), 'success')
     } catch (e) {
-      const msg = String(e)
-      if (msg.includes('503')) toast(t('queue.featureDisabled'), 'error')
-      else toast(t('queue.pauseFailed', { reason: msg }), 'error')
+      toast(t('queue.pauseFailed', { reason: String(e) }), 'error')
       setPauseModalOpen(false)
     }
   }

--- a/tests/test_resume_path.py
+++ b/tests/test_resume_path.py
@@ -268,10 +268,7 @@ def test_clear_pause_artifacts_missing_files_robust(env) -> None:
 @pytest.fixture
 def server_env(env, monkeypatch):
     """初始化 db.STUDIO_DB monkeypatch 让 server module 用 isolated db。"""
-    # Ensure feature flag is on for tests
-    monkeypatch.setenv("ENABLE_PAUSE_RESUME", "1")
-    # 重导入 server 让 _ENABLE_PAUSE_RESUME 重读 env
-    import importlib
+    # ADR 0006 PR-5 删 feature flag 后这里无需注入 env，直接 monkeypatch db 路径
     if "studio.server" in sys.modules:
         del sys.modules["studio.server"]
     # 触发 server 不要起 supervisor / FastAPI client：只 import module
@@ -294,7 +291,7 @@ def _create_paused_task(env, state_pt: Path, cfg_json: Path) -> int:
 
 
 def _import_server_module():
-    """每次干净 import server module — 让 _ENABLE_PAUSE_RESUME 读最新 env。"""
+    """每次干净 import server module — 测试 isolation 用。"""
     import importlib
     if "studio.server" in sys.modules:
         del sys.modules["studio.server"]
@@ -303,20 +300,6 @@ def _import_server_module():
         return _s
     except ImportError:
         pytest.skip("fastapi not installed; cannot import studio.server")
-
-
-def test_resume_endpoint_rejects_when_feature_flag_off(server_env, monkeypatch) -> None:
-    monkeypatch.delenv("ENABLE_PAUSE_RESUME", raising=False)
-    server = _import_server_module()
-    state_pt = server_env["root"] / "pause_step_100.pt"
-    cfg_json = server_env["root"] / "pause_step_100.config.json"
-    state_pt.write_bytes(b"")
-    cfg_json.write_text("{}", encoding="utf-8")
-    tid = _create_paused_task(server_env, state_pt, cfg_json)
-
-    with pytest.raises(server.HTTPException) as exc:
-        server.resume_task(tid)
-    assert exc.value.status_code == 503
 
 
 def test_resume_endpoint_rejects_unknown_task(server_env) -> None:


### PR DESCRIPTION
## 背景

ADR 0006 系列 PR-1~PR-4 已合入 dev：

- #96 — PR-0 spike：信号链路验证
- #97 — PR-1：state 文件按 task_id 隔离
- #98 — PR-2：pause / queue-hold 后端骨架（flag off）
- #99 — PR-3：resume 路径 + cmd_builder（flag off）
- #100 — PR-4：前端 UI（flag off）

本 PR 收尾激活：把 \`ENABLE_PAUSE_RESUME\` env flag 完全删掉、feature
永远 on，并把 ADR 0006 status 改 Accepted。

## 改动

### 删 feature flag

- \`studio/server.py\`：删 \`_ENABLE_PAUSE_RESUME\` + \`_require_pause_resume_enabled()\`；
  5 个 endpoint（pause / resume / hold / release / get-hold）直接 enabled
- \`studio/web/src/pages/Queue.tsx\`：删 \`featureEnabled\` state + reloadHold
  错误 fallback；pause/hold UI 永远显示
- \`studio/web/src/pages/QueueDetail.tsx\` + \`Queue.tsx\`：删 \`msg.includes('503')\` 分支
- \`studio/web/src/i18n/locales/{en,zh}.json\`：删 \`queue.featureDisabled\` key
- \`tests/test_resume_path.py\`：删 flag-off 测试，server_env fixture 不
  再注入 env

### ADR status + 索引

- \`docs/adr/0006-queue-pause-resume.md\` 顶部 status: Proposed → Accepted
  （含 4 个 PR 引用 + spike 报告路径）
- \`docs/adr/README.md\` 索引同步

### Doc + release notes

- \`README.md\` 顶部特性列表加一行（v0.9 新）
- \`release_notes.yaml\` 新 0.9.0 block，5 条 entry：UI 暂停/恢复 +
  state 按 task_id 隔离 + Windows cancel 改 taskkill +
  paused 状态机 + spike 脚本

## 测试

- 后端：96 个 case 全过（test_resume_path / test_supervisor_pause /
  test_db_pause_resume / test_snapshot / test_supervisor / test_lora_ckpt_scan）
- 前端：13 个 case 全过（PauseProgressModal + HoldQueueModal）；tsc/lint clean
- \`PYTHONIOENCODING=utf-8 python tools/bump_version.py validate\` → ok
  (2 个 warning 跟旧版本有关，不阻塞)

## 风险 / 回滚

删 flag = feature 默认全开。生产发现问题需重新发版回滚（不能像 PR-2~4
那样靠 env 关闭）。决策依据：

- PR-0 spike 已端到端验证 Windows 信号链路
- PR-1~4 单测 109 case 全过
- ADR §5.7 config snapshot freeze 让 paused task 跟用户后续改 config
  解耦，"灰度激活时 config 漂移" 风险已 design-out
- 用户主动选删 flag 而不是默认 on + DISABLE_PAUSE_RESUME 兜底

## 不在本 PR

- bump_version 到 0.9.0 + 重 render CHANGELOG.md（CONTRIBUTING.md 流程：
  maintainer 走 release PR 时做）
- 详细 user-guide 文档（按用户偏好不写，详细留 ADR + design doc）
- spike 脚本 cleanup（待 0.9.0 ship 后单独 PR 删 tools/spike/，保留
  spike report 作为历史证据）
- E2E 真训练栈手测（建议 0.9.0 release 前跑一次：pause N step → resume
  → 验证 global_step + loss 连续；Windows + POSIX 各一次）

Refs: ADR 0006 / release-notes spec / CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)