### PR TITLE
fix(train): ARB 桶尾零头不丢图 + __len__ 按桶算

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@
 
 ---
 
+## [0.8.3] — 2026-05-19
+
+hotfix：ARB 桶不再丢小桶图 + 每 epoch step 数按桶算
+
+### 修复
+
+- **ARB 桶尾不足 batch_size 时整桶被丢 → 改成出短 batch（对齐 kohya / ai-toolkit）**
+  `BucketBatchSampler` 默认 `drop_last=True`：每个 ARB 桶里
+  `len(bucket) % batch_size` 张图被丢。最严重的是
+  **桶 size < batch_size 时整桶被丢**，例如 batch_size=2
+  时所有单图奇形比例的桶都永远训不到。
+
+  排查 git history：`drop_last=True` 是 ARB 初版（commit
+  `6774079` "feat: add arb"，2026-02-08）默认写下的，没有
+  commit message / ADR 解释设计意图，应是沿用 PyTorch
+  `DataLoader` 的卫生默认 —— 但 ARB 场景下 trade-off 已经
+  翻转：普通 DataLoader 一个 epoch 丢 1 个零头，ARB 是
+  **每个桶各丢一个零头**，丢失量随桶数线性放大。
+
+  - `phases/dataset.py`：`drop_last=False`，对齐 kohya
+    `sd-scripts`（`math.ceil(len/bs)`）与 ostris `ai-toolkit`
+    （`min(end_idx, len(bucket))`）的「短 batch 不丢」语义
+  - diffusion DiT 用 LayerNorm/GroupNorm，对动态 batch
+    不敏感；`loop.py` 已按 `latents.shape[0]` 动态读 bs，
+    短 batch 不会引入数值问题
+
+- **BucketBatchSampler.__len__ 按桶算（之前用全局 n/bs 偏）**
+  `__len__` 之前用全局 `n // batch_size`（或 `ceil(n/bs)`），
+  但 ARB 实际 batch 数 = `Σ_b f(n_b, bs)`，每桶各自有零头。
+  全局公式低估 batch 数 → `steps_per_epoch` 偏 → scheduler
+  `total_steps` 偏 → 末尾几步 LR 不对齐。
+
+  例：数据集 129 张 + batch_size=2，日志报「每 epoch 步数: 64」
+  （=129//2），但实际跑出来按桶 floor 求和会更小（每桶各掉一个
+  零头）。修后按桶遍历 `bucket_for_index` 分别 floor/ceil 求和。
+
+  加 `tests/test_bucket_batch_sampler.py` 覆盖：小桶不丢 / 历史
+  drop_last=True 行为 / `__len__` 按桶算 / `__len__` == 实际
+  yield 的 batch 数 / 无桶信息时退回全局公式。
+
+---
+
 ## [0.8.2] — 2026-05-17
 
 hotfix：预设系统脱钩 redesign + hf-mirror 暂不可用 + 新建预设预览补齐项目路径

--- a/release_notes.yaml
+++ b/release_notes.yaml
@@ -5,6 +5,49 @@
 #
 # 顺序：最新版本在 list 顶。
 
+- version: "0.8.3"
+  date: "2026-05-19"
+  summary: "hotfix：ARB 桶不再丢小桶图 + 每 epoch step 数按桶算"
+  entries:
+    - kind: fixed
+      summary: "ARB 桶尾不足 batch_size 时整桶被丢 → 改成出短 batch（对齐 kohya / ai-toolkit）"
+      detail: |
+        `BucketBatchSampler` 默认 `drop_last=True`：每个 ARB 桶里
+        `len(bucket) % batch_size` 张图被丢。最严重的是
+        **桶 size < batch_size 时整桶被丢**，例如 batch_size=2
+        时所有单图奇形比例的桶都永远训不到。
+
+        排查 git history：`drop_last=True` 是 ARB 初版（commit
+        `6774079` "feat: add arb"，2026-02-08）默认写下的，没有
+        commit message / ADR 解释设计意图，应是沿用 PyTorch
+        `DataLoader` 的卫生默认 —— 但 ARB 场景下 trade-off 已经
+        翻转：普通 DataLoader 一个 epoch 丢 1 个零头，ARB 是
+        **每个桶各丢一个零头**，丢失量随桶数线性放大。
+
+        - `phases/dataset.py`：`drop_last=False`，对齐 kohya
+          `sd-scripts`（`math.ceil(len/bs)`）与 ostris `ai-toolkit`
+          （`min(end_idx, len(bucket))`）的「短 batch 不丢」语义
+        - diffusion DiT 用 LayerNorm/GroupNorm，对动态 batch
+          不敏感；`loop.py` 已按 `latents.shape[0]` 动态读 bs，
+          短 batch 不会引入数值问题
+
+    - kind: fixed
+      summary: "BucketBatchSampler.__len__ 按桶算（之前用全局 n/bs 偏）"
+      detail: |
+        `__len__` 之前用全局 `n // batch_size`（或 `ceil(n/bs)`），
+        但 ARB 实际 batch 数 = `Σ_b f(n_b, bs)`，每桶各自有零头。
+        全局公式低估 batch 数 → `steps_per_epoch` 偏 → scheduler
+        `total_steps` 偏 → 末尾几步 LR 不对齐。
+
+        例：数据集 129 张 + batch_size=2，日志报「每 epoch 步数: 64」
+        （=129//2），但实际跑出来按桶 floor 求和会更小（每桶各掉一个
+        零头）。修后按桶遍历 `bucket_for_index` 分别 floor/ceil 求和。
+
+        加 `tests/test_bucket_batch_sampler.py` 覆盖：小桶不丢 / 历史
+        drop_last=True 行为 / `__len__` 按桶算 / `__len__` == 实际
+        yield 的 batch 数 / 无桶信息时退回全局公式。
+
+
 - version: "0.8.2"
   date: "2026-05-17"
   summary: "hotfix：预设系统脱钩 redesign + hf-mirror 暂不可用 + 新建预设预览补齐项目路径"

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -380,10 +380,27 @@ class BucketBatchSampler:
         self.epoch = int(epoch)
 
     def __len__(self):
-        n = len(self.dataset)
-        if self.drop_last:
-            return n // self.batch_size
-        return (n + self.batch_size - 1) // self.batch_size
+        # ARB 下实际 batch 数 = Σ_bucket f(n_b, bs)；用全局 n 会偏（每桶各自有零头）。
+        # 没有桶信息时退回到全局公式（线性 DataLoader 行为）。
+        if self._cached_dataset is None:
+            n = len(self.dataset)
+            if self.drop_last:
+                return n // self.batch_size
+            return (n + self.batch_size - 1) // self.batch_size
+        counts = {}
+        for idx in range(len(self.dataset)):
+            base_idx = idx % self._base_len
+            bucket = self._cached_dataset.bucket_for_index[base_idx]
+            if bucket is None:
+                bucket = (0, 0)
+            counts[bucket] = counts.get(bucket, 0) + 1
+        total = 0
+        for n in counts.values():
+            if self.drop_last:
+                total += n // self.batch_size
+            else:
+                total += (n + self.batch_size - 1) // self.batch_size
+        return total
 
     def __iter__(self):
         rng = random.Random(self.seed + self.epoch)

--- a/runtime/training/phases/dataset.py
+++ b/runtime/training/phases/dataset.py
@@ -92,9 +92,12 @@ def run(ctx: TrainingContext) -> None:
         args.num_workers = 0
 
     if ctx.use_cached:
+        # drop_last=False：桶尾不足 batch_size 出短 batch 而非丢图。
+        # 对齐 kohya sd-scripts / ostris ai-toolkit；diffusion 用 LayerNorm/GroupNorm，
+        # 对动态 batch 不敏感，loop.py 也按 latents.shape[0] 动态读 bs。
         batch_sampler = BucketBatchSampler(
             ctx.dataset, batch_size=args.batch_size,
-            drop_last=True, shuffle=True,
+            drop_last=False, shuffle=True,
             seed=getattr(args, "seed", 42),
         )
         ctx.dataloader = DataLoader(

--- a/tests/test_bucket_batch_sampler.py
+++ b/tests/test_bucket_batch_sampler.py
@@ -1,0 +1,86 @@
+"""ARB BucketBatchSampler 回归：桶尾零头不丢图 + __len__ 按桶算。
+
+旧默认 drop_last=True 写死 → 桶 size < batch_size 时整桶被丢（单图奇形比例图永远训不到）；
+__len__ 用全局 n/bs，没按桶各自零头算 → steps_per_epoch / total_steps / scheduler 都偏。
+对齐 kohya sd-scripts / ostris ai-toolkit 的「短 batch 不丢」语义。
+"""
+from __future__ import annotations
+
+from training.dataset import BucketBatchSampler
+
+
+class _MockBucketedDataset:
+    """模拟 CachedLatentDataset：暴露 bucket_for_index 给 BucketBatchSampler 走桶分支。"""
+    def __init__(self, bucket_for_index):
+        self.bucket_for_index = list(bucket_for_index)
+
+    def __len__(self):
+        return len(self.bucket_for_index)
+
+    def __getitem__(self, idx):
+        return idx
+
+
+def test_small_bucket_yields_short_batch_when_drop_last_false():
+    bucket_for_index = [(1, 1), (2, 2), (2, 2)]
+    ds = _MockBucketedDataset(bucket_for_index)
+    sampler = BucketBatchSampler(ds, batch_size=2, drop_last=False, shuffle=False)
+    all_indices = sorted(idx for batch in sampler for idx in batch)
+    assert all_indices == [0, 1, 2]
+
+
+def test_small_bucket_dropped_when_drop_last_true():
+    """记录历史行为：drop_last=True 时单图桶被整桶丢（回归保护，防误改默认）。"""
+    bucket_for_index = [(1, 1), (2, 2), (2, 2)]
+    ds = _MockBucketedDataset(bucket_for_index)
+    sampler = BucketBatchSampler(ds, batch_size=2, drop_last=True, shuffle=False)
+    all_indices = sorted(idx for batch in sampler for idx in batch)
+    assert all_indices == [1, 2]
+
+
+def test_len_counts_per_bucket_not_globally_drop_last_false():
+    bucket_for_index = [(1, 1), (1, 1), (1, 1), (2, 2)]
+    ds = _MockBucketedDataset(bucket_for_index)
+    sampler = BucketBatchSampler(ds, batch_size=2, drop_last=False, shuffle=False)
+    assert len(sampler) == 3
+    assert sum(1 for _ in sampler) == 3
+
+
+def test_len_counts_per_bucket_not_globally_drop_last_true():
+    bucket_for_index = [(1, 1)] * 3 + [(2, 2)] * 5
+    ds = _MockBucketedDataset(bucket_for_index)
+    sampler = BucketBatchSampler(ds, batch_size=2, drop_last=True, shuffle=False)
+    assert len(sampler) == 3
+    assert sum(1 for _ in sampler) == 3
+
+
+def test_len_matches_iter_count_realistic_distribution():
+    sizes = [30, 27, 25, 24, 23]
+    assert sum(sizes) == 129
+    bucket_for_index = []
+    for i, n in enumerate(sizes):
+        bucket_for_index += [(i, i)] * n
+    ds = _MockBucketedDataset(bucket_for_index)
+
+    sampler_drop = BucketBatchSampler(ds, batch_size=2, drop_last=True, shuffle=False)
+    actual_drop = sum(1 for _ in sampler_drop)
+    assert len(sampler_drop) == actual_drop == 63
+
+    sampler_keep = BucketBatchSampler(ds, batch_size=2, drop_last=False, shuffle=False)
+    actual_keep = sum(1 for _ in sampler_keep)
+    assert len(sampler_keep) == actual_keep == 66
+
+
+def test_len_falls_back_to_global_when_no_bucket_info():
+    class _PlainDataset:
+        def __init__(self, n):
+            self._n = n
+        def __len__(self):
+            return self._n
+        def __getitem__(self, idx):
+            return idx
+
+    sampler = BucketBatchSampler(_PlainDataset(10), batch_size=3, drop_last=True, shuffle=False)
+    assert len(sampler) == 3
+    sampler = BucketBatchSampler(_PlainDataset(10), batch_size=3, drop_last=False, shuffle=False)
+    assert len(sampler) == 4


### PR DESCRIPTION
## Summary
- `BucketBatchSampler` 默认 `drop_last=True` 把每个 ARB 桶里 `len(bucket) % batch_size` 张图丢掉；最严重的是**桶 size < batch_size 时整桶丢**（例如 bs=2 时所有单图奇形比例桶永远训不到）。改成 `False`，桶尾出短 batch
- 顺带修 `__len__`：之前用全局 `n // batch_size` 算，没考虑 ARB 每桶各自零头，`steps_per_epoch` 偏低 → scheduler `total_steps` 偏 → 末尾 LR 不对齐。改成按桶遍历 `bucket_for_index` 分别 floor/ceil 求和
- 对齐 kohya sd-scripts（`math.ceil`）与 ostris ai-toolkit（`min(end_idx)`）的「短 batch 不丢」语义
- diffusion DiT 用 LayerNorm/GroupNorm 对动态 batch 不敏感，`loop.py` 按 `latents.shape[0]` 动态读 bs，短 batch 不引入数值问题
- 历史考古：`drop_last=True` 是 ARB 初版（commit `6774079`，2026-02-08）默认写下的，没有 commit message / ADR 解释，应是沿用 PyTorch 卫生默认 —— 但 ARB 场景 trade-off 已翻转（每桶各丢一个零头，丢失量随桶数线性放大）

## Test plan
- [x] `tests/test_bucket_batch_sampler.py` 新增 6 条 — 桶 size=1 不丢 / 旧 `drop_last=True` 行为回归保护 / `__len__` 按桶算两种 drop_last / 129 张分 5 桶真实分布（drop=63 ≠ 旧 64；keep=66 ≠ 旧 65）/ 无桶信息退回全局
- [x] `tests/test_anima_train_migration.py` 8 条邻近回归 passing
- [x] `tools/bump_version.py validate` ok
- [x] `tools/bump_version.py render-changelog` 派生 0.8.3 block 干净（没错挂旧 entries）
- [ ] 用户实战：data=129、batch_size=2 时日志「每 epoch 步数」应小于 64（按桶 floor），不再是 129//2

🤖 Generated with [Claude Code](https://claude.com/claude-code)