### PR TITLE
feat(tag): trigger word — Step 4 填一次，自动写入 caption + sample_prompt

### DIFF
--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -62,6 +62,33 @@ def _maybe_apply_pause_snapshot(args, resume_state_path: Path) -> None:
         args.sample_prompts = sp
 
 
+def _prepend_trigger_to_sample_prompts(args) -> None:
+    """trigger_word 非空 → prepend 到 sample_prompt / sample_prompts 每条。
+
+    与 caption 端行为一致（tag_worker 也把 trigger 写为第一个 tag）：训练
+    采样图必带 trigger，能直观验证 LoRA 是否激活。判定"已含 trigger"用 token
+    级匹配（按逗号 split 后等值比较，不区分大小写），避免被 substring 误判。
+    空 prompt 不注入，防止生成残缺的 ``"trigger, "`` 字符串。
+    """
+    trigger = (getattr(args, "trigger_word", "") or "").strip()
+    if not trigger:
+        return
+    lower = trigger.lower()
+
+    def _contains(prompt: str) -> bool:
+        return any(t.strip().lower() == lower for t in prompt.split(",") if t.strip())
+
+    sp = getattr(args, "sample_prompt", "") or ""
+    if sp and not _contains(sp):
+        args.sample_prompt = f"{trigger}, {sp}"
+
+    sps = getattr(args, "sample_prompts", None) or []
+    if sps:
+        args.sample_prompts = [
+            (f"{trigger}, {p}" if (p and not _contains(p)) else p) for p in sps
+        ]
+
+
 def run(ctx: TrainingContext) -> None:
     """完成训练前一切非模型/数据的准备：
 
@@ -111,6 +138,12 @@ def run(ctx: TrainingContext) -> None:
     if args.interactive or any(not x for x in required):
         ctx.args = prompt_for_args(args)
         args = ctx.args
+
+    # 触发词注入：caption 端 tag_worker 把 trigger 写为第一个 tag，这里同步
+    # 注入 sample_prompt(s)，让采样图天然带 trigger。pause snapshot 已 freeze
+    # trigger_word（写在 args 里），resume 也照此 normalize 一次幂等。
+    _prepend_trigger_to_sample_prompts(args)
+    ctx.args = args
 
     # 依赖检测
     ensure_dependencies(auto_install=args.auto_install)

--- a/studio/migrations/__init__.py
+++ b/studio/migrations/__init__.py
@@ -19,6 +19,7 @@ from ._v3_monitor_state import migrate as _migrate_v3
 from ._v4_task_config_path import migrate as _migrate_v4
 from ._v5_task_type import migrate as _migrate_v5
 from ._v6_pause_resume import migrate as _migrate_v6
+from ._v7_version_trigger_word import migrate as _migrate_v7
 
 Migration = Callable[[sqlite3.Connection], None]
 
@@ -29,6 +30,7 @@ MIGRATIONS: list[Migration] = [
     _migrate_v4,  # v4: tasks.config_path（PP6.3 私有 config 路径）
     _migrate_v5,  # v5: tasks.task_type（PR-9 区分 train / reg_ai / generate）
     _migrate_v6,  # v6: tasks.paused_* 列 + queue_settings 表（ADR 0006 PR-2）
+    _migrate_v7,  # v7: versions.trigger_word（触发词字段）
 ]
 
 

--- a/studio/migrations/_v7_version_trigger_word.py
+++ b/studio/migrations/_v7_version_trigger_word.py
@@ -1,0 +1,18 @@
+"""v6 → v7: versions.trigger_word — 项目级触发词由 Step 4 (Tagging) 填写。
+
+加列 `versions.trigger_word TEXT DEFAULT ''`。空串语义 = 不启用触发词。
+Tag worker 用它在写 caption 时 prepend 第一个 tag；version_config 把它注入
+私有 yaml，runtime bootstrap_phase 顺便把它注入 sample_prompt/sample_prompts。
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from ._v2_projects import _add_column_if_missing
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    _add_column_if_missing(
+        conn, "versions", "trigger_word",
+        "trigger_word TEXT NOT NULL DEFAULT ''"
+    )

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -643,6 +643,13 @@ class TrainingConfig(BaseModel):
         description="多 prompt 轮换（优先于 sample_prompt）",
         json_schema_extra=_meta("sample", "string-list"),
     )
+    trigger_word: str = Field(
+        "",
+        description="触发词（version 级，由 Step 4 Tagging 页面写入；空串=不启用）。"
+                    "训练时 bootstrap_phase 会自动 prepend 到 sample_prompt / "
+                    "sample_prompts，确保采样图能反映 LoRA 是否激活。",
+        json_schema_extra=_meta("sample", hidden=True),
+    )
 
     # ---------------------------------------------------------------- 监控/进度
     # 这一组对 Studio 用户全部隐藏（hidden=True）—— Studio 跑训练用 subprocess 把

--- a/studio/server.py
+++ b/studio/server.py
@@ -632,6 +632,7 @@ class VersionUpdate(BaseModel):
     note: Optional[str] = None
     stage: Optional[str] = None
     config_name: Optional[str] = None
+    trigger_word: Optional[str] = None
 
 
 def _project_payload(p: dict[str, Any]) -> dict[str, Any]:
@@ -1644,6 +1645,9 @@ class TagJobRequest(BaseModel):
     wd14_overrides: Optional[Wd14Overrides] = None
     cltagger_overrides: Optional[CLTaggerOverrides] = None
     llm_overrides: Optional[LLMTaggerOverrides] = None
+    # 触发词；空串 / None = 不启用。打标时作为第一个 tag prepend 到 caption；
+    # 同时持久化到 version.trigger_word，后续 train 阶段从私有 yaml 读出。
+    trigger_word: Optional[str] = None
 
 
 class LLMModelsRefreshRequest(BaseModel):
@@ -1960,11 +1964,18 @@ def start_tag(pid: int, vid: int, body: TagJobRequest) -> dict[str, Any]:
         raise HTTPException(400, "output_format must be txt|json")
     _, v, _ = _version_train_dir_or_404(pid, vid)
 
+    # 触发词：先 strip，落到 version 表（持久化，TagEdit / Train 都能读），再
+    # 顺手放进 worker params。body.trigger_word=None 表示前端没传字段（不改
+    # version 现有值）；空串 "" 表示用户主动清空。
+    trigger_word = body.trigger_word.strip() if body.trigger_word is not None else None
+
     params: dict[str, Any] = {
         "tagger": body.tagger,
         "version_id": vid,
         "output_format": body.output_format,
     }
+    if trigger_word:
+        params["trigger_word"] = trigger_word
     # 通用：按 tagger 名取 `<name>_overrides` 字段并落到 params 同名键。
     # 仅保留用户实际填写的字段；空 dict 也不写。
     overrides_field = getattr(body, f"{body.tagger}_overrides", None)
@@ -1974,6 +1985,10 @@ def start_tag(pid: int, vid: int, body: TagJobRequest) -> dict[str, Any]:
             params[f"{body.tagger}_overrides"] = ov
 
     with db.connection_for() as conn:
+        if trigger_word is not None and trigger_word != (v.get("trigger_word") or ""):
+            updated = versions.update_version(conn, vid, trigger_word=trigger_word)
+            _publish_version_state(updated)
+            v = updated
         job = project_jobs.create_job(
             conn,
             project_id=pid,

--- a/studio/services/version_config.py
+++ b/studio/services/version_config.py
@@ -40,6 +40,7 @@ PROJECT_SPECIFIC_FIELDS: frozenset[str] = frozenset({
     "output_name",
     "resume_lora",
     "resume_state",
+    "trigger_word",
 })
 
 
@@ -51,6 +52,8 @@ def project_specific_overrides(
     `data_dir` / `output_dir` / `output_name` 永远确定地填上；
     `reg_data_dir` 只有 reg 集存在（meta.json）才填，否则空（让 trainer 走默认）。
     `resume_lora` / `resume_state` 默认空 —— 用户要接续训练时显式 PUT 改写。
+    `trigger_word` 来自 version 表（Step 4 Tagging 写入），保证 yaml 与 caption
+    同源，runtime bootstrap_phase 会据此把 trigger 注入 sample_prompt。
     """
     pid = int(project["id"])
     slug = str(project["slug"])
@@ -62,6 +65,7 @@ def project_specific_overrides(
         "output_name": f"{slug}_{label}",
         "resume_lora": None,
         "resume_state": None,
+        "trigger_word": str(version.get("trigger_word") or ""),
     }
     reg_meta = vdir / "reg" / "meta.json"
     if reg_meta.exists():

--- a/studio/versions.py
+++ b/studio/versions.py
@@ -395,7 +395,7 @@ def _copytree(src: Path, dst: Path) -> None:
             shutil.copy2(sub, target)
 
 
-_UPDATABLE = {"note", "stage", "config_name", "output_lora_path"}
+_UPDATABLE = {"note", "stage", "config_name", "output_lora_path", "trigger_word"}
 
 
 def update_version(

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -551,6 +551,8 @@ export interface Version {
   created_at: number
   output_lora_path: string | null
   note: string | null
+  /** 触发词；由 Step 4 (Tagging) 写入，打标时 prepend 到每张 caption；空串=未启用。 */
+  trigger_word: string
   stats?: VersionStats
 }
 
@@ -1480,6 +1482,11 @@ export const api = {
       llm_overrides?:
         & { current_preset?: string }
         & Partial<Omit<LLMPreset, 'id' | 'label' | 'builtin' | 'api_key' | 'model_ids'>>
+      /**
+       * 触发词；空串 / undefined = 不启用。worker 端写 caption 时 prepend 为
+       * 第一个 tag，并同步落库到 version.trigger_word，后续 train 读出。
+       */
+      trigger_word?: string
     }
   ) =>
     req<Job>(`/api/projects/${pid}/versions/${vid}/tag`, {

--- a/studio/web/src/components/ProjectStepper.test.tsx
+++ b/studio/web/src/components/ProjectStepper.test.tsx
@@ -30,6 +30,7 @@ function version(stage: Version['stage']): Version {
     created_at: 0,
     output_lora_path: null,
     note: null,
+    trigger_word: '',
   }
 }
 

--- a/studio/web/src/components/VersionTabs.test.tsx
+++ b/studio/web/src/components/VersionTabs.test.tsx
@@ -14,6 +14,7 @@ const versions: Version[] = [
     created_at: 0,
     output_lora_path: null,
     note: null,
+    trigger_word: '',
   },
   {
     id: 2,
@@ -24,6 +25,7 @@ const versions: Version[] = [
     created_at: 1,
     output_lora_path: null,
     note: null,
+    trigger_word: '',
   },
 ]
 

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1207,7 +1207,9 @@
     "noImagesWithTag": "No images contain «{{tag}}»",
     "noImagesHint": "No images yet. Complete the curation and tagging steps first.",
     "selectedContaining": "Selected {{n}} images containing «{{tag}}»",
-    "savedToast": "Saved {{written}} images, restore point {{id}}"
+    "savedToast": "Saved {{written}} images, restore point {{id}}",
+    "triggerWord": "trigger",
+    "triggerWordHint": "Already written as the first token of every caption during Step 4 (Tagging). To change it, go back to Step 4, update the trigger word, and re-tag."
   },
   "download": {
     "tagEmpty": "Tag cannot be empty",
@@ -1420,7 +1422,10 @@
     "taggingEnqueued": "Queued #{{id}}",
     "taggingEnqueuedOverrides": " ({{n}} overrides)",
     "taggerUnavailable": "{{tagger}} unavailable: {{msg}}",
-    "cancelToast": "Cancelled"
+    "cancelToast": "Cancelled",
+    "triggerWord": "trigger word",
+    "triggerWordPlaceholder": "e.g. ohwx / mychar",
+    "triggerWordHint": "Prepended as the first tag of every caption during tagging; empty = disabled. Changing this and starting tagging will persist it to the current version."
   },
   "presets": {
     "loadSchemaFailed": "Failed to load schema: {{error}}",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1207,7 +1207,9 @@
     "noImagesWithTag": "没有图含「{{tag}}」",
     "noImagesHint": "还没有图。请先在筛选和打标步骤完成操作。",
     "selectedContaining": "已选含「{{tag}}」的 {{n}} 张",
-    "savedToast": "已保存 {{written}} 张，还原点 {{id}}"
+    "savedToast": "已保存 {{written}} 张，还原点 {{id}}",
+    "triggerWord": "触发词",
+    "triggerWordHint": "Step 4 打标时已写入每张 caption 第一位。要改，回 Step 4 改触发词并重新打标。"
   },
   "download": {
     "tagEmpty": "tag 不能为空",
@@ -1420,7 +1422,10 @@
     "taggingEnqueued": "已入队 #{{id}}",
     "taggingEnqueuedOverrides": "（含 {{n}} 项覆盖）",
     "taggerUnavailable": "{{tagger}} 不可用：{{msg}}",
-    "cancelToast": "已取消"
+    "cancelToast": "已取消",
+    "triggerWord": "触发词",
+    "triggerWordPlaceholder": "如 ohwx / mychar",
+    "triggerWordHint": "打标时作为第一个 tag 写入每张 caption；空 = 不启用。改后启动打标会同步落库到当前 version。"
   },
   "presets": {
     "loadSchemaFailed": "schema 加载失败: {{error}}",

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -244,6 +244,12 @@ export default function TagEditPage() {
       subtitle={t('tagEdit.subtitle')}
       actions={
         <>
+          {activeVersion.trigger_word && (
+            <span className="badge badge-neutral" title={t('tagEdit.triggerWordHint')}>
+              {t('tagEdit.triggerWord')}:{' '}
+              <code className="font-mono">{activeVersion.trigger_word}</code>
+            </span>
+          )}
           {stats && (
             <span className={allTagged ? 'badge badge-ok' : 'badge badge-neutral'}>
               {t('tagEdit.taggedBadge', { tagged: taggedTotal, total: trainTotal })}

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -116,6 +116,9 @@ export default function TaggingPage() {
   const [tagger, setTagger] = useState<TaggerName>('wd14')
   const [taggerStatus, setTaggerStatus] = useState<TaggerStatus | null>(null)
   const [outputFormat, setOutputFormat] = useState<'txt' | 'json'>('txt')
+  // 触发词：初值从 activeVersion 取（持久化在 version 表）；启动打标时一并提交，
+  // 后端会同步落库 + 传给 worker prepend 到每张 caption。
+  const [triggerWord, setTriggerWord] = useState<string>('')
 
   const [wd14Defaults, setWd14Defaults] = useState<WD14Config | null>(null)
   const [wd14Form, setWd14Form] = useState<Wd14Form | null>(null)
@@ -168,6 +171,11 @@ export default function TaggingPage() {
       })
       .catch(() => {})
   }, [project.id, vid])
+
+  // version 切换时同步 triggerWord 初值（持久化字段，避免回到 "" 让用户以为没保存）
+  useEffect(() => {
+    setTriggerWord(activeVersion?.trigger_word ?? '')
+  }, [activeVersion?.id, activeVersion?.trigger_word])
 
   useEventStream((evt) => {
     const jid = jobIdRef.current
@@ -253,13 +261,20 @@ export default function TaggingPage() {
       const cltagger_overrides = tagger === 'cltagger' ? buildCLTaggerOverrides() : undefined
       const llm_overrides = tagger === 'llm' ? buildLLMOverrides() : undefined
       const overrides = wd14_overrides ?? cltagger_overrides ?? llm_overrides
+      const trigger = triggerWord.trim()
       const j = await api.startTag(project.id, activeVersion.id, {
         tagger, output_format: outputFormat, wd14_overrides, cltagger_overrides, llm_overrides,
+        // 传 trigger 永远，让 server 决定是否落库（与现有值比较），空串显式清空
+        trigger_word: trigger,
       })
       setJob(j)
       setLogs([])
       const note = overrides ? t('tag.taggingEnqueuedOverrides', { n: Object.keys(overrides).length }) : ''
       toast(t('tag.taggingEnqueued', { id: j.id }) + note, 'success')
+      // 触发词改了 → 让父级 reload version 状态，下次重渲染拿新的 trigger_word
+      if (trigger !== (activeVersion.trigger_word ?? '')) {
+        void reload()
+      }
     } catch (e) {
       toast(String(e), 'error')
     }
@@ -330,6 +345,23 @@ export default function TaggingPage() {
               <option value="txt">.txt</option>
               <option value="json">.json</option>
             </select>
+
+            <span className="text-dim">|</span>
+            <span className="text-fg-tertiary" title={t('tag.triggerWordHint')}>
+              {t('tag.triggerWord')}
+            </span>
+            <input
+              type="text"
+              value={triggerWord}
+              onChange={(e) => setTriggerWord(e.target.value)}
+              placeholder={t('tag.triggerWordPlaceholder')}
+              disabled={isLive}
+              className={`input input-mono text-sm ${
+                triggerWord.trim() !== (activeVersion.trigger_word ?? '') ? 'border-warn' : ''
+              }`}
+              style={{ padding: '3px 8px', width: 180 }}
+              title={t('tag.triggerWordHint')}
+            />
 
             <span className="flex-1" />
           </section>

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -78,6 +78,8 @@ def run(job_id: int) -> int:
         tagger_name = params.get("tagger", "wd14")
         version_id = int(params["version_id"])
         fmt = str(params.get("output_format", "txt"))
+        # 触发词：worker 端 prepend 到 caption 第一位。空串 / 缺省 = 不启用。
+        trigger_word = str(params.get("trigger_word") or "").strip()
         # 约定：每个支持本次覆盖的 tagger 都把 overrides 存在 `<name>_overrides` 键下
         overrides = params.get(f"{tagger_name}_overrides") or None
 
@@ -99,6 +101,8 @@ def run(job_id: int) -> int:
             f"[start] tagger={tagger_name} version={v['label']} "
             f"images={len(images)} format={fmt}"
         )
+        if trigger_word:
+            progress(f"[trigger] '{trigger_word}' 将作为第一个 tag prepend 到每张图")
 
         tagger = get_tagger(tagger_name, overrides=overrides)
         tagger.prepare()
@@ -124,6 +128,7 @@ def run(job_id: int) -> int:
                 fmt,
                 caption_text=r.get("caption"),
                 caption_json=r.get("caption_json"),
+                trigger_word=trigger_word,
             )
             ok += 1
         progress(f"[done] tagged {ok}/{len(images)} (errors={errs})")
@@ -134,6 +139,27 @@ def run(job_id: int) -> int:
         return 1
 
 
+def _prepend_trigger_to_tags(tags: list[str], trigger_word: str) -> list[str]:
+    """trigger 作为第一个 tag 注入；已存在（case-insensitive）则跳过。"""
+    if not trigger_word:
+        return list(tags)
+    lower = trigger_word.lower()
+    if any((t or "").strip().lower() == lower for t in tags):
+        return list(tags)
+    return [trigger_word, *tags]
+
+
+def _prepend_trigger_to_text(text: str, trigger_word: str) -> str:
+    """trigger prepend 到逗号分隔的 caption 字符串；已存在则跳过。"""
+    if not trigger_word:
+        return text
+    lower = trigger_word.lower()
+    tokens = [t.strip() for t in text.split(",")]
+    if any(t.lower() == lower for t in tokens if t):
+        return text
+    return f"{trigger_word}, {text}" if text else trigger_word
+
+
 def _write_caption(
     image: Path,
     tags: list[str],
@@ -141,34 +167,67 @@ def _write_caption(
     *,
     caption_text: str | None = None,
     caption_json: dict[str, Any] | None = None,
+    trigger_word: str = "",
 ) -> None:
-    """fmt 仅决定「不存在 caption 时」用什么格式；已存在的 .json 仍走 .json。"""
+    """fmt 仅决定「不存在 caption 时」用什么格式；已存在的 .json 仍走 .json。
+
+    trigger_word 非空时：
+      - 标签列表：作为第 0 项 prepend（去重）
+      - 字符串 caption：prepend 到最前
+      - JSON：写入 ``meta.trigger`` 字段；caption_utils.build_caption_from_json
+        会把它作为输出的第一个 token，不参与 shuffle —— 与 .txt 路径行为一致。
+    """
     if caption_json is not None:
         if fmt == "json":
+            doc = standard_to_documented_full(caption_json)
+            if trigger_word:
+                meta = doc.get("meta")
+                if not isinstance(meta, dict):
+                    meta = {}
+                meta["trigger"] = trigger_word
+                doc["meta"] = meta
             image.with_suffix(".json").write_text(
-                json.dumps(
-                    standard_to_documented_full(caption_json),
-                    ensure_ascii=False,
-                    indent=2,
-                ),
+                json.dumps(doc, ensure_ascii=False, indent=2),
                 encoding="utf-8",
             )
             image.with_suffix(".txt").unlink(missing_ok=True)
             return
         text = caption_text if caption_text is not None else caption_json_to_text(caption_json)
+        text = _prepend_trigger_to_text(text, trigger_word)
         image.with_suffix(".txt").write_text(text, encoding="utf-8")
         image.with_suffix(".json").unlink(missing_ok=True)
         return
     if fmt == "json" and not image.with_suffix(".txt").exists():
         # 强制写 json（即使没有现成 json 文件）
-        data = {"tags": list(tags)}
+        data: dict[str, Any] = {"tags": _prepend_trigger_to_tags(tags, trigger_word)}
+        if trigger_word:
+            data["meta"] = {"trigger": trigger_word}
         image.with_suffix(".json").write_text(
             json.dumps(data, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
         return
-    # 否则交给 tagedit 决定（已有 .json 就写 .json，否则 .txt）
-    tagedit.write_tags(image, tags)
+    # 否则交给 tagedit 决定（已有 .json 就写 .json，否则 .txt）。
+    # 已有 .json 时 tagedit 保留其他字段（包括 meta.trigger 如有），只覆盖 tags 数组；
+    # 这里我们把 trigger prepend 进 tags list，并保证 .json 走 tagedit 的同时也补 meta.trigger。
+    new_tags = _prepend_trigger_to_tags(tags, trigger_word)
+    written = tagedit.write_tags(image, new_tags)
+    if trigger_word and written.suffix == ".json":
+        try:
+            existing = json.loads(written.read_text(encoding="utf-8"))
+        except Exception:
+            existing = {}
+        if not isinstance(existing, dict):
+            existing = {}
+        meta = existing.get("meta")
+        if not isinstance(meta, dict):
+            meta = {}
+        meta["trigger"] = trigger_word
+        existing["meta"] = meta
+        written.write_text(
+            json.dumps(existing, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
 
 
 def main() -> None:

--- a/tests/test_resume_path.py
+++ b/tests/test_resume_path.py
@@ -178,6 +178,85 @@ def test_snapshot_schema_wrong_falls_back(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# bootstrap_phase: _prepend_trigger_to_sample_prompts (PR #102 触发词功能)
+# ---------------------------------------------------------------------------
+
+
+def test_trigger_prepended_to_sample_prompt() -> None:
+    from runtime.training.phases.bootstrap import _prepend_trigger_to_sample_prompts
+
+    args = argparse.Namespace(
+        trigger_word="ohwx",
+        sample_prompt="1girl, masterpiece",
+        sample_prompts=[],
+    )
+    _prepend_trigger_to_sample_prompts(args)
+    assert args.sample_prompt == "ohwx, 1girl, masterpiece"
+
+
+def test_trigger_prepended_to_sample_prompts_list() -> None:
+    from runtime.training.phases.bootstrap import _prepend_trigger_to_sample_prompts
+
+    args = argparse.Namespace(
+        trigger_word="ohwx",
+        sample_prompt="",
+        sample_prompts=["a cat", "a dog"],
+    )
+    _prepend_trigger_to_sample_prompts(args)
+    assert args.sample_prompts == ["ohwx, a cat", "ohwx, a dog"]
+
+
+def test_trigger_skips_when_already_present_token_match() -> None:
+    """trigger 在 prompt 里作为独立 token（逗号分隔后等值）→ 不重复 prepend。"""
+    from runtime.training.phases.bootstrap import _prepend_trigger_to_sample_prompts
+
+    args = argparse.Namespace(
+        trigger_word="ohwx",
+        sample_prompt="ohwx, 1girl",
+        sample_prompts=["1girl, ohwx, blue eyes", "OHWX, masterpiece"],
+    )
+    _prepend_trigger_to_sample_prompts(args)
+    assert args.sample_prompt == "ohwx, 1girl"
+    assert args.sample_prompts == [
+        "1girl, ohwx, blue eyes",      # 已含
+        "OHWX, masterpiece",            # case-insensitive 已含
+    ]
+
+
+def test_trigger_empty_or_missing_is_noop() -> None:
+    from runtime.training.phases.bootstrap import _prepend_trigger_to_sample_prompts
+
+    args = argparse.Namespace(
+        trigger_word="",
+        sample_prompt="1girl",
+        sample_prompts=["a cat"],
+    )
+    _prepend_trigger_to_sample_prompts(args)
+    assert args.sample_prompt == "1girl"
+    assert args.sample_prompts == ["a cat"]
+
+    # 字段缺失（老 yaml） — 不抛错
+    args2 = argparse.Namespace(sample_prompt="1girl", sample_prompts=["a"])
+    _prepend_trigger_to_sample_prompts(args2)
+    assert args2.sample_prompt == "1girl"
+    assert args2.sample_prompts == ["a"]
+
+
+def test_trigger_skips_empty_prompt_strings() -> None:
+    """空 prompt 字符串不被填成 "trigger, "（残缺值）。"""
+    from runtime.training.phases.bootstrap import _prepend_trigger_to_sample_prompts
+
+    args = argparse.Namespace(
+        trigger_word="ohwx",
+        sample_prompt="",
+        sample_prompts=["", "a cat", ""],
+    )
+    _prepend_trigger_to_sample_prompts(args)
+    assert args.sample_prompt == ""
+    assert args.sample_prompts == ["", "ohwx, a cat", ""]
+
+
+# ---------------------------------------------------------------------------
 # supervisor._clear_pause_artifacts
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tag_worker.py
+++ b/tests/test_tag_worker.py
@@ -218,6 +218,156 @@ def test_run_unknown_job(env) -> None:
     assert tag_worker.run(99999) == 1
 
 
+# ---------------------------------------------------------------------------
+# trigger_word (PR #102): tag worker 把 trigger 写为 caption 第一个 tag。
+# ---------------------------------------------------------------------------
+
+
+def _set_trigger(env, trigger: str) -> None:
+    with db.connection_for(env["db"]) as conn:
+        conn.execute(
+            "UPDATE project_jobs SET params = json_set(params, '$.trigger_word', ?) "
+            "WHERE id = ?",
+            (trigger, env["job_id"]),
+        )
+        conn.commit()
+
+
+def test_trigger_word_prepended_to_txt(env) -> None:
+    _set_trigger(env, "ohwx")
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    # trigger 是第一个 tag；原始 tagger 给的 ["tag_a", "common"] 跟在后面
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "ohwx, tag_a, common"
+    assert (env["train"] / "b.txt").read_text(encoding="utf-8") == "ohwx, tag_b, common"
+
+
+def test_trigger_word_writes_meta_in_simple_json(env) -> None:
+    """fmt=json + tagger 只给 tags list（无 caption_json）→ meta.trigger 写入。"""
+    _set_trigger(env, "ohwx")
+    with db.connection_for(env["db"]) as conn:
+        conn.execute(
+            "UPDATE project_jobs SET params = json_set(params, '$.output_format', 'json') "
+            "WHERE id = ?",
+            (env["job_id"],),
+        )
+        conn.commit()
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    data = json.loads((env["train"] / "a.json").read_text(encoding="utf-8"))
+    assert data["tags"] == ["ohwx", "tag_a", "common"]
+    assert data["meta"]["trigger"] == "ohwx"
+
+
+def test_trigger_word_writes_meta_in_llm_json(env, monkeypatch) -> None:
+    """LLM tagger + fmt=json → documented_full 增加顶层 meta.trigger。"""
+    _set_trigger(env, "ohwx")
+    monkeypatch.setattr(
+        "studio.workers.tag_worker.get_tagger",
+        lambda name, overrides=None: _FakeLLMTagger(),
+    )
+    with db.connection_for(env["db"]) as conn:
+        conn.execute(
+            "UPDATE project_jobs SET params = json_set(params, "
+            "'$.tagger', 'llm', '$.output_format', 'json') WHERE id = ?",
+            (env["job_id"],),
+        )
+        conn.commit()
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    data = json.loads((env["train"] / "a.json").read_text(encoding="utf-8"))
+    # documented_full 主体不变
+    assert data["ai_output"]["count"] == "1girl"
+    # 顶层 meta.trigger 注入
+    assert data["meta"]["trigger"] == "ohwx"
+
+
+def test_trigger_word_prepended_to_llm_txt(env, monkeypatch) -> None:
+    """LLM tagger + fmt=txt → caption_text 前 prepend trigger。"""
+    _set_trigger(env, "ohwx")
+    monkeypatch.setattr(
+        "studio.workers.tag_worker.get_tagger",
+        lambda name, overrides=None: _FakeLLMTagger(),
+    )
+    with db.connection_for(env["db"]) as conn:
+        conn.execute(
+            "UPDATE project_jobs SET params = json_set(params, '$.tagger', 'llm') "
+            "WHERE id = ?",
+            (env["job_id"],),
+        )
+        conn.commit()
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == (
+        "ohwx, 1girl, watercolor, blue background. Soft watercolor style."
+    )
+
+
+def test_trigger_word_idempotent_when_already_present(env) -> None:
+    """tagger 已经返回了 trigger（边界情况）→ 不重复 prepend（case-insensitive）。"""
+
+    class _TaggerWithTrigger:
+        name = "wd14"
+        requires_service = False
+
+        def is_available(self):
+            return True, "ok"
+
+        def prepare(self):
+            pass
+
+        def tag(self, paths, on_progress=lambda d, t: None):
+            for p in paths:
+                yield {"image": p, "tags": ["OHWX", "common"]}  # 大小写不同
+
+    _set_trigger(env, "ohwx")
+    import studio.workers.tag_worker as _tw
+    orig = _tw.get_tagger
+    _tw.get_tagger = lambda name, overrides=None: _TaggerWithTrigger()
+    try:
+        rc = tag_worker.run(env["job_id"])
+    finally:
+        _tw.get_tagger = orig
+    assert rc == 0
+    # 原 "OHWX" 保留（不替换大小写），不再前置一份小写的 "ohwx"
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "OHWX, common"
+
+
+def test_trigger_word_empty_string_no_op(env) -> None:
+    """trigger_word="" → 与不传等效，输出和老行为一致。"""
+    _set_trigger(env, "")
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "tag_a, common"
+
+
+def test_trigger_word_dataset_loader_sees_meta(env, tmp_path: Path) -> None:
+    """端到端：worker 写 meta.trigger → utils.caption_utils.build_caption_from_json
+    把 trigger 输出在第一位。验证 dataset 训练时确实拿到 trigger。"""
+    import sys
+
+    # 把仓库根加进 sys.path 让 `import utils.caption_utils` 工作
+    repo_root = Path(__file__).resolve().parent.parent
+    if str(repo_root) not in sys.path:
+        sys.path.insert(0, str(repo_root))
+    from utils.caption_utils import load_and_build_caption
+
+    _set_trigger(env, "ohwx")
+    with db.connection_for(env["db"]) as conn:
+        conn.execute(
+            "UPDATE project_jobs SET params = json_set(params, '$.output_format', 'json') "
+            "WHERE id = ?",
+            (env["job_id"],),
+        )
+        conn.commit()
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    caption = load_and_build_caption(env["train"] / "a.json", shuffle=False)
+    assert caption is not None
+    # trigger 在第一位，后面跟原 tags
+    assert caption.startswith("ohwx,")
+
+
 def test_worker_imports_onnxruntime_setup_at_module_level() -> None:
     """worker 是独立 subprocess —— 必须在任何 `import onnxruntime` 之前触发
     onnxruntime_setup 的顶层 preload。回归测试：防止有人删掉那行 import 后

--- a/utils/caption_utils.py
+++ b/utils/caption_utils.py
@@ -4,6 +4,8 @@ Caption 处理工具
 - 标准化格式（实现在 studio.services.caption_format，本模块只 re-export）
 - 分类 shuffle
 """
+from __future__ import annotations
+
 import json
 import random
 import sys
@@ -66,10 +68,17 @@ def build_caption_from_json(
         最终的 caption 字符串
     """
     tags_dict = json_data.get("tags", {})
-    
+    meta = json_data.get("meta") if isinstance(json_data.get("meta"), dict) else {}
+
     # 固定部分（不打乱、不 dropout）
     parts = []
-    
+
+    # 0. trigger word（meta.trigger）— Studio 在打标时注入，永远在第一位、
+    # 不参与 shuffle / dropout，等价于 .txt 模式 keep_tokens=1 的保护。
+    trigger = (meta.get("trigger") or "").strip() if isinstance(meta.get("trigger"), str) else ""
+    if trigger:
+        parts.append(trigger)
+
     # 1. quality
     quality = tags_dict.get("quality", [])
     if quality:
@@ -161,9 +170,14 @@ def load_and_build_caption(
     raw_json = load_caption_json(json_path)
     if raw_json is None:
         return None
-    
-    # 检查是否已经是标准格式
-    if "tags" in raw_json and "meta" in raw_json:
+
+    # 检查是否已经是标准格式：tags 必须是 dict（分类形态）+ 有 meta；
+    # 否则一律走 normalize（包括 Studio 写的 {"tags": [list], "meta": {trigger}}
+    # 这种简化形式 —— normalize 会把 tags list 搬到 tags.tags 字段，meta 保留）。
+    if (
+        isinstance(raw_json.get("tags"), dict)
+        and isinstance(raw_json.get("meta"), dict)
+    ):
         normalized = raw_json
     else:
         normalized = normalize_caption_json(raw_json)


### PR DESCRIPTION
## Summary

终结"忘记加触发词导致白训"的 footgun。Step 4 (Tagging) 顶部加一个紧凑输入框，启动打标时把 trigger 落库到 `versions.trigger_word`（migration v7），并由 tag worker 把 trigger 作为第一个 tag 注入每张 caption；后续训练 runtime 自动把 trigger 注入 sample_prompt 让采样图天然带触发词。

**起因**：现状用户只能在 Step 5 (TagEdit) 手动给每张图加 trigger，**经常忘记**，发现时 LoRA 已经训完不激活，浪费一轮训练。

## 调研：其他主流 trainer 怎么做

| Trainer | 填写位置 | 落到 caption 的方式 |
|---|---|---|
| **Civitai 在线 trainer** | 项目创建（必填） | 打标后作为第一个 tag 写入 caption 文件 |
| **AI-Toolkit (ostris)** | YAML \`trigger_word\` | \`[trigger]\` 占位符 / runtime auto-prepend |
| **Replicate flux-lora-trainer** | API 字段 | 走 ai-toolkit 同一套 |
| **kohya_ss (CLI/GUI)** | 文件夹名 \`nn_<tok>\` | 有 caption 文件时静默忽略（footgun） |

## Alternatives considered

**A：Step 4 (Tagging) 打标参数 + 写时注入 caption（采纳）**

用户在 Tagging 页面填一次 trigger，启动打标时落库到 \`versions.trigger_word\` + 传给 worker 写入 caption；version_config 把 trigger 注入私有 yaml，runtime bootstrap_phase 同步注入 sample_prompt。
- ✅ 作者写时规范化（符合 \`feedback_authoring_time_normalize.md\`）
- ✅ caption 文件落盘 = 任何 trainer 实现都生效
- ✅ TagEdit 页能直接看到 trigger 已写入（所见即所得）

**B：项目创建时必填（Civitai 风）—— 否决**

trigger 作为 project 一等字段，wizard step 1 就要填。
- ❌ 用户常常打完几张图、看到风格才确定 trigger，强制必填造成 friction
- ❌ style LoRA / 不需要 trigger 的训练也被强制

**C：\`[trigger]\` 占位符 + runtime 替换（AI-Toolkit 风）—— 否决**

caption 里写 \`[trigger]\`，dataset loader 训练时替换。
- ❌ runtime free-form 解析，违反 \`feedback_authoring_time_normalize.md\` 偏好
- ❌ TagEdit 页面看到 \`[trigger]\` 占位符，所见非所得
- ❌ 切 trainer 时 caption 不可移植

**D：训练前 caption 缺 trigger 拦截 banner —— 否决**

queue submit 时统计"N/M captions 缺 trigger"，banner 提示或拒绝启动。
- ❌ 用户明确说"不做，有人不希望训练被这种校验拦住"
- ❌ 外部 trainer 都没做这一步（friction > value）

## 实施要点

**数据模型** — \`versions.trigger_word TEXT NOT NULL DEFAULT ''\`（migration v7）。空串 = 未启用，向后兼容。projects 表不动；多 version 训不同角色时各自带 trigger 自然支持。

**Caption 写入** — \`studio/workers/tag_worker.py\`：
- \`.txt\` / 简单 list \`.json\`：trigger 作为 \`tags[0]\`（case-insensitive 去重）
- LLM \`documented_full\` \`.json\`：顶层 \`meta.trigger\` 注入（不污染 \`ai_output\` / \`fixed\` / \`character\` 等业务字段）
- caption_text 模式：\`f"{trigger}, {text}"\` prepend

**采样图注入** — \`runtime/training/phases/bootstrap.py\` \`_prepend_trigger_to_sample_prompts\`：apply_yaml_config 之后 normalize 一次，sample_prompt / sample_prompts 不含 trigger 时 prepend；**token 级匹配**（逗号分隔后 case-insensitive 等值）避免被 substring 误判（e.g. trigger="art" 不会匹配 "artist"）。

**caption_utils 位置语义** — \`utils/caption_utils.py build_caption_from_json\` 加 \`meta.trigger\` 作为第 0 项，**不参与 shuffle / dropout**，等价 \`.txt\` 模式 \`keep_tokens=1\` 的保护行为。顺手修了 fast-path bug：原本 \`{"tags": list, "meta": {...}}\` 会被误当 normalized 跑挂，收紧 fast-path 条件为 \`tags + meta 都是 dict\` 才走。

**前端**：
- \`Tagging.tsx\` 顶部 toolbar 加紧凑输入框；初值从 \`activeVersion.trigger_word\` 取，未保存时 \`border-warn\`；切 version 时同步重置
- \`TagEdit.tsx\` actions 区显示 trigger badge（read-only），缩短"忘记什么是 trigger"的 cognitive distance

## Test plan

- [x] \`tests/test_tag_worker.py\` 加 8 个新 case：trigger prepend 到 .txt / 简单 .json / LLM documented_full .json / LLM .txt / idempotent（case-insensitive） / 空串 no-op / 端到端 caption_utils.load_and_build_caption 看到 meta.trigger
- [x] \`tests/test_resume_path.py\` 加 5 个新 case：sample_prompt / sample_prompts 注入 / 已含 token 跳过（case-insensitive） / 空 trigger no-op / 空 prompt 字符串不被填残缺值
- [x] \`pytest tests/test_tag_worker.py tests/test_resume_path.py tests/test_tagedit.py tests/test_snapshot.py tests/test_argparse_bridge.py\` — 85 passed (Python 3.11)
- [x] \`npx tsc --noEmit\` 干净（Version type 加字段后旧 vitest 桩需要补 \`trigger_word: ''\`，已修）
- [ ] 手测：起 Studio 跑一轮端到端 — Step 4 填 trigger → 打标 → 看 caption 文件第一位是 trigger → Train → 看采样图 prompt 含 trigger（用户验收）

## 风险点

- pause/resume snapshot 一致性：ADR 0006 的 snapshot 已 freeze args（含 trigger_word，作为 TrainingConfig 字段），resume 时 snapshot 覆盖回 args，\`_prepend_trigger_to_sample_prompts\` 在 normalize 后是幂等的（已含 → 跳过），不会重复注入
- 大小写匹配：worker 端和 sample_prompt 端都用 case-insensitive token 比较，保留原大小写不替换

## 文件清单

18 个文件，458 加 19 减：
- migration: \`_v7_version_trigger_word.py\` + \`migrations/__init__.py\`
- backend: \`schema.py\` / \`server.py\` / \`versions.py\` / \`services/version_config.py\` / \`workers/tag_worker.py\`
- runtime: \`runtime/training/phases/bootstrap.py\` / \`utils/caption_utils.py\`
- frontend: \`api/client.ts\` / \`pages/project/steps/Tagging.tsx\` / \`pages/project/steps/TagEdit.tsx\` / \`i18n/locales/{zh,en}.json\`
- tests: \`tests/test_tag_worker.py\` / \`tests/test_resume_path.py\` + 2 个 vitest 桩补字段

🤖 Generated with [Claude Code](https://claude.com/claude-code)