### PR TITLE
fix(test): 测试环境 import i18n 初始化 + PreviewCompare 断言改 zh (vitest 28 fix)

### DIFF
--- a/studio/web/src/pages/tools/generate/PreviewCompare.test.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewCompare.test.tsx
@@ -51,8 +51,8 @@ describe('PreviewCompare', () => {
 
   it('shows axis labels for both samples (2D)', () => {
     renderCompare()
-    expect(screen.getByText(/Steps=20 · CFG Scale=3/)).toBeInTheDocument()
-    expect(screen.getByText(/Steps=30 · CFG Scale=5/)).toBeInTheDocument()
+    expect(screen.getByText(/步数=20 · CFG Scale=3/)).toBeInTheDocument()
+    expect(screen.getByText(/步数=30 · CFG Scale=5/)).toBeInTheDocument()
   })
 
   it('shows only X label when yDraft is null (1D)', () => {
@@ -60,8 +60,8 @@ describe('PreviewCompare', () => {
       samples: [makeSample(0, 0, 20, null), makeSample(1, 0, 25, null)],
       yDraft: null,
     })
-    expect(screen.getByText(/Steps=20$/)).toBeInTheDocument()
-    expect(screen.getByText(/Steps=25$/)).toBeInTheDocument()
+    expect(screen.getByText(/步数=20$/)).toBeInTheDocument()
+    expect(screen.getByText(/步数=25$/)).toBeInTheDocument()
     // 不应有 CFG Scale 文字
     expect(screen.queryByText(/CFG Scale/)).not.toBeInTheDocument()
   })
@@ -75,21 +75,21 @@ describe('PreviewCompare', () => {
   it('triggers onBack when Back to grid clicked', async () => {
     const user = userEvent.setup()
     const { onBack } = renderCompare()
-    await user.click(screen.getByText(/Back to grid/))
+    await user.click(screen.getByText(/返回网格/))
     expect(onBack).toHaveBeenCalled()
   })
 
   it('shows fallback message when selectedIndices are out of range', () => {
     renderCompare({ selectedIndices: [5, 7] })
-    expect(screen.getByText(/Selected samples are unavailable/)).toBeInTheDocument()
+    expect(screen.getByText(/所选样本已不可用/)).toBeInTheDocument()
     // 仍渲染返回按钮
-    expect(screen.getByText(/Back to grid/)).toBeInTheDocument()
+    expect(screen.getByText(/返回网格/)).toBeInTheDocument()
   })
 
   it('triggers onBack from fallback view too', async () => {
     const user = userEvent.setup()
     const { onBack } = renderCompare({ selectedIndices: [5, 7] })
-    await user.click(screen.getByText(/Back to grid/))
+    await user.click(screen.getByText(/返回网格/))
     expect(onBack).toHaveBeenCalled()
   })
 })

--- a/studio/web/src/test/setup.ts
+++ b/studio/web/src/test/setup.ts
@@ -1,1 +1,5 @@
 import '@testing-library/jest-dom/vitest'
+
+// 测试环境里默认 locale = zh（i18n/index.ts 读 localStorage 取不到就 fallback 'zh'）。
+// 不 import 这个,useTranslation 返回 raw key,所有断言中文字面量全打挂。
+import '../i18n'


### PR DESCRIPTION
## Summary

PR #76 (i18n 全前端本地化) 合并后，vitest **26/26 files 里 8 个文件 28 个测试断言全挂**。0.9.0 release prep 前清干净。

跑前：26 files, 186 passed, **28 failed**
跑后：26 files, **214 passed, 0 failed** ✅

## 根因

之前 memory ([vitest_i18n_failures_pre_09](https://github.com/WalkingMeatAxolotl/AnimaLoraStudio/blob/dev) 内部记录) 推断是 i18n key 改名后断言对不上 — 实际不是：

vitest 的 `setup.ts` **没引 i18n 模块**，导致 `useTranslation` 在测试环境拿不到 i18next 实例，`t(key)` 直接返回 **raw key** （比如渲染出 `bulkAction.addTag` 而不是 `+ 加 tag`），所有中文字面量断言全部对不上。

之所以 28 fail 而不是更多：那些只用 `getByRole('combobox')` / `getByLabelText` / data 校验的测试不依赖 i18n 文本，没受影响。

## 修复策略

### 1. `studio/web/src/test/setup.ts` 加 `import '../i18n'`

触发 `initReactI18next` + `getStoredLangWithDefault() = 'zh'`（jsdom localStorage 默认空 → fallback 'zh'）。

其他 7 个文件的中文断言自动复活：
| 文件 | 失败数 | 涉及断言 |
| --- | --- | --- |
| BulkActionBar.test.tsx | 2 | `+ 加 tag` (`bulkAction.addTag`) |
| ImageGrid.test.tsx | 1 | `选择 a.png` (`common.select` + name interpolation) |
| JobProgress.test.tsx | 2 | `取消` / `等待日志` |
| ProjectStepper.test.tsx | 7 | `下载` / `预处理` / `筛选` / `打标` / `标签编辑` / `正则集` |
| Sidebar.test.tsx | 2 | `项目` / `预设` |
| TagEditor.test.tsx | 5 | `添加标签` / `自然语言` / `删除 a` |
| NewVersionDialog.test.tsx | 3 | `从…创建` / `baseline` / `label 已存在` |

小计 **23 个测试**，零代码改动复活。

### 2. `PreviewCompare.test.tsx` 5 处 English → zh

这个文件原本断言写错方向（其他文件都按默认 locale=zh 写），i18n 初始化好后反倒会暴露出来。统一到 zh：

```diff
- expect(screen.getByText(/Steps=20 · CFG Scale=3/)).toBeInTheDocument()
+ expect(screen.getByText(/步数=20 · CFG Scale=3/)).toBeInTheDocument()
- await user.click(screen.getByText(/Back to grid/))
+ await user.click(screen.getByText(/返回网格/))
- expect(screen.getByText(/Selected samples are unavailable/)).toBeInTheDocument()
+ expect(screen.getByText(/所选样本已不可用/)).toBeInTheDocument()
```

(共 5 个测试)

### 为什么不全局 force locale=en

之前在 0.9.0 release prep 时试过：
```ts
localStorage.setItem('studio.lang', 'en')
import('../i18n').then((m) => m.default.changeLanguage('en'))
```
把 PreviewCompare 5 个修对了 **但把其他 23 个中文断言全打挂**，净失败 28 → 38。结论：默认 zh 初始化 + PreviewCompare 文件单独改成 zh 断言，比强制切 locale 干净。

## Test plan

- [x] `npx vitest run` 26 files / 214 tests / 0 fail
- [x] 跑两次确认不 flaky
- [x] pytest 没动（之前 release prep session 已全绿）

## Release context

是 v0.9.0 release blocker（另一个 session 在做 release prep，发现这 28 个 fail 暂停）。merge 后那个 session 直接继续推 0.9.0。

🤖 Generated with [Claude Code](https://claude.com/claude-code)