### PR TITLE
fix(ui): 修补 4 处 overflow 回归（队列 / Monitor / QueueDetail overview / 项目卡片）

### DIFF
--- a/studio/web/src/components/MonitorDashboard.tsx
+++ b/studio/web/src/components/MonitorDashboard.tsx
@@ -313,7 +313,7 @@ export default function MonitorDashboard({ taskId }: { taskId: number }) {
   const lrSparkline = lrHistory.slice(-60).map((l) => l.lr)
 
   return (
-    <div className="flex flex-col gap-3.5 p-4 overflow-y-auto">
+    <div className="flex flex-col gap-3.5 p-4 h-full overflow-y-auto">
       {/* Connection status + progress */}
       <div className="flex items-center gap-2.5 text-xs text-fg-tertiary font-mono shrink-0">
         <span className={`w-[7px] h-[7px] rounded-full inline-block shrink-0 ${connected ? 'bg-ok animate-pulse' : 'bg-err'}`} />

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -169,7 +169,7 @@ export default function ProjectsPage() {
             <div className="text-sm">{t('projects.noProjectsHint')}</div>
           </div>
         ) : (
-          <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
+          <div className="grid gap-4 auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
             {items.map((p) => (
               <ProjectCard
                 key={p.id}

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -396,7 +396,7 @@ export default function QueuePage() {
         </>
       }
     >
-      <div className="flex flex-col gap-2.5">
+      <div className="flex flex-col gap-2.5 flex-1 min-h-0 overflow-y-auto">
         {/* ADR §4.1 队列挂起 banner — 仅 held=true 时显示，sticky 顶部。 */}
         {holdState?.held && (
           <div

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -384,7 +384,7 @@ function OverviewTab({ task }: { task: Task }) {
   }
 
   return (
-    <div className="overflow-y-auto p-5">
+    <div className="flex-1 min-h-0 overflow-y-auto p-5">
       <div className="card overflow-hidden p-0" style={{ maxWidth: 720 }}>
         {items.map((row, i) => (
           <div


### PR DESCRIPTION
## 背景

4 处 UI 回归一并修：

| 路径 | 现象 |
|---|---|
| `/queue` | 任务多到撑爆视窗后无法下拉，被裁掉 |
| `/tools/monitor` | running 任务时面板内容超过视窗被裁，无滚动 |
| `/queue/:id#monitor` | 同上（共用 MonitorDashboard 组件） |
| `/queue/:id#overview` | 长 error_msg / 路径无法滚动（少见但同根因） |
| `/`（项目主页） | 带 note 的卡片把同行其它卡片撑成不齐 |

## 根因

**前 3 处同根因**：父层 `overflow-hidden` 锁视窗高度，子层有 `overflow-y-auto` 但缺 height-fill（`h-full` 或 `flex-1 min-h-0`），子 div 取 content 自然高度，超出后被父层裁掉，`overflow-y-auto` 不触发。

仓库其它页面（TagEdit / Train / Tagging / Download / Curation / Regularization / Presets / Settings / Generate）都正确遵守了 `flex-1 min-h-0 overflow-y-auto` 或 `h-full + overflow-y-auto` 的模式，这 3 处是漏写。

**第 4 处独立**：Projects 卡片 grid 缺 `auto-rows-fr`，grid 行高 = 该行最高卡片自然高度，但 `<button>` 子项在某些情况下不会 stretch；加 `auto-rows-fr` 让所有行 1fr 均分到最高，配合卡片内已有的 `mt-auto` 让 stats 贴底。

## 改动

每文件单行 className 改动，共 4 行：

- `studio/web/src/pages/Queue.tsx:399` — 外层 div 加 `flex-1 min-h-0 overflow-y-auto`
- `studio/web/src/components/MonitorDashboard.tsx:316` — 根 div 加 `h-full`
- `studio/web/src/pages/QueueDetail.tsx:387` — OverviewTab 外层 div 加 `flex-1 min-h-0`
- `studio/web/src/pages/Projects.tsx:172` — 卡片 grid 加 `auto-rows-fr`

## 测试

- [ ] 队列 50+ 任务能下拉到底，sticky banner 仍贴顶
- [ ] `/tools/monitor` running 任务时面板能滚到底
- [ ] `/queue/:id#monitor` 同上
- [ ] `/queue/:id#overview` 长 error_msg 任务能滚
- [ ] 项目主页同行卡片（含带 note 的）高度齐平，stats 贴底