### PR TITLE
fix: inference hot-swap, queue display, training state logs, route & CSS fixes

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -44,7 +44,7 @@ for _p in (_THIS_DIR, _REPO_ROOT):
 import anima_train as _T  # noqa: E402
 
 from studio.schema import migrate_legacy_attention  # noqa: E402
-from studio.services.inference_core import LoRASpec, apply_loras  # noqa: E402
+from studio.services.inference_core import LoRAMeta, LoRASpec, apply_loras, read_lora_meta  # noqa: E402
 
 # 日志走 stderr，stdout 留给协议
 logging.basicConfig(
@@ -80,6 +80,33 @@ def _emit_for(req_id: str, kind: str, **extra: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _lora_topology(meta: LoRAMeta) -> tuple[int, float, str, int]:
+    return (meta.rank, meta.alpha, meta.algo, meta.factor)
+
+
+def _load_lora_state_dict(path: str, device: str, dtype: Any) -> dict[str, Any]:
+    from safetensors import safe_open
+
+    sd: dict[str, Any] = {}
+    with safe_open(str(path), framework="pt", device="cpu") as f:
+        for k in f.keys():
+            sd[k] = f.get_tensor(k).to(device=device, dtype=dtype)
+    return sd
+
+
+def _reload_adapter_weights(adapter: Any, spec: LoRASpec, device: str, dtype: Any) -> None:
+    _set_lora_multiplier(adapter, spec.scale)
+    result = adapter.load_state_dict(
+        _load_lora_state_dict(spec.path, device, dtype),
+        strict=False,
+    )
+    missing = len(getattr(result, "missing_keys", []) or [])
+    unexpected = len(getattr(result, "unexpected_keys", []) or [])
+    logger.info(
+        f"已热换 LoRA 权重: {Path(spec.path).name} "
+        f"(scale={spec.scale}; missing={missing}, unexpected={unexpected})"
+    )
+
 class ModelCache:
     """缓存已加载的模型 / adapters。
 
@@ -107,6 +134,7 @@ class ModelCache:
         # adapters 必须保持引用，否则 forward hook 失效（lycoris closure）
         self.adapters: list[Any] = []
         self.last_lora_specs: list[LoRASpec] = []
+        self.last_lora_metas: list[LoRAMeta] = []
         # commit 14：TAEFlux for preview
         self.taeflux: Any = None
         self.taeflux_attempted: bool = False  # 失败后不再重试
@@ -234,17 +262,10 @@ class ModelCache:
         self.dtype = dtype
         self.adapters = []
         self.last_lora_specs = []
+        self.last_lora_metas = []
 
     def apply_loras(self, lora_configs: list[dict[str, Any]]) -> list[Any]:
-        """按 lora_configs (重新) inject adapters。
-
-        commit 20：先 detach 旧 adapters（撤销 lycoris hook + 还原 model.train
-        劫持），再 inject 新的。失败 fallback 到模型整体 reload（粗暴但安全 ——
-        旧版 lycoris 没 restore 接口时走这条）。具体路径：
-          - specs 不变且已 inject → 直接复用
-          - specs 变了 → adapter.detach() 全部成功 → inject 新的（快路径，<2s）
-          - detach 失败（hook 残留）→ unload+_load 重 load 整个 transformer（30-60s）
-        """
+        """按 lora_configs inject adapters；同结构 checkpoint 切换时只热换权重。"""
         specs = [
             LoRASpec(path=str(lc.get("path", "")), scale=float(lc.get("scale", 1.0)))
             for lc in lora_configs
@@ -252,7 +273,37 @@ class ModelCache:
         if specs == self.last_lora_specs and self.adapters:
             return self.adapters
 
-        # 撤销旧 adapters（commit 20 快路径）
+        current_metas: list[LoRAMeta] = []
+        if specs:
+            try:
+                for spec in specs:
+                    if not spec.path or not Path(spec.path).exists():
+                        current_metas = []
+                        break
+                    current_metas.append(read_lora_meta(spec.path))
+            except Exception:
+                logger.exception("read LoRA metadata failed")
+                current_metas = []
+
+        can_hot_reload = (
+            bool(self.adapters)
+            and bool(self.last_lora_specs)
+            and len(specs) == len(self.adapters) == len(self.last_lora_metas) == len(current_metas)
+            and [_lora_topology(m) for m in current_metas]
+            == [_lora_topology(m) for m in self.last_lora_metas]
+        )
+        if can_hot_reload:
+            try:
+                for adapter, spec in zip(self.adapters, specs):
+                    _reload_adapter_weights(adapter, spec, self.device, self.dtype)
+            except Exception:
+                logger.exception("LoRA hot reload failed; reinjecting adapters")
+            else:
+                self.last_lora_specs = specs
+                self.last_lora_metas = current_metas
+                self.model.eval()
+                return self.adapters
+
         all_detached = True
         for adapter in self.adapters:
             try:
@@ -263,7 +314,6 @@ class ModelCache:
                 all_detached = False
         self.adapters = []
 
-        # detach 不彻底 → fallback 到 model reload（保证 inference 干净）
         if not all_detached and self.last_lora_specs:
             logger.warning("detach failed, reloading model to ensure clean state")
             saved_paths = (
@@ -282,10 +332,11 @@ class ModelCache:
             )
             _emit_evt("loaded")
         self.last_lora_specs = []
+        self.last_lora_metas = []
 
-        # inject 新的
         self.adapters = apply_loras(self.model, specs, self.device, self.dtype)
         self.last_lora_specs = specs
+        self.last_lora_metas = current_metas
         self.model.eval()
         return self.adapters
 
@@ -300,6 +351,7 @@ class ModelCache:
         self.t5_tok = None
         self.adapters = []
         self.last_lora_specs = []
+        self.last_lora_metas = []
         # taeflux 也卸（占很小但保持一致）
         self.taeflux = None
         self.taeflux_attempted = False

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -490,7 +490,11 @@ def _encode_jpeg(img: Any, quality: int = 80) -> tuple[str, int]:
     return base64.b64encode(raw).decode("ascii"), len(raw)
 
 
-def _build_preview_callback(req_id: str, every_n: int) -> Any:
+def _build_preview_callback(
+    req_id: str,
+    every_n: int,
+    cancel_event: threading.Event | None = None,
+) -> Any:
     """每步推 preview_step 事件；TAEFlux 可用 + 节流命中时附 image_b64。
 
     用户反馈：进度条始终要可见（"当前在做什么，第几步"），预览图按需。
@@ -499,8 +503,11 @@ def _build_preview_callback(req_id: str, every_n: int) -> Any:
       - every_n>0 且步命中（含末步）+ TAEFlux 加载 OK → 附 image_b64
     callback 在 daemon 主线程同步执行；空逻辑 ~微秒级，TAEFlux decode +
     JPEG 编码 ~10-20ms。
+
+    cancel_event 注入后每步检查，取消延迟从"整张图"降到"一步"。
     """
     def _cb(step: int, total: int, latent: Any) -> None:
+        _raise_if_canceled(cancel_event)
         # 是否带预览图：preview_every_n_steps>0 + 节流命中 + TAEFlux 可用
         with_image = False
         b64: Optional[str] = None
@@ -580,7 +587,7 @@ def _run_generate(
     # 进度推送：永远建 callback 推 preview_step（含 step/total）；
     # preview_every_n_steps>0 时附 image_b64 中间预览图（commit 14）。
     preview_every = int(cfg.get("preview_every_n_steps", 0) or 0)
-    preview_callback = _build_preview_callback(req_id, preview_every)
+    preview_callback = _build_preview_callback(req_id, preview_every, cancel_event)
 
     prompts: list[str] = cfg.get("prompts") or [
         "newest, safe, 1girl, masterpiece, best quality"
@@ -654,6 +661,8 @@ def _run_generate(
                     step=img_idx + 1, total=total,
                     image_b64=b64, byte_size=byte_size,
                 )
+            except GenerationCanceled:
+                raise
             except Exception as e:
                 logger.exception("generate failed")
                 _emit_for(req_id, "image_error", step=img_idx + 1, message=str(e))
@@ -781,6 +790,8 @@ def _run_xy(
                     xy={"xi": xi, "yi": yi, "xv": xv, "yv": yv},
                     image_b64=b64, byte_size=byte_size,
                 )
+            except GenerationCanceled:
+                raise
             except Exception as e:
                 logger.exception("XY [%d,%d] failed", xi, yi)
                 _emit_for(

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -27,6 +27,7 @@ import json
 import logging
 import random
 import sys
+import threading
 from pathlib import Path
 from typing import Any, Optional
 
@@ -106,6 +107,41 @@ def _reload_adapter_weights(adapter: Any, spec: LoRASpec, device: str, dtype: An
         f"已热换 LoRA 权重: {Path(spec.path).name} "
         f"(scale={spec.scale}; missing={missing}, unexpected={unexpected})"
     )
+class GenerationCanceled(Exception):
+    pass
+
+
+_CANCEL_EVENTS: dict[str, threading.Event] = {}
+_CANCEL_LOCK = threading.Lock()
+_ACTIVE_WORKER: threading.Thread | None = None
+_ACTIVE_WORKER_LOCK = threading.Lock()
+
+
+def _register_cancel(req_id: str) -> threading.Event:
+    event = threading.Event()
+    with _CANCEL_LOCK:
+        _CANCEL_EVENTS[req_id] = event
+    return event
+
+
+def _pop_cancel(req_id: str) -> None:
+    with _CANCEL_LOCK:
+        _CANCEL_EVENTS.pop(req_id, None)
+
+
+def _request_cancel(req_id: str) -> bool:
+    with _CANCEL_LOCK:
+        event = _CANCEL_EVENTS.get(req_id)
+    if event is None:
+        return False
+    event.set()
+    return True
+
+
+def _raise_if_canceled(cancel_event: threading.Event | None) -> None:
+    if cancel_event is not None and cancel_event.is_set():
+        raise GenerationCanceled()
+
 
 class ModelCache:
     """缓存已加载的模型 / adapters。
@@ -518,7 +554,13 @@ def _virtual_path(task_id: int, filename: str) -> str:
     return f"/anima_gen_{task_id}/{filename}"
 
 
-def _run_generate(req_id: str, task_id: int, cfg: dict[str, Any], output_dir: Path) -> None:
+def _run_generate(
+    req_id: str,
+    task_id: int,
+    cfg: dict[str, Any],
+    output_dir: Path,
+    cancel_event: threading.Event | None = None,
+) -> None:
     """跑一次完整 generate（含可选 XY）。
 
     commit 10 起：PNG bytes base64 推 stdout（image_done 事件）→ server
@@ -531,6 +573,7 @@ def _run_generate(req_id: str, task_id: int, cfg: dict[str, Any], output_dir: Pa
     """
     update_monitor = _setup_monitor(cfg)
 
+    _raise_if_canceled(cancel_event)
     CACHE.ensure_loaded(cfg)
     adapters = CACHE.apply_loras(cfg.get("lora_configs", []))
 
@@ -563,6 +606,7 @@ def _run_generate(req_id: str, task_id: int, cfg: dict[str, Any], output_dir: Pa
             height=height, width=width,
             update_monitor=update_monitor,
             preview_callback=preview_callback,
+            cancel_event=cancel_event,
         )
         return
 
@@ -572,6 +616,7 @@ def _run_generate(req_id: str, task_id: int, cfg: dict[str, Any], output_dir: Pa
     img_idx = 0
     for pi, prompt in enumerate(prompts):
         for ci in range(count):
+            _raise_if_canceled(cancel_event)
             seed = (
                 (base_seed + img_idx) if base_seed != 0
                 else random.randint(0, 2**31 - 1)
@@ -634,6 +679,7 @@ def _run_xy(
     width: int,
     update_monitor: Any,
     preview_callback: Any = None,
+    cancel_event: threading.Event | None = None,
 ) -> None:
     x_spec = xy_matrix["x"]
     y_spec = xy_matrix.get("y")
@@ -660,6 +706,7 @@ def _run_xy(
     img_idx = 0
     for yi, yv in enumerate(y_values):
         for xi, xv in enumerate(x_values):
+            _raise_if_canceled(cancel_event)
             # lora_ckpt 切换：mutate cfg.lora_configs 的 path 然后调
             # CACHE.apply_loras —— commit 20 detach 路径会快速 reinject。
             x_is_ckpt = x_spec.get("axis") == "lora_ckpt"
@@ -744,6 +791,46 @@ def _run_xy(
             img_idx += 1
 
 
+def _run_generate_worker(
+    req_id: str,
+    task_id: int,
+    cfg: dict[str, Any],
+    output_dir: Path,
+    cancel_event: threading.Event,
+) -> None:
+    try:
+        _run_generate(req_id, task_id, cfg, output_dir, cancel_event)
+        _emit_for(req_id, "done", task_id=task_id)
+    except GenerationCanceled:
+        logger.info("generate canceled: task_id=%s", task_id)
+        _emit_for(req_id, "canceled", task_id=task_id)
+    except Exception as e:
+        logger.exception("generate failed")
+        _emit_for(req_id, "error", task_id=task_id, message=str(e))
+    finally:
+        _pop_cancel(req_id)
+        with _ACTIVE_WORKER_LOCK:
+            global _ACTIVE_WORKER
+            _ACTIVE_WORKER = None
+
+
+def _start_generate_worker(req_id: str, task_id: int, cfg: dict[str, Any], output_dir: Path) -> bool:
+    global _ACTIVE_WORKER
+    with _ACTIVE_WORKER_LOCK:
+        if _ACTIVE_WORKER is not None and _ACTIVE_WORKER.is_alive():
+            return False
+        cancel_event = _register_cancel(req_id)
+        worker = threading.Thread(
+            target=_run_generate_worker,
+            args=(req_id, task_id, cfg, output_dir, cancel_event),
+            daemon=False,
+            name=f"generate-{task_id}",
+        )
+        _ACTIVE_WORKER = worker
+        worker.start()
+        return True
+
+
 # ---------------------------------------------------------------------------
 # 主循环
 # ---------------------------------------------------------------------------
@@ -762,16 +849,19 @@ def _handle_message(msg: dict[str, Any]) -> None:
         _emit_evt("unloaded")
         return
 
+    if action == "cancel":
+        if _request_cancel(str(msg.get("target_id") or req_id)):
+            _emit_for(req_id, "cancel_ack")
+        else:
+            _emit_for(req_id, "cancel_missed")
+        return
+
     if action == "generate":
         task_id = int(msg.get("task_id", 0))
         cfg = msg.get("config") or {}
         output_dir = Path(msg.get("output_dir") or ".")
-        try:
-            _run_generate(req_id, task_id, cfg, output_dir)
-            _emit_for(req_id, "done", task_id=task_id)
-        except Exception as e:
-            logger.exception("generate failed")
-            _emit_for(req_id, "error", task_id=task_id, message=str(e))
+        if not _start_generate_worker(req_id, task_id, cfg, output_dir):
+            _emit_for(req_id, "error", task_id=task_id, message="daemon is already running a task")
         return
 
     logger.warning("unknown action: %r", action)
@@ -798,6 +888,10 @@ def main() -> int:
     except KeyboardInterrupt:
         pass
     finally:
+        with _ACTIVE_WORKER_LOCK:
+            worker = _ACTIVE_WORKER
+        if worker is not None:
+            worker.join()
         CACHE.unload()
     return 0
 

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -295,6 +295,7 @@ def run(ctx: TrainingContext) -> None:
                         # 同时保存 LoRA 权重
                         lora_path = ctx.output_dir / f"{args.output_name}_step{ctx.global_step}.safetensors"
                         ctx.injector.save(lora_path)
+                    ctx.emit(f"Saved training state (step {ctx.global_step}): {state_path.name}")
 
                 # 检查 max_steps
                 if args.max_steps and ctx.global_step >= args.max_steps:
@@ -356,7 +357,7 @@ def run(ctx: TrainingContext) -> None:
                     lora_path = ctx.output_dir / f"{args.output_name}_epoch{ctx.current_epoch}.safetensors"
                     if not lora_path.exists():
                         ctx.injector.save(lora_path)
-                ctx.emit(f"Saved training state: training_state_epoch{ctx.current_epoch}.pt")
+                ctx.emit(f"Saved training state (epoch {ctx.current_epoch}): {state_path.name}")
 
             # ADR 0006 Addendum 1 方案 Δ：每 epoch 末尾**强制**写 auto_epoch_state.pt（覆盖式）。
             # 跟用户主动开的 save_state_every_epochs（多份历史归档）独立，无 args gate ——

--- a/studio/preprocess.py
+++ b/studio/preprocess.py
@@ -109,21 +109,18 @@ def list_pending(p: dict[str, Any]) -> list[dict[str, Any]]:
     """
     from PIL import Image
 
-    download, preprocess = project_paths(p)
+    download, _ = project_paths(p)
     pdir = project_root(p)
     preprocess_manifest.ensure_manifest(pdir)  # 老项目首次访问触发迁移
-    manifested = preprocess_manifest.all_processed(pdir)
-    upscaled = preprocess_manifest.all_processed(pdir, stage="upscaled")
-    cropped = preprocess_manifest.all_processed(pdir, stage="cropped")
-    manifested_origins = {
+    processed = preprocess_manifest.all_processed(pdir)
+    processed_origins = {
         preprocess_manifest.entry_origin(entry, name)
-        for name, entry in manifested.items()
+        for name, entry in processed.items()
     }
-    upscaled_names = set(upscaled)
 
     items: list[dict[str, Any]] = []
     for f in _download_images(download):
-        if f.name in manifested_origins:
+        if f.name in processed_origins:
             continue
         st = f.stat()
         w: Optional[int] = None
@@ -140,31 +137,7 @@ def list_pending(p: dict[str, Any]) -> list[dict[str, Any]]:
             "w": w,
             "h": h,
         })
-
-    for name in sorted(cropped.keys()):
-        if name in upscaled_names:
-            continue
-        entry = cropped[name]
-        png = preprocess / name
-        if not png.is_file():
-            continue
-        st = png.stat()
-        w = None
-        h = None
-        try:
-            with Image.open(png) as im:
-                w, h = im.size
-        except (OSError, ValueError):
-            pass
-        items.append({
-            "name": name,
-            "mtime": st.st_mtime,
-            "size": st.st_size,
-            "w": w,
-            "h": h,
-            "origin": preprocess_manifest.entry_origin(entry, name),
-        })
-    return sorted(items, key=lambda it: it["name"])
+    return items
 
 
 def list_processed(p: dict[str, Any]) -> list[dict[str, Any]]:
@@ -182,7 +155,7 @@ def list_processed(p: dict[str, Any]) -> list[dict[str, Any]]:
     download, preprocess = project_paths(p)
     pdir = project_root(p)
     preprocess_manifest.ensure_manifest(pdir)
-    processed = preprocess_manifest.all_processed(pdir, stage="upscaled")
+    processed = preprocess_manifest.all_processed(pdir)
 
     download_stems = {f.stem for f in _download_images(download)}
 
@@ -231,13 +204,27 @@ def list_processed(p: dict[str, Any]) -> list[dict[str, Any]]:
     return items
 
 def summary(p: dict[str, Any]) -> dict[str, Any]:
-    """给 status 端点用的简短统计。"""
+    """给 status 端点用的简短统计。
+
+    `pending_count`：按 origin 判定 download 是否已处理。一张 download/X.jpg
+    只要 manifest 里有任一 entry 的 origin 指向它（含 multi-crop 派生），就不
+    再计入 pending。
+    `processed_count`：manifest 里所有已处理 entry 的数量（multi-crop 后会
+    > download_count）。
+    """
     download, _ = project_paths(p)
     pdir = project_root(p)
     preprocess_manifest.ensure_manifest(pdir)
     n_download = len(_download_images(download))
-    n_processed = len(preprocess_manifest.all_processed(pdir, stage="upscaled"))
-    n_pending = len(list_pending(p))
+    processed = preprocess_manifest.all_processed(pdir)
+    n_processed = len(processed)
+    processed_origins = {
+        preprocess_manifest.entry_origin(entry, name)
+        for name, entry in processed.items()
+    }
+    n_pending = sum(
+        1 for f in _download_images(download) if f.name not in processed_origins
+    )
     return {
         "download_count": n_download,
         "processed_count": n_processed,
@@ -271,17 +258,21 @@ def resolve_targets(
     if not download.exists():
         return []
     existing = {f.name for f in download.iterdir() if _is_image(f)}
-    pending = {it["name"] for it in list_pending(p)}
 
     if mode == "all":
-        return sorted(pending)
+        return sorted(it["name"] for it in list_pending(p))
     if mode == "all_force":
         return sorted(existing)
     if mode == "selected":
         if not names:
             raise PreprocessError("mode=selected 时 names 不能为空")
+        # selected 允许 download/ 原图 + manifest 里已有 entry 的产物名 ——
+        # 后者覆盖"重新上调 / 在裁剪产物上再 upscale"的链路（ADR 0004 Addendum 1
+        # §「Stage 不强制时序」）。worker 端用 resolve() 找实际源。
+        pdir = project_root(p)
+        manifest_names = set(preprocess_manifest.all_processed(pdir).keys())
+        selectable = existing | manifest_names
         chosen = []
-        selectable = existing | pending
         for n in names:
             _validate_name(n)
             if n in selectable:

--- a/studio/preprocess.py
+++ b/studio/preprocess.py
@@ -109,18 +109,21 @@ def list_pending(p: dict[str, Any]) -> list[dict[str, Any]]:
     """
     from PIL import Image
 
-    download, _ = project_paths(p)
+    download, preprocess = project_paths(p)
     pdir = project_root(p)
     preprocess_manifest.ensure_manifest(pdir)  # 老项目首次访问触发迁移
-    processed = preprocess_manifest.all_processed(pdir)
-    processed_origins = {
+    manifested = preprocess_manifest.all_processed(pdir)
+    upscaled = preprocess_manifest.all_processed(pdir, stage="upscaled")
+    cropped = preprocess_manifest.all_processed(pdir, stage="cropped")
+    manifested_origins = {
         preprocess_manifest.entry_origin(entry, name)
-        for name, entry in processed.items()
+        for name, entry in manifested.items()
     }
+    upscaled_names = set(upscaled)
 
     items: list[dict[str, Any]] = []
     for f in _download_images(download):
-        if f.name in processed_origins:
+        if f.name in manifested_origins:
             continue
         st = f.stat()
         w: Optional[int] = None
@@ -137,7 +140,31 @@ def list_pending(p: dict[str, Any]) -> list[dict[str, Any]]:
             "w": w,
             "h": h,
         })
-    return items
+
+    for name in sorted(cropped.keys()):
+        if name in upscaled_names:
+            continue
+        entry = cropped[name]
+        png = preprocess / name
+        if not png.is_file():
+            continue
+        st = png.stat()
+        w = None
+        h = None
+        try:
+            with Image.open(png) as im:
+                w, h = im.size
+        except (OSError, ValueError):
+            pass
+        items.append({
+            "name": name,
+            "mtime": st.st_mtime,
+            "size": st.st_size,
+            "w": w,
+            "h": h,
+            "origin": preprocess_manifest.entry_origin(entry, name),
+        })
+    return sorted(items, key=lambda it: it["name"])
 
 
 def list_processed(p: dict[str, Any]) -> list[dict[str, Any]]:
@@ -155,7 +182,7 @@ def list_processed(p: dict[str, Any]) -> list[dict[str, Any]]:
     download, preprocess = project_paths(p)
     pdir = project_root(p)
     preprocess_manifest.ensure_manifest(pdir)
-    processed = preprocess_manifest.all_processed(pdir)
+    processed = preprocess_manifest.all_processed(pdir, stage="upscaled")
 
     download_stems = {f.stem for f in _download_images(download)}
 
@@ -203,29 +230,14 @@ def list_processed(p: dict[str, Any]) -> list[dict[str, Any]]:
         })
     return items
 
-
 def summary(p: dict[str, Any]) -> dict[str, Any]:
-    """给 status 端点用的简短统计。
-
-    `pending_count`：按 origin 判定 download 是否已处理。一张 download/X.jpg
-    只要 manifest 里有任一 entry 的 origin 指向它（含 multi-crop 派生），就不
-    再计入 pending。
-    `processed_count`：manifest 里所有已处理 entry 的数量（multi-crop 后会
-    > download_count）。
-    """
+    """给 status 端点用的简短统计。"""
     download, _ = project_paths(p)
     pdir = project_root(p)
     preprocess_manifest.ensure_manifest(pdir)
     n_download = len(_download_images(download))
-    processed = preprocess_manifest.all_processed(pdir)
-    n_processed = len(processed)
-    processed_origins = {
-        preprocess_manifest.entry_origin(entry, name)
-        for name, entry in processed.items()
-    }
-    n_pending = sum(
-        1 for f in _download_images(download) if f.name not in processed_origins
-    )
+    n_processed = len(preprocess_manifest.all_processed(pdir, stage="upscaled"))
+    n_pending = len(list_pending(p))
     return {
         "download_count": n_download,
         "processed_count": n_processed,
@@ -259,18 +271,20 @@ def resolve_targets(
     if not download.exists():
         return []
     existing = {f.name for f in download.iterdir() if _is_image(f)}
+    pending = {it["name"] for it in list_pending(p)}
 
     if mode == "all":
-        return sorted(it["name"] for it in list_pending(p))
+        return sorted(pending)
     if mode == "all_force":
         return sorted(existing)
     if mode == "selected":
         if not names:
             raise PreprocessError("mode=selected 时 names 不能为空")
         chosen = []
+        selectable = existing | pending
         for n in names:
             _validate_name(n)
-            if n in existing:
+            if n in selectable:
                 chosen.append(n)
         # 保留唯一 + 字典序，便于日志稳定
         return sorted(set(chosen))

--- a/studio/server.py
+++ b/studio/server.py
@@ -3644,17 +3644,17 @@ def _select_task_output_files(task_id: int, files: Optional[list[str]] = None) -
     out_dir = _task_output_dir(task)
     if not out_dir or not out_dir.exists():
         raise HTTPException(404, "no output dir")
-    all_files = [f for f in sorted(out_dir.iterdir()) if f.is_file()]
+    all_files = _iter_task_output_files(out_dir)
     if not all_files:
         raise HTTPException(404, "empty output dir")
     if not files:
         return task, all_files, False
-    by_name = {f.name: f for f in all_files}
+    by_path = {_task_output_relpath(out_dir, f): f for f in all_files}
     selected: list[Path] = []
     missing: list[str] = []
     for name in files:
-        _validate_component_or_400(name)
-        f = by_name.get(name)
+        _safe_output_relpath_or_400(out_dir, name)
+        f = by_path.get(name)
         if f:
             selected.append(f)
         else:
@@ -3666,10 +3666,10 @@ def _select_task_output_files(task_id: int, files: Optional[list[str]] = None) -
     return task, selected, True
 
 
-def _write_outputs_zip(dest: Path, selected: list[Path]) -> None:
+def _write_outputs_zip(dest: Path, out_dir: Path, selected: list[Path]) -> None:
     with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
         for f in selected:
-            zf.write(f, arcname=f.name)
+            zf.write(f, arcname=_task_output_relpath(out_dir, f))
 
 
 def _task_archive_basename(task: dict[str, Any]) -> Optional[str]:
@@ -3695,13 +3695,40 @@ def _is_loopback(request: Request) -> bool:
     return bool(client and client.host in _LOCALHOST_HOSTS)
 
 
+def _task_output_kind(path: Path) -> str:
+    name = path.name
+    suffix = path.suffix.lower()
+    if name.startswith("training_state_") and suffix == ".pt":
+        return "training_state"
+    if name.startswith("pause_step_") and suffix == ".pt":
+        return "pause_state"
+    if name == "auto_epoch_state.pt":
+        return "auto_epoch_state"
+    if suffix in _LORA_EXTS and not name.startswith("training_state_"):
+        return "lora"
+    return "other"
+
+
+def _task_output_relpath(out_dir: Path, path: Path) -> str:
+    return path.relative_to(out_dir).as_posix()
+
+
+def _iter_task_output_files(out_dir: Path) -> list[Path]:
+    return sorted((p for p in out_dir.rglob("*") if p.is_file()), key=lambda p: _task_output_relpath(out_dir, p))
+
+
+def _safe_output_relpath_or_400(base: Path, relpath: str) -> Path:
+    if not relpath or relpath.startswith(("/", "\\")):
+        raise HTTPException(400, "invalid path")
+    parts = Path(relpath.replace("\\", "/")).parts
+    if any(part in ("", ".", "..") for part in parts):
+        raise HTTPException(400, "invalid path")
+    return _safe_join_or_400(base, *parts)
+
+
 @app.get("/api/queue/{task_id}/outputs")
 def list_task_outputs(task_id: int, request: Request) -> dict[str, Any]:
-    """列出 task 关联 version 的 output 目录里所有文件。
-
-    `supports_open_folder` 仅在请求来自 loopback（同机浏览器）时为 True；
-    云端部署时永远为 False，避免前端显示一个无意义按钮。
-    """
+    """列出 task 关联 version 的 output 目录里所有文件。"""
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task:
@@ -3709,18 +3736,20 @@ def list_task_outputs(task_id: int, request: Request) -> dict[str, Any]:
     out_dir = _task_output_dir(task)
     files: list[dict[str, Any]] = []
     if out_dir and out_dir.exists():
-        for f in sorted(out_dir.iterdir(), key=lambda p: p.name):
-            if not f.is_file():
-                continue
+        for f in _iter_task_output_files(out_dir):
+            relpath = _task_output_relpath(out_dir, f)
             try:
                 st = f.stat()
             except OSError:
                 continue
+            kind = _task_output_kind(f)
             files.append({
                 "name": f.name,
+                "path": relpath,
                 "size": st.st_size,
                 "mtime": st.st_mtime,
-                "is_lora": f.suffix.lower() in _LORA_EXTS,
+                "kind": kind,
+                "is_lora": kind == "lora",
             })
     return {
         "task_id": task_id,
@@ -3738,24 +3767,20 @@ def download_task_outputs_zip(
     background: BackgroundTasks,
     files: Optional[str] = None,
 ) -> FileResponse:
-    """把 output 目录里的文件打包成 zip 一次性下载。
-
-    没传 `files` → 全量打包（向后兼容）。
-    传了 `files`（逗号分隔的文件名）→ 仅打包这些，路径必须是 out_dir 下的直接
-    子文件，禁止 path traversal / 子目录。
-
-    实现：写到临时文件再 FileResponse；响应发完后用 BackgroundTasks 清理。
-    safetensors / pt 几乎都是已压缩二进制，用 ZIP_STORED（不再压缩，CPU 省一倍）。
-    """
+    """把 output 目录里的文件打包成 zip 一次性下载。"""
     import tempfile
     wanted = [n for n in files.split(",") if n] if files else None
+    if files is not None and not wanted:
+        raise HTTPException(400, "empty files list")
     task, selected, partial = _select_task_output_files(task_id, wanted)
+    out_dir = _task_output_dir(task)
+    assert out_dir is not None  # _select_task_output_files 已经校验
 
     tmp = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
     tmp.close()
     tmp_path = Path(tmp.name)
     try:
-        _write_outputs_zip(tmp_path, selected)
+        _write_outputs_zip(tmp_path, out_dir, selected)
     except Exception as e:
         tmp_path.unlink(missing_ok=True)
         bus.publish({
@@ -3792,8 +3817,10 @@ def export_task_outputs_to_data_exports(
     basename = _task_archive_basename(task) or f"task_{task_id}"
     archive_name = f"{basename}_outputs_selected.zip" if partial else f"{basename}_outputs.zip"
     dest = _unique_data_export_path(archive_name)
+    out_dir = _task_output_dir(task)
+    assert out_dir is not None
     try:
-        _write_outputs_zip(dest, selected)
+        _write_outputs_zip(dest, out_dir, selected)
     except Exception as e:
         dest.unlink(missing_ok=True)
         bus.publish({"type": "task_outputs_zip_failed", "task_id": task_id, "error": str(e)})
@@ -3802,10 +3829,9 @@ def export_task_outputs_to_data_exports(
     return _export_result(dest)
 
 
-@app.get("/api/queue/{task_id}/output/{filename}")
+@app.get("/api/queue/{task_id}/output/{filename:path}")
 def download_task_output(task_id: int, filename: str) -> FileResponse:
-    """下载 output 目录下的指定文件。`Content-Disposition: attachment` 让
-    浏览器走「保存」对话框而不是 inline 渲染。"""
+    """下载 output 目录下的指定文件。"""
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task:
@@ -3813,13 +3839,13 @@ def download_task_output(task_id: int, filename: str) -> FileResponse:
     out_dir = _task_output_dir(task)
     if not out_dir or not out_dir.exists():
         raise HTTPException(404, "no output dir")
-    f = _safe_join_or_400(out_dir, filename)
+    f = _safe_output_relpath_or_400(out_dir, filename)
     if not f.exists() or not f.is_file():
         raise HTTPException(404, "file not found")
     return FileResponse(
         f,
         media_type="application/octet-stream",
-        filename=filename,  # 让 starlette 自动加 Content-Disposition
+        filename=f.name,
     )
 
 

--- a/studio/server.py
+++ b/studio/server.py
@@ -3959,7 +3959,9 @@ def get_log(task_id: int) -> dict[str, Any]:
     p = LOGS_DIR / f"{task_id}.log"
     if not p.exists():
         return {"task_id": task_id, "content": "", "size": 0}
-    text = p.read_text(encoding="utf-8", errors="replace")
+    raw = p.read_text(encoding="utf-8", errors="replace")
+    lines = [ln for ln in raw.splitlines(keepends=True) if not ln.startswith("__EVENT__:")]
+    text = "".join(lines)
     return {"task_id": task_id, "content": text, "size": len(text.encode("utf-8"))}
 
 

--- a/studio/server.py
+++ b/studio/server.py
@@ -3644,7 +3644,7 @@ def _select_task_output_files(task_id: int, files: Optional[list[str]] = None) -
     out_dir = _task_output_dir(task)
     if not out_dir or not out_dir.exists():
         raise HTTPException(404, "no output dir")
-    all_files = _iter_task_output_files(out_dir)
+    all_files = _iter_task_output_files(out_dir, task_id)
     if not all_files:
         raise HTTPException(404, "empty output dir")
     if not files:
@@ -3713,8 +3713,15 @@ def _task_output_relpath(out_dir: Path, path: Path) -> str:
     return path.relative_to(out_dir).as_posix()
 
 
-def _iter_task_output_files(out_dir: Path) -> list[Path]:
-    return sorted((p for p in out_dir.rglob("*") if p.is_file()), key=lambda p: _task_output_relpath(out_dir, p))
+def _iter_task_output_files(out_dir: Path, task_id: int) -> list[Path]:
+    files = [p for p in out_dir.iterdir() if p.is_file()]
+    state_dir = out_dir / "state" / f"task_{task_id}"
+    if state_dir.exists():
+        files.extend(
+            p for p in state_dir.rglob("*")
+            if p.is_file() and _task_output_kind(p) in {"training_state", "pause_state", "auto_epoch_state"}
+        )
+    return sorted(files, key=lambda p: _task_output_relpath(out_dir, p))
 
 
 def _safe_output_relpath_or_400(base: Path, relpath: str) -> Path:
@@ -3736,7 +3743,7 @@ def list_task_outputs(task_id: int, request: Request) -> dict[str, Any]:
     out_dir = _task_output_dir(task)
     files: list[dict[str, Any]] = []
     if out_dir and out_dir.exists():
-        for f in _iter_task_output_files(out_dir):
+        for f in _iter_task_output_files(out_dir, task_id):
             relpath = _task_output_relpath(out_dir, f)
             try:
                 st = f.stat()

--- a/studio/server.py
+++ b/studio/server.py
@@ -3410,6 +3410,44 @@ def enqueue(body: EnqueueRequest) -> dict[str, Any]:
     return task or {"id": task_id}
 
 
+@app.get("/api/queue/hold")
+def get_queue_hold() -> dict[str, Any]:
+    """查看当前队列挂起状态 + 等待恢复调度的 pending task 数（UI banner 用）。"""
+    with db.connection_for() as conn:
+        held = db.get_queue_held(conn)
+        pending = db.list_tasks(conn, status="pending")
+    return {"held": held, "pending_waiting": len(pending)}
+
+
+@app.post("/api/queue/hold")
+def hold_queue() -> dict[str, Any]:
+    """挂起队列：dispatcher 不再拉新 task。已 running 的不受影响（ADR §3.2）。
+
+    "同时暂停 running task" 由前端 modal 拆成两步：先调本 endpoint，再
+    单独调 `/api/queue/{id}/pause`。后端不做合一操作。
+    """
+    with db.connection_for() as conn:
+        db.set_queue_held(conn, True)
+    bus.publish({"type": "queue_hold_changed", "held": True})
+    return {"held": True}
+
+
+@app.post("/api/queue/release")
+def release_queue() -> dict[str, Any]:
+    """恢复调度：dispatcher 重新按 priority + created_at 拉 pending。"""
+    with db.connection_for() as conn:
+        db.set_queue_held(conn, False)
+    bus.publish({"type": "queue_hold_changed", "held": False})
+    return {"held": False}
+
+
+@app.post("/api/queue/reorder")
+def reorder_queue(body: ReorderRequest) -> dict[str, Any]:
+    with db.connection_for() as conn:
+        db.reorder(conn, body.ordered_ids)
+    return {"reordered": len(body.ordered_ids)}
+
+
 @app.get("/api/queue/{task_id}")
 def get_queue_item(task_id: int) -> dict[str, Any]:
     with db.connection_for() as conn:
@@ -3478,37 +3516,6 @@ def pause_task(task_id: int) -> dict[str, Any]:
             raise HTTPException(404, "task not found")
         raise HTTPException(409, reason or "pause rejected")
     return {"task_id": task_id, "pause_pending": True}
-
-
-@app.get("/api/queue/hold")
-def get_queue_hold() -> dict[str, Any]:
-    """查看当前队列挂起状态 + 等待恢复调度的 pending task 数（UI banner 用）。"""
-    with db.connection_for() as conn:
-        held = db.get_queue_held(conn)
-        pending = db.list_tasks(conn, status="pending")
-    return {"held": held, "pending_waiting": len(pending)}
-
-
-@app.post("/api/queue/hold")
-def hold_queue() -> dict[str, Any]:
-    """挂起队列：dispatcher 不再拉新 task。已 running 的不受影响（ADR §3.2）。
-
-    "同时暂停 running task" 由前端 modal 拆成两步：先调本 endpoint，再
-    单独调 `/api/queue/{id}/pause`。后端不做合一操作。
-    """
-    with db.connection_for() as conn:
-        db.set_queue_held(conn, True)
-    bus.publish({"type": "queue_hold_changed", "held": True})
-    return {"held": True}
-
-
-@app.post("/api/queue/release")
-def release_queue() -> dict[str, Any]:
-    """恢复调度：dispatcher 重新按 priority + created_at 拉 pending。"""
-    with db.connection_for() as conn:
-        db.set_queue_held(conn, False)
-    bus.publish({"type": "queue_hold_changed", "held": False})
-    return {"held": False}
 
 
 @app.post("/api/queue/{task_id}/resume")
@@ -3893,13 +3900,6 @@ def delete_queue_item(task_id: int) -> dict[str, Any]:
             raise HTTPException(400, "only terminal tasks can be deleted")
         db.delete_task(conn, task_id)
     return {"deleted": task_id}
-
-
-@app.post("/api/queue/reorder")
-def reorder_queue(body: ReorderRequest) -> dict[str, Any]:
-    with db.connection_for() as conn:
-        db.reorder(conn, body.ordered_ids)
-    return {"reordered": len(body.ordered_ids)}
 
 
 # ---------------------------------------------------------------------------

--- a/studio/server.py
+++ b/studio/server.py
@@ -2796,13 +2796,6 @@ class RegAiRequest(BaseModel):
     seed: int = 0
     incremental: bool = False
     mixed_precision: str = "bf16"
-    attention_backend: AttentionBackend = "flash_attn"
-
-    # 兼容老前端送 xformers / flash_attn 双 bool（自动映射成 attention_backend）
-    @model_validator(mode="before")
-    @classmethod
-    def _migrate_attention(cls, data: Any) -> Any:
-        return migrate_legacy_attention(data)
 
 
 @app.post("/api/projects/{pid}/versions/{vid}/reg/generate-prior")
@@ -2821,6 +2814,7 @@ def reg_generate_prior(pid: int, vid: int, body: RegAiRequest) -> dict[str, Any]
     rdir = _reg_dir(vdir)
     rdir.mkdir(parents=True, exist_ok=True)
 
+    from studio.services.xformers_setup import detect_attention_backend
     cfg = RegAiConfig(
         **model_paths,
         train_dir=str(train),
@@ -2836,7 +2830,7 @@ def reg_generate_prior(pid: int, vid: int, body: RegAiRequest) -> dict[str, Any]
         seed=body.seed,
         incremental=body.incremental,
         mixed_precision=body.mixed_precision,
-        attention_backend=body.attention_backend,
+        attention_backend=detect_attention_backend(),
     )
 
     cfg_dir = STUDIO_DATA / "reg_ai_configs"
@@ -3387,7 +3381,7 @@ def list_queue(
     with db.connection_for() as conn:
         items = db.list_tasks(conn, status=status)
     if not include_generate:
-        items = db.filter_out_task_types(items, ("generate",))
+        items = db.filter_out_task_types(items, ("generate", "reg_ai"))
     # ADR 0006 PR-4 — is_pausable 信号每行注入（§8.1 / 上面 get_queue_item 注释）
     try:
         sup = _supervisor()

--- a/studio/services/inference_daemon.py
+++ b/studio/services/inference_daemon.py
@@ -262,6 +262,28 @@ class InferenceDaemon:
             raise RuntimeError(f"daemon write failed: {e}") from e
         return req_id
 
+    def cancel_active_task(self, task_id: int) -> bool:
+        """请求取消当前 generate task；daemon 保持常驻，模型缓存不卸载。"""
+        with self._lock:
+            active = self._active
+            if self._state != STATE_BUSY or active is None or active.task_id != task_id:
+                return False
+            assert self._proc is not None and self._proc.stdin is not None
+            stdin = self._proc.stdin
+            req_id = active.request_id
+
+        try:
+            stdin.write(json.dumps({
+                "id": f"cancel-{task_id}",
+                "action": "cancel",
+                "target_id": req_id,
+            }) + "\n")
+            stdin.flush()
+        except Exception:
+            logger.exception("failed to send cancel")
+            return False
+        return True
+
     def request_unload(self) -> None:
         """通知 daemon 卸载模型（释放 VRAM）。daemon 处理完会推 unloaded 事件。
 
@@ -357,9 +379,9 @@ class InferenceDaemon:
                 logger.exception("cache_image failed for %s", filename)
             forward_msg = {k: v for k, v in msg.items() if k != "image_b64"}
 
-        # done/error 先切状态，再回调 —— 让 callback 内查询 is_busy/state 时
+        # done/error/canceled 先切状态，再回调 —— 让 callback 内查询 is_busy/state 时
         # 看到准确的 IDLE 状态（commit 13 daemon_state_changed 依赖这个顺序）
-        if kind in ("done", "error"):
+        if kind in ("done", "error", "canceled"):
             with self._lock:
                 self._active = None
                 self._state = STATE_IDLE

--- a/studio/services/preprocess_manifest.py
+++ b/studio/services/preprocess_manifest.py
@@ -122,10 +122,6 @@ def entry_origin(entry: dict[str, Any], fallback_name: str) -> str:
     return entry.get("origin") or entry.get("source") or fallback_name
 
 
-def entry_stage(entry: dict[str, Any]) -> str:
-    return str(entry.get("stage") or "upscaled")
-
-
 def resolve(project_dir: Path, name: str) -> Optional[Path]:
     """给定产物文件名（如 `foo.png`），返回它实际指向的磁盘路径。
 
@@ -175,20 +171,17 @@ def get_entry(project_dir: Path, name: str) -> Optional[dict[str, Any]]:
     return m["images"].get(name)
 
 
-def all_processed(project_dir: Path, stage: str | None = None) -> dict[str, dict[str, Any]]:
-    """返回 `{name: entry}` 所有已知预处理产物，可按 stage 过滤。"""
+def all_processed(project_dir: Path) -> dict[str, dict[str, Any]]:
+    """返回 `{name: entry}` 所有"已处理" entry。
+
+    新 schema：任何 entry 都算已处理（无 `kind` 字段）。
+    老 schema：兼容性按 `kind == "processed"` 过滤；非 processed 视为未来扩展。
+    """
     m = load(project_dir)
-    items = {
+    return {
         name: entry
         for name, entry in m["images"].items()
         if entry.get("kind", "processed") == "processed"
-    }
-    if stage is None:
-        return items
-    return {
-        name: entry
-        for name, entry in items.items()
-        if entry_stage(entry) == stage
     }
 
 
@@ -214,7 +207,6 @@ def add_processed(project_dir: Path, name: str, meta: dict[str, Any]) -> None:
         entry: dict[str, Any] = {
             "origin": origin,
             "mtime": meta.get("mtime", time.time()),
-            "stage": "upscaled",
         }
         if "size" in meta:
             entry["size"] = meta["size"]
@@ -264,7 +256,6 @@ def replace_with_crops(
                 "origin": o.get("origin") or source_name,
                 "mtime": o.get("mtime", now),
                 "size": int(o.get("size", 0)),
-                "stage": "cropped",
             }
             m["images"][o["name"]] = entry
         _atomic_write(manifest_path(project_dir), m)

--- a/studio/services/preprocess_manifest.py
+++ b/studio/services/preprocess_manifest.py
@@ -122,6 +122,10 @@ def entry_origin(entry: dict[str, Any], fallback_name: str) -> str:
     return entry.get("origin") or entry.get("source") or fallback_name
 
 
+def entry_stage(entry: dict[str, Any]) -> str:
+    return str(entry.get("stage") or "upscaled")
+
+
 def resolve(project_dir: Path, name: str) -> Optional[Path]:
     """给定产物文件名（如 `foo.png`），返回它实际指向的磁盘路径。
 
@@ -171,17 +175,20 @@ def get_entry(project_dir: Path, name: str) -> Optional[dict[str, Any]]:
     return m["images"].get(name)
 
 
-def all_processed(project_dir: Path) -> dict[str, dict[str, Any]]:
-    """返回 `{name: entry}` 所有"已处理" entry。
-
-    新 schema：任何 entry 都算已处理（无 `kind` 字段）。
-    老 schema：兼容性按 `kind == "processed"` 过滤；非 processed 视为未来扩展。
-    """
+def all_processed(project_dir: Path, stage: str | None = None) -> dict[str, dict[str, Any]]:
+    """返回 `{name: entry}` 所有已知预处理产物，可按 stage 过滤。"""
     m = load(project_dir)
-    return {
+    items = {
         name: entry
         for name, entry in m["images"].items()
         if entry.get("kind", "processed") == "processed"
+    }
+    if stage is None:
+        return items
+    return {
+        name: entry
+        for name, entry in items.items()
+        if entry_stage(entry) == stage
     }
 
 
@@ -207,6 +214,7 @@ def add_processed(project_dir: Path, name: str, meta: dict[str, Any]) -> None:
         entry: dict[str, Any] = {
             "origin": origin,
             "mtime": meta.get("mtime", time.time()),
+            "stage": "upscaled",
         }
         if "size" in meta:
             entry["size"] = meta["size"]
@@ -256,6 +264,7 @@ def replace_with_crops(
                 "origin": o.get("origin") or source_name,
                 "mtime": o.get("mtime", now),
                 "size": int(o.get("size", 0)),
+                "stage": "cropped",
             }
             m["images"][o["name"]] = entry
         _atomic_write(manifest_path(project_dir), m)

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -360,15 +360,14 @@ class Supervisor:
             if slot is not None:
                 self._signal_terminate_async(slot)
                 return True
-            # daemon 上跑的 generate task：kill daemon 进程让它带着丢 cache 退出，
-            # 下次 generate task 再 lazy spawn。粗暴但可接受（用户主动取消低频）。
             with self._daemon_lock:
-                if self._daemon_active_task_id == task_id:
+                is_daemon_task = self._daemon_active_task_id == task_id
+                if is_daemon_task:
                     self._daemon_cancel_pending = True
-            try:
-                get_daemon().stop(timeout=3.0)
-            except Exception:
-                logger.exception("failed to stop daemon for cancel")
+            if is_daemon_task:
+                if get_daemon().cancel_active_task(task_id):
+                    return True
+                logger.warning("daemon cancel request missed; task_id=%s", task_id)
             return True
         return False
 
@@ -1008,6 +1007,9 @@ class Supervisor:
             return
         if kind == "done":
             self._finalize_daemon_task(tid, status="done")
+            self._emit_daemon_state()
+        elif kind == "canceled":
+            self._finalize_daemon_task(tid, status="canceled")
             self._emit_daemon_state()
         elif kind == "error":
             self._finalize_daemon_task(

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1076,8 +1076,10 @@ export interface MonitorState {
 
 export interface TaskOutputFile {
   name: string
+  path: string
   size: number
   mtime: number
+  kind: 'lora' | 'training_state' | 'pause_state' | 'auto_epoch_state' | 'other'
   is_lora: boolean
 }
 
@@ -1839,10 +1841,10 @@ export const api = {
   getTaskOutputs: (id: number) =>
     req<TaskOutputs>(`/api/queue/${id}/outputs`),
   /** 下载单个 output 文件的直链，不发请求。<a href={...} download> 即可。 */
-  taskOutputDownloadUrl: (id: number, filename: string) =>
-    `/api/queue/${id}/output/${encodeURIComponent(filename)}`,
+  taskOutputDownloadUrl: (id: number, path: string) =>
+    `/api/queue/${id}/output/${path.split('/').map(encodeURIComponent).join('/')}`,
   /** output 目录打包 zip 下载直链。
-   * 不传 files → 全量；传文件名数组 → 仅打包这些（后端 whitelist 校验）。
+   * 不传 files → 全量；传相对路径数组 → 仅打包这些（后端 whitelist 校验）。
    * 配合 <a href download> 触发，浏览器原生接管下载条；后端 zip 写完会
    * publish task_outputs_zip_ready / task_outputs_zip_failed 事件供前端清 loading。 */
   taskOutputsZipUrl: (id: number, files?: ReadonlyArray<string>) => {

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -884,7 +884,6 @@ export interface RegAiRequest {
   seed?: number
   incremental?: boolean
   mixed_precision?: string
-  attention_backend?: AttentionBackend
 }
 
 /** PR-9 — 测试出图（独立工具页，多 LoRA + multi-prompt）。 */

--- a/studio/web/src/components/preprocess/FreeCropEditor.tsx
+++ b/studio/web/src/components/preprocess/FreeCropEditor.tsx
@@ -322,7 +322,7 @@ export default function FreeCropEditor({
         style={{
           width: renderW,
           height: renderH,
-          backgroundImage: `url(${image.thumbUrl})`,
+          backgroundImage: `url("${image.thumbUrl}")`,
           backgroundSize: 'cover',
           backgroundPosition: 'center',
         }}

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1841,6 +1841,7 @@
     "postprocessStretch": "stretch (may distort)",
     "postprocessCrop": "crop (crop then scale)",
     "maxCropTitle": "Maximum crop ratio within one cluster (default 0.1 = 10%)",
+    "aiLogTitle": "Prior generation log",
     "aiStatusDone": "Done",
     "aiStatusRunning": "Generating",
     "aiStatusFailed": "Failed",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1841,6 +1841,7 @@
     "postprocessStretch": "stretch（拉伸，可能变形）",
     "postprocessCrop": "crop（先裁后缩）",
     "maxCropTitle": "单聚类内最大允许裁剪比例（默认 0.1 = 10%）",
+    "aiLogTitle": "先验生成日志",
     "aiStatusDone": "已完成",
     "aiStatusRunning": "生成中",
     "aiStatusFailed": "失败",

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -526,8 +526,8 @@ export function OutputsTab({ taskId }: { taskId: number }) {
     const sign = sortDir === 'asc' ? 1 : -1
     return [...data.files].sort((a, b) => {
       if (sortKey === 'name') {
-        // numeric: true 让 ep_002 排在 ep_010 之前，避免字典序的 ep_10 < ep_2
-        return a.name.localeCompare(b.name, undefined, { numeric: true }) * sign
+        // numeric 让 ep_002 排在 ep_010 之前，避免字典序的 ep_10 < ep_2
+        return (a.path || a.name).localeCompare(b.path || b.name, undefined, { numeric: true }) * sign
       }
       if (sortKey === 'size') return (a.size - b.size) * sign
       return (a.mtime - b.mtime) * sign
@@ -545,10 +545,10 @@ export function OutputsTab({ taskId }: { taskId: number }) {
   const sortArrow = (key: SortKey) =>
     sortKey === key ? (sortDir === 'asc' ? ' ↑' : ' ↓') : ''
 
-  // 刷新后剔除选中里已不存在的文件名（比如有人手动删了 ep_001.safetensors）
+  // 刷新后剔除选中里已不存在的文件路径
   useEffect(() => {
     if (selected.size === 0) return
-    const names = new Set(sortedFiles.map((f) => f.name))
+    const names = new Set(sortedFiles.map((f) => f.path))
     let dropped = false
     const next = new Set<string>()
     for (const n of selected) {
@@ -559,7 +559,7 @@ export function OutputsTab({ taskId }: { taskId: number }) {
 
   const selectedSize = useMemo(() => {
     let total = 0
-    for (const f of sortedFiles) if (selected.has(f.name)) total += f.size
+    for (const f of sortedFiles) if (selected.has(f.path)) total += f.size
     return total
   }, [sortedFiles, selected])
 
@@ -568,7 +568,7 @@ export function OutputsTab({ taskId }: { taskId: number }) {
   const partialSelected = !allSelected && !noneSelected
 
   const toggleSelectAll = () => {
-    setSelected(allSelected ? new Set() : new Set(sortedFiles.map((f) => f.name)))
+    setSelected(allSelected ? new Set() : new Set(sortedFiles.map((f) => f.path)))
   }
   const toggleOne = (name: string) => {
     setSelected((prev) => {
@@ -731,17 +731,20 @@ export function OutputsTab({ taskId }: { taskId: number }) {
               </span>
             </div>
             {sortedFiles.map((f) => {
-              const isSel = selected.has(f.name)
+              const isSel = selected.has(f.path)
               return (
               <div
-                key={f.name}
-                onClick={selectMode ? () => toggleOne(f.name) : undefined}
+                key={f.path}
+                onClick={selectMode ? () => toggleOne(f.path) : undefined}
                 className={`grid gap-2 px-4 py-2 items-center border-b border-subtle text-xs transition-colors ${selectMode ? `cursor-pointer ${isSel ? 'bg-accent-soft' : 'hover:bg-overlay'}` : 'hover:bg-overlay'}`}
                 style={{ gridTemplateColumns: '1fr 100px 160px 80px' }}
               >
                 <div className="flex items-center gap-1.5 min-w-0">
-                  <code className="font-mono text-fg-primary overflow-hidden text-ellipsis whitespace-nowrap">{f.name}</code>
+                  <code className="font-mono text-fg-primary overflow-hidden text-ellipsis whitespace-nowrap">{f.path || f.name}</code>
                   {f.is_lora && <span className="badge badge-ok">LoRA</span>}
+                  {f.kind === 'training_state' && <span className="badge badge-warn">State</span>}
+                  {f.kind === 'pause_state' && <span className="badge badge-warn">Pause</span>}
+                  {f.kind === 'auto_epoch_state' && <span className="badge badge-warn">Auto</span>}
                 </div>
                 <span className="text-right font-mono text-fg-tertiary">{fmtBytes(f.size)}</span>
                 <span className="text-right font-mono text-fg-tertiary">{fmtTime(f.mtime)}</span>
@@ -750,13 +753,13 @@ export function OutputsTab({ taskId }: { taskId: number }) {
                     <input
                       type="checkbox"
                       checked={isSel}
-                      onChange={() => toggleOne(f.name)}
+                      onChange={() => toggleOne(f.path)}
                       onClick={(e) => e.stopPropagation()}
                       style={{ width: 14, height: 14, accentColor: 'var(--accent)', cursor: 'pointer' }}
-                      aria-label={`${t('common.select')} ${f.name}`}
+                      aria-label={`${t('common.select')} ${f.path || f.name}`}
                     />
                   ) : (
-                    <a href={api.taskOutputDownloadUrl(taskId, f.name)} download={f.name}
+                    <a href={api.taskOutputDownloadUrl(taskId, f.path)} download={f.name}
                       className="text-accent no-underline hover:underline text-xs"
                     >{t('queueDetail.downloadFile')}</a>
                   )}

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -533,6 +533,14 @@ export function OutputsTab({ taskId }: { taskId: number }) {
       return (a.mtime - b.mtime) * sign
     })
   }, [data, sortKey, sortDir])
+  const stateFiles = useMemo(
+    () => sortedFiles.filter((f) => f.kind === 'training_state' || f.kind === 'pause_state' || f.kind === 'auto_epoch_state'),
+    [sortedFiles]
+  )
+  const regularFiles = useMemo(
+    () => sortedFiles.filter((f) => f.kind !== 'training_state' && f.kind !== 'pause_state' && f.kind !== 'auto_epoch_state'),
+    [sortedFiles]
+  )
 
   const onHeaderClick = (key: SortKey) => {
     if (key === sortKey) {
@@ -636,6 +644,79 @@ export function OutputsTab({ taskId }: { taskId: number }) {
     catch { toast(t('queueDetail.copyFailed'), 'error') }
   }
 
+  const renderFileRows = (files: typeof sortedFiles) => files.map((f) => {
+    const isSel = selected.has(f.path)
+    return (
+      <div
+        key={f.path}
+        onClick={selectMode ? () => toggleOne(f.path) : undefined}
+        className={`grid gap-2 px-4 py-2 items-center border-b border-subtle text-xs transition-colors ${selectMode ? `cursor-pointer ${isSel ? 'bg-accent-soft' : 'hover:bg-overlay'}` : 'hover:bg-overlay'}`}
+        style={{ gridTemplateColumns: '1fr 100px 160px 80px' }}
+      >
+        <div className="flex items-center gap-1.5 min-w-0">
+          <code className="font-mono text-fg-primary overflow-hidden text-ellipsis whitespace-nowrap">{f.path || f.name}</code>
+          {f.is_lora && <span className="badge badge-ok">LoRA</span>}
+          {f.kind === 'training_state' && <span className="badge badge-warn">State</span>}
+          {f.kind === 'pause_state' && <span className="badge badge-warn">Pause</span>}
+          {f.kind === 'auto_epoch_state' && <span className="badge badge-warn">Auto</span>}
+        </div>
+        <span className="text-right font-mono text-fg-tertiary">{fmtBytes(f.size)}</span>
+        <span className="text-right font-mono text-fg-tertiary">{fmtTime(f.mtime)}</span>
+        <span className="text-right">
+          {selectMode ? (
+            <input
+              type="checkbox"
+              checked={isSel}
+              onChange={() => toggleOne(f.path)}
+              onClick={(e) => e.stopPropagation()}
+              style={{ width: 14, height: 14, accentColor: 'var(--accent)', cursor: 'pointer' }}
+              aria-label={`${t('common.select')} ${f.path || f.name}`}
+            />
+          ) : (
+            <a href={api.taskOutputDownloadUrl(taskId, f.path)} download={f.name}
+              className="text-accent no-underline hover:underline text-xs"
+            >{t('queueDetail.downloadFile')}</a>
+          )}
+        </span>
+      </div>
+    )
+  })
+
+  const renderFileTable = (files: typeof sortedFiles) => (
+    <div className="card overflow-hidden p-0">
+      <div
+        className="grid gap-2 px-4 py-2 text-xs text-fg-tertiary border-b border-subtle font-mono"
+        style={{ gridTemplateColumns: '1fr 100px 160px 80px' }}
+      >
+        <button
+          onClick={() => onHeaderClick('name')}
+          className="text-left bg-transparent border-0 p-0 text-xs font-mono text-fg-tertiary hover:text-fg-primary cursor-pointer"
+        >{t('common.file')}{sortArrow('name')}</button>
+        <button
+          onClick={() => onHeaderClick('size')}
+          className="text-right bg-transparent border-0 p-0 text-xs font-mono text-fg-tertiary hover:text-fg-primary cursor-pointer"
+        >{t('common.size')}{sortArrow('size')}</button>
+        <button
+          onClick={() => onHeaderClick('mtime')}
+          className="text-right bg-transparent border-0 p-0 text-xs font-mono text-fg-tertiary hover:text-fg-primary cursor-pointer"
+        >{t('queueDetail.modifiedTime')}{sortArrow('mtime')}</button>
+        <span className="text-right">
+          {selectMode ? (
+            <input
+              type="checkbox"
+              checked={allSelected}
+              ref={(el) => { if (el) el.indeterminate = partialSelected }}
+              onChange={toggleSelectAll}
+              style={{ width: 14, height: 14, accentColor: 'var(--accent)', cursor: 'pointer' }}
+              aria-label={t('common.selectAll')}
+            />
+          ) : null}
+        </span>
+      </div>
+      {renderFileRows(files)}
+    </div>
+  )
+
   return (
     <div className="flex flex-col flex-1 min-h-0 p-4 gap-2.5">
       {data?.output_dir ? (
@@ -700,73 +781,19 @@ export function OutputsTab({ taskId }: { taskId: number }) {
         ) : sortedFiles.length === 0 ? (
           <div className="text-fg-tertiary text-sm text-center p-5">{t('queueDetail.dirEmpty')}</div>
         ) : (
-          <div className="card overflow-hidden p-0">
-            <div
-              className="grid gap-2 px-4 py-2 text-xs text-fg-tertiary border-b border-subtle font-mono"
-              style={{ gridTemplateColumns: '1fr 100px 160px 80px' }}
-            >
-              <button
-                onClick={() => onHeaderClick('name')}
-                className="text-left bg-transparent border-0 p-0 text-xs font-mono text-fg-tertiary hover:text-fg-primary cursor-pointer"
-              >{t('common.file')}{sortArrow('name')}</button>
-              <button
-                onClick={() => onHeaderClick('size')}
-                className="text-right bg-transparent border-0 p-0 text-xs font-mono text-fg-tertiary hover:text-fg-primary cursor-pointer"
-              >{t('common.size')}{sortArrow('size')}</button>
-              <button
-                onClick={() => onHeaderClick('mtime')}
-                className="text-right bg-transparent border-0 p-0 text-xs font-mono text-fg-tertiary hover:text-fg-primary cursor-pointer"
-              >{t('queueDetail.modifiedTime')}{sortArrow('mtime')}</button>
-              <span className="text-right">
-                {selectMode ? (
-                  <input
-                    type="checkbox"
-                    checked={allSelected}
-                    ref={(el) => { if (el) el.indeterminate = partialSelected }}
-                    onChange={toggleSelectAll}
-                    style={{ width: 14, height: 14, accentColor: 'var(--accent)', cursor: 'pointer' }}
-                    aria-label={t('common.selectAll')}
-                  />
-                ) : null}
-              </span>
-            </div>
-            {sortedFiles.map((f) => {
-              const isSel = selected.has(f.path)
-              return (
-              <div
-                key={f.path}
-                onClick={selectMode ? () => toggleOne(f.path) : undefined}
-                className={`grid gap-2 px-4 py-2 items-center border-b border-subtle text-xs transition-colors ${selectMode ? `cursor-pointer ${isSel ? 'bg-accent-soft' : 'hover:bg-overlay'}` : 'hover:bg-overlay'}`}
-                style={{ gridTemplateColumns: '1fr 100px 160px 80px' }}
-              >
-                <div className="flex items-center gap-1.5 min-w-0">
-                  <code className="font-mono text-fg-primary overflow-hidden text-ellipsis whitespace-nowrap">{f.path || f.name}</code>
-                  {f.is_lora && <span className="badge badge-ok">LoRA</span>}
-                  {f.kind === 'training_state' && <span className="badge badge-warn">State</span>}
-                  {f.kind === 'pause_state' && <span className="badge badge-warn">Pause</span>}
-                  {f.kind === 'auto_epoch_state' && <span className="badge badge-warn">Auto</span>}
-                </div>
-                <span className="text-right font-mono text-fg-tertiary">{fmtBytes(f.size)}</span>
-                <span className="text-right font-mono text-fg-tertiary">{fmtTime(f.mtime)}</span>
-                <span className="text-right">
-                  {selectMode ? (
-                    <input
-                      type="checkbox"
-                      checked={isSel}
-                      onChange={() => toggleOne(f.path)}
-                      onClick={(e) => e.stopPropagation()}
-                      style={{ width: 14, height: 14, accentColor: 'var(--accent)', cursor: 'pointer' }}
-                      aria-label={`${t('common.select')} ${f.path || f.name}`}
-                    />
-                  ) : (
-                    <a href={api.taskOutputDownloadUrl(taskId, f.path)} download={f.name}
-                      className="text-accent no-underline hover:underline text-xs"
-                    >{t('queueDetail.downloadFile')}</a>
-                  )}
-                </span>
-              </div>
-              )
-            })}
+          <div className="flex flex-col gap-3">
+            {regularFiles.length > 0 && (
+              <section className="flex flex-col gap-1.5">
+                <div className="px-1 text-xs font-semibold text-fg-secondary">输出文件</div>
+                {renderFileTable(regularFiles)}
+              </section>
+            )}
+            {stateFiles.length > 0 && (
+              <section className="flex flex-col gap-1.5">
+                <div className="px-1 text-xs font-semibold text-warn">训练状态</div>
+                {renderFileTable(stateFiles)}
+              </section>
+            )}
           </div>
         )}
       </div>

--- a/studio/web/src/pages/project/steps/PreprocessCrop.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessCrop.tsx
@@ -821,7 +821,7 @@ function Filmstrip({
             <button
               onClick={() => onSelect(im.name)}
               className={'fs-thumb-sq ' + (isActive ? 'is-active' : '')}
-              style={{ backgroundImage: `url(${thumbUrl(im)})` }}
+              style={{ backgroundImage: `url("${thumbUrl(im)}")` }}
               title={im.name}
             >
               {crops.length > 0 && crops.map((c, i) => (

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -4,7 +4,6 @@ import { Trans, useTranslation } from 'react-i18next'
 import { useOutletContext } from 'react-router-dom'
 import {
   api,
-  type AttentionBackend,
   type Job,
   type ProjectDetail,
   type RegAiRequest,
@@ -84,8 +83,8 @@ export default function RegularizationPage() {
   const [aiCfg, setAiCfg] = useState(4.0)
   const [aiSeed, setAiSeed] = useState(0)
   const [aiIncremental, setAiIncremental] = useState(false)
-  const [aiBackend, setAiBackend] = useState<AttentionBackend>('flash_attn')
   const [aiTask, setAiTask] = useState<Task | null>(null)
+  const [aiLogs, setAiLogs] = useState<string[]>([])
   const [aiBusy, setAiBusy] = useState(false)
   const aiTaskIdRef = useRef<number | null>(null)
   aiTaskIdRef.current = aiTask?.id ?? null
@@ -177,6 +176,8 @@ export default function RegularizationPage() {
         // job 成功完成 → 自动切到图片 tab，让用户看成果
         if (evt.status === 'done') setActiveTab('images')
       }
+    } else if (evt.type === 'task_log_appended' && tid && evt.task_id === tid) {
+      setAiLogs((prev) => [...prev, String(evt.text ?? '')])
     } else if (evt.type === 'task_state_changed' && tid && evt.task_id === tid) {
       void api.getRegPriorTask(project.id, vid!, tid).then((t) => {
         setAiTask(t)
@@ -210,6 +211,7 @@ export default function RegularizationPage() {
     }
     setAiBusy(true)
     setAiTask(null)
+    setAiLogs([])
     try {
       const body: RegAiRequest = {
         excluded_tags: Array.from(excluded),
@@ -220,7 +222,6 @@ export default function RegularizationPage() {
         cfg_scale: aiCfg,
         seed: aiSeed,
         incremental: aiIncremental,
-        attention_backend: aiBackend,
       }
       const task = await api.enqueueRegPrior(project.id, vid, body)
       setAiTask(task)
@@ -359,7 +360,6 @@ export default function RegularizationPage() {
           cfg={aiCfg} onCfgChange={setAiCfg}
           seed={aiSeed} onSeedChange={setAiSeed}
           incremental={aiIncremental} onIncrementalChange={setAiIncremental}
-          backend={aiBackend} onBackendChange={setAiBackend}
           task={aiTask}
           trainImageCount={trainImageCount}
         />
@@ -424,6 +424,10 @@ export default function RegularizationPage() {
                 }
               }}
             />
+          )}
+
+          {aiTask && (
+            <AiTaskLogSection task={aiTask} logs={aiLogs} />
           )}
         </div>
       ) : (
@@ -839,6 +843,28 @@ function AiTaskStatus({ task }: { task: Task | null }) {
   )
 }
 
+function AiTaskLogSection({ task, logs }: { task: Task; logs: string[] }) {
+  const { t } = useTranslation()
+  const logEndRef = useRef<HTMLDivElement>(null)
+  useEffect(() => {
+    logEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [logs.length])
+  return (
+    <section className="rounded-md border border-subtle bg-surface px-3.5 py-2.5 flex flex-col gap-2 shrink-0">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-medium text-fg-secondary">{t('reg.aiLogTitle')}</span>
+        <AiTaskStatus task={task} />
+      </div>
+      {logs.length > 0 && (
+        <pre className="m-0 p-2.5 bg-sunken rounded-sm font-mono text-2xs text-fg-secondary leading-relaxed whitespace-pre-wrap break-words max-h-48 overflow-auto">
+          {logs.join('\n')}
+          <div ref={logEndRef} />
+        </pre>
+      )}
+    </section>
+  )
+}
+
 function AiGenPanel({
   trainTags,
   excluded, onToggle,
@@ -849,7 +875,6 @@ function AiGenPanel({
   cfg, onCfgChange,
   seed, onSeedChange,
   incremental, onIncrementalChange,
-  backend, onBackendChange,
   task,
   trainImageCount,
 }: {
@@ -862,7 +887,6 @@ function AiGenPanel({
   cfg: number; onCfgChange: (v: number) => void
   seed: number; onSeedChange: (v: number) => void
   incremental: boolean; onIncrementalChange: (v: boolean) => void
-  backend: AttentionBackend; onBackendChange: (v: AttentionBackend) => void
   task: Task | null
   trainImageCount: number
 }) {
@@ -903,28 +927,14 @@ function AiGenPanel({
         </div>
         <AiNumField label={t('reg.seedLabel')} value={seed} onChange={onSeedChange} min={0} />
 
-        <div className="flex flex-wrap gap-3 items-end">
-          <label className="flex items-center gap-1.5 cursor-pointer text-xs">
-            <input
-              type="checkbox"
-              checked={incremental}
-              onChange={(e) => onIncrementalChange(e.target.checked)}
-            />
-            <span className="text-fg-secondary">{t('reg.incrementalLabel')}</span>
-          </label>
-          <div className="flex flex-col gap-1">
-            <label className="caption text-2xs">{t('reg.backendLabel')}</label>
-            <select
-              className="input text-xs py-1"
-              value={backend}
-              onChange={(e) => onBackendChange(e.target.value as AttentionBackend)}
-            >
-              <option value="flash_attn">Flash Attention</option>
-              <option value="xformers">xformers</option>
-              <option value="none">{t('reg.backendNone')}</option>
-            </select>
-          </div>
-        </div>
+        <label className="flex items-center gap-1.5 cursor-pointer text-xs">
+          <input
+            type="checkbox"
+            checked={incremental}
+            onChange={(e) => onIncrementalChange(e.target.checked)}
+          />
+          <span className="text-fg-secondary">{t('reg.incrementalLabel')}</span>
+        </label>
 
         <AiTaskStatus task={task} />
       </section>

--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -11,6 +11,7 @@ let lastEnqueueBody: Record<string, unknown> | null = null
 
 beforeEach(() => {
   lastEnqueueBody = null
+  window.localStorage.clear()
   vi.stubGlobal('fetch', fetchMock)
   fetchMock.mockReset()
   fetchMock.mockImplementation((url: string, init?: RequestInit) => {
@@ -129,5 +130,25 @@ describe('GeneratePage 端到端 smoke', () => {
     await user.click(screen.getByRole('button', { name: '单图' }))
 
     expect(promptArea).toHaveValue('my custom prompt')
+  })
+
+  it('刷新后恢复左侧生成参数，但不恢复当前生成结果', async () => {
+    const user = userEvent.setup()
+    const first = setup()
+    await waitForInitialLorasLoad()
+
+    const promptArea = screen.getAllByPlaceholderText('输入正向提示词…')[0]
+    await user.clear(promptArea)
+    await user.type(promptArea, 'persist me')
+    await user.click(screen.getByRole('button', { name: 'XY 矩阵' }))
+
+    first.unmount()
+    setup()
+    await waitForInitialLorasLoad()
+
+    expect(screen.getAllByPlaceholderText('输入正向提示词…')[0]).toHaveValue('persist me')
+    expect(screen.getByRole('button', { name: /开始生成 · 3 张/ })).toBeInTheDocument()
+    expect(screen.queryByText('#1')).toBeNull()
+    expect(screen.getByText('填写参数后点击「开始生成」')).toBeInTheDocument()
   })
 })

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -11,6 +11,7 @@ import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
 import { useEventStream } from '../../lib/useEventStream'
 import { useMonitorProgress } from '../../lib/useMonitorProgress'
+import { useLocalStorageState } from '../../lib/useLocalStorageState'
 import AspectChips, { aspectFromDimensions, type AspectName } from './generate/AspectChips'
 import DaemonControls from './generate/DaemonControls'
 import GenerateProgressBar, { type GenerateProgress } from './generate/GenerateProgress'
@@ -30,21 +31,42 @@ import { DEFAULT_NEG } from './generate/types'
 import { useProjectLoras } from './generate/useProjectLoras'
 import { cellCount, draftToSpec, parseAxisValues, type XYAxisDraft } from './generate/xy'
 
+const GENERATE_PREFS_KEY = 'studio:generate:params:v1'
+
+const DEFAULT_GENERATE_PREFS = {
+  mode: 'single' as ViewMode,
+  prompts: ['newest, safe, 1girl, masterpiece, best quality'],
+  negPrompt: DEFAULT_NEG,
+  aspect: '1:1' as AspectName,
+  width: 1024,
+  height: 1024,
+  steps: 25,
+  cfgScale: 4.0,
+  count: 1,
+  seed: 0,
+  loras: [] as LoraEntry[],
+  xDraft: { axis: 'steps', raw: '20, 25, 30', loraIndex: null } as XYAxisDraft,
+  yDraft: null as XYAxisDraft | null,
+  datasetPick: null as DatasetPick | null,
+}
+
 export default function GeneratePage() {
   const { t } = useTranslation()
   const { toast } = useToast()
 
-  const [mode, setMode] = useState<ViewMode>('single')
-  const [prompts, setPrompts] = useState<string[]>(['newest, safe, 1girl, masterpiece, best quality'])
-  const [negPrompt, setNegPrompt] = useState(DEFAULT_NEG)
-  const [aspect, setAspect] = useState<AspectName>('1:1')
-  const [width, setWidth] = useState(1024)
-  const [height, setHeight] = useState(1024)
-  const [steps, setSteps] = useState(25)
-  const [cfgScale, setCfgScale] = useState(4.0)
-  const [count, setCount] = useState(1)
-  const [seed, setSeed] = useState(0)
-  const [loras, setLoras] = useState<LoraEntry[]>([])
+  const [prefs, setPrefs] = useLocalStorageState(GENERATE_PREFS_KEY, DEFAULT_GENERATE_PREFS)
+  const { mode, prompts, negPrompt, aspect, width, height, steps, cfgScale, count, seed, loras, xDraft, yDraft, datasetPick } = prefs
+  const setMode = (mode: ViewMode) => setPrefs((p) => ({ ...p, mode }))
+  const setPrompts = (prompts: string[]) => setPrefs((p) => ({ ...p, prompts }))
+  const setNegPrompt = (negPrompt: string) => setPrefs((p) => ({ ...p, negPrompt }))
+  const setAspect = (aspect: AspectName) => setPrefs((p) => ({ ...p, aspect }))
+  const setWidth = (width: number) => setPrefs((p) => ({ ...p, width }))
+  const setHeight = (height: number) => setPrefs((p) => ({ ...p, height }))
+  const setSteps = (steps: number) => setPrefs((p) => ({ ...p, steps }))
+  const setCfgScale = (cfgScale: number) => setPrefs((p) => ({ ...p, cfgScale }))
+  const setCount = (count: number) => setPrefs((p) => ({ ...p, count }))
+  const setSeed = (seed: number) => setPrefs((p) => ({ ...p, seed }))
+  const setLoras = (loras: LoraEntry[]) => setPrefs((p) => ({ ...p, loras }))
 
   // LoRA 预填 via URL query (?lora=<path>&projectId=N&versionId=N)
   // Overview StatusBanner "在测试中加载" CTA 跳进来时，把 LoRA 直接塞入 loras。
@@ -55,14 +77,17 @@ export default function GeneratePage() {
     if (!lora) return
     const projectId = sp.get('projectId')
     const versionId = sp.get('versionId')
-    setLoras((prev) => {
-      if (prev.some((l) => l.path === lora)) return prev
-      return [...prev, {
-        path: lora,
-        scale: 1.0,
-        project_id: projectId ? Number(projectId) : null,
-        version_id: versionId ? Number(versionId) : null,
-      }]
+    setPrefs((p) => {
+      if (p.loras.some((l) => l.path === lora)) return p
+      return {
+        ...p,
+        loras: [...p.loras, {
+          path: lora,
+          scale: 1.0,
+          project_id: projectId ? Number(projectId) : null,
+          version_id: versionId ? Number(versionId) : null,
+        }],
+      }
     })
     const url = new URL(window.location.href)
     url.searchParams.delete('lora')
@@ -70,13 +95,12 @@ export default function GeneratePage() {
     url.searchParams.delete('versionId')
     window.history.replaceState({}, '', url.toString())
   }, [])
-
   // commit C: attention backend 已从 Generate 页移到 Settings；server 端
   // enqueue_generate 会自动从 secrets.generate.attention_backend 注入。
 
-  // XY 模式 state（mode='single' 时不参与 enqueue）
-  const [xDraft, setXDraft] = useState<XYAxisDraft>({ axis: 'steps', raw: '20, 25, 30', loraIndex: null })
-  const [yDraft, setYDraft] = useState<XYAxisDraft | null>(null)
+  const setXDraft = (xDraft: XYAxisDraft) => setPrefs((p) => ({ ...p, xDraft }))
+  const setYDraft = (yDraft: XYAxisDraft | null) => setPrefs((p) => ({ ...p, yDraft }))
+  const setDatasetPick = (datasetPick: DatasetPick | null) => setPrefs((p) => ({ ...p, datasetPick }))
 
   // 双图对比：选中的 2 个 sample 索引（从 PreviewXYGrid cell click 收集）
   const [selectedIndices, setSelectedIndices] = useState<number[]>([])
@@ -98,9 +122,6 @@ export default function GeneratePage() {
     batchIdx: null, batchTotal: null, currentStep: null, totalSteps: null,
   })
   const [datasetPickerOpen, setDatasetPickerOpen] = useState(false)
-  // dataset picker 选中状态：picker 关掉再开都保留；不写进 prompts 数组，
-  // 而是在 handleGenerate 里把 tags 拼到每条 prompt 末尾再 enqueue。
-  const [datasetPick, setDatasetPick] = useState<DatasetPick | null>(null)
   // commit 16：图片历史栏。点击历史项 → 主预览替换为该项封面
   const history = useGenerateHistory()
   const [historyOverride, setHistoryOverride] = useState<HistoryEntry | null>(null)

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -97,6 +97,7 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
 
         download_dir, preprocess_dir = preprocess.project_paths(project)
         preprocess_dir.mkdir(parents=True, exist_ok=True)
+        project_dir = projects.project_dir(project["id"], project["slug"])
 
         # 模型权重必须先下载（UI 在开始按钮前会引导用户下载）
         model_path = model_downloader.upscaler_target(model_label)
@@ -155,8 +156,10 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
             if _stop_requested:
                 log(f"[cancel] 收到取消信号，已处理 {idx - 1}/{total}")
                 break
-            src_path = download_dir / src_name
-            if not src_path.exists():
+            src_path, origin_name = _resolve_upscale_source(
+                project_dir, download_dir, preprocess_dir, src_name
+            )
+            if src_path is None or not src_path.exists():
                 log(f"[skip] ({idx}/{total}) {src_name}: 源已不存在")
                 skipped += 1
                 emit_event(
@@ -168,8 +171,11 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
             dst_path = preprocess.product_path_for(preprocess_dir, src_name)
             # 'all' 是增量（已 resolve 过）；这里再过一遍 manifest，防止两个 worker
             # 同时被调起（罕见但便宜）。'all_force' / 'selected' 走重跑路径。
-            if mode == "all" and preprocess_manifest.get_entry(
-                projects.project_dir(project["id"], project["slug"]), dst_path.name
+            existing_entry = preprocess_manifest.get_entry(project_dir, dst_path.name)
+            if (
+                mode == "all"
+                and existing_entry is not None
+                and preprocess_manifest.entry_stage(existing_entry) == "upscaled"
             ):
                 skipped += 1
                 emit_event(
@@ -195,8 +201,9 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
                     prewarm_thumb_sizes=[256, 768],
                 )
                 # 写 manifest：ADR 0004 — 状态唯一真理，downstream resolve 用
+                meta["origin"] = origin_name
                 preprocess_manifest.add_processed(
-                    projects.project_dir(project["id"], project["slug"]),
+                    project_dir,
                     dst_path.name,
                     meta,
                 )
@@ -227,6 +234,22 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
         log(f"[error] {exc}")
         print(traceback.format_exc(), flush=True)
         return 1
+
+
+def _resolve_upscale_source(
+    project_dir: Path,
+    download_dir: Path,
+    preprocess_dir: Path,
+    name: str,
+) -> tuple[Path | None, str]:
+    entry = preprocess_manifest.get_entry(project_dir, name)
+    if entry is not None:
+        origin = preprocess_manifest.entry_origin(entry, name)
+        return preprocess_dir / name, origin
+    dl = download_dir / name
+    if dl.is_file():
+        return dl, name
+    return None, name
 
 
 def _resolve_crop_source(

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -156,9 +156,9 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
             if _stop_requested:
                 log(f"[cancel] 收到取消信号，已处理 {idx - 1}/{total}")
                 break
-            src_path, origin_name = _resolve_upscale_source(
-                project_dir, download_dir, preprocess_dir, src_name
-            )
+            # ADR 0004 §149 resolver 单点：manifest 有 entry → preprocess/{name}；
+            # 否则 → download/{name}（隐式 original）。worker 不自己决定源在哪。
+            src_path = preprocess_manifest.resolve(project_dir, src_name)
             if src_path is None or not src_path.exists():
                 log(f"[skip] ({idx}/{total}) {src_name}: 源已不存在")
                 skipped += 1
@@ -168,15 +168,18 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
                     succeeded=succeeded, failed=failed, skipped=skipped,
                 )
                 continue
+            # origin 沿用 manifest 里已有的（含 multi-crop 的根 origin），没就用 name 本身。
+            existing_entry = preprocess_manifest.get_entry(project_dir, src_name)
+            origin_name = (
+                preprocess_manifest.entry_origin(existing_entry, src_name)
+                if existing_entry is not None
+                else src_name
+            )
             dst_path = preprocess.product_path_for(preprocess_dir, src_name)
-            # 'all' 是增量（已 resolve 过）；这里再过一遍 manifest，防止两个 worker
-            # 同时被调起（罕见但便宜）。'all_force' / 'selected' 走重跑路径。
-            existing_entry = preprocess_manifest.get_entry(project_dir, dst_path.name)
-            if (
-                mode == "all"
-                and existing_entry is not None
-                and preprocess_manifest.entry_stage(existing_entry) == "upscaled"
-            ):
+            # 'all' 增量去重：dst 已有 entry 跳过；race guard 也走这里。
+            # ADR 0004 Addendum 1 §「Stage 不强制时序」—— 不按 stage 判断该不该跑，
+            # 用户在 selected / all_force 明确表态时一律放行。
+            if mode == "all" and preprocess_manifest.get_entry(project_dir, dst_path.name) is not None:
                 skipped += 1
                 emit_event(
                     "preprocess_progress",
@@ -234,22 +237,6 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
         log(f"[error] {exc}")
         print(traceback.format_exc(), flush=True)
         return 1
-
-
-def _resolve_upscale_source(
-    project_dir: Path,
-    download_dir: Path,
-    preprocess_dir: Path,
-    name: str,
-) -> tuple[Path | None, str]:
-    entry = preprocess_manifest.get_entry(project_dir, name)
-    if entry is not None:
-        origin = preprocess_manifest.entry_origin(entry, name)
-        return preprocess_dir / name, origin
-    dl = download_dir / name
-    if dl.is_file():
-        return dl, name
-    return None, name
 
 
 def _resolve_crop_source(

--- a/tests/test_inference_core.py
+++ b/tests/test_inference_core.py
@@ -179,6 +179,76 @@ def test_apply_loras_empty_specs() -> None:
     assert apply_loras(model, [], device="cpu", dtype=torch.float32) == []
 
 
+def test_model_cache_hot_reloads_same_topology_lora_ckpt(tmp_path: Path) -> None:
+    """XY lora_ckpt 切同结构 checkpoint 时只换权重，不 detach/reinject。"""
+    p1 = tmp_path / "a.safetensors"
+    p2 = tmp_path / "b.safetensors"
+    _write_lora_safetensors(p1, rank=16, alpha=8.0, algo="lokr", factor=8)
+    _write_lora_safetensors(p2, rank=16, alpha=8.0, algo="lokr", factor=8)
+
+    created: list[MagicMock] = []
+
+    def _fake_adapter(*args: object, **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        m.network = MagicMock()
+        m.network.loras = []
+        m.load_state_dict.return_value = MagicMock(missing_keys=[], unexpected_keys=[])
+        created.append(m)
+        return m
+
+    from runtime.anima_daemon import ModelCache
+
+    cache = ModelCache()
+    cache.model = MagicMock()
+    cache.device = "cpu"
+    cache.dtype = torch.float32
+
+    with _patched_adapter(_fake_adapter):
+        first = cache.apply_loras([{"path": str(p1), "scale": 1.0}])
+        second = cache.apply_loras([{"path": str(p2), "scale": 0.5}])
+
+    assert first is second
+    assert len(created) == 1
+    created[0].detach.assert_not_called()
+    assert created[0].inject.call_count == 1
+    assert created[0].load_state_dict.call_count == 2
+    assert created[0].network.multiplier == 0.5
+    assert cache.last_lora_specs == [LoRASpec(path=str(p2), scale=0.5)]
+
+
+def test_model_cache_reinjects_when_lora_topology_changes(tmp_path: Path) -> None:
+    p1 = tmp_path / "rank16.safetensors"
+    p2 = tmp_path / "rank8.safetensors"
+    _write_lora_safetensors(p1, rank=16, alpha=8.0, algo="lokr", factor=8)
+    _write_lora_safetensors(p2, rank=8, alpha=4.0, algo="lokr", factor=8)
+
+    created: list[MagicMock] = []
+
+    def _fake_adapter(*args: object, **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        m.network = MagicMock()
+        m.network.loras = []
+        m.detach.return_value = True
+        m.load_state_dict.return_value = MagicMock(missing_keys=[], unexpected_keys=[])
+        created.append(m)
+        return m
+
+    from runtime.anima_daemon import ModelCache
+
+    cache = ModelCache()
+    cache.model = MagicMock()
+    cache.device = "cpu"
+    cache.dtype = torch.float32
+
+    with _patched_adapter(_fake_adapter):
+        cache.apply_loras([{"path": str(p1), "scale": 1.0}])
+        cache.apply_loras([{"path": str(p2), "scale": 1.0}])
+
+    assert len(created) == 2
+    created[0].detach.assert_called_once()
+    created[1].inject.assert_called_once_with(cache.model)
+
+
 # ---------------------------------------------------------------------------
 # generate tempdir helpers
 # ---------------------------------------------------------------------------

--- a/tests/test_inference_daemon.py
+++ b/tests/test_inference_daemon.py
@@ -55,10 +55,16 @@ _MOCK_DAEMON = textwrap.dedent(
             tid = msg.get("task_id", 0)
             sys.stdout.write(json.dumps({"id":rid,"kind":"started","task_id":tid}) + "\\n")
             sys.stdout.flush()
+            if msg.get("config", {}).get("wait_for_cancel"):
+                continue
             # 出 1 张图：bytes 走协议 b64 字段（commit 10），不写磁盘
             sys.stdout.write(json.dumps({"id":rid,"kind":"image_done","task_id":tid,"filename":"fake.png","path":"/anima_gen_%d/fake.png" % tid,"step":1,"total":1,"image_b64":fake_b64,"byte_size":8}) + "\\n")
             sys.stdout.flush()
             sys.stdout.write(json.dumps({"id":rid,"kind":"done","task_id":tid}) + "\\n")
+            sys.stdout.flush()
+        elif action == "cancel":
+            target = msg.get("target_id") or rid
+            sys.stdout.write(json.dumps({"id":target,"kind":"canceled","task_id":0}) + "\\n")
             sys.stdout.flush()
         elif action == "unload":
             sys.stdout.write(json.dumps({"id":"_evt","kind":"unloaded"}) + "\\n")
@@ -280,6 +286,37 @@ def test_supervisor_cancel_pending_generate(env, mock_daemon_script, monkeypatch
     # 不 start sup —— pending 直接 cancel
     assert sup.cancel(tid) is True
     assert _task_status(env["db"], tid) == "canceled"
+
+
+def test_supervisor_cancel_running_generate_keeps_daemon_alive(env, mock_daemon_script, monkeypatch):
+    from studio.supervisor import Supervisor
+
+    d = InferenceDaemon(script_path=mock_daemon_script)
+    _patch_singleton(d, monkeypatch)
+    events: list[dict[str, Any]] = []
+    sup = Supervisor(
+        on_event=events.append,
+        db_path=env["db"], logs_dir=env["logs"], configs_dir=env["configs"],
+        poll_interval=0.05,
+    )
+    tid = _make_generate_task(env, cfg_overrides={"wait_for_cancel": True})
+
+    sup.start()
+    try:
+        assert _wait_for(lambda: _task_status(env["db"], tid) == "running", timeout=5)
+        assert d.is_alive
+        assert d.state == STATE_BUSY
+
+        assert sup.cancel(tid) is True
+        assert _wait_for(lambda: _task_status(env["db"], tid) == "canceled", timeout=5)
+        assert d.is_alive
+        assert d.state == STATE_IDLE
+    finally:
+        sup.stop()
+
+    daemon_evts = [e for e in events if e.get("type") == "daemon_state_changed"]
+    assert daemon_evts
+    assert any(e.get("busy") is False for e in daemon_evts)
 
 
 def test_supervisor_train_dispatch_skips_generate(env, monkeypatch):

--- a/tests/test_studio_queue_endpoints.py
+++ b/tests/test_studio_queue_endpoints.py
@@ -175,17 +175,30 @@ def test_outputs_list_with_files(
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "lora_final.safetensors").write_bytes(b"x" * 100)
     (out_dir / "training_state_step100.pt").write_bytes(b"y" * 50)
+    state_dir = out_dir / "state" / f"task_{tid}"
+    state_dir.mkdir(parents=True)
+    (state_dir / "training_state_epoch2.pt").write_bytes(b"z" * 25)
 
     resp = client.get(f"/api/queue/{tid}/outputs")
     assert resp.status_code == 200
     body = resp.json()
     assert body["task_id"] == tid
     assert body["exists"] is True
-    names = sorted(f["name"] for f in body["files"])
-    assert names == ["lora_final.safetensors", "training_state_step100.pt"]
-    by_name = {f["name"]: f for f in body["files"]}
-    assert by_name["lora_final.safetensors"]["is_lora"] is True
-    assert by_name["lora_final.safetensors"]["size"] == 100
+    paths = sorted(f["path"] for f in body["files"])
+    assert paths == [
+        "lora_final.safetensors",
+        "state/task_%d/training_state_epoch2.pt" % tid,
+        "training_state_step100.pt",
+    ]
+    by_path = {f["path"]: f for f in body["files"]}
+    assert by_path["lora_final.safetensors"]["is_lora"] is True
+    assert by_path["lora_final.safetensors"]["kind"] == "lora"
+    assert by_path["lora_final.safetensors"]["size"] == 100
+    assert by_path["training_state_step100.pt"]["is_lora"] is False
+    assert by_path["training_state_step100.pt"]["kind"] == "training_state"
+    nested_state = by_path["state/task_%d/training_state_epoch2.pt" % tid]
+    assert nested_state["name"] == "training_state_epoch2.pt"
+    assert nested_state["kind"] == "training_state"
     # TestClient 默认 client.host 是 "testclient" 不在 loopback 集合里 → False
     assert body["supports_open_folder"] is False
 
@@ -214,10 +227,17 @@ def test_download_output_file(
     out_dir = versions_mod.version_dir(p["id"], p["slug"], v["label"]) / "output"
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "lora_final.safetensors").write_bytes(b"BLOB")
+    state_dir = out_dir / "state" / f"task_{tid}"
+    state_dir.mkdir(parents=True)
+    (state_dir / "training_state_epoch2.pt").write_bytes(b"STATE")
 
     resp = client.get(f"/api/queue/{tid}/output/lora_final.safetensors")
     assert resp.status_code == 200
     assert resp.content == b"BLOB"
+
+    resp = client.get(f"/api/queue/{tid}/output/state/task_{tid}/training_state_epoch2.pt")
+    assert resp.status_code == 200
+    assert resp.content == b"STATE"
     # FileResponse(filename=...) 自动加 Content-Disposition: attachment
     assert "attachment" in resp.headers.get("content-disposition", "").lower()
 
@@ -239,6 +259,9 @@ def test_download_outputs_zip(
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "lora_final.safetensors").write_bytes(b"AAA")
     (out_dir / "training_state_step100.pt").write_bytes(b"BB")
+    state_dir = out_dir / "state" / f"task_{tid}"
+    state_dir.mkdir(parents=True)
+    (state_dir / "training_state_epoch2.pt").write_bytes(b"CC")
 
     resp = client.get(f"/api/queue/{tid}/outputs.zip")
     assert resp.status_code == 200
@@ -249,9 +272,14 @@ def test_download_outputs_zip(
 
     with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
         names = sorted(zf.namelist())
-        assert names == ["lora_final.safetensors", "training_state_step100.pt"]
+        assert names == [
+            "lora_final.safetensors",
+            "state/task_%d/training_state_epoch2.pt" % tid,
+            "training_state_step100.pt",
+        ]
         assert zf.read("lora_final.safetensors") == b"AAA"
         assert zf.read("training_state_step100.pt") == b"BB"
+        assert zf.read("state/task_%d/training_state_epoch2.pt" % tid) == b"CC"
 
 
 def test_list_task_outputs_returns_archive_basename(
@@ -295,17 +323,22 @@ def test_download_outputs_zip_partial(
     (out_dir / "ep_001.safetensors").write_bytes(b"E1")
     (out_dir / "ep_002.safetensors").write_bytes(b"E2")
     (out_dir / "ep_003.safetensors").write_bytes(b"E3")
+    state_dir = out_dir / "state" / f"task_{tid}"
+    state_dir.mkdir(parents=True)
+    (state_dir / "training_state_epoch2.pt").write_bytes(b"S2")
 
     resp = client.get(
-        f"/api/queue/{tid}/outputs.zip?files=ep_001.safetensors,ep_003.safetensors"
+        f"/api/queue/{tid}/outputs.zip?files=ep_001.safetensors,state/task_{tid}/training_state_epoch2.pt"
     )
     assert resp.status_code == 200
     expected_name = f"{p['slug']}-{v['label']}_outputs_selected.zip"
     assert expected_name in resp.headers.get("content-disposition", "")
     with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
         names = sorted(zf.namelist())
-        assert names == ["ep_001.safetensors", "ep_003.safetensors"]
+        nested = f"state/task_{tid}/training_state_epoch2.pt"
+        assert names == ["ep_001.safetensors", nested]
         assert zf.read("ep_001.safetensors") == b"E1"
+        assert zf.read(nested) == b"S2"
 
 
 def test_download_outputs_zip_partial_missing_file_404(
@@ -330,7 +363,7 @@ def test_download_outputs_zip_partial_missing_file_404(
 def test_download_outputs_zip_partial_blocks_traversal(
     client: TestClient, isolated, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """?files= 里含路径分隔符 / .. → 400，防止读 output 目录之外的文件。"""
+    """?files= 允许安全相对路径，但禁止 path traversal / 绝对路径。"""
     from studio import projects as projects_mod, versions as versions_mod
     monkeypatch.setattr(projects_mod, "PROJECTS_DIR", isolated / "projects")
     with db.connection_for() as conn:
@@ -341,12 +374,18 @@ def test_download_outputs_zip_partial_blocks_traversal(
     out_dir = versions_mod.version_dir(p["id"], p["slug"], v["label"]) / "output"
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "a.safetensors").write_bytes(b"A")
+    nested_dir = out_dir / "state" / f"task_{tid}"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "training_state_epoch2.pt").write_bytes(b"S2")
 
-    for bad in ("../secret", "..\\secret", "sub/x", "sub\\x"):
-        resp = client.get(
-            f"/api/queue/{tid}/outputs.zip", params={"files": bad}
-        )
+    safe = f"state/task_{tid}/training_state_epoch2.pt"
+    resp = client.get(f"/api/queue/{tid}/outputs.zip", params={"files": safe})
+    assert resp.status_code == 200
+
+    for bad in ("../secret", "..\\secret", "/abs", "state/../secret"):
+        resp = client.get(f"/api/queue/{tid}/outputs.zip", params={"files": bad})
         assert resp.status_code == 400, f"{bad!r} should be 400, got {resp.status_code}"
+
 
 
 def test_download_outputs_zip_empty_dir_404(

--- a/tests/test_studio_queue_endpoints.py
+++ b/tests/test_studio_queue_endpoints.py
@@ -178,6 +178,16 @@ def test_outputs_list_with_files(
     state_dir = out_dir / "state" / f"task_{tid}"
     state_dir.mkdir(parents=True)
     (state_dir / "training_state_epoch2.pt").write_bytes(b"z" * 25)
+    (state_dir / "notes.txt").write_text("ignore", encoding="utf-8")
+    other_state_dir = out_dir / "state" / "task_999"
+    other_state_dir.mkdir(parents=True)
+    (other_state_dir / "training_state_epoch20.pt").write_bytes(b"other")
+    wandb_dir = out_dir / "wandb" / "wandb" / "run-20260522_133229-rw752qai" / "files"
+    wandb_dir.mkdir(parents=True)
+    (wandb_dir / "wandb-metadata.json").write_text("{}", encoding="utf-8")
+    samples_dir = out_dir / "samples"
+    samples_dir.mkdir()
+    (samples_dir / "step_0_baseline_0.png").write_bytes(b"png")
 
     resp = client.get(f"/api/queue/{tid}/outputs")
     assert resp.status_code == 200
@@ -262,6 +272,12 @@ def test_download_outputs_zip(
     state_dir = out_dir / "state" / f"task_{tid}"
     state_dir.mkdir(parents=True)
     (state_dir / "training_state_epoch2.pt").write_bytes(b"CC")
+    wandb_dir = out_dir / "wandb" / "wandb" / "run-20260522_133229-rw752qai" / "files"
+    wandb_dir.mkdir(parents=True)
+    (wandb_dir / "requirements.txt").write_text("wandb", encoding="utf-8")
+    samples_dir = out_dir / "samples"
+    samples_dir.mkdir()
+    (samples_dir / "vae_roundtrip.png").write_bytes(b"png")
 
     resp = client.get(f"/api/queue/{tid}/outputs.zip")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- **推理 (Inference)**：支持热换同结构 LoRA checkpoint，取消生成任务时保留推理 daemon 不被误杀，持久化测试页生成参数
- **队列 (Queue)**：仅展示当前任务训练状态 + 嵌套训练输出正确显示；FastAPI 路由顺序修复（`/api/queue/hold` 等静态路径被 `{task_id}` 参数路由抢匹配导致 422）
- **训练 (Training)**：训练状态保存日志与自动 epoch 备份隔离，`__EVENT__:` 协议行不再污染日志页面
- **正则化 (Regularization)**：prior generation 从队列隐藏，日志移至 config tab，自动检测 attention backend
- **预处理 (Preprocess)**：允许裁剪图片被放大（upscale）；CSS `url()` 加引号修复含括号文件名的图片加载失败

## Test plan

- [ ] 推理页面切换同结构 LoRA 不重启 daemon
- [ ] 取消推理任务后 daemon 仍存活可复用
- [x] 生成参数刷新页面后保留
- [ ] 队列页面仅显示当前任务状态，嵌套输出正确渲染
- [ ] `/api/queue/hold` `/api/queue/release` `/api/queue/reorder` 不返回 422
- [ ] 训练日志页不显示 `__EVENT__:` 开头行
- [ ] epoch/step 保存各自有独立日志提示
- [ ] 含括号文件名的图片在 crop 页正常加载
- [ ] 裁剪后分辨率小于目标时图片能被放大

---

## Maintainer update (2026-05-24)

为了在 squash-merge 前清掉冲突 + 对齐 ADR 0004，我（maintainer）直接 push 了两类改动到本 fork branch（开启了 `maintainerCanModify` 所以走这条快路径，原 10 个 commit 的 authorship 保留）：

**1. Rebase onto `dev`** — 解掉跟最近 5 个 dev PR 的冲突：
- `Generate.tsx`：跟 dev 的 URL query LoRA 预填 useEffect 合并到 prefs/setPrefs 路径
- `server.py`：把 dev 引入的 `_select_task_output_files` / `_write_outputs_zip` helper 跟 PR ④/⑤ 的递归 + `_safe_output_relpath_or_400` 合并，helper 现在内部走 rglob + relpath

**2. 反转 `fix(preprocess): allow cropped images to be upscaled` 的 stage 字段方案** — 多加 1 个 commit（`110ce05`）改写。原 PR 思路是对的（crop 后想再 upscale 应该走得通），但实现引入 `stage: "cropped" | "upscaled"` 字段，跟 [ADR 0004 Addendum 1 §「Stage 不强制时序」](docs/adr/0004-preprocess-manifest.md#stage-不强制时序) 直接冲突 —— ADR 明文规定所有产物 entry 同类 `(origin + mtime + size)`，stage 信息只在 worker 运行时存在，不进 manifest。

改写后保留了 PR 想达到的能力（worker 能处理 cropped 产物作为源），但走的是 ADR 一致的路径：

- worker 通过 `preprocess_manifest.resolve()` 单点拿源（ADR §149），不自己写 `_resolve_upscale_source`
- `resolve_targets(mode='selected')` 接受 download 实存名 ∪ manifest 已记 entry 名 —— 用户在 UI selected 模式选 cropped 产物名即可触发再 upscale
- 删除 stage-based skip：用户明确表态时一律放行，符合 ADR §「Stage 不强制时序」的"放大 → 裁剪 → 放大 → 裁剪是合法链路"
- `list_pending` / `summary` 回到原"download 未处理" 定义

所有 preprocess / manifest / queue / inference 相关单测仍 100% pass（44 + 30 + 46 个）。

如果你拉本地分支有冲突，`git fetch && git reset --hard saltysalrua/check/upstream-dev-lora-xy` 即可同步。