### PR TITLE
feat(backend): _v8 schema + VersionStatus/Phase enum + accessor (ADR-0007 PR-2)

### DIFF
--- a/studio/migrations/__init__.py
+++ b/studio/migrations/__init__.py
@@ -20,6 +20,7 @@ from ._v4_task_config_path import migrate as _migrate_v4
 from ._v5_task_type import migrate as _migrate_v5
 from ._v6_pause_resume import migrate as _migrate_v6
 from ._v7_version_trigger_word import migrate as _migrate_v7
+from ._v8_version_status_phase import migrate as _migrate_v8
 
 Migration = Callable[[sqlite3.Connection], None]
 
@@ -31,6 +32,7 @@ MIGRATIONS: list[Migration] = [
     _migrate_v5,  # v5: tasks.task_type（PR-9 区分 train / reg_ai / generate）
     _migrate_v6,  # v6: tasks.paused_* 列 + queue_settings 表（ADR 0006 PR-2）
     _migrate_v7,  # v7: versions.trigger_word（触发词字段）
+    _migrate_v8,  # v8: versions.status / phase / last_failure_reason（ADR-0007）
 ]
 
 

--- a/studio/migrations/_v8_version_status_phase.py
+++ b/studio/migrations/_v8_version_status_phase.py
@@ -1,0 +1,113 @@
+"""v7 → v8: versions 加 status / phase / last_failure_reason — ADR-0007 §11.3-B。
+
+把 master `versions.stage` 一个 enum 字段拆成两个正交字段：
+
+- `status` (5 enum): preparing / training / completed / failed / canceled
+- `phase`  (5 enum, 仅 status=preparing 时有意义):
+  curating / tagging / editing / regularizing / ready
+- `last_failure_reason` TEXT: 训练失败原因（UI 派生用，可空）
+
+本迁移只 add 字段并按映射表回填，**不删** `versions.stage` 列（删除走 v9）。
+迁移期间 backend 由 PR-3 双写新旧字段，保持老 frontend 兼容。
+
+映射表（ADR-0007 §11.3-B）：
+
+  master versions.stage → 新 status / phase
+  ────────────────────────────────────────────────────────────
+  curating         → status=preparing, phase=curating
+  tagging          → status=preparing, phase=tagging
+  regularizing     → status=preparing, phase=regularizing
+  ready            → status=preparing, phase=ready
+  training         → 看 latest task:
+                       done     → completed
+                       failed   → failed
+                       canceled → canceled
+                       running / pending / paused → training
+                       task 不存在 → preparing + phase=ready (脏数据 fallback)
+  done             → status=completed, phase=ready
+  未知 stage       → preparing + phase=ready (fallback)
+
+phase 在 status != preparing 时无业务意义，但字段必填以保 schema 简单 —
+统一落 ready 表示"已走完准备阶段"。
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from ._v2_projects import _add_column_if_missing
+
+
+# stage → (status, phase) 静态映射（training 例外，需要 task lookup）
+_STATIC_STAGE_MAP: dict[str, tuple[str, str]] = {
+    "curating":     ("preparing", "curating"),
+    "tagging":      ("preparing", "tagging"),
+    "regularizing": ("preparing", "regularizing"),
+    "ready":        ("preparing", "ready"),
+    "done":         ("completed", "ready"),
+}
+
+# 老 stage='training' 时，按 latest task.status 派生
+_TASK_STATUS_MAP: dict[str, str] = {
+    "done":     "completed",
+    "failed":   "failed",
+    "canceled": "canceled",
+    "pending":  "training",
+    "running":  "training",
+    "paused":   "training",
+}
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    _add_columns(conn)
+    _backfill(conn)
+
+
+def _add_columns(conn: sqlite3.Connection) -> None:
+    _add_column_if_missing(
+        conn, "versions", "status",
+        "status TEXT NOT NULL DEFAULT 'preparing'",
+    )
+    _add_column_if_missing(
+        conn, "versions", "phase",
+        "phase TEXT NOT NULL DEFAULT 'curating'",
+    )
+    _add_column_if_missing(
+        conn, "versions", "last_failure_reason",
+        "last_failure_reason TEXT",
+    )
+
+
+def _backfill(conn: sqlite3.Connection) -> None:
+    """按 ADR §11.3-B 迁移表把现有 versions.stage 翻译成 status + phase。"""
+    rows = conn.execute("SELECT id, stage FROM versions").fetchall()
+    for vid, stage in rows:
+        if stage in _STATIC_STAGE_MAP:
+            status, phase = _STATIC_STAGE_MAP[stage]
+        elif stage == "training":
+            status, phase = _derive_from_latest_task(conn, vid)
+        else:
+            # 未知 stage（理论上不应出现）→ fallback
+            status, phase = "preparing", "ready"
+        conn.execute(
+            "UPDATE versions SET status = ?, phase = ? WHERE id = ?",
+            (status, phase, vid),
+        )
+    conn.commit()
+
+
+def _derive_from_latest_task(
+    conn: sqlite3.Connection, version_id: int
+) -> tuple[str, str]:
+    """training stage 时按 latest task 推 status；phase 落 'ready'（终态无意义）。"""
+    row = conn.execute(
+        "SELECT status FROM tasks "
+        "WHERE version_id = ? "
+        "ORDER BY created_at DESC LIMIT 1",
+        (version_id,),
+    ).fetchone()
+    if row is None:
+        # 脏数据 fallback：stage=training 但无关联 task
+        return ("preparing", "ready")
+    task_status = str(row[0]) if row[0] else ""
+    new_status = _TASK_STATUS_MAP.get(task_status, "preparing")
+    return (new_status, "ready")

--- a/studio/versions.py
+++ b/studio/versions.py
@@ -25,6 +25,53 @@ VALID_STAGES: frozenset[str] = frozenset({
     "ready", "training", "done",
 })
 
+# ADR-0007 §11.3-B：versions.stage 被拆成 status + phase 两个正交字段。
+# 本节加 enum + readonly accessor；写入路径由 PR-3 双写过渡，v9 删 stage 同步清理。
+
+
+class VersionStatus:
+    """版本运行态状态机（5 enum，ADR-0007 §11.3-B）。"""
+
+    PREPARING = "preparing"
+    TRAINING = "training"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+    VALUES: frozenset[str] = frozenset({
+        PREPARING, TRAINING, COMPLETED, FAILED, CANCELED,
+    })
+
+
+class VersionPhase:
+    """版本准备 cursor，仅 status=preparing 时有业务语义（ADR-0007 §11.3-B / §11.5-A）。
+
+    顺序：curating → tagging → editing → regularizing → ready。
+    regularizing 可跳过（SKIPPABLE），其余必经。
+    """
+
+    CURATING = "curating"
+    TAGGING = "tagging"
+    EDITING = "editing"
+    REGULARIZING = "regularizing"
+    READY = "ready"
+
+    ORDER: tuple[str, ...] = (
+        CURATING, TAGGING, EDITING, REGULARIZING, READY,
+    )
+    VALUES: frozenset[str] = frozenset(ORDER)
+    SKIPPABLE: frozenset[str] = frozenset({REGULARIZING})
+
+
+def get_status(v: dict[str, Any]) -> str:
+    """读 version.status；None / 缺字段 fallback → preparing。"""
+    return str(v.get("status") or VersionStatus.PREPARING)
+
+
+def get_phase(v: dict[str, Any]) -> str:
+    """读 version.phase；None / 缺字段 fallback → curating。"""
+    return str(v.get("phase") or VersionPhase.CURATING)
+
 # label 必须是路径安全的：字母 / 数字 / 下划线 / 连字符 / 点
 _VALID_LABEL = re.compile(r"^[A-Za-z0-9_.-]+$")
 

--- a/tests/test_version_status_phase.py
+++ b/tests/test_version_status_phase.py
@@ -1,0 +1,264 @@
+"""ADR-0007 §11.3-B: versions.status / phase 双字段 + v8 migration 测试。"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from studio import db, versions
+from studio.migrations import current_version
+
+
+def _open(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# schema 加列 + 默认值
+# ---------------------------------------------------------------------------
+
+
+def test_v8_adds_status_phase_columns(tmp_path: Path) -> None:
+    """新库 init 后 versions 含 status / phase / last_failure_reason 三列。"""
+    dbfile = tmp_path / "fresh.db"
+    db.init_db(dbfile)
+    with _open(dbfile) as c:
+        cols = {r["name"] for r in c.execute("PRAGMA table_info(versions)")}
+        assert {"status", "phase", "last_failure_reason"} <= cols
+
+
+def test_v8_default_values_for_new_versions(tmp_path: Path) -> None:
+    """新建 version 不显式指定 status/phase → DEFAULT 'preparing' / 'curating'。"""
+    dbfile = tmp_path / "fresh.db"
+    db.init_db(dbfile)
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+        c.execute(
+            "INSERT INTO versions(project_id, label, stage, created_at) "
+            "VALUES (?, 'v', 'curating', ?)",
+            (pid, time.time()),
+        )
+        c.commit()
+
+        row = c.execute(
+            "SELECT status, phase, last_failure_reason FROM versions WHERE label='v'"
+        ).fetchone()
+        assert row["status"] == "preparing"
+        assert row["phase"] == "curating"
+        assert row["last_failure_reason"] is None
+
+
+def test_v8_apply_all_idempotent(tmp_path: Path) -> None:
+    """重复跑 init_db 不应重复添加列或丢数据。"""
+    dbfile = tmp_path / "fresh.db"
+    db.init_db(dbfile)
+    db.init_db(dbfile)
+    with _open(dbfile) as c:
+        cols = {r["name"] for r in c.execute("PRAGMA table_info(versions)")}
+        assert {"status", "phase", "last_failure_reason"} <= cols
+        assert current_version(c) == 8
+
+
+# ---------------------------------------------------------------------------
+# v8 backfill: 静态映射
+# ---------------------------------------------------------------------------
+
+
+def test_v8_backfill_static_stages(tmp_path: Path) -> None:
+    """老 5 stage 静态映射：curating/tagging/regularizing/ready → preparing+phase；done → completed+ready。"""
+    from studio.migrations._v8_version_status_phase import _backfill
+
+    dbfile = tmp_path / "test.db"
+    db.init_db(dbfile)
+
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # 插入老 stage 5 种，模拟 v8 跑之前的状态
+        for stage in ("curating", "tagging", "regularizing", "ready", "done"):
+            c.execute(
+                "INSERT INTO versions(project_id, label, stage, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (pid, stage, stage, time.time()),
+            )
+        c.commit()
+
+        # 再跑一次 backfill 强制重算（默认 v8 跑过已经设了，这里验证函数本身）
+        _backfill(c)
+
+        rows = {
+            r["label"]: (r["status"], r["phase"])
+            for r in c.execute("SELECT label, status, phase FROM versions")
+        }
+        assert rows["curating"] == ("preparing", "curating")
+        assert rows["tagging"] == ("preparing", "tagging")
+        assert rows["regularizing"] == ("preparing", "regularizing")
+        assert rows["ready"] == ("preparing", "ready")
+        assert rows["done"] == ("completed", "ready")
+
+
+# ---------------------------------------------------------------------------
+# v8 backfill: training stage 按 latest task 推
+# ---------------------------------------------------------------------------
+
+
+def test_v8_backfill_training_by_latest_task(tmp_path: Path) -> None:
+    """stage=training 时按 latest task.status 派生 version.status。"""
+    from studio.migrations._v8_version_status_phase import _backfill
+
+    dbfile = tmp_path / "test.db"
+    db.init_db(dbfile)
+
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        cases = [
+            ("v_done",     "done",     "completed"),
+            ("v_failed",   "failed",   "failed"),
+            ("v_canceled", "canceled", "canceled"),
+            ("v_running",  "running",  "training"),
+            ("v_pending",  "pending",  "training"),
+            ("v_paused",   "paused",   "training"),
+        ]
+        for label, task_status, _ in cases:
+            c.execute(
+                "INSERT INTO versions(project_id, label, stage, created_at) "
+                "VALUES (?, ?, 'training', ?)",
+                (pid, label, time.time()),
+            )
+            vid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+            c.execute(
+                "INSERT INTO tasks(name, config_name, status, project_id, version_id, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (label, "cfg", task_status, pid, vid, time.time()),
+            )
+        c.commit()
+        _backfill(c)
+
+        rows = {
+            r["label"]: r["status"]
+            for r in c.execute("SELECT label, status FROM versions")
+        }
+        for label, _, expected in cases:
+            assert rows[label] == expected, f"{label} → expected {expected}, got {rows[label]}"
+
+
+def test_v8_backfill_training_without_task_fallback(tmp_path: Path) -> None:
+    """脏数据：stage=training 但 task 不存在 → fallback preparing+ready。"""
+    from studio.migrations._v8_version_status_phase import _backfill
+
+    dbfile = tmp_path / "test.db"
+    db.init_db(dbfile)
+
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+        c.execute(
+            "INSERT INTO versions(project_id, label, stage, created_at) "
+            "VALUES (?, 'orphan', 'training', ?)",
+            (pid, time.time()),
+        )
+        c.commit()
+        _backfill(c)
+
+        row = c.execute(
+            "SELECT status, phase FROM versions WHERE label='orphan'"
+        ).fetchone()
+        assert row["status"] == "preparing"
+        assert row["phase"] == "ready"
+
+
+def test_v8_backfill_training_uses_latest_task(tmp_path: Path) -> None:
+    """同 version 多 task 时，按 created_at 最新的 task.status 派生。"""
+    from studio.migrations._v8_version_status_phase import _backfill
+
+    dbfile = tmp_path / "test.db"
+    db.init_db(dbfile)
+
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+        c.execute(
+            "INSERT INTO versions(project_id, label, stage, created_at) "
+            "VALUES (?, 'v', 'training', ?)",
+            (pid, time.time()),
+        )
+        vid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # 老 task failed，新 task done —— 应取新的（completed）
+        now = time.time()
+        c.execute(
+            "INSERT INTO tasks(name, config_name, status, project_id, version_id, created_at) "
+            "VALUES ('old', 'cfg', 'failed', ?, ?, ?)",
+            (pid, vid, now - 100),
+        )
+        c.execute(
+            "INSERT INTO tasks(name, config_name, status, project_id, version_id, created_at) "
+            "VALUES ('new', 'cfg', 'done', ?, ?, ?)",
+            (pid, vid, now),
+        )
+        c.commit()
+        _backfill(c)
+
+        row = c.execute("SELECT status FROM versions WHERE label='v'").fetchone()
+        assert row["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# VersionStatus / VersionPhase enum + helper
+# ---------------------------------------------------------------------------
+
+
+def test_version_status_enum_values() -> None:
+    assert versions.VersionStatus.PREPARING == "preparing"
+    assert versions.VersionStatus.TRAINING == "training"
+    assert versions.VersionStatus.COMPLETED == "completed"
+    assert versions.VersionStatus.FAILED == "failed"
+    assert versions.VersionStatus.CANCELED == "canceled"
+    assert len(versions.VersionStatus.VALUES) == 5
+
+
+def test_version_phase_order_and_skippable() -> None:
+    assert versions.VersionPhase.ORDER == (
+        "curating", "tagging", "editing", "regularizing", "ready",
+    )
+    assert len(versions.VersionPhase.VALUES) == 5
+    assert versions.VersionPhase.SKIPPABLE == frozenset({"regularizing"})
+
+
+def test_get_status_fallback_to_preparing() -> None:
+    assert versions.get_status({}) == "preparing"
+    assert versions.get_status({"status": None}) == "preparing"
+    assert versions.get_status({"status": ""}) == "preparing"
+    assert versions.get_status({"status": "training"}) == "training"
+
+
+def test_get_phase_fallback_to_curating() -> None:
+    assert versions.get_phase({}) == "curating"
+    assert versions.get_phase({"phase": None}) == "curating"
+    assert versions.get_phase({"phase": "editing"}) == "editing"


### PR DESCRIPTION
## Summary

ADR-0007 实施计划 PR-2（依赖 PR-1 #115）：backend schema add-only + models 新字段 readonly。

- `_v8_version_status_phase.py` migration: ADD COLUMN `versions.status` / `phase` / `last_failure_reason` + 按 §11.3-B 映射表数据回填
- `versions.py`: `VersionStatus` (5 enum) + `VersionPhase` (5 enum + ORDER + SKIPPABLE) + `get_status` / `get_phase` readonly accessor
- 老 `versions.stage` 列**保留**，PR-3 双写过渡，PR-5 v9 destructive 删除

## Commits

1. `feat(migration): _v8 加 versions.status / phase / last_failure_reason`
2. `feat(versions): 加 VersionStatus / VersionPhase enum + readonly accessor`
3. `test(versions): v8 migration + status/phase enum/accessor 单测`

## 映射表（来自 ADR §11.3-B）

| master `versions.stage` | 新 `status` | 新 `phase` |
|---|---|---|
| curating | preparing | curating |
| tagging | preparing | tagging |
| regularizing | preparing | regularizing |
| ready | preparing | ready |
| training | 看 latest task: done→completed / failed→failed / canceled→canceled / pending/running/paused→training | ready |
| training (no task) | preparing | ready (fallback) |
| done | completed | ready |

## 依赖

**Base = `feat/project-queue-relation`（PR-1 分支）**。合并顺序：先 PR-1 #115 → 再本 PR。PR-1 合到 dev 后 GitHub 自动 rebase 本 PR 的 base 到 dev。

## Test plan

- [x] `tests/test_migrations.py` 5 个老测试不挂
- [x] `tests/test_version_status_phase.py` 11 个新测试全绿（schema / 默认值 / 静态映射 / training 推 / 边界）
- [x] 全 suite 1384 通过（10 fail / 10 error 全是预先存在的 env 问题：lycoris/flash_attn 缺包 + Python 3.9 types.UnionType，与本 PR 无关）
- [ ] 老 frontend 兼容验证（API 同时返回旧 stage + 新 status/phase 字段）—— PR-3 接管

🤖 Generated with [Claude Code](https://claude.com/claude-code)