### PR TITLE
feat(backend): phase 推进 + supervisor 双写 + task snapshot (ADR-0007 PR-3)

### DIFF
--- a/docs/adr/0007-project-version-lifecycle-refactor.md
+++ b/docs/adr/0007-project-version-lifecycle-refactor.md
@@ -1,0 +1,204 @@
+# 0007 — Project / Version / Task 生命周期重构
+
+**状态**：Proposed
+**日期**：2026-05-23
+**决策者**：@WalkingMeatAxolotl
+
+> **维护约定**：本 ADR 承袭 `docs/design/project-version-task-lifecycle.md` 两轮讨论稿。
+> 一轮决议在设计稿 §1–§10；二轮 review 翻盘 9 处，收敛在 §11；§12 park 的 follow-up 不在本 ADR scope。
+> 已 Accept 的初版决策不修改、不删除；后续 audit / 翻盘 → 在末尾「## 增量更新」追加。
+
+## 背景
+
+master 当前 `Project.stage`（9 态）/ `Version.stage`（6 态）混合了"运行态"和"准备阶段"两个正交概念，结构性问题：
+
+- **Project 卡片撒谎**：训练失败 / 取消 / 暂停后 `projects.stage` 不被推进，badge 永远显示 `training` + 动画 dot
+- **死状态**：`projects.stage` 的 `curating / configured / regularizing` 从无代码推进，3/9 颜色映射用户永远看不到
+- **跳级**：上传 train 图直接跳到 `tagging`，跳过 5 个 stage —— 说明 stage 本质是"做过哪些步骤的集合"，但 UI 把它当线性进度展示
+- **无 source of truth**：`advance_stage()` 是无条件 setter，规则散在 13 个调用点；Project / Version / Task 三套状态机互不对账
+- **数据模型错位**：Project 是聚合体（1:N → Version），不应有"过程状态"
+
+详细痛点 + 三方（PM / User / Designer）两轮辩论过程见 `docs/design/project-version-task-lifecycle.md`，本 ADR 承袭其逻辑模型，重点固化决策和实施路径。
+
+## 候选方案
+
+下列每条都列了否决的方案以记录否决理由。完整辩论见设计稿 §11.x。
+
+### Project 数据模型
+
+- **A 加 status 字段**：项目是聚合体（1:N → Version），不该有过程状态。否决
+- **B 保留 stage**：不解决根因（stage 混合状态）。否决
+- **C 极简，无 stage 无 process 字段（采纳）**：所有"过程"派生自下属 versions 聚合 + 项目级数据集实时扫文件系统
+
+### Version 状态机粒度
+
+- **A 单 status 字段 5 态（draft / training / completed / failed / canceled）**：失去"当前在准备哪一步"信息。否决
+- **B 保留 master 6 stage + training 子态按 task 推**：stage 概念仍混合两层。否决
+- **C status + phase 双字段正交（采纳）**：
+  - `status` (5 enum) 答"运行态如何"
+  - `phase` (5 enum, 仅 preparing 时有意义) 答"准备到哪一步"
+
+### Version 级 paused 状态
+
+- **A 加 version-level paused**：task pause（ADR 0006）已 cover 短中期场景；"版本长期搁置"是伪需求。否决
+- **B 去掉（采纳）**：task=paused 时 UI 派生 "训练中 · 已暂停 Nmin"
+
+### Phase 模型
+
+- **A 5 个独立 bool 可乱序**（设计稿一轮原方案）：违背用户线性心智（筛选→打标→编辑→正则→训练有强暗示）。否决
+- **B enum cursor，5 值（采纳）**：`curating → tagging → editing → regularizing → ready`，cursor 单向，已完成集合直接派生
+
+### Phase 推进模式
+
+- **A 强制单向**：跳过正则集 / 回头改 caption 需要"phase 回退"心智重。否决
+- **B 完全自由（点哪到哪）**：cursor 失去"客观进度"语义，✓ 变成"用户点过没"。否决
+- **C 混合（采纳）**：cursor 单向；`regularizing` 可跳过；header"下一步"按钮**永远可点**（不 disabled，对新手友好）+ 校验失败给 toast 提示；**cursor 不主动回退**（user 自删数据后 ✓ 显示假象，等 next 校验时才发现）
+
+### 再训练数据冻结
+
+- **A 强制 Version Up（每次重训 = 新 version + 全套复制）**：磁盘双倍。否决
+- **B 同 version 多 task 不冻结**（master 现状）：旧 task 看到 current config / 当前 train 集 → forensics 失真。否决
+- **D 同 version 多 task + 全数据冻结（caption 复制 + 图硬链接）**：硬链接跨 OS export 失效（Windows 训完 → Linux 算力平台导入崩）；`preprocess→train` 既有复制链是独立问题，扯进来 scope 失控。否决
+- **G 同 version 多 task + 仅冻结 config（采纳）**：
+  - task 创建时 `tasks/{task_id}/snapshot/config.yaml` ← cp 自 version 当前 config
+  - caption / 图 / 正则集 **不冻结**
+  - **心智分离 UI**：task 详情独立 "关联配置" tab（不点 task 跳 version config 编辑页），有 "套用此配置" 按钮 → 跳 ⑦ 训练 phase + 预填 + 标准流程
+
+### 数据集归属
+
+- **A version 级（每 version 独立 train 集）**：不符 user 心智（同角色不同 version 用同批原图是 90% 用法），磁盘浪费。否决
+- **B 项目级 + 实时扫（采纳）**：`download/` + `preprocess/` 留在项目目录；项目级 phase 不存 DB 字段，UI 实时 `os.listdir` 派生（§6.10）
+
+### `active_version_id` 字段
+
+- **A 删除**（设计稿一轮原方案）：连带 10+ 处代码改动，UX 退化。否决
+- **B 保留，语义为 "最后打开的 version"（采纳）**：和 master 当前行为一致；不是 PM/UX 意义上的 "pinned" 或 "代表 version"
+
+### `project_jobs` 表
+
+- **A 拆表（download / preprocess / tag / reg_build 各一张）**：schema 洁癖，多 supervisor / 事件 / migration 代码。否决
+- **B 单表 + kind 区分 scope（采纳）**：`version_id` 可空，project 级 job 为 NULL，version 级为 NOT NULL
+
+## 决策
+
+### 最终数据模型
+
+**Project**（极简）：
+```
+id, title, slug, note, active_version_id, created_at, updated_at
+```
+- 删 `stage` 字段
+- 保留 `active_version_id`（"最后打开"语义）
+- 无任何 process / phase 字段；数据集状态由 UI 实时扫派生
+
+**Version**（双字段正交）：
+```
+id, project_id, label, note, trigger_word, created_at, updated_at,
+status: preparing | training | completed | failed | canceled,
+phase:  curating | tagging | editing | regularizing | ready  (仅 status=preparing 时有意义),
+output_lora_path, last_task_id, last_failure_reason
+```
+- 删 `stage` 字段
+- 已完成集合 / skipped 集合 / 回退状态全部**派生**，不存
+
+**Task**（保留现状 + 新增 snapshot）：
+- task 状态机不动（ADR 0006 已定）
+- 新增：task 创建时 `tasks/{task_id}/snapshot/config.yaml` ← cp version 当前 config
+- 新增 endpoint：GET `/api/tasks/{tid}/snapshot/config`（只读）
+
+**project_jobs**（不动）：单表 + kind 区分
+
+### 状态机定义
+
+**Version status 转换**（由 supervisor 推，UI 永不直写）：
+- task `done` → `completed`
+- task `failed` → `failed`
+- task `canceled` → `canceled`
+- 三个分支独立（不撒谎）
+
+**Version status 派生**（无 active task 时）：
+- 有 active task（pending / running / paused）→ `training`
+- 无 active 看最近终态 task → `completed / failed / canceled`
+- 从未有 task → `preparing`
+
+**Phase 推进规则**（详 §11.5-A）：
+- cursor 单向（只前进）
+- 推进入口：phase 页面 header 右侧 "← phase 名 | phase 名 →" 按钮，永远可点
+- 必经 phase (`curating / tagging / editing / ready`) 校验失败 → toast 提示
+- 可跳过 phase (`regularizing`) 校验 = 无 reg job running，无 confirm dialog
+- 侧栏 phase 项：cursor 之前 + 当前可点（focus 跳）；cursor 之后 disabled
+- cursor 不主动回退（user 删数据后 ✓ 显示假象，下次 next 才发现）
+
+### 各 phase 完成判定（§11.5-B）
+
+| phase | 校验 |
+|---|---|
+| `curating` | `train/ ≥ 1 张图` |
+| `tagging` | caption 100% 覆盖（每张 train 图都有 .txt） |
+| `editing` | 同 tagging（兜底） |
+| `regularizing` | 无 reg job running/pending（可跳过） |
+| `ready` | config 文件存在 + schema 校验通过；next 通过 = `status: preparing → training` + submit task |
+
+### UI Layout v3（§11.8）
+
+详 `design §11.8` 完整 ASCII：
+- **A 侧栏**：项目/队列/工具/设置顶级 tab 不收缩；进入项目后在"项目"下展开
+- **B Phase 页面 header**：`[← ④ 打标]  [⑥ 正则集 →]`（带编号 + phase 名 + 箭头）
+- **C 项目详情页**（侧栏点"概览"进入）：三 tab `[详情] [Tasks] [Output]`；详情 tab grid 布局；右上角 = 当前 version 的 status
+- **D Task 详情页**：5 tab `[概览] [日志] [Monitor] [Output] [关联配置]`；最后一个新增，含 "套用此配置" 按钮
+- **E 项目列表卡片**：去 stage badge；右上角 = active version status；不显产物 / 不显时间
+
+## 理由
+
+否决其他方案的核心理由汇总：
+
+1. **Project 加 status** → 项目是聚合体，无过程状态语义
+2. **Version 6 态合并** → 失去 "当前在哪一步" 信息
+3. **5 bool phases** → 违背用户线性心智，✓ 表达不清
+4. **Version paused** → task pause 已 cover (ADR 0006)
+5. **Phase 强制单向** → 跳过场景 UX 差
+6. **Phase 完全自由** → cursor 失去客观进度语义
+7. **Task 全数据冻结 / 硬链接** → 跨 OS export 失效
+8. **强制 Version Up 重训** → 磁盘双倍
+9. **数据集 version 级** → 不符 user 心智，浪费磁盘
+10. **删 `active_version_id`** → UX 退化无收益
+
+## 后果
+
+**好处**：
+- `status` 永远不撒谎（task 终态独立映射，supervisor 是唯一推进者）
+- 模型最简（status + phase + active_task 三个变量描述完整状态机，已完成 / skipped / 失效全派生）
+- forensics 95% 价值（config 100% 准确；caption / 图允许失真）
+- 跨 OS export 完全 OK（不依赖硬链接 / COW）
+- phase header 按钮 UX 对新手友好（永远可点 + 校验提示比 disabled 沉默好）
+- migration 可渐进（v8 add-only → 双写 → frontend 切 → v9 destructive）
+
+**约束 / 新债**：
+- frontend 改动量大（layout v3 五块全改 → 3 个 frontend PR）
+- `_v9` migration 打破 `studio/migrations/__init__.py` 既有约定（"不允许向后改写已有列"）—— 本次显式例外
+- §11.5-C 接受 "UI 假象"：cursor 不回退 → user 删数据后 ✓ 显示假象，等 next 校验才发现（设计有意接受）
+- task snapshot 配套要求：各删除 endpoint 加 confirm dialog 文案（→ §12.2）
+
+**Park 的 follow-up（不在本 ADR scope）**：
+- §12.1 `preprocess → train` 数据流复制链改造（硬链接 / project 级 manifest 取代 train/）— 独立 ADR
+- §12.2 删除 endpoint confirm dialog 文案审计 — §9 frontend 改造子项
+
+## 实施计划
+
+7 个 PR，每个独立合 dev 不破坏现状。详细 commit 拆分见设计稿 § 实施 plan 段，PR 合入顺序：
+
+| PR | 范围 | 阻塞关系 |
+|---|---|---|
+| 1 | ADR + 设计稿 banner + README 索引 | 无 |
+| 2 | `_v8` schema (add-only) + models 新字段 readonly | 1 |
+| 3 | backend 业务逻辑：phase 校验 / supervisor 推 status / 一致性 / task snapshot | 2 |
+| 4 | frontend layout v3 第一波：侧栏 + phase header + 项目详情页三 tab | 3 |
+| 5 | frontend task 详情 [关联配置] tab + "套用此配置" 流程 | 3, 4 |
+| 6 | frontend 项目列表卡片 | 3 |
+| 7 | 清理 + `_v9` destructive migration (DROP `stage` 列) | 2, 3, 4, 5, 6 |
+
+## 参考
+
+- `docs/design/project-version-task-lifecycle.md` —— 两轮 review 完整讨论稿
+- 相关 ADR：[0006](0006-queue-pause-resume.md)（task pause/resume）/ [0004](0004-preprocess-manifest.md)（preprocess manifest）
+- 实施 PR：合入时回填编号

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@
 | 0004 | [预处理状态用单 manifest 替代「双 bucket + per-image sidecar」](0004-preprocess-manifest.md) | Accepted (amended 2026-05-21) | 2026-05-15 |
 | 0005 | [更新通道作为用户视图偏好，与 git 工作树状态解耦](0005-update-channel-as-preference.md) | Accepted | 2026-05-16 |
 | 0006 | [Queue 任务暂停 / 恢复 + 队列挂起 / 恢复调度](0006-queue-pause-resume.md) | Accepted | 2026-05-18 |
+| 0007 | [Project / Version / Task 生命周期重构](0007-project-version-lifecycle-refactor.md) | Proposed | 2026-05-23 |
 
 ## 状态值
 

--- a/docs/design/project-version-task-lifecycle.md
+++ b/docs/design/project-version-task-lifecycle.md
@@ -1,0 +1,947 @@
+# 项目 / 版本 / 任务 生命周期重构（讨论稿）
+
+> 🚦 **文档状态**：本文档是两轮讨论稿。**最终决议见 [ADR-0007](../adr/0007-project-version-lifecycle-refactor.md)**。
+> 作为讨论历史保留 —— §1–§10 是一轮决议（部分已被 §11 推翻）、§11 是二轮收敛、§12 是 park 的 follow-up。
+> 实施请按 ADR-0007 走，不要按本文档前 10 节走。
+>
+> 分支：`feat/project-queue-relation` · 起草：2026-05-22 · 二轮收敛：2026-05-23
+
+---
+
+## 1. 背景与动机
+
+当前 `Project.stage` / `Version.stage` 各 9 个枚举值的状态机存在结构性问题：
+
+- **Project 卡片在说谎**：训练失败 / 取消 / 暂停后，`projects.stage` 不被推进，徽章永远显示"训练中"+ 动画 dot，用户回来以为还在跑。
+- **死状态**：`curating` / `configured` / `regularizing`（项目级）从无代码推进，3/9 颜色映射用户永远看不到。
+- **跳级与自相矛盾**：上传 train 图直接跳到 `tagging`，跳过 5 个 stage —— 说明 stage 本质是"做过哪些步骤的集合"，但 UI 把它当线性进度展示。
+- **无 source of truth**：`advance_stage()` 是无条件 setter，规则散在 9 个调用点，Project / Version / Task 三套状态机互不对账。
+- **数据模型错位**：Project 是聚合体（1:N → Version），不应该有"过程状态"。
+
+经过 PM / User / Designer 三方两轮辩论后形成共识：**模型层面就错了**，需要彻底重构而非补丁修复。
+
+---
+
+## 2. 重构核心原则
+
+1. **Project 没有过程状态**。Project 是收纳盒，只有"存在 / 不存在"两态（不做软删除，详见 §3）。
+2. **Version 是真正的"训练实验"实体**，承载完整的运行状态机。
+3. **Phase（做过哪些工序）和 Status（当前运行态）必须分离** —— 这是消除"stage 跳级"矛盾的根因。
+4. **Task 是事实（fact），Version.status 是派生 + cached**。supervisor 是唯一推进者，UI 永远不直接写 status。
+5. **数据集（download + preprocess）属于项目级**，多个 version 共享同一份原图（与本地工具用户心智一致）。
+
+---
+
+## 3. 数据模型（最终决策）
+
+### Project（极简，纯收纳盒）
+
+```python
+{
+    id, title, slug, note, created_at, updated_at,
+}
+```
+
+**删除字段**：`stage`、`active_version_id`
+
+**关于 phase**：Project 表**不存任何 phase 字段**。数据集相关信息（download/ 是否非空、图片数）由 UI 实时扫文件系统计算 —— 这本质就是文件系统状态的派生，存 bool 是冗余且有漂移风险。
+
+**关于"代表 version" / focus / pinned**：**不做**。理由：metric strip 已经回答了"哪些在跑 / 哪些挂了 / 哪些完了"这个核心问题；用户想看具体哪个在跑，点进去看 version 列表即可，**卡片上不需要"代表 version"**。pinned 更是负担（要手动操作、pin 错反而迷茫）。
+- Project 详情页默认打开 version：取最近更新的 version（纯派生，不存字段）
+- 项目卡片：metric strip + 数据集快照 + 最新产物入口，**无焦点行**
+
+**关于软删除**：本次重构**不做** archive / trashed 状态。Project 只有"存在 / 物理删除"两态。未来如需软删可单独开 ADR。
+
+### Version（核心实体）
+
+```python
+{
+    id, project_id, label, note, created_at, updated_at,
+
+    # 运行状态（状态机，详见 §4.2）
+    status: "draft" | "training" | "paused"
+          | "completed" | "failed" | "canceled",
+
+    # 工序完成标记（5 个独立 bool，从筛选开始）
+    # 注：数据集导入/预处理是项目级，UI checklist 动态拼为"第 0 项"
+    phases: {
+        curated:             bool,   # 已为本 version 选定 train 图集
+        captioned:           bool,   # 训练图 caption 覆盖率达标
+        regularization_ready: bool,  # 有正则集 或 显式声明不用
+        training_configured: bool,   # 训练 config 存在且校验通过
+        artifact_produced:   bool,   # output/*.safetensors 落盘
+    },
+
+    # 派生 / 缓存
+    output_lora_path: str | None,
+    last_task_id:     int | None,
+    last_failure_reason: str | None,
+}
+```
+
+**删除字段**：`stage`
+
+### Task（保留 project_id 作为冗余）
+
+```python
+{
+    id, project_id, version_id, kind: "train" | "reg_ai" | "generate" | ...,
+    status: "pending" | "running" | "paused" | "done" | "failed" | "canceled",
+    # ... 其余执行字段保持现状
+}
+```
+
+**保留 `project_id` 字段**，但**作为冗余 of `versions.project_id`**：
+- NOT NULL（迁移后所有 task 都必须挂在 version 下）
+- 一致性约束：`task.project_id == version.project_id`，应用层强制 + DB CHECK 双重保险
+- 收益：队列页 / Monitor 等高频查询零 JOIN；点击 task 跳 project 直接可用
+- 代价：写入路径必须维护一致性（supervisor / API 创建 task 时强制赋值）
+
+### project_jobs（一张表，按 kind 区分 scope）
+
+不拆表。`project_jobs` 表的 schema 已经支持 `version_id` 可空：
+
+| kind | scope | version_id | 完成时影响 |
+|---|---|---|---|
+| `download` | project | NULL | UI 实时算（无 DB phase） |
+| `preprocess` | project | NULL | UI 实时算 |
+| `tag` | version | NOT NULL | `version.phases.captioned = true` |
+| `reg_build` | version | NOT NULL | `version.phases.regularization_ready = true` |
+
+各 kind 共享 5 状态：`pending → running → done | failed | canceled`（无 paused）
+
+> 命名讨论：`project_jobs` 表名其实涵盖了版本级 job，可改名 `async_jobs` 更准确。但改名涉及 migration，暂不动。
+
+---
+
+## 4. 状态机定义
+
+### 4.1 Project Lifecycle
+
+Project 没有显式状态机，只有 `created → 物理删除` 两个生命事件。卡片显示信息完全派生自 Version 聚合 + 项目级 phases。
+
+### 4.2 Version Status（6 态）
+
+```
+                  [createVersion]
+                        │
+                        ▼
+                  ┌─────────────┐
+              ┌──▶│    draft    │ ← 合并了旧 draft + ready + preparing
+              │   └──────┬──────┘   涵盖"未在训练 / 未完成"所有准备态
+              │          │ submit train task
+              │          ▼
+              │   ┌─────────────┐  pause     ┌─────────────┐
+              │   │  training   │ ─────────▶ │   paused    │
+              │   │             │ ◀───────── │             │
+              │   └──────┬──────┘  resume    └─────────────┘
+              │          │             ↑ 合并了旧 queued + training
+              │          │
+              │          ├── task done ─────▶ ┌────────────┐
+              │          ├── task failed ───▶ │ completed  │ ★ 终态
+              │          └── task canceled ─▶ └────────────┘
+              │                                ┌────────────┐
+              │                                │   failed   │ ★ 终态
+              │                                └────────────┘
+              │                                ┌────────────┐
+              │                                │  canceled  │ ★ 终态
+              │                                └─────┬──────┘
+              │                                      │
+              └──────────────────────────────────────┘
+                  用户点"再训练" → 回 draft 或直接 training
+```
+
+**合并决策**：
+- `draft + ready + preparing` → **统一为 `draft`**
+  - 理由：用户"还在准备阶段"是单一心智，区分子态对用户无价值
+  - 命名注：`draft` 字面偏"空白"，但实际涵盖"已经准备很多还没 submit 训练"的所有非运行态。用户实际感知靠 phases checklist 进度而非 status 标签
+- `queued + training` → **统一为 `training`**
+  - 理由：用户视角"在跑"，等 GPU slot 和真正跑的体感无差异
+
+**转换约束**：
+- ❌ 不能从 `completed` 退回 `draft`（拒绝倒退，保护历史事实）
+- ✅ 从 `completed / failed / canceled` 可启动新训练 → 回 `training`
+- ✅ `resume` 只能从 `paused`
+- ✅ 在 `training / paused` 时**禁止 submit 新 task**（一次一个）
+- ✅ `status` 由 supervisor 推进，**UI 永远不直接写**
+
+### 4.3 Task Status（保持现状）
+
+```
+[submit] → pending → running → done | failed | canceled
+                       │
+                       └─ pause ─▶ paused ─ resume ─▶ running
+```
+
+终态：`done / failed / canceled`。每个终态向所属 Version 投递 transition event。
+
+### 4.4 project_jobs Status（一张表，按 kind 分流）
+
+```
+[create] → pending → running → done | failed | canceled
+```
+
+终态影响：
+
+| Job kind | scope | version_id | 完成时影响 |
+|---|---|---|---|
+| `download` | project | NULL | UI 实时算（无 DB phase） |
+| `preprocess` | project | NULL | UI 实时算（无 DB phase） |
+| `tag` | version | NOT NULL | `version.phases.captioned = true` |
+| `reg_build` | version | NOT NULL | `version.phases.regularization_ready = true` |
+
+### 4.5 Phases（独立 bool，非状态机）
+
+**存储策略**：**持久化为 DB 字段**（决策 §6.2）。仅存于 Version 表，Project 表无 phase 字段。
+
+**Version phases**（5 个）：`curated`、`captioned`、`regularization_ready`、`training_configured`、`artifact_produced`
+
+每个 phase 是独立 bool，无序、可重复、**可回退**。UI 用 capability checklist 展示。
+
+**前向写入**（设为 true）：
+- 对应 job 完成时由 supervisor 写
+- 用户主动动作（保存 config → `training_configured = true`、curate 选图 → `curated = true`）
+
+**回退写入**（设为 false）—— 决策 §6.2 强制做：
+| 用户/系统动作 | 触发回退 |
+|---|---|
+| 删除训练图至 caption 覆盖率 < 阈值 | `captioned = false` |
+| 删除训练 config | `training_configured = false` |
+| 清空正则集 | `regularization_ready = false` |
+| 删除全部训练图 | `curated = false` |
+| 删除 output safetensors | `artifact_produced = false` |
+
+回退逻辑写在每个相关 endpoint 内，作为副作用提交。
+
+**UI checklist 第 0 项（项目数据集）动态拼装**：
+- if project `download/` 为空 → 显示"导入数据集" CTA（跳项目页）
+- if 非空 → 显示"✓ 数据集就绪 (N 张)"
+- 这一项**不**作为 Version.phases 的字段，是 UI 派生
+
+---
+
+## 5. 关联关系
+
+```
+Project (id, title, slug, note)
+   │  1:N
+   ▼
+Version (id, project_id, status, phases, output_lora_path)
+   │  1:N
+   ▼
+Task (id, project_id, version_id, status)
+                       ↑
+              project_jobs (id, project_id, version_id?, kind, status)
+```
+
+- Project ─1:N→ Version：项目下多个训练实验
+- Version ─1:N→ Task：一个 version 可以重训多次（前一次失败/重新调参）
+- Project ─1:N→ project_jobs：表统一，按 kind 区分 scope（version_id 可空）
+
+**关于 Task.project_id**：保留作为冗余字段，强一致约束 `task.project_id == version.project_id`。高频查询（队列页、Monitor）零 JOIN；点击 task 跳 project 链路直接可用。
+
+---
+
+## 6. 关键决策（已确认）
+
+### 6.1 数据集归属 → 项目级（保留现状）
+
+`download/` 和 `preprocess/` 留在 **项目目录**，多个 version 共享同一份原图。
+
+- 理由：本地训练场景中"同一角色不同 version 用同批原图"是 90% 用法，独立 download 浪费磁盘且违背用户心智。
+- UI 影响：
+  - 项目卡片**不**直接显示数据集状态（避免噪音）
+  - 项目详情页新增"训练集"区域，展示 download/preprocess 图片数、状态、操作入口
+  - Version 的 capability checklist **第 0 项动态拼装**：项目无数据集 → "导入数据集" CTA；项目有数据集 → "✓ 数据集就绪"
+  - Version.phases 字段从 `curated` 开始（不存数据集 phase）
+
+### 6.2 Version Phases → 持久化存储 + 强制回退
+
+phases 存为 DB 字段，**不实时算**。
+
+**写入策略**：
+- 前向（设 true）：job 完成 / 用户动作（保存 config、选图等）
+- 回退（设 false）：删图、清 config、删正则集等动作必须同步回退对应 phase
+- 一致性靠各 endpoint 显式维护，不靠"事后扫描修复"
+
+理由：
+- 写入路径明确，状态机一致性容易保证
+- 读取性能：列表页可能展示几十个项目 × 多版本，每次扫文件系统不可接受
+- 代价是工作量（每个回退路径要写代码），但回退逻辑都是 1 行 SQL UPDATE，可控
+
+### 6.3 Project 不存任何 phase
+
+数据集状态（`download/` 是否非空、图片数）由 UI 实时扫文件系统计算。
+
+- 理由：这是文件系统状态的派生事实，存 bool 是冗余且有漂移风险
+- 实现：项目详情页"训练集"区域读 `len(os.listdir(download_dir))`，列表页**不**显示这个信息
+- Project 表彻底干净：`id / title / slug / note / pinned_version_id / 时间戳`
+
+### 6.4 Version status 粒度 → 6 态
+
+合并后从 9 态降到 6 态：
+- `draft`（合并 draft + ready + preparing）
+- `training`（合并 queued + training）
+- `paused`
+- `completed`
+- `failed`
+- `canceled`
+
+### 6.5 Task.project_id 保留 + 一致性约束
+
+不删 `task.project_id` 字段，但定位为 `versions.project_id` 的冗余。
+
+- NOT NULL（迁移后所有 task 都必须挂在 version 下）
+- 约束 `task.project_id == version.project_id`：应用层强制（创建 task 时显式赋值）+ DB CHECK 双保险
+- 收益：队列页 / Monitor 等高频查询零 JOIN；点击 task 跳 project 链路直接可用
+
+### 6.6 Project 不做软删除
+
+不引入 `lifecycle: active/archived/trashed`，Project 只有"存在 / 物理删除"两态。未来需要时单独开 ADR。
+
+### 6.7 project_jobs 不拆表 / 不改名
+
+`download / preprocess / tag / reg_build` 统一放在 `project_jobs` 表，按 kind 区分 scope（`version_id` 可空）。
+
+- 不拆表：拆表是 schema 洁癖，但多一份 supervisor / 事件 / migration 代码；一张表已经够清晰
+- 不改名为 `async_jobs`：命名瑕疵不值得专门 migration；如未来搭车其它 migration 可顺手做
+
+### 6.8 不做"代表 version" / 焦点行 / pinned
+
+项目卡片**不**显示"哪个 version 是代表"。
+
+- 理由：metric strip 已经回答了"哪些在跑 / 哪些挂了 / 哪些完了"这个核心问题
+- 用户想看具体哪个在跑 → 点进项目详情看 version 列表，**卡片不需要"猜代表是谁"**
+- pinned 让用户手动指定 → 是操作负担，pin 错反而更迷茫
+- 项目详情页默认打开 version：取最近更新的（纯派生，不存字段）
+
+### 6.9 一致性校验：完整跑
+
+每次读 version（list / get / 任何 endpoint）都校验 `version.status` vs 最新 task.status 推导值。
+
+- 不一致 → log warning + 以 task 推导为准修正字段 + 发 SSE 让前端 refresh
+- 性能：如发现是瓶颈，加 cached 字段 `status_implied_at` 由 supervisor 写时同步更新
+- 决策原则：真理优先于性能
+
+### 6.10 数据集实时扫不加 cache
+
+项目详情页"训练集"区域每次都实时 `os.listdir(download_dir)`，**不**加 mtime cache。
+
+- 理由：几百个文件的 listdir 本来就是毫秒级，cache 是过度优化
+- 用户改了 download/ 内容立刻看到变化，体验更诚实
+
+### 6.11 "再训练"语义与入口
+
+Version 在终态（`completed / failed / canceled`）时显示明确 CTA：
+- `completed` → `[再训一次]`（复用 config）
+- `failed` → `[查看日志] [复用配置重试] [用更小 batch 重试（OOM 时）]`
+- `canceled` → `[继续训练] [复用配置重新开始]`
+
+**重训不创建新 Version**：保留同一 version 的多次 task 历史；用户想换 config 就开新 version。
+
+与现状的差别：现状没有"重训"概念，要重训只能重新 submit task；重构后"重训"是 Version 上的一等动作，UI 一键完成。
+
+---
+
+## 7. UI 派生规则（项目卡片）
+
+Project 卡片显示完全派生，**无焦点行 / 无 pinned**：
+
+```python
+def project_card_view(project):
+    versions = list_versions(project.id)
+    return {
+        # metric strip（核心信息）
+        "total":     len(versions),
+        "running":   count(v.status in ["training", "paused"]),
+        "completed": count(v.status == "completed"),
+        "failed":    count(v.status in ["failed", "canceled"]),
+
+        # 数据集快照（项目级，实时扫）
+        "dataset_image_count": len(os.listdir(download_dir)),
+
+        # 最新产物入口（取最近完成的 version）
+        "latest_artifact": latest_completed_version_output(versions),
+    }
+```
+
+**项目详情页默认打开的 version**：取最近更新的（纯派生，不存字段）。
+
+```python
+def default_version_for_detail(project):
+    versions = list_versions(project.id)
+    return max(versions, key=lambda v: v.updated_at) if versions else None
+```
+
+详细 UI 设计（metric strip / capability checklist / 失败 affordance / 三级通知）见单独的 UI 设计稿（待写）。
+
+---
+
+## 8. 旧数据迁移映射
+
+```
+旧 projects.stage              → 全部丢弃（Project 不再有 stage）
+旧 projects.active_version_id  → 删除（不需要"代表 version"概念）
+
+旧 versions.stage → 映射:
+    "created"                  → status="draft", phases 全 false
+    "downloading"              → status="draft"（download 状态归项目，UI 实时算）
+    "preprocessing"            → status="draft"
+    "curating"                 → status="draft", phases.curated=true
+    "tagging"                  → status="draft", phases.captioned=true
+    "regularizing"             → status="draft", phases.regularization_ready=true
+    "configured" / "ready"     → status="draft", phases.training_configured=true
+    "training"                 → 查最新 task：
+                                   task.status=running    → "training"
+                                   task.status=paused     → "paused"
+                                   task.status=done       → "completed"
+                                   task.status=failed     → "failed"
+                                   task.status=canceled   → "canceled"
+                                   task 不存在            → "draft"
+    "done"                     → status="completed", phases.artifact_produced=true
+
+旧 tasks.project_id            → 保留字段，加 NOT NULL + CHECK 约束
+                                 （从 version JOIN 回填 NULL 行）
+
+旧 Project.phase / 数据集状态  → 不迁移（Project 表无 phase 字段，UI 实时算）
+```
+
+---
+
+## 9. 改造范围清单（给 ADR 用）
+
+### Backend
+- [ ] `studio/projects.py`：删 stage / advance_stage / active_version_id（不再需要"代表 version"概念）
+- [ ] `studio/versions.py`：重写状态机（6 态）、5 个 phases 字段、转换约束、前向+回退写入函数
+- [ ] `studio/db.py` (tasks)：保留 project_id，加 NOT NULL + DB CHECK；迁移回填 NULL 行
+- [ ] `studio/project_jobs.py`：不拆表；明确各 kind 的 version_id 必填/可空规则
+- [ ] `studio/supervisor.py`：完成 task 时推 version.status + 相关 phases；失败/取消/暂停也要推
+- [ ] `studio/server.py`：删除 9 处 `projects.advance_stage()` + 4 处 `versions.advance_stage()` 调用，改为相应 phases / version status 推进
+- [ ] 各 endpoint 加 phases 回退逻辑（删图 / 删 config / 清正则集 / 删 artifact）
+- [ ] 新建 DB migration：删字段 + 加字段 + 数据回填（按 §8）
+- [ ] 一致性校验函数：读 version 时 assert `version.status_implied_by_tasks() == version.status`，不一致 → log + 以 task 推导为准修正 + 发 SSE
+
+### Frontend
+- [ ] 删除 `StageBadge` 组件（或保留改用于 Version status）
+- [ ] 新建 `MetricStripBadge` 组件（项目卡片用）
+- [ ] 新建 `PhasesChecklist` 组件（Version 详情页用，第 0 项动态拼装数据集）
+- [ ] 项目详情页新增"训练集"区域（实时扫 download/ preprocess/ 显示图片数）
+- [ ] `Projects.tsx` 卡片重写：metric strip + 数据集快照 + 产物入口（**无焦点行**）
+- [ ] `Sidebar.tsx` 内联 Stepper 改为 Capability Checklist
+- [ ] Version 详情页：终态时显示"再训练"CTA（completed/failed/canceled）
+- [ ] 失败状态 affordance：静止图标 + 红 hue + 显式动词文案 + "查看日志" / "用更小 batch 重试" actions
+- [ ] 三级通知（tab 红点 / 桌面通知 / 邮件）—— 可单独 ADR
+
+### 文档 / ADR
+- [ ] 本文档讨论收敛后转 `docs/adr/000X-project-version-lifecycle-refactor.md`
+- [ ] 单独 UI 设计稿 `docs/design/project-card-redesign.md`
+- [ ] 更新 `AGENTS.md` 第 3.6 节（Stage 推进规则全部失效）
+- [ ] 更新 `architecture/studio-pipeline.md` 状态转换表
+
+---
+
+## 10. 决策记录（2026-05-23 已全部收敛）
+
+- [x] **Version status 命名**：`draft`（合并旧 draft + ready + preparing）
+- [x] **不做"焦点 version"**：metric strip 已经回答了核心问题，焦点行是冗余；卡片只显示 metric strip + 数据集快照 + 最新产物入口
+- [x] **不做 pinned_version**：用户手动 pin 是负担，pin 错更迷茫
+- [x] **不要 active_version_id 字段**：项目详情页默认打开 version 取"最近更新"，纯派生不存
+- [x] **phases 回退**：做。每个删除/清空动作 endpoint 内显式 UPDATE 回退（见 §4.5 / §6.2 表）
+- [x] **project_jobs 不拆表**：一张表按 kind 区分 scope，version_id 可空
+- [x] **不改名 async_jobs**：命名瑕疵不值得专门 migration
+- [x] **一致性校验完整跑**：每次读 version 时都校验 `version.status` vs 最新 task.status 推导值；不一致 → log + 以 task 推导为准修正 + 发 SSE
+- [x] **数据集实时扫不加 cache**：`os.listdir` 几百文件本来毫秒级，mtime cache 是过度优化
+- [x] **"再训练"入口**：Version 详情页终态时显示 CTA（completed → "再训一次"；failed → "查看日志/复用配置重试/用更小 batch 重试"）；不创建新 version，保留同 version 的多次 task 历史
+
+~~**剩余无 open question，可进入 ADR。**~~
+**↑ 2026-05-23 用户二轮 review 推翻，见 §11。**
+
+---
+
+## 11. 第二轮 open questions（2026-05-23）
+
+> §10 的"全部收敛"在用户二轮 review 后被推翻。9 个新问题 + 2 个事实修正。
+> 简单的标 ✅，复杂的标 🔥 待逐个讨论。
+> **本章节所有变更只记在 §11**；前面 §1–§10 暂不动，等讨论收敛再回头统一改 §3 / §4 / §6 / §8 / §9。
+
+### 11.0 事实修正（与 master 对账）
+
+- **§1 错** —— "`Project.stage` / `Version.stage` 各 9 个枚举值" 不对。
+  - `projects.VALID_STAGES` 真的是 9 态（`created/downloading/preprocessing/curating/tagging/regularizing/configured/training/done`）
+  - `versions.VALID_STAGES` **只有 6 态**（`curating/tagging/regularizing/ready/training/done`）—— 没有 `draft` / `preparing` / `created`
+- **§4.2 / §6.4 论证基准错** —— "合并旧 draft + ready + preparing → draft" 是相对**早期重构方案**说的，不是 master 现状。
+  - master 实际是 6 → 新 6 的重切分，不是 9 → 6。
+  - 真实映射建议（待 §11.3 收敛）：
+    - `curating / tagging / regularizing / ready` → `draft`（区分靠 phases）
+    - `training` → `training`
+    - `done` → `completed`
+
+### 11.1 `active_version_id` 保留 ✅
+
+不删。语义改为 **"最后打开的 version"**（current 行为不变），不是 PM/UX 意义上的 "pinned" 或 "代表 version"。
+
+**待回头改的章节**：
+- §3 Project 字段 → 重新加回 `active_version_id`
+- §6.8 → 改为 "不做 pinned / 代表 version，但保留 last-opened 轻量语义"
+- §8 → 移除 "active_version_id → 删除" 一行
+- §9 → backend 任务移除 "删 active_version_id"，frontend `Layout.tsx` / `Overview.tsx` / `Sidebar.tsx` 保留
+
+### 11.2 侧栏 stepper 映射与完成判定 ✅ 已定（§11.5 + §11.8 落地）
+
+**映射 7 步 → 新模型**：
+- ① 下载 / ② 预处理 → **项目级**（在侧栏 Version 之上，跟随项目而不是 version）
+- ③ 筛选 / ④ 打标 / ⑤ 编辑 / ⑥ 正则集 / ⑦ 训练 → **version phase**（5 enum cursor，§11.3-B）
+- 数字 ①–⑦ **全局保留**（不重新编号，保留 master UX 心智）
+
+**完成判定**（§11.5 派生）：
+- version phase ③–⑦：`phase_index < cursor_index` 即"完成"
+- 项目级 ①②：实时扫文件系统派生（§6.10）
+
+**视觉表现**（§11.8 落定）：
+- 完成 phase：**数字字符变绿**（"③" 单字符绿色，文字常规）
+- 当前 cursor：所在侧栏项**背景高亮**
+- 当前路由：所在侧栏项**背景高亮**（cursor 和 focus 都用背景表达；同 phase 时叠加 OK）
+- 项目级 ①② 右侧括号内显示文件数（"① 下载 (80)"），不显示完成 ✓
+
+**结论**：不需要"打勾"图标 —— 数字本身变绿 = 完成的 UI 表达。
+
+### 11.3 Version 状态机：paused / 6→5 态合并 / 多 task 聚合
+
+§11.0 已说明合并基准要按 master 现状重写。本节拆三个子问题，A 已定，B 待写，C 新 open。
+
+#### 11.3-A version 级 `paused` ✅ 去掉
+
+**决定**（2026-05-23 讨论）：去掉 version-level `paused`。`paused` 不在 version 状态机里。
+
+**理由**：
+- task-level pause（ADR 0006）已经 cover 短/中期暂停场景（case 1/2）
+- "version 长期搁置"（case 3）是伪需求 —— 真要搁置就用 `completed` + note，或 cancel 重开
+- 多一态多一处一致性维护（supervisor 写入 + SSE 触发 + version vs task 状态不一致 race）
+- 心智一致：pause 按钮只对应一个动作（task pause），不会有"应该 pause task 还是 pause version"的犹豫
+
+**UI 退化方案**：
+- pause 按钮 → 只发 task pause（不动 version.status）
+- version 卡片 / metric strip 渲染：`status === 'training' && active_task?.status === 'paused'` → 显示 "训练中 · 已暂停 Nmin" + pause icon
+- 不需要 `version_state_changed` 在 task pause/resume 时触发
+
+**最终状态机**：5 态 = `draft / training / completed / failed / canceled`
+
+#### 11.3-B 状态模型：5 态 status + 5 enum phase ✅
+
+**决定**（2026-05-23 讨论）：把 master `versions.stage` 一个字段**拆成两个正交字段**。
+
+**正交模型图**：
+```
+status (主状态机，5 态)
+   preparing / training / completed / failed / canceled
+       │
+       └─ 仅 status=preparing 时 phase 字段才有意义
+              │
+              ▼
+          phase (cursor，5 enum)
+              curating → tagging → editing → regularizing → ready
+                                                ↑
+                                            仅此 phase 可跳过 (§11.5)
+```
+
+**status**：回答"运行态如何"（用于 metric strip、是否能 submit、是否撒谎）。
+**phase**：回答"准备到哪一步"，对应当前侧栏 stepper ③–⑦（数据集 ①② 步已归项目级 §6.1，不入 version phase）。
+
+**关键认知**：phase 是 **enum cursor**，**不是** 5 个独立 bool。
+
+→ **推翻设计稿 §4.5 原方案**（5 phases bool 可乱序）。
+→ "已完成集合" 如果允许跳过部分 phase 怎么存 / phase 推进规则 / 时间锁 / 强制顺序 → 全部留 **§11.5** 讨论。
+→ phase 5 值中 `editing` 是 master 没有的新值（master 把"打标"和"标签编辑"都归在 `tagging`），按侧栏 step ⑤ 独立。
+
+**迁移表（master `versions.stage` → 新 status + phase）**：
+
+| master `versions.stage` | 新 `status` | 新 `phase` | 备注 |
+|---|---|---|---|
+| `curating` | `preparing` | `curating` | |
+| `tagging` | `preparing` | `tagging` | 即使用户已经在编辑，新版打开仍显示 tagging，无法判别可接受 |
+| `regularizing` | `preparing` | `regularizing` | |
+| `ready` | `preparing` | `ready` | |
+| `training` | 看 latest task | `N/A` | task `done → completed` / `failed → failed` / `canceled → canceled` / `pending/running/paused → training` |
+| `done` | `completed` | `N/A` | |
+
+**脏数据 fallback**（stage='training' 但无 task —— 几乎不会发生但 SQL 需 default）：
+`status=preparing + phase=ready`。理由：让 user 看到"准备就绪可点开始"，自己决定下一步。
+
+**status 转换约束**（task 终态独立映射，"不撒谎"原则）：
+- task `done` → version `completed`
+- task `failed` → version `failed`
+- task `canceled` → version `canceled`
+- 三个分支独立，不合并到 `completed`
+
+**phase 命名小尾巴**（不阻塞收敛）：`ready` 字面是"已就绪"，但语义上是"用户在 /train 配 training config"，是否改名为 `configuring` 留待回头改前面章节时一并 review。
+
+#### 11.3-C 多 task 并存时 version.status 聚合 ✅ 已定（见 §11.7 收尾）
+
+**决定**（2026-05-23 讨论，§11.7 收敛后解开）：
+
+- active task ≤ 1（§4.2 队列约束保证）
+- `version.status` 计算逻辑：
+  - 有 active task（pending / running / paused）→ `training`
+  - 无 active 看最近终态 task → `completed / failed / canceled`
+  - 从未有 task → `preparing`
+- "看 active task" 一句话搞定，不需要复杂聚合逻辑
+
+### 11.4 `project_jobs` 含义展开 ✅
+
+§3 / §4.4 要补一段澄清：
+
+> "`project_jobs` 实质上是 download / preprocess / tag / reg_build 这些 **async job 的统一表**，
+>  **不是**训练 task —— 训练 task 走 `tasks` 表。两张表的关系是平行的、不同生命周期的执行单元。"
+
+避免读者把 `project_jobs` 误认为"项目级训练任务"。
+
+### 11.5 phase cursor 推进 / 失效逻辑
+
+§11.3-B 已定 phase 是 enum cursor（不是 5 bool）。本节拆 sub-question：
+- **11.5-A** 推进模式（已定 ✅）
+- **11.5-B** 每个 phase 的完成 / 失效判定（待）
+- **11.5-C** 回退动作（删图 / 删 config / 清正则集 / 删 artifact 触发 cursor 回退）（待）
+- **11.5-D** "已完成集合"存储方式（如果有跳过场景，cursor 不能完全派生完成集合）（待）
+
+#### 11.5-A 推进规则 ✅ 已定
+
+**决定**（2026-05-23 讨论）：
+
+**推进模式**：混合
+- cursor 单向（只前进）
+- 必经 phase：`curating / tagging / editing / ready`
+- 可跳过 phase：`regularizing`
+
+**推进入口**：**Header 右侧统一 "上一步 / 下一步" 按钮**（取代每页底部按钮，位置一致更醒目）。**永远可点**（不 disabled —— 对新手友好，错了给提示比沉默点不动好）。
+
+| 按钮 | focus 状态 | 行为 |
+|---|---|---|
+| 下一步 | `focus < cursor` | focus++（cursor 不动，只是 navigation） |
+| 下一步 | `focus == cursor` (必经 phase) | 校验完成条件；通过 → cursor++ + focus++；失败 → toast 提示（如 "训练集为空，请先选择训练集"），cursor 不动 |
+| 下一步 | `focus == cursor` (可跳过 phase) | 无校验，cursor++ + focus++（实质就是 skip） |
+| 上一步 | `focus > 0` | focus--（cursor 不动） |
+| 上一步 | `focus == 0` | disabled |
+
+**侧栏 phase 项**：
+- cursor 之前 + cursor 当前 → 可点（focus 跳，cursor 不动）
+- **cursor 之后 → disabled**，灰色不可点
+- 理由：允许连续跳多步会让"中间每步的提示"无处展示，UI 行为无定义 → 不允许
+
+**UI 双展示（彻底解耦）**：
+| 元素 | 表达 |
+|---|---|
+| ✓ 勾选 | phase 已完成（= cursor 之前的所有 phase） |
+| 背景色高亮 | cursor 当前所在 phase |
+| 哪个页面在显示 | focus（URL 决定） |
+
+三者独立维度 —— 用户在 cursor 之前 phase 上 navigate 不动 cursor，不动 ✓。
+
+**核心概念分离**：
+- **cursor** = 准备进度（最远到哪），存 DB
+- **focus** = 用户当前路由（URL），不存
+- **completion ✓** = cursor 之前的派生，不存
+- "下一步"按钮的 advance 是 cursor 推进的**唯一入口**（除回退动作 §11.5-C）
+
+#### 11.5-B 每个 phase 的完成判定 ✅ 已定
+
+**决定**（2026-05-23 讨论）：
+
+| phase | 校验条件 | 失败提示样例 |
+|---|---|---|
+| `curating` | `train/ ≥ 1 张图`（不能空，无 warning 阈值） | "训练集为空，请先选择训练图" |
+| `tagging` | caption 文件 **100% 覆盖**（每张 train 图都有同名 .txt） | "还有 N 张未生成 caption，请重跑或删除" |
+| `editing` | caption 文件 **100% 覆盖**（同 tagging，作为兜底） | 同上。大多数时间从 tagging 来时已 100% → 自动通过；仅当 user 删了 caption 时才触发 |
+| `regularizing` | **无相关 reg job 处于 running / pending**（可跳过 = 不要求正则集非空） | "正则任务进行中，请等待完成" |
+| `ready` | training config 文件存在 + schema 校验通过 | "请先完成训练配置" / 具体哪个字段非法 |
+
+**ready phase + next 的特殊性**：通过校验后 = `status: preparing → training` + submit task。这是 §11.5（phase）和 §11.3（status）状态机的**接口点**，cursor 不再前进（已是最后），由 status 转换接管。
+
+**regularizing 校验设计优点**（与 confirm dialog 对比）：
+- 不强迫用户做"用 / 不用正则集"的二元决定（很多用户不想被打断）
+- 只防止"job 在跑时 cursor 跳走"造成的状态错乱
+- 正则集为空 vs 非空都允许通过 —— 用户的选择被尊重
+
+**实现位置**：每个 phase 一个 `check_completion(version_id) -> (ok: bool, reason: str)`，统一放 `studio/versions_phase.py` 或类似 module。`advance_cursor()` 调用 check，失败 reason 给前端 toast。
+
+#### 11.5-C 回退动作 ✅ 已定
+
+**决定**（2026-05-23 讨论）：**cursor 不做主动回退**。
+
+**理由**：
+- 用户对"回退"的语义是"自由浏览已完成的页面"（即 focus 跳，已在 §11.5-A 覆盖），不是 cursor 退
+- 删图 / 删 caption / 删 config 等破坏性动作，**UI 应该在动作前 confirm 提示**告知后果（user 教育）
+- 用户在提示后仍然删除是 user 行为责任 → cursor 不主动校正，避免复杂的回退状态机
+- 后续 next 时按 §11.5-B 校验会自然 fail 并给出明确提示 → user redo 即可
+
+**5 个 case 行为汇总**：
+
+| # | 触发动作 | cursor 行为 | next 时校验 |
+|---|---|---|---|
+| 1 | 删 train 图（→ 0 张或部分） | 不动 | curating/tagging/editing next 时 fail（按 §11.5-B 各自的覆盖率校验） |
+| 2 | 删 caption (.txt) | 不动 | tagging/editing next 时 fail |
+| 3 | 删 training config | 不动 | ready next 时 fail |
+| 4 | 清空 / 删正则集图 | 不动 | regularizing next 仍通过（只看 no job running） |
+| 5 | 删 LoRA artifact | status 不退 | status=completed 保留 + UI 派生标"产物丢失" |
+
+**有意接受的 UI 假象**：侧栏 ✓ 仍按 cursor 派生（cursor 之前的全 ✓），即使数据已被 user 破坏。代价是 user next 时才发现需要 redo —— 这本来就是 user 自愿的破坏选择。
+
+**配套要求**（写入 §9）：各删除 endpoint 在 UI 层必须有 confirm dialog，文案告知"删除会导致 X phase 数据不一致，需要重做才能继续推进"。
+
+#### 11.5-D 已完成集合 / skipped 表达 ✅ 已定
+
+**决定**（2026-05-23 讨论，作为 §11.5-C "cursor 不退" 的直接派生）：
+
+**不需要额外存"已完成集合"或"skipped 集合"字段**。
+
+理由：
+- cursor 单向 + 永不回退 → cursor 之前的所有 phase 都视为"已通过"
+- ✓ 直接派生：phase_index < cursor_index 即 ✓
+- skipped vs done 在 cursor 维度**等同** —— 都是"已经通过了"
+
+**UI 是否区分 skipped vs done**（推荐派生，不存字段）：
+- 检查该 phase 的"实际数据"是否存在
+  - regularizing: `reg/` 是否非空
+  - tagging: caption 文件覆盖率
+- 数据存在 → "✓ 已完成"；不存在 → "✓ (跳过)"
+- 派生不 100% 准确不影响功能，仅 UI hint
+
+**模型最终极简形态**：
+- `version.status` (enum 5 态)
+- `version.phase` (enum 5 值，仅 status=preparing 时有意义)
+- 全部已完成 / skipped / 失效 信息**都派生**，不存
+
+→ 推翻设计稿 §4.5 全表（5 bool phases + 回退表）；§4.5 的 5 bool 模型完全废弃。
+
+### 11.6 数据集 UI 表达 ✅ 已定
+
+**决定**（2026-05-23 讨论）：
+
+**项目级数据集**：
+- 文案：**"数据集"**（不是"训练集"）
+- 显示位置：
+  - 侧栏顶部（① 下载 / ② 预处理，括号显示数字）
+  - 项目详情页顶部（数字 + [管理] 链接，最简）
+- 不弹"数据集是项目级"教学 dialog（保持简洁，用 layout 表达从属关系）
+
+**Version 级数据集**：
+- 文案：仍叫"数据集"（同名 OK，上下文区分 —— 在 version 详情页就是 version 的）
+- 显示位置：项目详情页 [详情] tab 内（grid 布局，§11.8-C）
+- 内容（按 §11.8-C grid 各格）：
+  - **文件夹（repeat_N_concept/）列表 + 各自文件数 + 总计**
+  - **分辨率分布**（参考放大页右侧统计组件）
+  - **长宽比分布**（参考裁剪页右侧分桶统计）
+  - **tag 分布**（参考标签编辑页统计）
+  - **正则集数量**
+- **未完成项 placeholder**：每格各自的 empty state，参考关联 phase 页面已有的 empty state 风格（不统一灰底文字）
+
+**教育机制**（隐式而非显式）：
+- 项目级数据集放最上面 + 标注"项目级"
+- version 详情数据集在 [详情] tab 内
+- 文案保持简洁，靠 layout 层级表达从属
+
+### 11.7 再训练数据处理 ✅ 已定
+
+**决定**（2026-05-23 讨论）：同 version 多 task（B 模型）+ task 内**仅冻结 config**（G 简化版）。D（硬链接）方案放弃。
+
+**冻结内容**：
+- ✅ `config.yaml` —— task 创建时复制到 task snapshot 目录
+- ❌ caption / 图 / 正则集 —— 都不冻结
+
+放弃 D（硬链接全冻结）的理由：
+- 跨 OS 导出失效（用户 Windows 训完 → Linux 算力平台导入 用例下崩）
+- preprocess→train 既有复制链是独立问题，扯进来 scope 失控（→ §12.1）
+
+**心智分离（核心 UX 设计）**：
+- task 详情有**独立的"训练 config 记录"页面**（只读 yaml / 复用 version config 组件 readonly 模式）
+- **不点 task 跳 version config 编辑页**（避免 user 误以为"task 看到的就是当时的 config"）
+- 用页面分离表达：**config 是历史快照，caption / 图是 version 当前状态**（每次训练用当前数据，user 自己理解）
+
+**重训入口**：task config 记录页面上一个按钮（命名暂"用此 config 重训"）：
+- 点击 → 跳 version config 编辑页 + 自动加载这份冻结 config
+- user 可编辑（也可不改）→ 正常点开始训练 → 创建新 task
+- 不需要单独的"再训练"按钮（你的 Q3：正常走训练流程就是新 task）
+
+**与设计稿 §6.11 关系**：
+- "重训不创建新 Version，保留同 version 多 task 历史" → **保留** ✅
+- §6.11 多个 CTA（"再训一次 / 复用配置重试 / 用更小 batch 重试"）→ 简化为一个"用此 config 重训"按钮
+
+**实现要点**：
+- task 创建（supervisor enqueue）时：`tasks/{task_id}/snapshot/config.yaml` ← cp 自 version 当前 config
+- task 详情新增路由 `/projects/:pid/v/:vid/task/:tid/config`（只读）
+- 配套要求（→ §9）：
+  - backend：task snapshot 目录创建 + config 复制逻辑
+  - frontend：task config 只读页面组件 + "用此 config 重训"按钮的路由跳转 + 自动 prefill
+
+**实验矩阵（你的 Q4 答）**：不专门支持，user 想要 matrix 自己手动 fork version（§6.11 PP10.1 已有"从老 version 全量副本"功能）。
+
+### 11.8 UI 重构 layout v3 ✅ 已定
+
+**完整 layout 决定**（2026-05-23 讨论）。分 5 块：
+
+#### A. 侧栏 layout（进入项目后）
+
+- 顶级 tab（**项目 / 队列 / 工具 / 设置**）不收缩，始终可见
+- 进入项目后，在"项目" tab 下**展开**项目内容（表示从属）
+- 队列 / 测试等顶级 tab 仍可见在下方
+- 视觉规则见 §11.2（完成 phase 数字变绿 / 当前页背景高亮）
+
+```
+┌─────────────────────────────┐
+│  Anima · 0.9.1              │
+├─────────────────────────────┤
+│ ▼ 项目                       │ ← 顶级 tab，进入项目后展开
+│    项目: Cosmic Kaguya       │
+│                              │
+│    概览           ← 当前页    │ ← 背景高亮表示 active 路由
+│    ① 下载  (80)              │ ← 项目级 phase，括号为文件数
+│    ② 预处理 (50)             │
+│                              │
+│    Version (list 全显示):    │
+│     ● test                   │ ← 当前 active version
+│       baseline               │
+│       highlr                 │
+│                              │
+│    ③ 筛选                    │ ← 完成时数字变绿
+│    ④ 打标                    │
+│    ⑤ 编辑                    │ ← cursor，背景高亮
+│    ⑥ 正则集 (可跳过)         │
+│    ⑦ 训练                    │
+│                              │
+│   队列                        │ ← 顶级 tab，仍可见
+│   测试                        │
+│   工具 / 设置                │
+└─────────────────────────────┘
+```
+
+#### B. Phase 页面 header
+
+右上角推进按钮（带编号 + phase 名 + 箭头方向），替代通用"上一步 / 下一步"文案：
+
+```
+┌──────────────────────────────────────────────────┐
+│ 标签编辑           [← ④ 打标]    [⑥ 正则集 →]   │
+├──────────────────────────────────────────────────┤
+│                                                  │
+│   ... phase 页面内容 ...                          │
+│                                                  │
+└──────────────────────────────────────────────────┘
+```
+
+- 按钮永远可点（§11.5-A 哲学，对新手友好）
+- 不可跳过 phase：next 校验失败 → toast 提示
+- 可跳过 phase（regularizing）：无校验直接推进
+- 最早 / 最末 phase：方向按钮 disabled
+
+#### C. 项目详情页（侧栏点"概览"进入）
+
+三个 tab：**[详情] [Tasks] [Output]**，右上角 = 当前 version 的 status badge。
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Cosmic Kaguya / test                    [● preparing]   │ ← 右上角 = test 的 status
+├─────────────────────────────────────────────────────────┤
+│ Tabs: [详情] [Tasks] [Output]                           │
+├─────────────────────────────────────────────────────────┤
+│ [详情 tab — grid 布局，非上下排]                          │
+│                                                         │
+│  ┌──────────────────┬──────────────────┐                │
+│  │ 文件夹 / repeat  │ tag 分布         │                │
+│  │  repeat_5_… 30   │  [chart / list]  │                │
+│  │  repeat_2_… 17   │                  │                │
+│  │  总计 47         │                  │                │
+│  ├──────────────────┼──────────────────┤                │
+│  │ 分辨率分布       │ 长宽比分布       │                │
+│  │  [chart]         │  [chart]         │                │
+│  ├──────────────────┴──────────────────┤                │
+│  │ 正则集：0 张（未生成）                │                │
+│  └──────────────────────────────────────┘               │
+│                                                         │
+│  未完成的格子 → 各自 empty state（参考关联 phase 页面）  │
+│                                                         │
+├─────────────────────────────────────────────────────────┤
+│ [Tasks tab]  = 现有 /queue 页面同款                      │
+│               点 task → 跳 task 详情页（D 块）           │
+├─────────────────────────────────────────────────────────┤
+│ [Output tab] = 现有 task output 页面同款                 │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### D. Task 详情页
+
+5 个 tab：**[概览] [日志] [Monitor] [Output] [关联配置]**（最后一个新增，§11.7 决定）。
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Task #45                                                │
+│ Tabs: [概览] [日志] [Monitor] [Output] [关联配置]       │
+├─────────────────────────────────────────────────────────┤
+│ [关联配置 tab — 新增]                                    │
+│                                                         │
+│   只读 yaml / 复用 version config 组件 readonly 模式     │
+│   （不点 task 跳 version config 编辑页 —— 心智分离）    │
+│                                                         │
+│   ┌────────────────────────────────┐                    │
+│   │  config 只读展示...             │                    │
+│   │                                │                    │
+│   └────────────────────────────────┘                    │
+│                                                         │
+│   [套用此配置]  ← 点击跳 ⑦ 训练 phase 配置页 + 预填     │
+│                  → user 编辑后正常点开始训练            │
+│                  → 创建新 task（同 version 多 task）    │
+└─────────────────────────────────────────────────────────┘
+```
+
+#### E. 项目列表卡片（首页 /projects）
+
+```
+┌────────────────────────────────┐
+│ Cosmic Kaguya     [preparing]  │ ← 右上角 = active version 的 status
+│ test                           │ ← active version 名（直接，无前缀文案）
+└────────────────────────────────┘
+```
+
+- 去掉 stage badge（§1 痛点 = master 撒谎那个）
+- 右上角状态 = **当前 active version** 的 status（不是项目 stage —— 项目无 stage）
+- 不显示产物 / 不显示时间 / 不写"最近 active 版本"前缀
+- 其它布局保持当前 UI（不重新设计卡片整体结构）
+
+### 11.9 讨论顺序建议
+
+低耦合先聊，UI 留最后：
+
+1. ~~**§11.4 + §11.1**（已定 ✅，仅落笔）~~ ✅
+2. ~~**§11.3** version paused 必要性 + 6 态重写~~ ✅ A/B/C 全定
+3. ~~**§11.5** phases 推进 / 失效逻辑~~ ✅ A/B/C/D 全定
+4. ~~**§11.7** 再训练 vs Version Up 磁盘代价~~ ✅
+5. ~~**§11.6 + §11.8** UI 联动~~ ✅
+6. ~~**§11.2** 侧栏 checklist~~ ✅
+
+**§11 全部收敛 ✅** —— 下一步：回头改 §1–§10 反映 §11 决议，再转 ADR-0007。
+
+---
+
+## 12. Follow-up Issues（不在本次 scope 的独立改造）
+
+§11 讨论中浮出但**不属于本次重构 scope** 的事项，独立 issue 跟踪。
+
+### 12.1 `preprocess → train` 数据流改造
+
+**现状**：
+- `preprocess/` 项目级；`train/` version 级
+- curate 选图 = `preprocess → train` 物理复制（占 2x 磁盘）
+- user 改 preprocess 不反映到已选过的 train
+
+**讨论中浮出的方向**（未定）：
+- 改硬链接（省磁盘，但跨 OS export 难）
+- preprocess 替代 train（version 只存 "选了哪些" 的 manifest）
+- 保持现状（接受复制代价）
+
+**触发场景**：§11.7 讨论 D 硬链接 task snapshot 方案时浮出，与 task 数据冻结无直接耦合但同涉数据流模型。
+
+**Park 处理**：独立 issue / 单独 ADR，**不在 ADR-0007 范围**。
+
+### 12.2 删除 endpoint 的 confirm dialog 文案审计
+
+§11.5-C 决定 cursor 不主动回退后，前端各删除 endpoint（删图 / 删 caption / 删 config）的 confirm dialog 必须告知"删除会影响 X phase 数据一致性"。需要审计当前哪些 endpoint 有 confirm、文案是否合适。
+
+**Park 处理**：作为 §9 frontend 改造清单的子项，留待落笔时一并处理。

--- a/studio/migrations/__init__.py
+++ b/studio/migrations/__init__.py
@@ -20,6 +20,7 @@ from ._v4_task_config_path import migrate as _migrate_v4
 from ._v5_task_type import migrate as _migrate_v5
 from ._v6_pause_resume import migrate as _migrate_v6
 from ._v7_version_trigger_word import migrate as _migrate_v7
+from ._v8_version_status_phase import migrate as _migrate_v8
 
 Migration = Callable[[sqlite3.Connection], None]
 
@@ -31,6 +32,7 @@ MIGRATIONS: list[Migration] = [
     _migrate_v5,  # v5: tasks.task_type（PR-9 区分 train / reg_ai / generate）
     _migrate_v6,  # v6: tasks.paused_* 列 + queue_settings 表（ADR 0006 PR-2）
     _migrate_v7,  # v7: versions.trigger_word（触发词字段）
+    _migrate_v8,  # v8: versions.status / phase / last_failure_reason（ADR-0007）
 ]
 
 

--- a/studio/migrations/_v8_version_status_phase.py
+++ b/studio/migrations/_v8_version_status_phase.py
@@ -1,0 +1,113 @@
+"""v7 → v8: versions 加 status / phase / last_failure_reason — ADR-0007 §11.3-B。
+
+把 master `versions.stage` 一个 enum 字段拆成两个正交字段：
+
+- `status` (5 enum): preparing / training / completed / failed / canceled
+- `phase`  (5 enum, 仅 status=preparing 时有意义):
+  curating / tagging / editing / regularizing / ready
+- `last_failure_reason` TEXT: 训练失败原因（UI 派生用，可空）
+
+本迁移只 add 字段并按映射表回填，**不删** `versions.stage` 列（删除走 v9）。
+迁移期间 backend 由 PR-3 双写新旧字段，保持老 frontend 兼容。
+
+映射表（ADR-0007 §11.3-B）：
+
+  master versions.stage → 新 status / phase
+  ────────────────────────────────────────────────────────────
+  curating         → status=preparing, phase=curating
+  tagging          → status=preparing, phase=tagging
+  regularizing     → status=preparing, phase=regularizing
+  ready            → status=preparing, phase=ready
+  training         → 看 latest task:
+                       done     → completed
+                       failed   → failed
+                       canceled → canceled
+                       running / pending / paused → training
+                       task 不存在 → preparing + phase=ready (脏数据 fallback)
+  done             → status=completed, phase=ready
+  未知 stage       → preparing + phase=ready (fallback)
+
+phase 在 status != preparing 时无业务意义，但字段必填以保 schema 简单 —
+统一落 ready 表示"已走完准备阶段"。
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from ._v2_projects import _add_column_if_missing
+
+
+# stage → (status, phase) 静态映射（training 例外，需要 task lookup）
+_STATIC_STAGE_MAP: dict[str, tuple[str, str]] = {
+    "curating":     ("preparing", "curating"),
+    "tagging":      ("preparing", "tagging"),
+    "regularizing": ("preparing", "regularizing"),
+    "ready":        ("preparing", "ready"),
+    "done":         ("completed", "ready"),
+}
+
+# 老 stage='training' 时，按 latest task.status 派生
+_TASK_STATUS_MAP: dict[str, str] = {
+    "done":     "completed",
+    "failed":   "failed",
+    "canceled": "canceled",
+    "pending":  "training",
+    "running":  "training",
+    "paused":   "training",
+}
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    _add_columns(conn)
+    _backfill(conn)
+
+
+def _add_columns(conn: sqlite3.Connection) -> None:
+    _add_column_if_missing(
+        conn, "versions", "status",
+        "status TEXT NOT NULL DEFAULT 'preparing'",
+    )
+    _add_column_if_missing(
+        conn, "versions", "phase",
+        "phase TEXT NOT NULL DEFAULT 'curating'",
+    )
+    _add_column_if_missing(
+        conn, "versions", "last_failure_reason",
+        "last_failure_reason TEXT",
+    )
+
+
+def _backfill(conn: sqlite3.Connection) -> None:
+    """按 ADR §11.3-B 迁移表把现有 versions.stage 翻译成 status + phase。"""
+    rows = conn.execute("SELECT id, stage FROM versions").fetchall()
+    for vid, stage in rows:
+        if stage in _STATIC_STAGE_MAP:
+            status, phase = _STATIC_STAGE_MAP[stage]
+        elif stage == "training":
+            status, phase = _derive_from_latest_task(conn, vid)
+        else:
+            # 未知 stage（理论上不应出现）→ fallback
+            status, phase = "preparing", "ready"
+        conn.execute(
+            "UPDATE versions SET status = ?, phase = ? WHERE id = ?",
+            (status, phase, vid),
+        )
+    conn.commit()
+
+
+def _derive_from_latest_task(
+    conn: sqlite3.Connection, version_id: int
+) -> tuple[str, str]:
+    """training stage 时按 latest task 推 status；phase 落 'ready'（终态无意义）。"""
+    row = conn.execute(
+        "SELECT status FROM tasks "
+        "WHERE version_id = ? "
+        "ORDER BY created_at DESC LIMIT 1",
+        (version_id,),
+    ).fetchone()
+    if row is None:
+        # 脏数据 fallback：stage=training 但无关联 task
+        return ("preparing", "ready")
+    task_status = str(row[0]) if row[0] else ""
+    new_status = _TASK_STATUS_MAP.get(task_status, "preparing")
+    return (new_status, "ready")

--- a/studio/server.py
+++ b/studio/server.py
@@ -3082,6 +3082,24 @@ def get_queue_item(task_id: int) -> dict[str, Any]:
     return task
 
 
+@app.get("/api/queue/{task_id}/snapshot/config")
+def get_task_snapshot_config(task_id: int) -> dict[str, Any]:
+    """ADR-0007 §11.7：返回 task 启动时冻结的 config。
+
+    返回 ``{"yaml": str, "config": dict}``。task 不存在 / 无 snapshot → 404。
+    UI [关联配置] tab 用此 + 触发 "套用此配置" 路由跳转到 ⑦ 训练 phase + prefill。
+    """
+    from . import task_snapshot
+    with db.connection_for() as conn:
+        task = db.get_task(conn, task_id)
+    if not task:
+        raise HTTPException(404, "task not found")
+    data = task_snapshot.read_snapshot_config(task_id)
+    if data is None:
+        raise HTTPException(404, "snapshot not found")
+    return data
+
+
 @app.post("/api/queue/{task_id}/cancel")
 def cancel_task(task_id: int) -> dict[str, Any]:
     if not _supervisor().cancel(task_id):

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -151,12 +151,18 @@ def _default_cmd_builder(task: dict[str, Any], config_path: Path) -> list[str]:
     return cmd
 
 
-def _maybe_finalize_version(conn: Any, task_id: int) -> None:
-    """PP6.3：task 成功完成 → 找 version → 回填 output_lora_path + stage=done。
+def _maybe_finalize_version(
+    conn: Any, task_id: int, task_status: str = "done"
+) -> None:
+    """task 终态 → 推 version.status（ADR-0007 §11.3-B）+ 维护老 stage 双写。
 
-    output_lora_path 推断：`versions/{label}/output/{output_name}_final.safetensors`
-    （anima_train 标准命名）。文件不存在不报错 — 有可能用户用别的命名规则。
-    project.stage 也推到 'done' 让 Stepper 反映。
+    task_status 映射到 version.status（task 终态 → version 终态）：
+    - done → completed（含 output_lora_path 回填 + 老 stage='done' 双写）
+    - failed → failed（含 last_failure_reason 写入）
+    - canceled → canceled
+
+    paused 不进此函数（§11.3-A：task=paused 时 version 仍 training，UI 派生显示）。
+    PR-5 v9 删 stage 时同步移除老 stage / project.advance_stage 调用。
     """
     from . import projects as _projects, versions as _versions
     task_row = db.get_task(conn, task_id)
@@ -170,16 +176,36 @@ def _maybe_finalize_version(conn: Any, task_id: int) -> None:
     p = _projects.get_project(conn, int(pid))
     if not v or not p:
         return
-    # 推断 output_lora_path（与 anima_train 默认 `{output_name}_final.safetensors` 一致）
-    output_name = f"{p['slug']}_{v['label']}"
-    vdir = _versions.version_dir(int(pid), p["slug"], v["label"])
-    candidate = vdir / "output" / f"{output_name}_final.safetensors"
-    fields: dict[str, Any] = {"stage": "done"}
-    if candidate.exists():
-        fields["output_lora_path"] = str(candidate)
+
+    # ADR-0007 §11.3-B：task 终态独立映射，不撒谎
+    new_status_map = {
+        "done":     _versions.VersionStatus.COMPLETED,
+        "failed":   _versions.VersionStatus.FAILED,
+        "canceled": _versions.VersionStatus.CANCELED,
+    }
+    new_status = new_status_map.get(task_status)
+    if new_status is None:
+        return  # 未知 task_status（如 paused / running）不动 version
+
+    fields: dict[str, Any] = {"status": new_status}
+
+    if task_status == "done":
+        # 走完整 finalize：双写老 stage + LoRA 路径
+        output_name = f"{p['slug']}_{v['label']}"
+        vdir = _versions.version_dir(int(pid), p["slug"], v["label"])
+        candidate = vdir / "output" / f"{output_name}_final.safetensors"
+        fields["stage"] = "done"
+        if candidate.exists():
+            fields["output_lora_path"] = str(candidate)
+    elif task_status == "failed":
+        err = task_row.get("error_msg")
+        if err:
+            fields["last_failure_reason"] = str(err)
+
     _versions.update_version(conn, int(vid), **fields)
-    # 项目也推到 done（用户视角整条链跑完了）
-    if p.get("stage") in ("training", "configured"):
+
+    # 项目老 stage 双写（done 时；PR-5 删此行）
+    if task_status == "done" and p.get("stage") in ("training", "configured"):
         _projects.advance_stage(conn, int(pid), "done")
 
 
@@ -754,6 +780,20 @@ class Supervisor:
                 pid=proc.pid,
                 monitor_state_path=str(monitor_state_path),
             )
+            # ADR-0007 §11.3-B 双写：task 启动 → version.status = training
+            vid = task.get("version_id")
+            if vid:
+                try:
+                    from . import versions as _versions
+                    _versions.update_version(
+                        conn, int(vid),
+                        status=_versions.VersionStatus.TRAINING,
+                    )
+                except Exception:
+                    logger.exception(
+                        "version.status=training write failed for task %s",
+                        task["id"],
+                    )
         self._on_event(
             {
                 "type": "task_state_changed",
@@ -1177,9 +1217,10 @@ class Supervisor:
                     fields["paused_step"] = slot.pause_step
                     fields["paused_at"] = time.time()
                 db.update_task(conn, cid, **fields)
-                # PP6.3：训练成功时回填 version.output_lora_path + 推 stage=done
-                if status == "done":
-                    _maybe_finalize_version(conn, cid)
+                # ADR-0007 §11.3-B：task 终态（done/failed/canceled）独立映射到
+                # version.status。paused 不进（task 还能 resume，§11.3-A）。
+                if status in ("done", "failed", "canceled"):
+                    _maybe_finalize_version(conn, cid, status)
             # commit 10 起：generate task 走 daemon 不进 SLOT_TRAIN，
             # 这条 _finish_slot 路径只跑 train / reg_ai；不再需要 generate
             # tempdir 清理（已搬到 _finalize_daemon_task）。

--- a/studio/supervisor.py
+++ b/studio/supervisor.py
@@ -683,6 +683,17 @@ class Supervisor:
             )
             return
 
+        # ADR-0007 §11.7 / PR-3 commit 4：task 启动 → 冻结当时的 config
+        # 到 studio_data/tasks/{tid}/snapshot/config.yaml。失败不阻 task
+        # 启动（snapshot 是 forensics 不是必需）。
+        try:
+            from . import task_snapshot
+            task_snapshot.freeze_config(int(task["id"]), cfg_path)
+        except Exception:
+            logger.exception(
+                "task %s config snapshot freeze failed (non-fatal)", task["id"]
+            )
+
         # PP6.1 — 计算 per-task monitor 状态文件路径
         # 有 version_id：versions/{label}/monitor_state.json
         # 没有：studio_data/monitors/task_{id}/state.json（兜底）

--- a/studio/task_snapshot.py
+++ b/studio/task_snapshot.py
@@ -1,0 +1,73 @@
+"""Task config snapshot — ADR-0007 §11.7。
+
+task 启动时把当时的 version config.yaml 冻结一份到
+``studio_data/tasks/{task_id}/snapshot/config.yaml``。
+
+设计要点：
+- **仅冻 config**，不冻 caption / 图 / 正则集（跨 OS export OK，磁盘代价 KB 级）
+- 心智分离 UI：task 详情独立 [关联配置] tab，**不点 task 跳 version config 编辑页**
+  → 让 user 理解 config 是历史快照，caption / 图是 version 当前状态
+- 冻结时机：supervisor `_spawn_task` 把 cfg_path 给 worker 之前
+- 失败不阻塞 task 启动（snapshot 是 forensics 不是必需）
+
+用 user 视角："点 task 详情 [关联配置] 看当时跑的什么参数，按'套用此配置'按钮
+跳到 ⑦ 训练 phase 页面 + prefill → 编辑 → 训练 = 新 task" （§11.7 流程）。
+"""
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any, Optional
+
+import yaml
+
+from .paths import STUDIO_DATA
+
+SNAPSHOT_CONFIG_FILENAME = "config.yaml"
+
+
+def snapshot_root() -> Path:
+    """所有 task snapshot 落到 ``studio_data/tasks/``。"""
+    return STUDIO_DATA / "tasks"
+
+
+def snapshot_dir(task_id: int) -> Path:
+    """``studio_data/tasks/{task_id}/snapshot/``。"""
+    return snapshot_root() / str(int(task_id)) / "snapshot"
+
+
+def snapshot_config_path(task_id: int) -> Path:
+    return snapshot_dir(task_id) / SNAPSHOT_CONFIG_FILENAME
+
+
+def has_snapshot(task_id: int) -> bool:
+    return snapshot_config_path(task_id).exists()
+
+
+def freeze_config(task_id: int, source: Path) -> Path:
+    """复制 source yaml 到 ``snapshot_config_path(task_id)``，返回目标路径。
+
+    重复调用会覆盖（同 task_id 重启场景）。source 不存在时 raise FileNotFoundError。
+    """
+    if not source.exists():
+        raise FileNotFoundError(f"snapshot source not found: {source}")
+    dst = snapshot_config_path(task_id)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, dst)
+    return dst
+
+
+def read_snapshot_config(task_id: int) -> Optional[dict[str, Any]]:
+    """读 task config snapshot；不存在返回 None。
+
+    返回 ``{"yaml": raw_text, "config": parsed_dict}`` —— UI 既能展示原始 yaml
+    （只读 monaco），也能 prefill 训练 config 表单。
+    """
+    p = snapshot_config_path(task_id)
+    if not p.exists():
+        return None
+    text = p.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(text) or {}
+    if not isinstance(parsed, dict):
+        parsed = {}
+    return {"yaml": text, "config": parsed}

--- a/studio/versions.py
+++ b/studio/versions.py
@@ -72,6 +72,82 @@ def get_phase(v: dict[str, Any]) -> str:
     """读 version.phase；None / 缺字段 fallback → curating。"""
     return str(v.get("phase") or VersionPhase.CURATING)
 
+
+# ---------------------------------------------------------------------------
+# ADR-0007 §11.3-C / §6.9: version.status 派生 + 一致性校验
+# ---------------------------------------------------------------------------
+
+
+_TASK_TO_VERSION_STATUS: dict[str, str] = {
+    "done":     VersionStatus.COMPLETED,
+    "failed":   VersionStatus.FAILED,
+    "canceled": VersionStatus.CANCELED,
+}
+
+
+def derive_status_from_tasks(
+    conn: sqlite3.Connection, version_id: int
+) -> str:
+    """按 ADR §11.3-C 派生 version.status：
+
+    - 有 active task（pending / running / paused）→ training
+    - 无 active 看最近终态 task → completed / failed / canceled
+    - 从未有 task → preparing
+    """
+    row = conn.execute(
+        "SELECT 1 FROM tasks "
+        "WHERE version_id = ? AND status IN ('pending', 'running', 'paused') "
+        "LIMIT 1",
+        (version_id,),
+    ).fetchone()
+    if row:
+        return VersionStatus.TRAINING
+
+    row = conn.execute(
+        "SELECT status FROM tasks "
+        "WHERE version_id = ? AND status IN ('done', 'failed', 'canceled') "
+        "ORDER BY created_at DESC LIMIT 1",
+        (version_id,),
+    ).fetchone()
+    if row:
+        return _TASK_TO_VERSION_STATUS.get(str(row[0]), VersionStatus.PREPARING)
+
+    return VersionStatus.PREPARING
+
+
+def reconcile_version_status(
+    conn: sqlite3.Connection, version_id: int
+) -> tuple[Optional[dict[str, Any]], bool]:
+    """读 version + 校正 status 不一致；返回 (version, was_corrected)。
+
+    ADR §6.9 安全网：双写过渡期 supervisor 偶尔漏写时，此函数能让
+    任意 read 路径自愈。
+    - 计算 derive_status_from_tasks
+    - 与存储值不一致 → log warning + UPDATE + 返回 corrected version + True
+    - 一致 → 直接返回 (version, False)
+    - version 不存在 → (None, False)
+
+    本函数不发 SSE（保持纯 db 操作），调用方根据 was_corrected 决定要不要 publish。
+    """
+    import logging
+    logger = logging.getLogger(__name__)
+
+    v = get_version(conn, version_id)
+    if not v:
+        return None, False
+
+    derived = derive_status_from_tasks(conn, version_id)
+    stored = get_status(v)
+    if stored == derived:
+        return v, False
+
+    logger.warning(
+        "version %d status mismatch: stored=%r derived=%r → correcting",
+        version_id, stored, derived,
+    )
+    update_version(conn, version_id, status=derived)
+    return get_version(conn, version_id), True
+
 # label 必须是路径安全的：字母 / 数字 / 下划线 / 连字符 / 点
 _VALID_LABEL = re.compile(r"^[A-Za-z0-9_.-]+$")
 

--- a/studio/versions.py
+++ b/studio/versions.py
@@ -442,7 +442,11 @@ def _copytree(src: Path, dst: Path) -> None:
             shutil.copy2(sub, target)
 
 
-_UPDATABLE = {"note", "stage", "config_name", "output_lora_path", "trigger_word"}
+_UPDATABLE = {
+    "note", "stage", "config_name", "output_lora_path", "trigger_word",
+    # ADR-0007 §11.3-B 新字段（PR-3 起允许写入；v9 删 stage 后 stage 离开此集合）
+    "status", "phase", "last_failure_reason",
+}
 
 
 def update_version(
@@ -452,6 +456,10 @@ def update_version(
     keep = {k: val for k, val in fields.items() if k in _UPDATABLE}
     if "stage" in keep and keep["stage"] not in VALID_STAGES:
         raise VersionError(f"非法 stage: {keep['stage']!r}")
+    if "status" in keep and keep["status"] not in VersionStatus.VALUES:
+        raise VersionError(f"非法 status: {keep['status']!r}")
+    if "phase" in keep and keep["phase"] not in VersionPhase.VALUES:
+        raise VersionError(f"非法 phase: {keep['phase']!r}")
     if not keep:
         return v
     cols = ", ".join(f"{k} = ?" for k in keep)

--- a/studio/versions.py
+++ b/studio/versions.py
@@ -25,6 +25,53 @@ VALID_STAGES: frozenset[str] = frozenset({
     "ready", "training", "done",
 })
 
+# ADR-0007 §11.3-B：versions.stage 被拆成 status + phase 两个正交字段。
+# 本节加 enum + readonly accessor；写入路径由 PR-3 双写过渡，v9 删 stage 同步清理。
+
+
+class VersionStatus:
+    """版本运行态状态机（5 enum，ADR-0007 §11.3-B）。"""
+
+    PREPARING = "preparing"
+    TRAINING = "training"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELED = "canceled"
+
+    VALUES: frozenset[str] = frozenset({
+        PREPARING, TRAINING, COMPLETED, FAILED, CANCELED,
+    })
+
+
+class VersionPhase:
+    """版本准备 cursor，仅 status=preparing 时有业务语义（ADR-0007 §11.3-B / §11.5-A）。
+
+    顺序：curating → tagging → editing → regularizing → ready。
+    regularizing 可跳过（SKIPPABLE），其余必经。
+    """
+
+    CURATING = "curating"
+    TAGGING = "tagging"
+    EDITING = "editing"
+    REGULARIZING = "regularizing"
+    READY = "ready"
+
+    ORDER: tuple[str, ...] = (
+        CURATING, TAGGING, EDITING, REGULARIZING, READY,
+    )
+    VALUES: frozenset[str] = frozenset(ORDER)
+    SKIPPABLE: frozenset[str] = frozenset({REGULARIZING})
+
+
+def get_status(v: dict[str, Any]) -> str:
+    """读 version.status；None / 缺字段 fallback → preparing。"""
+    return str(v.get("status") or VersionStatus.PREPARING)
+
+
+def get_phase(v: dict[str, Any]) -> str:
+    """读 version.phase；None / 缺字段 fallback → curating。"""
+    return str(v.get("phase") or VersionPhase.CURATING)
+
 # label 必须是路径安全的：字母 / 数字 / 下划线 / 连字符 / 点
 _VALID_LABEL = re.compile(r"^[A-Za-z0-9_.-]+$")
 

--- a/studio/versions_phase.py
+++ b/studio/versions_phase.py
@@ -1,0 +1,192 @@
+"""Phase 推进 / 完成校验 — ADR-0007 §11.5-A / §11.5-B。
+
+Phase enum 见 ``versions.VersionPhase``：
+``curating → tagging → editing → regularizing → ready``。
+
+完成判定（§11.5-B）：
+- ``curating``: ``train/ ≥ 1`` 张图
+- ``tagging``: caption 100% 覆盖（每张 train 图都有同名 .txt）
+- ``editing``: 同 tagging（兜底，防 user 删了 caption）
+- ``regularizing``: 无 reg_build job 处于 pending/running（可跳过，§11.5-A SKIPPABLE）
+- ``ready``: training config 文件存在 + schema 校验通过
+
+cursor 推进规则（§11.5-A）：
+- 单向（只前进）
+- header "下一步" 按钮永远可点；校验失败给用户提示
+- 必经 phase 校验失败 → 不推进
+- 可跳过 phase 校验 = 无 concurrent job（regularizing 无 confirm dialog）
+- cursor 不主动回退（§11.5-C；user 删数据后下次 next 校验时才提示）
+"""
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from . import projects as _projects
+from . import versions as _versions
+from .services import version_config as _version_config
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """Phase 校验结果。ok=True 时 reason 可空；ok=False 时 reason 是 user 可读提示。"""
+    ok: bool
+    reason: str = ""
+
+
+# ---------------------------------------------------------------------------
+# 单 phase 校验函数（参数取最小所需，便于 unit test 隔离）
+# ---------------------------------------------------------------------------
+
+
+def check_curating(stats: dict[str, Any]) -> CheckResult:
+    """train/ ≥ 1 张图（§11.5-B）。"""
+    if stats.get("train_image_count", 0) < 1:
+        return CheckResult(False, "训练集为空，请先选择训练图")
+    return CheckResult(True)
+
+
+def check_tagging(stats: dict[str, Any]) -> CheckResult:
+    """caption 100% 覆盖（§11.5-B）。"""
+    total = int(stats.get("train_image_count", 0))
+    tagged = int(stats.get("tagged_image_count", 0))
+    if total < 1:
+        return CheckResult(False, "训练集为空，请先选择训练图")
+    if tagged < total:
+        missing = total - tagged
+        return CheckResult(False, f"还有 {missing} 张未生成 caption，请重跑或删除")
+    return CheckResult(True)
+
+
+def check_editing(stats: dict[str, Any]) -> CheckResult:
+    """editing 同 tagging（兜底，§11.5-B；大多数情况自动通过）。"""
+    return check_tagging(stats)
+
+
+def check_regularizing(
+    conn: sqlite3.Connection, version_id: int
+) -> CheckResult:
+    """无 reg_build job 处于 pending/running（§11.5-B；可跳过 = 不强求正则集非空）。"""
+    row = conn.execute(
+        "SELECT COUNT(*) FROM project_jobs "
+        "WHERE version_id = ? "
+        "  AND kind = 'reg_build' "
+        "  AND status IN ('pending', 'running')",
+        (version_id,),
+    ).fetchone()
+    if int(row[0]) > 0:
+        return CheckResult(False, "正则任务进行中，请等待完成")
+    return CheckResult(True)
+
+
+def check_ready(
+    project: dict[str, Any], version: dict[str, Any]
+) -> CheckResult:
+    """training config 存在 + schema 校验通过（§11.5-B）。"""
+    try:
+        _version_config.read_version_config(project, version)
+    except _version_config.VersionConfigError as exc:
+        return CheckResult(False, f"请先完成训练配置：{exc}")
+    return CheckResult(True)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher + 推进
+# ---------------------------------------------------------------------------
+
+
+def check_phase(
+    conn: sqlite3.Connection, version_id: int, phase: str
+) -> CheckResult:
+    """根据 phase 选择对应 check 函数；version / project 不存在也以 CheckResult 返回。"""
+    v = _versions.get_version(conn, version_id)
+    if not v:
+        return CheckResult(False, "版本不存在")
+    p = _projects.get_project(conn, int(v["project_id"]))
+    if not p:
+        return CheckResult(False, "项目不存在")
+
+    P = _versions.VersionPhase
+    if phase == P.CURATING:
+        return check_curating(_versions.stats_for_version(p, v))
+    if phase == P.TAGGING:
+        return check_tagging(_versions.stats_for_version(p, v))
+    if phase == P.EDITING:
+        return check_editing(_versions.stats_for_version(p, v))
+    if phase == P.REGULARIZING:
+        return check_regularizing(conn, version_id)
+    if phase == P.READY:
+        return check_ready(p, v)
+    return CheckResult(False, f"未知 phase: {phase}")
+
+
+def advance_phase(
+    conn: sqlite3.Connection, version_id: int
+) -> tuple[bool, CheckResult, Optional[str]]:
+    """尝试推进 phase cursor 到下一个（必经/可跳过都走这个）。
+
+    返回 ``(advanced, result, new_phase)``:
+    - ``advanced=True``: cursor 已推进；``new_phase`` 是新 phase 名
+    - ``advanced=False``: ``result.reason`` 含失败原因；``new_phase=None``
+
+    ``ready`` 是最后一个 phase — 调用方收到 ``(False, ok-but-end, None)`` 后
+    应转入 status: ``preparing → training`` + submit task（即 enqueue 训练）。
+    """
+    v = _versions.get_version(conn, version_id)
+    if not v:
+        return False, CheckResult(False, "版本不存在"), None
+
+    current_phase = _versions.get_phase(v)
+    order = _versions.VersionPhase.ORDER
+
+    # phase 不在已知集合 → fallback 拒绝
+    if current_phase not in order:
+        return False, CheckResult(False, f"未知 phase: {current_phase}"), None
+
+    # 已到最后 phase（ready）→ phase 不再推进；由调用方触发 status 转换
+    idx = order.index(current_phase)
+    if idx >= len(order) - 1:
+        result = check_phase(conn, version_id, current_phase)
+        # 即使到 ready 也跑一次校验，让调用方决定是否进 training
+        return False, result, None
+
+    # 走校验
+    result = check_phase(conn, version_id, current_phase)
+    if not result.ok:
+        return False, result, None
+
+    next_phase = order[idx + 1]
+    _versions.update_version(conn, version_id, phase=next_phase)
+    return True, CheckResult(True), next_phase
+
+
+def skip_phase(
+    conn: sqlite3.Connection, version_id: int
+) -> tuple[bool, CheckResult, Optional[str]]:
+    """跳过当前 phase（仅 ``SKIPPABLE`` 集合允许；当前 = regularizing）。
+
+    与 ``advance_phase`` 区别：不要求"完成条件"满足（如不要求生成正则集），
+    仅校验"无 concurrent job"防止状态错乱。
+    """
+    v = _versions.get_version(conn, version_id)
+    if not v:
+        return False, CheckResult(False, "版本不存在"), None
+
+    current_phase = _versions.get_phase(v)
+    if current_phase not in _versions.VersionPhase.SKIPPABLE:
+        return False, CheckResult(False, f"phase {current_phase} 不可跳过"), None
+
+    # regularizing 跳过也要 no job running
+    if current_phase == _versions.VersionPhase.REGULARIZING:
+        result = check_regularizing(conn, version_id)
+        if not result.ok:
+            return False, result, None
+
+    order = _versions.VersionPhase.ORDER
+    idx = order.index(current_phase)
+    if idx >= len(order) - 1:
+        return False, CheckResult(False, "已到最后 phase"), None
+    next_phase = order[idx + 1]
+    _versions.update_version(conn, version_id, phase=next_phase)
+    return True, CheckResult(True), next_phase

--- a/tests/test_supervisor_version_status.py
+++ b/tests/test_supervisor_version_status.py
@@ -1,0 +1,226 @@
+"""ADR-0007 §11.3-B / §11.7: supervisor 推 version.status 双写 + task snapshot 集成测试。"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from studio import db, projects, task_snapshot, versions
+from studio.supervisor import Supervisor, _maybe_finalize_version
+
+
+def _wait_for(predicate, timeout: float = 8.0, interval: float = 0.05) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """初始化 db + 目录 + 项目 + version + valid config 文件。"""
+    db_path = tmp_path / "studio.db"
+    db.init_db(db_path)
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(db, "STUDIO_DB", db_path)
+    # snapshot 落 tmp_path 避免污染真实 studio_data
+    monkeypatch.setattr(task_snapshot, "STUDIO_DATA", tmp_path / "studio_data")
+
+    logs = tmp_path / "logs"
+    configs = tmp_path / "configs"
+    logs.mkdir()
+    configs.mkdir()
+    (configs / "fake.yaml").write_text("epochs: 1\nlr: 0.001\n", encoding="utf-8")
+
+    # 建一个 project + version 以便挂 task
+    with db.connection_for(db_path) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label="baseline")
+
+    return {
+        "db": db_path,
+        "logs": logs,
+        "configs": configs,
+        "project": p,
+        "version": v,
+    }
+
+
+def _create_versioned_task(env, name: str = "t1") -> int:
+    """创建一个挂在 env['version'] 的 task。"""
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name=name, config_name="fake")
+        db.update_task(
+            conn, tid,
+            project_id=env["project"]["id"],
+            version_id=env["version"]["id"],
+        )
+    return tid
+
+
+# ---------------------------------------------------------------------------
+# _maybe_finalize_version 单测
+# ---------------------------------------------------------------------------
+
+
+def test_finalize_done_sets_completed_and_stage_done(env) -> None:
+    tid = _create_versioned_task(env)
+    with db.connection_for(env["db"]) as conn:
+        _maybe_finalize_version(conn, tid, "done")
+        v = versions.get_version(conn, env["version"]["id"])
+    assert v["status"] == "completed"
+    assert v["stage"] == "done"  # 老字段双写
+
+
+def test_finalize_failed_sets_failed_and_writes_reason(env) -> None:
+    tid = _create_versioned_task(env)
+    with db.connection_for(env["db"]) as conn:
+        db.update_task(conn, tid, status="failed", error_msg="OOM at step 500")
+        _maybe_finalize_version(conn, tid, "failed")
+        v = versions.get_version(conn, env["version"]["id"])
+    assert v["status"] == "failed"
+    assert v["last_failure_reason"] == "OOM at step 500"
+
+
+def test_finalize_canceled_sets_canceled(env) -> None:
+    tid = _create_versioned_task(env)
+    with db.connection_for(env["db"]) as conn:
+        _maybe_finalize_version(conn, tid, "canceled")
+        v = versions.get_version(conn, env["version"]["id"])
+    assert v["status"] == "canceled"
+
+
+def test_finalize_paused_does_not_change_version(env) -> None:
+    """task=paused（非终态）不该改 version.status；§11.3-A: UI 派生 pause icon。"""
+    tid = _create_versioned_task(env)
+    with db.connection_for(env["db"]) as conn:
+        versions.update_version(conn, env["version"]["id"], status="training")
+        _maybe_finalize_version(conn, tid, "paused")  # paused 不是已知终态
+        v = versions.get_version(conn, env["version"]["id"])
+    assert v["status"] == "training"
+
+
+def test_finalize_no_version_id_is_noop(env) -> None:
+    """task 没 version_id 时 finalize 不应抛错。"""
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name="orphan", config_name="fake")
+        # 不挂 version_id
+        _maybe_finalize_version(conn, tid, "done")  # 不抛
+
+
+# ---------------------------------------------------------------------------
+# 集成测试：supervisor 全流程驱动 version.status + snapshot
+# ---------------------------------------------------------------------------
+
+
+def test_done_task_sets_version_completed_and_creates_snapshot(env) -> None:
+    """完整跑：pending → running → done → version.status=completed + snapshot 落盘。"""
+    def fast_cmd(task: dict[str, Any], cfg: Path) -> list[str]:
+        return [sys.executable, "-c", "import sys; sys.exit(0)"]
+
+    sup = Supervisor(
+        cmd_builder=fast_cmd,
+        db_path=env["db"], logs_dir=env["logs"], configs_dir=env["configs"],
+        poll_interval=0.05,
+    )
+
+    tid = _create_versioned_task(env)
+    sup.start()
+    try:
+        assert _wait_for(
+            lambda: db.get_task(_open(env["db"]), tid)["status"] == "done",
+            timeout=10,
+        )
+    finally:
+        sup.stop()
+
+    # version.status 应该被推到 completed
+    with db.connection_for(env["db"]) as conn:
+        v = versions.get_version(conn, env["version"]["id"])
+    assert v["status"] == "completed"
+
+    # snapshot 应该已落盘
+    snap = task_snapshot.snapshot_config_path(tid)
+    assert snap.exists()
+    assert "epochs: 1" in snap.read_text(encoding="utf-8")
+
+
+def test_failed_task_sets_version_failed(env) -> None:
+    def fail_cmd(task: dict[str, Any], cfg: Path) -> list[str]:
+        return [sys.executable, "-c", "import sys; sys.exit(1)"]
+
+    sup = Supervisor(
+        cmd_builder=fail_cmd,
+        db_path=env["db"], logs_dir=env["logs"], configs_dir=env["configs"],
+        poll_interval=0.05,
+    )
+
+    tid = _create_versioned_task(env)
+    sup.start()
+    try:
+        assert _wait_for(
+            lambda: db.get_task(_open(env["db"]), tid)["status"] == "failed",
+            timeout=10,
+        )
+    finally:
+        sup.stop()
+
+    with db.connection_for(env["db"]) as conn:
+        v = versions.get_version(conn, env["version"]["id"])
+    assert v["status"] == "failed"
+    assert v["last_failure_reason"] is not None  # task.error_msg "exit code 1" 被写入
+
+
+def test_spawn_sets_version_training_then_terminal(env) -> None:
+    """task 启动时 version.status 立刻变 training，task 完成后变 completed。"""
+    def slow_cmd(task: dict[str, Any], cfg: Path) -> list[str]:
+        # 给 supervisor 有时间观察 training 状态
+        return [sys.executable, "-c", "import time; time.sleep(0.3)"]
+
+    sup = Supervisor(
+        cmd_builder=slow_cmd,
+        db_path=env["db"], logs_dir=env["logs"], configs_dir=env["configs"],
+        poll_interval=0.05,
+    )
+
+    tid = _create_versioned_task(env)
+    sup.start()
+    try:
+        # 等到 task 状态变 running 并验证 version.status='training'
+        assert _wait_for(
+            lambda: db.get_task(_open(env["db"]), tid)["status"] == "running",
+            timeout=10,
+        )
+        with db.connection_for(env["db"]) as conn:
+            v = versions.get_version(conn, env["version"]["id"])
+        assert v["status"] == "training"
+
+        # 等到 done
+        assert _wait_for(
+            lambda: db.get_task(_open(env["db"]), tid)["status"] == "done",
+            timeout=10,
+        )
+    finally:
+        sup.stop()
+
+    with db.connection_for(env["db"]) as conn:
+        v = versions.get_version(conn, env["version"]["id"])
+    assert v["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _open(db_path: Path):
+    """返回一个 connection（不关），用于单次 select 不开 with。"""
+    import sqlite3
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    return conn

--- a/tests/test_task_snapshot.py
+++ b/tests/test_task_snapshot.py
@@ -1,0 +1,140 @@
+"""ADR-0007 §11.7: task config snapshot module + endpoint 测试。"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from studio import db, projects, server, task_snapshot
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
+    # task_snapshot 用 STUDIO_DATA：mock 到 tmp_path / studio_data
+    monkeypatch.setattr(task_snapshot, "STUDIO_DATA", tmp_path / "studio_data")
+    return {"db": dbfile, "data": tmp_path / "studio_data"}
+
+
+# ---------------------------------------------------------------------------
+# 纯 module tests
+# ---------------------------------------------------------------------------
+
+
+def test_snapshot_paths_under_studio_data(isolated) -> None:
+    root = task_snapshot.snapshot_root()
+    assert root == isolated["data"] / "tasks"
+    assert task_snapshot.snapshot_dir(42) == root / "42" / "snapshot"
+    assert task_snapshot.snapshot_config_path(42) == root / "42" / "snapshot" / "config.yaml"
+
+
+def test_freeze_config_creates_file(isolated, tmp_path: Path) -> None:
+    src = tmp_path / "src.yaml"
+    src.write_text("lr: 0.001\nbatch_size: 4\n", encoding="utf-8")
+    dst = task_snapshot.freeze_config(7, src)
+    assert dst == task_snapshot.snapshot_config_path(7)
+    assert dst.exists()
+    assert dst.read_text(encoding="utf-8") == "lr: 0.001\nbatch_size: 4\n"
+
+
+def test_freeze_config_overwrites_existing(isolated, tmp_path: Path) -> None:
+    src1 = tmp_path / "v1.yaml"
+    src1.write_text("lr: 0.001\n", encoding="utf-8")
+    task_snapshot.freeze_config(7, src1)
+
+    src2 = tmp_path / "v2.yaml"
+    src2.write_text("lr: 0.0005\n", encoding="utf-8")
+    task_snapshot.freeze_config(7, src2)
+
+    final = task_snapshot.read_snapshot_config(7)
+    assert final is not None
+    assert final["config"]["lr"] == 0.0005
+
+
+def test_freeze_config_missing_source_raises(isolated, tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        task_snapshot.freeze_config(7, tmp_path / "nonexistent.yaml")
+
+
+def test_has_snapshot_true_false(isolated, tmp_path: Path) -> None:
+    assert not task_snapshot.has_snapshot(8)
+    src = tmp_path / "src.yaml"
+    src.write_text("x: 1\n", encoding="utf-8")
+    task_snapshot.freeze_config(8, src)
+    assert task_snapshot.has_snapshot(8)
+
+
+def test_read_snapshot_returns_yaml_and_dict(isolated, tmp_path: Path) -> None:
+    src = tmp_path / "src.yaml"
+    src.write_text("lr: 0.001\nbatch_size: 4\n", encoding="utf-8")
+    task_snapshot.freeze_config(7, src)
+
+    data = task_snapshot.read_snapshot_config(7)
+    assert data is not None
+    assert data["yaml"] == "lr: 0.001\nbatch_size: 4\n"
+    assert data["config"] == {"lr": 0.001, "batch_size": 4}
+
+
+def test_read_snapshot_missing_returns_none(isolated) -> None:
+    assert task_snapshot.read_snapshot_config(99999) is None
+
+
+def test_read_snapshot_non_mapping_falls_back_to_empty(
+    isolated, tmp_path: Path
+) -> None:
+    """如果 yaml 不是 mapping（如纯字符串），config 字段应是 {}。"""
+    src = tmp_path / "weird.yaml"
+    src.write_text("just_a_string\n", encoding="utf-8")
+    task_snapshot.freeze_config(10, src)
+    data = task_snapshot.read_snapshot_config(10)
+    assert data is not None
+    assert data["config"] == {}
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(isolated) -> TestClient:
+    return TestClient(server.app)
+
+
+def _create_task(isolated, name: str = "t1") -> int:
+    with db.connection_for(isolated["db"]) as conn:
+        return db.create_task(conn, name=name, config_name="cfg")
+
+
+def test_endpoint_404_when_task_missing(client: TestClient) -> None:
+    resp = client.get("/api/queue/99999/snapshot/config")
+    assert resp.status_code == 404
+    assert "task" in resp.json()["detail"].lower()
+
+
+def test_endpoint_404_when_snapshot_missing(client: TestClient, isolated) -> None:
+    tid = _create_task(isolated)
+    resp = client.get(f"/api/queue/{tid}/snapshot/config")
+    assert resp.status_code == 404
+    assert "snapshot" in resp.json()["detail"].lower()
+
+
+def test_endpoint_returns_snapshot_data(
+    client: TestClient, isolated, tmp_path: Path
+) -> None:
+    tid = _create_task(isolated)
+    src = tmp_path / "cfg.yaml"
+    src.write_text("lr: 0.001\noptimizer: adamw\n", encoding="utf-8")
+    task_snapshot.freeze_config(tid, src)
+
+    resp = client.get(f"/api/queue/{tid}/snapshot/config")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["yaml"] == "lr: 0.001\noptimizer: adamw\n"
+    assert body["config"] == {"lr": 0.001, "optimizer": "adamw"}

--- a/tests/test_version_status_phase.py
+++ b/tests/test_version_status_phase.py
@@ -1,0 +1,264 @@
+"""ADR-0007 §11.3-B: versions.status / phase 双字段 + v8 migration 测试。"""
+from __future__ import annotations
+
+import sqlite3
+import time
+from pathlib import Path
+
+from studio import db, versions
+from studio.migrations import current_version
+
+
+def _open(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# schema 加列 + 默认值
+# ---------------------------------------------------------------------------
+
+
+def test_v8_adds_status_phase_columns(tmp_path: Path) -> None:
+    """新库 init 后 versions 含 status / phase / last_failure_reason 三列。"""
+    dbfile = tmp_path / "fresh.db"
+    db.init_db(dbfile)
+    with _open(dbfile) as c:
+        cols = {r["name"] for r in c.execute("PRAGMA table_info(versions)")}
+        assert {"status", "phase", "last_failure_reason"} <= cols
+
+
+def test_v8_default_values_for_new_versions(tmp_path: Path) -> None:
+    """新建 version 不显式指定 status/phase → DEFAULT 'preparing' / 'curating'。"""
+    dbfile = tmp_path / "fresh.db"
+    db.init_db(dbfile)
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+        c.execute(
+            "INSERT INTO versions(project_id, label, stage, created_at) "
+            "VALUES (?, 'v', 'curating', ?)",
+            (pid, time.time()),
+        )
+        c.commit()
+
+        row = c.execute(
+            "SELECT status, phase, last_failure_reason FROM versions WHERE label='v'"
+        ).fetchone()
+        assert row["status"] == "preparing"
+        assert row["phase"] == "curating"
+        assert row["last_failure_reason"] is None
+
+
+def test_v8_apply_all_idempotent(tmp_path: Path) -> None:
+    """重复跑 init_db 不应重复添加列或丢数据。"""
+    dbfile = tmp_path / "fresh.db"
+    db.init_db(dbfile)
+    db.init_db(dbfile)
+    with _open(dbfile) as c:
+        cols = {r["name"] for r in c.execute("PRAGMA table_info(versions)")}
+        assert {"status", "phase", "last_failure_reason"} <= cols
+        assert current_version(c) == 8
+
+
+# ---------------------------------------------------------------------------
+# v8 backfill: 静态映射
+# ---------------------------------------------------------------------------
+
+
+def test_v8_backfill_static_stages(tmp_path: Path) -> None:
+    """老 5 stage 静态映射：curating/tagging/regularizing/ready → preparing+phase；done → completed+ready。"""
+    from studio.migrations._v8_version_status_phase import _backfill
+
+    dbfile = tmp_path / "test.db"
+    db.init_db(dbfile)
+
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # 插入老 stage 5 种，模拟 v8 跑之前的状态
+        for stage in ("curating", "tagging", "regularizing", "ready", "done"):
+            c.execute(
+                "INSERT INTO versions(project_id, label, stage, created_at) "
+                "VALUES (?, ?, ?, ?)",
+                (pid, stage, stage, time.time()),
+            )
+        c.commit()
+
+        # 再跑一次 backfill 强制重算（默认 v8 跑过已经设了，这里验证函数本身）
+        _backfill(c)
+
+        rows = {
+            r["label"]: (r["status"], r["phase"])
+            for r in c.execute("SELECT label, status, phase FROM versions")
+        }
+        assert rows["curating"] == ("preparing", "curating")
+        assert rows["tagging"] == ("preparing", "tagging")
+        assert rows["regularizing"] == ("preparing", "regularizing")
+        assert rows["ready"] == ("preparing", "ready")
+        assert rows["done"] == ("completed", "ready")
+
+
+# ---------------------------------------------------------------------------
+# v8 backfill: training stage 按 latest task 推
+# ---------------------------------------------------------------------------
+
+
+def test_v8_backfill_training_by_latest_task(tmp_path: Path) -> None:
+    """stage=training 时按 latest task.status 派生 version.status。"""
+    from studio.migrations._v8_version_status_phase import _backfill
+
+    dbfile = tmp_path / "test.db"
+    db.init_db(dbfile)
+
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        cases = [
+            ("v_done",     "done",     "completed"),
+            ("v_failed",   "failed",   "failed"),
+            ("v_canceled", "canceled", "canceled"),
+            ("v_running",  "running",  "training"),
+            ("v_pending",  "pending",  "training"),
+            ("v_paused",   "paused",   "training"),
+        ]
+        for label, task_status, _ in cases:
+            c.execute(
+                "INSERT INTO versions(project_id, label, stage, created_at) "
+                "VALUES (?, ?, 'training', ?)",
+                (pid, label, time.time()),
+            )
+            vid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+            c.execute(
+                "INSERT INTO tasks(name, config_name, status, project_id, version_id, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (label, "cfg", task_status, pid, vid, time.time()),
+            )
+        c.commit()
+        _backfill(c)
+
+        rows = {
+            r["label"]: r["status"]
+            for r in c.execute("SELECT label, status FROM versions")
+        }
+        for label, _, expected in cases:
+            assert rows[label] == expected, f"{label} → expected {expected}, got {rows[label]}"
+
+
+def test_v8_backfill_training_without_task_fallback(tmp_path: Path) -> None:
+    """脏数据：stage=training 但 task 不存在 → fallback preparing+ready。"""
+    from studio.migrations._v8_version_status_phase import _backfill
+
+    dbfile = tmp_path / "test.db"
+    db.init_db(dbfile)
+
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+        c.execute(
+            "INSERT INTO versions(project_id, label, stage, created_at) "
+            "VALUES (?, 'orphan', 'training', ?)",
+            (pid, time.time()),
+        )
+        c.commit()
+        _backfill(c)
+
+        row = c.execute(
+            "SELECT status, phase FROM versions WHERE label='orphan'"
+        ).fetchone()
+        assert row["status"] == "preparing"
+        assert row["phase"] == "ready"
+
+
+def test_v8_backfill_training_uses_latest_task(tmp_path: Path) -> None:
+    """同 version 多 task 时，按 created_at 最新的 task.status 派生。"""
+    from studio.migrations._v8_version_status_phase import _backfill
+
+    dbfile = tmp_path / "test.db"
+    db.init_db(dbfile)
+
+    with _open(dbfile) as c:
+        c.execute(
+            "INSERT INTO projects(slug, title, stage, created_at, updated_at) "
+            "VALUES ('p', 'P', 'created', ?, ?)",
+            (time.time(), time.time()),
+        )
+        pid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+        c.execute(
+            "INSERT INTO versions(project_id, label, stage, created_at) "
+            "VALUES (?, 'v', 'training', ?)",
+            (pid, time.time()),
+        )
+        vid = c.execute("SELECT last_insert_rowid()").fetchone()[0]
+
+        # 老 task failed，新 task done —— 应取新的（completed）
+        now = time.time()
+        c.execute(
+            "INSERT INTO tasks(name, config_name, status, project_id, version_id, created_at) "
+            "VALUES ('old', 'cfg', 'failed', ?, ?, ?)",
+            (pid, vid, now - 100),
+        )
+        c.execute(
+            "INSERT INTO tasks(name, config_name, status, project_id, version_id, created_at) "
+            "VALUES ('new', 'cfg', 'done', ?, ?, ?)",
+            (pid, vid, now),
+        )
+        c.commit()
+        _backfill(c)
+
+        row = c.execute("SELECT status FROM versions WHERE label='v'").fetchone()
+        assert row["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
+# VersionStatus / VersionPhase enum + helper
+# ---------------------------------------------------------------------------
+
+
+def test_version_status_enum_values() -> None:
+    assert versions.VersionStatus.PREPARING == "preparing"
+    assert versions.VersionStatus.TRAINING == "training"
+    assert versions.VersionStatus.COMPLETED == "completed"
+    assert versions.VersionStatus.FAILED == "failed"
+    assert versions.VersionStatus.CANCELED == "canceled"
+    assert len(versions.VersionStatus.VALUES) == 5
+
+
+def test_version_phase_order_and_skippable() -> None:
+    assert versions.VersionPhase.ORDER == (
+        "curating", "tagging", "editing", "regularizing", "ready",
+    )
+    assert len(versions.VersionPhase.VALUES) == 5
+    assert versions.VersionPhase.SKIPPABLE == frozenset({"regularizing"})
+
+
+def test_get_status_fallback_to_preparing() -> None:
+    assert versions.get_status({}) == "preparing"
+    assert versions.get_status({"status": None}) == "preparing"
+    assert versions.get_status({"status": ""}) == "preparing"
+    assert versions.get_status({"status": "training"}) == "training"
+
+
+def test_get_phase_fallback_to_curating() -> None:
+    assert versions.get_phase({}) == "curating"
+    assert versions.get_phase({"phase": None}) == "curating"
+    assert versions.get_phase({"phase": "editing"}) == "editing"

--- a/tests/test_versions_phase.py
+++ b/tests/test_versions_phase.py
@@ -1,0 +1,293 @@
+"""ADR-0007 §11.5-A / §11.5-B: phase check_completion + advance / skip 函数测试。"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from studio import db, projects, versions, versions_phase
+from studio.versions_phase import CheckResult
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    pdir = tmp_path / "projects"
+    monkeypatch.setattr(projects, "PROJECTS_DIR", pdir)
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    return {"db": dbfile}
+
+
+def _make_version(isolated, label: str = "v1") -> dict:
+    with db.connection_for(isolated["db"]) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label=label)
+    return v
+
+
+def _put_image(folder: Path, name: str, with_caption: bool = True) -> None:
+    folder.mkdir(parents=True, exist_ok=True)
+    (folder / f"{name}.png").write_bytes(b"fake")
+    if with_caption:
+        (folder / f"{name}.txt").write_text("tag1, tag2", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Pure check function tests (stats dict 直接喂)
+# ---------------------------------------------------------------------------
+
+
+def test_check_curating_empty() -> None:
+    result = versions_phase.check_curating({"train_image_count": 0})
+    assert not result.ok
+    assert "训练集为空" in result.reason
+
+
+def test_check_curating_with_images() -> None:
+    assert versions_phase.check_curating({"train_image_count": 1}).ok
+    assert versions_phase.check_curating({"train_image_count": 100}).ok
+
+
+def test_check_tagging_full_coverage() -> None:
+    result = versions_phase.check_tagging({
+        "train_image_count": 10, "tagged_image_count": 10,
+    })
+    assert result.ok
+
+
+def test_check_tagging_partial_coverage() -> None:
+    result = versions_phase.check_tagging({
+        "train_image_count": 10, "tagged_image_count": 7,
+    })
+    assert not result.ok
+    assert "3 张" in result.reason
+
+
+def test_check_tagging_empty() -> None:
+    result = versions_phase.check_tagging({"train_image_count": 0})
+    assert not result.ok
+    assert "训练集为空" in result.reason
+
+
+def test_check_editing_same_as_tagging() -> None:
+    """editing 是 tagging 的兜底，应该 100% 行为一致。"""
+    stats = {"train_image_count": 10, "tagged_image_count": 5}
+    assert (
+        versions_phase.check_editing(stats).reason
+        == versions_phase.check_tagging(stats).reason
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regularizing check (要 DB，因为查 project_jobs)
+# ---------------------------------------------------------------------------
+
+
+def test_check_regularizing_no_jobs(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        result = versions_phase.check_regularizing(conn, v["id"])
+    assert result.ok
+
+
+def test_check_regularizing_blocks_when_job_running(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        conn.execute(
+            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
+            "VALUES (?, ?, 'reg_build', '{}', 'running')",
+            (v["project_id"], v["id"]),
+        )
+        conn.commit()
+        result = versions_phase.check_regularizing(conn, v["id"])
+    assert not result.ok
+    assert "正则" in result.reason
+
+
+def test_check_regularizing_blocks_when_job_pending(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        conn.execute(
+            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
+            "VALUES (?, ?, 'reg_build', '{}', 'pending')",
+            (v["project_id"], v["id"]),
+        )
+        conn.commit()
+        result = versions_phase.check_regularizing(conn, v["id"])
+    assert not result.ok
+
+
+def test_check_regularizing_done_job_doesnt_block(isolated) -> None:
+    """已完成的 reg job 不阻塞 cursor 前进。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        conn.execute(
+            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
+            "VALUES (?, ?, 'reg_build', '{}', 'done')",
+            (v["project_id"], v["id"]),
+        )
+        conn.commit()
+        result = versions_phase.check_regularizing(conn, v["id"])
+    assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# Ready check (要 file system，因为读 config.yaml)
+# ---------------------------------------------------------------------------
+
+
+def test_check_ready_no_config(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        p = projects.get_project(conn, v["project_id"])
+        result = versions_phase.check_ready(p, v)
+    assert not result.ok
+    assert "配置" in result.reason
+
+
+# ---------------------------------------------------------------------------
+# advance_phase / skip_phase
+# ---------------------------------------------------------------------------
+
+
+def test_advance_phase_blocked_by_failed_check(isolated) -> None:
+    """curating phase + train 为空 → next 失败 + cursor 不动。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        advanced, result, new_phase = versions_phase.advance_phase(conn, v["id"])
+    assert not advanced
+    assert not result.ok
+    assert new_phase is None
+    # cursor 应该还在 curating
+    with db.connection_for(isolated["db"]) as conn:
+        v2 = versions.get_version(conn, v["id"])
+    assert versions.get_phase(v2) == "curating"
+
+
+def test_advance_phase_curating_to_tagging(isolated) -> None:
+    """curating phase + train 有图 → 推进到 tagging。"""
+    v = _make_version(isolated)
+    vdir = versions.version_dir(v["project_id"],
+                                 projects.PROJECTS_DIR.name and v["label"] or v["label"],
+                                 v["label"])
+    # 用真正的 project slug
+    with db.connection_for(isolated["db"]) as conn:
+        p = projects.get_project(conn, v["project_id"])
+    vdir = versions.version_dir(p["id"], p["slug"], v["label"])
+    _put_image(vdir / "train" / "5_concept", "001", with_caption=False)
+
+    with db.connection_for(isolated["db"]) as conn:
+        advanced, result, new_phase = versions_phase.advance_phase(conn, v["id"])
+    assert advanced
+    assert result.ok
+    assert new_phase == "tagging"
+    with db.connection_for(isolated["db"]) as conn:
+        v2 = versions.get_version(conn, v["id"])
+    assert versions.get_phase(v2) == "tagging"
+
+
+def test_advance_phase_tagging_blocked_by_missing_caption(isolated) -> None:
+    """tagging phase + caption 覆盖不到 100% → 失败。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        p = projects.get_project(conn, v["project_id"])
+        # 强制把 cursor 跳到 tagging
+        versions.update_version(conn, v["id"], phase="tagging")
+    vdir = versions.version_dir(p["id"], p["slug"], v["label"])
+    _put_image(vdir / "train" / "5_concept", "001", with_caption=False)
+    _put_image(vdir / "train" / "5_concept", "002", with_caption=True)
+
+    with db.connection_for(isolated["db"]) as conn:
+        advanced, result, _ = versions_phase.advance_phase(conn, v["id"])
+    assert not advanced
+    assert "1 张" in result.reason
+
+
+def test_skip_phase_only_works_for_skippable(isolated) -> None:
+    """curating 不允许 skip。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        advanced, result, _ = versions_phase.skip_phase(conn, v["id"])
+    assert not advanced
+    assert "不可跳过" in result.reason
+
+
+def test_skip_phase_regularizing_jumps_to_ready(isolated) -> None:
+    """regularizing skip → cursor 跳 ready。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        versions.update_version(conn, v["id"], phase="regularizing")
+        advanced, result, new_phase = versions_phase.skip_phase(conn, v["id"])
+    assert advanced
+    assert result.ok
+    assert new_phase == "ready"
+
+
+def test_skip_phase_regularizing_blocked_by_running_job(isolated) -> None:
+    """regularizing skip 校验"无 job running"，有 job 时拒绝。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        versions.update_version(conn, v["id"], phase="regularizing")
+        conn.execute(
+            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
+            "VALUES (?, ?, 'reg_build', '{}', 'running')",
+            (v["project_id"], v["id"]),
+        )
+        conn.commit()
+        advanced, result, _ = versions_phase.skip_phase(conn, v["id"])
+    assert not advanced
+    assert "正则" in result.reason
+
+
+def test_advance_phase_at_ready_returns_check_result(isolated) -> None:
+    """已到 ready（最后 phase）→ phase 不再前进，但返回 check 结果让调用方决定 status 转换。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        versions.update_version(conn, v["id"], phase="ready")
+        advanced, result, new_phase = versions_phase.advance_phase(conn, v["id"])
+    assert not advanced
+    assert new_phase is None
+    # 无 config → check_ready 应失败
+    assert not result.ok
+
+
+# ---------------------------------------------------------------------------
+# update_version 新字段校验
+# ---------------------------------------------------------------------------
+
+
+def test_update_version_accepts_valid_status(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        v2 = versions.update_version(conn, v["id"], status="training")
+    assert v2["status"] == "training"
+
+
+def test_update_version_rejects_invalid_status(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        with pytest.raises(versions.VersionError, match="非法 status"):
+            versions.update_version(conn, v["id"], status="bogus")
+
+
+def test_update_version_accepts_valid_phase(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        v2 = versions.update_version(conn, v["id"], phase="editing")
+    assert v2["phase"] == "editing"
+
+
+def test_update_version_rejects_invalid_phase(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        with pytest.raises(versions.VersionError, match="非法 phase"):
+            versions.update_version(conn, v["id"], phase="bogus")
+
+
+def test_update_version_accepts_last_failure_reason(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        v2 = versions.update_version(conn, v["id"], last_failure_reason="OOM at step 500")
+    assert v2["last_failure_reason"] == "OOM at step 500"

--- a/tests/test_versions_reconcile.py
+++ b/tests/test_versions_reconcile.py
@@ -1,0 +1,160 @@
+"""ADR-0007 §11.3-C / §6.9: derive_status_from_tasks + reconcile_version_status 测试。"""
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from studio import db, projects, versions
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    pdir = tmp_path / "projects"
+    monkeypatch.setattr(projects, "PROJECTS_DIR", pdir)
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    return {"db": dbfile}
+
+
+def _make_version(isolated, label: str = "v1") -> dict:
+    with db.connection_for(isolated["db"]) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label=label)
+    return v
+
+
+def _insert_task(isolated, version_id: int, project_id: int, status: str,
+                 created_at: float | None = None) -> int:
+    with db.connection_for(isolated["db"]) as conn:
+        cur = conn.execute(
+            "INSERT INTO tasks(name, config_name, status, project_id, version_id, created_at) "
+            "VALUES (?, 'cfg', ?, ?, ?, ?)",
+            (f"task-{status}", status, project_id, version_id, created_at or time.time()),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+# ---------------------------------------------------------------------------
+# derive_status_from_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_derive_no_tasks_returns_preparing(isolated) -> None:
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        assert versions.derive_status_from_tasks(conn, v["id"]) == "preparing"
+
+
+def test_derive_pending_task_returns_training(isolated) -> None:
+    v = _make_version(isolated)
+    _insert_task(isolated, v["id"], v["project_id"], "pending")
+    with db.connection_for(isolated["db"]) as conn:
+        assert versions.derive_status_from_tasks(conn, v["id"]) == "training"
+
+
+def test_derive_running_task_returns_training(isolated) -> None:
+    v = _make_version(isolated)
+    _insert_task(isolated, v["id"], v["project_id"], "running")
+    with db.connection_for(isolated["db"]) as conn:
+        assert versions.derive_status_from_tasks(conn, v["id"]) == "training"
+
+
+def test_derive_paused_task_returns_training(isolated) -> None:
+    """§11.3-A: task=paused 时 version 仍 training，UI 派生显示 pause icon。"""
+    v = _make_version(isolated)
+    _insert_task(isolated, v["id"], v["project_id"], "paused")
+    with db.connection_for(isolated["db"]) as conn:
+        assert versions.derive_status_from_tasks(conn, v["id"]) == "training"
+
+
+def test_derive_done_task_returns_completed(isolated) -> None:
+    v = _make_version(isolated)
+    _insert_task(isolated, v["id"], v["project_id"], "done")
+    with db.connection_for(isolated["db"]) as conn:
+        assert versions.derive_status_from_tasks(conn, v["id"]) == "completed"
+
+
+def test_derive_failed_task_returns_failed(isolated) -> None:
+    v = _make_version(isolated)
+    _insert_task(isolated, v["id"], v["project_id"], "failed")
+    with db.connection_for(isolated["db"]) as conn:
+        assert versions.derive_status_from_tasks(conn, v["id"]) == "failed"
+
+
+def test_derive_canceled_task_returns_canceled(isolated) -> None:
+    v = _make_version(isolated)
+    _insert_task(isolated, v["id"], v["project_id"], "canceled")
+    with db.connection_for(isolated["db"]) as conn:
+        assert versions.derive_status_from_tasks(conn, v["id"]) == "canceled"
+
+
+def test_derive_active_takes_priority_over_terminal(isolated) -> None:
+    """老 task done + 新 task running → training（active 优先）。"""
+    v = _make_version(isolated)
+    now = time.time()
+    _insert_task(isolated, v["id"], v["project_id"], "done", created_at=now - 100)
+    _insert_task(isolated, v["id"], v["project_id"], "running", created_at=now)
+    with db.connection_for(isolated["db"]) as conn:
+        assert versions.derive_status_from_tasks(conn, v["id"]) == "training"
+
+
+def test_derive_picks_latest_terminal_task(isolated) -> None:
+    """多个终态 task → 按 created_at 取最新的。"""
+    v = _make_version(isolated)
+    now = time.time()
+    _insert_task(isolated, v["id"], v["project_id"], "failed", created_at=now - 100)
+    _insert_task(isolated, v["id"], v["project_id"], "done", created_at=now - 50)
+    _insert_task(isolated, v["id"], v["project_id"], "canceled", created_at=now)
+    with db.connection_for(isolated["db"]) as conn:
+        assert versions.derive_status_from_tasks(conn, v["id"]) == "canceled"
+
+
+# ---------------------------------------------------------------------------
+# reconcile_version_status
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_noop_when_consistent(isolated) -> None:
+    """status 与 derived 一致 → was_corrected=False。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        ver, corrected = versions.reconcile_version_status(conn, v["id"])
+    assert ver is not None
+    assert ver["status"] == "preparing"  # 无 task → preparing
+    assert corrected is False
+
+
+def test_reconcile_corrects_stale_status(isolated) -> None:
+    """版本 status=training 但已经无 active task → 派生 preparing → 修正。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        # 手动写入"撒谎"的 status
+        versions.update_version(conn, v["id"], status="training")
+        # reconcile 应修正
+        ver, corrected = versions.reconcile_version_status(conn, v["id"])
+    assert ver is not None
+    assert ver["status"] == "preparing"  # 无 task 派生
+    assert corrected is True
+
+
+def test_reconcile_corrects_when_task_terminal_but_version_still_training(isolated) -> None:
+    """task done 但 version 还停留 training（supervisor 漏写）→ 修正成 completed。"""
+    v = _make_version(isolated)
+    _insert_task(isolated, v["id"], v["project_id"], "done")
+    with db.connection_for(isolated["db"]) as conn:
+        versions.update_version(conn, v["id"], status="training")
+        ver, corrected = versions.reconcile_version_status(conn, v["id"])
+    assert ver is not None
+    assert ver["status"] == "completed"
+    assert corrected is True
+
+
+def test_reconcile_returns_none_for_missing_version(isolated) -> None:
+    with db.connection_for(isolated["db"]) as conn:
+        ver, corrected = versions.reconcile_version_status(conn, 99999)
+    assert ver is None
+    assert corrected is False


### PR DESCRIPTION
## Summary

ADR-0007 实施计划 PR-3：backend 业务逻辑双写过渡 + task snapshot。

5 commits（依次合 dev OK，每个独立可合）：

### 1. `feat(versions_phase)` - phase check_completion + advance/skip 函数
- 新 module `studio/versions_phase.py`：CheckResult + 5 个 phase check
- check 规则按 ADR §11.5-B
- advance_phase / skip_phase（cursor 单向，§11.5-A）
- `versions._UPDATABLE` 扩 status/phase/last_failure_reason + 值校验

### 2. `feat(supervisor)` - task 状态 ↔ version.status 双写
- `_spawn_task`: task 启动 → version.status='training'
- `_maybe_finalize_version` 扩展：task_status done/failed/canceled 独立映射
  - done → completed（+ stage='done' + output_lora_path 老路径双写）
  - failed → failed（+ last_failure_reason ← task.error_msg）
  - canceled → canceled
- `_finish_slot` 在所有终态都调 finalize（原来只 done）
- paused 不进 finalize（§11.3-A）

### 3. `feat(versions)` - derive_status_from_tasks + reconcile helpers
- `derive_status_from_tasks`: 按 ADR §11.3-C 派生（active > terminal > preparing）
- `reconcile_version_status`: 双写过渡安全网（log warning + fix）

### 4. `feat(task-snapshot)` - task 启动冻结 config + 只读 endpoint
- 新 module `studio/task_snapshot.py`：freeze_config / read_snapshot_config
- 冻结路径 `studio_data/tasks/{tid}/snapshot/config.yaml`
- `supervisor._spawn_task` 调 freeze（失败不阻 task 启动）
- 新 endpoint `GET /api/queue/{tid}/snapshot/config` → `{yaml, config}`
- 心智分离（ADR §11.7）：snapshot 是历史 vs version config 是当前

### 5. `test(supervisor)` - 双写 + snapshot 集成测试

## Commits

- `feat(versions_phase): phase check_completion + advance / skip 函数`
- `feat(supervisor): task 状态 ↔ version.status 双写`
- `feat(versions): derive_status_from_tasks + reconcile_version_status helpers`
- `feat(task-snapshot): task 启动冻结 config + 只读 endpoint`
- `test(supervisor): version.status 双写 + task snapshot 集成测试`

## Test plan

- [x] 55 个新测试（23 phase + 13 reconcile + 11 snapshot + 8 supervisor 集成）
- [x] 1399 个测试全过（10 fail/error 全是预先存在 env 问题: lycoris/flash_attn/UnionType，与本 PR 无关）
- [x] 老 frontend 兼容（双写：旧 stage + 新 status/phase 同时更新）
- [ ] PR-4 frontend 切到新字段消费

## 依赖

base = `dev`。PR-1 / PR-2 已 merge 到 `feat/project-queue-relation`，但**还未 promote 到 dev**。
本 PR 改的是 backend 逻辑，依赖 PR-2 v8 schema（status/phase 字段）。merge 顺序：

1. promote PR `feat/project-queue-relation → dev`（带入 v8 schema）
2. 再 merge 本 PR

或者：把本 PR base 临时改为 `feat/project-queue-relation`（stacked），合后自动 rebase。

## 后续 PR

- PR-4: frontend layout v3 全部（侧栏 / phase header / 项目页 / task 详情新 tab / 卡片）
- PR-5: v9 destructive 清理（DROP stage 列 + 删 advance_stage 13 处调用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)