### PR TITLE
polish: overview UI 细节 + preset 导出 bug + tools 文档

### DIFF
--- a/docs/architecture/studio-pipeline.md
+++ b/docs/architecture/studio-pipeline.md
@@ -357,3 +357,14 @@ python -m studio test    # pytest + vitest
 | 单 GPU | 训练循环未实现 DDP/FSDP；多 GPU 需切训练后端（详见 [ADR 0001](../adr/0001-lokr-via-lycoris-lora.md)） |
 | JoyCaption 需用户自起 vLLM | Studio 不在 Win 下管 vLLM 进程，只通过 base_url 调用 |
 | 用户手动改磁盘 | 每次进 step 重扫，以磁盘为准（不维护 stale 缓存） |
+
+---
+
+## 11. 前端样式约定
+
+**现阶段不做全局响应式**，布局以桌面端宽屏为主。单个页面 / 组件如有窄屏拥挤，可加简单单点适配，但必须遵守下述约定，方便未来做全局响应式时统一升级：
+
+- 所有媒体查询集中在 `studio/web/src/styles/responsive.css`，不要散落到组件里
+- 断点统一 `max-width: 1280px`（< laptop 中屏阈值），不要自创新断点
+- 单点适配只动 padding / 尺寸 / 显隐 label，**不改布局结构**（结构性改造留给未来的全局响应式）
+- 给目标元素加专属 className（如 `.banner-shell` / `.phase-timeline-label`），CSS 用 className 命中，不写到全局选择器

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1191,6 +1191,10 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ config }),
     }),
+  /** 端到端 yaml 文件下载直链，server FileResponse 已设 Content-Disposition。
+   *  <a href={...} download> 触发即可，不发 fetch。 */
+  presetDownloadUrl: (name: string) =>
+    `/api/presets/${encodeURIComponent(name)}/download`,
   importPresetFromPath: (path: string) =>
     req<{ name: string; path: string }>('/api/presets/import-from-path', {
       method: 'POST',

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1717,7 +1717,8 @@
     "tomlReadable": "sd-scripts-readable config file",
     "tomlCollapsed": "Expand to view / copy",
     "copied": "Copied to clipboard",
-    "copyFailed": "Copy failed"
+    "copyFailed": "Copy failed",
+    "saveBeforeDownload": "Save the preset first; download streams the on-disk yaml from the server."
   },
   "train": {
     "loadConfigFailed": "Failed to load training config: {{error}}",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1717,7 +1717,8 @@
     "tomlReadable": "sd-scripts 可读的配置文件",
     "tomlCollapsed": "展开查看 / 复制",
     "copied": "已复制到剪贴板",
-    "copyFailed": "复制失败"
+    "copyFailed": "复制失败",
+    "saveBeforeDownload": "请先保存预设，再触发下载（服务端直发磁盘上的原 yaml）"
   },
   "train": {
     "loadConfigFailed": "加载训练配置失败: {{error}}",

--- a/studio/web/src/index.css
+++ b/studio/web/src/index.css
@@ -2,6 +2,7 @@
 @import './styles/info-button.css';
 @import './styles/version-section.css';
 @import './styles/preprocess-crop.css';
+@import './styles/responsive.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/studio/web/src/pages/project/Overview.tsx
+++ b/studio/web/src/pages/project/Overview.tsx
@@ -256,21 +256,20 @@ function BannerShell({
   }
   const tCfg = tintMap[tint]
   return (
-    <div style={{
-      padding: '16px 18px',
+    <div className="banner-shell" style={{
       background: tCfg.bg,
       border: '1px solid ' + tCfg.border,
       borderRadius: 'var(--r-lg)',
       display: 'flex', flexDirection: 'column', gap: 4,
     }}>
       <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-        <span style={{
-          width: 32, height: 32, flexShrink: 0,
+        <span className="banner-shell-icon" style={{
+          flexShrink: 0,
           borderRadius: '50%',
           background: 'var(--bg-surface)',
           border: '1px solid ' + tCfg.border,
           display: 'grid', placeItems: 'center',
-          color: iconColor, fontSize: 16, fontWeight: 700,
+          color: iconColor, fontWeight: 700,
           animation: iconPulse ? 'pulse 1.6s infinite' : 'none',
         }}>{iconChar}</span>
         <div style={{ flex: 1, minWidth: 0 }}>
@@ -350,8 +349,8 @@ function PhaseTimeline({
                 display: 'flex', alignItems: 'center', gap: 6,
                 padding: '4px 10px',
                 borderRadius: 'var(--r-md)',
-                background: here ? 'var(--accent-soft)' : 'transparent',
-                border: here ? '1px solid var(--accent)' : '1px solid transparent',
+                background: 'transparent',
+                border: '1px solid transparent',
                 cursor: disabled ? 'not-allowed' : clickable ? 'pointer' : 'default',
                 opacity: disabled ? 0.4 : 1,
                 font: 'inherit',
@@ -361,7 +360,7 @@ function PhaseTimeline({
                 fontFamily: 'var(--font-mono)', fontSize: 'var(--t-sm)', fontWeight: 600,
                 color: done ? 'var(--ok)' : here ? 'var(--accent)' : 'var(--fg-disabled)',
               }}>{p.n}</span>
-              <span style={{
+              <span className="phase-timeline-label" style={{
                 fontSize: 'var(--t-xs)',
                 color: done ? 'var(--fg-secondary)' : here ? 'var(--fg-primary)' : 'var(--fg-tertiary)',
                 fontWeight: here ? 600 : 400,
@@ -1088,7 +1087,7 @@ function DetailGrid({ project, version }: { project: ProjectDetail; version: Ver
   const regCount = version?.stats?.reg_image_count ?? 0
 
   return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, height: '100%', minHeight: 0 }}>
+    <div style={{ display: 'grid', gridTemplateRows: '1.4fr 1fr', gap: 12, height: '100%', minHeight: 0 }}>
       <div style={{ display: 'grid', gridTemplateColumns: '1.4fr 1fr', gap: 12, minHeight: 0 }}>
         <TrainSetCard project={project} version={version} />
         <TagDistCard project={project} version={version} />

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -380,17 +380,17 @@ export default function PresetsPage() {
 
   const downloadCurrentPreset = () => {
     if (!config) return
-    const name = currentExportName()
-    const yaml = generateToml(config)
-    const blob = new Blob([yaml + '\n'], { type: 'application/yaml;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
+    if (isNew || !selected || hasAnyChange) {
+      toast(t('presets.saveBeforeDownload'), 'info')
+      return
+    }
+    // server FileResponse 直发磁盘上的原 yaml，已设 Content-Disposition。
     const a = document.createElement('a')
-    a.href = url
-    a.download = `${name}.yaml`
+    a.href = api.presetDownloadUrl(selected)
+    a.download = `${selected}.yaml`
     document.body.appendChild(a)
     a.click()
     document.body.removeChild(a)
-    URL.revokeObjectURL(url)
   }
 
   const exportCurrentPresetToDataExports = async () => {

--- a/studio/web/src/styles/responsive.css
+++ b/studio/web/src/styles/responsive.css
@@ -1,0 +1,13 @@
+/* 单点窄屏优化 —— 项目当前不做系统级响应式（见
+ * docs/architecture/studio-pipeline.md §11），需要时再单独加 className + 媒体查询。
+ * 断点取 viewport 1280px（< laptop "中屏" 阈值），不用 container query。
+ */
+
+.banner-shell { padding: 16px 18px; }
+.banner-shell-icon { width: 32px; height: 32px; font-size: 16px; }
+
+@media (max-width: 1280px) {
+  .banner-shell { padding: 10px 14px; }
+  .banner-shell-icon { width: 26px; height: 26px; font-size: 13px; }
+  .phase-timeline-label { display: none; }
+}

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,126 @@
+# tools/
+
+仓库根的一次性脚本、bootstrap helper、诊断和 release / migration 工具集。所有脚本均在 **仓库根目录** 跑（`python tools/xxx.py ...`），多数需要先激活 venv。
+
+> 不属于这里：训练 / 推理代码（在 `runtime/`）、Studio 服务（在 `studio/`）、生产时调用的子进程（在 `studio/services/`）。
+
+---
+
+## Bootstrap helpers（被 studio.bat / studio.sh 调用，stdlib only）
+
+### `check_requirements_changed.py`
+启动期检测 `requirements.txt` 内容 hash 是否变了，决定是否补装新依赖。用 content hash 不用 mtime，避免 `git checkout` 后误判 stale。
+
+```
+python tools/check_requirements_changed.py             # 输出 stale / current / missing
+python tools/check_requirements_changed.py --update-marker   # 同步成功后写新 hash
+```
+
+### `select_torch_index.py`
+venv **首装**时按 `nvidia-smi` 检测的驱动版本输出对应的 PyTorch wheel index URL，让 caller 用对应的 CUDA wheel 装 torch（而不是 PyPI 默认 CPU 版）。
+
+```
+python tools/select_torch_index.py     # 检测到 → 输出 URL；否则静默 exit 0
+```
+
+驱动 → cu wheel 映射跟 `studio/services/torch_setup.py:_DRIVER_TO_BEST_CU` 双向同步。
+
+---
+
+## 模型 / 环境 setup
+
+### `download_models.py`
+下载 Anima 训练所需的全部模型 + tokenizer（CLI 薄壳，逻辑在 `studio.services.model_downloader`，跟 Studio 设置页 UI 共用）。
+
+```
+python tools/download_models.py
+python tools/download_models.py --variant preview3-base
+python tools/download_models.py --no-mirror              # 不走 ModelScope 镜像
+python tools/download_models.py --skip-main --skip-vae
+python tools/download_models.py --output /data/anima
+```
+
+### `install_flash_attn.py`
+flash_attn prebuild wheel 安装 CLI（跟 Settings UI 共享 `studio.services.flash_attention_setup` 的 wheel 选择逻辑）。
+
+```
+python tools/install_flash_attn.py            # 自动选最优 wheel
+python tools/install_flash_attn.py --url URL  # 手动指定
+python tools/install_flash_attn.py --dry-run  # 只列环境 + 候选不真装
+python tools/install_flash_attn.py --force    # 已装也重装
+```
+
+退出码：0 成功 / 1 安装失败 / 2 环境不支持。
+
+### `validate_local_models.py`
+离线验证本地模型可正常加载（设 `HF_HUB_OFFLINE=1` + `TRANSFORMERS_OFFLINE=1`，分别测 T5 tokenizer / Qwen tokenizer + model）。默认从 `tools/models/` 找权重。
+
+```
+python tools/validate_local_models.py
+```
+
+---
+
+## 诊断 / benchmark
+
+### `diagnose_onnx_gpu.py`
+WD14 打标遇到 "CUDA EP 静默降级到 CPU" 警告时跑这个定位根因。在 studio 同一个 venv 里执行，把 stdout 全文贴到 PR / issue。
+
+```
+python tools/diagnose_onnx_gpu.py
+```
+
+### `bench_wd14.py`
+WD14 打标性能诊断：分阶段计时（preprocess / session.run / postprocess）+ EP / preload / 模型 / 线程数自检。同时回答：CPU vs GPU 实测吞吐差几倍。
+
+```
+python tools/bench_wd14.py [<图目录>] [--n 10] [--model <hf_id>]
+```
+
+不传图目录时默认扫 `studio_data/projects/*/raw_*` 找最近一批图取前 N 张。日志同时打 stdout 与 `bench_wd14.log`。
+
+### `bench_gelbooru.py`
+三步定位 gelbooru 下载速度瓶颈：网络 / 上游限速 / Studio 代码。
+
+```
+python tools/bench_gelbooru.py
+```
+
+凭证自动从 `studio_data/secrets.json` 读；缺失时回退环境变量 `GELBOORU_USER_ID` / `GELBOORU_API_KEY`。日志同时打 stdout 与 `bench_gelbooru.log`。
+
+---
+
+## Release / schema 维护
+
+### `bump_version.py`
+`release_notes.yaml` 校验 + 版本号同步 + `CHANGELOG.md` 派生。详见 `docs/release-notes-spec.md`。**不创建 entries**，那是 agent 改 yaml 的事。
+
+```
+python tools/bump_version.py validate          # schema 校验整个 yaml
+python tools/bump_version.py bump              # 读 yaml top version，同步 3 处版本文件
+python tools/bump_version.py bump --version 0.6.1
+python tools/bump_version.py render-changelog  # 只重写 CHANGELOG.md，不动版本号
+python tools/bump_version.py verify-versions   # __init__.py / package.json / package-lock.json drift 检查 (CI 用)
+```
+
+---
+
+## 一次性 migration
+
+### `preset_toml_to_yaml.py`
+救活 **2026-05-21 ~ 2026-05-24** 期间前端 `downloadCurrentPreset` bug 导出的"假 yaml 真 toml"预设文件。新版前端已改走 server `/api/presets/{name}/download` 端点直发原 yaml，本工具仅用于回收历史下载。
+
+```
+python tools/preset_toml_to_yaml.py broken.yaml          # 输出 broken.fixed.yaml
+python tools/preset_toml_to_yaml.py --in-place x.yaml    # 覆盖 + 备份 .toml-bak
+python tools/preset_toml_to_yaml.py --output o.yaml x.yaml
+python tools/preset_toml_to_yaml.py --no-validate x.yaml # 跳 schema 校验
+```
+
+处理 3 类破损：多行 `{...}` → inline table、空值 key → drop、TOML → tomllib 解析 + TrainingConfig 校验 → yaml 落盘。py 3.11+ 走 stdlib `tomllib`，3.10 及更早需 `pip install tomli`。
+
+---
+
+## `spike/`
+
+ADR 验证用的临时脚本（验证完会随 cleanup PR 删）。当前内容是 ADR 0006 暂停/恢复的信号链路 spike，独立 README 见 [`spike/README.md`](spike/README.md)。

--- a/tools/preset_toml_to_yaml.py
+++ b/tools/preset_toml_to_yaml.py
@@ -1,0 +1,187 @@
+"""把 2026-05-21 ~ 2026-05-24 之间前端 `downloadCurrentPreset` bug 导出的
+"假 yaml 真 toml"预设文件转成真 yaml。
+
+Bug 详情：那 3 天的 Studio 前端在导出预设时调 `generateToml(config)` 生成
+手写 TOML（key = value 平铺 + 多行 `{...}` 假 inline table + null 写成
+`key = `），但 blob MIME / 文件后缀都打了 yaml 标签。server
+`parse_preset_bytes` 仅认 yaml/json，所以这些文件再上传会被拒：
+    "预设格式错误（顶层不是 mapping）"
+
+新版前端已改走 server `GET /api/presets/{name}/download` 端点直发磁盘上的
+原始 yaml，不再产生此类文件。本工具仅用于救活历史下载文件，不进 server
+依赖链路（avoid 给生产 import 加 TOML parser）。
+
+Usage:
+    python tools/preset_toml_to_yaml.py broken1.yaml [broken2.yaml ...]
+        每个文件输出到同目录的 `<stem>.fixed.yaml`，原文件保留。
+    python tools/preset_toml_to_yaml.py --in-place broken.yaml
+        就地覆盖原文件，覆盖前备份为 `<stem>.yaml.toml-bak`。
+    python tools/preset_toml_to_yaml.py --output out.yaml broken.yaml
+        指定输出路径（仅单文件适用）。
+    python tools/preset_toml_to_yaml.py --no-validate broken.yaml
+        跳过 TrainingConfig 校验（schema 漂移时应急用，默认开启）。
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+try:
+    import tomllib  # py 3.11+
+except ImportError:  # pragma: no cover - py 3.10 及以下走 tomli 兜底
+    try:
+        import tomli as tomllib  # type: ignore[import-not-found,no-redef]
+    except ImportError:
+        sys.stderr.write(
+            "缺 TOML 解析库：py < 3.11 需先 `pip install tomli`。\n"
+        )
+        sys.exit(2)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _preprocess(text: str) -> tuple[str, list[str]]:
+    """修复前端 `generateToml` 产出的非标准 TOML，返回 (cleaned_text, warnings)。
+
+    两类已知不合规：
+    - **多行 `{...}` 块**：TOML inline table 必须单行；这里把多行块的每行
+      `k = v` 拼成单行 `{ k = v, k2 = v2 }`。
+    - **空值 `key = `（null/undefined）**：TOML 不允许空 rhs；直接 drop 这些
+      key，由 pydantic 走 schema 默认值 / Optional[None] 兜底。
+    """
+    warnings: list[str] = []
+    out: list[str] = []
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        stripped = line.strip()
+        # 多行块开头：`key = {`
+        m = re.match(r"^(\S.*?=\s*)\{\s*$", line)
+        if m:
+            prefix = m.group(1).rstrip()
+            inner: list[str] = []
+            j = i + 1
+            while j < len(lines) and lines[j].strip() != "}":
+                s = lines[j].strip()
+                if s:
+                    inner.append(s)
+                j += 1
+            if j >= len(lines):
+                # 没找到闭合 } —— 留给 tomllib 报原始错
+                out.append(line)
+                i += 1
+                continue
+            out.append(f"{prefix} {{ {', '.join(inner)} }}")
+            i = j + 1
+            continue
+        # 空值：`key = ` 或 `key =`（rhs 全空白）
+        if "=" in stripped and not stripped.startswith("#"):
+            k, _, v = stripped.partition("=")
+            if v.strip() == "":
+                warnings.append(f"drop 空值 key: {k.strip()}")
+                i += 1
+                continue
+        out.append(line)
+        i += 1
+    return "\n".join(out) + "\n", warnings
+
+
+def _validate(data: dict[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """走 TrainingConfig.model_validate 规范化；返回 (规范化后的 dict, warnings)。"""
+    # 延迟 import：tool 默认应该能在不装训练栈的环境跑（仅 yaml + tomllib）
+    try:
+        sys.path.insert(0, str(REPO_ROOT))
+        from studio.schema import TrainingConfig  # type: ignore[import-not-found]
+    except ImportError as exc:
+        return data, [f"跳过 schema 校验（import 失败：{exc}）"]
+    try:
+        cfg = TrainingConfig.model_validate(data)
+    except Exception as exc:
+        # 校验失败不致命：写一份原始数据 + 警告，让用户人工修
+        return data, [f"TrainingConfig 校验失败（已写原始数据，请手工修）：{exc}"]
+    return cfg.model_dump(mode="python"), []
+
+
+def convert(text: str, validate: bool = True) -> tuple[str, list[str]]:
+    """主转换：返回 (yaml_text, warnings)。"""
+    warnings: list[str] = []
+    cleaned, pre_warns = _preprocess(text)
+    warnings.extend(pre_warns)
+    try:
+        data = tomllib.loads(cleaned)
+    except Exception as exc:
+        raise SystemExit(f"TOML 解析失败：{exc}\n（预处理后内容前 200 字符）\n{cleaned[:200]}")
+    if not isinstance(data, dict):
+        raise SystemExit(f"TOML 顶层不是 mapping，得到 {type(data).__name__}")
+    if validate:
+        data, val_warns = _validate(data)
+        warnings.extend(val_warns)
+    yaml_text = yaml.safe_dump(
+        data, allow_unicode=True, sort_keys=False, default_flow_style=False
+    )
+    return yaml_text, warnings
+
+
+def _convert_file(src: Path, dst: Path, validate: bool, in_place: bool) -> None:
+    if not src.exists():
+        raise SystemExit(f"文件不存在：{src}")
+    text = src.read_text(encoding="utf-8")
+    yaml_text, warnings = convert(text, validate=validate)
+    if in_place:
+        bak = src.with_suffix(src.suffix + ".toml-bak")
+        if bak.exists():
+            raise SystemExit(f"备份目标已存在，先删它再重试：{bak}")
+        src.rename(bak)
+        sys.stderr.write(f"  备份原文件 → {bak}\n")
+    dst.write_text(yaml_text, encoding="utf-8")
+    sys.stderr.write(f"  写入 → {dst}\n")
+    for w in warnings:
+        sys.stderr.write(f"  ⚠ {w}\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("files", nargs="+", type=Path, help="待转换的 .yaml（实为 TOML）文件")
+    ap.add_argument(
+        "--in-place", action="store_true",
+        help="就地覆盖原文件，原文件备份为 .yaml.toml-bak",
+    )
+    ap.add_argument(
+        "--output", type=Path, default=None,
+        help="指定输出路径，仅在传单个文件时生效",
+    )
+    ap.add_argument(
+        "--no-validate", action="store_true",
+        help="跳过 TrainingConfig schema 校验（schema 漂移时应急用）",
+    )
+    args = ap.parse_args(argv)
+
+    if args.output and len(args.files) > 1:
+        ap.error("--output 仅支持单文件输入")
+    if args.output and args.in_place:
+        ap.error("--output 与 --in-place 互斥")
+
+    validate = not args.no_validate
+    for src in args.files:
+        sys.stderr.write(f"转换 {src}\n")
+        if args.in_place:
+            dst = src
+        elif args.output:
+            dst = args.output
+        else:
+            dst = src.with_name(f"{src.stem}.fixed{src.suffix}")
+        _convert_file(src, dst, validate=validate, in_place=args.in_place)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

三件不相关的小修打包（dev 分支，按"小修复合集"惯例合一个 PR）：

### 1. Overview 概览页 UI
- `DetailGrid` 外层 flex column → grid `1.4fr 1fr` rows，empty 时两行不再塌缩
- `PhaseTimeline` 当前 phase 去掉 accent-soft 背景 + accent border，只保留红色编号
- `StatusBanner` / `PhaseTimeline` 窄屏单点适配（< 1280px 收紧 padding / icon 尺寸 / 隐藏 phase label）
- 新建 `styles/responsive.css` 集中所有媒体查询；`studio-pipeline.md §11` 写入"暂不做全局响应式 / 单点加适配"的规范，方便未来全局响应式落地时统一升级

### 2. Preset 导出 bug fix
- 旧逻辑：前端 `downloadCurrentPreset` 调 `generateToml` 生成手写 TOML，再标 `.yaml` 后缀 + `application/yaml` MIME → server `parse_preset_bytes` 仅认 yaml/json，上传被拒（"顶层不是 mapping"）
- 改走 server `GET /api/presets/{name}/download` (FileResponse 直发磁盘原 yaml)
- 加 `isNew / hasAnyChange` 校验，未保存时 toast "请先保存"
- `generateToml` 保留给 TOML 预览（i18n 已说明是 sd-scripts 可读格式）
- Bug 影响窗口：2026-05-21 ~ 2026-05-24，约 3 天

### 3. 一次性迁移工具 + tools 文档
- `tools/preset_toml_to_yaml.py` 救活窗口期破损文件（处理多行 `{...}` → inline / drop 空值 key / tomllib 解析 + TrainingConfig 校验 → yaml 落盘）
- 不进 server 依赖链；py 3.11+ 用 stdlib `tomllib`，更早需 `pip install tomli`
- `tools/README.md` 补齐 10 个脚本的作用 + usage，分 bootstrap / setup / 诊断 / release / migration 5 类

## Test plan
- [ ] Overview 详情 tab：宽屏布局两行 1.4:1，empty version 也不塌缩
- [ ] Overview 详情 tab：当前 phase 只有红色编号，没有 accent border / 背景框
- [ ] 缩窗口至 < 1280px：StatusBanner padding/icon 缩小、phase pill 只剩编号；放回大屏完全不变
- [ ] Presets 页：选择已保存预设 + 无未保存改动 → 下载，得到真 yaml 文件（内容能再上传 round-trip）
- [ ] Presets 页：未保存或有改动时点下载 → toast "请先保存"
- [ ] `python tools/preset_toml_to_yaml.py` 用一个手工伪造的旧 TOML 文件跑一遍，能产出能再上传成功的真 yaml

🤖 Generated with [Claude Code](https://claude.com/claude-code)