### PR TITLE
fix(schema): grad_clip_max_norm 默认 0 → 1.0

### DIFF
--- a/studio/schema.py
+++ b/studio/schema.py
@@ -495,8 +495,8 @@ class TrainingConfig(BaseModel):
         json_schema_extra=_meta("noise_schedule", show_when="loss_weighting==detail_inv_t", advanced=True),
     )
     grad_clip_max_norm: float = Field(
-        0.0, ge=0.0,
-        description="梯度裁剪最大范数（0=禁用）",
+        1.0, ge=0.0,
+        description="梯度裁剪最大范数：当本步所有可训练参数的梯度全局范数超过该值时按比例缩到该值，防止单步极端梯度把模型推飞；默认 1.0 适合绝大多数场景，bf16+DoRA/LoKr 不稳可降到 0.5，0=禁用",
         json_schema_extra=_meta("training", advanced=True),
     )
 

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -387,7 +387,7 @@
       "loss_weighting": "[Loss weighting] Scheme (min_snr recommended; detail_inv_t enhances details; cosmap follows SD3 style)",
       "min_snr_gamma": "[Loss weighting] Min-SNR gamma (only when loss_weighting=min_snr)",
       "weight_cap_ratio": "[Loss weighting] Batch max/min weight cap (0 disables; 5 recommended for small batch + Prodigy)",
-      "grad_clip_max_norm": "Maximum gradient clipping norm (0 disables)",
+      "grad_clip_max_norm": "Max gradient norm: when the step's total gradient norm exceeds this value, rescale it down to this value to prevent a single outlier step from blowing up the model. Default 1.0 fits most cases; lower to 0.5 if bf16+DoRA/LoKr is unstable; 0 disables.",
       "mixed_precision": "Mixed precision",
       "attention_backend": "Attention backend: none (PyTorch SDPA) / xformers / Flash Attention (flash_attn recommended for 5090)",
       "num_workers": "Data loader workers (must be 0 on Windows)",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -387,7 +387,7 @@
       "loss_weighting": "【损失加权】方案（min_snr 推荐；detail_inv_t 细节强化；cosmap SD3 风格）",
       "min_snr_gamma": "【损失加权】Min-SNR gamma 值（仅 loss_weighting=min_snr）",
       "weight_cap_ratio": "【损失加权】Batch 内权重 max/min 比上限（0=禁用；小 batch+Prodigy 建议 5）",
-      "grad_clip_max_norm": "梯度裁剪最大范数（0=禁用）",
+      "grad_clip_max_norm": "梯度范数上限：本步所有可训练参数的梯度总范数超过该值时按比例缩到该值，防止单步极端梯度把模型推飞。默认 1.0 适合绝大多数场景；bf16+DoRA/LoKr 不稳可降到 0.5；0=禁用。",
       "mixed_precision": "混合精度",
       "attention_backend": "Attention backend：none（PyTorch SDPA）/ xformers / Flash Attention（5090 推荐 flash_attn）",
       "num_workers": "数据加载线程（Windows 必须 0）",


### PR DESCRIPTION
## Summary

把 `grad_clip_max_norm` 默认值从 0（禁用）改成 1.0。

## 背景

近期一次 Qwen-image LoRA 训练在 step 1220 附近发生 mode collapse（loss 从 0.1 飙到 0.9~1.0、prediction latent std 从 0.99 收缩到 0.68）。5 个算法 expert 跨方向 audit 后，确认 `grad_clip = 0` 是放大风险的关键因素之一：

- **Prodigy + ScheduleFree** 在偏分布梯度下 SF averaging 窗口会漂走，没有 grad_clip 时单步极端梯度直接打进 z/y 累积
- **DoRA + LoKr** 的 row-norm renormalization 把可恢复的发散转成静默 plateau，需要 grad_clip 阻止 magnitude 跳到病态区
- bf16 + flow matching 下 outlier step 偶发就足以触发

主流 trainer 都把 1.0 作为默认（SimpleTuner/OneTrainer/ai-toolkit），Prodigy 自家 docstring 写 "do not use with gradient clipping" 是基于 well-behaved gradients 假设的，在 DoRA + FM 这种 outlier 多的 regime 下不适用。

## 改动

- `studio/schema.py`：`grad_clip_max_norm: float = Field(1.0, ...)` + description 重写说明参数行为和场景化推荐值
- `studio/web/src/i18n/locales/{en,zh}.json`：同步 description

## Test plan

- [x] `pytest tests/test_studio_configs.py` 24 单测全过
- [ ] 实际跑一轮 Qwen-image LoRA 训练观察 loss 曲线（用户验证）

## Notes

InfoNoise pivot 反向（P0）+ 缺 σ Jacobian（P3）+ 缺 `/w(σ)`（P1）+ 缺 r̂ smoothing（P2）等代码层 bug 单独走 exp 分支，不在本 PR scope。