### PR TITLE
feat(web): Settings 路由化 → 抽屉化

### DIFF
--- a/studio/web/src/App.tsx
+++ b/studio/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Outlet,
   RouterProvider,
 } from 'react-router-dom'
+import SettingsDrawer from './components/SettingsDrawer'
 import Sidebar from './components/Sidebar'
 import Topbar from './components/Topbar'
 import { ProjectContext, ProjectSetterContext, type ProjectCtxValue } from './context/ProjectContext'
@@ -38,7 +39,10 @@ function QueueDetailRedirect({ tab }: { tab: 'log' | 'monitor' }) {
   )
 }
 
-/** Sidebar + Topbar 外壳；所有路由 element 渲染进 <Outlet />。 */
+/** Sidebar + Topbar 外壳；所有路由 element 渲染进 <Outlet />。
+ *  SettingsDrawer 也挂在这层 —— 它是个 fixed 定位的全局抽屉，永远在 RouterProvider 内
+ *  这样可以共用 react-router context（虽然抽屉本身不依赖路由，但内部的 SettingsPage 用到
+ *  useLocation 等 hook，需要 router 上下文）。 */
 function RootLayout() {
   return (
     <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
@@ -49,6 +53,7 @@ function RootLayout() {
           <Outlet />
         </main>
       </div>
+      <SettingsDrawer />
     </div>
   )
 }

--- a/studio/web/src/App.tsx
+++ b/studio/web/src/App.tsx
@@ -1,14 +1,17 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   createBrowserRouter,
   Navigate,
   Outlet,
   RouterProvider,
+  useLocation,
+  useNavigate,
 } from 'react-router-dom'
 import SettingsDrawer from './components/SettingsDrawer'
 import Sidebar from './components/Sidebar'
 import Topbar from './components/Topbar'
 import { ProjectContext, ProjectSetterContext, type ProjectCtxValue } from './context/ProjectContext'
+import { useSettingsDrawer } from './lib/SettingsDrawer'
 import ProjectsPage from './pages/Projects'
 import QueuePage from './pages/Queue'
 import QueueDetailPage from './pages/QueueDetail'
@@ -24,7 +27,26 @@ import TrainPage from './pages/project/steps/Train'
 import GeneratePage from './pages/tools/Generate'
 import MonitorPage from './pages/tools/Monitor'
 import PresetsPage from './pages/tools/Presets'
-import SettingsPage from './pages/tools/Settings'
+
+/**
+ * 老路径 `/tools/settings?section=…` 的兼容跳转：跳首页同时把抽屉打开（保留
+ * section 参数）。Settings 不再有自己的 URL；旧书签 / Topbar 通知按钮链接进
+ * 来时不会 404，但落地是抽屉而非整页。
+ */
+function SettingsRedirect() {
+  const drawer = useSettingsDrawer()
+  const navigate = useNavigate()
+  const location = useLocation()
+  useEffect(() => {
+    const section = new URLSearchParams(location.search).get('section')
+    drawer.open(section ? { section } : undefined)
+    navigate('/', { replace: true })
+    // 只在 mount 时执行一次；deps 留空是有意的 —— 后续 location.search 变化是
+    // navigate('/') 自己引起的，不要重复触发 open。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+  return null
+}
 
 /**
  * 老路径 `/queue/:id/log` 和 `/queue/:id/monitor` 的兼容跳转：保留 URL 不删，
@@ -93,7 +115,7 @@ const router = createBrowserRouter(
         },
         { path: '/tools/presets', element: <PresetsPage /> },
         { path: '/tools/monitor', element: <MonitorPage /> },
-        { path: '/tools/settings', element: <SettingsPage /> },
+        { path: '/tools/settings', element: <SettingsRedirect /> },
         { path: '/tools/generate', element: <GeneratePage /> },
         { path: '/configs', element: <Navigate to="/tools/presets" replace /> },
         { path: '/monitor', element: <Navigate to="/tools/monitor" replace /> },

--- a/studio/web/src/App.tsx
+++ b/studio/web/src/App.tsx
@@ -62,20 +62,20 @@ function QueueDetailRedirect({ tab }: { tab: 'log' | 'monitor' }) {
 }
 
 /** Sidebar + Topbar 外壳；所有路由 element 渲染进 <Outlet />。
- *  SettingsDrawer 也挂在这层 —— 它是个 fixed 定位的全局抽屉，永远在 RouterProvider 内
- *  这样可以共用 react-router context（虽然抽屉本身不依赖路由，但内部的 SettingsPage 用到
- *  useLocation 等 hook，需要 router 上下文）。 */
+ *  SettingsDrawer 挂在主内容列内（含 Topbar），用 absolute 定位铺满该列 —— 这样
+ *  backdrop 自然不会盖到左侧 Sidebar，sidebar 上的导航 / 主题切换照常可用。
+ *  列父级 position:relative 给 drawer 的 absolute inset-0 做锚点。 */
 function RootLayout() {
   return (
     <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
       <Sidebar />
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, position: 'relative' }}>
         <Topbar />
         <main style={{ flex: 1, overflow: 'auto', background: 'var(--bg-canvas)' }}>
           <Outlet />
         </main>
+        <SettingsDrawer />
       </div>
-      <SettingsDrawer />
     </div>
   )
 }

--- a/studio/web/src/components/CommandPalette.tsx
+++ b/studio/web/src/components/CommandPalette.tsx
@@ -3,13 +3,17 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { api, type CaptionEntry, type PresetSummary, type ProjectSummary } from '../api/client'
 import { useProjectCtx } from '../context/ProjectContext'
+import { useSettingsDrawer } from '../lib/SettingsDrawer'
 
 interface Item {
   id: string
   label: string
   sub?: string
   group: string
-  path: string
+  /** 路由跳转。跟 action 二选一。 */
+  path?: string
+  /** 自定义动作（如打开抽屉）。优先于 path。 */
+  action?: () => void
 }
 
 const SEARCH_ICON = (
@@ -42,6 +46,7 @@ export default function CommandPalette({ open, onClose, anchorEl }: Props) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const ctx = useProjectCtx()
+  const settingsDrawer = useSettingsDrawer()
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const [query, setQuery] = useState('')
@@ -139,7 +144,7 @@ export default function CommandPalette({ open, onClose, anchorEl }: Props) {
     items.push({ id: 'queue',    label: t('nav.queue'),               sub: t('commandPalette.queueSub'),    group: t('commandPalette.pages'), path: '/queue' })
     items.push({ id: 'presets',  label: t('nav.presets'),             sub: t('commandPalette.presetsSub'), group: t('commandPalette.pages'), path: '/tools/presets' })
     items.push({ id: 'monitor',  label: t('nav.monitor'),             sub: t('commandPalette.monitorSub'), group: t('commandPalette.pages'), path: '/tools/monitor' })
-    items.push({ id: 'settings', label: t('nav.settings'),            sub: t('commandPalette.settingsSub'), group: t('commandPalette.pages'), path: '/tools/settings' })
+    items.push({ id: 'settings', label: t('nav.settings'),            sub: t('commandPalette.settingsSub'), group: t('commandPalette.pages'), action: () => settingsDrawer.open() })
 
     for (const p of presets) {
       items.push({
@@ -178,7 +183,7 @@ export default function CommandPalette({ open, onClose, anchorEl }: Props) {
     }
 
     return items
-  }, [projects, presets, ctx, t])
+  }, [projects, presets, ctx, t, settingsDrawer])
 
   const filteredNav = useMemo(() => {
     if (!query.trim()) return allItems
@@ -236,7 +241,11 @@ export default function CommandPalette({ open, onClose, anchorEl }: Props) {
   }, [grouped])
 
   const select = useCallback(
-    (item: Item) => { navigate(item.path); onClose() },
+    (item: Item) => {
+      if (item.action) item.action()
+      else if (item.path) navigate(item.path)
+      onClose()
+    },
     [navigate, onClose],
   )
 

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -37,12 +37,14 @@ export default function SettingsDrawer() {
   return (
     <div
       aria-hidden={!isOpen}
-      className={`fixed inset-0 z-30 flex ${isOpen ? '' : 'pointer-events-none'}`}
+      className={`fixed inset-0 z-30 ${isOpen ? '' : 'pointer-events-none'}`}
     >
-      {/* backdrop：透明 + 轻模糊；过渡覆盖 backdrop-filter 让模糊也是渐变的 */}
+      {/* backdrop：absolute 铺满 viewport，让 panel slide-in 中途不会从右边露出底页。
+       *  之前用 flex + flex-1 时 backdrop 只占 panel 左边那条，panel 滑动期间右侧
+       *  panel 槽位无人覆盖 → 看见底层页面 / 出现黑白闪屏。 */}
       <div
         onClick={() => void close()}
-        className={`flex-1 transition-[background-color,backdrop-filter,-webkit-backdrop-filter] ease-out ${
+        className={`absolute inset-0 transition-[background-color,backdrop-filter,-webkit-backdrop-filter] ease-out ${
           isOpen ? 'bg-black/25 backdrop-blur-sm' : 'bg-black/0 backdrop-blur-0'
         }`}
         style={{ transitionDuration: `${ANIM_MS}ms` }}
@@ -51,7 +53,7 @@ export default function SettingsDrawer() {
       <aside
         role="dialog"
         aria-modal="true"
-        className={`relative flex flex-col h-full bg-canvas border-l border-subtle shadow-2xl transition-transform ease-out ${
+        className={`absolute top-0 right-0 bottom-0 flex flex-col bg-canvas border-l border-subtle shadow-2xl transition-transform ease-out ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
         style={{ width: DRAWER_WIDTH, transitionDuration: `${ANIM_MS}ms` }}

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -16,14 +16,14 @@ import { useSettingsDrawer } from '../lib/SettingsDrawer'
 
 const SettingsPageLazy = lazy(() => import('../pages/tools/Settings'))
 
-// 响应式宽度：
-//   < 2200 viewport：min(1280px, 80vw) —— 笔记本走 80vw，1k FHD（1920）/ 缩放后的
-//     2k（~1707）都吃满 1280 上限
-//   ≥ 2200 viewport：1960px —— 含 Win 110/125% 缩放的物理 2k（实际 viewport
-//     2300+）和原生 2560 屏；1960 在 2320 viewport 上 ≈ 84%
-// 注意：物理"2k 屏"的 viewport 受 DPI 缩放影响，不是 2560。这里断点按 CSS
-// viewport 取值，不是物理分辨率。
-const DRAWER_WIDTH_CLASS = 'w-[min(1280px,80vw)] min-[2200px]:w-[1960px]'
+// 宽度：70vw，小屏给 1024px 兜底（避免笔记本 viewport 太小时表单挤）。
+//   1366 viewport（小笔记本）：70vw=956 → 撑到 1024
+//   1707 viewport（缩放后 2k 150%）：70vw=1195
+//   1920 viewport（1k FHD）：70vw=1344
+//   2320 viewport（缩放后 2k 110-125%）：70vw=1624
+//   2560 viewport（原生 2k）：70vw=1792
+//   3840 viewport（4k）：70vw=2688
+const DRAWER_WIDTH_CLASS = 'w-[max(1024px,70vw)]'
 const ANIM_MS = 220
 
 export default function SettingsDrawer() {

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -42,7 +42,7 @@ export default function SettingsDrawer() {
   return (
     <div
       aria-hidden={!isOpen}
-      className={`fixed inset-0 z-30 ${isOpen ? '' : 'pointer-events-none'}`}
+      className={`absolute inset-0 z-30 ${isOpen ? '' : 'pointer-events-none'}`}
     >
       {/* backdrop：absolute 铺满 viewport，让 panel slide-in 中途不会从右边露出底页。
        *  之前用 flex + flex-1 时 backdrop 只占 panel 左边那条，panel 滑动期间右侧

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -19,9 +19,9 @@ const SettingsPageLazy = lazy(() => import('../pages/tools/Settings'))
 // 响应式宽度：
 //   < 1600 viewport（笔记本 / 小桌面）：80vw —— 1280屏≈1024，1440屏≈1152，1600屏≈1280
 //   1600–2559（含 1k FHD）：1280px 上限，避免大屏吞太多
-//   ≥ 2560（2k QHD 及以上）：1440px
+//   ≥ 2560（2k QHD 及以上）：1960px —— 大屏给到接近 80% 可视宽
 // 用 Tailwind arbitrary breakpoint 表达。
-const DRAWER_WIDTH_CLASS = 'w-[min(1280px,80vw)] min-[2560px]:w-[1440px]'
+const DRAWER_WIDTH_CLASS = 'w-[min(1280px,80vw)] min-[2560px]:w-[1960px]'
 const ANIM_MS = 220
 
 export default function SettingsDrawer() {

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -16,7 +16,12 @@ import { useSettingsDrawer } from '../lib/SettingsDrawer'
 
 const SettingsPageLazy = lazy(() => import('../pages/tools/Settings'))
 
-const DRAWER_WIDTH = 'min(960px, 75vw)'
+// 响应式宽度：
+//   < 1600 viewport（笔记本 / 小桌面）：80vw —— 1280屏≈1024，1440屏≈1152，1600屏≈1280
+//   1600–2559（含 1k FHD）：1280px 上限，避免大屏吞太多
+//   ≥ 2560（2k QHD 及以上）：1440px
+// 用 Tailwind arbitrary breakpoint 表达。
+const DRAWER_WIDTH_CLASS = 'w-[min(1280px,80vw)] min-[2560px]:w-[1440px]'
 const ANIM_MS = 220
 
 export default function SettingsDrawer() {
@@ -53,10 +58,10 @@ export default function SettingsDrawer() {
       <aside
         role="dialog"
         aria-modal="true"
-        className={`absolute top-0 right-0 bottom-0 flex flex-col bg-canvas border-l border-subtle shadow-2xl transition-transform ease-out ${
+        className={`absolute top-0 right-0 bottom-0 flex flex-col bg-canvas border-l border-subtle shadow-2xl transition-transform ease-out ${DRAWER_WIDTH_CLASS} ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         }`}
-        style={{ width: DRAWER_WIDTH, transitionDuration: `${ANIM_MS}ms` }}
+        style={{ transitionDuration: `${ANIM_MS}ms` }}
       >
         {contentReady && isOpen ? (
           <Suspense fallback={<DrawerSkeleton />}>

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -17,11 +17,13 @@ import { useSettingsDrawer } from '../lib/SettingsDrawer'
 const SettingsPageLazy = lazy(() => import('../pages/tools/Settings'))
 
 // 响应式宽度：
-//   < 1600 viewport（笔记本 / 小桌面）：80vw —— 1280屏≈1024，1440屏≈1152，1600屏≈1280
-//   1600–2559（含 1k FHD）：1280px 上限，避免大屏吞太多
-//   ≥ 2560（2k QHD 及以上）：1960px —— 大屏给到接近 80% 可视宽
-// 用 Tailwind arbitrary breakpoint 表达。
-const DRAWER_WIDTH_CLASS = 'w-[min(1280px,80vw)] min-[2560px]:w-[1960px]'
+//   < 2200 viewport：min(1280px, 80vw) —— 笔记本走 80vw，1k FHD（1920）/ 缩放后的
+//     2k（~1707）都吃满 1280 上限
+//   ≥ 2200 viewport：1960px —— 含 Win 110/125% 缩放的物理 2k（实际 viewport
+//     2300+）和原生 2560 屏；1960 在 2320 viewport 上 ≈ 84%
+// 注意：物理"2k 屏"的 viewport 受 DPI 缩放影响，不是 2560。这里断点按 CSS
+// viewport 取值，不是物理分辨率。
+const DRAWER_WIDTH_CLASS = 'w-[min(1280px,80vw)] min-[2200px]:w-[1960px]'
 const ANIM_MS = 220
 
 export default function SettingsDrawer() {

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -1,0 +1,89 @@
+// SettingsDrawer.tsx —— 右侧滑出的设置抽屉外壳。
+//
+// 渲染策略（解决"打开瞬间 mount 1000+ 行 Settings 卡帧"问题）：
+//
+// 1. 代码分割（React.lazy）：Settings 不进首屏 bundle，首次 open 才下载
+// 2. Skeleton-first：抽屉外壳立即滑入显示骨架，下一帧（rAF）才真正 mount Settings；
+//    动画跑在 GPU 上（transform + opacity），mount 卡顿被动画掩盖
+// 3. 关闭对称：isOpen=false 时立刻卸掉 Settings，再播 slide-out；
+//    避免 React 卸 8 个 tab 组件树跟动画抢主线程
+//
+// Settings 数据（secrets / catalog / SSE）住在 SettingsDataProvider 里常驻，
+// 所以这里 mount/unmount Settings 不付重新拉数据的成本，只付 React render 的成本。
+import { lazy, Suspense, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useSettingsDrawer } from '../lib/SettingsDrawer'
+
+const SettingsPageLazy = lazy(() => import('../pages/tools/Settings'))
+
+const DRAWER_WIDTH = 'min(960px, 75vw)'
+const ANIM_MS = 220
+
+export default function SettingsDrawer() {
+  const { isOpen, close } = useSettingsDrawer()
+  const [contentReady, setContentReady] = useState(false)
+
+  // open: 让外壳先滑进来（GPU 动画），下一帧再 mount Settings
+  // close: 立刻卸 Settings，外壳的 slide-out 在空骨架上跑
+  useEffect(() => {
+    if (!isOpen) {
+      setContentReady(false)
+      return
+    }
+    const id = requestAnimationFrame(() => setContentReady(true))
+    return () => cancelAnimationFrame(id)
+  }, [isOpen])
+
+  return (
+    <div
+      aria-hidden={!isOpen}
+      className={`fixed inset-0 z-30 flex ${isOpen ? '' : 'pointer-events-none'}`}
+    >
+      {/* backdrop：透明 + 轻模糊；过渡覆盖 backdrop-filter 让模糊也是渐变的 */}
+      <div
+        onClick={() => void close()}
+        className={`flex-1 transition-[background-color,backdrop-filter,-webkit-backdrop-filter] ease-out ${
+          isOpen ? 'bg-black/25 backdrop-blur-sm' : 'bg-black/0 backdrop-blur-0'
+        }`}
+        style={{ transitionDuration: `${ANIM_MS}ms` }}
+        aria-label="close settings"
+      />
+      <aside
+        role="dialog"
+        aria-modal="true"
+        className={`relative flex flex-col h-full bg-canvas border-l border-subtle shadow-2xl transition-transform ease-out ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+        style={{ width: DRAWER_WIDTH, transitionDuration: `${ANIM_MS}ms` }}
+      >
+        {contentReady && isOpen ? (
+          <Suspense fallback={<DrawerSkeleton />}>
+            <SettingsPageLazy />
+          </Suspense>
+        ) : (
+          <DrawerSkeleton />
+        )}
+      </aside>
+    </div>
+  )
+}
+
+function DrawerSkeleton() {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col h-full">
+      {/* 跟 PageHeader 同结构的占位条 —— 高度对齐，slide-in 切到真内容时不跳 */}
+      <div className="px-6 pt-5 pb-4 bg-canvas border-b border-subtle">
+        <div className="h-7 w-24 rounded bg-overlay" />
+        <div className="mt-4 flex gap-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div key={i} className="h-7 w-16 rounded bg-overlay/60" />
+          ))}
+        </div>
+      </div>
+      <div className="flex-1 grid place-items-center text-fg-tertiary text-sm">
+        {t('settings.drawerLoading')}
+      </div>
+    </div>
+  )
+}

--- a/studio/web/src/components/Sidebar.test.tsx
+++ b/studio/web/src/components/Sidebar.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it } from 'vitest'
+import { SettingsDrawerProvider } from '../lib/SettingsDrawer'
+import { DialogProvider } from './Dialog'
 import Sidebar from './Sidebar'
 
 function renderAt(path: string) {
@@ -9,7 +11,11 @@ function renderAt(path: string) {
       initialEntries={[path]}
       future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
     >
-      <Sidebar />
+      <DialogProvider>
+        <SettingsDrawerProvider>
+          <Sidebar />
+        </SettingsDrawerProvider>
+      </DialogProvider>
     </MemoryRouter>
   )
 }
@@ -26,8 +32,7 @@ describe('Sidebar (PP0)', () => {
       'href',
       '/queue'
     )
-    // 工具区（重设计后没有 "工具" 分组 label，只是用 border-top 分隔；
-    // 这里只验证三个链接到位即可）
+    // 工具区（重设计后没有 "工具" 分组 label，只是用 border-top 分隔）
     expect(screen.getByRole('link', { name: /预设/ })).toHaveAttribute(
       'href',
       '/tools/presets'
@@ -36,10 +41,9 @@ describe('Sidebar (PP0)', () => {
       'href',
       '/tools/monitor'
     )
-    expect(screen.getByRole('link', { name: /设置/ })).toHaveAttribute(
-      'href',
-      '/tools/settings'
-    )
+    // 设置不再是路由 link，而是打开右侧抽屉的 button；没有 href
+    expect(screen.getByRole('button', { name: /设置/ })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /设置/ })).toBeNull()
   })
 
   it('marks the active route', () => {

--- a/studio/web/src/components/Sidebar.tsx
+++ b/studio/web/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { Fragment, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation, useNavigate } from 'react-router-dom'
 import { api, PHASE_ORDER, PHASE_SKIPPABLE, type Version, type VersionPhase, type VersionStatus } from '../api/client'
+import { useSettingsDrawer } from '../lib/SettingsDrawer'
 import { getStoredTheme, toggleTheme, type Theme } from '../lib/theme'
 import { useToast } from './Toast'
 
@@ -89,6 +90,19 @@ function Logo({ collapsed }: { collapsed: boolean }) {
 }
 
 // ── nav item ───────────────────────────────────────────────────────────────
+function navItemClass(active: boolean, collapsed: boolean, prominent: boolean): string {
+  return [
+    'flex w-full items-center gap-2.5 rounded-md no-underline transition-colors relative bg-transparent border-none cursor-pointer',
+    prominent ? 'text-md' : 'text-sm',
+    collapsed
+      ? 'py-[9px] px-0 justify-center'
+      : prominent ? 'py-2.5 px-3 justify-start' : 'py-2 px-3 justify-start',
+    active
+      ? 'bg-surface text-fg-primary font-semibold shadow-sm'
+      : 'text-fg-secondary font-medium hover:bg-overlay',
+  ].join(' ')
+}
+
 function NavItem({ to, label, icon, active, collapsed, prominent = false }: {
   to: string; label: string; icon: React.ReactNode; active: boolean; collapsed: boolean
   /** 顶级 tab 用更大字号 + 更大 padding，跟项目下属 sub-nav 区分。 */
@@ -98,16 +112,7 @@ function NavItem({ to, label, icon, active, collapsed, prominent = false }: {
     <Link
       to={to}
       title={collapsed ? label : undefined}
-      className={[
-        'flex w-full items-center gap-2.5 rounded-md no-underline transition-colors relative',
-        prominent ? 'text-md' : 'text-sm',
-        collapsed
-          ? 'py-[9px] px-0 justify-center'
-          : prominent ? 'py-2.5 px-3 justify-start' : 'py-2 px-3 justify-start',
-        active
-          ? 'bg-surface text-fg-primary font-semibold shadow-sm'
-          : 'text-fg-secondary font-medium hover:bg-overlay',
-      ].join(' ')}
+      className={navItemClass(active, collapsed, prominent)}
     >
       {active && !collapsed && (
         <span className="absolute left-0 top-2 bottom-2 w-[3px] bg-accent rounded-[2px]" />
@@ -115,6 +120,27 @@ function NavItem({ to, label, icon, active, collapsed, prominent = false }: {
       {icon}
       {!collapsed && <span className="flex-1">{label}</span>}
     </Link>
+  )
+}
+
+/** NavItem 的 button 变体 —— 给设置抽屉用，不走路由。 */
+function NavButton({ onClick, label, icon, active, collapsed, prominent = false }: {
+  onClick: () => void; label: string; icon: React.ReactNode; active: boolean; collapsed: boolean
+  prominent?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={collapsed ? label : undefined}
+      className={navItemClass(active, collapsed, prominent) + ' text-left'}
+    >
+      {active && !collapsed && (
+        <span className="absolute left-0 top-2 bottom-2 w-[3px] bg-accent rounded-[2px]" />
+      )}
+      {icon}
+      {!collapsed && <span className="flex-1">{label}</span>}
+    </button>
   )
 }
 
@@ -438,6 +464,7 @@ export default function Sidebar() {
   const { t } = useTranslation()
   const location = useLocation()
   const ctx = useProjectCtx()
+  const settingsDrawer = useSettingsDrawer()
 
   const pid = location.pathname.match(/^\/projects\/([^/]+)/)?.[1] ?? null
   const urlVid = location.pathname.match(/\/v\/([^/]+)/)?.[1] ?? null
@@ -501,7 +528,7 @@ export default function Sidebar() {
       <div className={`border-t border-subtle flex flex-col gap-0.5 shrink-0 ${collapsed ? 'px-1.5 py-2' : 'p-2.5'}`}>
         <NavItem to="/tools/presets" label={t('nav.presets')} icon={I.preset} active={isMain('/tools/presets')} collapsed={collapsed} />
         <NavItem to="/tools/monitor" label={t('nav.monitor')} icon={I.monitor} active={isMain('/tools/monitor')} collapsed={collapsed} />
-        <NavItem to="/tools/settings" label={t('nav.settings')} icon={I.cog} active={isMain('/tools/settings')} collapsed={collapsed} />
+        <NavButton onClick={() => settingsDrawer.open()} label={t('nav.settings')} icon={I.cog} active={settingsDrawer.isOpen} collapsed={collapsed} />
         <ThemeToggle collapsed={collapsed} />
         <button
           onClick={toggle}

--- a/studio/web/src/components/Sidebar.tsx
+++ b/studio/web/src/components/Sidebar.tsx
@@ -528,7 +528,13 @@ export default function Sidebar() {
       <div className={`border-t border-subtle flex flex-col gap-0.5 shrink-0 ${collapsed ? 'px-1.5 py-2' : 'p-2.5'}`}>
         <NavItem to="/tools/presets" label={t('nav.presets')} icon={I.preset} active={isMain('/tools/presets')} collapsed={collapsed} />
         <NavItem to="/tools/monitor" label={t('nav.monitor')} icon={I.monitor} active={isMain('/tools/monitor')} collapsed={collapsed} />
-        <NavButton onClick={() => settingsDrawer.open()} label={t('nav.settings')} icon={I.cog} active={settingsDrawer.isOpen} collapsed={collapsed} />
+        <NavButton
+          onClick={() => settingsDrawer.isOpen ? void settingsDrawer.close() : settingsDrawer.open()}
+          label={t('nav.settings')}
+          icon={I.cog}
+          active={false}
+          collapsed={collapsed}
+        />
         <ThemeToggle collapsed={collapsed} />
         <button
           onClick={toggle}

--- a/studio/web/src/components/Topbar.tsx
+++ b/studio/web/src/components/Topbar.tsx
@@ -5,6 +5,7 @@ import { useProjectCtx } from '../context/ProjectContext'
 import { api, type Task } from '../api/client'
 import { useEventStream, type StudioEvent } from '../lib/useEventStream'
 import { useMonitorProgress } from '../lib/useMonitorProgress'
+import { useSettingsDrawer } from '../lib/SettingsDrawer'
 import CommandPalette from './CommandPalette'
 import SystemStats from './SystemStats'
 
@@ -106,6 +107,7 @@ export default function Topbar() {
   const crumbs = useBreadcrumbs()
   const navigate = useNavigate()
   const ctx = useProjectCtx()
+  const settingsDrawer = useSettingsDrawer()
   const [paletteOpen, setPaletteOpen] = useState(false)
   const searchBtnRef = useRef<HTMLButtonElement>(null)
 
@@ -235,10 +237,7 @@ export default function Topbar() {
 
         {updateInfo?.has_update && (
           <button
-            onClick={() => {
-              try { localStorage.setItem('studio.settings.activeTab', 'system') } catch { /* ignore */ }
-              navigate('/tools/settings')
-            }}
+            onClick={() => settingsDrawer.open({ section: 'version' })}
             title={t('topbar.newVersion', { tag: updateInfo.latest_tag ?? updateInfo.latest_commit.slice(0, 8) })}
             className="flex items-center gap-1.5 px-2 py-[5px] rounded-md text-xs font-mono text-accent bg-accent-soft border border-accent cursor-pointer hover:bg-accent/10 transition-colors shrink-0"
           >

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -654,6 +654,12 @@
     "sourceLink": "Project #{{projectId}} / v#{{versionId}}"
   },
   "settings": {
+    "drawerTitle": "Settings",
+    "drawerClose": "Close settings",
+    "drawerLoading": "Loading…",
+    "closeDirtyTitle": "Unsaved changes",
+    "closeDirtyConfirm": "Closing the drawer will discard unsaved changes. Close anyway?",
+    "closeDirtyOk": "Discard & close",
     "tabDataset": "Dataset",
     "tabPreprocess": "Preprocess",
     "tabTagging": "Tagging",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -654,6 +654,12 @@
     "sourceLink": "项目 #{{projectId}} / v#{{versionId}}"
   },
   "settings": {
+    "drawerTitle": "设置",
+    "drawerClose": "关闭设置",
+    "drawerLoading": "加载中…",
+    "closeDirtyTitle": "未保存的改动",
+    "closeDirtyConfirm": "关闭抽屉会丢弃未保存的改动，确认关闭？",
+    "closeDirtyOk": "丢弃并关闭",
     "tabDataset": "数据集",
     "tabPreprocess": "预处理",
     "tabTagging": "打标",

--- a/studio/web/src/lib/SettingsData.tsx
+++ b/studio/web/src/lib/SettingsData.tsx
@@ -1,0 +1,97 @@
+// SettingsData.tsx —— Settings 全局数据层。
+//
+// 把 secrets / catalog / downloadBusy / SSE 订阅从 SettingsPage 提到根级 Provider，
+// 让 SettingsPage 本身可以 unmount + remount 不付重新拉数据的代价：
+// - secrets：一次 fetch，常驻 context；save 后由 SettingsPage 调 setSecrets 更新
+// - catalog：reloadCatalog + model_download_changed SSE 订阅常驻，跟下载组件共享
+// - downloadBusy：跟 startDownload 配对的 in-flight Set
+//
+// 这层只持有数据，不渲染 UI。SettingsDrawer 关闭时 SettingsPage 卸载，
+// 第二次打开瞬间渲染——数据已经在 context 里。
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import { api, type ModelsCatalog, type Secrets } from '../api/client'
+import { useToast } from '../components/Toast'
+import { useEventStream } from './useEventStream'
+
+interface SettingsData {
+  secrets: Secrets | null
+  secretsError: string | null
+  setSecrets: (s: Secrets) => void
+  catalog: ModelsCatalog | null
+  catalogError: string | null
+  reloadCatalog: () => Promise<void>
+  downloadBusy: Set<string>
+  startDownload: (model_id: string, variant?: string) => Promise<void>
+}
+
+const Ctx = createContext<SettingsData | null>(null)
+
+export function SettingsDataProvider({ children }: { children: ReactNode }) {
+  const { t } = useTranslation()
+  const { toast } = useToast()
+  const [secrets, setSecrets] = useState<Secrets | null>(null)
+  const [secretsError, setSecretsError] = useState<string | null>(null)
+  const [catalog, setCatalog] = useState<ModelsCatalog | null>(null)
+  const [catalogError, setCatalogError] = useState<string | null>(null)
+  const [downloadBusy, setDownloadBusy] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    api.getSecrets()
+      .then((s) => { setSecrets(s); setSecretsError(null) })
+      .catch((e) => setSecretsError(String(e)))
+  }, [])
+
+  const reloadCatalog = useCallback(async () => {
+    try {
+      const c = await api.getModelsCatalog()
+      setCatalog(c)
+      setCatalogError(null)
+    } catch (e) {
+      setCatalogError(String(e))
+    }
+  }, [])
+
+  useEffect(() => { void reloadCatalog() }, [reloadCatalog])
+
+  useEventStream((evt) => {
+    if (evt.type === 'model_download_changed') { void reloadCatalog() }
+  })
+
+  const startDownload = useCallback(async (model_id: string, variant?: string) => {
+    const key = variant ? `${model_id}:${variant}` : model_id
+    setDownloadBusy((s) => new Set(s).add(key))
+    try {
+      await api.startModelDownload({ model_id, variant })
+      toast(t('settings.downloadStarted', { name: key }), 'success')
+      await reloadCatalog()
+    } catch (e) {
+      toast(String(e), 'error')
+    } finally {
+      setDownloadBusy((s) => { const n = new Set(s); n.delete(key); return n })
+    }
+  }, [reloadCatalog, t, toast])
+
+  return (
+    <Ctx.Provider value={{
+      secrets, secretsError, setSecrets,
+      catalog, catalogError, reloadCatalog,
+      downloadBusy, startDownload,
+    }}>
+      {children}
+    </Ctx.Provider>
+  )
+}
+
+export function useSettingsData(): SettingsData {
+  const ctx = useContext(Ctx)
+  if (!ctx) throw new Error('useSettingsData must be used inside <SettingsDataProvider>')
+  return ctx
+}

--- a/studio/web/src/lib/SettingsDrawer.tsx
+++ b/studio/web/src/lib/SettingsDrawer.tsx
@@ -1,0 +1,101 @@
+// SettingsDrawer.tsx —— Settings 抽屉的全局打开/关闭 store。
+//
+// 路由化的旧设置页（/tools/settings）已删除，现在所有"打开设置"动作都走
+// useSettingsDrawer().open({ section? })。状态在内存，刷新页面默认关闭，
+// 跟用户对"抽屉"的心智模型一致。
+//
+// dirty guard：SettingsPage 通过 registerDirtyGuard 注册一个查询函数，
+// drawer 关闭前调用它决定是否弹 confirm。这样守护逻辑住在表单侧（它本来就知道
+// 自己 dirty 不 dirty），drawer 侧只负责询问用户。
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDialog } from '../components/Dialog'
+
+interface OpenOptions {
+  /** 跳转到指定 section（对应 SettingsPage 内的 DOM id）；不传则维持上次 tab。 */
+  section?: string
+}
+
+interface SettingsDrawerApi {
+  isOpen: boolean
+  /** 上一次 open 调用带的 section；SettingsPage 内 effect 监听它做 scrollIntoView。
+   *  每次 open 哪怕同一 section 也会换引用，便于触发 effect。 */
+  sectionRequest: { section: string; nonce: number } | null
+  open: (opts?: OpenOptions) => void
+  close: () => void
+  /** SettingsPage mount 时注册「当前 draft 是否 dirty」的查询函数；unmount 时传 null。 */
+  registerDirtyGuard: (fn: (() => boolean) | null) => void
+}
+
+const Ctx = createContext<SettingsDrawerApi | null>(null)
+
+export function SettingsDrawerProvider({ children }: { children: ReactNode }) {
+  const { t } = useTranslation()
+  const { confirm } = useDialog()
+  const [isOpen, setIsOpen] = useState(false)
+  const [sectionRequest, setSectionRequest] = useState<SettingsDrawerApi['sectionRequest']>(null)
+  const dirtyGuardRef = useRef<(() => boolean) | null>(null)
+  const nonceRef = useRef(0)
+
+  const open = useCallback((opts?: OpenOptions) => {
+    // 每次 open 都重置 sectionRequest：没传 section 就显式清空，避免上次 open 留下
+    // 的 section 在下一次"无 section 打开 → SettingsPage 重新 mount"时被旧 effect
+    // 再次消费，导致预期外的滚动。
+    if (opts?.section) {
+      nonceRef.current += 1
+      setSectionRequest({ section: opts.section, nonce: nonceRef.current })
+    } else {
+      setSectionRequest(null)
+    }
+    setIsOpen(true)
+  }, [])
+
+  const close = useCallback(async () => {
+    if (dirtyGuardRef.current?.()) {
+      const ok = await confirm(t('settings.closeDirtyConfirm'), {
+        tone: 'warn',
+        title: t('settings.closeDirtyTitle'),
+        okText: t('settings.closeDirtyOk'),
+      })
+      if (!ok) return
+    }
+    setIsOpen(false)
+  }, [confirm, t])
+
+  const registerDirtyGuard = useCallback((fn: (() => boolean) | null) => {
+    dirtyGuardRef.current = fn
+  }, [])
+
+  // ESC 关：放在 Provider 里而非 Drawer 组件，避免 lazy 加载期间快捷键失效。
+  useEffect(() => {
+    if (!isOpen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        void close()
+      }
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [isOpen, close])
+
+  return (
+    <Ctx.Provider value={{ isOpen, sectionRequest, open, close, registerDirtyGuard }}>
+      {children}
+    </Ctx.Provider>
+  )
+}
+
+export function useSettingsDrawer(): SettingsDrawerApi {
+  const ctx = useContext(Ctx)
+  if (!ctx) throw new Error('useSettingsDrawer must be used inside <SettingsDrawerProvider>')
+  return ctx
+}

--- a/studio/web/src/main.tsx
+++ b/studio/web/src/main.tsx
@@ -5,6 +5,7 @@ import { DialogProvider } from './components/Dialog'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { FirstRunLangModal } from './components/FirstRunLangModal'
 import { ToastProvider } from './components/Toast'
+import { SettingsDataProvider } from './lib/SettingsData'
 import { initTheme } from './lib/theme'
 import './i18n'
 import './index.css'
@@ -16,8 +17,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     <ErrorBoundary>
       <ToastProvider>
         <DialogProvider>
-          <FirstRunLangModal />
-          <App />
+          <SettingsDataProvider>
+            <FirstRunLangModal />
+            <App />
+          </SettingsDataProvider>
         </DialogProvider>
       </ToastProvider>
     </ErrorBoundary>

--- a/studio/web/src/main.tsx
+++ b/studio/web/src/main.tsx
@@ -6,6 +6,7 @@ import { ErrorBoundary } from './components/ErrorBoundary'
 import { FirstRunLangModal } from './components/FirstRunLangModal'
 import { ToastProvider } from './components/Toast'
 import { SettingsDataProvider } from './lib/SettingsData'
+import { SettingsDrawerProvider } from './lib/SettingsDrawer'
 import { initTheme } from './lib/theme'
 import './i18n'
 import './index.css'
@@ -18,8 +19,10 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
       <ToastProvider>
         <DialogProvider>
           <SettingsDataProvider>
-            <FirstRunLangModal />
-            <App />
+            <SettingsDrawerProvider>
+              <FirstRunLangModal />
+              <App />
+            </SettingsDrawerProvider>
           </SettingsDataProvider>
         </DialogProvider>
       </ToastProvider>

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link, useOutletContext } from 'react-router-dom'
+import { useOutletContext } from 'react-router-dom'
 import {
   api,
   type Job,
@@ -18,6 +18,7 @@ import LLMMessagesEditor from '../../../components/LLMMessagesEditor'
 import JobProgress from '../../../components/JobProgress'
 import StepShell from '../../../components/StepShell'
 import { useToast } from '../../../components/Toast'
+import { useSettingsDrawer } from '../../../lib/SettingsDrawer'
 import { useEventStream } from '../../../lib/useEventStream'
 
 interface Ctx {
@@ -118,6 +119,7 @@ export default function TaggingPage() {
   const { t } = useTranslation()
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
   const { toast } = useToast()
+  const settingsDrawer = useSettingsDrawer()
 
   const [tagger, setTagger] = useState<TaggerName>('wd14')
   const [taggerStatus, setTaggerStatus] = useState<TaggerStatus | null>(null)
@@ -336,9 +338,14 @@ export default function TaggingPage() {
                 : t('tag.statusChecking')}
             </span>
             {taggerStatus && !taggerStatus.ok && taggerStatus.msg.includes('需下载模型') && (
-              <Link to="/tools/settings" className="text-xs text-accent underline" title={t('tag.goDownload')}>
+              <button
+                type="button"
+                onClick={() => settingsDrawer.open({ section: tagger === 'cltagger' ? 'cltagger' : 'wd14' })}
+                className="text-xs text-accent underline bg-transparent border-none p-0 cursor-pointer"
+                title={t('tag.goDownload')}
+              >
                 {t('tag.goDownload')}
-              </Link>
+              </button>
             )}
 
             <span className="text-dim">|</span>
@@ -450,6 +457,7 @@ function Wd14Panel({
   disabled: boolean
 }) {
   const { t } = useTranslation()
+  const settingsDrawer = useSettingsDrawer()
   if (!form || !defaults) {
     return (
       <section className="rounded-md border border-subtle bg-surface px-3 py-2 text-xs text-fg-tertiary shrink-0">
@@ -474,9 +482,14 @@ function Wd14Panel({
         <span className="caption">{t('tag.wd14Params')}</span>
         <span className="text-xs text-fg-tertiary">
           {t('tag.prefilledFrom')}{' '}
-          <Link to="/tools/settings" className="text-accent" title={t('tag.globalSettings')}>
+          <button
+            type="button"
+            onClick={() => settingsDrawer.open({ section: 'wd14' })}
+            className="bg-transparent border-none p-0 text-accent cursor-pointer"
+            title={t('tag.globalSettings')}
+          >
             {t('tag.globalSettings')}
-          </Link>
+          </button>
           {' · '}{t('tag.effectiveThisRun')}
         </span>
         <span className="flex-1" />
@@ -542,6 +555,7 @@ function CLTaggerPanel({
   disabled: boolean
 }) {
   const { t } = useTranslation()
+  const settingsDrawer = useSettingsDrawer()
   if (!form || !defaults) {
     return (
       <section className="rounded-md border border-subtle bg-surface px-3 py-2 text-xs text-fg-tertiary shrink-0">
@@ -570,9 +584,14 @@ function CLTaggerPanel({
         <span className="caption">{t('tag.cltaggerParams')}</span>
         <span className="text-xs text-fg-tertiary">
           {t('tag.prefilledFrom')}{' '}
-          <Link to="/tools/settings" className="text-accent" title={t('tag.globalSettings')}>
+          <button
+            type="button"
+            onClick={() => settingsDrawer.open({ section: 'cltagger' })}
+            className="bg-transparent border-none p-0 text-accent cursor-pointer"
+            title={t('tag.globalSettings')}
+          >
             {t('tag.globalSettings')}
-          </Link>
+          </button>
           {' · '}{t('tag.effectiveThisRun')}
         </span>
         <span className="flex-1" />
@@ -860,6 +879,7 @@ function LabeledModelSelect({ label, value, options, disabled, onChange, modifie
   onChange: (v: string) => void; modified?: boolean
 }) {
   const { t } = useTranslation()
+  const settingsDrawer = useSettingsDrawer()
   const opts = options.includes(value) ? options : [value, ...options]
   return (
     <label className="grid grid-cols-[140px_1fr] items-center gap-2">
@@ -873,9 +893,14 @@ function LabeledModelSelect({ label, value, options, disabled, onChange, modifie
         >
           {opts.map((m) => <option key={m} value={m}>{m}</option>)}
         </select>
-        <Link to="/tools/settings" className="text-xs text-fg-tertiary shrink-0" title={t('tag.globalSettings')}>
+        <button
+          type="button"
+          onClick={() => settingsDrawer.open()}
+          className="text-xs text-fg-tertiary shrink-0 bg-transparent border-none p-0 cursor-pointer"
+          title={t('tag.globalSettings')}
+        >
           +
-        </Link>
+        </button>
       </div>
     </label>
   )

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link, useNavigate, useOutletContext } from 'react-router-dom'
+import { useNavigate, useOutletContext } from 'react-router-dom'
 import {
   api,
   type ConfigData,
@@ -16,6 +16,7 @@ import { useDialog } from '../../../components/Dialog'
 import SchemaForm from '../../../components/SchemaForm'
 import StepShell from '../../../components/StepShell'
 import { useToast } from '../../../components/Toast'
+import { useSettingsDrawer } from '../../../lib/SettingsDrawer'
 import { useAdvancedMode } from '../../../lib/useAdvancedMode'
 import {
   PRESET_NAME_RE,
@@ -44,6 +45,7 @@ export default function TrainPage() {
   const { toast } = useToast()
   const { confirm, prompt } = useDialog()
   const navigate = useNavigate()
+  const settingsDrawer = useSettingsDrawer()
 
   const [schema, setSchema] = useState<SchemaResponse | null>(null)
   const [presets, setPresets] = useState<PresetSummary[]>([])
@@ -131,18 +133,19 @@ export default function TrainPage() {
       const node = (
         <>
           {t('train.globalAutoLockedPrefix')} ·{' '}
-          <Link
-            to="/tools/settings?section=models"
-            className="underline text-warn hover:opacity-80"
+          <button
+            type="button"
+            onClick={() => settingsDrawer.open({ section: 'models' })}
+            className="bg-transparent border-none p-0 underline text-warn hover:opacity-80 cursor-pointer"
           >
             {t('train.globalAutoLockedLink')}
-          </Link>
+          </button>
         </>
       )
       for (const f of GLOBAL_MODEL_FIELDS) h[f] = node
     }
     return h
-  }, [t, autoSyncPaths])
+  }, [t, autoSyncPaths, settingsDrawer])
   // 项目特定字段（data_dir / reg_data_dir / output_dir 等）：值由项目预填，但
   // 不锁定，挂「自动 · 项目设置」徽章让用户知道这是预填的，不是预设里来的。
   // toggle OFF 时全局模型字段也挂 hint「默认来自 Settings · 可改」。

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
 import {
   api,
   type ApiError,
@@ -13,6 +12,7 @@ import { useDialog } from '../../components/Dialog'
 import PathPicker from '../../components/PathPicker'
 import SchemaForm from '../../components/SchemaForm'
 import { useToast } from '../../components/Toast'
+import { useSettingsDrawer } from '../../lib/SettingsDrawer'
 import { useAdvancedMode } from '../../lib/useAdvancedMode'
 import {
   PRESET_NAME_RE,
@@ -64,6 +64,7 @@ export default function PresetsPage() {
   const { t } = useTranslation()
   const { toast } = useToast()
   const { confirm } = useDialog()
+  const settingsDrawer = useSettingsDrawer()
 
   // ── backend state ──
   const [schema, setSchema] = useState<SchemaResponse | null>(null)
@@ -231,18 +232,19 @@ export default function PresetsPage() {
       const node = (
         <>
           {t('train.globalAutoLockedPrefix')} ·{' '}
-          <Link
-            to="/tools/settings?section=models"
-            className="underline text-warn hover:opacity-80"
+          <button
+            type="button"
+            onClick={() => settingsDrawer.open({ section: 'models' })}
+            className="bg-transparent border-none p-0 underline text-warn hover:opacity-80 cursor-pointer"
           >
             {t('train.globalAutoLockedLink')}
-          </Link>
+          </button>
         </>
       )
       for (const f of MODEL_PATH_FIELDS) h[f] = node
     }
     return h
-  }, [t, autoSyncPaths, MODEL_PATH_FIELDS])
+  }, [t, autoSyncPaths, MODEL_PATH_FIELDS, settingsDrawer])
   const autoHints = useMemo(() => {
     const h: Record<string, string> = {}
     if (!autoSyncPaths) {

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -5,6 +5,7 @@ import { MemoryRouter } from 'react-router-dom'
 import { DialogProvider } from '../../components/Dialog'
 import { ToastProvider } from '../../components/Toast'
 import { SettingsDataProvider } from '../../lib/SettingsData'
+import { SettingsDrawerProvider } from '../../lib/SettingsDrawer'
 import SettingsPage from './Settings'
 
 const initialServerState = {
@@ -234,7 +235,9 @@ function renderPage() {
       <ToastProvider>
         <DialogProvider>
           <SettingsDataProvider>
-            <SettingsPage />
+            <SettingsDrawerProvider>
+              <SettingsPage />
+            </SettingsDrawerProvider>
           </SettingsDataProvider>
         </DialogProvider>
       </ToastProvider>

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { MemoryRouter } from 'react-router-dom'
 import { DialogProvider } from '../../components/Dialog'
 import { ToastProvider } from '../../components/Toast'
+import { SettingsDataProvider } from '../../lib/SettingsData'
 import SettingsPage from './Settings'
 
 const initialServerState = {
@@ -232,7 +233,9 @@ function renderPage() {
     <MemoryRouter>
       <ToastProvider>
         <DialogProvider>
-          <SettingsPage />
+          <SettingsDataProvider>
+            <SettingsPage />
+          </SettingsDataProvider>
         </DialogProvider>
       </ToastProvider>
     </MemoryRouter>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -31,7 +31,7 @@ import { InfoButton } from '../../components/InfoButton'
 import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
-import { useEventStream } from '../../lib/useEventStream'
+import { useSettingsData } from '../../lib/SettingsData'
 import {
   formatMasterStateText,
   formatDevStateText,
@@ -263,22 +263,41 @@ function translatedCatalogText(keys: Record<string, string>, id: string, fallbac
 
 export default function SettingsPage() {
   const { t } = useTranslation()
-  const [server, setServer] = useState<Secrets | null>(null)
+  // 共享数据层（SettingsDataProvider）：secrets / catalog / SSE / downloadBusy 都在根级常驻，
+  // 本组件 mount/unmount（抽屉开关）不再触发重拉。`server` 别名保留是为了让下方
+  // 大段表单代码改动最小。
+  const {
+    secrets: server,
+    secretsError,
+    setSecrets: setServer,
+    catalog,
+    catalogError,
+    reloadCatalog,
+    downloadBusy,
+    startDownload,
+  } = useSettingsData()
   const [draft, setDraft] = useState<Secrets>(EMPTY)
   const [error, setError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [tab, setTab] = useState<Tab>(getStoredTab)
-  // Models catalog hoisted here so 打标 tab 的 WD14/CLTagger 卡片和 训练 tab
-  // 的 ModelsSection 共用一份数据 + 一个 SSE 订阅。
-  const [catalog, setCatalog] = useState<ModelsCatalog | null>(null)
-  const [catalogError, setCatalogError] = useState<string | null>(null)
-  const [downloadBusy, setDownloadBusy] = useState<Set<string>>(new Set())
   const [llmModelsBusy, setLlmModelsBusy] = useState(false)
   const [llmTestBusy, setLlmTestBusy] = useState(false)
   const { toast } = useToast()
   const { prompt } = useDialog()
   // 右侧 section index 用：sticky nav 的 IntersectionObserver root + 滚动平移容器
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+
+  // 第一次拿到 secrets 时把 draft 同步过来；之后 server 变化（save 后）不再
+  // 覆盖 draft，避免抹掉用户的未保存编辑（save 里会自己 setDraft(next)）。
+  const draftInitRef = useRef(false)
+  useEffect(() => {
+    if (server && !draftInitRef.current) {
+      setDraft(server)
+      draftInitRef.current = true
+    }
+  }, [server])
+  // 数据层 fetch secrets 失败时把错误透出到本组件 error 状态，复用底部错误条。
+  useEffect(() => { if (secretsError) setError(secretsError) }, [secretsError])
 
   const switchTab = (next: Tab) => {
     setTab(next)
@@ -306,46 +325,6 @@ export default function SettingsPage() {
     }, 50)
     return () => clearTimeout(t1)
   }, [location.search])
-
-  const reloadCatalog = useCallback(async () => {
-    try {
-      const c = await api.getModelsCatalog()
-      setCatalog(c)
-      setCatalogError(null)
-    } catch (e) {
-      setCatalogError(String(e))
-    }
-  }, [])
-
-  useEffect(() => { void reloadCatalog() }, [reloadCatalog])
-
-  useEventStream((evt) => {
-    if (evt.type === 'model_download_changed') { void reloadCatalog() }
-  })
-
-  const startDownload = useCallback(async (model_id: string, variant?: string) => {
-    const key = variant ? `${model_id}:${variant}` : model_id
-    setDownloadBusy((s) => new Set(s).add(key))
-    try {
-      await api.startModelDownload({ model_id, variant })
-      toast(t('settings.downloadStarted', { name: key }), 'success')
-      await reloadCatalog()
-    } catch (e) {
-      toast(String(e), 'error')
-    } finally {
-      setDownloadBusy((s) => { const n = new Set(s); n.delete(key); return n })
-    }
-  }, [reloadCatalog, t, toast])
-
-  useEffect(() => {
-    api
-      .getSecrets()
-      .then((s) => {
-        setServer(s)
-        setDraft(s)
-      })
-      .catch((e) => setError(String(e)))
-  }, [])
 
   const dirty = useMemo(
     () => server !== null && JSON.stringify(server) !== JSON.stringify(draft),

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import type { TFunction } from 'i18next'
 import { Trans, useTranslation } from 'react-i18next'
-import { useLocation } from 'react-router-dom'
 import {
   api,
   DEFAULT_WD14_MODELS,
@@ -66,6 +65,8 @@ type Tab = 'dataset' | 'tagging' | 'preprocess' | 'training' | 'monitor' | 'test
 const SECTION_TO_TAB: Record<string, Tab> = {
   'models': 'training',
   'download-source': 'training',
+  'version': 'system',
+  'service': 'system',
 }
 
 const TAB_LIST: { id: Tab; labelKey: string }[] = [
@@ -309,24 +310,6 @@ export default function SettingsPage() {
       /* ignore localStorage errors */
     }
   }
-
-  // 外部页面通过 `/tools/settings?section=models` 跳进来时，先切到对应 tab，
-  // 等 section 渲染完再 scrollIntoView。不写 localStorage，避免覆盖用户平常
-  // 偏好的 tab。
-  const location = useLocation()
-  useEffect(() => {
-    const params = new URLSearchParams(location.search)
-    const section = params.get('section')
-    if (!section) return
-    const targetTab = SECTION_TO_TAB[section]
-    if (targetTab) setTab(targetTab)
-    // tab 切换 → section 重新渲染，需要等 DOM 更新后再 scroll
-    const t1 = setTimeout(() => {
-      const el = document.getElementById(section)
-      el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    }, 50)
-    return () => clearTimeout(t1)
-  }, [location.search])
 
   const dirty = useMemo(
     () => server !== null && JSON.stringify(server) !== JSON.stringify(draft),

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -32,6 +32,7 @@ import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
 import { useSettingsData } from '../../lib/SettingsData'
+import { useSettingsDrawer } from '../../lib/SettingsDrawer'
 import {
   formatMasterStateText,
   formatDevStateText,
@@ -284,6 +285,7 @@ export default function SettingsPage() {
   const [llmTestBusy, setLlmTestBusy] = useState(false)
   const { toast } = useToast()
   const { prompt } = useDialog()
+  const drawer = useSettingsDrawer()
   // 右侧 section index 用：sticky nav 的 IntersectionObserver root + 滚动平移容器
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
@@ -330,6 +332,30 @@ export default function SettingsPage() {
     () => server !== null && JSON.stringify(server) !== JSON.stringify(draft),
     [server, draft]
   )
+
+  // 抽屉关闭前用这个 ref 询问"是否 dirty"；ref 每次 render 刷新，
+  // 注册的函数只挂载一次，避免 effect churn。
+  const dirtyRef = useRef(false)
+  dirtyRef.current = dirty
+  useEffect(() => {
+    drawer.registerDirtyGuard(() => dirtyRef.current)
+    return () => drawer.registerDirtyGuard(null)
+  }, [drawer])
+
+  // 抽屉以 open({ section }) 打开时跳到对应 section（取代旧的 ?section= URL 参数）。
+  // sectionRequest 带 nonce，相同 section 重复 open 也会触发 effect 重跑。
+  const drawerSectionReq = drawer.sectionRequest
+  useEffect(() => {
+    if (!drawerSectionReq) return
+    const section = drawerSectionReq.section
+    const targetTab = SECTION_TO_TAB[section]
+    if (targetTab) setTab(targetTab)
+    const t1 = setTimeout(() => {
+      const el = document.getElementById(section)
+      el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    }, 50)
+    return () => clearTimeout(t1)
+  }, [drawerSectionReq])
 
   const update = <S extends Section, K extends keyof Secrets[S]>(
     section: S,
@@ -536,6 +562,18 @@ export default function SettingsPage() {
         title={t('settings.title')}
         tabs={tabNav}
         sticky
+        topRight={drawer.isOpen ? (
+          <button
+            onClick={() => void drawer.close()}
+            title={t('settings.drawerClose')}
+            aria-label={t('settings.drawerClose')}
+            className="w-7 h-7 grid place-items-center text-fg-tertiary bg-transparent border-none rounded-sm cursor-pointer hover:bg-overlay hover:text-fg-primary transition-colors"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+              <path d="M6 6l12 12M18 6l-12 12" />
+            </svg>
+          </button>
+        ) : undefined}
         actions={
           <button
             onClick={save}


### PR DESCRIPTION
重开 PR：#132 漏了 squash merge，直接 merge commit 把 10 个原始 commit 都灌进 dev。原 merge 已 force-revert，这次请用 **Squash and merge**。

## Summary

Settings 页（`/tools/settings`）改成右侧滑出抽屉，全局可调起、不打断当前页。

- **数据层提到根级 Provider**：`SettingsDataProvider` 持有 secrets / catalog / SSE / downloadBusy，SettingsPage mount/unmount 不再重拉
- **抽屉化**：`SettingsDrawerProvider` 全局 store（`open({section?})` / `close()` / `isOpen`），`SettingsDrawer` 渲染在主内容列内（absolute inset-0），不罩侧边栏
- **去路由**：删 `/tools/settings`，替换 8 处 Link（Sidebar / Topbar / CommandPalette / Train / Presets / Tagging × 4）。旧 URL 由 `SettingsRedirect` 兼容跳转
- **渲染优化**：`React.lazy(Settings)` 分包（独立 chunk ~116KB gzip 27KB，不进首屏）+ skeleton-first + rAF-defer mount，slide-in 动画期间不卡

## Behavior

- 宽度：`max(1024px, 70vw)` —— 小笔记本兜底 1024，大屏按 70% 自然放大（4k 屏到 2688）
- 关闭：点 backdrop / ESC / 再点侧边栏「设置」/ 标题栏 × 都可关
- Dirty 守护：未保存改动关抽屉时弹 confirm
- 抽屉打开时侧边栏仍可点（切项目 / 切版本 / 切主题不用先关抽屉）
- 侧边栏「设置」按钮 toggle 行为：开着再点就关；不显示 active 高亮（不是页面）
- `?section=models` 等深链通过 `open({section})` 落地，scroll-into-view 行为不变

## Test plan

- [x] tsc clean / eslint clean / vitest 259/259 pass
- [x] vite build：Settings 独立分包（116KB / 27KB gzip）
- [ ] 浏览器手测：抽屉滑入/滑出动画无露底
- [ ] 浏览器手测：宽度档位（1366 / 1920 / 2k / 4k）
- [ ] 浏览器手测：8 处入口都能正确打开抽屉（含 section 跳转）
- [ ] 浏览器手测：dirty 状态关抽屉弹 confirm
- [ ] 浏览器手测：抽屉打开时侧边栏可交互
- [ ] 浏览器手测：点设置按钮 toggle 关闭

🤖 Generated with [Claude Code](https://claude.com/claude-code)