### PR TITLE
fix: 0.10.0 silent regression 三修 — JSON caption 路径 / 测试页 GPU 互锁 / snapshot tab 重拉

### DIFF
--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -105,8 +105,10 @@ class ImageDataset(Dataset):
                 import importlib.util
                 import sys
                 
-                # 直接加载 caption_utils.py
-                utils_path = Path(__file__).parent.parent / "utils" / "caption_utils.py"  # noqa: E501 — 等价原 runtime/utils/...，见 ADR 0003 PR-A
+                # 直接加载 caption_utils.py（ADR 0003 PR-A 后 utils/ 在仓库根，
+                # 不在 runtime/utils/；__file__ 是 runtime/training/dataset.py，
+                # 因此要回溯三层 parent 到仓库根。）
+                utils_path = Path(__file__).parent.parent.parent / "utils" / "caption_utils.py"
                 if utils_path.exists():
                     spec = importlib.util.spec_from_file_location("caption_utils", utils_path)
                     caption_module = importlib.util.module_from_spec(spec)

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1065,6 +1065,8 @@
     "swapSizeTitle": "Swap width and height (landscape ↔ portrait)",
     "cancelCurrentTitle": "Cancel current task",
     "sharedGpu": "Shares GPU with training",
+    "blockedByActiveTask": "Queue task #{{id}} is using the GPU — wait for it to finish or cancel before generating (running both will fight for VRAM)",
+    "blockedByActiveTaskHint": "Waiting for queue #{{id}}",
     "results": "Results",
     "originalReleasedCoverOnly": "Original image was released; only the cover thumbnail is available",
     "originalReleasedThumbOnly": "Original image was released; only the thumbnail is available",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1065,6 +1065,8 @@
     "swapSizeTitle": "交换宽高（横版 ↔ 竖版）",
     "cancelCurrentTitle": "取消当前任务",
     "sharedGpu": "与训练共享 GPU",
+    "blockedByActiveTask": "队列任务 #{{id}} 正在占用 GPU — 等它完成或取消后再生成（同时跑会撞 VRAM）",
+    "blockedByActiveTaskHint": "等队列 #{{id}} 完成",
     "results": "生成结果",
     "originalReleasedCoverOnly": "原图已释放，仅封面缩略可见",
     "originalReleasedThumbOnly": "原图已释放，仅缩略图可见",

--- a/studio/web/src/pages/QueueDetail.test.tsx
+++ b/studio/web/src/pages/QueueDetail.test.tsx
@@ -1,0 +1,111 @@
+/** QueueDetail page 组件级 regression test。
+ *
+ *  目前只覆盖 SnapshotConfigTab 的 refetch trap：父组件每 2s 浅 clone task
+ *  做 elapsed time tick，旧实现 [task] 作 deps 会让 snapshot config 也跟着
+ *  2s 重拉 —— 浏览器卡顿、loading flash。 */
+import { render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../components/Toast'
+import type { Task } from '../api/client'
+import { SnapshotConfigTab } from './QueueDetail'
+
+const SNAPSHOT_URL_PREFIX = '/api/queue/'
+const SNAPSHOT_URL_SUFFIX = '/snapshot/config'
+
+const fetchMock = vi.fn()
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 1, name: 'train', config_name: 'train',
+    status: 'running', priority: 0,
+    created_at: 1000, started_at: 1100, finished_at: null,
+    pid: 1234, exit_code: null, output_dir: null, error_msg: null,
+    ...overrides,
+  }
+}
+
+function snapshotResponse() {
+  const body = { yaml: 'key: val\n', config: { key: 'val' } }
+  return {
+    ok: true, status: 200,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+    headers: new Headers({ 'content-type': 'application/json' }),
+  } as Response
+}
+
+function snapshotCallCount(): number {
+  return fetchMock.mock.calls.filter(([url]) =>
+    typeof url === 'string'
+    && url.startsWith(SNAPSHOT_URL_PREFIX)
+    && url.endsWith(SNAPSHOT_URL_SUFFIX),
+  ).length
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock)
+  fetchMock.mockReset()
+  fetchMock.mockImplementation((url: string) => {
+    if (url.startsWith(SNAPSHOT_URL_PREFIX) && url.endsWith(SNAPSHOT_URL_SUFFIX)) {
+      return Promise.resolve(snapshotResponse())
+    }
+    return Promise.resolve({
+      ok: false, status: 404, json: async () => null, text: async () => '',
+      headers: new Headers(),
+    } as Response)
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function setup(task: Task | null) {
+  return render(
+    <MemoryRouter>
+      <ToastProvider>
+        <SnapshotConfigTab task={task} />
+      </ToastProvider>
+    </MemoryRouter>
+  )
+}
+
+describe('SnapshotConfigTab', () => {
+  it('父组件 2s 浅 clone task 不会触发重拉 — snapshot 是不可变的', async () => {
+    const task = makeTask()
+    const view = setup(task)
+
+    await waitFor(() => expect(snapshotCallCount()).toBe(1))
+
+    // 模拟父组件的 2s tick：shallow clone 出新引用，id / started_at 不变
+    for (let i = 0; i < 5; i++) {
+      view.rerender(
+        <MemoryRouter>
+          <ToastProvider>
+            <SnapshotConfigTab task={{ ...task }} />
+          </ToastProvider>
+        </MemoryRouter>
+      )
+    }
+
+    // 等一下让任何额外 useEffect 走完
+    await new Promise((r) => setTimeout(r, 20))
+    expect(snapshotCallCount()).toBe(1)
+  })
+
+  it('pending → running 转换（started_at null→number）触发一次重拉', async () => {
+    const view = setup(makeTask({ status: 'pending', started_at: null }))
+    await waitFor(() => expect(snapshotCallCount()).toBe(1))
+
+    view.rerender(
+      <MemoryRouter>
+        <ToastProvider>
+          <SnapshotConfigTab task={makeTask({ status: 'running', started_at: 1234 })} />
+        </ToastProvider>
+      </MemoryRouter>
+    )
+
+    await waitFor(() => expect(snapshotCallCount()).toBe(2))
+  })
+})

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -873,7 +873,7 @@ function OutputsDownloadDialog({
  *  按钮 "套用此配置" → confirm → PUT version config → navigate train phase 页。
  *  user 在 train 页可编辑后点 "开始训练" → 创建新 task（同 version 多 task）。
  */
-function SnapshotConfigTab({ task }: { task: Task | null }) {
+export function SnapshotConfigTab({ task }: { task: Task | null }) {
   const { t } = useTranslation()
   const navigate = useNavigate()
   const { toast } = useToast()
@@ -883,16 +883,22 @@ function SnapshotConfigTab({ task }: { task: Task | null }) {
   const [applying, setApplying] = useState(false)
   const [confirmApply, setConfirmApply] = useState(false)
 
+  // 父组件每 2s 浅 clone task 让 elapsed time 走表（QueueDetailPage:133），
+  // 用 [task] 作 deps 会让 snapshot config 也跟着 2s 重拉，浏览器闪烁卡顿。
+  // snapshot 是 task 启动时冻结的不可变数据 —— 只在 id 变 / pending→running
+  // 时拉一次即可（started_at null→number 那一刻 snapshot 才落盘）。
+  const taskId = task?.id ?? null
+  const startedAt = task?.started_at ?? null
   useEffect(() => {
-    if (!task) { setLoading(false); return }
+    if (taskId == null) { setLoading(false); return }
     let cancelled = false
     setLoading(true)
-    void api.getTaskSnapshotConfig(task.id)
+    void api.getTaskSnapshotConfig(taskId)
       .then((r) => { if (!cancelled) { setData(r); setError(null) } })
       .catch((e) => { if (!cancelled) setError(String(e)) })
       .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
-  }, [task])
+  }, [taskId, startedAt])
 
   const apply = async () => {
     if (!task || !data) return

--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -24,6 +24,15 @@ beforeEach(() => {
         headers: new Headers({ 'content-type': 'application/json' }),
       } as Response)
     }
+    // listQueue('running') — 默认无运行中任务（个别 case 内通过 mockImplementationOnce 覆盖）
+    if (url.startsWith('/api/queue') && (init?.method ?? 'GET') === 'GET') {
+      return Promise.resolve({
+        ok: true, status: 200,
+        json: async () => ({ items: [] }),
+        text: async () => '{"items":[]}',
+        headers: new Headers({ 'content-type': 'application/json' }),
+      } as Response)
+    }
     // enqueueGenerate
     if (url.endsWith('/api/generate') && init?.method === 'POST') {
       lastEnqueueBody = JSON.parse(String(init.body))
@@ -130,6 +139,39 @@ describe('GeneratePage 端到端 smoke', () => {
     await user.click(screen.getByRole('button', { name: '单图' }))
 
     expect(promptArea).toHaveValue('my custom prompt')
+  })
+
+  it('训练 / reg-ai 等任务在跑时，禁用生成按钮 + 鼠标 hover tooltip 说明原因', async () => {
+    // listQueue('running') 默认返 [] —— 覆盖这次返回 1 个 running task。
+    // /api/queue 默认排除 generate task（client.ts:1918），所以这里返的就是
+    // train / reg-ai 等抢 GPU 的任务。
+    const previousImpl = fetchMock.getMockImplementation()
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.startsWith('/api/queue') && (init?.method ?? 'GET') === 'GET') {
+        const running = {
+          id: 42, name: 'train', config_name: 'train', status: 'running',
+          priority: 0, created_at: 0, started_at: 0, finished_at: null,
+          pid: 1234, exit_code: null, output_dir: null, error_msg: null,
+        }
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({ items: [running] }),
+          text: async () => `{"items":[${JSON.stringify(running)}]}`,
+          headers: new Headers({ 'content-type': 'application/json' }),
+        } as Response)
+      }
+      return previousImpl ? previousImpl(url, init) : Promise.resolve({
+        ok: false, status: 404, json: async () => null, text: async () => '',
+        headers: new Headers(),
+      } as Response)
+    })
+
+    setup()
+
+    const btn = await screen.findByRole('button', { name: /开始生成/ })
+    await waitFor(() => expect(btn).toBeDisabled())
+    expect(btn).toHaveAttribute('title', expect.stringContaining('#42'))
+    expect(screen.getByText(/等队列 #42 完成/)).toBeInTheDocument()
   })
 
   it('刷新后恢复左侧生成参数，但不恢复当前生成结果', async () => {

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   api,
@@ -124,6 +124,10 @@ export default function GeneratePage() {
   })
   const [datasetPickerOpen, setDatasetPickerOpen] = useState(false)
   const [logOpen, setLogOpen] = useState(false)
+  // 训练 / reg-ai / 打标等 GPU 任务在跑时，禁用生成防 VRAM 竞争（driver 抢
+  // 3D / Copy engine 触发图像渲染卡顿，甚至训练进程 OOM）。listQueue 默认
+  // 不含 generate 任务自身，所以自己生成时不会自锁。
+  const [activeBlockingTask, setActiveBlockingTask] = useState<Task | null>(null)
   // commit 16：图片历史栏。点击历史项 → 主预览替换为该项封面
   const history = useGenerateHistory()
   const [historyOverride, setHistoryOverride] = useState<HistoryEntry | null>(null)
@@ -168,8 +172,22 @@ export default function GeneratePage() {
     }
   }, [mode, xDraft, yDraft])
 
+  const refreshBlockingTask = useCallback(async () => {
+    try {
+      const running = await api.listQueue('running')
+      setActiveBlockingTask(running.length > 0 ? running[0] : null)
+    } catch {
+      // 拉队列失败时不阻塞生成 — bug 修保守，宁愿放过也别误锁。
+    }
+  }, [])
+
+  useEffect(() => {
+    void refreshBlockingTask()
+  }, [refreshBlockingTask])
+
   // SSE：task_state_changed 触发 task refresh；monitor_state_updated 推 sample 列表。
   useEventStream((evt) => {
+    if (evt.type === 'task_state_changed') void refreshBlockingTask()
     const tid = taskIdRef.current
     if (tid == null) return
     if (evt.type === 'task_state_changed' && evt.task_id === tid) {
@@ -532,7 +550,12 @@ export default function GeneratePage() {
                 className="btn btn-primary flex-1"
                 style={{ padding: 12, fontWeight: 600, justifyContent: 'center' }}
                 onClick={handleGenerate}
-                disabled={busy}
+                disabled={busy || activeBlockingTask !== null}
+                title={
+                  activeBlockingTask
+                    ? t('generate.blockedByActiveTask', { id: activeBlockingTask.id })
+                    : undefined
+                }
               >
                 {generateLabel}
               </button>
@@ -544,7 +567,13 @@ export default function GeneratePage() {
               {!cancelable && (
                 <div className="font-mono text-xs text-fg-tertiary text-right" style={{ lineHeight: 1.3 }}>
                   <div>{width}×{height}</div>
-                  <div>{busy ? t('generate.generating') : t('generate.sharedGpu')}</div>
+                  <div>
+                    {busy
+                      ? t('generate.generating')
+                      : activeBlockingTask
+                        ? t('generate.blockedByActiveTaskHint', { id: activeBlockingTask.id })
+                        : t('generate.sharedGpu')}
+                  </div>
                 </div>
               )}
             </div>

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -49,6 +49,20 @@ def test_cached_latent_invalidates_when_resolution_bucket_changes(tmp_path: Path
     assert cached._is_cache_valid(img_path, npz_path) is True
 
 
+def test_image_dataset_loads_caption_utils_when_prefer_json(tmp_path: Path) -> None:
+    """Regression: dataset.py 算 caption_utils.py 路径时少回溯一层 parent 会让
+    JSON caption 模式静默 fallback 到 TXT（utils/ 在仓库根，不在 runtime/utils/）。"""
+    pytest.importorskip("torch")
+    from runtime.training.dataset import ImageDataset
+
+    dataset = ImageDataset(tmp_path, prefer_json=True)
+    assert dataset.caption_utils is not None, (
+        "prefer_json=True 应启用 JSON caption 模式 — None 说明 caption_utils.py 路径解析失败"
+    )
+    for key in ("load_and_build", "load_json", "normalize", "build"):
+        assert key in dataset.caption_utils
+
+
 def test_parse_repeat_kohya_prefix() -> None:
     assert datasets.parse_repeat("5_concept") == (5, "concept")
     assert datasets.parse_repeat("12_a_long_name") == (12, "a_long_name")


### PR DESCRIPTION
三条 0.10.0 引入的 silent regression bundle 走 hotfix（用户都不会立刻看出问题但实际损害），squash merge 后一起进 0.10.1。

---

## Fix 1 — `caption_utils.py` 路径错算导致 JSON caption 模式静默失效

### 背景

用户训练日志报警告：

```
WARNING - caption_utils.py 未找到: G:\AnimaLoraStudio\runtime\utils\caption_utils.py
```

`runtime/training/dataset.py:109` 用 `Path(__file__).parent.parent / "utils"` 拼路径。ADR 0003 PR-A 把 `utils/` 从 `runtime/utils/` 搬到仓库根后，少删了一层 `.parent`，从此永远找不到。原注释 `等价原 runtime/utils/...，见 ADR 0003 PR-A` 写错了。

### 后果

silent regression：

- `prefer_json=True` 变成 no-op，强制走 TXT 模式
- JSON caption 的**分类 shuffle**失效（character / appearance / action 分组洗牌全废）
- tag_worker 写入 `meta.trigger` 的**触发词首位 + 不参与 shuffle** 特性失效
- loss 曲线照常下降，silent regression，模型实际学到的 caption 分布跟期望不一致

### 改动

- `runtime/training/dataset.py:109` — `.parent.parent` → `.parent.parent.parent`，回溯三层到仓库根；改对误导注释
- `tests/test_datasets.py` — 新增 `test_image_dataset_loads_caption_utils_when_prefer_json` regression test

---

## Fix 2 — 训练 / reg-ai 等 GPU 任务在跑时禁用测试页生成按钮

### 背景

训练 task 跑的时候点测试页 Generate，Windows Task Manager 看 GPU 3D / Copy engine 互抢，渲染卡顿，严重时训练进程 OOM。原 sidebar 只标了 `与训练共享 GPU` 文字提示，没真禁用按钮。

### 改动

- 进页 + 每次 `task_state_changed` SSE 调 `listQueue('running')` 检测；`/api/queue` 默认排 generate 任务自身（`client.ts:1918`），不会自锁
- 检测到 running task → Generate 按钮 `disabled` + `title="队列任务 #N 正在占用 GPU，等它完成或取消"`
- 右下 `sharedGpu` 提示同步切到 `等队列 #N 完成`
- 队列任务结束 SSE → 自动恢复可点
- 新 i18n keys `generate.blockedByActiveTask` / `blockedByActiveTaskHint`（zh + en）
- vitest 加 mock running task 端到端断言

---

## Fix 3 — 关联配置 tab 每 2s 重拉 snapshot config 导致浏览器卡顿

### 背景

用户反馈：训练运行期间打开任务详情 → 关联配置 tab 不断刷新，浏览器吃力。

根因 = React deps trap。`QueueDetailPage:131-135` 父组件每 2s 浅 clone task `setTask((t) => (t ? { ...t } : t))` 让 `fmtDuration` 显示的 elapsed time 走表。`SnapshotConfigTab` 的 `useEffect(..., [task])` 用对象引用作 deps —— 父 2s 浅 clone 出新引用，effect 重新 fire，重新 `GET /api/queue/:id/snapshot/config`。训练运行期间每 2s 一个无意义 GET + loading flash。

### 改动

- `QueueDetail.tsx` SnapshotConfigTab — deps 改 `[task?.id, task?.started_at]` 双 primitive
  - 同 task 浅 clone → 引用新但值不变 → 不重拉
  - 切到另一个 task → id 变 → 重拉
  - pending → running 转换 → started_at null→number → 重拉一次（snapshot 那一刻才落盘）
- 加详细注释解释 deps trap
- 新增 `QueueDetail.test.tsx` regression test：父 5 次浅 clone 断言 fetch 仍 1 次 + pending→running 重拉一次

snapshot config 是 task 启动时冻结的不可变数据（ADR 0007 §11.7），本来就不该跟 task 一起重拉。

---

## 测试

后端：
- `python -m pytest tests/test_datasets.py -v` 15/15 绿
- Fix 1 regression test 抓 bug 验证过：临时 revert dataset.py 后该测试 FAIL，warning 输出和用户报告**字字一致**
- `python -m studio test` 另有 42 个 pre-existing failure（pydantic + Python 3.9 `typing.Literal` 不兼容 / RTX 5090 sm_120 vs PyTorch / 缺 `lycoris`），与本 PR 无关，stash 后在 master HEAD 复现确认

前端：
- `npx vitest run src/pages/tools/Generate.test.tsx` 6/6 绿
- `npx vitest run src/pages/QueueDetail.test.tsx` 2/2 绿；Fix 3 regression test 抓 bug 验证过：临时 revert 只 deps 那行（保留 export），该测试 FAIL 报 `expected 6 to be 1`（5 次浅 clone + 1 初次 = 6 次 fetch），确认 deps 切回 `[task]` 立刻复现
- `npm run lint` 0 errors（1 pre-existing warning 在另一处 useEffect）
- `npx tsc --noEmit` 干净

## 后续（maintainer，按 CONTRIBUTING §Hotfix）

1. squash merge 本 PR 进 master
2. 直接在 master 上 bump 到 `v0.10.1`（`studio/__init__.py` + `package.json` + `release_notes.yaml` 加 0.10.1 block + 跑 `bump_version.py` 重渲 CHANGELOG + `README.md`）
3. 打 `v0.10.1` tag + GitHub Release
4. `git checkout dev && git merge master && git push origin dev`（关键，否则 dev 缺修复）

🤖 Generated with [Claude Code](https://claude.com/claude-code)