### PR TITLE
chore: release flow 文档 + 工具清理（v0.10.1 hotfix 复盘）

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -241,6 +241,13 @@ git commit -m "chore(release): v0.X.0"
 git push origin dev
 ```
 
+**Release commit body 默认空 / 极简**。release commit 是机械的 version bump
++ render，不是 fix 真正发生的地方。fix 的根因 / 修法已经在原 fix commit 的
+message + PR description 里；CHANGELOG.md / GitHub Release body 承担用户视角
+描述。Release commit body 重复这些信息反而模糊 git log archeology 的层次
+（commit message 给工程师、release notes 给用户、各司其职）。例：v0.9.1 /
+v0.10.0 release commit body 都是空。
+
 ### 3. 开 Release PR：dev → master
 
 - **Base = master，compare = dev**
@@ -265,7 +272,8 @@ git push origin v0.X.0
 
 - 去 `https://github.com/WalkingMeatAxolotl/AnimaLoraStudio/releases`
 - 找到刚 push 的 tag → **Create release from tag**
-- **Title**：`v0.X.0 — <主题>`
+- **Title**：`vX.Y.Z`（纯版本号，**不**带主题 —— 仓库历史 release title 都是
+  这风格：v0.10.0 / v0.9.1 / v0.8.3 ...。tag 的 message 才带主题，见 §5）
 - **Body**：复制 [`CHANGELOG.md`](CHANGELOG.md) 对应段
 - 勾选 **Set as the latest release**
 - Publish

--- a/docs/release-notes-spec.md
+++ b/docs/release-notes-spec.md
@@ -4,6 +4,33 @@
 **不需要任何额外问问题**就能：(1) 知道改哪个文件、(2) 从哪儿拿内容、
 (3) 用什么结构 / 风格 / 语气写、(4) 跑哪个工具校验。
 
+> **核心原则 —— 三 surface 共享文本，全部 user-facing**
+>
+> `release_notes.yaml` 的 `summary` + `detail` 文本会被同时渲染到三个用户
+> 可见 surface：
+>
+> 1. **Studio Web UI** Settings → 系统 → 版本卡片：summary 一行展示 + 点开
+>    detail modal
+> 2. **`CHANGELOG.md`** 仓库根 + GitHub repo 主页可达；`render-changelog` 从
+>    yaml 派生，summary + detail 都进
+> 3. **GitHub Release body**（`/releases` 每个 tag 一页）；maintainer 手动从
+>    CHANGELOG 复制对应段
+>
+> 三处共享同一份 yaml，**summary 和 detail 都得 user 视角写**。旧说法
+> 「summary 给用户，detail 给开发者技术词随便用」错了 —— detail 在 CHANGELOG
+> 和 Release body 两个用户表面同样可见。技术 ref（实现路径 / 内部符号名 /
+> 重构理由 / 设计权衡 / 替代方案对比）属于 **commit message + PR
+> description**，不进 yaml。
+>
+> 4 层 archeology 分工：
+>
+> | 层 | 受众 | 内容 |
+> |---|---|---|
+> | Commit message | git blame / 工程师 | atomic 改动的根因 / 修法 |
+> | PR description | reviewer / 历史考古 | 设计权衡、替代方案、scope |
+> | CHANGELOG / Release body | 升级的用户 | 「升上去看到什么变化」 |
+> | ADR | 架构决策回溯 | 「为啥选这条路不选另一条」 |
+
 ## 1. 单一来源：`release_notes.yaml`
 
 **永远改 `release_notes.yaml`；永远不要手改 `CHANGELOG.md`。**
@@ -138,6 +165,9 @@ python tools/bump_version.py bump --version 0.6.1 --date 2026-05-13
 - **末尾带 `（#N）`**：链接 PR；多 PR 就 `（#N, #M）`，最多 3 个
 - **specific 而不是 generic**：「修复 Danbooru 403」比「修复一些 bug」好
 - **避开技术术语**（除非用户必须知道）：「训练监控加 GPU 占用」比「`_StatsThread` 推 SSE event」好
+- **三 surface 一致 user 视角**：写完想象这条 entry 同时出现在 Studio 版本
+  卡片、CHANGELOG、GitHub Release body —— 都是给升级用户看的，不是给
+  reviewer 或 git blame 来的人。技术 ref 进 commit / PR，不进这里
 
 ### Don't
 
@@ -172,8 +202,13 @@ python tools/bump_version.py bump --version 0.6.1 --date 2026-05-13
 ### Don't
 
 - ❌ 重复 summary 已经说的话
-- ❌ 把 commit message 原样 paste 进来
+- ❌ 把 commit message 原样 paste 进来 —— detail 也是 user-facing surface
+  （CHANGELOG / Release body 都展示它）
 - ❌ 写实现细节而不写用户能感知的部分（"`_StatsThread` 用 nvidia-ml-py 而不是 pynvml" → 用户不在乎，跳过）
+- ❌ 写「实现路径」/「内部类名」/「重构理由」/「替代方案对比」/「设计权衡」
+  —— 这些属于 commit message 或 PR description，不进 yaml。例如
+  「`useEffect` deps 用 `[task]` 对象引用，React 浅 clone 触发重拉」就是
+  典型踩线 —— 用户不知道 `useEffect` 是什么
 - ❌ 单行 detail（一行能写完的内容直接进 summary）
 
 ### 例
@@ -305,6 +340,8 @@ next: review changes, then:
 | `pr_refs: ["18", "34"]` | 必须是 int 不是 str | `pr_refs: [18, 34]` |
 | `kind: refactor` | 不在白名单；refactor 通常用户不感知 | 跳过这条 PR，或者用 `changed` / `improved` |
 | `summary: "新增 LLM tagger（#18）。修复 Danbooru 403（#41）。"` | 两个独立改动塞一行 | 拆成两条 entry |
+| `detail: "useEffect deps 用 [task] 对象引用，React 浅 clone 触发重拉..."` | detail 是用户 surface（CHANGELOG / Release body），不应露 React 内部实现 | `detail: "关联配置 tab 训练运行期间每 2 秒重拉，浏览器卡顿..."` |
+| `detail: "ADR 0003 PR-A 把 utils/ 搬到根后 Path(__file__).parent.parent 少回溯一层..."` | 实现路径细节属于 commit message / PR | `detail: "v0.10.0 引入的路径错算让训练找不到 JSON caption 工具文件..."` |
 | 写完 yaml 后直接 commit | 没跑 `bump_version.py validate` | 先校验，错了 CI 也会拒 |
 
 ## 10. 维护这份文档

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -29,6 +29,19 @@ from typing import Any, Optional
 
 import yaml
 
+# Windows Python stdout 默认 cp932 / cp936（活动 code page），打中文校验
+# 信息直接 UnicodeEncodeError 挂掉。每次跑前 `set PYTHONIOENCODING=utf-8`
+# 容易忘 —— 工具自带正确编码，跨平台一致行为。
+# `reconfigure` 是 Py3.7+；3.9+ 一直支持。
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        try:
+            _stream.reconfigure(encoding="utf-8")
+        except Exception:
+            # 罕见环境（如 IO 被替换成不支持 reconfigure 的对象）忽略，
+            # 让 caller 走原编码 —— 至少非中文 path 不会被这行打挂。
+            pass
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 YAML_PATH = REPO_ROOT / "release_notes.yaml"
 CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"


### PR DESCRIPTION
## 背景

跑 v0.10.1 hotfix 流程时踩到四个坑，前三条值得 codify 进 docs / 工具，第四条只是单纯注意（不入文档）。本 PR 修前三条。

## 改动

### 1. CONTRIBUTING.md — Release title 纯 `vX.Y.Z`（line 268）

原文：`**Title**：v0.X.0 — <主题>`

仓库历史所有 GitHub release title 实际都是纯 `vX.Y.Z`：

```
v0.10.0	Latest
v0.9.1
v0.9.0
v0.8.3
v0.8.2
```

按文档差点写成 `v0.10.1 — hotfix 三修`，被 maintainer 叫停才发现文档跟实际脱钩。改文档对齐实际。tag message 才带主题（`git tag -a v0.10.1 -m "v0.10.1 — hotfix 三修"`），见 §5。

### 2. CONTRIBUTING.md — Release commit body 极简约定（line 235 后补一段）

新规则：release commit body 默认空 / 极简。

理由：release commit 是机械的 version bump + render，不是 fix 真正发生的地方。fix 根因 / 修法已经在原 fix commit + PR description 里；CHANGELOG / GitHub Release body 承担用户视角描述。Release commit body 重复反而模糊 git log archeology 的层次（commit message 给工程师、release notes 给用户、各司其职）。

历史 release commit (`v0.10.0` / `v0.9.1`) 都是空 body 一直按此风格，这次只是把惯例写进文档。

### 3. docs/release-notes-spec.md — 三 surface 全 user-facing

旧 framing「summary 给用户 / detail 给开发者技术词随便用」错了。yaml summary + detail 会被同时渲染到三处用户表面：

1. Studio Web UI Settings → 系统 → 版本卡片
2. CHANGELOG.md（仓库根 + GitHub repo 主页）
3. GitHub Release body（maintainer 手动从 CHANGELOG 复制）

三处共享同一份 yaml，**detail 跟 summary 同等 user-facing**。技术 ref（实现路径 / 内部符号 / 重构理由 / 设计权衡 / 替代方案）属于 commit message + PR description，不进 yaml。

文首加 callout box + 4 层 archeology 表（commit / PR / CHANGELOG / ADR 各司其职）；§5 Do 加一条；§6 Don't 改加两条；§9 anti-pattern 表加两行（以本次 hotfix 的「useEffect deps 用 [task]」/「Path(__file__).parent.parent 少回溯一层」为反例素材）。

### 4. tools/bump_version.py — force utf-8 stdout/stderr

Windows Python stdout 默认 cp932 / cp936（活动 code page），打 yaml validate 中文校验信息时直接挂：

```
UnicodeEncodeError: 'cp932' codec can't encode character '虑' ...
```

2026-05-26 发 v0.10.1 hotfix 时第一次跑 validate 就翻车，要 `set PYTHONIOENCODING=utf-8` workaround。工具顶部 `sys.stdout.reconfigure(encoding="utf-8")` 一次性解决，跨平台一致；Linux / macOS no-op 无副作用。

## 测试

- 手跑 `python tools/bump_version.py validate`（**不**带 `PYTHONIOENCODING=utf-8` env）→ 输出 5 个中文 warning + `validate ok`，不再 UnicodeEncodeError
- 文档改动纯文字 / 无 schema 变更，不影响现有 yaml entries

## 不做的部分

#4 释放 commit body 默认空 这条只对 release commit 适用 —— 普通 fix / feat commit 应该写详细 body（commit body 是 archeology 主表面）。文档只在 release flow 章节里补这条，不全局。

🤖 Generated with [Claude Code](https://claude.com/claude-code)