### PR TITLE
hotfix: load-in-test 缓存替换 + bundle 跨机器模型路径

### DIFF
--- a/studio/presets_io.py
+++ b/studio/presets_io.py
@@ -35,6 +35,9 @@ class PresetError(Exception):
     """预设 I/O 错误。"""
 
 
+_WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
+
 def _absolutize_model_paths(data: dict[str, Any]) -> dict[str, Any]:
     """规范化 4 个模型字段：相对路径 → REPO_ROOT 绝对；分隔符统一 POSIX `/`。
 
@@ -43,11 +46,18 @@ def _absolutize_model_paths(data: dict[str, Any]) -> dict[str, Any]:
     - Windows 上 `str(Path)` 给反斜杠（`G:\\foo`），PathPicker 给 POSIX
       （`G:/foo`），混存会让同一字段在不同来源下视觉不一致；统一 `as_posix()`
       让 yaml 落盘 + UI 显示一律 `/`
+    - 跨平台 bundle import：Windows 盘符路径（`G:/...`）在 POSIX 上
+      `Path.is_absolute()` 返 False，会被误当相对路径拼到 REPO_ROOT 下变成
+      `<repo>/G:/...`。这里额外用正则识别盘符前缀视作绝对，避免静默 mangle。
+      （路径在异机器上仍然不可解析，但保持原样让 UI/日志能定位到原始来源。）
     不动 yaml 文件；下次保存自然落规范化后的形式。
     """
     for f in _MODEL_PATH_FIELDS:
         v = data.get(f)
         if isinstance(v, str) and v:
+            if _WIN_DRIVE_RE.match(v):
+                data[f] = v.replace("\\", "/")
+                continue
             p = Path(v)
             if not p.is_absolute():
                 p = (REPO_ROOT / p).resolve()

--- a/studio/services/train_io.py
+++ b/studio/services/train_io.py
@@ -674,6 +674,17 @@ def import_bundle(
                             except Exception:
                                 raw = {}
                         if isinstance(raw, dict):
+                            # 4 全局模型路径字段不在 PROJECT_SPECIFIC_FIELDS 里，
+                            # bundle 里带的源机器绝对路径（如 `G:/models/...`）会
+                            # 原样落盘，跨机器导入时被 `_absolutize_model_paths`
+                            # 拼成 `<repo>/G:/...`。对齐 fork_preset_for_version：
+                            # auto_sync_paths=ON 时用本机全局值覆盖 4 字段；OFF
+                            # 时尊重 bundle 内容（盘符识别已在
+                            # _absolutize_model_paths 修过，POSIX 下不再误拼前缀）。
+                            from . import presets as _presets_svc
+                            from . import model_downloader as _md
+                            if _presets_svc._auto_sync_paths():
+                                raw.update(_md.default_paths_for_new_version())
                             try:
                                 _vc.write_version_config(p, v, raw, force_project_overrides=True)
                                 config_imported = True

--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -174,6 +174,54 @@ describe('GeneratePage 端到端 smoke', () => {
     expect(screen.getByText(/等队列 #42 完成/)).toBeInTheDocument()
   })
 
+  it('URL ?lora= 进入时 replace 缓存 LoRA list + clamp xDraft.loraIndex', async () => {
+    // 用户场景：localStorage 缓存里有旧 LoRA + xDraft 指 loraIndex=1（lora_ckpt 轴
+    // 绑第 2 条 LoRA）；从项目页 "在测试中加载" 跳过来，URL 带新 LoRA。
+    // 修前：append → loras=[旧, 新]（视觉拥挤）+ loraIndex=1 偶然合法；如果用户
+    //   之前没第 2 条 LoRA 但 loraIndex=1（脏 state）→ axisLoraMissing。
+    // 修后：replace → loras=[新]，loraIndex 越界 → clamp 到 0。
+    window.localStorage.setItem(
+      'studio:generate:params:v1',
+      JSON.stringify({
+        mode: 'single',
+        prompts: ['persist'],
+        negPrompt: '',
+        aspect: '1:1',
+        width: 1024, height: 1024,
+        steps: 25, cfgScale: 4, count: 1, seed: 0,
+        loras: [
+          { path: 'G:/old/cached.safetensors', scale: 1, project_id: 1, version_id: 1 },
+        ],
+        xDraft: { axis: 'lora_ckpt', raw: 'a, b', loraIndex: 5 },
+        yDraft: { axis: 'lora_scale', raw: '0.5, 1.0', loraIndex: 3 },
+        datasetPick: null,
+      })
+    )
+
+    const newLoraPath = 'G:/new/from_project.safetensors'
+    const search = `?lora=${encodeURIComponent(newLoraPath)}&projectId=2&versionId=3`
+    window.history.replaceState({}, '', `/tools/generate${search}`)
+
+    const user = userEvent.setup()
+    setup()
+    await waitForInitialLorasLoad()
+
+    // submit single，看 enqueue payload 里的 loras 只剩 URL 来的那条
+    await user.click(await screen.findByRole('button', { name: /开始生成/ }))
+    await waitFor(() => expect(lastEnqueueBody).not.toBeNull())
+    const body = lastEnqueueBody!
+    expect(body.lora_configs).toEqual([
+      { path: newLoraPath, scale: 1.0, project_id: 2, version_id: 3 },
+    ])
+
+    // localStorage 里 xDraft/yDraft.loraIndex 应被 clamp（5/3 都越界）
+    const stored = JSON.parse(window.localStorage.getItem('studio:generate:params:v1')!)
+    expect(stored.xDraft.loraIndex).toBe(0)
+    expect(stored.yDraft.loraIndex).toBe(0)
+    // URL query 已被 replaceState 清掉
+    expect(window.location.search).toBe('')
+  })
+
   it('刷新后恢复左侧生成参数，但不恢复当前生成结果', async () => {
     const user = userEvent.setup()
     const first = setup()

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -100,6 +100,7 @@ export default function GeneratePage() {
         yDraft: clamp(p.yDraft),
       }
     })
+    setUrlConsumedKey((k) => k + 1)
     const url = new URL(window.location.href)
     url.searchParams.delete('lora')
     url.searchParams.delete('projectId')
@@ -122,6 +123,11 @@ export default function GeneratePage() {
   // 没法重试也没法取消（status=failed 时 cancelable=false）
   const [submitting, setSubmitting] = useState(false)
   const [currentTask, setCurrentTask] = useState<Task | null>(null)
+  // URL ?lora= 消费计数：bump 一次让 SidebarLoras 整块 remount，强制内部
+  // InlineLoraPicker 用新 value 重新初始化 pid/vid（picker 内 useState 只
+  // 一次性从 props.value 取 projectId/versionId，后续 props 变化不会同步，
+  // 不 remount 就会看到下拉 / chip 还卡在旧缓存项目）。
+  const [urlConsumedKey, setUrlConsumedKey] = useState(0)
   // monitor 走 useMonitorProgress hook (PR #37 增量协议)：currentTask 变 →
   // hook 自动重拉快照 + 订阅 SSE delta 合并；本组件只用 samples 字段，其余
   // 字段在这页生成场景下不需要。
@@ -428,12 +434,18 @@ export default function GeneratePage() {
                   <h3 className="m-0 text-md font-semibold">LoRA</h3>
                   <span className="text-xs text-fg-tertiary">{t('generate.loraHint')}</span>
                 </div>
-                <SidebarLoras loras={loras} onChange={setLoras} projectLoras={projectLoras} />
+                <SidebarLoras
+                  key={`single-${urlConsumedKey}`}
+                  loras={loras}
+                  onChange={setLoras}
+                  projectLoras={projectLoras}
+                />
               </div>
             )}
 
             {mode === 'xy' && (
               <SidebarXYAxes
+                key={`xy-${urlConsumedKey}`}
                 xDraft={xDraft}
                 yDraft={yDraft}
                 onXChange={setXDraft}

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -70,7 +70,10 @@ export default function GeneratePage() {
   const setLoras = (loras: LoraEntry[]) => setPrefs((p) => ({ ...p, loras }))
 
   // LoRA 预填 via URL query (?lora=<path>&projectId=N&versionId=N)
-  // Overview StatusBanner "在测试中加载" CTA 跳进来时，把 LoRA 直接塞入 loras。
+  // Overview StatusBanner "在测试中加载" CTA 跳进来时，URL 是显式 "测这条 LoRA"
+  // 意图——丢掉缓存 list 直接 replace 成 [urlLora]，避免旧/已删 LoRA 与新条目
+  // 并排出现（旧 append 行为会让 xDraft.loraIndex 指向脏 slot，submit 抛
+  // axisLoraMissing）。同时 clamp xDraft/yDraft.loraIndex 到合法范围。
   // 用 history.replaceState 清掉 query 避免刷新时重复触发。
   useEffect(() => {
     const sp = new URLSearchParams(window.location.search)
@@ -79,15 +82,22 @@ export default function GeneratePage() {
     const projectId = sp.get('projectId')
     const versionId = sp.get('versionId')
     setPrefs((p) => {
-      if (p.loras.some((l) => l.path === lora)) return p
+      const newLoras: LoraEntry[] = [{
+        path: lora,
+        scale: 1.0,
+        project_id: projectId ? Number(projectId) : null,
+        version_id: versionId ? Number(versionId) : null,
+      }]
+      const clamp = (d: XYAxisDraft | null): XYAxisDraft | null => {
+        if (!d || d.loraIndex == null) return d
+        if (d.loraIndex < newLoras.length) return d
+        return { ...d, loraIndex: 0 }
+      }
       return {
         ...p,
-        loras: [...p.loras, {
-          path: lora,
-          scale: 1.0,
-          project_id: projectId ? Number(projectId) : null,
-          version_id: versionId ? Number(versionId) : null,
-        }],
+        loras: newLoras,
+        xDraft: clamp(p.xDraft) ?? p.xDraft,
+        yDraft: clamp(p.yDraft),
       }
     })
     const url = new URL(window.location.href)

--- a/tests/test_presets_io.py
+++ b/tests/test_presets_io.py
@@ -203,3 +203,27 @@ def test_write_preset_absolutizes_relative_paths(presets_dir: Path) -> None:
     raw = yaml.safe_load((presets_dir / "alpha.yaml").read_text(encoding="utf-8"))
     assert Path(raw["transformer_path"]).is_absolute()
     assert "\\" not in raw["transformer_path"]
+
+
+def test_absolutize_preserves_windows_drive_letter_on_posix(monkeypatch) -> None:
+    """跨平台 bundle import：Windows 盘符 (`G:/...`) 在 POSIX 上
+    `Path.is_absolute()` 返回 False，会被误拼到 REPO_ROOT 下变成
+    `<repo>/G:/...`。盘符前缀必须被识别为绝对，原样保留（含反斜杠归一为 `/`）。
+
+    monkeypatch 强制 Path.is_absolute 返回 False，模拟 Linux 处理 Windows 盘符的
+    行为 —— 否则在 Windows 上跑 `Path("G:/foo").is_absolute()` 本来就是 True，
+    没法 catch 修前的 bug。"""
+    from studio import presets_io
+    from studio.presets_io import _absolutize_model_paths
+
+    monkeypatch.setattr(
+        presets_io.Path, "is_absolute", lambda self: False
+    )
+
+    data = {
+        "transformer_path": "G:/models/diffusion_models/anima.safetensors",
+        "vae_path": "D:\\anima\\vae.safetensors",
+    }
+    out = _absolutize_model_paths(data)
+    assert out["transformer_path"] == "G:/models/diffusion_models/anima.safetensors"
+    assert out["vae_path"] == "D:/anima/vae.safetensors"

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -241,3 +241,93 @@ def test_import_bad_zip(isolated, tmp_path: Path) -> None:
     bad.write_bytes(b"not a zip file at all")
     with db.connection_for(isolated["db"]) as conn, pytest.raises(train_io.TrainIOError):
         train_io.import_train(conn, bad)
+
+
+# ---------------------------------------------------------------------------
+# bundle import: 4 全局模型路径字段跨机器处理
+# ---------------------------------------------------------------------------
+
+
+def _build_bundle_with_config(
+    tmp_path: Path,
+    *,
+    transformer_path: str,
+) -> Path:
+    """构造一个最小 v2 bundle.zip：1 张训练图 + presets/config.yaml。
+
+    transformer_path 用来塞 "源机器" 的绝对路径，模拟跨机器导入场景。
+    """
+    import yaml
+    from studio.schema import TrainingConfig
+
+    cfg = TrainingConfig().model_dump(mode="python")
+    cfg["transformer_path"] = transformer_path
+
+    bundle = tmp_path / "in.bundle.zip"
+    with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr(
+            "manifest.json",
+            json.dumps({
+                "schema_version": 2,
+                "source": {"title": "Imported", "slug": "imported", "version_label": "v1"},
+                "includes": {"train": True, "config": True},
+            }),
+        )
+        zf.writestr("train/1_data/a.png", b"fake")
+        zf.writestr(
+            "presets/config.yaml",
+            yaml.safe_dump(cfg, allow_unicode=True, sort_keys=False),
+        )
+    return bundle
+
+
+def test_import_bundle_config_with_auto_sync_on_overrides_model_paths(
+    isolated, tmp_path: Path, monkeypatch
+) -> None:
+    """auto_sync_paths=ON（默认）：bundle 内 4 全局模型字段被本机 globals 覆盖。
+
+    源机器（Windows）导出的 `G:/models/foo.safetensors` 在异机器不可解析；
+    fork_preset_for_version 走的就是这个语义，bundle import 必须一致。
+    """
+    from studio.services import model_downloader, presets as preset_flow
+
+    monkeypatch.setattr(preset_flow, "_auto_sync_paths", lambda: True)
+    src_path = "G:/source-machine/anima.safetensors"
+    bundle = _build_bundle_with_config(tmp_path, transformer_path=src_path)
+
+    with db.connection_for(isolated["db"]) as conn:
+        result = train_io.import_bundle(conn, bundle, presets_base=tmp_path / "presets")
+
+    assert result["stats"]["config_imported"] is True
+    p = result["project"]
+    v = result["version"]
+    from studio.services import version_config
+    cfg = version_config.read_version_config(p, v)
+    expected = model_downloader.default_paths_for_new_version()["transformer_path"]
+    assert cfg["transformer_path"] == Path(expected).as_posix()
+    # 源路径已被覆盖，不残留
+    assert cfg["transformer_path"] != src_path
+
+
+def test_import_bundle_config_with_auto_sync_off_preserves_windows_path(
+    isolated, tmp_path: Path, monkeypatch
+) -> None:
+    """auto_sync_paths=OFF：尊重 bundle 内的绝对路径；POSIX 上 Windows 盘符
+    不被 REPO_ROOT 误拼成 `<repo>/G:/...`（盘符识别在 _absolutize_model_paths 里）。"""
+    from studio.services import presets as preset_flow
+
+    monkeypatch.setattr(preset_flow, "_auto_sync_paths", lambda: False)
+    src_path = "G:/source-machine/anima.safetensors"
+    bundle = _build_bundle_with_config(tmp_path, transformer_path=src_path)
+
+    with db.connection_for(isolated["db"]) as conn:
+        result = train_io.import_bundle(conn, bundle, presets_base=tmp_path / "presets")
+
+    assert result["stats"]["config_imported"] is True
+    p = result["project"]
+    v = result["version"]
+    from studio.services import version_config
+    cfg = version_config.read_version_config(p, v)
+    # 路径原样保留（POSIX 形式）；关键点是不会出现 REPO_ROOT 前缀
+    assert cfg["transformer_path"] == src_path
+    assert "G:/" in cfg["transformer_path"]


### PR DESCRIPTION
两个 0.10.x 引入的 bug，独立修。

## 1. Generate 页 "在测试中加载" 缓存污染

**症状**：从 project Overview 点 "在测试中加载" 跳到测试页 →
- 单图模式 LoRA 卡里同时显示新 LoRA + 旧/已删 LoRA
- picker 下拉显示的还是缓存项目，不是 URL 指定的项目
- 点击生成抛 \`axisLoraMissing: LoRA 绑定的 LoRA #2 不存在\`

**根因**：
- \`Generate.tsx\` URL useEffect 是 append 而非 replace —— 新 LoRA 被追加到 localStorage 缓存 list 末尾
- 缓存的 \`xDraft.loraIndex\` 可能指向新 list 不存在的 slot → \`draftToSpec\` 抛 \`axisLoraMissing\`
- \`InlineLoraPicker\` 内部 \`useState(initialPid)\` 一次性从 props.value 取 projectId/versionId，后续 props 变化不会同步 → 即便 setPrefs 替换了 loras，picker 下拉还卡在缓存项目

**修复** (Generate.tsx)：
- URL \`?lora=\` 视作显式 "测这条" 意图：replace loras = [urlLora]，不与缓存合并
- \`xDraft / yDraft.loraIndex\` 越界 → clamp 到 0
- bump \`urlConsumedKey\` 让 SidebarLoras / SidebarXYAxes 整块 remount，picker 用新 value 重新初始化

## 2. Bundle import 跨机器全局模型路径

**症状**：本地 (Windows) 导出 bundle 带 config，云端 (Linux) 导入后 \`transformer_path\` 等 4 字段变成 \`<repo>/G:/models/...\`（"models + 完整绝对路径"），训练 ckpt-not-found。

**根因**：
- \`import_bundle\` 写 version config 时只走 \`force_project_overrides=True\`，覆盖 \`PROJECT_SPECIFIC_FIELDS\`（data_dir / output_dir 等）；**4 个全局模型字段不在清单里**，源机器 Windows 绝对路径原样落到目标盘
- \`_absolutize_model_paths\` 在 POSIX 上把 \`G:/models/...\` 误判为相对路径，\`(REPO_ROOT / "G:/models/...").resolve()\` 拼成 \`<repo>/G:/models/...\`

**修复**：
- \`train_io.py\` import_bundle config branch：对齐 \`fork_preset_for_version\` 语义。\`auto_sync_paths=ON\` （默认 "项目接管"）→ 用 \`default_paths_for_new_version()\` 覆盖 4 字段；OFF → 尊重 bundle 内容
- \`presets_io.py _absolutize_model_paths\`：加 \`_WIN_DRIVE_RE\` 正则识别 Windows 盘符前缀视作绝对，避免 POSIX 上静默 mangle

## 测试

- \`Generate.test.tsx\`：URL ?lora= 进入时 enqueue payload 的 lora_configs 只剩 URL 那条；xDraft/yDraft.loraIndex 越界值 clamp 到 0；URL query 被 replaceState 清掉。验证过 stash fix 跑测会失败（received [cached, new] vs expected [new]）。
- \`test_presets_io.py\`：\`_WIN_DRIVE_RE\` 短路 \`Path.is_absolute\`，monkeypatch 强制 \`is_absolute=False\` 模拟 POSIX 行为下盘符不被拼前缀。
- \`test_train_io.py\`：构造含 \`presets/config.yaml\` 的最小 v2 bundle，分别验证 \`auto_sync_paths=ON\` 时 4 字段被本机 globals 覆盖、\`OFF\` 时尊重 bundle 内容。验证过 stash fix 跑测：\`auto_sync_on\` case fail（路径仍是源机器 G:/source-machine/...）。

## Test plan

- [x] vitest \`Generate.test.tsx\` 7 tests pass
- [x] pytest \`test_presets_io.py / test_train_io.py / test_version_config.py\` 50 tests pass
- [ ] Push 后 merge 前手测：从 project Overview 点 "在测试中加载"，确认 picker 下拉、chip 列表、submit payload 都是 URL 指定的项目，不是缓存项目
- [ ] Linux 环境跑一次 \`test_presets_io.py::test_absolutize_preserves_windows_drive_letter_on_posix\` 和 \`test_train_io.py::test_import_bundle_config_with_auto_sync_off_preserves_windows_path\`（Windows 上是 trivial pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)