### PR TITLE
feat(web): 浏览器上传进度条 + 网速 + ETA

### DIFF
--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1249,6 +1249,69 @@ async function req<T>(
   return (await resp.json()) as T
 }
 
+/** 上传进度事件 — 与 XMLHttpRequestEventTarget#progress 字段一一对应。 */
+export interface UploadProgressEvent {
+  loaded: number
+  total: number
+  /** total === 0 时为 false（服务端没回 Content-Length 或 chunked），ETA 无法计算。 */
+  lengthComputable: boolean
+}
+
+/**
+ * XHR-based multipart upload；fetch() 没有 request body progress 事件，所以
+ * 上传进度必须走 XHR。错误格式跟 `req` 对齐（ApiError + 解析 detail）。
+ */
+async function xhrUpload<T>(
+  url: string,
+  body: FormData,
+  onProgress?: (e: UploadProgressEvent) => void,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    xhr.open('POST', url, true)
+    xhr.responseType = 'text'
+    if (onProgress) {
+      xhr.upload.onprogress = (e) => {
+        onProgress({
+          loaded: e.loaded,
+          total: e.total,
+          lengthComputable: e.lengthComputable,
+        })
+      }
+    }
+    xhr.onload = () => {
+      const text = xhr.responseText
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          resolve(text ? (JSON.parse(text) as T) : (undefined as T))
+        } catch {
+          reject(new Error('invalid JSON response'))
+        }
+        return
+      }
+      let detail = `${xhr.status} ${xhr.statusText}`
+      let rawDetail: unknown = null
+      try {
+        const j = JSON.parse(text)
+        if (typeof j?.detail === 'string') {
+          detail = j.detail
+        } else if (j?.detail && typeof j.detail === 'object') {
+          rawDetail = j.detail
+          detail = (j.detail as { message?: string }).message ?? JSON.stringify(j.detail)
+        }
+      } catch {
+        /* body 不是 JSON：保持 statusText */
+      }
+      const err = new Error(detail) as ApiError
+      err.status = xhr.status
+      err.detail = rawDetail
+      reject(err)
+    }
+    xhr.onerror = () => reject(new Error('network error'))
+    xhr.send(body)
+  })
+}
+
 export const api = {
   health: () => req<HealthResponse>('/api/health'),
   systemStats: () => req<SystemStats>('/api/system/stats'),
@@ -1504,30 +1567,18 @@ export const api = {
       `/api/projects/${pid}/download/status`
     ),
   /**
-   * 本地上传：单图（jpg/png）或 zip 包。绕过 `req` 的 JSON header，
-   * 让浏览器自己加 multipart boundary。后端同步处理并返回结果。
+   * 本地上传：单图（jpg/png）或 zip 包。走 XHR 以拿到 upload progress 事件
+   * （fetch 没有 request body progress）。后端同步解 zip / 落盘，所以
+   * progress 到 100% 后还有一段 server processing 时间。
    */
-  uploadProjectFiles: async (
+  uploadProjectFiles: (
     pid: number,
-    files: File[]
+    files: File[],
+    onProgress?: (e: UploadProgressEvent) => void,
   ): Promise<UploadResult> => {
     const fd = new FormData()
     for (const f of files) fd.append('files', f, f.name)
-    const resp = await fetch(`/api/projects/${pid}/upload`, {
-      method: 'POST',
-      body: fd,
-    })
-    if (!resp.ok) {
-      let detail = `${resp.status} ${resp.statusText}`
-      try {
-        const body = await resp.json()
-        if (body?.detail) detail = body.detail
-      } catch {
-        /* ignore */
-      }
-      throw new Error(detail)
-    }
-    return (await resp.json()) as UploadResult
+    return xhrUpload<UploadResult>(`/api/projects/${pid}/upload`, fd, onProgress)
   },
   uploadProjectFileFromPath: (pid: number, path: string) =>
     req<UploadResult>(`/api/projects/${pid}/upload-from-path`, {
@@ -2084,42 +2135,26 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ filename }),
     }),
-  importBundleUpload: async (file: File): Promise<BundleImportResult> => {
+  importBundleUpload: (
+    file: File,
+    onProgress?: (e: UploadProgressEvent) => void,
+  ): Promise<BundleImportResult> => {
     const fd = new FormData()
     fd.append('file', file, file.name)
-    const resp = await fetch('/api/projects/import-bundle/upload', { method: 'POST', body: fd })
-    if (!resp.ok) {
-      let detail = `${resp.status} ${resp.statusText}`
-      try {
-        const body = await resp.json()
-        if (body?.detail) detail = body.detail
-      } catch {
-        // ignore
-      }
-      throw new Error(detail)
-    }
-    return resp.json()
+    return xhrUpload<BundleImportResult>('/api/projects/import-bundle/upload', fd, onProgress)
   },
   /** 上传训练集 zip → 新建 project + v1，返回新项目。 */
-  importTrainProject: async (file: File): Promise<{
+  importTrainProject: (
+    file: File,
+    onProgress?: (e: UploadProgressEvent) => void,
+  ): Promise<{
     project: ProjectDetail
     version: Version
     stats: { image_count: number; tagged_count: number; untagged_count: number; concepts: string[] }
   }> => {
     const fd = new FormData()
     fd.append('file', file)
-    const resp = await fetch('/api/projects/import-train', { method: 'POST', body: fd })
-    if (!resp.ok) {
-      let detail = `${resp.status} ${resp.statusText}`
-      try {
-        const body = await resp.json()
-        if (body?.detail) detail = body.detail
-      } catch {
-        // ignore
-      }
-      throw new Error(detail)
-    }
-    return resp.json()
+    return xhrUpload('/api/projects/import-train', fd, onProgress)
   },
   /** 在 server 主机的 OS 文件管理器里打开 output 目录（仅 loopback 可用）。 */
   openTaskFolder: (id: number) =>

--- a/studio/web/src/components/UploadProgressBar.tsx
+++ b/studio/web/src/components/UploadProgressBar.tsx
@@ -1,0 +1,92 @@
+/**
+ * UploadProgressBar — 浏览器上传共用进度条 UI。
+ *
+ * 三个阶段视觉区分：
+ *   - uploading  → 实进度 + speed + ETA
+ *   - processing → 100% 满条 + "处理中…"（server 同步解包 / 落盘的等待）
+ *   - error      → 红色边 + 错误信息
+ *
+ * 业务侧只负责喂 state（来自 useUploadProgress），其余完全 stateless。
+ */
+import { useTranslation } from 'react-i18next'
+
+import {
+  formatBytes,
+  formatEta,
+  formatSpeed,
+  type UploadProgressState,
+} from '../lib/useUploadProgress'
+
+interface Props {
+  state: UploadProgressState
+  className?: string
+}
+
+export default function UploadProgressBar({ state, className }: Props) {
+  const { t } = useTranslation()
+  if (state.phase === 'idle') return null
+
+  const pct =
+    state.total > 0
+      ? Math.min(100, Math.max(0, (state.loaded / state.total) * 100))
+      : state.phase === 'processing' || state.phase === 'done'
+        ? 100
+        : 0
+
+  const isErr = state.phase === 'error'
+  const isUploading = state.phase === 'uploading'
+  const isProcessing = state.phase === 'processing'
+
+  return (
+    <div
+      className={`flex flex-col gap-1 ${className ?? ''}`}
+      role="status"
+      aria-live="polite"
+    >
+      <div
+        className={`relative w-full h-1.5 rounded-sm overflow-hidden ${
+          isErr ? 'bg-err-soft' : 'bg-overlay'
+        }`}
+      >
+        <div
+          className={`absolute inset-y-0 left-0 transition-[width] duration-150 ease-out ${
+            isErr ? 'bg-err' : isProcessing ? 'bg-accent animate-pulse' : 'bg-accent'
+          }`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="flex items-center gap-2 text-[11px] text-fg-tertiary font-mono">
+        {isErr ? (
+          <span className="text-err truncate">
+            {t('upload.failed')}: {state.error}
+          </span>
+        ) : isProcessing ? (
+          <span>{t('upload.processing')}</span>
+        ) : isUploading ? (
+          <>
+            <span>{pct.toFixed(0)}%</span>
+            <span>·</span>
+            <span>
+              {formatBytes(state.loaded)}
+              {state.total > 0 && ` / ${formatBytes(state.total)}`}
+            </span>
+            {state.speedBps > 0 && (
+              <>
+                <span>·</span>
+                <span>{formatSpeed(state.speedBps)}</span>
+              </>
+            )}
+            {state.etaSec != null && (
+              <>
+                <span>·</span>
+                <span>
+                  {t('upload.etaPrefix')} {formatEta(state.etaSec)}
+                </span>
+              </>
+            )}
+          </>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1950,5 +1950,10 @@
     "agoMinutes": "{{n}} min ago",
     "agoHours": "{{n}} hr ago",
     "agoDays": "{{n}} days ago"
+  },
+  "upload": {
+    "processing": "Server processing…",
+    "failed": "Failed",
+    "etaPrefix": "ETA"
   }
 }

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1950,5 +1950,10 @@
     "agoMinutes": "{{n}} 分钟前",
     "agoHours": "{{n}} 小时前",
     "agoDays": "{{n}} 天前"
+  },
+  "upload": {
+    "processing": "服务器处理中…",
+    "failed": "失败",
+    "etaPrefix": "剩余"
   }
 }

--- a/studio/web/src/lib/useUploadProgress.test.ts
+++ b/studio/web/src/lib/useUploadProgress.test.ts
@@ -1,0 +1,142 @@
+/**
+ * useUploadProgress 单元测试 —— 状态机 + formatter。
+ *
+ * 进度状态机：
+ *   - start(n) → phase='uploading', total=n, loaded=0
+ *   - onProgress(half) → phase='uploading', speed/eta 推断合理
+ *   - onProgress(full) → phase='processing'（loaded === total）
+ *   - finish() → phase='done', speed=0, eta=null
+ *   - fail(e) → phase='error', error message
+ *   - reset() → INITIAL
+ *
+ * lengthComputable=false 时 total 归 0、ETA 返回 null。
+ */
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  formatBytes,
+  formatEta,
+  formatSpeed,
+  useUploadProgress,
+} from './useUploadProgress'
+
+describe('useUploadProgress state machine', () => {
+  it('start sets phase=uploading and total', () => {
+    const { result } = renderHook(() => useUploadProgress())
+    act(() => result.current.start(1000))
+    expect(result.current.state.phase).toBe('uploading')
+    expect(result.current.state.total).toBe(1000)
+    expect(result.current.state.loaded).toBe(0)
+  })
+
+  it('switches to processing when loaded === total', () => {
+    const { result } = renderHook(() => useUploadProgress())
+    act(() => result.current.start(1000))
+    act(() => {
+      result.current.onProgress({ loaded: 1000, total: 1000, lengthComputable: true })
+    })
+    expect(result.current.state.phase).toBe('processing')
+    expect(result.current.state.speedBps).toBe(0)
+    expect(result.current.state.etaSec).toBeNull()
+  })
+
+  it('stays in uploading mid-transfer with positive speed', () => {
+    vi.useFakeTimers()
+    const start = 1000
+    vi.setSystemTime(start)
+    const perfSpy = vi.spyOn(performance, 'now').mockReturnValue(0)
+    try {
+      const { result } = renderHook(() => useUploadProgress())
+      perfSpy.mockReturnValue(0)
+      act(() => result.current.start(1000))
+      perfSpy.mockReturnValue(500) // 0.5s later
+      act(() => {
+        result.current.onProgress({ loaded: 250, total: 1000, lengthComputable: true })
+      })
+      expect(result.current.state.phase).toBe('uploading')
+      expect(result.current.state.speedBps).toBeGreaterThan(0)
+      // 速度 ≈ 250 bytes / 0.5s = 500 B/s；剩余 750 → ETA ≈ 1.5s
+      expect(result.current.state.etaSec).not.toBeNull()
+      expect(result.current.state.etaSec!).toBeGreaterThan(0)
+    } finally {
+      perfSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('treats lengthComputable=false as unknown total / no ETA', () => {
+    const { result } = renderHook(() => useUploadProgress())
+    act(() => result.current.start(1000))
+    act(() => {
+      result.current.onProgress({ loaded: 500, total: 0, lengthComputable: false })
+    })
+    expect(result.current.state.total).toBe(0)
+    expect(result.current.state.etaSec).toBeNull()
+    expect(result.current.state.phase).toBe('uploading')
+  })
+
+  it('finish marks loaded=total and phase=done', () => {
+    const { result } = renderHook(() => useUploadProgress())
+    act(() => result.current.start(1000))
+    act(() =>
+      result.current.onProgress({ loaded: 600, total: 1000, lengthComputable: true }),
+    )
+    act(() => result.current.finish())
+    expect(result.current.state.phase).toBe('done')
+    expect(result.current.state.loaded).toBe(1000)
+    expect(result.current.state.speedBps).toBe(0)
+  })
+
+  it('fail captures error message', () => {
+    const { result } = renderHook(() => useUploadProgress())
+    act(() => result.current.start(1000))
+    act(() => result.current.fail(new Error('boom')))
+    expect(result.current.state.phase).toBe('error')
+    expect(result.current.state.error).toBe('boom')
+  })
+
+  it('reset returns to idle', () => {
+    const { result } = renderHook(() => useUploadProgress())
+    act(() => result.current.start(1000))
+    act(() => result.current.reset())
+    expect(result.current.state.phase).toBe('idle')
+    expect(result.current.state.total).toBe(0)
+    expect(result.current.state.loaded).toBe(0)
+  })
+})
+
+describe('formatters', () => {
+  it('formatBytes handles 0 / negative / NaN', () => {
+    expect(formatBytes(0)).toBe('0 B')
+    expect(formatBytes(-5)).toBe('0 B')
+    expect(formatBytes(Number.NaN)).toBe('0 B')
+  })
+
+  it('formatBytes picks unit and precision', () => {
+    expect(formatBytes(512)).toBe('512 B')
+    expect(formatBytes(1024)).toBe('1.0 KB')
+    expect(formatBytes(1536)).toBe('1.5 KB')
+    expect(formatBytes(1024 * 1024)).toBe('1.0 MB')
+    expect(formatBytes(50 * 1024 * 1024)).toBe('50 MB')
+    expect(formatBytes(2 * 1024 * 1024 * 1024)).toBe('2.0 GB')
+  })
+
+  it('formatSpeed returns — for 0', () => {
+    expect(formatSpeed(0)).toBe('—')
+    expect(formatSpeed(1024)).toBe('1.0 KB/s')
+  })
+
+  it('formatEta handles null / negative / inf', () => {
+    expect(formatEta(null)).toBe('—')
+    expect(formatEta(-1)).toBe('—')
+    expect(formatEta(Number.POSITIVE_INFINITY)).toBe('—')
+  })
+
+  it('formatEta picks unit', () => {
+    expect(formatEta(0.5)).toBe('<1s')
+    expect(formatEta(45)).toBe('45s')
+    expect(formatEta(125)).toBe('2m05s')
+    expect(formatEta(3725)).toBe('1h02m')
+  })
+})

--- a/studio/web/src/lib/useUploadProgress.ts
+++ b/studio/web/src/lib/useUploadProgress.ts
@@ -1,0 +1,155 @@
+/**
+ * useUploadProgress — 浏览器上传进度状态机。
+ *
+ * 协议：
+ *   1. caller 在请求前 `start(totalBytes)` 让进度条立即 0%
+ *   2. caller 把 `onProgress` 透传给 `api.xxx(..., onProgress)` —— XHR.upload
+ *      progress 事件回调（fetch 没有 request body progress）
+ *   3. loaded === total 时自动切到 'processing'（server 还在解 zip / 落盘，
+ *      没有事件，UI 转菊花区分「上传完了在等服务端」）
+ *   4. 请求 resolve / reject 后 caller 调 `finish()` / `fail(e)` / `reset()`
+ *
+ * 速度计算用 1s 滑动窗口避免数字跳得太厉害；ETA = (total - loaded) / speed。
+ */
+import { useCallback, useRef, useState } from 'react'
+
+export type UploadPhase = 'idle' | 'uploading' | 'processing' | 'done' | 'error'
+
+export interface UploadProgressState {
+  phase: UploadPhase
+  loaded: number
+  total: number
+  /** bytes/sec，1s 滑动平均；processing/idle/done 时为 0 */
+  speedBps: number
+  /** 秒；null = 无法计算（speed=0 或 total=0） */
+  etaSec: number | null
+  error: string | null
+}
+
+const INITIAL: UploadProgressState = {
+  phase: 'idle',
+  loaded: 0,
+  total: 0,
+  speedBps: 0,
+  etaSec: null,
+  error: null,
+}
+
+export interface UseUploadProgress {
+  state: UploadProgressState
+  /** 请求前调，让 UI 立即显示 0% / total */
+  start: (totalBytes: number) => void
+  /** 透传给 api.xxx 作为 onProgress 回调 */
+  onProgress: (e: { loaded: number; total: number; lengthComputable: boolean }) => void
+  finish: () => void
+  fail: (e: unknown) => void
+  /** 重置回 idle，用于关闭对话框 / 隐藏面板 */
+  reset: () => void
+}
+
+interface Sample {
+  t: number
+  loaded: number
+}
+
+const SPEED_WINDOW_MS = 1500
+
+export function useUploadProgress(): UseUploadProgress {
+  const [state, setState] = useState<UploadProgressState>(INITIAL)
+  const samplesRef = useRef<Sample[]>([])
+
+  const start = useCallback((totalBytes: number) => {
+    samplesRef.current = [{ t: performance.now(), loaded: 0 }]
+    setState({
+      phase: 'uploading',
+      loaded: 0,
+      total: totalBytes,
+      speedBps: 0,
+      etaSec: null,
+      error: null,
+    })
+  }, [])
+
+  const onProgress = useCallback((e: { loaded: number; total: number; lengthComputable: boolean }) => {
+    const now = performance.now()
+    const samples = samplesRef.current
+    samples.push({ t: now, loaded: e.loaded })
+    const cutoff = now - SPEED_WINDOW_MS
+    while (samples.length > 1 && samples[0].t < cutoff) samples.shift()
+    const first = samples[0]
+    const dt = (now - first.t) / 1000
+    const speed = dt > 0 ? Math.max(0, (e.loaded - first.loaded) / dt) : 0
+    const total = e.lengthComputable && e.total > 0 ? e.total : 0
+    const remaining = total > 0 ? Math.max(0, total - e.loaded) : 0
+    const eta = speed > 0 && remaining > 0 ? remaining / speed : null
+    const isComplete = total > 0 && e.loaded >= total
+    setState({
+      phase: isComplete ? 'processing' : 'uploading',
+      loaded: e.loaded,
+      total,
+      speedBps: isComplete ? 0 : speed,
+      etaSec: isComplete ? null : eta,
+      error: null,
+    })
+  }, [])
+
+  const finish = useCallback(() => {
+    samplesRef.current = []
+    setState((s) => ({
+      ...s,
+      phase: 'done',
+      speedBps: 0,
+      etaSec: null,
+      loaded: s.total > 0 ? s.total : s.loaded,
+    }))
+  }, [])
+
+  const fail = useCallback((e: unknown) => {
+    samplesRef.current = []
+    setState((s) => ({
+      ...s,
+      phase: 'error',
+      speedBps: 0,
+      etaSec: null,
+      error: e instanceof Error ? e.message : String(e),
+    }))
+  }, [])
+
+  const reset = useCallback(() => {
+    samplesRef.current = []
+    setState(INITIAL)
+  }, [])
+
+  return { state, start, onProgress, finish, fail, reset }
+}
+
+// ── 格式化 helpers（独立 export，方便单测 / 别处复用） ──────────────────
+
+export function formatBytes(n: number): string {
+  if (!Number.isFinite(n) || n <= 0) return '0 B'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let v = n
+  let i = 0
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024
+    i++
+  }
+  return `${v < 10 && i > 0 ? v.toFixed(1) : Math.round(v)} ${units[i]}`
+}
+
+export function formatSpeed(bps: number): string {
+  if (!Number.isFinite(bps) || bps <= 0) return '—'
+  return `${formatBytes(bps)}/s`
+}
+
+export function formatEta(sec: number | null): string {
+  if (sec == null || !Number.isFinite(sec) || sec < 0) return '—'
+  if (sec < 1) return '<1s'
+  if (sec < 60) return `${Math.ceil(sec)}s`
+  const m = Math.floor(sec / 60)
+  const s = Math.floor(sec % 60)
+  if (m < 60) return `${m}m${String(s).padStart(2, '0')}s`
+  const h = Math.floor(m / 60)
+  const mm = m % 60
+  return `${h}h${String(mm).padStart(2, '0')}m`
+}

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -4,10 +4,12 @@ import { useNavigate } from 'react-router-dom'
 import { api, type BundleImportResult, type ProjectSummary } from '../api/client'
 import PageHeader from '../components/PageHeader'
 import PathPicker from '../components/PathPicker'
+import UploadProgressBar from '../components/UploadProgressBar'
 import VersionStatusBadge from '../components/VersionStatusBadge'
 import { useDialog } from '../components/Dialog'
 import { useToast } from '../components/Toast'
 import { useEventStream } from '../lib/useEventStream'
+import { useUploadProgress } from '../lib/useUploadProgress'
 
 export default function ProjectsPage() {
   const { t } = useTranslation()
@@ -22,6 +24,7 @@ export default function ProjectsPage() {
   const navigate = useNavigate()
   const { toast } = useToast()
   const { confirm } = useDialog()
+  const uploadProgress = useUploadProgress()
 
   const refresh = async () => {
     try {
@@ -107,8 +110,21 @@ export default function ProjectsPage() {
 
   const handleImportUpload = async (file: File | null | undefined) => {
     if (!file) return
-    setShowImportDialog(false)
-    await runBundleImport(() => api.importBundleUpload(file))
+    // dialog 不立即关：进度条要显示在 dialog 里直到完成 / 失败
+    uploadProgress.start(file.size)
+    setImporting(true)
+    try {
+      const result = await api.importBundleUpload(file, uploadProgress.onProgress)
+      uploadProgress.finish()
+      setShowImportDialog(false)
+      uploadProgress.reset()
+      finishBundleImport(result)
+    } catch (e) {
+      uploadProgress.fail(e)
+      toast(t('projects.importFailed', { e }), 'error')
+    } finally {
+      setImporting(false)
+    }
   }
 
   const openProject = (p: ProjectSummary) => {
@@ -184,12 +200,16 @@ export default function ProjectsPage() {
       {showImportDialog && (
         <BundleImportDialog
           importing={importing}
+          uploadState={uploadProgress.state}
           onUpload={handleImportUpload}
           onPickPath={() => {
             setShowImportDialog(false)
             setShowImportPicker(true)
           }}
-          onCancel={() => setShowImportDialog(false)}
+          onCancel={() => {
+            setShowImportDialog(false)
+            uploadProgress.reset()
+          }}
         />
       )}
 
@@ -206,11 +226,13 @@ export default function ProjectsPage() {
 
 function BundleImportDialog({
   importing,
+  uploadState,
   onUpload,
   onPickPath,
   onCancel,
 }: {
   importing: boolean
+  uploadState: ReturnType<typeof useUploadProgress>['state']
   onUpload: (file: File | null | undefined) => void
   onPickPath: () => void
   onCancel: () => void
@@ -245,6 +267,9 @@ function BundleImportDialog({
               disabled={importing}
               onChange={(e) => onUpload(e.target.files?.[0])}
             />
+            {uploadState.phase !== 'idle' && (
+              <UploadProgressBar state={uploadState} className="mt-3" />
+            )}
           </label>
 
           <button

--- a/studio/web/src/pages/project/steps/Download.tsx
+++ b/studio/web/src/pages/project/steps/Download.tsx
@@ -13,9 +13,11 @@ import ImageGrid, { applySelection } from '../../../components/ImageGrid'
 import ImagePreviewModal from '../../../components/ImagePreviewModal'
 import PathPicker from '../../../components/PathPicker'
 import StepShell from '../../../components/StepShell'
+import UploadProgressBar from '../../../components/UploadProgressBar'
 import { useDialog } from '../../../components/Dialog'
 import { useToast } from '../../../components/Toast'
 import { useEventStream } from '../../../lib/useEventStream'
+import { useUploadProgress } from '../../../lib/useUploadProgress'
 
 // 跟 studio/datasets.py:IMAGE_EXTS 对齐 — 上传白名单 = 全链路图片白名单 + .zip。
 const UPLOAD_ACCEPT =
@@ -542,6 +544,7 @@ function UploadPanel({
   const [uploading, setUploading] = useState(false)
   const [dragging, setDragging] = useState(false)
   const [showPathPicker, setShowPathPicker] = useState(false)
+  const uploadProgress = useUploadProgress()
 
   const choose = (fl: FileList | null) => {
     if (!fl || fl.length === 0) return
@@ -562,12 +565,18 @@ function UploadPanel({
   }
   const submit = async () => {
     if (picked.length === 0) return
+    const totalBytes = picked.reduce((s, f) => s + f.size, 0)
     setUploading(true)
+    uploadProgress.start(totalBytes)
     try {
-      const r = await api.uploadProjectFiles(pid, picked)
+      const r = await api.uploadProjectFiles(pid, picked, uploadProgress.onProgress)
+      uploadProgress.finish()
       applyUploadResult(r)
       reset()
+      // 短延迟后清掉进度条；让用户看清完成状态
+      window.setTimeout(() => uploadProgress.reset(), 800)
     } catch (e) {
+      uploadProgress.fail(e)
       toast(String(e), 'error')
     } finally {
       setUploading(false)
@@ -660,6 +669,9 @@ function UploadPanel({
             {fileNames}
           </span>
         </div>
+      )}
+      {uploadProgress.state.phase !== 'idle' && (
+        <UploadProgressBar state={uploadProgress.state} />
       )}
       {showPathPicker && (
         <PathPicker


### PR DESCRIPTION
## Summary

- 三处上传（项目本地图/zip、bundle import、train zip import）从 `fetch` 迁到 `XMLHttpRequest`，拿 request body progress 事件（fetch 无此能力）。
- 新增 `useUploadProgress` hook（状态机：idle → uploading → processing → done/error）+ `UploadProgressBar` 共享组件；1.5s 滑动窗口算 speed，`loaded === total` 自动切 `processing` 区分「服务端同步解 zip / 落盘」的等待。
- Bundle import dialog 改为上传期间保持打开显示进度条，成功后才关闭。
- 加 `useUploadProgress` 单测（状态机 6 case + formatter）。

## Files

- `studio/web/src/api/client.ts` — 新增 `xhrUpload<T>` helper + `UploadProgressEvent` 类型，三处上传接收可选 `onProgress`。
- `studio/web/src/lib/useUploadProgress.ts` (new) + `.test.ts` (new)
- `studio/web/src/components/UploadProgressBar.tsx` (new)
- `studio/web/src/pages/Projects.tsx` — bundle import dialog 接进度条
- `studio/web/src/pages/project/steps/Download.tsx` — 本地上传面板接进度条
- `studio/web/src/i18n/locales/{en,zh}.json` — 加 `upload.processing / failed / etaPrefix`

## Test plan

- [ ] `cd studio/web && pnpm vitest run src/lib/useUploadProgress.test.ts` 全绿
- [ ] 浏览器上传大 zip（≥100 MB），观察 progress / speed / ETA 实时更新
- [ ] 上传至 100% 后看到「服务器处理中…」状态直到 server 返回
- [ ] Bundle import：上传期间 dialog 保持打开，成功后才关闭
- [ ] 上传失败时进度条变红显示错误
- [ ] `lengthComputable=false`（比如 chunked）能正常显示，无 NaN/Infinity

🤖 Generated with [Claude Code](https://claude.com/claude-code)