### PR TITLE
fix(launcher): Windows npm 解析优先 .cmd，规避 bash 脚本 / .ps1 触发 WinError 193

### DIFF
--- a/studio/cli.py
+++ b/studio/cli.py
@@ -40,8 +40,15 @@ NODE_MODULES = WEB_DIR / "node_modules"
 
 
 def find_npm() -> Optional[str]:
-    """Windows 上 npm 是 .cmd / .ps1，需要找全名。"""
-    for candidate in ("npm", "npm.cmd", "npm.ps1"):
+    """Windows 优先 .cmd（CreateProcess 可直接跑），.ps1 兜底；Linux/Mac 走裸名。
+
+    注意不要把裸 ``npm`` 放在 Windows 候选首位：Node.js 官方安装包在
+    ``C:\\Program Files\\nodejs\\`` 同时铺了 ``npm`` (Git Bash 用的 bash 脚本)
+    / ``npm.cmd`` / ``npm.ps1`` 三份，``shutil.which("npm")`` 在 Windows 上
+    会先吃裸名那份，subprocess 直接报 WinError 193（不是有效 Win32 应用）。
+    """
+    candidates = ("npm.cmd", "npm.ps1", "npm") if os.name == "nt" else ("npm",)
+    for candidate in candidates:
         path = shutil.which(candidate)
         if path:
             return path
@@ -57,9 +64,20 @@ _NPM_MIRROR = "https://mirrors.cloud.tencent.com/npm/"
 _PIP_MIRROR = "https://mirrors.cloud.tencent.com/pypi/simple/"
 
 
+def _npm_argv(npm: str, args: list[str]) -> list[str]:
+    """拼出真正可被 subprocess 执行的 argv。
+
+    ``.ps1`` 无法被 ``CreateProcess`` 直接拉起，必须包 ``powershell.exe -File``；
+    ``.cmd`` 和裸名（Linux）直接拼即可。
+    """
+    if npm.lower().endswith(".ps1"):
+        return ["powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", npm, *args]
+    return [npm, *args]
+
+
 def _npm_call(npm: str, args: list[str], cwd: str, timeout: int = 180) -> int:
     """运行 npm 命令；超时则 kill 并返回 1。"""
-    proc = subprocess.Popen([npm] + args, cwd=cwd)
+    proc = subprocess.Popen(_npm_argv(npm, args), cwd=cwd)
     try:
         return proc.wait(timeout=timeout)
     except subprocess.TimeoutExpired:
@@ -100,7 +118,7 @@ def npm_install_if_missing(npm: str) -> int:
     if rc != 0:
         print(f"[studio] npm install 失败或超时，切换国内源 ({_NPM_MIRROR}) 重试...")
         rc = subprocess.call(
-            [npm, "install", "--registry", _NPM_MIRROR],
+            _npm_argv(npm, ["install", "--registry", _NPM_MIRROR]),
             cwd=str(WEB_DIR),
         )
     return rc
@@ -135,7 +153,7 @@ def _ensure_python_deps() -> int:
 
 def npm_build(npm: str) -> int:
     print("[studio] 构建前端 (npm run build)...")
-    return subprocess.call([npm, "run", "build"], cwd=str(WEB_DIR))
+    return subprocess.call(_npm_argv(npm, ["run", "build"]), cwd=str(WEB_DIR))
 
 
 # ---------------------------------------------------------------------------
@@ -717,7 +735,7 @@ def cmd_dev(args: argparse.Namespace) -> int:
 
     pg = ProcGroup()
     try:
-        pg.spawn("frontend", [npm, "run", "dev", "--", "--port", str(args.fe_port)], cwd=WEB_DIR)
+        pg.spawn("frontend", _npm_argv(npm, ["run", "dev", "--", "--port", str(args.fe_port)]), cwd=WEB_DIR)
         pg.spawn(
             "backend",
             [
@@ -757,7 +775,7 @@ def cmd_test(_args: argparse.Namespace) -> int:
         print("[studio] 跳过 vitest (node_modules 缺失，先 npm install)")
         return 0
     print("[studio] vitest...")
-    return subprocess.call([npm, "run", "test"], cwd=str(WEB_DIR))
+    return subprocess.call(_npm_argv(npm, ["run", "test"]), cwd=str(WEB_DIR))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- 用户报错：Windows 启动 `python -m studio` 时炸 `OSError: [WinError 193] %1 不是有效的 Win32 应用程序`，栈打到 `subprocess.Popen([npm, 'install'], ...)`。
- 根因：`find_npm` 的候选顺序 `(\"npm\", \"npm.cmd\", \"npm.ps1\")` 让 `shutil.which(\"npm\")` 在 Windows 上先吃中 `C:\Program Files\nodejs\npm` —— 这是 Node.js 官方装包给 Git Bash / MSYS 用的 **bash 脚本（无扩展名）**，`CreateProcess` 没法直接拉起。
- 修法：Windows 候选改为 `.cmd` 优先 → `.ps1` → 裸名兜底；Linux/Mac 按 `os.name` 收窄到 `(\"npm\",)`。同时新增 `_npm_argv` helper，命中 `.ps1` 时自动包 `powershell.exe -NoProfile -ExecutionPolicy Bypass -File`，全部 5 处 npm 调用统一走它。

## 现场复现

报错用户 `python -c \"import shutil; print(shutil.which('npm'))\"` 返回：

```
C:\Program Files\nodejs\npm
```

—— 没扩展名，正是 Node 官方装包带的 bash 脚本。`Get-Command` 同时能看到 `npm.cmd` 和 `npm.ps1`，证明 `.cmd` 在 PATH 里，只是被裸名抢先了。

## 改动文件

- `studio/cli.py`
  - `find_npm`：按 `os.name` 区分候选，Windows 优先 `.cmd`
  - 新增 `_npm_argv(npm, args)`：`.ps1` 自动包 powershell，其他情形原样返回
  - 5 处 npm 调用统一替换：`_npm_call` / 镜像重试 / `npm_build` / dev 模式 `pg.spawn` / `cmd_test`

## Linux 影响

零。`shutil.which(\"npm.cmd\")` 在 Linux 上必返 `None`，自动 fallthrough 到 `shutil.which(\"npm\")`，行为与改前完全一致；`.ps1` 包 powershell 的分支按 `endswith` 判断，Linux 永远走不到。

## Test plan

- [ ] Windows 复现机（之前报 193 那台）跑 `python -m studio run`，应能正常装依赖 / 构建 / 起后端
- [ ] Windows 上 `python -m studio dev` 起 Vite + uvicorn，前端可访问 5173
- [ ] Linux 自检：`python -m studio test` 不回归
- [ ] 边角验证：PATH 中只放 `npm.ps1`（人为重命名 `.cmd`）时也能跑起来，证明 `.ps1` powershell 包裹生效

🤖 Generated with [Claude Code](https://claude.com/claude-code)