### PR TITLE
test(studio): PR-1 重构安全网 — route snapshot + import smoke + invariants

### DIFF
--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,0 +1,1295 @@
+{
+  "version": 1,
+  "generated_from": "studio.server.app",
+  "count": 160,
+  "routes": [
+    {
+      "path": "/",
+      "methods": [
+        "GET"
+      ],
+      "name": "root",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/browse",
+      "methods": [
+        "GET"
+      ],
+      "name": "browse_dir",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/configs",
+      "methods": [
+        "DELETE",
+        "GET",
+        "POST",
+        "PUT"
+      ],
+      "name": "_configs_root_redirect",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/configs/{rest:path}",
+      "methods": [
+        "DELETE",
+        "GET",
+        "POST",
+        "PUT"
+      ],
+      "name": "_configs_redirect",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/data-exports",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_data_exports",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/datasets",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_datasets",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/datasets/thumbnail",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_dataset_thumbnail",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/events",
+      "methods": [
+        "GET"
+      ],
+      "name": "events",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/flash-attention/install",
+      "methods": [
+        "POST"
+      ],
+      "name": "flash_attn_install",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/flash-attention/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "flash_attn_status",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate",
+      "methods": [
+        "POST"
+      ],
+      "name": "enqueue_generate",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/daemon/logs",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_daemon_logs",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/daemon/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_daemon_status",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/daemon/unload",
+      "methods": [
+        "POST"
+      ],
+      "name": "unload_daemon",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/taeflux/install",
+      "methods": [
+        "POST"
+      ],
+      "name": "install_taeflux",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/taeflux/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_taeflux_status",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/{task_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_generate_task",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/{task_id}/sample/{filename}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_generate_sample",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/health",
+      "methods": [
+        "GET"
+      ],
+      "name": "health",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/jobs/{jid}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_job_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/jobs/{jid}/cancel",
+      "methods": [
+        "POST"
+      ],
+      "name": "cancel_job_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/jobs/{jid}/log",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_job_log",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/llm-tagger/models/refresh",
+      "methods": [
+        "POST"
+      ],
+      "name": "refresh_llm_tagger_models",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/llm-tagger/test",
+      "methods": [
+        "POST"
+      ],
+      "name": "test_llm_tagger_connection",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/logs/{task_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_log",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/models/catalog",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_models_catalog",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/models/download",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_model_download",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/models/path-defaults",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_models_path_defaults",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_presets_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets/import",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_preset",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets/import-from-data-exports",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_preset_from_data_exports",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets/import-from-path",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_preset_from_path",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets/{name}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_preset_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets/{name}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_preset",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets/{name}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "put_preset",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets/{name}/download",
+      "methods": [
+        "GET"
+      ],
+      "name": "download_preset",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets/{name}/duplicate",
+      "methods": [
+        "POST"
+      ],
+      "name": "duplicate_preset_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/presets/{name}/export",
+      "methods": [
+        "POST"
+      ],
+      "name": "export_preset_to_data_exports",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_projects_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_project_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/import-bundle",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_bundle_zip",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/import-bundle/upload",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_bundle_upload",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/import-train",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_train_zip",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_project_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_project_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}",
+      "methods": [
+        "PATCH"
+      ],
+      "name": "patch_project_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/download",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_download",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/download/estimate",
+      "methods": [
+        "POST"
+      ],
+      "name": "estimate_download",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/download/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "download_status",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/duplicates/apply",
+      "methods": [
+        "POST"
+      ],
+      "name": "apply_project_duplicates",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/duplicates/scan",
+      "methods": [
+        "POST"
+      ],
+      "name": "scan_project_duplicates",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/files",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_files",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/files/delete",
+      "methods": [
+        "POST"
+      ],
+      "name": "delete_project_files",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/lora_ckpts",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_project_lora_ckpts",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/crop",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_preprocess_crop",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/crop/workspace",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_crop_workspace",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/duplicates/apply",
+      "methods": [
+        "POST"
+      ],
+      "name": "apply_preprocess_duplicates",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/duplicates/removed",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_duplicate_removed",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/duplicates/scan",
+      "methods": [
+        "POST"
+      ],
+      "name": "scan_preprocess_duplicates",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/files",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_preprocess_files",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/files/reset",
+      "methods": [
+        "POST"
+      ],
+      "name": "reset_preprocess_files",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/files/restore",
+      "methods": [
+        "POST"
+      ],
+      "name": "restore_preprocess_files",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/start",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_preprocess",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "preprocess_status",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/preprocess/thumb",
+      "methods": [
+        "GET"
+      ],
+      "name": "preprocess_thumb",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/state_ckpts",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_project_state_ckpts",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/thumb",
+      "methods": [
+        "GET"
+      ],
+      "name": "project_thumb",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/upload",
+      "methods": [
+        "POST"
+      ],
+      "name": "upload_local_files",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/upload-from-path",
+      "methods": [
+        "POST"
+      ],
+      "name": "upload_local_file_from_path",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_versions_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_version_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_version_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_version_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}",
+      "methods": [
+        "PATCH"
+      ],
+      "name": "patch_version_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/activate",
+      "methods": [
+        "POST"
+      ],
+      "name": "activate_version_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/advance-phase",
+      "methods": [
+        "POST"
+      ],
+      "name": "advance_phase_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/bundle.zip",
+      "methods": [
+        "GET"
+      ],
+      "name": "export_version_bundle",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/captions",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_captions_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/captions/batch",
+      "methods": [
+        "POST"
+      ],
+      "name": "batch_caption_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/captions/commit",
+      "methods": [
+        "POST"
+      ],
+      "name": "commit_captions",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/captions/snapshot",
+      "methods": [
+        "POST"
+      ],
+      "name": "create_caption_snapshot",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/captions/snapshots",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_caption_snapshots",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/captions/snapshots/{sid}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_caption_snapshot",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/captions/snapshots/{sid}/restore",
+      "methods": [
+        "POST"
+      ],
+      "name": "restore_caption_snapshot",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/captions/{folder}/{filename}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_caption_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/captions/{folder}/{filename}",
+      "methods": [
+        "PUT"
+      ],
+      "name": "put_caption_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/config",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_version_config_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/config",
+      "methods": [
+        "PUT"
+      ],
+      "name": "put_version_config_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/config/from_preset",
+      "methods": [
+        "POST"
+      ],
+      "name": "fork_preset_for_version_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/config/save_as_preset",
+      "methods": [
+        "POST"
+      ],
+      "name": "save_version_config_as_preset_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/curation",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_curation",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/curation/copy",
+      "methods": [
+        "POST"
+      ],
+      "name": "copy_to_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/curation/folder",
+      "methods": [
+        "POST"
+      ],
+      "name": "folder_op",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/curation/remove",
+      "methods": [
+        "POST"
+      ],
+      "name": "remove_from_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/export-bundle",
+      "methods": [
+        "POST"
+      ],
+      "name": "export_version_bundle_to_data_exports",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/jobs/latest",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_latest_version_job",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/lora_ckpts",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_version_lora_ckpts",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/queue",
+      "methods": [
+        "POST"
+      ],
+      "name": "enqueue_version_training",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/reg",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_reg",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/reg",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_reg_status",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/reg/build",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_reg_build",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/reg/caption",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_reg_caption",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/reg/generate-prior",
+      "methods": [
+        "POST"
+      ],
+      "name": "reg_generate_prior",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/reg/generate-prior/{task_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_reg_prior_task",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/reg/preview-tags",
+      "methods": [
+        "GET"
+      ],
+      "name": "reg_preview_tags",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/skip-phase",
+      "methods": [
+        "POST"
+      ],
+      "name": "skip_phase_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/tag",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_tag",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/thumb",
+      "methods": [
+        "GET"
+      ],
+      "name": "version_thumb",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/train.zip",
+      "methods": [
+        "GET"
+      ],
+      "name": "export_version_train_zip",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_queue",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue",
+      "methods": [
+        "POST"
+      ],
+      "name": "enqueue",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/export",
+      "methods": [
+        "GET"
+      ],
+      "name": "export_queue",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/hold",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_queue_hold",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/hold",
+      "methods": [
+        "POST"
+      ],
+      "name": "hold_queue",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/import",
+      "methods": [
+        "POST"
+      ],
+      "name": "import_queue",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/release",
+      "methods": [
+        "POST"
+      ],
+      "name": "release_queue",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/reorder",
+      "methods": [
+        "POST"
+      ],
+      "name": "reorder_queue",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_queue_item",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_queue_item",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/cancel",
+      "methods": [
+        "POST"
+      ],
+      "name": "cancel_task",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/export-outputs",
+      "methods": [
+        "POST"
+      ],
+      "name": "export_task_outputs_to_data_exports",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/open-folder",
+      "methods": [
+        "POST"
+      ],
+      "name": "open_task_folder",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/output/{filename:path}",
+      "methods": [
+        "GET"
+      ],
+      "name": "download_task_output",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/outputs",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_task_outputs",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/outputs.zip",
+      "methods": [
+        "GET"
+      ],
+      "name": "download_task_outputs_zip",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/pause",
+      "methods": [
+        "POST"
+      ],
+      "name": "pause_task",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/resume",
+      "methods": [
+        "POST"
+      ],
+      "name": "resume_task",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/retry",
+      "methods": [
+        "POST"
+      ],
+      "name": "retry_task",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/snapshot/config",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_task_snapshot_config",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/schema",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_schema",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/secrets",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_secrets",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/secrets",
+      "methods": [
+        "PUT"
+      ],
+      "name": "put_secrets",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/state",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_state",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/dev_commits",
+      "methods": [
+        "GET"
+      ],
+      "name": "system_dev_commits",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/init_git",
+      "methods": [
+        "POST"
+      ],
+      "name": "system_init_git",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/preflight",
+      "methods": [
+        "GET"
+      ],
+      "name": "system_preflight",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/release_notes",
+      "methods": [
+        "GET"
+      ],
+      "name": "system_release_notes",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/restart",
+      "methods": [
+        "POST"
+      ],
+      "name": "system_restart",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/rollback",
+      "methods": [
+        "POST"
+      ],
+      "name": "system_rollback",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/stats",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_system_stats",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/update",
+      "methods": [
+        "POST"
+      ],
+      "name": "system_update",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/update_check",
+      "methods": [
+        "GET"
+      ],
+      "name": "system_update_check",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/update_log",
+      "methods": [
+        "GET"
+      ],
+      "name": "system_update_log",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/update_status",
+      "methods": [
+        "GET"
+      ],
+      "name": "system_update_status",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/system/version",
+      "methods": [
+        "GET"
+      ],
+      "name": "system_version",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/tagger/{name}/check",
+      "methods": [
+        "GET"
+      ],
+      "name": "check_tagger",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/torch/reinstall",
+      "methods": [
+        "POST"
+      ],
+      "name": "torch_reinstall",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/torch/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "torch_status",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/upscalers/download_custom",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_upscaler_custom_download",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/upscalers/select",
+      "methods": [
+        "POST"
+      ],
+      "name": "select_upscaler",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/wd14/install",
+      "methods": [
+        "POST"
+      ],
+      "name": "wd14_install",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/wd14/runtime",
+      "methods": [
+        "GET"
+      ],
+      "name": "wd14_runtime",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/xformers/install",
+      "methods": [
+        "POST"
+      ],
+      "name": "xformers_install",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/xformers/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "xformers_status",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/docs",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "swagger_ui_html",
+      "type": "Route"
+    },
+    {
+      "path": "/docs/oauth2-redirect",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "swagger_ui_redirect",
+      "type": "Route"
+    },
+    {
+      "path": "/openapi.json",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "openapi",
+      "type": "Route"
+    },
+    {
+      "path": "/redoc",
+      "methods": [
+        "GET",
+        "HEAD"
+      ],
+      "name": "redoc_html",
+      "type": "Route"
+    },
+    {
+      "path": "/samples/{filename}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_sample",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/studio",
+      "methods": [],
+      "name": "studio",
+      "type": "Mount"
+    }
+  ]
+}

--- a/tests/test_route_invariants.py
+++ b/tests/test_route_invariants.py
@@ -1,0 +1,42 @@
+"""PR-1 安全网 — route 数量与 decorator 计数的粗粒度不变量。
+
+snapshot 是精细网（任何字符变化都触发），本文件是粗粒度二道防线：
+- 数量落在合理区间
+- server.py 源里的 @app.<verb> 装饰器数 == APIRoute 数
+
+如果某个未来 PR 把 router 拆走了，snapshot 测试会同时挂；但本测试也会挂，
+能在 reviewer 视野里多出一条提醒：APIRoute 数量变了。
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from fastapi.routing import APIRoute
+
+from studio.server import app
+
+SERVER_PY = Path(__file__).parent.parent / "studio" / "server.py"
+
+
+def test_route_count_in_sane_range() -> None:
+    n = len(app.routes)
+    assert 100 <= n <= 250, f"len(app.routes) = {n}，超出合理区间 [100, 250]"
+
+
+def test_decorator_count_matches_api_routes() -> None:
+    src = SERVER_PY.read_text(encoding="utf-8")
+    # 匹配 @app.get(...) / @app.post(...) / ... 以及 @app.api_route(...)
+    decorator_count = len(
+        re.findall(
+            r"^@app\.(get|post|put|delete|patch|api_route)\b",
+            src,
+            flags=re.MULTILINE,
+        )
+    )
+    api_route_count = sum(1 for r in app.routes if isinstance(r, APIRoute))
+    assert decorator_count == api_route_count, (
+        f"server.py 里 @app.* 装饰器 {decorator_count} 个，"
+        f"但 app.routes 里 APIRoute 实例 {api_route_count} 个 —— "
+        f"差额可能来自 include_router 或 router 注册时丢了一个"
+    )

--- a/tests/test_route_snapshot.py
+++ b/tests/test_route_snapshot.py
@@ -1,0 +1,123 @@
+"""PR-1 安全网 — 冻结 studio.server.app 的全部 route 三元组。
+
+后续重构 PR（拆 router、搬 endpoint）必须保持 (methods, path, name) 集合不变；
+任何意外丢路由 / 改路径 / 改函数名都会让本测试 fail 并给出可读 diff。
+
+snapshot 文件：tests/_snapshots/studio_routes.json
+- 首次运行（snapshot 不存在）→ 创建并 emit warning，测试通过
+- 之后每次运行 → 读出比对，不一致用 pytest.fail 列出 added/removed/changed
+"""
+from __future__ import annotations
+
+import json
+import warnings
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from studio.server import app
+
+SNAPSHOT_PATH = Path(__file__).parent / "_snapshots" / "studio_routes.json"
+SNAPSHOT_VERSION = 1
+
+
+def _route_entry(route: Any) -> dict[str, Any]:
+    methods = sorted(getattr(route, "methods", None) or [])
+    return {
+        "path": getattr(route, "path", ""),
+        "methods": methods,
+        "name": getattr(route, "name", ""),
+        "type": type(route).__name__,
+    }
+
+
+def _collect_routes() -> list[dict[str, Any]]:
+    entries = [_route_entry(r) for r in app.routes]
+    entries.sort(key=lambda e: (e["path"], ",".join(e["methods"]), e["name"]))
+    return entries
+
+
+def _entry_key(e: dict[str, Any]) -> tuple[str, str, str]:
+    return (e["path"], ",".join(e["methods"]), e["type"])
+
+
+def _load_snapshot() -> dict[str, Any] | None:
+    if not SNAPSHOT_PATH.exists():
+        return None
+    return json.loads(SNAPSHOT_PATH.read_text(encoding="utf-8"))
+
+
+def _write_snapshot(routes: list[dict[str, Any]]) -> None:
+    SNAPSHOT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": SNAPSHOT_VERSION,
+        "generated_from": "studio.server.app",
+        "count": len(routes),
+        "routes": routes,
+    }
+    SNAPSHOT_PATH.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _format_diff(current: list[dict[str, Any]], saved: list[dict[str, Any]]) -> str:
+    cur_by_key = {_entry_key(e): e for e in current}
+    saved_by_key = {_entry_key(e): e for e in saved}
+    added = [k for k in cur_by_key if k not in saved_by_key]
+    removed = [k for k in saved_by_key if k not in cur_by_key]
+    changed = []
+    for k in cur_by_key.keys() & saved_by_key.keys():
+        if cur_by_key[k]["name"] != saved_by_key[k]["name"]:
+            changed.append(
+                (k, saved_by_key[k]["name"], cur_by_key[k]["name"])
+            )
+
+    lines: list[str] = []
+    if added:
+        lines.append(f"新增 {len(added)} 个 route（snapshot 里没有）：")
+        for path, methods, type_ in sorted(added):
+            lines.append(f"  + [{type_}] {methods or '-'} {path}")
+    if removed:
+        lines.append(f"丢失 {len(removed)} 个 route（snapshot 里有但当前没有）：")
+        for path, methods, type_ in sorted(removed):
+            lines.append(f"  - [{type_}] {methods or '-'} {path}")
+    if changed:
+        lines.append(f"name 改了 {len(changed)} 个 route：")
+        for (path, methods, type_), old_name, new_name in sorted(changed):
+            lines.append(f"  ~ [{type_}] {methods or '-'} {path}: {old_name} → {new_name}")
+    if not lines:
+        lines.append("（key 集合相同但 JSON 仍不一致 —— 可能是 snapshot 版本字段或排序变了）")
+    lines.append("")
+    lines.append("如果你确实增删改了 route 且这是预期：删除 snapshot 文件后重跑生成新的，")
+    lines.append(f"然后 commit：{SNAPSHOT_PATH.relative_to(Path(__file__).parent.parent)}")
+    return "\n".join(lines)
+
+
+def test_route_snapshot() -> None:
+    current = _collect_routes()
+    assert len(current) > 100, (
+        f"app.routes 只有 {len(current)} 个，明显过少 —— 可能 server.py 装配出了问题"
+    )
+
+    saved = _load_snapshot()
+    if saved is None:
+        _write_snapshot(current)
+        warnings.warn(
+            f"snapshot 已创建：{SNAPSHOT_PATH} （{len(current)} 个 route）。"
+            "请将该文件 commit 进 git。",
+            stacklevel=1,
+        )
+        return
+
+    if saved.get("routes") == current:
+        return
+
+    diff = _format_diff(current, saved.get("routes", []))
+    pytest.fail(
+        f"studio.server.app.routes snapshot 不匹配。\n"
+        f"snapshot 路径：{SNAPSHOT_PATH}\n"
+        f"snapshot count = {saved.get('count')} / 当前 count = {len(current)}\n\n"
+        f"{diff}"
+    )

--- a/tests/test_studio_import_smoke.py
+++ b/tests/test_studio_import_smoke.py
@@ -1,0 +1,57 @@
+"""PR-1 安全网 — studio/ 下每个 .py 都能 import。
+
+重构期间最易出的事故是循环 import / 搬目录后 import 路径忘改。
+本测试用 parametrize 给每个模块独立 case，定位精确。
+
+排除：
+- __pycache__/
+- studio/web/（前端构建产物 + node_modules）
+- 任何 .py 在 web/node_modules/ 下
+- studio/__main__.py（无 `if __name__ == "__main__"` 守护，import 时直接执行 main()）
+
+已知 import-time 副作用（属现状，PR-5/PR-7 才改）：
+- studio.server: ensure_dirs() + db.init_db()
+- studio.services.onnxruntime_setup: DLL preload
+本测试接受这些副作用，只验证 import 不抛异常。
+"""
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+import pytest
+
+STUDIO_ROOT = Path(__file__).parent.parent / "studio"
+
+
+def _enumerate_modules() -> list[str]:
+    modules: list[str] = []
+    for py in sorted(STUDIO_ROOT.rglob("*.py")):
+        rel = py.relative_to(STUDIO_ROOT.parent)
+        parts = rel.with_suffix("").parts
+        # 跳过缓存
+        if "__pycache__" in parts:
+            continue
+        # 跳过前端目录下混进来的 .py（如 web/node_modules/flatted/python/flatted.py）
+        if "web" in parts:
+            continue
+        # 跳过 __main__：无 if __name__ 守护，import 即执行 main() 并 SystemExit
+        if parts[-1] == "__main__":
+            continue
+        # 包内 __init__ 用包名表示
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+        modules.append(".".join(parts))
+    return modules
+
+
+MODULES = _enumerate_modules()
+
+
+def test_module_list_not_empty() -> None:
+    assert len(MODULES) > 50, f"枚举到的 studio/ 模块数只有 {len(MODULES)}，可能扫描出错"
+
+
+@pytest.mark.parametrize("module_name", MODULES, ids=MODULES)
+def test_import_module(module_name: str) -> None:
+    importlib.import_module(module_name)


### PR DESCRIPTION
## Summary

0.11.0 studio/ 重构 8 PR 系列第一刀，零业务改动，纯新增 tests/。后续 PR 拆 server.py / 拆 services/ / 搬目录时靠本测试快速发现 "丢路由 / 改路径 / 改函数名 / 循环 import"。

## Changes

- `tests/test_route_snapshot.py`: 冻结 `studio.server.app.routes` 的 160 个 `(methods, path, name, type)` 三元组到 `tests/_snapshots/studio_routes.json`；不一致时 `pytest.fail` 列 added / removed / changed
- `tests/test_studio_import_smoke.py`: parametrize 72 个 studio/ 模块逐个 import；排除 web/ + `__main__`（无 `if __name__` 守护）
- `tests/test_route_invariants.py`: 数量区间断言（100-250）+ `@app.*` 装饰器数 == `APIRoute` 数的二道防线
- `tests/_snapshots/studio_routes.json`: 当前 160 个 route 的冻结快照

## Verification

- 新增 76 个测试用例（72 个 import smoke + 1 个 snapshot + 3 个 invariants）
- 完整 pytest tests/: **1578 passed**（baseline 1502 + 新增 76），0 failed
- `app.routes` 实测 160 ✓ 与重构规划文档 (`tmp/0.11.0_planning.md`) 预期一致

## Notes

- `studio/__main__.py` 无 `if __name__ == "__main__":` 守护，import 即执行 `main()` → smoke 跳过。PR-8 整理 cli 入口时可顺手加 guard
- 已知 import-time 副作用（PR-5 / PR-7 才修）：
  - `studio.server`: `ensure_dirs()` + `db.init_db()`
  - `studio.services.onnxruntime_setup`: DLL preload
- 此 PR 即使后续 0.11.0 重构取消，测试也应保留 — 是独立有价值的回归网