### PR TITLE
refactor(supervisor): PR-4 supervisor.py 1431 → supervisor/ 子包 + _spawn_task 拆 helper

### DIFF
--- a/studio/supervisor/__init__.py
+++ b/studio/supervisor/__init__.py
@@ -1,0 +1,56 @@
+"""任务调度守护线程 — PR-4 拆分。
+
+`studio.supervisor` 1431 行原单文件按职责切到本子包：
+
+    slot.py         _Slot dataclass + SLOT_TRAIN/DATA 常量
+    cmd_builder.py  默认 cmd builder + monitor_state_path + worker EVENT 协议常量
+    finalizer.py    task 终态 → version.status 映射（ADR-0007 §11.3-B）
+    process.py      _kill_process_tree（跨平台杀进程树）
+    core.py         Supervisor 主类（保单类不拆，状态耦合高 — 详 PR-4 决策日志）
+
+本 `__init__.py` 兼容 shim：把全部 public name re-export 到包顶层，旧
+`from studio.supervisor import Supervisor / _Slot / _default_cmd_builder
+/ _maybe_finalize_version` 等 import 路径透明工作。
+
+monkeypatch path 兼容：tests 用 `monkeypatch.setattr("studio.supervisor._secrets.load", X)`
+和 `monkeypatch.setattr("studio.supervisor.subprocess.Popen", X)`，依赖
+`studio.supervisor` 模块对象上的 `_secrets` / `subprocess` attribute。下面从
+core.py re-export 让 lookup 命中真实 module 单例（Python 模块对象单例 →
+patch 同时影响 core.py 内的调用）。
+"""
+from __future__ import annotations
+
+from .cmd_builder import (
+    _EVENT_MARKER,
+    GPU_BOUND_JOB_KINDS,
+    CmdBuilder,
+    EventCallback,
+    JobCmdBuilder,
+    _default_cmd_builder,
+    _default_job_cmd_builder,
+    _resolve_monitor_state_path,
+)
+from .core import Supervisor, _secrets, subprocess
+from .finalizer import _maybe_finalize_version
+from .process import _kill_process_tree
+from .slot import SLOT_DATA, SLOT_TRAIN, _Slot
+
+__all__ = [
+    "Supervisor",
+    "_Slot",
+    "SLOT_TRAIN",
+    "SLOT_DATA",
+    "GPU_BOUND_JOB_KINDS",
+    "EventCallback",
+    "CmdBuilder",
+    "JobCmdBuilder",
+    "_EVENT_MARKER",
+    "_default_cmd_builder",
+    "_default_job_cmd_builder",
+    "_resolve_monitor_state_path",
+    "_maybe_finalize_version",
+    "_kill_process_tree",
+    # 下方 2 个仅为 monkeypatch path 兼容暴露；不属于业务 API
+    "_secrets",
+    "subprocess",
+]

--- a/studio/supervisor/cmd_builder.py
+++ b/studio/supervisor/cmd_builder.py
@@ -1,0 +1,105 @@
+"""默认 cmd builder + worker EVENT 协议常量（PR-4 从 supervisor.py 抽出）。
+
+`Supervisor.__init__` 接受 `cmd_builder` / `job_cmd_builder` 注入参数，方便
+测试替换；这里实现 supervisor 内默认走真实 runtime/anima_train.py / workers
+模块的版本。
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from .. import db
+from ..paths import REPO_ROOT, STUDIO_DATA
+
+# PP10.2.b：哪些 job kind 吃 GPU。这些 kind 在训练运行中默认会被推迟，
+# 除非 secrets.queue.allow_gpu_during_train=True 显式允许并行。
+# preprocess 走 spandrel super-resolution，加载权重到 GPU 推理。
+GPU_BOUND_JOB_KINDS: frozenset[str] = frozenset({"preprocess", "tag", "reg_build"})
+
+# Worker → supervisor 的结构化事件标记。worker 写
+#   __EVENT__:my_event_type:{"foo":1,"bar":"x"}
+# 到 stdout，supervisor 在 _on_line 里识别并 publish 成 typed SSE 事件
+# （job_id / project_id 自动注入），不会进 job_log。比专门搭 IPC 轻。
+_EVENT_MARKER = "__EVENT__:"
+
+
+EventCallback = Callable[[dict[str, Any]], None]
+CmdBuilder = Callable[[dict[str, Any], Path], list[str]]
+JobCmdBuilder = Callable[[dict[str, Any]], list[str]]
+
+
+def _default_cmd_builder(task: dict[str, Any], config_path: Path) -> list[str]:
+    """根据 task_type 路由到对应脚本。
+
+    train (默认 / 老 task): runtime/anima_train.py
+    reg_ai: runtime/anima_reg_ai.py（先验生成）
+    generate: 走 inference_daemon，**不**经这个 cmd_builder，supervisor
+        在 _dispatch_generate 里直接派给 daemon。这里 fallback 到 anima_generate.py
+        只是为了某天测试可能注入 cmd_builder 时不爆 KeyError —— 实际跑
+        不到这条 path（_next_pending_task_in 在 dispatch_train 里只挑
+        train/reg_ai）。
+    """
+    task_type = task.get("task_type") or "train"
+    if task_type == "reg_ai":
+        script = REPO_ROOT / "runtime" / "anima_reg_ai.py"
+    elif task_type == "generate":
+        script = REPO_ROOT / "runtime" / "anima_generate.py"  # 兜底，正常路径不来这
+    else:
+        script = REPO_ROOT / "runtime" / "anima_train.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        "--config",
+        str(config_path),
+    ]
+    msp = task.get("monitor_state_path")
+    if msp:
+        cmd.extend(["--monitor-state-file", str(msp)])
+    # ADR 0006 PR-3: paused task 复活 → 注入 --resume-state，让 anima_train
+    # 的 resume_phase 加载 state；旁边的 .config.json snapshot 由 bootstrap_phase
+    # 自动检测并 freeze args（ADR §5.7）。
+    paused_state = task.get("paused_state_path")
+    if paused_state:
+        cmd.extend(["--resume-state", str(paused_state)])
+    return cmd
+
+
+def _resolve_monitor_state_path(task: dict[str, Any]) -> Path:
+    """PP6.1 — 决定 task 的 monitor_state.json 落盘路径。
+
+    有 version_id：`versions/{label}/monitor_state.json`，与 train/output/samples
+    放一起；用户切 version 监控自然独立。
+    没有 version_id（PP1 之前的旧任务）：兜底到
+    `studio_data/monitors/task_{id}/state.json`，避免老任务无处可写。
+    """
+    vid = task.get("version_id")
+    pid = task.get("project_id")
+    if vid and pid:
+        # 不在这里 import projects/versions（避免循环）；直接通过 db 查
+        with db.connection_for() as conn:
+            row = conn.execute(
+                "SELECT projects.slug AS slug, versions.label AS label "
+                "FROM versions JOIN projects ON versions.project_id = projects.id "
+                "WHERE versions.id = ?",
+                (vid,),
+            ).fetchone()
+        if row:
+            return (
+                STUDIO_DATA / "projects" / f"{pid}-{row['slug']}"
+                / "versions" / row["label"] / "monitor_state.json"
+            )
+    return STUDIO_DATA / "monitors" / f"task_{task['id']}" / "state.json"
+
+
+def _default_job_cmd_builder(job: dict[str, Any]) -> list[str]:
+    """默认按 kind 选 worker 模块。"""
+    kind = job["kind"]
+    return [
+        sys.executable,
+        "-m",
+        f"studio.workers.{kind}_worker",
+        "--job-id",
+        str(job["id"]),
+    ]

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -29,7 +29,7 @@ import subprocess
 import threading
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 from .. import db, project_jobs, secrets as _secrets
 from ..log_tail import LogTailer, MonitorStatePoller
@@ -459,47 +459,12 @@ class Supervisor:
 
     # -------------------------------------------------------------- 子进程
     def _spawn_task(self, slot: _Slot, task: dict[str, Any]) -> None:
-        # PP6.3：优先用 task.config_path（version 私有 config 绝对路径）；
-        # 没有时降级到老路径 _configs_dir / {config_name}.yaml。
-        explicit_cfg = task.get("config_path")
-        if explicit_cfg:
-            cfg_path = Path(explicit_cfg)
-        else:
-            cfg_path = self._configs_dir / f"{task['config_name']}.yaml"
+        cfg_path = self._resolve_task_config_path(task)
         if not cfg_path.exists():
-            with db.connection_for(self._db_path) as conn:
-                now = time.time()
-                db.update_task(
-                    conn,
-                    task["id"],
-                    status="failed",
-                    started_at=now,
-                    finished_at=now,
-                    error_msg=(
-                        f"config not found: {cfg_path}"
-                        if explicit_cfg
-                        else f"preset not found: {task['config_name']}"
-                    ),
-                )
-            self._on_event(
-                {
-                    "type": "task_state_changed",
-                    "task_id": task["id"],
-                    "status": "failed",
-                }
-            )
+            self._fail_task_config_missing(task, cfg_path)
             return
 
-        # ADR-0007 §11.7 / PR-3 commit 4：task 启动 → 冻结当时的 config
-        # 到 studio_data/tasks/{tid}/snapshot/config.yaml。失败不阻 task
-        # 启动（snapshot 是 forensics 不是必需）。
-        try:
-            from .. import task_snapshot
-            task_snapshot.freeze_config(int(task["id"]), cfg_path)
-        except Exception:
-            logger.exception(
-                "task %s config snapshot freeze failed (non-fatal)", task["id"]
-            )
+        self._freeze_task_snapshot(int(task["id"]), cfg_path)
 
         # PP6.1 — 计算 per-task monitor 状态文件路径
         # 有 version_id：versions/{label}/monitor_state.json
@@ -524,14 +489,91 @@ class Supervisor:
         slot.log_fp = log_fp
         slot.cancel_pending = False
 
-        # PP6.4 — log tail → SSE（取代前端 2s 轮询 /api/logs/{id}）
         tid = task["id"]
 
+        # PP6.4 — log tail → SSE（取代前端 2s 轮询 /api/logs/{id}）
+        slot.tailer = LogTailer(log_path, self._make_task_log_callback(slot, tid))
+        slot.tailer.start()
+
+        # PP6.4 → PR #37: monitor_state.json 变化 → SSE monitor_progress (增量协议)
+        slot.state_poller = MonitorStatePoller(
+            monitor_state_path, self._make_monitor_callback(tid)
+        )
+        slot.state_poller.start()
+
+        self._write_task_running_to_db(task, proc.pid, monitor_state_path)
+
+        self._on_event(
+            {
+                "type": "task_state_changed",
+                "task_id": task["id"],
+                "status": "running",
+            }
+        )
+        logger.info(
+            "started task %d on slot=%s (pid=%d)", task["id"], slot.name, proc.pid
+        )
+
+    def _resolve_task_config_path(self, task: dict[str, Any]) -> Path:
+        """PP6.3：优先用 task.config_path（version 私有 config 绝对路径）；
+        没有时降级到老路径 _configs_dir / {config_name}.yaml。
+        """
+        explicit_cfg = task.get("config_path")
+        if explicit_cfg:
+            return Path(explicit_cfg)
+        return self._configs_dir / f"{task['config_name']}.yaml"
+
+    def _fail_task_config_missing(
+        self, task: dict[str, Any], cfg_path: Path
+    ) -> None:
+        """config 不存在时把 task 标 failed 并 publish 事件。"""
+        explicit_cfg = task.get("config_path")
+        with db.connection_for(self._db_path) as conn:
+            now = time.time()
+            db.update_task(
+                conn,
+                task["id"],
+                status="failed",
+                started_at=now,
+                finished_at=now,
+                error_msg=(
+                    f"config not found: {cfg_path}"
+                    if explicit_cfg
+                    else f"preset not found: {task['config_name']}"
+                ),
+            )
+        self._on_event(
+            {
+                "type": "task_state_changed",
+                "task_id": task["id"],
+                "status": "failed",
+            }
+        )
+
+    def _freeze_task_snapshot(self, task_id: int, cfg_path: Path) -> None:
+        """ADR-0007 §11.7 / PR-3 commit 4：task 启动 → 冻结当时的 config
+        到 studio_data/tasks/{tid}/snapshot/config.yaml。失败不阻 task
+        启动（snapshot 是 forensics 不是必需）。
+        """
+        try:
+            from .. import task_snapshot
+            task_snapshot.freeze_config(task_id, cfg_path)
+        except Exception:
+            logger.exception(
+                "task %s config snapshot freeze failed (non-fatal)", task_id
+            )
+
+    def _make_task_log_callback(
+        self, slot: _Slot, tid: int
+    ) -> Callable[[str], None]:
+        """LogTailer 回调：识别 __EVENT__: 协议 → 镜像状态到 slot + publish SSE；
+        普通行 → task_log_appended。
+
+        ADR 0006 PR-2：训练 worker 通过 __EVENT__: 协议跟 supervisor 通信
+        （pause_state / train_loop_started / auto_epoch_backup_written /
+        resume_state_loaded）。跟 jobs 的 _on_line 路径对齐。
+        """
         def _on_task_log(line: str) -> None:
-            # ADR 0006 PR-2：训练 worker 通过 __EVENT__: 协议跟 supervisor 通信
-            # （pause_state / train_loop_started / resume_state_loaded）。跟
-            # jobs 的 _on_line 路径对齐 — 之前 task 这条 path 不识别 event marker，
-            # 现在补上。
             if line.startswith(_EVENT_MARKER):
                 try:
                     rest = line[len(_EVENT_MARKER):]
@@ -572,33 +614,40 @@ class Supervisor:
                 "text": line,
                 "seq": next(self._log_seq),
             })
+        return _on_task_log
 
-        slot.tailer = LogTailer(log_path, _on_task_log)
-        slot.tailer.start()
+    def _make_monitor_callback(
+        self, tid: int
+    ) -> Callable[[dict[str, Any]], None]:
+        """MonitorStatePoller 回调：把 monitor_state.json 的 delta publish 成
+        SSE monitor_progress（PR #37 增量协议）。
 
-        # PP6.4 → PR #37: monitor_state.json 变化 → SSE monitor_progress (增量协议)
-        # payload 是 delta（appended_losses/lr/samples + 最新 step/speed/...），
-        # 客户端首次 GET /api/state 拿快照后用这个增量持续 merge。
+        payload 是 delta（appended_losses/lr/samples + 最新 step/speed/...），
+        客户端首次 GET /api/state 拿快照后用这个增量持续 merge。
+        """
         def _on_state_delta(delta: dict[str, Any]) -> None:
             self._on_event({
                 "type": "monitor_progress",
                 "task_id": tid,
                 "delta": delta,
             })
+        return _on_state_delta
 
-        slot.state_poller = MonitorStatePoller(monitor_state_path, _on_state_delta)
-        slot.state_poller.start()
-
+    def _write_task_running_to_db(
+        self, task: dict[str, Any], pid: int, monitor_state_path: Path
+    ) -> None:
+        """task spawn 后的 db 写入：task.status=running + version.status=training
+        （ADR-0007 §11.3-B 双写）。
+        """
         with db.connection_for(self._db_path) as conn:
             db.update_task(
                 conn,
                 task["id"],
                 status="running",
                 started_at=time.time(),
-                pid=proc.pid,
+                pid=pid,
                 monitor_state_path=str(monitor_state_path),
             )
-            # ADR-0007 §11.3-B 双写：task 启动 → version.status = training
             vid = task.get("version_id")
             if vid:
                 try:
@@ -612,16 +661,6 @@ class Supervisor:
                         "version.status=training write failed for task %s",
                         task["id"],
                     )
-        self._on_event(
-            {
-                "type": "task_state_changed",
-                "task_id": task["id"],
-                "status": "running",
-            }
-        )
-        logger.info(
-            "started task %d on slot=%s (pid=%d)", task["id"], slot.name, proc.pid
-        )
 
     def _spawn_job(self, slot: _Slot, job: dict[str, Any]) -> None:
         log_path = Path(job.get("log_path") or project_jobs.log_path_for(job["id"]))
@@ -641,16 +680,44 @@ class Supervisor:
         slot.log_fp = log_fp
         slot.cancel_pending = False
 
-        # tail 增量 → SSE
         jid = job["id"]
         pid_ = job["project_id"]
         vid = job.get("version_id")
         kind = job["kind"]
 
+        slot.tailer = LogTailer(
+            log_path, self._make_job_log_callback(jid, pid_, vid, kind)
+        )
+        slot.tailer.start()
+
+        self._on_event({
+            "type": "job_state_changed",
+            "job_id": jid,
+            "project_id": pid_,
+            "version_id": vid,
+            "kind": kind,
+            "status": "running",
+        })
+        logger.info(
+            "started job %d on slot=%s (kind=%s, pid=%d)",
+            jid, slot.name, kind, proc.pid,
+        )
+
+    def _make_job_log_callback(
+        self,
+        jid: int,
+        pid_: Optional[int],
+        vid: Optional[int],
+        kind: str,
+    ) -> Callable[[str], None]:
+        """LogTailer 回调：识别 __EVENT__: 协议 publish typed SSE；普通行
+        → job_log_appended。
+
+        结构化事件标记：worker 写 `__EVENT__:type:json_payload` 让 supervisor
+        publish 成 typed SSE 事件（不进 job log）。比专门搭 IPC 通道轻，比
+        让前端按文本 grep 日志靠谱。job_id / project_id 由 supervisor 注入。
+        """
         def _on_line(line: str) -> None:
-            # 结构化事件标记：worker 写 `__EVENT__:type:json_payload` 让 supervisor
-            # publish 成 typed SSE 事件（不进 job log）。比专门搭 IPC 通道轻，比
-            # 让前端按文本 grep 日志靠谱。job_id / project_id 由 supervisor 注入。
             if line.startswith(_EVENT_MARKER):
                 try:
                     rest = line[len(_EVENT_MARKER):]
@@ -678,22 +745,7 @@ class Supervisor:
                 "text": line,
                 "seq": next(self._log_seq),
             })
-
-        slot.tailer = LogTailer(log_path, _on_line)
-        slot.tailer.start()
-
-        self._on_event({
-            "type": "job_state_changed",
-            "job_id": jid,
-            "project_id": pid_,
-            "version_id": vid,
-            "kind": kind,
-            "status": "running",
-        })
-        logger.info(
-            "started job %d on slot=%s (kind=%s, pid=%d)",
-            jid, slot.name, kind, proc.pid,
-        )
+        return _on_line
 
     # ----------------------------------------------- daemon 路径 (commit 9)
     def _submit_to_daemon(self, task: dict[str, Any]) -> None:

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -1,4 +1,4 @@
-"""任务调度守护线程：从 SQLite 拉 pending 任务，spawn 子进程。
+"""Supervisor 主类 — PR-4 从 supervisor.py 抽出（行为零变更）。
 
 设计要点：
     - 单进程串行（一次最多一个 worker，避开多任务抢 GPU 的复杂度）
@@ -11,6 +11,13 @@
     - 取消用 SIGTERM (Unix) / CTRL_BREAK_EVENT (Windows)，30 秒超时再 kill
     - 启动恢复：重启时把 status='running' 的孤儿 task / job 标 failed
     - 测试可注入 cmd_builder 替代真实 worker 调用
+
+主类**不拆**（保 1100 行单类）：37 个 method 全部 read/write 共享 self
+字段（`_slots / _daemon_* / _stop / _thread / _db_path`），状态耦合极高
+且缺乏清晰子域边界 — 拆 Mixin/helper class 反而增加未来扩展成本（详
+tmp/0.11.0_planning.md PR-4 决策日志）。叶子 helper（_Slot / 默认 cmd
+builder / _maybe_finalize_version / _kill_process_tree）已搬到 sibling
+模块，本文件仅保 Supervisor class 主体。
 """
 from __future__ import annotations
 
@@ -19,229 +26,34 @@ import logging
 import os
 import signal
 import subprocess
-import sys
 import threading
 import time
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Optional
+from typing import Any, Optional
 
-from . import db, project_jobs, secrets as _secrets
-from .log_tail import LogTailer, MonitorStatePoller
-from .paths import LOGS_DIR, REPO_ROOT, STUDIO_DATA, STUDIO_DB, USER_PRESETS_DIR
-from .services.inference_daemon import (
+from .. import db, project_jobs, secrets as _secrets
+from ..log_tail import LogTailer, MonitorStatePoller
+from ..paths import LOGS_DIR, REPO_ROOT, STUDIO_DATA, STUDIO_DB, USER_PRESETS_DIR
+from ..services.inference_daemon import (
     InferenceDaemon,
     STATE_STOPPED as _DAEMON_STOPPED,
     get_daemon,
 )
+from .cmd_builder import (
+    _EVENT_MARKER,
+    GPU_BOUND_JOB_KINDS,
+    CmdBuilder,
+    EventCallback,
+    JobCmdBuilder,
+    _default_cmd_builder,
+    _default_job_cmd_builder,
+    _resolve_monitor_state_path,
+)
+from .finalizer import _maybe_finalize_version
+from .process import _kill_process_tree
+from .slot import SLOT_DATA, SLOT_TRAIN, _Slot
 
 logger = logging.getLogger(__name__)
-
-# PP10.2.b：哪些 job kind 吃 GPU。这些 kind 在训练运行中默认会被推迟，
-# 除非 secrets.queue.allow_gpu_during_train=True 显式允许并行。
-# preprocess 走 spandrel super-resolution，加载权重到 GPU 推理。
-GPU_BOUND_JOB_KINDS: frozenset[str] = frozenset({"preprocess", "tag", "reg_build"})
-
-# Worker → supervisor 的结构化事件标记。worker 写
-#   __EVENT__:my_event_type:{"foo":1,"bar":"x"}
-# 到 stdout，supervisor 在 _on_line 里识别并 publish 成 typed SSE 事件
-# （job_id / project_id 自动注入），不会进 job_log。比专门搭 IPC 轻。
-_EVENT_MARKER = "__EVENT__:"
-
-# 槽位名常量
-SLOT_TRAIN = "train"
-SLOT_DATA = "data"
-
-
-@dataclass
-class _Slot:
-    """Supervisor 内的一个执行槽位。每个槽位最多跑 1 个子进程。
-
-    PP10.2.a 起从「单 _current_* 字段」改成「list[_Slot]」；10.2.b 拆成
-    两个槽位：
-      - TRAIN 槽：只跑 training tasks（db.tasks 表）
-      - DATA  槽：只跑 project_jobs（download / tag / reg_build）
-    download 永远跟训练并行；tag / reg_build 看 settings 开关。
-    """
-    name: str = "main"
-    proc: Optional[subprocess.Popen] = None
-    kind: Optional[str] = None  # "task" | "job"
-    id: Optional[int] = None
-    log_fp: Optional[Any] = None
-    tailer: Optional[LogTailer] = None
-    state_poller: Optional[MonitorStatePoller] = None
-    cancel_pending: bool = False
-    # ADR 0006 PR-2 pause/resume backend ----------------------------------
-    pause_pending: bool = False
-    # `__EVENT__:pause_state` payload — handle_interrupt 写好 .pt + snapshot 后
-    # 子进程通过 stdout emit；_on_line 抓到后填这三个字段，_finish_slot 据此
-    # 把 task 标 paused。pause_pending=True 但缺这几个字段 → 子进程退出前
-    # 没来得及 emit → 视为 cancel 兜底（ADR §4.3 modal "强制取消保存进度"）。
-    pause_state_path: Optional[str] = None
-    pause_config_path: Optional[str] = None
-    pause_step: Optional[int] = None
-    # ADR §8.1 is_pausable 信号 — resume phase emit `train_loop_started` 后才
-    # 允许暂停。UI 端 SSE 用这个解锁暂停按钮，API 端 defense-in-depth 拒绝
-    # 过早 pause 请求。
-    train_loop_started: bool = False
-    # ADR 0006 Addendum 1：epoch 末尾 auto backup 完成后填这两个字段。
-    # is_pausable 升级条件要求 `last_auto_epoch_state_path is not None` —— 首 epoch
-    # 未结束时按钮完全隐藏，避免用户暂停后无可恢复 state。
-    last_auto_epoch_state_path: Optional[str] = None
-    last_auto_epoch_config_path: Optional[str] = None
-
-    @property
-    def busy(self) -> bool:
-        return self.proc is not None
-
-    def reset(self) -> None:
-        self.proc = None
-        self.kind = None
-        self.id = None
-        self.log_fp = None
-        self.tailer = None
-        self.state_poller = None
-        self.cancel_pending = False
-        self.pause_pending = False
-        self.pause_state_path = None
-        self.pause_config_path = None
-        self.pause_step = None
-        self.train_loop_started = False
-        self.last_auto_epoch_state_path = None
-        self.last_auto_epoch_config_path = None
-
-EventCallback = Callable[[dict[str, Any]], None]
-CmdBuilder = Callable[[dict[str, Any], Path], list[str]]
-JobCmdBuilder = Callable[[dict[str, Any]], list[str]]
-
-
-def _default_cmd_builder(task: dict[str, Any], config_path: Path) -> list[str]:
-    """根据 task_type 路由到对应脚本。
-
-    train (默认 / 老 task): runtime/anima_train.py
-    reg_ai: runtime/anima_reg_ai.py（先验生成）
-    generate: 走 inference_daemon，**不**经这个 cmd_builder，supervisor
-        在 _dispatch_generate 里直接派给 daemon。这里 fallback 到 anima_generate.py
-        只是为了某天测试可能注入 cmd_builder 时不爆 KeyError —— 实际跑
-        不到这条 path（_next_pending_task_in 在 dispatch_train 里只挑
-        train/reg_ai）。
-    """
-    task_type = task.get("task_type") or "train"
-    if task_type == "reg_ai":
-        script = REPO_ROOT / "runtime" / "anima_reg_ai.py"
-    elif task_type == "generate":
-        script = REPO_ROOT / "runtime" / "anima_generate.py"  # 兜底，正常路径不来这
-    else:
-        script = REPO_ROOT / "runtime" / "anima_train.py"
-    cmd = [
-        sys.executable,
-        str(script),
-        "--config",
-        str(config_path),
-    ]
-    msp = task.get("monitor_state_path")
-    if msp:
-        cmd.extend(["--monitor-state-file", str(msp)])
-    # ADR 0006 PR-3: paused task 复活 → 注入 --resume-state，让 anima_train
-    # 的 resume_phase 加载 state；旁边的 .config.json snapshot 由 bootstrap_phase
-    # 自动检测并 freeze args（ADR §5.7）。
-    paused_state = task.get("paused_state_path")
-    if paused_state:
-        cmd.extend(["--resume-state", str(paused_state)])
-    return cmd
-
-
-def _maybe_finalize_version(
-    conn: Any, task_id: int, task_status: str = "done"
-) -> None:
-    """task 终态 → 推 version.status（ADR-0007 §11.3-B）。
-
-    task_status 映射：
-    - done → completed（+ output_lora_path 回填）
-    - failed → failed（+ last_failure_reason 写入 task.error_msg）
-    - canceled → canceled
-
-    paused 不进此函数（§11.3-A：task=paused 时 version 仍 training，UI 派生显示）。
-    """
-    from . import versions as _versions
-    task_row = db.get_task(conn, task_id)
-    if not task_row:
-        return
-    vid = task_row.get("version_id")
-    pid = task_row.get("project_id")
-    if not (vid and pid):
-        return
-    v = _versions.get_version(conn, int(vid))
-    if not v:
-        return
-    from . import projects as _projects
-    p = _projects.get_project(conn, int(pid))
-    if not p:
-        return
-
-    # ADR-0007 §11.3-B：task 终态独立映射，不撒谎
-    new_status_map = {
-        "done":     _versions.VersionStatus.COMPLETED,
-        "failed":   _versions.VersionStatus.FAILED,
-        "canceled": _versions.VersionStatus.CANCELED,
-    }
-    new_status = new_status_map.get(task_status)
-    if new_status is None:
-        return  # 未知 task_status（如 paused / running）不动 version
-
-    fields: dict[str, Any] = {"status": new_status}
-
-    if task_status == "done":
-        output_name = f"{p['slug']}_{v['label']}"
-        vdir = _versions.version_dir(int(pid), p["slug"], v["label"])
-        candidate = vdir / "output" / f"{output_name}_final.safetensors"
-        if candidate.exists():
-            fields["output_lora_path"] = str(candidate)
-    elif task_status == "failed":
-        err = task_row.get("error_msg")
-        if err:
-            fields["last_failure_reason"] = str(err)
-
-    _versions.update_version(conn, int(vid), **fields)
-
-
-def _resolve_monitor_state_path(task: dict[str, Any]) -> Path:
-    """PP6.1 — 决定 task 的 monitor_state.json 落盘路径。
-
-    有 version_id：`versions/{label}/monitor_state.json`，与 train/output/samples
-    放一起；用户切 version 监控自然独立。
-    没有 version_id（PP1 之前的旧任务）：兜底到
-    `studio_data/monitors/task_{id}/state.json`，避免老任务无处可写。
-    """
-    vid = task.get("version_id")
-    pid = task.get("project_id")
-    if vid and pid:
-        # 不在这里 import projects/versions（避免循环）；直接通过 db 查
-        with db.connection_for() as conn:
-            row = conn.execute(
-                "SELECT projects.slug AS slug, versions.label AS label "
-                "FROM versions JOIN projects ON versions.project_id = projects.id "
-                "WHERE versions.id = ?",
-                (vid,),
-            ).fetchone()
-        if row:
-            return (
-                STUDIO_DATA / "projects" / f"{pid}-{row['slug']}"
-                / "versions" / row["label"] / "monitor_state.json"
-            )
-    return STUDIO_DATA / "monitors" / f"task_{task['id']}" / "state.json"
-
-
-def _default_job_cmd_builder(job: dict[str, Any]) -> list[str]:
-    """默认按 kind 选 worker 模块。"""
-    kind = job["kind"]
-    return [
-        sys.executable,
-        "-m",
-        f"studio.workers.{kind}_worker",
-        "--job-id",
-        str(job["id"]),
-    ]
 
 
 class Supervisor:
@@ -682,7 +494,7 @@ class Supervisor:
         # 到 studio_data/tasks/{tid}/snapshot/config.yaml。失败不阻 task
         # 启动（snapshot 是 forensics 不是必需）。
         try:
-            from . import task_snapshot
+            from .. import task_snapshot
             task_snapshot.freeze_config(int(task["id"]), cfg_path)
         except Exception:
             logger.exception(
@@ -790,7 +602,7 @@ class Supervisor:
             vid = task.get("version_id")
             if vid:
                 try:
-                    from . import versions as _versions
+                    from .. import versions as _versions
                     _versions.update_version(
                         conn, int(vid),
                         status=_versions.VersionStatus.TRAINING,
@@ -1101,7 +913,7 @@ class Supervisor:
             db.update_task(conn, task_id, **fields)
 
         try:
-            from .services.inference_core import cleanup_generate_tempdir
+            from ..services.inference_core import cleanup_generate_tempdir
             cleanup_generate_tempdir(task_id)
         except Exception as e:
             logger.warning("cleanup generate tempdir failed: %s", e)
@@ -1406,25 +1218,3 @@ class Supervisor:
                 paused_step=None,
                 paused_at=None,
             )
-
-
-def _kill_process_tree(pid: int) -> None:
-    """杀掉以 pid 为根的整棵进程树。
-
-    Windows 上 `proc.kill()` 只杀 immediate child，DataLoader workers /
-    accelerate 的 sub-subprocess 会留下来占着 GPU；用 `taskkill /T /F` 能
-    递归到整个进程树。POSIX 用 killpg。
-    """
-    if os.name == "nt":
-        try:
-            subprocess.run(
-                ["taskkill", "/T", "/F", "/PID", str(pid)],
-                check=False, capture_output=True, timeout=10,
-            )
-        except Exception:
-            logger.exception("taskkill /T /F failed for pid %d", pid)
-    else:
-        try:
-            os.killpg(os.getpgid(pid), signal.SIGKILL)
-        except Exception:
-            logger.exception("killpg failed for pid %d", pid)

--- a/studio/supervisor/finalizer.py
+++ b/studio/supervisor/finalizer.py
@@ -1,0 +1,65 @@
+"""task 终态 → version.status 映射（PR-4 从 supervisor.py 抽出）。
+
+ADR-0007 §11.3-B：task 终态独立映射，不撒谎。done/failed/canceled 三种
+task_status 各映射到对应 VersionStatus；paused 不进此函数（§11.3-A：
+task=paused 时 version 仍 training，UI 派生显示）。
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from .. import db
+
+
+def _maybe_finalize_version(
+    conn: Any, task_id: int, task_status: str = "done"
+) -> None:
+    """task 终态 → 推 version.status（ADR-0007 §11.3-B）。
+
+    task_status 映射：
+    - done → completed（+ output_lora_path 回填）
+    - failed → failed（+ last_failure_reason 写入 task.error_msg）
+    - canceled → canceled
+
+    paused 不进此函数（§11.3-A：task=paused 时 version 仍 training，UI 派生显示）。
+    """
+    from .. import versions as _versions
+    task_row = db.get_task(conn, task_id)
+    if not task_row:
+        return
+    vid = task_row.get("version_id")
+    pid = task_row.get("project_id")
+    if not (vid and pid):
+        return
+    v = _versions.get_version(conn, int(vid))
+    if not v:
+        return
+    from .. import projects as _projects
+    p = _projects.get_project(conn, int(pid))
+    if not p:
+        return
+
+    # ADR-0007 §11.3-B：task 终态独立映射，不撒谎
+    new_status_map = {
+        "done":     _versions.VersionStatus.COMPLETED,
+        "failed":   _versions.VersionStatus.FAILED,
+        "canceled": _versions.VersionStatus.CANCELED,
+    }
+    new_status = new_status_map.get(task_status)
+    if new_status is None:
+        return  # 未知 task_status（如 paused / running）不动 version
+
+    fields: dict[str, Any] = {"status": new_status}
+
+    if task_status == "done":
+        output_name = f"{p['slug']}_{v['label']}"
+        vdir = _versions.version_dir(int(pid), p["slug"], v["label"])
+        candidate = vdir / "output" / f"{output_name}_final.safetensors"
+        if candidate.exists():
+            fields["output_lora_path"] = str(candidate)
+    elif task_status == "failed":
+        err = task_row.get("error_msg")
+        if err:
+            fields["last_failure_reason"] = str(err)
+
+    _versions.update_version(conn, int(vid), **fields)

--- a/studio/supervisor/process.py
+++ b/studio/supervisor/process.py
@@ -1,0 +1,36 @@
+"""跨平台杀进程树工具（PR-4 从 supervisor.py 抽出）。
+
+Windows 上 `proc.kill()` 只杀 immediate child，DataLoader workers /
+accelerate 的 sub-subprocess 会留下来占着 GPU；用 `taskkill /T /F` 能
+递归到整个进程树。POSIX 用 killpg。
+"""
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+
+def _kill_process_tree(pid: int) -> None:
+    """杀掉以 pid 为根的整棵进程树。
+
+    Windows 上 `proc.kill()` 只杀 immediate child，DataLoader workers /
+    accelerate 的 sub-subprocess 会留下来占着 GPU；用 `taskkill /T /F` 能
+    递归到整个进程树。POSIX 用 killpg。
+    """
+    if os.name == "nt":
+        try:
+            subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(pid)],
+                check=False, capture_output=True, timeout=10,
+            )
+        except Exception:
+            logger.exception("taskkill /T /F failed for pid %d", pid)
+    else:
+        try:
+            os.killpg(os.getpgid(pid), signal.SIGKILL)
+        except Exception:
+            logger.exception("killpg failed for pid %d", pid)

--- a/studio/supervisor/slot.py
+++ b/studio/supervisor/slot.py
@@ -1,0 +1,69 @@
+"""Supervisor 执行槽位（PR-4 从 supervisor.py 抽出）。
+
+PP10.2.a 起从「单 _current_* 字段」改成「list[_Slot]」；10.2.b 拆成两槽：
+  - TRAIN 槽：只跑 training tasks（db.tasks 表）
+  - DATA  槽：只跑 project_jobs（download / tag / reg_build）
+download 永远跟训练并行；tag / reg_build 看 settings 开关。
+"""
+from __future__ import annotations
+
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from ..log_tail import LogTailer, MonitorStatePoller
+
+# 槽位名常量
+SLOT_TRAIN = "train"
+SLOT_DATA = "data"
+
+
+@dataclass
+class _Slot:
+    """Supervisor 内的一个执行槽位。每个槽位最多跑 1 个子进程。"""
+    name: str = "main"
+    proc: Optional[subprocess.Popen] = None
+    kind: Optional[str] = None  # "task" | "job"
+    id: Optional[int] = None
+    log_fp: Optional[Any] = None
+    tailer: Optional[LogTailer] = None
+    state_poller: Optional[MonitorStatePoller] = None
+    cancel_pending: bool = False
+    # ADR 0006 PR-2 pause/resume backend ----------------------------------
+    pause_pending: bool = False
+    # `__EVENT__:pause_state` payload — handle_interrupt 写好 .pt + snapshot 后
+    # 子进程通过 stdout emit；_on_line 抓到后填这三个字段，_finish_slot 据此
+    # 把 task 标 paused。pause_pending=True 但缺这几个字段 → 子进程退出前
+    # 没来得及 emit → 视为 cancel 兜底（ADR §4.3 modal "强制取消保存进度"）。
+    pause_state_path: Optional[str] = None
+    pause_config_path: Optional[str] = None
+    pause_step: Optional[int] = None
+    # ADR §8.1 is_pausable 信号 — resume phase emit `train_loop_started` 后才
+    # 允许暂停。UI 端 SSE 用这个解锁暂停按钮，API 端 defense-in-depth 拒绝
+    # 过早 pause 请求。
+    train_loop_started: bool = False
+    # ADR 0006 Addendum 1：epoch 末尾 auto backup 完成后填这两个字段。
+    # is_pausable 升级条件要求 `last_auto_epoch_state_path is not None` —— 首 epoch
+    # 未结束时按钮完全隐藏，避免用户暂停后无可恢复 state。
+    last_auto_epoch_state_path: Optional[str] = None
+    last_auto_epoch_config_path: Optional[str] = None
+
+    @property
+    def busy(self) -> bool:
+        return self.proc is not None
+
+    def reset(self) -> None:
+        self.proc = None
+        self.kind = None
+        self.id = None
+        self.log_fp = None
+        self.tailer = None
+        self.state_poller = None
+        self.cancel_pending = False
+        self.pause_pending = False
+        self.pause_state_path = None
+        self.pause_config_path = None
+        self.pause_step = None
+        self.train_loop_started = False
+        self.last_auto_epoch_state_path = None
+        self.last_auto_epoch_config_path = None


### PR DESCRIPTION
## Summary

PR-4 of 0.11.0 底层重构（详 `tmp/0.11.0_planning.md`）。supervisor.py 1431 行单文件按职责切到 `supervisor/` 6 文件子包，叶子 helpers 独立成 sibling 模块，Supervisor 主类保单类不拆。

**两个 commit**：

- **commit 1** (`2cee942`) — 文件级拆分：supervisor.py → supervisor/{__init__, slot, cmd_builder, finalizer, process, core}.py。git rename detection 识别 supervisor.py → core.py 83% similarity。
- **commit 2** (`945d7a4`) — _spawn_task 164 / _spawn_job 72 行 method 内拆 7 个 helper method。主流程瘦到 _spawn_task 56 / _spawn_job 41 行；闭包 _on_task_log / _on_state_delta / _on_line 改 `_make_*_callback` method 返回 inner func。

## 关键决策（与 Agent A 原方案的偏离）

**Supervisor 主类不拆**（保 1100 行单类）：37 个 method 全部 read/write 共享 self 字段（`_slots / _daemon_* / _stop / _db_path`），状态耦合极高且缺乏清晰子域边界。拆 Mixin/helper class 反而增加未来扩展（pause/resume PR-3、多 GPU 槽位、quota）跨文件改 self 状态的成本。

跟 PR-2 决定 TrainingConfig 643 行单类不拆 mixin 是**同一性质判断**——状态耦合 > 行数痛点时，保单类。叶子 helper 拆出降低顶层 namespace 心智负担即可。

完整决策记录见 `tmp/0.11.0_planning.md`（PR-4 完成后会更新）。

## 兼容垫片

- `__init__.py` 全 public name re-export，旧 `from studio.supervisor import Supervisor / _Slot / _default_cmd_builder / _maybe_finalize_version` 透明
- monkeypatch path 兼容：暴露 `_secrets` / `subprocess` 作 supervisor 包 attribute，tests 用的 `monkeypatch.setattr("studio.supervisor._secrets.load", X)` / `"studio.supervisor.subprocess.Popen"` 仍能 hit module 单例

## 行为零变更

- callback 内逻辑逐行抄过去，未改 EVENT marker 处理 / db 写顺序 / event publish 字段集合
- 5 个 evt_type 分支（pause_state / train_loop_started / auto_epoch_backup_written / resume_state_loaded / 默认 publish）保留原样
- ADR-0007 §11.3-B version.status 双写 / ADR 0006 PR-2 pause/resume backend / ADR Addendum 1 is_pausable 升级条件全保留

## Test plan

- [x] tests/test_supervisor.py (13)
- [x] tests/test_supervisor_jobs.py (7)
- [x] tests/test_supervisor_pause.py (16)
- [x] tests/test_supervisor_version_status.py (8)
- [x] tests/test_resume_path.py (22)
- [x] tests/test_daemon_gpu_yield.py (8)
- [x] tests/test_inference_daemon.py (8)
- [x] tests/test_route_snapshot.py (1)
- [x] tests/test_studio_import_smoke.py (140)
- [x] tests/test_route_invariants.py (2)
- [x] **226/226 全绿**

🤖 Generated with [Claude Code](https://claude.com/claude-code)