### PR TITLE
refactor(workers+server): PR-8 workers _base + server.py 终极 shim 51 行

### DIFF
--- a/studio/server.py
+++ b/studio/server.py
@@ -1,252 +1,50 @@
-"""AnimaStudio 守护服务（FastAPI）。
+"""AnimaStudio FastAPI server — PR-8 final shim.
 
-P1 范围（本文件目前实现）：
-    - GET  /                   302 跳转到 /studio/
-    - GET  /api/health         健康检查
-    - GET  /api/state          读取 task 的 per-task monitor state
-    - GET  /samples/{name}     代理采样图（按 task_id 解析到 version 目录）
-    - GET  /studio/...         React 应用（构建后挂载，可缺省）
+历史上 server.py 一文件 4657 行装全 router / lifespan / middleware / 工具
+helper。PR-5..PR-6.5 把全部 routes + BaseModel + helper 搬到 `studio/api/`
+子包；PR-8 final shim 只剩 30+ 行：
 
-后续阶段会扩展（参见 plan）：
-    - P2: /api/schema, /api/configs/*
-    - P3: /api/queue/*, /api/events (SSE), /api/logs/{id}
-    - P4: /api/datasets
+- `app` —— FastAPI 实例（真实在 `studio/api/app.py`），所有 router 通过那里
+  `include_router` 注册。外部代码用 `from studio.server import app` 拿到的就是
+  同一对象。
+- `main` —— uvicorn 启动入口（真实在 `studio/api/main.py`）。
+- `HTTPException` —— `pytest.raises(server.HTTPException)` 兼容。
+- 6 个 path 常量 —— 测试 fixture 仍 `monkeypatch.setattr(server, X)` 期望存在；
+  保 re-import 不破坏老 fixture（新位置的 patch 也已加，详 PR-5/6 PR 描述）。
+- SPA mount —— 依赖运行时 `WEB_DIST.exists()` 检查，留在这里因为搬到
+  `api/app.py` 会让检查时机变成模块 import-time（lifespan 之前），行为漂。
 
-启动：
-    python -m studio.server [--host 127.0.0.1] [--port 8765] [--reload]
+入口：
+    uvicorn studio.server:app                # 老 cli.py / dev 模式
+    python -m studio                         # cli.py 默认 run
+    python -m studio.server [--host ...]     # 直接启 server（main()）
 """
 from __future__ import annotations
 
-import asyncio
-import io
-import json
-import logging
-import os
-import shutil
-import time
-import zipfile
-from pathlib import Path
-from typing import Any, AsyncIterator, Optional
+# pytest.raises(server.HTTPException) 兼容
+from fastapi import HTTPException  # noqa: F401
 
-from fastapi import (
-    BackgroundTasks,
-    File,
-    HTTPException,
-    Request,
-    UploadFile,
-)
-from fastapi.responses import FileResponse, Response, StreamingResponse
-from pydantic import BaseModel, model_validator
-
-from . import (
-    __version__,
-    browse,
-    curation,
-    datasets,
-    db,
-    preprocess as preprocess_svc,
-    presets_io,
-    project_jobs,
-    projects,
-    queue_io,
-    secrets,
-    thumb_cache,
-    versions,
-    versions_phase,
-)
+from . import db  # noqa: F401  test fixtures: monkeypatch.setattr(server.db, "STUDIO_DB", X)
 from .api.app import app
-from .api.errors import (
-    _data_export_path,
-    _export_result,
-    _preset_err_code as _err_code,
-    _safe_join_or_400,
-    _unique_data_export_path,
-    _validate_component_or_400,
-)
-from .api.responses import EMPTY_STATE, _thumb_response
+from .api.main import main
 from .api.static import SPAStaticFiles
-from .event_bus import bus
-from .services import (
-    caption_snapshot,
-    downloader,
-    duplicate_finder,
-    presets as preset_flow,
-    model_downloader,
-    preprocess_manifest,
-    reg_builder,
-    tagedit,
-    train_io,
-    uploads as uploads_svc,
-    version_config,
-)
-from .services.tagger import VALID_TAGGER_NAMES
 from .paths import (
-    DATA_EXPORTS,
-    LOGS_DIR,
-    OUTPUT_DIR,  # noqa: F401  test fixture monkeypatch path 兼容（samples router 用真位置）
-    REPO_ROOT,
-    STUDIO_DATA,
-    STUDIO_DB,
-    USER_PRESETS_DIR,
+    LOGS_DIR,          # noqa: F401  test fixture monkeypatch path
+    OUTPUT_DIR,        # noqa: F401
+    REPO_ROOT,         # noqa: F401
+    STUDIO_DB,         # noqa: F401
+    USER_PRESETS_DIR,  # noqa: F401
     WEB_DIST,
-    safe_join,
-)
-from .schema import (
-    GROUP_ORDER,
-    AttentionBackend,
-    GenerateConfig,
-    LoraEntry,
-    RegAiConfig,
-    TrainingConfig,
-    XYMatrixSpec,
-    migrate_legacy_attention,
-)
-from .supervisor import Supervisor
-
-logger = logging.getLogger(__name__)
-
-
-# health / system stats / state, presets CRUD + import/export, /api/schema,
-# /api/configs/* 308 redirects 已 PR-5 commit 2 抽到 api/routers/{health,presets}.py。
-# 仍需 server.py 内的 _err_code helper 给其它 router 用？无 —— 仅 presets 内部用。
-# DuplicateRequest / PresetXxxBody pydantic 模型也已抽到 api/schemas/presets.py。
-
-
-# ---------------------------------------------------------------------------
-# /api/secrets  (PP0 全局凭证 / 服务配置)
-# ---------------------------------------------------------------------------
-
-
-# /api/secrets, /api/models/*, /api/upscalers/* 已 PR-6 commit 2 抽到
-# api/routers/{secrets,models,upscalers}.py + api/schemas/models.py。
-
-
-# ---------------------------------------------------------------------------
-# /api/projects + /api/projects/{pid}/versions  (PP1)
-# ---------------------------------------------------------------------------
-
-
-# ProjectCreate / ProjectUpdate / VersionCreate / VersionUpdate BaseModel 已
-# PR-6.5 commit 1 抽到 api/schemas/projects.py。
-#
-# _project_payload / _publish_project_state / _publish_version_state /
-# _project_err_code 已 PR-6.5 commit 1 抽到 api/routers/projects/_shared.py
-# （projects 子包内共用，避免跨域反向耦合）。剩余 server.py 内 projects-域
-# handler（commit 2-5 抽走）通过下方 import 复用。
-from .api.routers.projects._shared import (  # noqa: E402
-    _project_and_version_or_404,
-    _project_err_code,
-    _project_payload,
-    _publish_project_state,
-    _publish_version_state,
-    _reg_dir,
-    _version_dir_or_404,
-    _version_train_dir_or_404,
 )
 
 
-# /api/projects + versions CRUD + activate + advance/skip-phase + lora_ckpts /
-# state_ckpts （16 routes） 已 PR-6.5 commit 1 抽到 api/routers/projects/crud.py。
-
-
-# Train / Bundle export + import (6 routes) + _BundleOptionsBody / _BundleImportBody +
-# _bundle_import_payload / _import_bundle_from_path helpers 已 PR-6.5 commit 2 抽到
-# api/routers/projects/exports.py + api/schemas/exports.py。
-
-
-# /api/projects/{pid}/download/* (4 routes), /upload + /upload-from-path (2),
-# /preprocess/* (8 routes incl. crop / files reset+restore / thumb) — 14 routes
-# + 6 BaseModel (Download/Estimate/UploadFromPath/PreprocessStart/PreprocessRestore/
-# CropRect/PreprocessCrop) + _publish_job_state / _apply_project_upload_result helpers
-# 已 PR-6.5 commit 3 抽到 api/routers/projects/ingestion.py + api/schemas/ingestion.py。
-# _publish_job_state 升 api/routers/projects/_shared.py（tag / reg 也用）。
-
-# /api/projects/{pid}/files (delete + list), /thumb, /versions/{vid}/jobs/latest,
-# /versions/{vid}/curation get + copy/remove/folder, /preprocess/duplicates/scan+apply
-# + backward-alias /duplicates/scan+apply (12 routes) + 6 BaseModel + 2 err_code
-# helpers 已 PR-6.5 commit 4 抽到 api/routers/projects/curation.py +
-# api/schemas/curation.py。
-
-
-# ---------------------------------------------------------------------------
-# /api/tagger/{name}/check + /api/projects/{pid}/versions/{vid}/tag
-# /api/projects/{pid}/versions/{vid}/captions/*  (PP4)
-# ---------------------------------------------------------------------------
-
-
-# /api/projects/{pid}/versions/{vid}/tag, /captions/* (8), /reg + /reg/preview-tags/build/caption/delete (5),
-# /reg/generate-prior + /reg/generate-prior/{task_id} (2), /config get/put/from_preset/save_as_preset (4),
-# /queue (training launch), /thumb (version thumb) = 23 routes + 12 BaseModel (Wd14/CLTagger/LLMTagger
-# Overrides + TagJob + Caption/CommitItem/Commit/BatchOp + RegBuild/RegAi + FromPreset/SaveAsPreset)
-# 已 PR-6.5 commit 5 抽到 api/routers/projects/training.py + api/schemas/training.py。
-
-
-
-# /api/queue/* (20 routes) + EnqueueRequest / ReorderRequest / ImportRequest /
-# ExportOutputsBody + _task_output_* helpers 已 PR-6 commit 6 抽到
-# api/routers/queue/{lifecycle,io,outputs}.py + api/schemas/queue.py（3 文件
-# 子包 internal split：12 lifecycle + 3 io + 5 outputs = 20）。
-
-# `_supervisor()` / `_resolve_anima_model_paths()` 已 PR-6 commit 2/5 抽到
-# api/deps.py，server.py 内剩余 handler 复用同函数
-from .api.deps import _resolve_anima_model_paths, _supervisor  # noqa: E402
-
-
-
-
-# ---------------------------------------------------------------------------
-# /api/datasets  (P4)
-# ---------------------------------------------------------------------------
-
-
-# /api/datasets, /api/browse, /api/datasets/thumbnail 已 PR-5 commit 2 抽到 api/routers/browse.py。
-
-
-# ---------------------------------------------------------------------------
-
-
-# /api/logs/{task_id} 已 PR-6 commit 1 抽到 api/routers/logs.py。
-
-
-# /api/events SSE 已 PR-5 commit 2 抽到 api/routers/events_sse.py。
-
-
-# ---------------------------------------------------------------------------
-# /samples
-# ---------------------------------------------------------------------------
-
-
-# /samples/{filename} 已 PR-6 commit 1 抽到 api/routers/samples.py。
-
-
-# ---------------------------------------------------------------------------
-# 静态资源
-# ---------------------------------------------------------------------------
-
-
-# React 应用：构建后通过 /studio 访问。开发期请用 `npm run dev` 起 5173。
-# `SPAStaticFiles` 已 PR-5 抽到 studio/api/static.py。
+# SPA mount — see module docstring for why this stays in server.py
 if WEB_DIST.exists():
     app.mount(
         "/studio",
         SPAStaticFiles(directory=str(WEB_DIST), html=True),
         name="studio",
     )
-
-
-# /api/system/* (11 routes) + UpdateRequest BaseModel + _RESTART_FLAG /
-# _SHUTDOWN_FORCE_EXIT_TIMEOUT / _raise_sigint_after_response / _check_no_running_tasks
-# helper 已 PR-6 commit 4 抽到 api/routers/system.py + api/schemas/system.py。
-
-
-# `/` 根路径 redirect 已 PR-6 commit 1 抽到 api/routers/root.py。
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
-
-from .api.main import main  # noqa: E402  # PR-5 抽到 api.main，re-export 保 `from studio.server import main` 兼容
 
 
 if __name__ == "__main__":

--- a/studio/workers/_base.py
+++ b/studio/workers/_base.py
@@ -1,0 +1,48 @@
+"""Worker 子进程入口通用模板（PR-8 commit 1 从 4 个 worker 抽出）。
+
+`supervisor` 启动每个 worker 子进程都是相同模式：
+    python -m studio.workers.<kind>_worker --job-id N
+    → 读 project_jobs 行 → 跑业务 → 退出码反映成败
+
+每个 worker 模块只需提供 `run(job_id: int) -> int` 主体，本模板包：
+    - argparse 解析 `--job-id`
+    - 调用 run + sys.exit
+
+可选 helper `reconfigure_console_utf8()` — Windows 控制台默认 cp932/cp936，
+写中文 / emoji 会 UnicodeEncodeError；调一次让 stdout/stderr 转 UTF-8 +
+replace 模式。当前只有 tag_worker 需要（其它 worker 不写中文 caption）。
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Callable
+
+
+def worker_main(run_fn: Callable[[int], int]) -> None:
+    """4 个 worker 共用的 `if __name__ == "__main__"` 入口。
+
+    worker 模块底部写：
+        if __name__ == "__main__":
+            from ._base import worker_main
+            worker_main(run)
+    """
+    p = argparse.ArgumentParser()
+    p.add_argument("--job-id", type=int, required=True)
+    args = p.parse_args()
+    sys.exit(run_fn(args.job_id))
+
+
+def reconfigure_console_utf8() -> None:
+    """Windows 控制台默认 cp932/cp936，写中文 / emoji 会 UnicodeEncodeError。
+    强制 stdout/stderr 用 UTF-8 + 替换不可编码字符，让 progress 永远不抛。
+
+    当前只 tag_worker 顶层调用（其它 worker 不写中文 caption）。supervisor
+    `_popen` 已经给所有 worker 子进程注入 `PYTHONIOENCODING=utf-8 / PYTHONUTF8=1`
+    env，但 Windows 上少数 console host 仍要 reconfigure 双保险。
+    """
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.reconfigure(encoding="utf-8", errors="replace")  # type: ignore[attr-defined]
+        except (AttributeError, OSError):
+            pass

--- a/studio/workers/download_worker.py
+++ b/studio/workers/download_worker.py
@@ -12,8 +12,6 @@ stderr=STDOUT)` 把整个子进程输出重定向到 task log 文件，worker �
 """
 from __future__ import annotations
 
-import argparse
-import sys
 import threading
 import traceback
 
@@ -85,12 +83,6 @@ def run(job_id: int) -> int:
         return 1
 
 
-def main() -> None:
-    p = argparse.ArgumentParser()
-    p.add_argument("--job-id", type=int, required=True)
-    args = p.parse_args()
-    sys.exit(run(args.job_id))
-
-
 if __name__ == "__main__":
-    main()
+    from ._base import worker_main
+    worker_main(run)

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -15,11 +15,9 @@ log 文件，避免 LogTailer 读两次。
 """
 from __future__ import annotations
 
-import argparse
 import json
 import math
 import signal
-import sys
 import time
 import traceback
 from pathlib import Path
@@ -429,12 +427,6 @@ def _run_crop(
     return 0
 
 
-def main() -> None:
-    p = argparse.ArgumentParser()
-    p.add_argument("--job-id", type=int, required=True)
-    args = p.parse_args()
-    sys.exit(run(args.job_id))
-
-
 if __name__ == "__main__":
-    main()
+    from ._base import worker_main
+    worker_main(run)

--- a/studio/workers/reg_build_worker.py
+++ b/studio/workers/reg_build_worker.py
@@ -25,19 +25,14 @@
 """
 from __future__ import annotations
 
-import argparse
-import sys
 import threading
 import traceback
 from pathlib import Path
 from typing import Any
 
-# Windows console cp932/cp936 → 强制 UTF-8 + replace（同 tag_worker）
-for _stream in (sys.stdout, sys.stderr):
-    try:
-        _stream.reconfigure(encoding="utf-8", errors="replace")
-    except (AttributeError, OSError):
-        pass
+from ._base import reconfigure_console_utf8
+
+reconfigure_console_utf8()
 
 # PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload。
 # auto_tag 路径会内联调 wd14_tagger（line ~105 `get_tagger("wd14")`），worker 是独立
@@ -240,12 +235,6 @@ def run(job_id: int) -> int:
         return 1
 
 
-def main() -> None:
-    p = argparse.ArgumentParser()
-    p.add_argument("--job-id", type=int, required=True)
-    args = p.parse_args()
-    sys.exit(run(args.job_id))
-
-
 if __name__ == "__main__":
-    main()
+    from ._base import worker_main
+    worker_main(run)

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -14,20 +14,14 @@
 """
 from __future__ import annotations
 
-import argparse
 import json
-import sys
 import traceback
 from pathlib import Path
 from typing import Any
 
-# Windows 控制台默认 cp932/cp936，写中文 / emoji 会 UnicodeEncodeError。
-# 强制 stdout/stderr 用 UTF-8 + 替换不可编码字符，让 progress 永远不抛。
-for _stream in (sys.stdout, sys.stderr):
-    try:
-        _stream.reconfigure(encoding="utf-8", errors="replace")
-    except (AttributeError, OSError):
-        pass
+from ._base import reconfigure_console_utf8
+
+reconfigure_console_utf8()
 
 # PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload
 # （Linux: RTLD_GLOBAL 加载 torch 自带 CUDA so；Windows: os.add_dll_directory）。
@@ -230,12 +224,6 @@ def _write_caption(
         )
 
 
-def main() -> None:
-    p = argparse.ArgumentParser()
-    p.add_argument("--job-id", type=int, required=True)
-    args = p.parse_args()
-    sys.exit(run(args.job_id))
-
-
 if __name__ == "__main__":
-    main()
+    from ._base import worker_main
+    worker_main(run)


### PR DESCRIPTION
## Summary

PR-8 of 0.11.0 底层重构最终 PR。完成 workers 公共模板抽出 + server.py 最终定稿。

**2 commit**：

| commit | hash | 内容 |
|---|---|---|
| commit 1 | `c7285c4` | workers/_base.py 抽 `worker_main` + `reconfigure_console_utf8`；4 worker 各瘦 ~10 行 |
| commit 2 | `bfcab48` | server.py 253 → **51 行**（−98.9% from PR-1 前的 4657） |

## server.py 终态

PR-1 前的 4657 行 → 51 行 shim。只剩：
- `app` — FastAPI 实例（真实在 api/app.py）
- `main` — uvicorn 启动入口（真实在 api/main.py）
- `HTTPException` / `db` / 6 paths 常量 — 测试 fixture monkeypatch 兼容
- SPA mount — `WEB_DIST.exists()` 运行时检查（搬走会让检查时机漂）
- `__main__` guard

## workers _base 抽出

4 个 worker 共享相同 `main()`（13 行 argparse + run + sys.exit）：

```python
# 之前每个 worker
def main() -> None:
    p = argparse.ArgumentParser()
    p.add_argument("--job-id", type=int, required=True)
    args = p.parse_args()
    sys.exit(run(args.job_id))

if __name__ == "__main__":
    main()

# 之后
if __name__ == "__main__":
    from ._base import worker_main
    worker_main(run)
```

外加 `reconfigure_console_utf8()` helper（tag_worker / reg_build_worker 顶层用）。

## 关键决策（偏离 planning）

**cli.py 841 行 7-way 拆延后到 0.11.1**：planning 写 "拆 studio/cli/{main,run,dev,build,test,discovery,bootstrap}.py"，本 PR 不做。理由：
- cli.py 是 launcher 入口，单文件可读性 OK
- 7-way split 收益主要是 review 体感
- 同 secrets / db 决策模式：独立 PR 风险隔离更稳

## 入口验证

- [x] `from studio.server import app` (route_snapshot + invariants)
- [x] `from studio.server import main`
- [x] `python -m studio.server` (`if __name__ == "__main__": main()`)
- [x] `pytest.raises(server.HTTPException)` (re-import)
- [x] `monkeypatch.setattr(server.X, ...)` for `db` + 6 path 常量
- [x] **1569 passed broader sweep**

🤖 Generated with [Claude Code](https://claude.com/claude-code)