### PR TITLE
feat(error): PR-2 错误体系 — DomainError + dual-write envelope + 30 处 router 迁移

### DIFF
--- a/studio/api/app.py
+++ b/studio/api/app.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 
 from .. import __version__
+from .exception_handlers import register_exception_handlers
 from .lifespan import lifespan
 from .middleware import _SelectiveGZipMiddleware
 from .trace_middleware import TraceIdMiddleware
@@ -50,6 +51,10 @@ app = FastAPI(title="AnimaStudio", version=__version__, lifespan=lifespan)
 # 之前 bind，gzip handler 内 logger.x 也能拿到。
 app.add_middleware(_SelectiveGZipMiddleware, minimum_size=1000)
 app.add_middleware(TraceIdMiddleware)
+# ADR-0009 PR-2 C2: 装 3 个 exception handler（DomainError / RequestValidation /
+# Exception fallback）— dual-write envelope 保 detail contract + 加 error 结构化字段。
+# HTTPException 不注册，让 starlette 默认 handler 跑保现有 175 处 raise 形状不变。
+register_exception_handlers(app)
 
 # Router 注册顺序无所谓（FastAPI 按 path 精确匹配，include_router 先后只影响
 # include_in_schema=False 的 catch-all 顺序）。按 PR / 字母序排列方便审查。

--- a/studio/api/errors.py
+++ b/studio/api/errors.py
@@ -64,14 +64,27 @@ def _export_result(path: Path) -> dict[str, Any]:
     }
 
 
-def _preset_err_code(exc: presets_io.PresetError) -> int:
-    """PresetError → HTTP 状态码：'不存在' → 404，名字非法/已存在 → 400，其它 → 422。
+def _preset_err_code(exc: presets_io.PresetError) -> None:
+    """PR-2 C4: 把 PresetError 的 message 字符串匹配映射写到 exc.http_status + exc.code，
+    让 DomainError handler 翻 dual-write envelope。
 
-    被 api/routers/presets.py 和 server.py 内的 preset fork / save-as 端点共用。
+    callsite 模式：
+        except PresetError as exc:
+            _preset_err_code(exc)  # mutate exc.http_status + exc.code
+            raise  # handler 翻 envelope（自带 trace_id）
+
+    PR-2 C5 / 0.13.x 的目标：service 内 raise PresetError(msg, http_status=N,
+    code="preset.xxx") 直接带这些属性，router 不再需要这个 helper + try/except。
     """
     msg = str(exc)
     if "不存在" in msg:
-        return 404
-    if "非法预设名" in msg or "已存在" in msg:
-        return 400
-    return 422
+        exc.http_status = 404
+        exc.code = "preset.not_found"
+    elif "非法预设名" in msg:
+        exc.http_status = 400
+        exc.code = "preset.name_invalid"
+    elif "已存在" in msg:
+        exc.http_status = 400
+        exc.code = "preset.exists"
+    else:
+        exc.http_status = 422

--- a/studio/api/exception_handlers.py
+++ b/studio/api/exception_handlers.py
@@ -1,0 +1,121 @@
+"""统一 exception handler 注册（ADR-0009 §4 / PR-2 C2）。
+
+3 个 handler:
+
+  1. DomainError → dual-write envelope:
+        {"detail": <message>,                # legacy contract（前端 client.ts
+                                              #   3 处解析点 + 5 测试 11 处断言）
+         "error": {"code", "message", "trace_id", "details"?}}  # 新结构化
+     4xx 不打 stack，5xx 才打 logger.exception（ADR-0009 §4.1）。
+
+  2. RequestValidationError → 保 starlette 默认 `{"detail": [...]}` 不动
+     （pydantic body 校验失败 — 前端有专门处理；改 envelope 破现状）。
+     middleware 已经自动加 X-Trace-Id header。
+
+  3. Exception fallback → 500 + dual-write envelope，message 脱敏：
+        {"detail": "Internal Server Error",
+         "error": {"code": "internal.server_error",
+                   "message": "Internal Server Error (see trace_id in server log)",
+                   "trace_id": "..."}}
+     原始 traceback **不**进 response（防 leak）；进 studio.log 让开发者按
+     trace_id grep。
+
+HTTPException 不重新注册 — starlette 默认 handler 已经处理（仅返 `{"detail":
+<orig>}`），X-Trace-Id header 由 TraceIdMiddleware 自动加。不动它保现有
+175 处 raise HTTPException(...) 完全不破。
+
+dual-write 渐进迁移路径（ADR-0009 §错误 envelope 渐进迁移）：
+  Phase 1 (0.12.0 / 本 PR): dual-write 同时填 detail + error
+  Phase 2 (0.13.0): raise HTTPException 加 deprecation log；前端迁 body.error.*
+  Phase 3 (0.14.0): handler 删 detail key
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from ..domain.errors import DomainError
+from ..infrastructure.logging import get_trace_id
+
+logger = logging.getLogger(__name__)
+
+
+def _trace_id_from(req: Optional[Request]) -> Optional[str]:
+    """优先 request.scope state（TraceIdMiddleware 写入，跨外层 handler 仍可用）；
+    fallback contextvar（同进程同 scope）。fallback handler 跑在 ServerErrorMiddleware
+    层，contextvar 已 reset — 必须靠 scope state。
+    """
+    if req is not None:
+        state = req.scope.get("state") if hasattr(req, "scope") else None
+        if state and state.get("trace_id"):
+            return state["trace_id"]
+    return get_trace_id()
+
+
+def _error_envelope(
+    *, message: str, code: str,
+    details: Optional[Dict[str, Any]] = None,
+    req: Optional[Request] = None,
+) -> Dict[str, Any]:
+    """dual-write body: detail (legacy str) + error (structured)。"""
+    err: Dict[str, Any] = {
+        "code": code,
+        "message": message,
+        "trace_id": _trace_id_from(req),
+    }
+    if details:
+        err["details"] = details
+    return {"detail": message, "error": err}
+
+
+async def _domain_error_handler(req: Request, exc: DomainError) -> JSONResponse:
+    # 4xx 业务异常用 info（非异常路径，是契约的一部分）；5xx 才 exception。
+    if exc.http_status >= 500:
+        logger.exception("domain error %s: %s", exc.code, exc.message)
+    else:
+        logger.info("domain error %s: %s", exc.code, exc.message)
+    return JSONResponse(
+        status_code=exc.http_status,
+        content=_error_envelope(
+            message=exc.message, code=exc.code, details=exc.details, req=req,
+        ),
+    )
+
+
+async def _request_validation_handler(
+    _req: Request, exc: RequestValidationError,
+) -> JSONResponse:
+    # pydantic 默认 detail 是 list[dict]；保现状（前端有专门处理）。
+    # 不 dual-write 因为 body validation 不是 DomainError，不强行套 envelope。
+    return JSONResponse(status_code=422, content={"detail": exc.errors()})
+
+
+async def _fallback_handler(req: Request, exc: Exception) -> JSONResponse:
+    # 未捕获异常 — 进 logger.exception 带完整 traceback + trace_id 给开发查；
+    # response body 脱敏不含 traceback 防 leak。
+    logger.exception(
+        "unhandled exception in %s %s", req.method, req.url.path,
+    )
+    return JSONResponse(
+        status_code=500,
+        content=_error_envelope(
+            message="Internal Server Error (see trace_id in server log)",
+            code="internal.server_error",
+            req=req,
+        ),
+    )
+
+
+def register_exception_handlers(app: FastAPI) -> None:
+    """app.py 启动时调一次。
+
+    顺序无关（FastAPI 按异常类型最具体匹配）。HTTPException **不**注册 — 让
+    starlette 默认 handler 跑（保现有 175 处 raise HTTPException 形状不变）。
+    """
+    app.add_exception_handler(DomainError, _domain_error_handler)
+    app.add_exception_handler(RequestValidationError, _request_validation_handler)
+    app.add_exception_handler(Exception, _fallback_handler)

--- a/studio/api/routers/presets.py
+++ b/studio/api/routers/presets.py
@@ -59,7 +59,7 @@ def get_preset(name: str) -> dict[str, Any]:
     try:
         return presets_io.read_preset(name)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
 
 
 @router.put("/api/presets/{name}")
@@ -67,7 +67,7 @@ def put_preset(name: str, body: dict[str, Any]) -> dict[str, str]:
     try:
         path = presets_io.write_preset(name, body)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     return {"name": name, "path": str(path)}
 
 
@@ -76,7 +76,7 @@ def delete_preset_endpoint(name: str) -> dict[str, str]:
     try:
         presets_io.delete_preset(name)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     return {"deleted": name}
 
 
@@ -85,7 +85,7 @@ def duplicate_preset_endpoint(name: str, body: DuplicateRequest) -> dict[str, st
     try:
         path = presets_io.duplicate_preset(name, body.new_name)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     return {"name": body.new_name, "path": str(path)}
 
 
@@ -95,7 +95,7 @@ def download_preset(name: str) -> FileResponse:
     try:
         path = presets_io.preset_path(name)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     if not path.exists():
         raise HTTPException(status_code=404, detail=f"预设不存在: {name}")
     return FileResponse(path, media_type="application/yaml", filename=f"{name}.yaml")
@@ -109,7 +109,7 @@ def export_preset_to_data_exports(name: str, body: PresetExportBody) -> dict[str
         dest = _errors._unique_data_export_path(f"{name}.yaml", (".yaml", ".yml"))
         path = presets_io.write_preset(dest.stem, body.config, DATA_EXPORTS)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     return _errors._export_result(path)
 
 
@@ -124,7 +124,7 @@ def import_preset_from_data_exports(body: PresetImportBody) -> dict[str, Any]:
     try:
         config, suggested = presets_io.parse_preset_bytes(src.read_bytes(), src.name)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     if presets_io.preset_path(suggested).exists():
         raise HTTPException(
             status_code=409,
@@ -137,7 +137,7 @@ def import_preset_from_data_exports(body: PresetImportBody) -> dict[str, Any]:
     try:
         path = presets_io.write_preset(suggested, config)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     return {"name": suggested, "path": str(path)}
 
 
@@ -153,7 +153,7 @@ def import_preset_from_path(body: PresetImportFromPathBody) -> dict[str, Any]:
     try:
         config, suggested = presets_io.parse_preset_bytes(src.read_bytes(), src.name)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     if presets_io.preset_path(suggested).exists():
         raise HTTPException(
             status_code=409,
@@ -166,7 +166,7 @@ def import_preset_from_path(body: PresetImportFromPathBody) -> dict[str, Any]:
     try:
         path = presets_io.write_preset(suggested, config)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     return {"name": suggested, "path": str(path)}
 
 
@@ -184,7 +184,7 @@ async def import_preset(file: UploadFile = File(...)) -> dict[str, Any]:
     try:
         config, suggested = presets_io.parse_preset_bytes(raw, file.filename or "")
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     if presets_io.preset_path(suggested).exists():
         raise HTTPException(
             status_code=409,
@@ -197,7 +197,7 @@ async def import_preset(file: UploadFile = File(...)) -> dict[str, Any]:
     try:
         path = presets_io.write_preset(suggested, config)
     except presets_io.PresetError as exc:
-        raise HTTPException(status_code=_err_code(exc), detail=str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     return {"name": suggested, "path": str(path)}
 
 

--- a/studio/api/routers/projects/_shared.py
+++ b/studio/api/routers/projects/_shared.py
@@ -16,14 +16,26 @@ from ....infrastructure.event_bus import bus
 from ....services import version_config
 
 
-def _project_err_code(exc: Exception) -> int:
-    """ProjectError / VersionError → HTTP 状态码。"""
+def _project_err_code(exc: Exception) -> None:
+    """PR-2 C4: mutate ProjectError/VersionError exc.http_status + exc.code，
+    让 DomainError handler 翻 dual-write envelope。
+
+    callsite 模式：
+        except (ProjectError, VersionError) as exc:
+            _project_err_code(exc); raise
+    """
     msg = str(exc)
     if "不存在" in msg:
-        return 404
-    if "已存在" in msg or "非法" in msg or "不能为空" in msg:
-        return 400
-    return 422
+        exc.http_status = 404
+        exc.code = "project.not_found"
+    elif "已存在" in msg:
+        exc.http_status = 400
+        exc.code = "project.exists"
+    elif "非法" in msg or "不能为空" in msg:
+        exc.http_status = 400
+        exc.code = "project.invalid"
+    else:
+        exc.http_status = 422
 
 
 def _project_payload(p: dict[str, Any]) -> dict[str, Any]:

--- a/studio/api/routers/projects/crud.py
+++ b/studio/api/routers/projects/crud.py
@@ -70,7 +70,7 @@ def create_project_endpoint(body: ProjectCreate) -> dict[str, Any]:
                 conn, title=body.title, slug=body.slug, note=body.note
             )
         except projects.ProjectError as exc:
-            raise HTTPException(_project_err_code(exc), str(exc)) from exc
+            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
         if body.initial_version_label:
             try:
                 versions.create_version(
@@ -78,7 +78,7 @@ def create_project_endpoint(body: ProjectCreate) -> dict[str, Any]:
                 )
             except versions.VersionError as exc:
                 # 项目已建好；版本失败给前端但保留项目
-                raise HTTPException(_project_err_code(exc), str(exc)) from exc
+                _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
         p = projects.get_project(conn, p["id"])
     assert p is not None
     _publish_project_state(p)
@@ -101,7 +101,7 @@ def patch_project_endpoint(pid: int, body: ProjectUpdate) -> dict[str, Any]:
         try:
             p = projects.update_project(conn, pid, **fields)
         except projects.ProjectError as exc:
-            raise HTTPException(_project_err_code(exc), str(exc)) from exc
+            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     _publish_project_state(p)
     return _project_payload(p)
 
@@ -112,7 +112,7 @@ def delete_project_endpoint(pid: int) -> dict[str, Any]:
         try:
             projects.delete_project(conn, pid)
         except projects.ProjectError as exc:
-            raise HTTPException(_project_err_code(exc), str(exc)) from exc
+            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     return {"deleted": pid}
 
 
@@ -183,7 +183,7 @@ def create_version_endpoint(pid: int, body: VersionCreate) -> dict[str, Any]:
                 note=body.note,
             )
         except versions.VersionError as exc:
-            raise HTTPException(_project_err_code(exc), str(exc)) from exc
+            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     _publish_version_state(v)
     return v
 
@@ -211,7 +211,7 @@ def patch_version_endpoint(
         try:
             v = versions.update_version(conn, vid, **fields)
         except versions.VersionError as exc:
-            raise HTTPException(_project_err_code(exc), str(exc)) from exc
+            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     _publish_version_state(v)
     return v
 

--- a/studio/api/routers/projects/curation.py
+++ b/studio/api/routers/projects/curation.py
@@ -226,13 +226,21 @@ def get_latest_version_job(pid: int, vid: int, kind: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _curation_err_code(exc: curation.CurationError) -> int:
+def _curation_err_code(exc: curation.CurationError) -> None:
+    """PR-2 C5: 同 _preset_err_code — mutate exc.http_status + exc.code 让
+    DomainError handler 翻 dual-write envelope。callsite: `_curation_err_code(exc); raise`."""
     msg = str(exc)
     if "不存在" in msg:
-        return 404
-    if "已存在" in msg or "非法" in msg:
-        return 400
-    return 422
+        exc.http_status = 404
+        exc.code = "curation.not_found"
+    elif "已存在" in msg:
+        exc.http_status = 400
+        exc.code = "curation.exists"
+    elif "非法" in msg:
+        exc.http_status = 400
+        exc.code = "curation.invalid"
+    else:
+        exc.http_status = 422
 
 
 @router.get("/api/projects/{pid}/versions/{vid}/curation")
@@ -241,18 +249,23 @@ def get_curation(pid: int, vid: int) -> dict[str, Any]:
         try:
             return curation.curation_view(conn, pid, vid)
         except curation.CurationError as exc:
-            raise HTTPException(_curation_err_code(exc), str(exc)) from exc
+            _curation_err_code(exc); raise  # PR-2 C5
 
 
-def _duplicate_err_code(exc: duplicate_finder.DuplicateFinderError) -> int:
+def _duplicate_err_code(exc: duplicate_finder.DuplicateFinderError) -> None:
+    """PR-2 C5: 同 _curation_err_code — mutate exc.http_status + exc.code。"""
     msg = str(exc)
     if "not found" in msg or "不存在" in msg:
-        return 404
-    if "invalid" in msg or "非法" in msg:
-        return 400
-    if "not installed" in msg:
-        return 422
-    return 422
+        exc.http_status = 404
+        exc.code = "duplicate.not_found"
+    elif "invalid" in msg or "非法" in msg:
+        exc.http_status = 400
+        exc.code = "duplicate.invalid"
+    elif "not installed" in msg:
+        exc.http_status = 422
+        exc.code = "duplicate.not_installed"
+    else:
+        exc.http_status = 422
 
 
 @router.post("/api/projects/{pid}/preprocess/duplicates/scan")
@@ -311,7 +324,7 @@ def scan_preprocess_duplicates(
                 "status": "failed",
                 "text": str(exc),
             })
-            raise HTTPException(_curation_err_code(exc), str(exc)) from exc
+            _curation_err_code(exc); raise  # PR-2 C5
         except duplicate_finder.DuplicateFinderError as exc:
             bus.publish({
                 "type": "duplicate_scan_progress",
@@ -319,7 +332,7 @@ def scan_preprocess_duplicates(
                 "status": "failed",
                 "text": str(exc),
             })
-            raise HTTPException(_duplicate_err_code(exc), str(exc)) from exc
+            _duplicate_err_code(exc); raise  # PR-2 C5
 
 
 @router.post("/api/projects/{pid}/preprocess/duplicates/apply")
@@ -335,9 +348,9 @@ def apply_preprocess_duplicates(
             )
             project = projects.get_project(conn, pid)
         except curation.CurationError as exc:
-            raise HTTPException(_curation_err_code(exc), str(exc)) from exc
+            _curation_err_code(exc); raise  # PR-2 C5
         except duplicate_finder.DuplicateFinderError as exc:
-            raise HTTPException(_duplicate_err_code(exc), str(exc)) from exc
+            _duplicate_err_code(exc); raise  # PR-2 C5
     if project:
         _publish_project_state(project)
     return result
@@ -369,7 +382,7 @@ def copy_to_train(
                 conn, pid, vid, body.files, body.dest_folder,
             )
         except curation.CurationError as exc:
-            raise HTTPException(_curation_err_code(exc), str(exc)) from exc
+            _curation_err_code(exc); raise  # PR-2 C5
     return result
 
 
@@ -383,7 +396,7 @@ def remove_from_train(
                 conn, pid, vid, body.folder, body.files,
             )
         except curation.CurationError as exc:
-            raise HTTPException(_curation_err_code(exc), str(exc)) from exc
+            _curation_err_code(exc); raise  # PR-2 C5
     return result
 
 
@@ -408,4 +421,4 @@ def folder_op(
                 return {"deleted": body.name}
             raise HTTPException(400, f"unknown op: {body.op}")
         except curation.CurationError as exc:
-            raise HTTPException(_curation_err_code(exc), str(exc)) from exc
+            _curation_err_code(exc); raise  # PR-2 C5

--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -518,7 +518,7 @@ def fork_preset_for_version_endpoint(
     try:
         cfg = preset_flow.fork_preset_for_version(body.name, project, ver)
     except presets_io.PresetError as exc:
-        raise HTTPException(_err_code(exc), str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     except version_config.VersionConfigError as exc:
         raise HTTPException(400, str(exc)) from exc
     # 同步 versions.config_name = 来源 preset 名（informational only）
@@ -538,7 +538,7 @@ def save_version_config_as_preset_endpoint(
             project, ver, body.name, overwrite=body.overwrite,
         )
     except presets_io.PresetError as exc:
-        raise HTTPException(_err_code(exc), str(exc)) from exc
+        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     except version_config.VersionConfigError as exc:
         raise HTTPException(400, str(exc)) from exc
     return {"saved_preset": body.name, "config": cfg}

--- a/studio/api/trace_middleware.py
+++ b/studio/api/trace_middleware.py
@@ -51,6 +51,14 @@ class TraceIdMiddleware:
         if not trace_id:
             trace_id = new_trace_id()
 
+        # 把 trace_id 写到 scope["state"]，让 ServerErrorMiddleware 外层的
+        # fallback Exception handler 能拿到（contextvar 在 finally 里 reset，
+        # 外层 handler 跑时 contextvar 已空）。DomainError handler 在 ExceptionMiddleware
+        # 内层，靠 contextvar 仍可用；fallback 必须靠 scope state。
+        if "state" not in scope:
+            scope["state"] = {}
+        scope["state"]["trace_id"] = trace_id
+
         token = bind_trace_id(trace_id)
 
         async def send_wrapper(message):

--- a/studio/domain/errors.py
+++ b/studio/domain/errors.py
@@ -1,0 +1,142 @@
+"""统一异常体系（ADR-0009 §4 / PR-2 C1）。
+
+业务层 (`studio.services.*`) raise DomainError 子类；FastAPI 在 api 层装
+exception_handler 翻成统一 JSON envelope 给前端。router 不再 try/except 翻
+HTTPException（PR-2 C4/C5 渐进迁移现有 380 处）。
+
+为什么放 `domain/` 而不是 `api/`：
+  - services 反向依赖 api 是反模式（ADR-0008 4 层架构 services → domain，不
+    应该 services → api）。把基类放 domain/errors.py 让 services 可直接
+    raise 而不破层依赖。
+  - api 层只装 exception_handler 注册，不持有错误类定义。
+  - 不引 fastapi 依赖（纯 Python Exception 子类）；api/exception_handlers.py
+    才 import FastAPI / Request / JSONResponse。
+
+文案规约（ADR-0009 §4.1 + B audit 跨D）：
+  - `message` 字段**英文** — 前端用 `code` 查 i18n 表渲染本地化字串；message
+    兜底显示英文。这避开 ADR-0008 §跨D 中文字符串匹配陷阱借 DomainError 复活。
+  - `code` 字段**领域.动作** 命名（`preset.not_found` / `curation.duplicate`）。
+  - 短期（0.12.0）现有 PresetError 等 service 错误的中文 message 仍存在
+    （C3 加 base 不改 message），但**新代码必须**英文 message + i18n code。
+
+用法：
+    from studio.domain.errors import NotFoundError, PresetNotFoundError
+
+    if not preset_exists(name):
+        raise PresetNotFoundError(f"preset {name!r} does not exist",
+                                  details={"name": name})
+
+handler 自动翻成（C2 后）：
+    HTTP 404
+    Headers: X-Trace-Id: <id>
+    Body: {
+      "detail": "preset 'foo' does not exist",   # legacy contract
+      "error": {
+        "code": "preset.not_found",
+        "message": "preset 'foo' does not exist",
+        "trace_id": "<id>",
+        "details": {"name": "foo"}
+      }
+    }
+"""
+from typing import Any, ClassVar, Dict, Optional
+
+
+class DomainError(Exception):
+    """业务异常基类。子类化指定 `http_status` + `default_code`。"""
+
+    http_status: ClassVar[int] = 400
+    default_code: ClassVar[str] = "domain.error"
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        http_status: Optional[int] = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.code = code or self.default_code
+        self.details = details or {}
+        if http_status is not None:
+            self.http_status = http_status
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.message!r}, code={self.code!r})"
+
+
+# ── 5 个核心子类（ADR-0009 §C round2 §1.1 决策："5 核心而非 7 一次落"）────
+
+
+class NotFoundError(DomainError):
+    """资源不存在 — 404。"""
+    http_status = 404
+    default_code = "not_found"
+
+
+class ValidationError(DomainError):
+    """请求字段 / 业务规则校验失败 — 422。
+
+    `details` 通常含 `{"field": "...", "reason": "..."}` 给前端字段级提示。
+    跟 fastapi RequestValidationError 区分：RequestValidationError 是 pydantic
+    解析 body 失败；本类是业务层判断（如 "epoch must be > 0"）。
+    """
+    http_status = 422
+    default_code = "validation"
+
+
+class ConflictError(DomainError):
+    """资源冲突（重名、状态冲突） — 409。"""
+    http_status = 409
+    default_code = "conflict"
+
+
+class AuthError(DomainError):
+    """未认证 — 401。当前 webui 单用户无认证，此类预留给未来多用户场景。"""
+    http_status = 401
+    default_code = "auth"
+
+
+class ForbiddenError(DomainError):
+    """已认证但无权限 — 403。同 AuthError 预留。"""
+    http_status = 403
+    default_code = "forbidden"
+
+
+# ── 子类常用别名（让 service raise 更可读） ──────────────────────────────
+
+
+class InvalidPathError(ValidationError):
+    """路径越界 / 非法分量 — 400（不是 422 因为 path 是 URL 一部分）。
+
+    `_safe_join_or_400` 触发本类。
+    """
+    default_code = "path.invalid"
+    http_status = 400
+
+
+class PresetNotFoundError(NotFoundError):
+    default_code = "preset.not_found"
+
+
+class PresetNameInvalidError(ValidationError):
+    default_code = "preset.name_invalid"
+    http_status = 400
+
+
+class PresetConflictError(ConflictError):
+    default_code = "preset.exists"
+
+
+__all__ = [
+    # 基类
+    "DomainError",
+    # 5 核心子类
+    "NotFoundError", "ValidationError", "ConflictError",
+    "AuthError", "ForbiddenError",
+    # preset / path 常用别名
+    "InvalidPathError",
+    "PresetNotFoundError", "PresetNameInvalidError", "PresetConflictError",
+]

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -64,8 +64,15 @@ class BundleOptions:
     include_config: bool = False
 
 
-class TrainIOError(Exception):
-    """导出 / 导入过程的业务错误。"""
+from studio.domain.errors import DomainError
+
+
+class TrainIOError(DomainError):
+    """导出 / 导入过程的业务错误。
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    """
+    default_code = "train_io.error"
 
 
 # ---------------------------------------------------------------------------

--- a/studio/services/dataset/browse.py
+++ b/studio/services/dataset/browse.py
@@ -11,8 +11,12 @@ from typing import Any
 from ...paths import REPO_ROOT
 
 
-class BrowseError(Exception):
-    pass
+from studio.domain.errors import DomainError
+
+
+class BrowseError(DomainError):
+    """PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。"""
+    default_code = "browse.error"
 
 
 def list_dir(target: Path, *, allow_outside_repo: bool = False) -> dict[str, Any]:

--- a/studio/services/dataset/curation.py
+++ b/studio/services/dataset/curation.py
@@ -32,8 +32,15 @@ _FOLDER_PATTERN = re.compile(r"^([0-9]+_)?[A-Za-z][A-Za-z0-9_-]*$")
 _FILE_PATTERN = re.compile(r"^[^\\/]+$")
 
 
-class CurationError(Exception):
-    """Curation 业务错误（路径非法 / 不存在 / 冲突）。"""
+from studio.domain.errors import DomainError
+
+
+class CurationError(DomainError):
+    """Curation 业务错误（路径非法 / 不存在 / 冲突）。
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    """
+    default_code = "curation.error"
 
 
 # ---------------------------------------------------------------------------

--- a/studio/services/preprocess/core.py
+++ b/studio/services/preprocess/core.py
@@ -55,8 +55,15 @@ PRODUCT_SUFFIX = ".png"
 MIN_CROP_NORM = 0.02
 
 
-class PreprocessError(Exception):
-    """预处理业务错误（项目不存在 / 参数非法 / 文件名非法）。"""
+from studio.domain.errors import DomainError
+
+
+class PreprocessError(DomainError):
+    """预处理业务错误（项目不存在 / 参数非法 / 文件名非法）。
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    """
+    default_code = "preprocess.error"
 
 
 # ---------------------------------------------------------------------------

--- a/studio/services/preprocess/duplicates.py
+++ b/studio/services/preprocess/duplicates.py
@@ -56,8 +56,15 @@ DEFAULT_COLOR_ALERT = 14
 MatchScope = Literal["strict", "both"]
 
 
-class DuplicateFinderError(Exception):
-    """Duplicate finder business error."""
+from studio.domain.errors import DomainError
+
+
+class DuplicateFinderError(DomainError):
+    """Duplicate finder business error.
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    """
+    default_code = "duplicate.error"
 
 
 @dataclass(frozen=True)

--- a/studio/services/presets/io.py
+++ b/studio/services/presets/io.py
@@ -31,8 +31,17 @@ _MODEL_PATH_FIELDS = (
 )
 
 
-class PresetError(Exception):
-    """预设 I/O 错误。"""
+from studio.domain.errors import DomainError
+
+
+class PresetError(DomainError):
+    """预设 I/O 错误。
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    现有 raise PresetError("xxx") 形态不变；http_status / code 由 router 或
+    C4/C5 精细化时按情况覆盖（now 用 default = 400 / preset.error）。
+    """
+    default_code = "preset.error"
 
 
 _WIN_DRIVE_RE = re.compile(r"^[A-Za-z]:[\\/]")

--- a/studio/services/projects/jobs.py
+++ b/studio/services/projects/jobs.py
@@ -26,8 +26,15 @@ VALID_STATUSES: frozenset[str] = frozenset({
 TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "failed", "canceled"})
 
 
-class JobError(Exception):
-    """project_jobs 业务错误。"""
+from studio.domain.errors import DomainError
+
+
+class JobError(DomainError):
+    """project_jobs 业务错误。
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    """
+    default_code = "job.error"
 
 
 def log_path_for(job_id: int) -> Path:

--- a/studio/services/projects/projects.py
+++ b/studio/services/projects/projects.py
@@ -21,8 +21,15 @@ from ...paths import STUDIO_DATA
 
 PROJECTS_DIR = STUDIO_DATA / "projects"
 
-class ProjectError(Exception):
-    """Project 业务错误（不存在 / 名字非法 / 冲突）。"""
+from studio.domain.errors import DomainError
+
+
+class ProjectError(DomainError):
+    """Project 业务错误（不存在 / 名字非法 / 冲突）。
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    """
+    default_code = "project.error"
 
 
 # ---------------------------------------------------------------------------

--- a/studio/services/projects/versions.py
+++ b/studio/services/projects/versions.py
@@ -147,8 +147,15 @@ def reconcile_version_status(
 _VALID_LABEL = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
-class VersionError(Exception):
-    """Version 业务错误。"""
+from studio.domain.errors import DomainError
+
+
+class VersionError(DomainError):
+    """Version 业务错误。
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    """
+    default_code = "version.error"
 
 
 # ---------------------------------------------------------------------------

--- a/studio/services/tagging/caption_snapshot.py
+++ b/studio/services/tagging/caption_snapshot.py
@@ -19,8 +19,15 @@ CAPTION_EXTS = (".txt", ".json")
 SNAPSHOT_DIRNAME = "caption_snapshots"
 
 
-class SnapshotError(Exception):
-    """Snapshot 业务错误。"""
+from studio.domain.errors import DomainError
+
+
+class SnapshotError(DomainError):
+    """Snapshot 业务错误。
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    """
+    default_code = "snapshot.error"
 
 
 def snapshot_root(version_dir: Path) -> Path:

--- a/studio/services/version_config.py
+++ b/studio/services/version_config.py
@@ -22,8 +22,15 @@ from .projects.versions import version_dir
 from .projects import projects as _projects
 
 
-class VersionConfigError(Exception):
-    """version 私有 config I/O 错误。"""
+from studio.domain.errors import DomainError
+
+
+class VersionConfigError(DomainError):
+    """version 私有 config I/O 错误。
+
+    PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
+    """
+    default_code = "version_config.error"
 
 
 CONFIG_FILENAME = "config.yaml"

--- a/tests/test_c4_c5_envelope_e2e.py
+++ b/tests/test_c4_c5_envelope_e2e.py
@@ -1,0 +1,65 @@
+"""PR-2 C4+C5 端到端 — 真实 router 走完 DomainError handler 后 envelope 形态。
+
+不仅锁 status code（test_error_response_baseline 已锁），还要锁：
+  - body.detail 仍是 string（前端老路径不破）
+  - body.error.code 是 service-domain 命名 (preset.not_found 等)
+  - body.error.trace_id 跟 X-Trace-Id header 一致
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from studio import db, server
+from studio.api.routers import root as _root_router
+from studio.api.routers import samples as _samples_router
+from studio.infrastructure.logging import TRACE_HEADER
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    output = tmp_path / "output"
+    (output / "samples").mkdir(parents=True)
+    web_dist = tmp_path / "web_dist"
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
+    monkeypatch.setattr(server, "OUTPUT_DIR", output)
+    monkeypatch.setattr(server, "WEB_DIST", web_dist)
+    monkeypatch.setattr(_samples_router, "OUTPUT_DIR", output)
+    monkeypatch.setattr(_root_router, "WEB_DIST", web_dist)
+    from studio.services.presets import io as presets_io
+    monkeypatch.setattr(presets_io, "USER_PRESETS_DIR", tmp_path / "presets")
+    return TestClient(server.app)
+
+
+# ── preset 404 路径（C4 batch 1）───────────────────────────────────────
+
+
+def test_preset_not_found_envelope_dual_write(client: TestClient) -> None:
+    resp = client.get("/api/presets/__nonexistent__")
+    assert resp.status_code == 404
+    body = resp.json()
+    # legacy contract
+    assert body["detail"] == "预设不存在: __nonexistent__" or "不存在" in body["detail"]
+    # 新结构化（C2 dual-write）
+    assert "error" in body
+    assert body["error"]["code"] == "preset.not_found"  # C4 _preset_err_code mutate
+    assert body["error"]["message"] == body["detail"]
+    # trace_id 跟 header 一致
+    assert body["error"]["trace_id"] == resp.headers[TRACE_HEADER]
+
+
+def test_preset_name_invalid_envelope_400(client: TestClient) -> None:
+    """PUT 非法 preset 名 — 走 PresetNameInvalidError → 400 / preset.name_invalid。"""
+    resp = client.put("/api/presets/bad..slash/name", json={})
+    # 路由匹配可能让这变 404（path 含 / FastAPI 看不到这是 single name）
+    # 我们接受 400 或 404；锁 envelope 形态
+    body = resp.json()
+    assert resp.status_code in (400, 404, 422)
+    assert "detail" in body
+    # 4xx 全部应该有 trace_id header（middleware）
+    assert TRACE_HEADER in resp.headers

--- a/tests/test_domain_errors.py
+++ b/tests/test_domain_errors.py
@@ -1,0 +1,124 @@
+"""PR-2 C1 — DomainError 体系基础测试。
+
+不依赖 fastapi / handler（C2 才有）；只验类层级 + 字段。
+"""
+from __future__ import annotations
+
+import pytest
+
+from studio.domain.errors import (
+    AuthError,
+    ConflictError,
+    DomainError,
+    ForbiddenError,
+    InvalidPathError,
+    NotFoundError,
+    PresetConflictError,
+    PresetNameInvalidError,
+    PresetNotFoundError,
+    ValidationError,
+)
+
+
+# ── 基类 ─────────────────────────────────────────────────────────────────
+
+
+def test_domain_error_default_fields() -> None:
+    e = DomainError("something broke")
+    assert e.message == "something broke"
+    assert e.code == "domain.error"
+    assert e.details == {}
+    assert e.http_status == 400
+    assert str(e) == "something broke"
+
+
+def test_domain_error_custom_code_and_details() -> None:
+    e = DomainError(
+        "x is bad", code="my.custom", details={"field": "x"}, http_status=418,
+    )
+    assert e.code == "my.custom"
+    assert e.details == {"field": "x"}
+    assert e.http_status == 418
+
+
+def test_domain_error_inherits_from_exception() -> None:
+    assert issubclass(DomainError, Exception)
+    with pytest.raises(DomainError):
+        raise DomainError("boom")
+
+
+def test_domain_error_repr_contains_code() -> None:
+    e = DomainError("x", code="my.code")
+    assert "my.code" in repr(e)
+    assert "DomainError" in repr(e)
+
+
+# ── 5 核心子类 ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("cls,expected_status,expected_code", [
+    (NotFoundError, 404, "not_found"),
+    (ValidationError, 422, "validation"),
+    (ConflictError, 409, "conflict"),
+    (AuthError, 401, "auth"),
+    (ForbiddenError, 403, "forbidden"),
+])
+def test_core_subclass_status_and_code(cls, expected_status, expected_code) -> None:
+    e = cls("msg")
+    assert e.http_status == expected_status
+    assert e.code == expected_code
+    assert isinstance(e, DomainError)
+
+
+# ── preset / path 别名 ───────────────────────────────────────────────────
+
+
+def test_preset_not_found_is_404_with_preset_code() -> None:
+    e = PresetNotFoundError("preset 'foo' missing")
+    assert isinstance(e, NotFoundError)
+    assert e.http_status == 404
+    assert e.code == "preset.not_found"
+
+
+def test_preset_name_invalid_is_400() -> None:
+    """name_invalid 是 400 而非 422 — name 是 URL path 一部分，URL 校验是 400 惯例。"""
+    e = PresetNameInvalidError("preset name contains '/'")
+    assert e.http_status == 400
+    assert e.code == "preset.name_invalid"
+
+
+def test_preset_conflict_is_409() -> None:
+    e = PresetConflictError("preset 'foo' already exists")
+    assert isinstance(e, ConflictError)
+    assert e.http_status == 409
+    assert e.code == "preset.exists"
+
+
+def test_invalid_path_is_400() -> None:
+    e = InvalidPathError("path '../etc' escapes safe root")
+    assert isinstance(e, ValidationError)
+    assert e.http_status == 400
+    assert e.code == "path.invalid"
+
+
+# ── 不依赖 fastapi ──────────────────────────────────────────────────────
+
+
+def test_domain_errors_module_does_not_import_fastapi() -> None:
+    """domain/ 层禁止反向依赖 api（ADR-0008 / ADR-0009 §4）。"""
+    import studio.domain.errors as _e
+    import sys
+    # 检查 module 不直接 import fastapi（不能 100% 阻止子模块传染，但能 catch 直接 import）
+    src = open(_e.__file__, encoding="utf-8").read()
+    for forbidden in ("import fastapi", "from fastapi"):
+        assert forbidden not in src, (
+            f"domain/errors.py 不应 import fastapi（services 通过 domain raise）；"
+            f"找到: {forbidden!r}"
+        )
+
+
+def test_subclass_can_override_per_instance() -> None:
+    """子类可以 per-instance 覆盖 http_status（罕见但合法）。"""
+    e = NotFoundError("x", http_status=410)  # Gone 而非 404
+    assert e.http_status == 410
+    assert e.code == "not_found"  # code 不变

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -1,0 +1,251 @@
+"""PR-2 C2 — exception handler + dual-write envelope 验证。
+
+覆盖：
+  - DomainError → dual-write envelope {detail, error: {code,message,trace_id}}
+  - HTTPException 不被新 handler 截胡（starlette 默认 → {detail} 保形）
+  - Exception fallback → 500 + 脱敏 envelope（不 leak traceback）
+  - RequestValidationError → 保 list[dict] 形状不变
+  - 4xx vs 5xx logger level（4xx info / 5xx exception）
+  - trace_id 进 body.error.trace_id 跟 header X-Trace-Id 一致
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from studio.domain.errors import (
+    ConflictError,
+    DomainError,
+    NotFoundError,
+    PresetNotFoundError,
+    ValidationError,
+)
+from studio.infrastructure.logging import TRACE_HEADER
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    """Bare FastAPI app + TraceIdMiddleware + exception handlers（不带业务 router）。"""
+    from studio.api.exception_handlers import register_exception_handlers
+    from studio.api.trace_middleware import TraceIdMiddleware
+
+    a = FastAPI()
+    a.add_middleware(TraceIdMiddleware)
+    register_exception_handlers(a)
+
+    @a.get("/raise_domain")
+    def _raise_domain():
+        raise PresetNotFoundError("preset 'foo' does not exist",
+                                   details={"name": "foo"})
+
+    @a.get("/raise_validation")
+    def _raise_validation():
+        raise ValidationError("epoch must be > 0", details={"field": "epoch"})
+
+    @a.get("/raise_conflict")
+    def _raise_conflict():
+        raise ConflictError("slug 'x' already exists")
+
+    @a.get("/raise_http")
+    def _raise_http():
+        raise HTTPException(status_code=400, detail="legacy http err string")
+
+    @a.get("/raise_http_dict")
+    def _raise_http_dict():
+        raise HTTPException(status_code=400,
+                            detail={"error": "running_tasks_present", "count": 3})
+
+    @a.get("/raise_uncaught")
+    def _raise_uncaught():
+        raise RuntimeError("oops something raw broke")
+
+    @a.get("/raise_domain_500")
+    def _raise_domain_500():
+        raise DomainError("upstream timed out", code="upstream.timeout",
+                          http_status=503)
+
+    return a
+
+
+@pytest.fixture
+def client(app: FastAPI) -> TestClient:
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ── DomainError → dual-write envelope ──────────────────────────────────
+
+
+def test_domain_error_returns_subclass_http_status(client: TestClient) -> None:
+    resp = client.get("/raise_domain")
+    assert resp.status_code == 404
+
+
+def test_domain_error_body_has_detail_legacy(client: TestClient) -> None:
+    """前端 client.ts 老路径读 body.detail 是 string — dual-write 保这条。"""
+    resp = client.get("/raise_domain")
+    body = resp.json()
+    assert "detail" in body
+    assert body["detail"] == "preset 'foo' does not exist", (
+        "detail 必须是 message 字符串（前端 client.ts:1233-1238 兜底）"
+    )
+
+
+def test_domain_error_body_has_error_struct(client: TestClient) -> None:
+    """新 envelope: body.error.{code,message,trace_id,details}。"""
+    resp = client.get("/raise_domain")
+    body = resp.json()
+    assert "error" in body
+    err = body["error"]
+    assert err["code"] == "preset.not_found"
+    assert err["message"] == "preset 'foo' does not exist"
+    assert err["trace_id"] is not None
+    assert len(err["trace_id"]) == 24
+    assert err["details"] == {"name": "foo"}
+
+
+def test_domain_error_trace_id_matches_header(client: TestClient) -> None:
+    """body.error.trace_id 必须等于 X-Trace-Id header — 前端两条路径取一处即可。"""
+    resp = client.get("/raise_domain")
+    assert resp.headers[TRACE_HEADER] == resp.json()["error"]["trace_id"]
+
+
+def test_domain_error_no_details_when_empty(client: TestClient) -> None:
+    """details 空时不输出该字段（不污染 JSON）。"""
+    resp = client.get("/raise_conflict")
+    body = resp.json()
+    assert body["error"]["code"] == "conflict"
+    assert "details" not in body["error"]
+
+
+def test_validation_error_returns_422(client: TestClient) -> None:
+    resp = client.get("/raise_validation")
+    assert resp.status_code == 422
+    assert resp.json()["error"]["code"] == "validation"
+    assert resp.json()["error"]["details"] == {"field": "epoch"}
+
+
+def test_domain_error_5xx_logs_exception(
+    client: TestClient, caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.ERROR, logger="studio.api.exception_handlers"):
+        resp = client.get("/raise_domain_500")
+    assert resp.status_code == 503
+    errors = [r for r in caplog.records
+              if r.name == "studio.api.exception_handlers" and r.levelname == "ERROR"]
+    assert errors, "5xx DomainError 应 logger.exception (ERROR level)"
+
+
+def test_domain_error_4xx_logs_info_not_exception(
+    client: TestClient, caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.INFO, logger="studio.api.exception_handlers"):
+        client.get("/raise_domain")
+    errors = [r for r in caplog.records
+              if r.name == "studio.api.exception_handlers" and r.levelname == "ERROR"]
+    assert errors == [], "4xx 不应 logger.exception（业务正常路径，不该 ERROR 噪音）"
+
+
+# ── HTTPException 形态保护（前端 client.ts 老路径不破）────────────────
+
+
+def test_http_exception_string_detail_preserved(client: TestClient) -> None:
+    """raise HTTPException(detail='str') 仍返 {detail: str}，handler 不截胡。"""
+    resp = client.get("/raise_http")
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body == {"detail": "legacy http err string"}, (
+        f"HTTPException 形状必须不变，实际 {body}"
+    )
+    # 应该 *没有* error 字段（不被 DomainError handler 处理）
+    assert "error" not in body
+
+
+def test_http_exception_dict_detail_preserved(client: TestClient) -> None:
+    """raise HTTPException(detail={"error": "x", ...}) 仍 {detail: {...}}。
+
+    test_studio_server.py 7 处断言 body['detail']['error'] 走这条；不能变。
+    """
+    resp = client.get("/raise_http_dict")
+    body = resp.json()
+    assert body == {"detail": {"error": "running_tasks_present", "count": 3}}
+
+
+def test_http_exception_still_has_trace_id_header(client: TestClient) -> None:
+    """HTTPException 也带 X-Trace-Id（middleware 在外层自动加）。"""
+    resp = client.get("/raise_http")
+    assert TRACE_HEADER in resp.headers
+    assert len(resp.headers[TRACE_HEADER]) == 24
+
+
+# ── Exception fallback ────────────────────────────────────────────────
+
+
+def test_uncaught_exception_returns_500_dual_envelope(client: TestClient) -> None:
+    resp = client.get("/raise_uncaught")
+    assert resp.status_code == 500
+    body = resp.json()
+    assert "detail" in body
+    assert "error" in body
+    assert body["error"]["code"] == "internal.server_error"
+    assert body["error"]["trace_id"] is not None
+
+
+def test_uncaught_exception_body_does_not_leak_traceback(client: TestClient) -> None:
+    """脱敏 — body 不能含 RuntimeError 字面 / "oops" 字面 / 任何 stack 关键字。"""
+    resp = client.get("/raise_uncaught")
+    body_text = resp.text
+    for forbidden in ("RuntimeError", "oops", "Traceback", "File ", "line "):
+        assert forbidden not in body_text, (
+            f"500 body 不应 leak {forbidden!r}（开发者按 trace_id 查 studio.log）"
+        )
+
+
+def test_uncaught_exception_logs_with_traceback(
+    client: TestClient, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """开发者通过 trace_id 在 server log 找 traceback — 必须打 logger.exception。"""
+    with caplog.at_level(logging.ERROR, logger="studio.api.exception_handlers"):
+        client.get("/raise_uncaught")
+    errors = [r for r in caplog.records
+              if r.name == "studio.api.exception_handlers" and r.levelname == "ERROR"]
+    assert errors, "fallback handler 必须 logger.exception"
+    # 至少一条 record 带 exc_info
+    assert any(r.exc_info for r in errors), "logger.exception 必须带 exc_info"
+
+
+# ── 测 webui server 真实 router 注册后 baseline 不破 ────────────────
+
+
+def test_existing_preset_404_path_still_works(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """跑现有 preset 404 endpoint — handler 注册后 detail 形状保持。"""
+    from studio import db, server
+    from studio.api.routers import root as _root_router
+    from studio.api.routers import samples as _samples_router
+    from studio.services.presets import io as presets_io
+
+    output = tmp_path / "output"
+    (output / "samples").mkdir(parents=True)
+    web_dist = tmp_path / "web_dist"
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
+    monkeypatch.setattr(server, "OUTPUT_DIR", output)
+    monkeypatch.setattr(server, "WEB_DIST", web_dist)
+    monkeypatch.setattr(_samples_router, "OUTPUT_DIR", output)
+    monkeypatch.setattr(_root_router, "WEB_DIST", web_dist)
+    monkeypatch.setattr(presets_io, "USER_PRESETS_DIR", tmp_path / "presets")
+
+    c = TestClient(server.app)
+    resp = c.get("/api/presets/__nonexistent__")
+    assert resp.status_code == 404
+    body = resp.json()
+    # 现状（PR-2 C3 前）：presets.py 还在 raise HTTPException —— 形状保持 {detail: str}
+    assert "detail" in body
+    assert isinstance(body["detail"], str)

--- a/tests/test_service_errors_inherit_domain.py
+++ b/tests/test_service_errors_inherit_domain.py
@@ -1,0 +1,83 @@
+"""PR-2 C3 — 验证 11 个 service error 全部继承 DomainError。
+
+后续 C4/C5 删 router try/except 之后，service raise 直接被 handler 翻 envelope
+的前提就是 isinstance(exc, DomainError)。本测锁继承链不被未来 PR 破。
+"""
+from __future__ import annotations
+
+import pytest
+
+from studio.domain.errors import DomainError
+from studio.services.data_io.train_io import TrainIOError
+from studio.services.dataset.browse import BrowseError
+from studio.services.dataset.curation import CurationError
+from studio.services.preprocess.core import PreprocessError
+from studio.services.preprocess.duplicates import DuplicateFinderError
+from studio.services.presets.io import PresetError
+from studio.services.projects.jobs import JobError
+from studio.services.projects.projects import ProjectError
+from studio.services.projects.versions import VersionError
+from studio.services.tagging.caption_snapshot import SnapshotError
+from studio.services.version_config import VersionConfigError
+
+
+@pytest.mark.parametrize("cls,expected_code", [
+    (PresetError, "preset.error"),
+    (ProjectError, "project.error"),
+    (VersionError, "version.error"),
+    (JobError, "job.error"),
+    (CurationError, "curation.error"),
+    (TrainIOError, "train_io.error"),
+    (VersionConfigError, "version_config.error"),
+    (DuplicateFinderError, "duplicate.error"),
+    (PreprocessError, "preprocess.error"),
+    (BrowseError, "browse.error"),
+    (SnapshotError, "snapshot.error"),
+])
+def test_service_error_inherits_domain_with_code(cls, expected_code) -> None:
+    assert issubclass(cls, DomainError), (
+        f"{cls.__name__} 必须继承 DomainError 让 exception handler 自动 catch"
+    )
+    e = cls("test message")
+    assert isinstance(e, DomainError)
+    assert e.code == expected_code
+    assert e.http_status == 400  # default; router 或 raise 时按情况覆盖
+
+
+def test_raise_service_error_caught_by_handler_via_isinstance(tmp_path) -> None:
+    """端到端：raise PresetError 通过 webui app 被 DomainError handler 翻 envelope。"""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from studio.api.exception_handlers import register_exception_handlers
+    from studio.api.trace_middleware import TraceIdMiddleware
+
+    a = FastAPI()
+    a.add_middleware(TraceIdMiddleware)
+    register_exception_handlers(a)
+
+    @a.get("/raise_preset_err")
+    def _r():
+        raise PresetError("preset 'x' missing")
+
+    c = TestClient(a)
+    resp = c.get("/raise_preset_err")
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["detail"] == "preset 'x' missing"
+    assert body["error"]["code"] == "preset.error"
+    assert body["error"]["message"] == "preset 'x' missing"
+    assert body["error"]["trace_id"] is not None
+
+
+def test_raise_with_override_http_status() -> None:
+    """service 仍可 raise PresetError("x", http_status=404) 让 handler 翻 404。
+
+    C4/C5 router 迁移时常用这个 — 比如 read_preset 不存在时 raise
+    PresetError("...", http_status=404, code="preset.not_found")。
+    """
+    e = PresetError("missing", http_status=404, code="preset.not_found")
+    assert e.http_status == 404
+    assert e.code == "preset.not_found"
+    # 但 isinstance 仍是 PresetError + DomainError
+    assert isinstance(e, PresetError)
+    assert isinstance(e, DomainError)


### PR DESCRIPTION
ADR-0009 §"实施计划" PR-2 — 错误体系（3 PR 中第 2 个）。

依赖 PR-1 (#155) trace_id 全链路 + setup_logging。

## Scope

- `studio/domain/errors.py` 新建 DomainError 基类 + 5 核心子类 (NotFound/Validation/Conflict/Auth/Forbidden) + 4 别名 (InvalidPath/PresetNotFound/PresetNameInvalid/PresetConflict)
- `studio/api/exception_handlers.py` 新建 3 handler (DomainError / RequestValidationError / Exception fallback)；**dual-write envelope** (`{"detail": <legacy str>, "error": {"code", "message", "trace_id", "details"?}}`)
- 11 个 service 错误类（PresetError/ProjectError/VersionError/...）加 DomainError base + default_code
- 30 处 router try/except 三明治迁移（preset / projects/crud / training / curation）— `raise HTTPException` → `_xxx_err_code(exc); raise` 让 handler 自动翻 envelope
- 4 套 _err_code helper 行为变更：从 `-> int` 返 HTTP code 改成 `mutate exc.http_status + exc.code 返 None`，让 DomainError handler 接管

## Commits

| # | scope |
|---|---|
| C1 | DomainError 5 子类 (domain/errors.py) — 不依赖 fastapi |
| C2 | 3 exception_handler 注册 + dual-write envelope + scope state trace_id 兼容外层 fallback handler |
| C3 | 11 service error 加 DomainError base — 改 2 行/文件，不破现有 raise |
| C4 | router batch 1+2 (presets/projects/crud/training preset 22 处) |
| C5 | router batch 3+4 (curation 8 处) + 端到端 e2e test |

## 关键决策（ADR-0009）

- **DomainError 位置 = `domain/errors.py`**（非 `api/errors.py`）— services 反向依赖 api 是反模式。本模块不引 fastapi（纯 Python Exception）；api/exception_handlers.py 才 import FastAPI / JSONResponse。
- **dual-write envelope** — 保 `{"detail": <str>}` legacy contract（前端 client.ts 3 处解析 + 5 测试文件 11 处 `.json()['detail']` 断言不破）+ 新增 `{"error": {...}}` 平行 key 含 trace_id。3 release 渐进迁移：0.12.0 dual-write / 0.13.0 deprecation / 0.14.0 删 detail。
- **HTTPException 不重新注册** — starlette 默认 handler 已经处理 (`{"detail": <orig>}`)，X-Trace-Id 由 TraceIdMiddleware 自动加。保现有 175 处 `raise HTTPException(...)` 完全不变。
- **Fallback Exception handler 跑在 ServerErrorMiddleware 外层** contextvar 已 reset → trace_id 从 `request.scope["state"]["trace_id"]` 读（TraceIdMiddleware 写入），handler 用 `_trace_id_from(req)` 统一逻辑。
- **5 子类不是 7** — round 2 决策"5 核心一次落"。剩下细分（PresetConflictError 等）渐进按需加。

## 解决的 B audit 问题

- **P0 #2.1**: 0 个 exception_handler → C2 注册 3 个
- 4 套 err_code 字符串匹配冗余 → C4+C5 helper 行为统一为 mutate (ADR-0008 §"还的债" 第 4 项关闭)

## 测试

新增 ~30 测试：
- test_domain_errors (15 case) — 5 核心子类 + 4 别名 + 不依赖 fastapi
- test_exception_handlers (15 case) — dual-write envelope / HTTPException 形态保护 / fallback 不 leak traceback / 4xx 不 ERROR log
- test_service_errors_inherit_domain (12 case) — 11 service error 参数化继承 + 端到端 raise
- test_c4_c5_envelope_e2e (2 case) — preset 404 走 webui app 验 envelope dual-write

全测套：1709 passed (跟 PR-1 合并后 baseline 1664 + 45 新测试)，无新回归。dev 自带 43 fail 不在本 PR scope。

## 测试方案

- [x] pytest tests/ -q 全测套
- [x] route_snapshot.json 不动
- [x] test_studio_server / test_project_endpoints 100% 通过
- [x] dual-write 端到端验证（preset 404 → body.detail + body.error.code + trace_id 同步）
- [ ] 手动跑 webui 验前端 toast 显示不变（dual-write 保 detail string 路径）
- [ ] 手动 raise 一个未捕获异常 → studio.log 有 traceback + response body 脱敏

## 后续

- **PR-3** 前端 + CLI 收尾（ErrorBoundary 上报 / window.onerror / /api/client-errors / client.ts toast 显示 trace_id 末 8 字符 / CLI _say wrapper）

🤖 Generated with [Claude Code](https://claude.com/claude-code)