### PR TITLE
fix: 修复测试页三个问题（tagger 模块路径 / 出图入队竞态 / LoRA 跨模式串味）

### DIFF
--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -46,48 +46,66 @@ def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
         )
         db.update_task(conn, task_id, task_type="generate")
 
-    tempdir = generate_tempdir(task_id)
-    tempdir.mkdir(parents=True, exist_ok=True)
-
-    # attention_backend：secrets 读默认；body 给值则覆盖（兼容旧客户端）
-    # secrets 默认 'auto' → 调 detect_attention_backend 按"装了什么用什么"决定
+    # create_task 已把 task 落成 pending+generate，但 config_path 还没写；supervisor
+    # _dispatch_generate 会跳过 config_path=NULL 的 generate task（视为还在入队），等
+    # 下面 config.json 落库后再派。这里任一步失败必须把 task 标 failed，否则它会以
+    # config_path=NULL 永远 pending（dispatcher 永远跳过）。
     try:
-        gen_cfg = secrets.load().generate
-        attn_default = gen_cfg.attention_backend
-        preview_n = int(gen_cfg.preview_every_n_steps or 0)
-    except Exception:
-        attn_default = "auto"
-        preview_n = 0
-    attn = body.attention_backend or attn_default
-    if attn == "auto":
-        from ...services.runtime.xformers import detect_attention_backend
-        attn = detect_attention_backend()
+        tempdir = generate_tempdir(task_id)
+        tempdir.mkdir(parents=True, exist_ok=True)
 
-    cfg = GenerateConfig(
-        **model_paths,
-        output_dir=str(tempdir),
-        prompts=body.prompts,
-        negative_prompt=body.negative_prompt,
-        width=body.width,
-        height=body.height,
-        steps=body.steps,
-        cfg_scale=body.cfg_scale,
-        sampler_name=body.sampler_name,
-        scheduler=body.scheduler,
-        count=body.count,
-        seed=body.seed,
-        lora_configs=[lc.model_dump() for lc in body.lora_configs],
-        mixed_precision=body.mixed_precision,
-        attention_backend=attn,
-        xy_matrix=body.xy_matrix.model_dump() if body.xy_matrix else None,
-    )
+        # attention_backend：secrets 读默认；body 给值则覆盖（兼容旧客户端）
+        # secrets 默认 'auto' → 调 detect_attention_backend 按"装了什么用什么"决定
+        try:
+            gen_cfg = secrets.load().generate
+            attn_default = gen_cfg.attention_backend
+            preview_n = int(gen_cfg.preview_every_n_steps or 0)
+        except Exception:
+            attn_default = "auto"
+            preview_n = 0
+        attn = body.attention_backend or attn_default
+        if attn == "auto":
+            from ...services.runtime.xformers import detect_attention_backend
+            attn = detect_attention_backend()
 
-    # commit 14：注入 daemon 端用的 preview 节流参数（settings 全局开关）
-    cfg_dict = cfg.model_dump()
-    cfg_dict["preview_every_n_steps"] = preview_n
+        cfg = GenerateConfig(
+            **model_paths,
+            output_dir=str(tempdir),
+            prompts=body.prompts,
+            negative_prompt=body.negative_prompt,
+            width=body.width,
+            height=body.height,
+            steps=body.steps,
+            cfg_scale=body.cfg_scale,
+            sampler_name=body.sampler_name,
+            scheduler=body.scheduler,
+            count=body.count,
+            seed=body.seed,
+            lora_configs=[lc.model_dump() for lc in body.lora_configs],
+            mixed_precision=body.mixed_precision,
+            attention_backend=attn,
+            xy_matrix=body.xy_matrix.model_dump() if body.xy_matrix else None,
+        )
 
-    cfg_path = tempdir / "config.json"
-    cfg_path.write_text(json.dumps(cfg_dict, indent=2, ensure_ascii=False), encoding="utf-8")
+        # commit 14：注入 daemon 端用的 preview 节流参数（settings 全局开关）
+        cfg_dict = cfg.model_dump()
+        cfg_dict["preview_every_n_steps"] = preview_n
+
+        cfg_path = tempdir / "config.json"
+        cfg_path.write_text(
+            json.dumps(cfg_dict, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+    except Exception as e:
+        import time as _time
+        with db.connection_for() as conn:
+            now = _time.time()
+            db.update_task(
+                conn, task_id, status="failed",
+                started_at=now, finished_at=now,
+                error_msg=f"enqueue failed: {e}",
+            )
+        bus.publish({"type": "task_state_changed", "task_id": task_id, "status": "failed"})
+        raise HTTPException(500, f"failed to enqueue generate task: {e}")
 
     with db.connection_for() as conn:
         db.update_task(conn, task_id, config_path=str(cfg_path))

--- a/studio/services/__init__.py
+++ b/studio/services/__init__.py
@@ -21,7 +21,8 @@
 
 ## shim 兼容（PR-3 起）
 
-为保 `from studio.services.X import Y` 老路径兼容，老平铺位置留 sys.modules
-别名 shim：`studio.services.wd14_tagger` → `studio.services.tagging.wd14_tagger`
-等。0.11.1+ 会按子包逐批删 shim（详 0.11.0 ADR-0008 follow-ups）。
+部分老平铺路径留 sys.modules 别名 shim（如 `model_downloader` → `models` 包），
+保 `from studio.services.X import Y` 兼容。tagger 家族不留 shim —— 新代码直接
+`from studio.services.tagging import X`，factory 也按子包路径加载。
+0.11.1+ 会按子包逐批删剩余 shim（详 0.11.0 ADR-0008 follow-ups）。
 """

--- a/studio/services/tagging/base.py
+++ b/studio/services/tagging/base.py
@@ -49,10 +49,10 @@ class Tagger(Protocol):
 # 加新 tagger 在这里加一行；server.py 的 TagJobRequest 同步加 `<name>_overrides`
 # 字段（如果支持本次任务覆盖）即可。worker 走通用 `params.get(f"{name}_overrides")`。
 _TAGGER_SPEC: dict[str, tuple[str, str, bool]] = {
-    "wd14": ("studio.services.wd14_tagger", "WD14Tagger", True),
-    "cltagger": ("studio.services.cltagger_tagger", "CLTagger", True),
-    "joycaption": ("studio.services.joycaption_tagger", "JoyCaptionTagger", False),
-    "llm": ("studio.services.llm_tagger", "LLMTagger", True),
+    "wd14": ("studio.services.tagging.wd14", "WD14Tagger", True),
+    "cltagger": ("studio.services.tagging.cltagger", "CLTagger", True),
+    "joycaption": ("studio.services.tagging.joycaption", "JoyCaptionTagger", False),
+    "llm": ("studio.services.tagging.llm", "LLMTagger", True),
 }
 
 

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -412,6 +412,12 @@ class Supervisor:
         task = self._next_pending_task_in(("generate",))
         if task is None:
             return
+        # enqueue_generate 先 create_task(pending, task_type=generate) 再写 config.json
+        # 落 config_path —— 两步之间（含 detect_attention_backend 等耗时）这条 task 已
+        # 是 pending+generate 但 config_path 还是 NULL。此时别提交（否则 daemon 报
+        # "config not found: <none>"），等下个 tick config_path 落库后再派。
+        if not task.get("config_path"):
+            return
         self._submit_to_daemon(task)
 
     def _queue_held(self) -> bool:

--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -241,4 +241,62 @@ describe('GeneratePage 端到端 smoke', () => {
     expect(screen.queryByText('#1')).toBeNull()
     expect(screen.getByText('填写参数后点击「开始生成」')).toBeInTheDocument()
   })
+
+  // ---- LoRA 列表 single / xy 完全独立（2026-05-29 修复跨 mode 串味 bug）----
+
+  const A = { path: 'G:/a.safetensors', scale: 1, project_id: null, version_id: null }
+  const B = { path: 'G:/b.safetensors', scale: 1, project_id: null, version_id: null }
+  const seedPrefs = (over: Record<string, unknown>) =>
+    window.localStorage.setItem(
+      'studio:generate:params:v1',
+      JSON.stringify({
+        mode: 'single', prompts: ['x'], negPrompt: '',
+        aspect: '1:1', width: 1024, height: 1024,
+        steps: 25, cfgScale: 4, count: 1, seed: 0,
+        xDraft: { axis: 'steps', raw: '20, 25, 30', loraIndex: null },
+        yDraft: null, datasetPick: null,
+        ...over,
+      })
+    )
+
+  it('single 提交只用 singleLoras（不带 xyLoras）', async () => {
+    seedPrefs({ mode: 'single', singleLoras: [A], xyLoras: [B] })
+    const user = userEvent.setup()
+    setup()
+    await waitForInitialLorasLoad()
+
+    await user.click(await screen.findByRole('button', { name: /开始生成/ }))
+    await waitFor(() => expect(lastEnqueueBody).not.toBeNull())
+    expect(lastEnqueueBody!.lora_configs).toEqual([A])
+    expect(lastEnqueueBody!.xy_matrix).toBeNull()
+  })
+
+  it('xy 提交只用 xyLoras（不带 singleLoras）', async () => {
+    seedPrefs({ mode: 'xy', singleLoras: [A], xyLoras: [B] })
+    const user = userEvent.setup()
+    setup()
+    await waitForInitialLorasLoad()
+
+    await user.click(await screen.findByRole('button', { name: /开始生成/ }))
+    await waitFor(() => expect(lastEnqueueBody).not.toBeNull())
+    expect(lastEnqueueBody!.lora_configs).toEqual([B])
+    expect(lastEnqueueBody!.xy_matrix).not.toBeNull()
+  })
+
+  it('老版本共享 loras 迁移：拆成 singleLoras/xyLoras 各一份，不丢已选 LoRA', async () => {
+    // 老 shape 只有共享 loras=[A]（无 singleLoras/xyLoras）
+    seedPrefs({ mode: 'single', loras: [A] })
+    const user = userEvent.setup()
+    setup()
+    await waitForInitialLorasLoad()
+
+    await user.click(await screen.findByRole('button', { name: /开始生成/ }))
+    await waitFor(() => expect(lastEnqueueBody).not.toBeNull())
+    expect(lastEnqueueBody!.lora_configs).toEqual([A])
+
+    // 落库后 shape 已迁移：两边都拿到 A
+    const stored = JSON.parse(window.localStorage.getItem('studio:generate:params:v1')!)
+    expect(stored.singleLoras).toEqual([A])
+    expect(stored.xyLoras).toEqual([A])
+  })
 })

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -45,18 +45,77 @@ const DEFAULT_GENERATE_PREFS = {
   cfgScale: 4.0,
   count: 1,
   seed: 0,
-  loras: [] as LoraEntry[],
+  // single / xy 的 LoRA 列表完全独立（用户决策 2026-05-29）：切 mode 互不影响。
+  // compare 是 xy 的子视图，跟 xy 共用 xyLoras。
+  singleLoras: [] as LoraEntry[],
+  xyLoras: [] as LoraEntry[],
   xDraft: { axis: 'steps', raw: '20, 25, 30', loraIndex: null } as XYAxisDraft,
   yDraft: null as XYAxisDraft | null,
   datasetPick: null as DatasetPick | null,
+}
+
+type GeneratePrefs = typeof DEFAULT_GENERATE_PREFS
+
+/** 归一化 / 迁移持久化 prefs（readPersisted 不 merge default，必须自己补齐）：
+ *  - 老版本只有共享 `loras`（single/xy 共用，正是被修的 bug）→ 拆成
+ *    singleLoras/xyLoras 各复制一份，迁移不丢任何已选 LoRA；迁移后两边独立。
+ *  - 补齐缺失字段（老 shape / 跨版本新增字段）。
+ *  - clamp xDraft/yDraft.loraIndex 到 xyLoras 合法范围（xy 轴 loraIndex 指向
+ *    xyLoras；越界会让 submit 抛 axisLoraMissing）。
+ */
+function normalizePrefs(p: GeneratePrefs): GeneratePrefs {
+  const anyP = p as Partial<GeneratePrefs> & { loras?: LoraEntry[] }
+  const legacy = Array.isArray(anyP.loras) ? anyP.loras : []
+  const singleLoras = Array.isArray(anyP.singleLoras) ? anyP.singleLoras : legacy
+  const xyLoras = Array.isArray(anyP.xyLoras) ? anyP.xyLoras : legacy
+  const clampIdx = (d: XYAxisDraft | null): XYAxisDraft | null => {
+    if (!d || d.loraIndex == null || d.loraIndex < xyLoras.length) return d
+    return { ...d, loraIndex: xyLoras.length > 0 ? 0 : null }
+  }
+  const { loras: _legacy, ...rest } = anyP
+  return {
+    ...DEFAULT_GENERATE_PREFS,
+    ...rest,
+    singleLoras,
+    xyLoras,
+    xDraft: clampIdx(rest.xDraft ?? DEFAULT_GENERATE_PREFS.xDraft) ?? DEFAULT_GENERATE_PREFS.xDraft,
+    yDraft: clampIdx(rest.yDraft ?? null),
+  }
 }
 
 export default function GeneratePage() {
   const { t } = useTranslation()
   const { toast } = useToast()
 
-  const [prefs, setPrefs] = useLocalStorageState(GENERATE_PREFS_KEY, DEFAULT_GENERATE_PREFS)
-  const { mode, prompts, negPrompt, aspect, width, height, steps, cfgScale, count, seed, loras, xDraft, yDraft, datasetPick } = prefs
+  const [rawPrefs, setRawPrefs] = useLocalStorageState(GENERATE_PREFS_KEY, DEFAULT_GENERATE_PREFS)
+  const prefs = useMemo(() => normalizePrefs(rawPrefs), [rawPrefs])
+  // 所有 setPrefs 更新都先把 prev 归一化（迁移老 shape + clamp），保证 updater
+  // 收到的永远是新 shape（含 singleLoras/xyLoras，无遗留 loras）。
+  const setPrefs = useCallback(
+    (next: GeneratePrefs | ((p: GeneratePrefs) => GeneratePrefs)) =>
+      setRawPrefs((prev) => {
+        const norm = normalizePrefs(prev)
+        return typeof next === 'function' ? next(norm) : next
+      }),
+    [setRawPrefs],
+  )
+  // 一次性把老 shape（共享 loras）迁移落库，避免 storage 长期残留遗留字段；
+  // 之后读到的就是干净的 singleLoras/xyLoras 双桶 shape。
+  useEffect(() => {
+    const raw = rawPrefs as Partial<GeneratePrefs> & { loras?: unknown }
+    if ('loras' in raw || !('singleLoras' in raw) || !('xyLoras' in raw)) {
+      setRawPrefs(normalizePrefs(rawPrefs))
+    }
+    // 仅 mount 跑一次：迁移是幂等的，rawPrefs 后续变化不需要重跑
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const { mode, prompts, negPrompt, aspect, width, height, steps, cfgScale, count, seed, xDraft, yDraft, datasetPick } = prefs
+  // LoRA 列表按 mode 完全独立：single 用 singleLoras，xy（含 compare 子视图）用
+  // xyLoras。读写都按当前 mode 路由，切 mode 互不影响。
+  const loras = mode === 'single' ? prefs.singleLoras : prefs.xyLoras
+  const setLoras = (loras: LoraEntry[]) =>
+    setPrefs((p) => (p.mode === 'single' ? { ...p, singleLoras: loras } : { ...p, xyLoras: loras }))
   const setMode = (mode: ViewMode) => setPrefs((p) => ({ ...p, mode }))
   const setPrompts = (prompts: string[]) => setPrefs((p) => ({ ...p, prompts }))
   const setNegPrompt = (negPrompt: string) => setPrefs((p) => ({ ...p, negPrompt }))
@@ -67,13 +126,11 @@ export default function GeneratePage() {
   const setCfgScale = (cfgScale: number) => setPrefs((p) => ({ ...p, cfgScale }))
   const setCount = (count: number) => setPrefs((p) => ({ ...p, count }))
   const setSeed = (seed: number) => setPrefs((p) => ({ ...p, seed }))
-  const setLoras = (loras: LoraEntry[]) => setPrefs((p) => ({ ...p, loras }))
 
   // LoRA 预填 via URL query (?lora=<path>&projectId=N&versionId=N)
   // Overview StatusBanner "在测试中加载" CTA 跳进来时，URL 是显式 "测这条 LoRA"
-  // 意图——丢掉缓存 list 直接 replace 成 [urlLora]，避免旧/已删 LoRA 与新条目
-  // 并排出现（旧 append 行为会让 xDraft.loraIndex 指向脏 slot，submit 抛
-  // axisLoraMissing）。同时 clamp xDraft/yDraft.loraIndex 到合法范围。
+  // 意图 = 测这一条 → 落到 single 模式的列表（replace 成 [urlLora]）并切到 single；
+  // xy 列表独立、不受影响（xy 轴 loraIndex 已由 normalizePrefs clamp 到 xyLoras）。
   // 用 history.replaceState 清掉 query 避免刷新时重复触发。
   useEffect(() => {
     const sp = new URLSearchParams(window.location.search)
@@ -88,17 +145,7 @@ export default function GeneratePage() {
         project_id: projectId ? Number(projectId) : null,
         version_id: versionId ? Number(versionId) : null,
       }]
-      const clamp = (d: XYAxisDraft | null): XYAxisDraft | null => {
-        if (!d || d.loraIndex == null) return d
-        if (d.loraIndex < newLoras.length) return d
-        return { ...d, loraIndex: 0 }
-      }
-      return {
-        ...p,
-        loras: newLoras,
-        xDraft: clamp(p.xDraft) ?? p.xDraft,
-        yDraft: clamp(p.yDraft),
-      }
+      return { ...p, mode: 'single', singleLoras: newLoras }
     })
     setUrlConsumedKey((k) => k + 1)
     const url = new URL(window.location.href)

--- a/tests/test_inference_daemon.py
+++ b/tests/test_inference_daemon.py
@@ -334,3 +334,32 @@ def test_supervisor_train_dispatch_skips_generate(env, monkeypatch):
     # 拉 generate 才能找到
     found = sup._next_pending_task_in(("generate",))
     assert found is not None and found["id"] == tid_gen
+
+
+def test_dispatch_generate_skips_task_without_config_path(env, monkeypatch):
+    """enqueue 竞态：task 已 pending+generate 但 config_path 还没落库时，
+    _dispatch_generate 必须跳过（不能 submit → daemon 报 config not found: <none>），
+    等 config_path 落库后下个 tick 才派。"""
+    from studio.supervisor import Supervisor
+
+    sup = Supervisor(
+        on_event=lambda _e: None,
+        db_path=env["db"], logs_dir=env["logs"], configs_dir=env["configs"],
+    )
+    submitted: list[int] = []
+    monkeypatch.setattr(sup, "_submit_to_daemon", lambda t: submitted.append(t["id"]))
+
+    # config_path 还是 NULL（模拟 create_task 刚落、config.json 还没写）
+    with db.connection_for(env["db"]) as conn:
+        tid = db.create_task(conn, name="g", config_name="gen", priority=0)
+        db.update_task(conn, tid, task_type="generate")
+
+    sup._dispatch_generate()
+    assert submitted == [], "config_path=NULL 的 generate task 不应被 submit"
+    assert _task_status(env["db"], tid) == "pending", "应保持 pending 等待，不该 failed"
+
+    # config_path 落库后应被派
+    with db.connection_for(env["db"]) as conn:
+        db.update_task(conn, tid, config_path=str(env["configs"] / "gen.json"))
+    sup._dispatch_generate()
+    assert submitted == [tid]


### PR DESCRIPTION
修复测试页（Generate）反馈的三个问题，三个独立 commit，**squash 合并**到 dev。

## 1. WD14 tagger "不可用 No module named 'studio.services.wd14_tagger'"
0.11.0 / ADR-0008 把 tagger 家族移到 `tagging/` 子包，但 factory 的 `_TAGGER_SPEC` 仍指向旧平铺路径，且声称的 sys.modules 别名 shim 从未真正创建（只有 `model_downloader` 有）→ `importlib` 抛 `No module named`，前端状态条显示"不可用"。

- 四个 tagger（wd14/cltagger/joycaption/llm）重新指向真实子包模块路径
- 订正 `services/__init__.py` 误导性 docstring

## 2. 测试出图 `config not found: <none>`
`enqueue_generate` 先 `create_task` 把任务落成 `pending+generate`（即可被派发），随后才构建 config（含耗时的 `detect_attention_backend`）并写 `config_path`。supervisor 每 1s tick，若在"`task_type` 已是 generate、`config_path` 还是 NULL"的窗口派发，`_submit_to_daemon` 读到空路径 → 任务直接 failed。

- `_dispatch_generate` 跳过 `config_path` 未落库的任务（视为仍在入队），下个 tick 再派
- `enqueue_generate` 构建/写入失败时把任务标 failed，避免永远 pending
- 新增回归测试

## 3. single / xy 模式的 LoRA 列表串味
`loras` 是 prefs 单份共享数组，single 与 xy 读写同一份 → single 加 A 切 xy 加 B，xy 生成吃 A+B，切回 single 又显示 A+B。

- 拆成 `singleLoras` / `xyLoras` 双桶，按 mode 路由（compare 共用 xy 桶）
- `normalizePrefs` 补齐字段 + 把老版本共享 `loras` 迁移到两桶各一份（不丢已选）+ clamp xy 轴 `loraIndex`
- URL `?lora=` 深链落到 single 桶并切到 single
- 新增 3 个测试

## 测试
- 后端：`test_inference_daemon.py` / `test_wd14_tagger.py` / `test_tag_worker.py` / `test_generate_cache.py` 等全绿
- 前端：`Generate.test.tsx` 10 项 + generate 子目录共 59 项全绿；`tsc --noEmit` 干净

> 注：本 PR 取代已误用 rebase 合并的 #158（按 CONTRIBUTING 改为 squash 合并）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)