### PR TITLE
fix(updater): self-update marker 跟随重构后的 updater.py 路径

### DIFF
--- a/studio/services/runtime/updater.py
+++ b/studio/services/runtime/updater.py
@@ -548,19 +548,32 @@ def exact_tag_for(sha: str) -> Optional[str]:
     return out if rc == 0 and out else None
 
 
-# Self-update feature 引入的 marker 文件。target 上不存在 → 切过去就丢失
-# webui 升级能力（只能 CLI git pull 救援）。preflight() err 级别阻断。
-_SELF_UPDATE_MARKER = "studio/services/updater.py"
+# Self-update feature 引入的 marker 文件。target 上一个都不存在 → 切过去就
+# 丢失 webui 升级能力（只能 CLI git pull 救援）。preflight() err 级别阻断。
+#
+# 多路径：0.11.0 (PR #143 / ADR 0008) services/ 重构把 updater.py 从
+# studio/services/ 搬到 studio/services/runtime/。老 commit 用旧路径、重构后
+# 的 commit 用新路径——任一存在即视为带自更新能力。**文件再搬时务必往这里
+# 追加新路径**，否则所有新 commit 会被误判为"早于自更新 feature"而被 preflight
+# 阻断（test_self_update_markers_track_real_file 守这条不变量）。
+_SELF_UPDATE_MARKERS = (
+    "studio/services/runtime/updater.py",  # 0.11.0+ 重构后
+    "studio/services/updater.py",          # 0.11.0 之前（ADR 0002 初版）
+)
 
 
 def target_has_self_update(target_ref: str) -> bool:
     """目标 ref 上是否带 webui 自更新 feature。
 
     用 `git cat-file -e <ref>:<path>` 测文件存在性（不读内容，效率比 git
-    show 高且无 stdout 输出污染）。失败 / ref 无效 → False（保守）。
+    show 高且无 stdout 输出污染）。任一候选路径存在即 True；全部失败 / ref
+    无效 → False（保守，让 preflight 阻断）。
     """
-    rc, _, _ = _git("cat-file", "-e", f"{target_ref}:{_SELF_UPDATE_MARKER}")
-    return rc == 0
+    for path in _SELF_UPDATE_MARKERS:
+        rc, _, _ = _git("cat-file", "-e", f"{target_ref}:{path}")
+        if rc == 0:
+            return True
+    return False
 
 
 _REQ_NAME_RE = re.compile(r"^([A-Za-z0-9_\-\.\[\]]+)")

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -781,14 +781,14 @@ def test_bootstrap_honors_env_origin_url_override(
 
 
 def test_target_has_self_update_true_when_marker_exists(monkeypatch: pytest.MonkeyPatch) -> None:
-    """git cat-file -e <ref>:studio/services/updater.py 返 0 → True。"""
+    """任一候选路径 git cat-file -e <ref>:<path> 返 0 → True。"""
     monkeypatch.setattr(updater, "_git",
                        lambda *args, **_k: (0, "", "") if args[0] == "cat-file" else (1, "", ""))
     assert updater.target_has_self_update("any-ref") is True
 
 
 def test_target_has_self_update_false_when_marker_missing(monkeypatch: pytest.MonkeyPatch) -> None:
-    """marker 文件不存在（pre-self-update commit）→ False。"""
+    """所有候选路径都不存在（pre-self-update commit）→ False。"""
     monkeypatch.setattr(updater, "_git", lambda *args, **_k: (1, "", "does not exist"))
     assert updater.target_has_self_update("ancient-commit") is False
 
@@ -797,6 +797,22 @@ def test_target_has_self_update_false_on_git_error(monkeypatch: pytest.MonkeyPat
     """git 失败（ref 无效 / 仓库损坏）→ 保守返 False，让 preflight 阻断。"""
     monkeypatch.setattr(updater, "_git", lambda *args, **_k: (128, "", "fatal: invalid object"))
     assert updater.target_has_self_update("garbage") is False
+
+
+def test_self_update_markers_track_real_file() -> None:
+    """marker 路径必须跟着 updater.py 的真实位置走。
+
+    回归守卫：0.11.0 (PR #143) services/ 重构把 updater.py 从
+    studio/services/ 搬到 studio/services/runtime/，但 _SELF_UPDATE_MARKER
+    没跟着改，导致所有重构后的 commit 都没有旧路径文件 → target_has_self_update
+    恒返 False → preflight 把每个新版本误判为"早于自更新 feature"并阻断切换。
+    断言至少一个候选路径在当前工作树真实存在，搬文件忘改 marker 时直接挂。
+    """
+    from studio.paths import REPO_ROOT
+    assert any((REPO_ROOT / p).exists() for p in updater._SELF_UPDATE_MARKERS), (
+        f"_SELF_UPDATE_MARKERS 没有一个指向真实文件：{updater._SELF_UPDATE_MARKERS}"
+        "——updater.py 搬家后忘了更新 marker 路径？"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景 / 动机

版本面板切换任意 dev commit 时，pre-flight 检查恒报红叉并阻断：

> ✗ 目标版本早于 webui 自更新 feature — 切过去后只能 CLI / shell 升级（webui 无救援能力）

即便目标是最近的 commit（明明带自更新能力）也被判成"早于自更新 feature"——**越新的版本越被判成老版本**。

根因不是 commit 排序（那部分由 `check_update` 用 `rev-list` + tag 正确算）。触发红叉的 `self_update_compat` 检查走的是**代码识别**：`target_has_self_update()` 用 `git cat-file -e <ref>:<path>` 看目标 commit 里 marker 文件在不在。marker 写死成旧路径 `studio/services/updater.py`。

0.11.0 services/ 重构（#143 / `b55ed16`，ADR 0008）把 `updater.py` 从 `studio/services/` 搬到了 `studio/services/runtime/`，但 `_SELF_UPDATE_MARKER` 常量没跟着改。于是 `b55ed16` 之后的**每个 commit** 旧路径都不存在 → `target_has_self_update` 恒返 `False` → preflight 以 err 级阻断。

已用 git 核实：`HEAD` / `9626ec1` 上 `studio/services/updater.py` 均不存在，`studio/services/runtime/updater.py` 存在。

## 改动概要

- `_SELF_UPDATE_MARKER`（单路径字符串）→ `_SELF_UPDATE_MARKERS`（多路径元组），含新路径 `studio/services/runtime/updater.py` 与旧路径 `studio/services/updater.py`；`target_has_self_update()` 改为任一路径存在即 `True`（兼容重构前的老 commit，不在另一个方向制造误判）。
- 加 `test_self_update_markers_track_real_file`：断言至少一个 marker 指向工作树里真实存在的文件——以后再搬 `updater.py` 又忘改 marker，这条直接挂掉。现有 3 个单测全 monkeypatch 掉 `_git`、从不校验真实路径，正是本 bug 静默漏过的原因。

## 测试方式

- `python -m pytest tests/test_updater.py tests/test_studio_server.py -q` → 115 passed
- 真实仓库验证修复后：`target_has_self_update('HEAD' / '9626ec1' / '22a83ff7')` 全部返 `True`（红叉消失）

🤖 Generated with [Claude Code](https://claude.com/claude-code)