### PR TITLE
fix(generate): XY lora_ckpt 轴按 ckpt 展示序排列，不随点击顺序乱跳

### DIFF
--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.test.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.test.tsx
@@ -50,6 +50,7 @@ describe('InlineLoraPicker — multi mode (default)', () => {
     existingPaths: Set<string>
     showWeight: boolean
     ckpts: LoraCkpt[]
+    live: boolean
   }> = {}) {
     vi.spyOn(api, 'listVersionLoraCkpts').mockResolvedValue(overrides.ckpts ?? ckptsV3)
     const onPick = vi.fn()
@@ -61,6 +62,7 @@ describe('InlineLoraPicker — multi mode (default)', () => {
         projectLoras={overrides.projectLoras ?? sample}
         existingPaths={overrides.existingPaths ?? new Set()}
         showWeight={overrides.showWeight ?? true}
+        live={overrides.live ?? false}
         onPick={onPick}
         onClose={onClose}
         onPickExternal={onPickExternal}
@@ -103,6 +105,40 @@ describe('InlineLoraPicker — multi mode (default)', () => {
     ])
     expect(weight).toBe(1.0)
     expect(onClose).toHaveBeenCalled()
+  })
+
+  it('commits picks in ckpt display order, not click order (添加 N 个)', async () => {
+    const user = userEvent.setup()
+    const { onPick } = renderMulti()
+    await waitFor(() => expect(screen.getByText('step 2000')).toBeInTheDocument())
+    // 故意乱序点击：step 1000 → final → step 2000
+    await user.click(screen.getByText('step 1000').closest('button')!)
+    await user.click(screen.getByText('final').closest('button')!)
+    await user.click(screen.getByText('step 2000').closest('button')!)
+    await user.click(screen.getByText(/添加 3 个/))
+    const [picks] = onPick.mock.calls[0]
+    // 输出跟随 ckpts 展示序（final → step↓），与点击先后无关
+    expect(picks.map((p: PickedLora) => p.path)).toEqual([
+      '/loras/cute_chibi/v3/final.safetensors',
+      '/loras/cute_chibi/v3/step_2000.safetensors',
+      '/loras/cute_chibi/v3/step_1000.safetensors',
+    ])
+  })
+
+  it('live mode commits in display order on each toggle (XY ckpt 轴单调)', async () => {
+    const user = userEvent.setup()
+    const { onPick } = renderMulti({ live: true, showWeight: false })
+    await waitFor(() => expect(screen.getByText('step 2000')).toBeInTheDocument())
+    // 乱序点击；live 模式每次 toggle 即时 commit，取最后一次（三个都选中）
+    await user.click(screen.getByText('step 1000').closest('button')!)
+    await user.click(screen.getByText('step 2000').closest('button')!)
+    await user.click(screen.getByText('final').closest('button')!)
+    const lastPicks = onPick.mock.calls[onPick.mock.calls.length - 1][0]
+    expect(lastPicks.map((p: PickedLora) => p.path)).toEqual([
+      '/loras/cute_chibi/v3/final.safetensors',
+      '/loras/cute_chibi/v3/step_2000.safetensors',
+      '/loras/cute_chibi/v3/step_1000.safetensors',
+    ])
   })
 
   it('existingPaths disables the chip; click does not toggle', async () => {

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
@@ -169,6 +169,14 @@ export default function InlineLoraPicker(props: Props) {
 
   const currentVersion = versions.find((v) => v.id === vid)
 
+  // 选中集合 → picks：按 ckpts 展示顺序排（list_lora_ckpts 的 canonical sort：
+  // final → step↓ → epoch↓），而非用户点击顺序。XY ckpt 轴必须单调，否则
+  // 网格列/行随点击先后乱跳，读不出过拟合拐点（ep60 应恒在 ep80 / ep40 之间）。
+  const orderedPicks = (sel: Set<string>): PickedLora[] =>
+    ckpts
+      .filter((c) => sel.has(c.path))
+      .map((c) => ({ path: c.path, projectId: pid, versionId: vid }))
+
   // chip 点击
   const onChipClick = (c: LoraCkpt) => {
     if (existingPaths.has(c.path)) return
@@ -192,10 +200,7 @@ export default function InlineLoraPicker(props: Props) {
       if (next.has(c.path)) next.delete(c.path); else next.add(c.path)
       // live 模式：每次 chip toggle 都即时 commit，不等用户点「添加 N 个」
       if (isLive && pid !== null && vid !== null) {
-        const picks: PickedLora[] = Array.from(next).map((path) => ({
-          path, projectId: pid, versionId: vid,
-        }))
-        ;(props as MultiModeProps).onPick(picks, internalWeight)
+        ;(props as MultiModeProps).onPick(orderedPicks(next), internalWeight)
       }
       return next
     })
@@ -207,10 +212,7 @@ export default function InlineLoraPicker(props: Props) {
     } else {
       setInternalWeight(w)
       if (isLive && pid !== null && vid !== null && picked.size > 0) {
-        const picks: PickedLora[] = Array.from(picked).map((path) => ({
-          path, projectId: pid, versionId: vid,
-        }))
-        ;(props as MultiModeProps).onPick(picks, w)
+        ;(props as MultiModeProps).onPick(orderedPicks(picked), w)
       }
     }
   }
@@ -218,12 +220,7 @@ export default function InlineLoraPicker(props: Props) {
   const commitMulti = () => {
     if (isSingle) return
     if (picked.size === 0) return
-    const picks: PickedLora[] = Array.from(picked).map((path) => ({
-      path,
-      projectId: pid,
-      versionId: vid,
-    }))
-    props.onPick(picks, internalWeight)
+    props.onPick(orderedPicks(picked), internalWeight)
     onClose()
   }
 


### PR DESCRIPTION
## 为什么

测试页 XY 图的 `lora_ckpt` 轴（扫同一 LoRA 不同 epoch/step ckpt 找过拟合拐点）选中多个 ckpt 时，轴值的顺序是**用户点击 chip 的先后顺序**，不是按 epoch/step 排序。

后果：选 ep80 / ep60 / ep40，如果点击顺序乱（如 80→40→60），网格列/行就排成 `[80, 40, 60]`，ep60 落到末尾。这种轴本应单调（ep60 恒在 ep80 和 ep40 之间），否则肉眼对不上「训练越往后越过拟合」的趋势，拐点读不出来。

根因：`InlineLoraPicker` 多选用 `Set<string>` 存选中，commit 时 `Array.from(set)` 取的是 **Set 插入顺序 = 点击顺序**。

## 怎么改

改为按 **ckpt 展示序**输出，即后端 `list_lora_ckpts`（`studio/services/projects/versions.py`）已经算好的 canonical sort：`final → step↓ → epoch↓ → other 自然序`。picker 本来就是按这个顺序渲染 chip 的。

- 新增 `orderedPicks(sel)` 助手：`ckpts.filter(c => sel.has(c.path)).map(...)` —— 跟随 API 返回的 `ckpts` 数组序，而非点击序。
- `onChipClick`(live) / `onWeightChange`(live) / `commitMulti` 三条 commit 路径统一走它。
- 复用后端排序，前端**不**重新解析 `"ep80" → 80`，step/epoch/final/other 一律统一处理。

普通 LoRA 栈（single/multi 出图）顺序不影响结果（adapter delta 加法可交换），故一律应用无副作用，唯一可见变化就是 XY ckpt 轴变单调。

## 怎么验证

- 新增 2 条回归测试（`InlineLoraPicker.test.tsx`）：乱序点击 → commit 按展示序（`final → step 2000 → step 1000`），分别覆盖 `添加 N 个`（非 live）与 live 两条路径。
- 本地校验全绿：
  - `npm run lint` ✅
  - `npm run typecheck` ✅
  - `npm run test` ✅ 32 files / 289 tests
