### PR TITLE
fix(proxy): proxy_manager 删除幻觉 import 让 booru 链路能加载

### DIFF
--- a/studio/services/proxy_manager.py
+++ b/studio/services/proxy_manager.py
@@ -1,67 +1,57 @@
+"""全局 HTTP/HTTPS 代理 helpers。
+
+读 `secrets.proxy` 配置，组装 requests 库要的 proxies dict + 给现有
+`requests.Session` 注入 proxies。当前只覆盖 booru 下载链路；对
+`huggingface_hub` 的 transport-level 代理注入需要单独的 monkeypatch，
+不在本模块范围内（PR #162 原版本里的 `setup_global_httpx_client` 用了
+`huggingface_hub.set_client_factory` —— 该符号在 huggingface_hub 内不存在，
+import 时直接 ImportError；本 hotfix 一并删除该 dead 函数）。
+"""
 from typing import Dict, Optional
 import logging
-import os
-import httpx
-from huggingface_hub import set_client_factory
+
+from .. import secrets
 
 logger = logging.getLogger(__name__)
 
-# 导入Secrets模块，用于获取用户的代理配置
-from .. import secrets 
 
 def get_proxy_dict() -> Optional[Dict[str, str]]:
-    """
-    从secrets配置中读取代理设置，并返回requests库需要的字典格式。
-    如果代理未启用或配置无效，返回None。
-    """
+    """从 secrets 读代理设置，返回 requests 库要的字典格式；未启用返 None。"""
     try:
         cfg = secrets.load().proxy
         if not cfg.enabled:
             return None
-        
-        proxies = {}
-        # 直接使用用户填写的地址，requests库会自行处理
-        if cfg.http_proxy and cfg.http_proxy.startswith('socks5://'):
-            proxies['http'] = cfg.http_proxy
-            proxies['https'] = cfg.http_proxy
+
+        proxies: Dict[str, str] = {}
+        if cfg.http_proxy and cfg.http_proxy.startswith("socks5://"):
+            proxies["http"] = cfg.http_proxy
+            proxies["https"] = cfg.http_proxy
         else:
-            # 原有的HTTP代理逻辑
             if cfg.http_proxy:
-                proxies['http'] = cfg.http_proxy
+                proxies["http"] = cfg.http_proxy
             if cfg.https_proxy:
-                proxies['https'] = cfg.https_proxy
-        
+                proxies["https"] = cfg.https_proxy
+
         logger.info(f"Using proxies: {proxies}")
         return proxies if proxies else None
     except Exception as e:
         logger.error(f"Failed to get proxy: {e}")
         return None
 
-def setup_global_httpx_client():
-    """全局配置 huggingface_hub 的 HTTP 客户端以支持 SOCKS5"""
-    proxy_config = get_proxy_dict()
-    if not proxy_config:
-        return
-    proxy_url = proxy_config.get('http', proxy_config.get('https'))
-    if proxy_url and proxy_url.startswith('socks5://'):
-        # 为 httpx 客户端配置 SOCKS5 代理
-        client = httpx.Client(proxies=proxy_url, transport=httpx.HTTPTransport())
-    else:
-        # 为一般的 HTTP 代理配置
-        client = httpx.Client(proxies=proxy_url)
-    set_client_factory(lambda: client)
 
 def get_no_proxy_list() -> list[str]:
-    """获取不需要代理的地址列表"""
+    """`no_proxy` 字段拆成 host 列表。"""
     try:
-        proxy_cfg = secrets.get().proxy
+        proxy_cfg = secrets.load().proxy
         if not proxy_cfg.no_proxy:
             return []
-        return [host.strip() for host in proxy_cfg.no_proxy.split(',')]
+        return [host.strip() for host in proxy_cfg.no_proxy.split(",")]
     except Exception:
         return []
 
+
 def patch_requests_session(session):
+    """给已有 requests.Session 注入 proxies；未启用代理则原样返回。"""
     proxies = get_proxy_dict()
     if proxies:
         session.proxies.update(proxies)


### PR DESCRIPTION
## 背景

PR #162（已直接 merge 到 master，应该走 dev 但当时走错了 base）在
`studio/services/proxy_manager.py` 顶部写了：

```python
from huggingface_hub import set_client_factory
```

`set_client_factory` **不存在**于 huggingface_hub 公开 API（疑似 LLM 协作幻觉
出来的符号）。该 module-level import 让任何 `from .proxy_manager import ...`
直接 ImportError —— 包括 `studio/services/booru/downloader.py`（dev 路径）/
`studio/services/booru_pool.py`（master 路径）等下载链路入口，等于 booru 下载
页加载就崩。

同时 `get_no_proxy_list` 里 `secrets.get().proxy` 调用错了 API ——
`secrets.get(path: str)` 是按点路径取值，无参调用会 TypeError。

## 改动

1. 删 `from huggingface_hub import set_client_factory` 幻觉 import
2. 删 `setup_global_httpx_client` —— 它依赖那个不存在的符号，且全仓库无任何
   调用点（dead code）
3. 删 `import httpx` / `import os` —— 只在上面 dead 函数里被引用
4. `get_no_proxy_list` 的 `secrets.get().proxy` → `secrets.load().proxy`
5. 顶部补 module docstring 记录这段历史

## 行为变化

原 PR 设计的"全局 huggingface_hub 走代理"从未生效（import 就炸），所以删
dead 函数不引入回归 —— 它本来就没工作。booru 下载链路
（`get_proxy_dict` + `patch_requests_session`）保留。

## 紧急性 / 走 hotfix 路径的理由

按 CONTRIBUTING.md §Hotfix 加急路径：
- master 当前 tip `bb21e11` 是 broken commit，import 即崩
- dev 已经 merge 了 master（commit `3c91985`，本地未推），同样带这个 broken
  symbol —— 等下次 release 太晚
- 修法极小（删 4 行 dead import + 改 1 行 API 调用），不该塞 feature PR

## 测试方式

```bash
python -c "from studio.services.proxy_manager import get_proxy_dict, patch_requests_session, get_no_proxy_list; print('OK')"
# → 之前 ImportError: cannot import name 'set_client_factory' from 'huggingface_hub'
# → 修后 OK
```

## 合并后

按 CONTRIBUTING §Hotfix 步骤 5 sync 回 dev：
```bash
git checkout dev && git merge origin/master && git push origin dev
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)