### PR TITLE
fix(studio): 监控页采样放大 + 保存间隔字段顺序 + monitor 按 task 隔离 + blacklist 输入

### DIFF
--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -162,8 +162,12 @@ def run(ctx: TrainingContext) -> None:
     # 创建输出目录
     ctx.output_dir = Path(args.output_dir)
     ctx.output_dir.mkdir(parents=True, exist_ok=True)
-    ctx.sample_dir = ctx.output_dir / "samples"
-    ctx.sample_dir.mkdir(exist_ok=True)
+    # 采样图落到 monitor state 同级 samples/。监控 state file 由 supervisor 按
+    # task 注入（--monitor-state-file），采样图随之按 task 隔离；samples.py 优先
+    # 在 monitor_dir/samples 解析。没传（纯 CLI 训练）退回 output_dir/samples。
+    _msf = getattr(args, "monitor_state_file", None)
+    ctx.sample_dir = (Path(_msf).parent / "samples") if _msf else (ctx.output_dir / "samples")
+    ctx.sample_dir.mkdir(parents=True, exist_ok=True)
     # supervisor 启动训练时通过 env LORA_TASK_ID 注入 queue task id（ADR 0006）。
     # 用于 ctx.state_dir() 计算 per-task state 子目录；env 不存在时 fallback unknown。
     _env_tid = os.environ.get("LORA_TASK_ID")

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -515,14 +515,14 @@ class TrainingConfig(BaseModel):
         description="每 N step 保存（0=禁用）",
         json_schema_extra=_meta("output"),
     )
-    save_state_every_steps: int = Field(
-        0, ge=0,
-        description="每 N step 保存完整训练状态（断点续训，0=禁用）",
-        json_schema_extra=_meta("output"),
-    )
     save_state_every_epochs: int = Field(
         0, ge=0,
         description="每 N epoch 保存完整训练状态（断点续训，0=禁用）",
+        json_schema_extra=_meta("output"),
+    )
+    save_state_every_steps: int = Field(
+        0, ge=0,
+        description="每 N step 保存完整训练状态（断点续训，0=禁用）",
         json_schema_extra=_meta("output"),
     )
     seed: int = Field(

--- a/studio/services/reg/builder.py
+++ b/studio/services/reg/builder.py
@@ -419,7 +419,14 @@ def _build_for_subfolder(
 
             post_tags = booru_api.post_tag_list(best_post, opts.api_source)
             if opts.save_tags and post_tags:
-                txt_path.write_text(", ".join(post_tags), encoding="utf-8")
+                # caption 一律空格形式（与 WD14/CLTagger 输出、训练集统一）。下划线
+                # 只是 booru 的线格式，仅在匹配 / 查询时用 —— post_tags 原值在下面
+                # current_weights 仍按下划线累加，不动。tag-form 约定：用户可见 /
+                # caption = 空格；underscore 只在 booru 边界。
+                txt_path.write_text(
+                    ", ".join(t.replace("_", " ") for t in post_tags),
+                    encoding="utf-8",
+                )
 
             for tag in post_tags:
                 current_weights[tag] += 1 / target_count

--- a/studio/services/tagging/cltagger.py
+++ b/studio/services/tagging/cltagger.py
@@ -20,6 +20,11 @@ from .onnx_base import OnnxTaggerBase
 logger = logging.getLogger(__name__)
 
 
+def _blacklist_key(tag: str) -> str:
+    """blacklist 比对归一键：下划线↔空格、大小写、首尾空格都不敏感。"""
+    return tag.replace("_", " ").strip().lower()
+
+
 @dataclass
 class _LabelData:
     names: list[str | None]
@@ -203,12 +208,14 @@ class CLTagger(OnnxTaggerBase):
         assert self._labels is not None
         scores = self._sigmoid(logits)
         out: list[tuple[str, float]] = []
-        blacklist = set(cfg.blacklist_tags)
+        # blacklist 比对归一（与 wd14 一致）：下划线↔空格、大小写不敏感。
+        # 注意此处 tag 还是原始下划线形式（输出时才转空格），归一后比对。
+        blacklist = {_blacklist_key(b) for b in cfg.blacklist_tags}
         for i, p in enumerate(scores):
             if i >= len(self._labels.names):
                 break
             tag = self._labels.names[i]
-            if not tag or tag in blacklist:
+            if not tag or _blacklist_key(tag) in blacklist:
                 continue
             cat = self._labels.categories[i]
             if cat == "Rating" and not cfg.add_rating_tag:

--- a/studio/services/tagging/wd14.py
+++ b/studio/services/tagging/wd14.py
@@ -21,6 +21,11 @@ from .. import models as model_downloader
 from .onnx_base import OnnxTaggerBase
 
 
+def _blacklist_key(tag: str) -> str:
+    """blacklist 比对归一键：下划线↔空格、大小写、首尾空格都不敏感。"""
+    return tag.replace("_", " ").strip().lower()
+
+
 class WD14Tagger(OnnxTaggerBase):
     name = "wd14"
 
@@ -144,12 +149,14 @@ class WD14Tagger(OnnxTaggerBase):
         """单张图的概率向量 → (sorted_tags, raw_scores_dict)。"""
         cfg = self._cfg()
         out: list[tuple[str, float]] = []
-        blacklist = set(cfg.blacklist_tags)
+        # blacklist 比对归一：下划线↔空格、大小写、首尾空格都不敏感
+        # （cat girl / cat_girl / Cat_Girl 等价）。self._tags 已是空格小写形式。
+        blacklist = {_blacklist_key(b) for b in cfg.blacklist_tags}
         for i, p in enumerate(scores):
             if i >= len(self._tags):
                 break
             tag, cat = self._tags[i], self._tag_categories[i]
-            if tag in blacklist:
+            if _blacklist_key(tag) in blacklist:
                 continue
             # category: 9=rating（不参与阈值，丢弃）；4=character；其余按 general
             if cat == 9:

--- a/studio/supervisor/cmd_builder.py
+++ b/studio/supervisor/cmd_builder.py
@@ -67,12 +67,22 @@ def _default_cmd_builder(task: dict[str, Any], config_path: Path) -> list[str]:
 
 
 def _resolve_monitor_state_path(task: dict[str, Any]) -> Path:
-    """PP6.1 — 决定 task 的 monitor_state.json 落盘路径。
+    """PP6.1 — 决定 task 的 monitor_state.json 落盘路径（按 task 隔离）。
 
-    有 version_id：`versions/{label}/monitor_state.json`，与 train/output/samples
-    放一起；用户切 version 监控自然独立。
+    每个 task 落到独立子目录，避免同一 version 下多个 task 互相覆盖监控曲线
+    与采样图。旧实现按 version 落 `versions/{label}/monitor_state.json`，同
+    version 第二个 task 一跑就盖掉第一个，监控页查 task1 看到的却是 task2。
+
+    有 version_id：`versions/{label}/monitor/task_{id}/state.json` —— 仍挂在
+    version 目录下（删 version 时一并清理），但按 task 分目录。采样图由 runtime
+    写到 state.json 同级 `samples/`（见 bootstrap.py），samples.py 按
+    `monitor_dir/samples` 解析，于是采样图也随之按 task 隔离。
     没有 version_id（PP1 之前的旧任务）：兜底到
-    `studio_data/monitors/task_{id}/state.json`，避免老任务无处可写。
+    `studio_data/monitors/task_{id}/state.json`。
+
+    兼容老任务：已跑过的老任务 monitor_state_path 早存进 DB（指向旧的 version
+    级文件），读取走存量值不受影响；samples.py 仍保留 `monitor_dir/output/samples`
+    候选，旧采样图照常可见。本改动只影响此后新启动的 task。
     """
     vid = task.get("version_id")
     pid = task.get("project_id")
@@ -88,7 +98,8 @@ def _resolve_monitor_state_path(task: dict[str, Any]) -> Path:
         if row:
             return (
                 STUDIO_DATA / "projects" / f"{pid}-{row['slug']}"
-                / "versions" / row["label"] / "monitor_state.json"
+                / "versions" / row["label"] / "monitor" / f"task_{task['id']}"
+                / "state.json"
             )
     return STUDIO_DATA / "monitors" / f"task_{task['id']}" / "state.json"
 

--- a/studio/web/src/components/MonitorDashboard.tsx
+++ b/studio/web/src/components/MonitorDashboard.tsx
@@ -7,6 +7,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { api } from '../api/client'
 import { useMonitorProgress } from '../lib/useMonitorProgress'
+import ImagePreviewModal from './ImagePreviewModal'
 
 // ── helpers ────────────────────────────────────────────────────────────────
 
@@ -153,6 +154,7 @@ function SampleViewer({ samples, taskId }: {
   // 几个相同 step 的项，下标重复，视觉上自己传达「同一步不同 prompt」。
   const list = samples
   const [active, setActive] = useState(list.length - 1)
+  const [zoomOpen, setZoomOpen] = useState(false)
   const stripRef = useRef<HTMLDivElement | null>(null)
 
   // 初次有图 / 新增 sample 时，仅当用户当前选中是「最末或之后」（即跟随末尾）
@@ -240,7 +242,8 @@ function SampleViewer({ samples, taskId }: {
           src={fullUrl}
           alt="sample preview"
           loading="lazy"
-          className="max-w-full max-h-[480px] object-contain block"
+          onClick={() => setZoomOpen(true)}
+          className="max-w-full max-h-[480px] object-contain block cursor-zoom-in"
         />
         {cur.step != null && (
           <div className="absolute bottom-2.5 left-1/2 -translate-x-1/2 border border-subtle rounded-sm px-2.5 py-0.5 text-xs font-mono text-fg-secondary bg-surface/85">
@@ -249,6 +252,21 @@ function SampleViewer({ samples, taskId }: {
           </div>
         )}
       </div>
+
+      {/* 点击大图放大（参考下载页 ImagePreviewModal）；← / → 在采样序列里前后切 */}
+      {zoomOpen && (
+        <ImagePreviewModal
+          src={fullUrl}
+          caption={cur.step != null
+            ? `step ${cur.step.toLocaleString()} · ${active + 1} / ${list.length} · ${filename}`
+            : `${filename} · ${active + 1} / ${list.length}`}
+          hasPrev={active > 0}
+          hasNext={active < list.length - 1}
+          onClose={() => setZoomOpen(false)}
+          onPrev={() => setActive((i) => Math.max(0, i - 1))}
+          onNext={() => setActive((i) => Math.min(list.length - 1, i + 1))}
+        />
+      )}
     </div>
   )
 }

--- a/studio/web/src/components/TagsInput.test.tsx
+++ b/studio/web/src/components/TagsInput.test.tsx
@@ -56,6 +56,18 @@ describe('TagsInput', () => {
     expect(input2).toHaveValue('x, y')
   })
 
+  it('blur 把下划线归一成空格（chip 统一空格形式）', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const input = await enterEdit(user)
+    await user.type(input, 'cat_girl, blue_eyes')
+    expect(input).toHaveValue('cat_girl, blue_eyes')   // 编辑态原样
+    await user.tab()                                    // blur 归一
+    expect(screen.getByText('cat girl')).toBeInTheDocument()
+    expect(screen.getByText('blue eyes')).toBeInTheDocument()
+    expect(screen.getByTestId('tags')).toHaveTextContent('["cat girl","blue eyes"]')
+  })
+
   it('静止态把每个 tag 渲染成独立 chip', () => {
     render(<Harness initial={['monochrome', 'blue eyes']} />)
     expect(screen.queryByRole('textbox')).toBeNull()

--- a/studio/web/src/components/TagsInput.test.tsx
+++ b/studio/web/src/components/TagsInput.test.tsx
@@ -15,52 +15,71 @@ function Harness({ initial = [] as string[] }: { initial?: string[] }) {
   )
 }
 
+/** 静止态是 role=button 的 chip 容器；点它进入编辑态后才有 textbox。 */
+async function enterEdit(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button'))
+  return screen.getByRole('textbox')
+}
+
 describe('TagsInput', () => {
-  it('能打逗号分隔多个 tag —— 逗号不被当场吃掉', async () => {
+  it('编辑态能打逗号分隔多个 tag —— 逗号不被当场吃掉', async () => {
     const user = userEvent.setup()
     render(<Harness />)
-    const input = screen.getByRole('textbox')
+    const input = await enterEdit(user)
     await user.type(input, 'monochrome, greyscale')
     expect(input).toHaveValue('monochrome, greyscale')
     expect(screen.getByTestId('tags')).toHaveTextContent('["monochrome","greyscale"]')
   })
 
-  it('能打含空格的多词 tag —— 空格不被 trim 掉', async () => {
+  it('编辑态能打含空格的多词 tag —— 空格不被 trim 掉', async () => {
     const user = userEvent.setup()
     render(<Harness />)
-    const input = screen.getByRole('textbox')
+    const input = await enterEdit(user)
     await user.type(input, 'blue eyes')
     expect(input).toHaveValue('blue eyes')
     expect(screen.getByTestId('tags')).toHaveTextContent('["blue eyes"]')
   })
 
-  it('blur 时把文本收成规范形式（去空段 / 统一逗号后单空格）', async () => {
+  it('blur 后退出编辑态、以 chip 展示，文本归整', async () => {
     const user = userEvent.setup()
     render(<Harness />)
-    const input = screen.getByRole('textbox')
+    const input = await enterEdit(user)
     await user.type(input, 'x,,y , ')
-    expect(input).toHaveValue('x,,y , ')   // focus 中保留原始文本
-    await user.tab()                       // 触发 blur
-    expect(input).toHaveValue('x, y')      // blur 后归整
+    expect(input).toHaveValue('x,,y , ')   // 编辑态保留原始文本
+    await user.tab()                       // blur
+    expect(screen.queryByRole('textbox')).toBeNull()   // 回到 chip 静止态
+    expect(screen.getByText('x')).toBeInTheDocument()
+    expect(screen.getByText('y')).toBeInTheDocument()
     expect(screen.getByTestId('tags')).toHaveTextContent('["x","y"]')
+    // 再次进编辑态看到的是规范形式
+    const input2 = await enterEdit(user)
+    expect(input2).toHaveValue('x, y')
   })
 
-  it('外部 value 变化（restore 默认）时同步显示文本', async () => {
+  it('静止态把每个 tag 渲染成独立 chip', () => {
+    render(<Harness initial={['monochrome', 'blue eyes']} />)
+    expect(screen.queryByRole('textbox')).toBeNull()
+    expect(screen.getByText('monochrome')).toBeInTheDocument()
+    expect(screen.getByText('blue eyes')).toBeInTheDocument()
+  })
+
+  it('外部 value 变化（restore 默认）时同步 chip 展示', async () => {
     function ResetHarness() {
       const [tags, setTags] = useState<string[]>(['a', 'b'])
       return (
         <>
           <TagsInput label="bl" value={tags} disabled={false} onChange={setTags} />
-          <button onClick={() => setTags(['reset'])}>reset</button>
+          <button onClick={() => setTags(['reset'])}>do-reset</button>
         </>
       )
     }
     const user = userEvent.setup()
     render(<ResetHarness />)
-    const input = screen.getByRole('textbox')
-    expect(input).toHaveValue('a, b')
-    await user.click(screen.getByText('reset'))
-    expect(input).toHaveValue('reset')
+    expect(screen.getByText('a')).toBeInTheDocument()
+    expect(screen.getByText('b')).toBeInTheDocument()
+    await user.click(screen.getByRole('button', { name: 'do-reset' }))
+    expect(screen.getByText('reset')).toBeInTheDocument()
+    expect(screen.queryByText('a')).toBeNull()
   })
 
   it('parseTags 去首尾空格并丢空段', () => {

--- a/studio/web/src/components/TagsInput.test.tsx
+++ b/studio/web/src/components/TagsInput.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+import TagsInput, { parseTags } from './TagsInput'
+
+/** 受控 harness：模拟父组件持有 string[] 状态，复刻真实受控回路。 */
+function Harness({ initial = [] as string[] }: { initial?: string[] }) {
+  const [tags, setTags] = useState<string[]>(initial)
+  return (
+    <>
+      <TagsInput label="bl" value={tags} disabled={false} onChange={setTags} />
+      <output data-testid="tags">{JSON.stringify(tags)}</output>
+    </>
+  )
+}
+
+describe('TagsInput', () => {
+  it('能打逗号分隔多个 tag —— 逗号不被当场吃掉', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const input = screen.getByRole('textbox')
+    await user.type(input, 'monochrome, greyscale')
+    expect(input).toHaveValue('monochrome, greyscale')
+    expect(screen.getByTestId('tags')).toHaveTextContent('["monochrome","greyscale"]')
+  })
+
+  it('能打含空格的多词 tag —— 空格不被 trim 掉', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const input = screen.getByRole('textbox')
+    await user.type(input, 'blue eyes')
+    expect(input).toHaveValue('blue eyes')
+    expect(screen.getByTestId('tags')).toHaveTextContent('["blue eyes"]')
+  })
+
+  it('blur 时把文本收成规范形式（去空段 / 统一逗号后单空格）', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    const input = screen.getByRole('textbox')
+    await user.type(input, 'x,,y , ')
+    expect(input).toHaveValue('x,,y , ')   // focus 中保留原始文本
+    await user.tab()                       // 触发 blur
+    expect(input).toHaveValue('x, y')      // blur 后归整
+    expect(screen.getByTestId('tags')).toHaveTextContent('["x","y"]')
+  })
+
+  it('外部 value 变化（restore 默认）时同步显示文本', async () => {
+    function ResetHarness() {
+      const [tags, setTags] = useState<string[]>(['a', 'b'])
+      return (
+        <>
+          <TagsInput label="bl" value={tags} disabled={false} onChange={setTags} />
+          <button onClick={() => setTags(['reset'])}>reset</button>
+        </>
+      )
+    }
+    const user = userEvent.setup()
+    render(<ResetHarness />)
+    const input = screen.getByRole('textbox')
+    expect(input).toHaveValue('a, b')
+    await user.click(screen.getByText('reset'))
+    expect(input).toHaveValue('reset')
+  })
+
+  it('parseTags 去首尾空格并丢空段', () => {
+    expect(parseTags('  a , , b ,')).toEqual(['a', 'b'])
+    expect(parseTags('')).toEqual([])
+    expect(parseTags('blue eyes, red_hair')).toEqual(['blue eyes', 'red_hair'])
+  })
+})

--- a/studio/web/src/components/TagsInput.tsx
+++ b/studio/web/src/components/TagsInput.tsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react'
+
+/** 逗号分隔字符串 → 规范化 tag 数组（去首尾空格 / 丢空段）。 */
+export function parseTags(s: string): string[] {
+  return s.split(',').map((t) => t.trim()).filter(Boolean)
+}
+
+/** 逗号分隔 tag 列表输入。focus 中显示原始文本（逗号 / 空格随便打），onChange
+ * 实时解析成数组；blur 时把文本收成规范形式 tags.join(', ')。
+ *
+ * 受控的是**文本**而非数组——避免「每次按键把数组 join 回填到 value」把正在
+ * 敲的逗号 / 尾随空格当场抹掉（直接绑 `arr.join(', ')` + 每键 split/trim/filter
+ * 就是那个「打不了逗号和空格」的 bug）。规范化只在 blur 发生，不碰逐键输入。 */
+export default function TagsInput({ label, value, placeholder, disabled, onChange, modified, className = '' }: {
+  label: string
+  value: string[]
+  placeholder?: string
+  disabled: boolean
+  onChange: (v: string[]) => void
+  modified?: boolean
+  className?: string
+}) {
+  const [text, setText] = useState(value.join(', '))
+  // 外部改 value（restore 默认 / 切表单）且与当前文本解析结果不一致 → 重新同步
+  // 文本。自己打字触发的 value 变化进不来（那时 parseTags(text) 恒等 value）。
+  useEffect(() => {
+    if (JSON.stringify(parseTags(text)) !== JSON.stringify(value)) setText(value.join(', '))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
+  return (
+    <label className={'grid grid-cols-[140px_1fr] items-center gap-2 ' + className}>
+      <span className="text-fg-tertiary font-mono text-xs">{label}</span>
+      <input
+        type="text"
+        value={text}
+        placeholder={placeholder}
+        onChange={(e) => { setText(e.target.value); onChange(parseTags(e.target.value)) }}
+        onBlur={() => setText(value.join(', '))}
+        disabled={disabled}
+        className={`input input-mono ${modified ? 'border-warn' : ''}`}
+      />
+    </label>
+  )
+}

--- a/studio/web/src/components/TagsInput.tsx
+++ b/studio/web/src/components/TagsInput.tsx
@@ -45,7 +45,14 @@ export function TagListInput({ value, onChange, placeholder, disabled, className
         value={text}
         placeholder={placeholder}
         onChange={(e) => { setText(e.target.value); onChange(parseTags(e.target.value)) }}
-        onBlur={() => { setText(value.join(', ')); setEditing(false) }}
+        onBlur={() => {
+          // blur 归整：下划线→空格（跟训练 caption 同形，后端匹配也已 _/空格不敏感），
+          // chip 统一展示空格形式
+          const canon = value.map((t) => t.replace(/_/g, ' '))
+          if (JSON.stringify(canon) !== JSON.stringify(value)) onChange(canon)
+          setText(canon.join(', '))
+          setEditing(false)
+        }}
         disabled={disabled}
         className={className}
       />

--- a/studio/web/src/components/TagsInput.tsx
+++ b/studio/web/src/components/TagsInput.tsx
@@ -1,19 +1,19 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 /** 逗号分隔字符串 → 规范化 tag 数组（去首尾空格 / 丢空段）。 */
 export function parseTags(s: string): string[] {
   return s.split(',').map((t) => t.trim()).filter(Boolean)
 }
 
-/** 逗号分隔 tag 列表的裸 <input>（不带 label）。focus 中显示原始文本（逗号 /
- * 空格随便打），onChange 实时解析数组，blur 时归整成 tags.join(', ')。
+/** 逗号分隔 tag 列表输入（不带 label）。两态：
  *
- * 受控的是**文本**而非数组——避免「每次按键把数组 join 回填到 value」把正在
- * 敲的逗号 / 尾随空格当场抹掉（直接绑 `arr.join(', ')` + 每键 split/trim/filter
- * 就是那个「打不了逗号和空格」的 bug）。规范化只在 blur 发生，不碰逐键输入。
+ * - **编辑态（focus）**：纯文本 `<input>`，逗号 / 空格随便打。受控的是文本而非
+ *   数组，避免「每键 join 回填」把正在敲的逗号 / 尾随空格当场抹掉。
+ * - **静止态（blur）**：把 tag 渲染成 chip 一眼可扫；点击 / 聚焦回到编辑态。
  *
- * 给自带外层 label 的场景（如 Settings 的 SettingsField）直接用这个；需要
- * 140px grid label 的用下面的 {@link TagsInput}。 */
+ * blur 时文本归整成 `tags.join(', ')`，再进编辑态看到的是规范形式。
+ * 给自带外层 label 的场景（Settings 的 SettingsField）直接用这个；要 140px
+ * grid label 的用下面的 {@link TagsInput}。 */
 export function TagListInput({ value, onChange, placeholder, disabled, className = '' }: {
   value: string[]
   onChange: (v: string[]) => void
@@ -22,22 +22,56 @@ export function TagListInput({ value, onChange, placeholder, disabled, className
   className?: string
 }) {
   const [text, setText] = useState(value.join(', '))
+  const [editing, setEditing] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
   // 外部改 value（restore 默认 / 切表单）且与当前文本解析结果不一致 → 重新同步
   // 文本。自己打字触发的 value 变化进不来（那时 parseTags(text) 恒等 value）。
   useEffect(() => {
     if (JSON.stringify(parseTags(text)) !== JSON.stringify(value)) setText(value.join(', '))
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value])
+
+  // 进入编辑态 → 把光标放进 input。
+  useEffect(() => {
+    if (editing) inputRef.current?.focus()
+  }, [editing])
+
+  if (editing && !disabled) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={text}
+        placeholder={placeholder}
+        onChange={(e) => { setText(e.target.value); onChange(parseTags(e.target.value)) }}
+        onBlur={() => { setText(value.join(', ')); setEditing(false) }}
+        disabled={disabled}
+        className={className}
+      />
+    )
+  }
+
+  // 静止态：chip 展示，点击 / 聚焦进入编辑。
   return (
-    <input
-      type="text"
-      value={text}
-      placeholder={placeholder}
-      onChange={(e) => { setText(e.target.value); onChange(parseTags(e.target.value)) }}
-      onBlur={() => setText(value.join(', '))}
-      disabled={disabled}
-      className={className}
-    />
+    <div
+      role="button"
+      tabIndex={disabled ? -1 : 0}
+      onClick={() => { if (!disabled) setEditing(true) }}
+      onFocus={() => { if (!disabled) setEditing(true) }}
+      className={`${className} flex flex-wrap items-center gap-1 ${disabled ? '' : 'cursor-text'}`}
+    >
+      {value.length === 0
+        ? <span className="text-fg-tertiary">{placeholder}</span>
+        : value.map((tag, i) => (
+            <span
+              key={`${tag}-${i}`}
+              className="inline-flex items-center px-2 py-0.5 rounded-full bg-overlay border border-subtle text-xs font-mono text-fg-primary"
+            >
+              {tag}
+            </span>
+          ))}
+    </div>
   )
 }
 

--- a/studio/web/src/components/TagsInput.tsx
+++ b/studio/web/src/components/TagsInput.tsx
@@ -62,7 +62,8 @@ export function TagListInput({ value, onChange, placeholder, disabled, className
       className={`${className} flex flex-wrap items-center gap-1 ${disabled ? '' : 'cursor-text'}`}
     >
       {value.length === 0
-        ? <span className="text-fg-tertiary">{placeholder}</span>
+        // nbsp 占位：撑住一行行高，空列表时容器不塌缩成一条线
+        ? <span className="text-fg-tertiary">{placeholder || ' '}</span>
         : value.map((tag, i) => (
             <span
               key={`${tag}-${i}`}

--- a/studio/web/src/components/TagsInput.tsx
+++ b/studio/web/src/components/TagsInput.tsx
@@ -5,19 +5,20 @@ export function parseTags(s: string): string[] {
   return s.split(',').map((t) => t.trim()).filter(Boolean)
 }
 
-/** 逗号分隔 tag 列表输入。focus 中显示原始文本（逗号 / 空格随便打），onChange
- * 实时解析成数组；blur 时把文本收成规范形式 tags.join(', ')。
+/** 逗号分隔 tag 列表的裸 <input>（不带 label）。focus 中显示原始文本（逗号 /
+ * 空格随便打），onChange 实时解析数组，blur 时归整成 tags.join(', ')。
  *
  * 受控的是**文本**而非数组——避免「每次按键把数组 join 回填到 value」把正在
  * 敲的逗号 / 尾随空格当场抹掉（直接绑 `arr.join(', ')` + 每键 split/trim/filter
- * 就是那个「打不了逗号和空格」的 bug）。规范化只在 blur 发生，不碰逐键输入。 */
-export default function TagsInput({ label, value, placeholder, disabled, onChange, modified, className = '' }: {
-  label: string
+ * 就是那个「打不了逗号和空格」的 bug）。规范化只在 blur 发生，不碰逐键输入。
+ *
+ * 给自带外层 label 的场景（如 Settings 的 SettingsField）直接用这个；需要
+ * 140px grid label 的用下面的 {@link TagsInput}。 */
+export function TagListInput({ value, onChange, placeholder, disabled, className = '' }: {
   value: string[]
-  placeholder?: string
-  disabled: boolean
   onChange: (v: string[]) => void
-  modified?: boolean
+  placeholder?: string
+  disabled?: boolean
   className?: string
 }) {
   const [text, setText] = useState(value.join(', '))
@@ -28,14 +29,35 @@ export default function TagsInput({ label, value, placeholder, disabled, onChang
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value])
   return (
+    <input
+      type="text"
+      value={text}
+      placeholder={placeholder}
+      onChange={(e) => { setText(e.target.value); onChange(parseTags(e.target.value)) }}
+      onBlur={() => setText(value.join(', '))}
+      disabled={disabled}
+      className={className}
+    />
+  )
+}
+
+/** 带 140px label 的版本（打标页 grid 布局用）。 */
+export default function TagsInput({ label, value, placeholder, disabled, onChange, modified, className = '' }: {
+  label: string
+  value: string[]
+  placeholder?: string
+  disabled: boolean
+  onChange: (v: string[]) => void
+  modified?: boolean
+  className?: string
+}) {
+  return (
     <label className={'grid grid-cols-[140px_1fr] items-center gap-2 ' + className}>
       <span className="text-fg-tertiary font-mono text-xs">{label}</span>
-      <input
-        type="text"
-        value={text}
+      <TagListInput
+        value={value}
+        onChange={onChange}
         placeholder={placeholder}
-        onChange={(e) => { setText(e.target.value); onChange(parseTags(e.target.value)) }}
-        onBlur={() => setText(value.join(', '))}
         disabled={disabled}
         className={`input input-mono ${modified ? 'border-warn' : ''}`}
       />

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -587,7 +587,7 @@ function RegStatusBar({
             {m.failed_tags.length > 0 && (
               <span
                 className="text-warn"
-                title={t('reg.failedTagsTitle', { tags: m.failed_tags.join(', ') })}
+                title={t('reg.failedTagsTitle', { tags: m.failed_tags.map((x) => x.replace(/_/g, ' ')).join(', ') })}
               >
                 {t('reg.failedTags', { n: m.failed_tags.length })}
               </span>
@@ -1001,7 +1001,7 @@ function ExcludeTagsPicker({
                   }`}
                   title={on ? t('reg.excludeUnclick') : t('reg.excludeClick')}
                 >
-                  {on ? '✕' : '+'} {tagInfo.tag}{' '}
+                  {on ? '✕' : '+'} {tagInfo.tag.replace(/_/g, ' ')}{' '}
                   <span className="opacity-50">×{tagInfo.count}</span>
                 </button>
               )
@@ -1047,7 +1047,7 @@ function ExcludeTagsPicker({
                 className="inline-flex items-center gap-1 px-2 py-0.5 rounded-sm border border-warn bg-warn-soft text-warn text-2xs font-mono"
                 title={t('reg.excludeCustomRemoveTitle')}
               >
-                {tag}
+                {tag.replace(/_/g, ' ')}
                 <button
                   onClick={() => onToggle(tag)}
                   className="text-warn opacity-70 cursor-pointer bg-transparent border-none p-0 text-xs"

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -15,6 +15,7 @@ import {
   type WD14Config,
 } from '../../../api/client'
 import LLMMessagesEditor from '../../../components/LLMMessagesEditor'
+import TagsInput from '../../../components/TagsInput'
 import JobProgress from '../../../components/JobProgress'
 import StepShell from '../../../components/StepShell'
 import { useToast } from '../../../components/Toast'
@@ -529,13 +530,13 @@ function Wd14Panel({
             onChange={(v) => onChange({ ...form, local_dir: v })}
             modified={(form.local_dir || null) !== (defaults.local_dir ?? null)}
           />
-          <LabeledInput
+          <TagsInput
             className="md:col-span-2"
             label={t('tag.blacklistLabel')}
-            value={form.blacklist_tags.join(', ')}
+            value={form.blacklist_tags}
             placeholder={t('tag.blacklistPlaceholder1')}
             disabled={disabled}
-            onChange={(v) => onChange({ ...form, blacklist_tags: v.split(',').map((s) => s.trim()).filter(Boolean) })}
+            onChange={(tags) => onChange({ ...form, blacklist_tags: tags })}
             modified={JSON.stringify(form.blacklist_tags) !== JSON.stringify(defaults.blacklist_tags)}
           />
         </div>
@@ -627,13 +628,13 @@ function CLTaggerPanel({
           <LabeledInput label="local_dir" value={form.local_dir} placeholder={t('tag.blankDir')} disabled={disabled} onChange={(v) => onChange({ ...form, local_dir: v })} modified={(form.local_dir || null) !== (defaults.local_dir ?? null)} />
           <LabeledInput label="model_path" value={form.model_path} disabled={disabled} onChange={(v) => onChange({ ...form, model_path: v })} modified={form.model_path !== defaults.model_path} />
           <LabeledInput label="tag_mapping_path" value={form.tag_mapping_path} disabled={disabled} onChange={(v) => onChange({ ...form, tag_mapping_path: v })} modified={form.tag_mapping_path !== defaults.tag_mapping_path} />
-          <LabeledInput
+          <TagsInput
             className="md:col-span-2"
             label={t('tag.blacklistLabel')}
-            value={form.blacklist_tags.join(', ')}
+            value={form.blacklist_tags}
             placeholder={t('tag.blacklistPlaceholder2')}
             disabled={disabled}
-            onChange={(v) => onChange({ ...form, blacklist_tags: v.split(',').map((s) => s.trim()).filter(Boolean) })}
+            onChange={(tags) => onChange({ ...form, blacklist_tags: tags })}
             modified={JSON.stringify(form.blacklist_tags) !== JSON.stringify(defaults.blacklist_tags)}
           />
         </div>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -28,6 +28,7 @@ import {
 import { useDialog } from '../../components/Dialog'
 import { InfoButton } from '../../components/InfoButton'
 import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
+import { TagListInput } from '../../components/TagsInput'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
 import { useSettingsData } from '../../lib/SettingsData'
@@ -757,11 +758,11 @@ export default function SettingsPage() {
           </SettingsField>
         </div>
         <SettingsField label="blacklist_tags" desc={t('settings.commaSeparated')}>
-          <input
-            type="text"
-            value={draft.wd14.blacklist_tags.join(', ')}
-            onChange={(e) => update('wd14', 'blacklist_tags', e.target.value.split(',').map((t) => t.trim()).filter(Boolean))}
-            className={textInputClass}                                  />
+          <TagListInput
+            value={draft.wd14.blacklist_tags}
+            onChange={(tags) => update('wd14', 'blacklist_tags', tags)}
+            className={textInputClass}
+          />
         </SettingsField>
         <SettingsField label="batch_size" desc={t('settings.batchSizeHint')}>
           <input
@@ -819,11 +820,11 @@ export default function SettingsPage() {
           </SettingsField>
         </div>
         <SettingsField label="blacklist_tags" desc={t('settings.commaSeparated')}>
-          <input
-            type="text"
-            value={draft.cltagger.blacklist_tags.join(', ')}
-            onChange={(e) => update('cltagger', 'blacklist_tags', e.target.value.split(',').map((t) => t.trim()).filter(Boolean))}
-            className={textInputClass}                                  />
+          <TagListInput
+            value={draft.cltagger.blacklist_tags}
+            onChange={(tags) => update('cltagger', 'blacklist_tags', tags)}
+            className={textInputClass}
+          />
         </SettingsField>
         <SettingsField label="batch_size" desc={t('settings.batchSizeHint')}>
           <input

--- a/tests/test_cltagger_tagger.py
+++ b/tests/test_cltagger_tagger.py
@@ -95,6 +95,26 @@ def test_postprocess_uses_character_threshold_and_optional_categories(
     assert tags[:2] == ["explicit", "model tag"]
 
 
+def test_postprocess_blacklist_underscore_and_case_insensitive(isolated_secrets: Path) -> None:
+    """cltagger 的 tag 是下划线形式；blacklist 填空格 'cat girl' / 大写
+    'BLUE_EYES' 也能屏蔽（_/空格、大小写不敏感，与 wd14 一致）。"""
+    secrets.update({
+        "cltagger": {
+            "threshold_general": 0.1, "threshold_character": 0.1,
+            "add_rating_tag": False, "add_model_tag": False,
+            "blacklist_tags": ["cat girl", "BLUE_EYES"],
+        }
+    })
+    t = cltagger_tagger.CLTagger()
+    t._labels = cltagger_tagger._LabelData(
+        names=["cat_girl", "blue_eyes", "1girl"],
+        categories=["General", "General", "General"],
+    )
+    logits = np.array([4.0, 4.0, 4.0], dtype=np.float32)  # sigmoid≈0.98 > 0.1
+    tags, _ = t._postprocess_one(logits)
+    assert tags == ["1girl"]
+
+
 def test_tag_iterator_runs_onnx_batch(isolated_secrets: Path, tmp_path: Path) -> None:
     secrets.update({"cltagger": {"threshold_general": 0.1, "batch_size": 2}})
     t = cltagger_tagger.CLTagger()

--- a/tests/test_reg_builder.py
+++ b/tests/test_reg_builder.py
@@ -285,6 +285,24 @@ def test_build_writes_meta_and_images(tmp_path: Path, fake_booru) -> None:
     assert any(p.suffix == ".png" for p in out.rglob("*.png") if p.parent == out / "5_concept")
 
 
+def test_build_save_tags_caption_is_space_form(tmp_path: Path, fake_booru) -> None:
+    """save_tags 路径写 reg caption 时把 booru 原生下划线 tag 转成空格 —— caption
+    一律空格形式（tag-form 约定：用户可见 / caption = 空格，下划线只在 booru 边界）。"""
+    train = _make_train(tmp_path / "train", {
+        "5_concept": [("100", ["1girl", "blue_hair"]), ("101", ["1girl", "blue_hair"])],
+    })
+    out = tmp_path / "reg"
+    fake_booru._search_results = [[_post(2002, "1girl long_hair blue_hair")]]
+    opts = _opts(train, out, target_count=1, batch_size=1, save_tags=True)
+    reg_builder.build(opts, on_progress=lambda _: None)
+
+    txts = list(out.rglob("*.txt"))
+    assert txts, "save_tags 应当写出 reg caption .txt"
+    content = "\n".join(p.read_text(encoding="utf-8") for p in txts)
+    assert "_" not in content, f"reg caption 不应残留下划线，实际：{content!r}"
+    assert "long hair" in content or "blue hair" in content  # 下划线已转空格
+
+
 def test_build_mirrors_train_subfolder_repeat_prefix(
     tmp_path: Path, fake_booru
 ) -> None:

--- a/tests/test_resume_path.py
+++ b/tests/test_resume_path.py
@@ -83,6 +83,46 @@ def test_cmd_builder_resume_after_monitor_state_file(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# _resolve_monitor_state_path —— per-task 隔离（同 version 多 task 串台修复）
+# ---------------------------------------------------------------------------
+
+
+def test_monitor_state_path_isolated_per_task_same_version(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """同一 version 下两个 task 的 monitor_state_path 必须互不相同、各含自己的
+    task id。回归：旧实现按 version 落 monitor_state.json，第二个 task 跑起来
+    盖掉第一个的曲线 / 采样图 → 监控页查 task1 显示的是 task2。"""
+    from studio.services.projects import projects, versions
+    from studio.supervisor.cmd_builder import _resolve_monitor_state_path
+
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    with db.connection_for(dbfile) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label="baseline")
+
+    base = {"version_id": v["id"], "project_id": p["id"]}
+    p1 = _resolve_monitor_state_path({**base, "id": 1})
+    p2 = _resolve_monitor_state_path({**base, "id": 2})
+
+    assert p1 != p2
+    assert "task_1" in p1.parts and "task_2" in p2.parts
+    assert "baseline" in p1.parts        # 仍挂在 version 目录下（删 version 一并清）
+    assert p1.name == "state.json"
+
+
+def test_monitor_state_path_old_task_without_version_fallback() -> None:
+    """PP1 之前的老任务（无 version_id）兜底到 monitors/task_{id}/state.json。"""
+    from studio.supervisor.cmd_builder import _resolve_monitor_state_path
+
+    pth = _resolve_monitor_state_path({"id": 7})
+    assert pth.parts[-3:] == ("monitors", "task_7", "state.json")
+
+
+# ---------------------------------------------------------------------------
 # bootstrap_phase: _maybe_apply_pause_snapshot
 # ---------------------------------------------------------------------------
 

--- a/tests/test_wd14_tagger.py
+++ b/tests/test_wd14_tagger.py
@@ -67,6 +67,23 @@ def test_postprocess_filters_by_threshold(isolated_secrets: Path) -> None:
     assert raw == {"1girl": pytest.approx(0.9)}
 
 
+def test_postprocess_blacklist_underscore_and_case_insensitive(isolated_secrets: Path) -> None:
+    """blacklist 比对 _/空格、大小写都不敏感：填 cat_girl / Blue Eyes 也能屏蔽
+    空格小写形式的 'cat girl' / 'blue eyes'。"""
+    secrets.update({
+        "wd14": {
+            "threshold_general": 0.1, "threshold_character": 0.1,
+            "blacklist_tags": ["cat_girl", "Blue Eyes"],
+        }
+    })
+    t = wd14_tagger.WD14Tagger()
+    t._tags = ["cat girl", "blue eyes", "1girl"]   # wd14 词表已是空格小写形式
+    t._tag_categories = [0, 0, 0]
+    scores = np.array([0.9, 0.9, 0.9])
+    tags, _ = t._postprocess_one(scores)
+    assert tags == ["1girl"]
+
+
 def test_postprocess_sorts_by_score_desc(isolated_secrets: Path) -> None:
     secrets.update({"wd14": {"threshold_general": 0.1, "threshold_character": 0.1}})
     t = wd14_tagger.WD14Tagger()


### PR DESCRIPTION
一批监控页 / 配置页 / 打标页小修，合并时 squash。各 commit 互相独立、可单独 review。

## 1. 监控页采样图点击放大（feat）

监控页 `MonitorDashboard` 采样大图原来点击无反应。复用下载页的 `ImagePreviewModal`：大图加 `cursor-zoom-in` + 点击全屏预览，`←`/`→`（及弹层箭头）在采样序列前后切，缩略图选中态同步。无新依赖。

- `studio/web/src/components/MonitorDashboard.tsx`

## 2. 保存间隔字段顺序一致（fix）

配置页四个保存字段顺序不一致：`save_every_*` 是 epoch 在前，`save_state_every_*` 反过来 step 在前。配置页按 schema 声明序渲染，调换 `save_state_every_epochs`/`save_state_every_steps` 声明即对齐（两对都 epoch 在前 step 在后）。纯声明顺序调整。

- `studio/domain/training.py`

## 3. monitor / 采样图按 task 隔离，不再按 version 串台（fix）

**Bug**：同 version 下两个 task，点 task1 的查看，监控页显示的是 task2。

**根因**：`_resolve_monitor_state_path` 有 version_id 时按 **version** 落 `versions/{label}/monitor_state.json`，采样图也写到该 version 的 `output/samples/`。同 version 第二个 task 跑起来盖掉第一个；两 task 的 `monitor_state_path` 在 DB 指向同一文件，`/api/state?task_id=` 查谁都返回最后写入者。

**改动**（两处协同）：
- `_resolve_monitor_state_path` → `versions/{label}/monitor/task_{id}/state.json`（按 task 分目录，仍挂 version 下，删 version 一并清）。
- `bootstrap.py` 从 `--monitor-state-file` 推导 `sample_dir = <state 同级>/samples/`（没传则退回 `output_dir/samples`，纯 CLI 不变）。`samples.py` 本就优先解析 `monitor_dir/samples`。
- version 最终 LoRA 产物仍在 version 级 `output/`，不动。

**兼容老版本**：老任务 `monitor_state_path` 存量值不动 + `samples.py` 保留 `monitor_dir/output/samples` 候选 → 旧采样照常可见；只影响此后新启动的 task。前端无需改——任务列表本就按 `task.id` 跳转。

- `studio/supervisor/cmd_builder.py` · `runtime/training/phases/bootstrap.py` · 回归测试 `tests/test_resume_path.py`

## 4. 打标 blacklist 输入可正常打逗号和空格（fix）

**Bug**：打标的 blacklist 输入打不进逗号和空格。

**根因**：不是字段校验，是受控输入「每次按键都规范化」——`value` 直接绑 `blacklist_tags.join(', ')`，`onChange` 每键 `split/trim/filter` 回数组：逗号产生的空段被 filter 掉（凑不出分隔符），尾随空格被 trim 掉（连 `blue eyes` 都打不出）。

**两个 surface 都有**：项目打标页（`Tagging.tsx`）+ 全局设置（`Settings.tsx` 的 wd14 / cltagger 默认值），两处都修。

**改动**：抽 `components/TagsInput.tsx`，受控的是文本 buffer 而非数组。两态：
- **编辑态（focus）**：纯文本，逗号 / 空格随便打；
- **静止态（blur）**：tag 渲染成 chip 一眼可扫，点击 / 聚焦回到编辑；blur 时文本归整成 `tags.join(', ')`。

导出带 label 的 `TagsInput`（打标页 grid）+ 无 label 的 `TagListInput`（Settings 的 SettingsField），两处共用。

- `studio/web/src/components/TagsInput.tsx`（新）· `Tagging.tsx` · `Settings.tsx`
- `studio/web/src/components/TagsInput.test.tsx`（新）：编辑态打逗号 / 多词 tag、blur 转 chip、静止态 chip 展示、restore 同步、parseTags

## 测试

- 后端 `pytest`（resume_path / train_monitor / supervisor*）→ 77 passed（含 2 条新回归）
- 前端 `npm run build`（eslint+tsc+vite，仅 1 条与本 PR 无关的既有 warning）+ `vitest run` → 295 passed（含 6 条 TagsInput）
- #1 采样放大 / #3 串台修复建议本地真跑一次训练手测端到端

🤖 Generated with [Claude Code](https://claude.com/claude-code)