### PR TITLE
fix(web): XY 提交只发被轴引用的 LoRA anchor，丢弃 picker 沉积的孤儿

### DIFF
--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -271,7 +271,13 @@ describe('GeneratePage 端到端 smoke', () => {
     expect(lastEnqueueBody!.xy_matrix).toBeNull()
   })
 
-  it('xy 提交只用 xyLoras（不带 singleLoras）', async () => {
+  it('xy 提交不带 singleLoras，也不带未被轴引用的 xyLoras 孤儿', async () => {
+    // 默认 X 轴是 steps（不引用任何 LoRA）。singleLoras=[A] 不该泄漏到 xy；
+    // xyLoras=[B] 是没被轴引用的孤儿（picker 切项目残留），也不该当 base 发。
+    // 修前：xy 整桶发 xyLoras → lora_configs=[B]（B 叠到每个 cell）。
+    // 修后：steps 轴不引用 anchor → lora_configs=[]。
+    // （lora_ckpt 轴的引用/重映射逻辑由 xy.test.ts buildXYMatrix 单测覆盖，
+    //  这里不 seed lora_ckpt 轴 —— picker 在无 projects 的 mock 下 mount 即清空它。）
     seedPrefs({ mode: 'xy', singleLoras: [A], xyLoras: [B] })
     const user = userEvent.setup()
     setup()
@@ -279,7 +285,7 @@ describe('GeneratePage 端到端 smoke', () => {
 
     await user.click(await screen.findByRole('button', { name: /开始生成/ }))
     await waitFor(() => expect(lastEnqueueBody).not.toBeNull())
-    expect(lastEnqueueBody!.lora_configs).toEqual([B])
+    expect(lastEnqueueBody!.lora_configs).toEqual([])
     expect(lastEnqueueBody!.xy_matrix).not.toBeNull()
   })
 

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -30,7 +30,7 @@ import StatusBadge from './generate/StatusBadge'
 import ViewModeTabs, { type ViewMode } from './generate/ViewModeTabs'
 import { DEFAULT_NEG } from './generate/types'
 import { useProjectLoras } from './generate/useProjectLoras'
-import { cellCount, draftToSpec, parseAxisValues, type XYAxisDraft } from './generate/xy'
+import { buildXYMatrix, cellCount, parseAxisValues, type XYAxisDraft } from './generate/xy'
 
 const GENERATE_PREFS_KEY = 'studio:generate:params:v1'
 
@@ -380,18 +380,20 @@ export default function GeneratePage() {
     }
 
     let xy_matrix: XYMatrixSpec | null = null
+    // single：base LoRA = singleLoras 全发。xy：只发被轴引用的 anchor（见
+    // buildXYMatrix —— xyLoras 会沉积 picker 切项目/版本/删轴遗留的孤儿 anchor，
+    // 整桶发出去会让孤儿叠到每个 cell，正是反复出现的「混进没选过的 LoRA」根因）。
+    let loraConfigs: LoraEntry[] = loras.filter((l) => l.path.trim())
     if (mode === 'xy') {
       // schema 强制 prompts 单条 + count=1
       if (prompts.filter((p) => p.trim()).length > 1) {
         toast(t('generate.xySinglePromptOnly'), 'error')
         return
       }
-      const filteredLoras = loras.filter((l) => l.path.trim())
       try {
-        xy_matrix = {
-          x: draftToSpec(xDraft, filteredLoras),
-          y: yDraft ? draftToSpec(yDraft, filteredLoras) : null,
-        }
+        const built = buildXYMatrix(xDraft, yDraft, loras)
+        xy_matrix = built.xy_matrix
+        loraConfigs = built.loraConfigs
       } catch (e) {
         toast(typeof e === 'string' ? e : String(e), 'error')
         return
@@ -418,7 +420,7 @@ export default function GeneratePage() {
         count: mode === 'xy' ? 1 : count,
         seed,
         cfg_scale: cfgScale,
-        lora_configs: loras.filter((l) => l.path.trim()),
+        lora_configs: loraConfigs,
         // attention_backend 不带：server 自动从 secrets.generate.attention_backend 读
         xy_matrix,
       }

--- a/studio/web/src/pages/tools/generate/xy.test.ts
+++ b/studio/web/src/pages/tools/generate/xy.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import type { LoraEntry } from '../../../api/client'
-import { cellCount, draftToSpec, parseAxisValues, type XYAxisDraft } from './xy'
+import { buildXYMatrix, cellCount, draftToSpec, parseAxisValues, type XYAxisDraft } from './xy'
 
 describe('parseAxisValues', () => {
   it('parses int axis (steps) splits by comma', () => {
@@ -72,6 +72,55 @@ describe('draftToSpec', () => {
     expect(s.axis).toBe('lora_ckpt')
     expect(s.lora_index).toBe(1)
     expect(s.values).toEqual(['/x/step.safetensors'])
+  })
+})
+
+describe('buildXYMatrix（只发被轴引用的 anchor，丢弃 picker 沉积的孤儿）', () => {
+  const CHEN = { path: 'G:/chen-bin_v3.4.safetensors', scale: 1, project_id: 2, version_id: 4 }
+  const ORPHAN = { path: 'G:/chen-bin_v3.2.safetensors', scale: 1, project_id: 1, version_id: 1 }
+  const HOSHI = { path: 'G:/hoshi.safetensors', scale: 1, project_id: 3, version_id: 9 }
+
+  it('非 lora_ckpt 轴（steps）→ lora_configs 为空（孤儿不当 base LoRA 发）', () => {
+    // 复现根因：xyLoras 里有 ORPHAN（picker 残留），但当前 X 轴是 steps，没引用它。
+    const x: XYAxisDraft = { axis: 'steps', raw: '20, 25, 30', loraIndex: null }
+    const { xy_matrix, loraConfigs } = buildXYMatrix(x, null, [ORPHAN, HOSHI])
+    expect(loraConfigs).toEqual([]) // ← 修前会把 [ORPHAN, HOSHI] 整桶发出去
+    expect(xy_matrix.x.values).toEqual([20, 25, 30])
+    expect(xy_matrix.y).toBeNull()
+  })
+
+  it('lora_ckpt 轴只发被引用的那条 anchor，loraIndex 重映射到 0', () => {
+    // xyLoras=[ORPHAN, CHEN]，X 轴 loraIndex=1 指向 CHEN；ORPHAN 没被引用 → 丢弃。
+    const x: XYAxisDraft = { axis: 'lora_ckpt', raw: CHEN.path, loraIndex: 1 }
+    const { xy_matrix, loraConfigs } = buildXYMatrix(x, null, [ORPHAN, CHEN])
+    expect(loraConfigs).toEqual([CHEN]) // ← 没选过的 ORPHAN(v3.2) 不混进来
+    expect(xy_matrix.x.lora_index).toBe(0) // 1 → 0 重映射
+    expect(xy_matrix.x.values).toEqual([CHEN.path])
+  })
+
+  it('X/Y 都是 lora_ckpt 引用不同 anchor → 两条都保留，各自重映射', () => {
+    const x: XYAxisDraft = { axis: 'lora_ckpt', raw: CHEN.path, loraIndex: 2 }
+    const y: XYAxisDraft = { axis: 'lora_ckpt', raw: HOSHI.path, loraIndex: 0 }
+    // loras=[HOSHI, ORPHAN, CHEN]：X→idx2(CHEN)，Y→idx0(HOSHI)，ORPHAN(idx1) 丢弃
+    const { xy_matrix, loraConfigs } = buildXYMatrix(x, y, [HOSHI, ORPHAN, CHEN])
+    expect(loraConfigs).toEqual([CHEN, HOSHI]) // 按出现顺序：X 先 → CHEN=0, Y → HOSHI=1
+    expect(xy_matrix.x.lora_index).toBe(0)
+    expect(xy_matrix.y?.lora_index).toBe(1)
+  })
+
+  it('X/Y 引用同一 anchor → 去重成一条，两轴指同一索引', () => {
+    const x: XYAxisDraft = { axis: 'lora_ckpt', raw: CHEN.path, loraIndex: 0 }
+    const y: XYAxisDraft = { axis: 'lora_scale', raw: '0.6, 0.8', loraIndex: 0 }
+    const { loraConfigs, xy_matrix } = buildXYMatrix(x, y, [CHEN])
+    expect(loraConfigs).toEqual([CHEN])
+    expect(xy_matrix.x.lora_index).toBe(0)
+    // lora_scale 不要求 lora_index，透传 undefined
+    expect(xy_matrix.y?.lora_index).toBeUndefined()
+  })
+
+  it('lora_ckpt 轴 loraIndex 越界 → 抛错（不静默吞掉）', () => {
+    const x: XYAxisDraft = { axis: 'lora_ckpt', raw: CHEN.path, loraIndex: 5 }
+    expect(() => buildXYMatrix(x, null, [CHEN])).toThrow(/不存在/)
   })
 })
 

--- a/studio/web/src/pages/tools/generate/xy.ts
+++ b/studio/web/src/pages/tools/generate/xy.ts
@@ -3,7 +3,7 @@
  * 后端 schema 要求 values 类型按 axis 派生（int / float / string）；前端
  * 把用户输入的逗号字符串解析成正确类型，并在解析失败时给出错误信息。 */
 
-import type { LoraEntry, XYAxisSpec, XYAxisType } from '../../../api/client'
+import type { LoraEntry, XYAxisSpec, XYAxisType, XYMatrixSpec } from '../../../api/client'
 import i18n from '../../../i18n'
 
 /** UI 侧 axis 状态：raw 是用户输入的逗号字符串（不实时解析便于编辑）。 */
@@ -77,6 +77,39 @@ export function draftToSpec(
     spec.lora_index = draft.loraIndex
   }
   return spec
+}
+
+/** XY 提交时构建 xy_matrix + 实际要发的 lora_configs。
+ *
+ * **为什么不能直接整桶发 loras**：XY 模式下唯一能往 loras（xyLoras）加 anchor
+ * 的入口是 lora_ckpt 轴 picker，且它只 push 不 prune（SidebarXYAxes.commitPicks）
+ * —— 切项目/版本、切轴类型、删 Y 轴都会把旧 anchor 留下成「孤儿」。后端把
+ * lora_configs 全部当 base LoRA 叠到每个 cell（anima_daemon._run_xy），孤儿就会
+ * 混进每张图（「选 chenbin V3.4 却带上没选过的 v3.2 / 跨 mode 的 hoshi」的根因）。
+ *
+ * 这里只保留被当前 X/Y 轴 loraIndex 引用的 anchor，按出现顺序重映射索引，孤儿
+ * 一律丢弃。非 lora_ckpt 轴不贡献任何 anchor → lora_configs 为空。
+ * 校验失败（轴值缺失 / loraIndex 越界）沿用 draftToSpec 抛 string error。 */
+export function buildXYMatrix(
+  xDraft: XYAxisDraft,
+  yDraft: XYAxisDraft | null,
+  loras: LoraEntry[],
+): { xy_matrix: XYMatrixSpec; loraConfigs: LoraEntry[] } {
+  const remap = new Map<number, number>()
+  const loraConfigs: LoraEntry[] = []
+  const remapDraft = (d: XYAxisDraft): XYAxisDraft => {
+    if (d.axis !== 'lora_ckpt' || d.loraIndex == null) return d
+    const entry = loras[d.loraIndex]
+    if (!entry || !entry.path.trim()) return d // draftToSpec 会抛 axisLoraMissing
+    if (!remap.has(d.loraIndex)) {
+      remap.set(d.loraIndex, loraConfigs.length)
+      loraConfigs.push(entry)
+    }
+    return { ...d, loraIndex: remap.get(d.loraIndex) ?? null }
+  }
+  const x = draftToSpec(remapDraft(xDraft), loraConfigs)
+  const y = yDraft ? draftToSpec(remapDraft(yDraft), loraConfigs) : null
+  return { xy_matrix: { x, y }, loraConfigs }
 }
 
 /** 计算 cell 总数（y=null 时退化成 1×N）。 */


### PR DESCRIPTION
## 现象
测试页 XY 图反复出现「混进没选过的 LoRA」：XY 轴选了 chenbin V3.4，结果每个 cell 都被钉上没选过的 chen-bin v3.2（或跨 mode 的 hoshi）。清 localStorage / 换匿名浏览器都复现 —— 说明跟前端缓存老数据无关。

## 根因（自 v0.8.0 XY 功能起就在）
XY 模式下往 `loras`（dev 上是 `xyLoras` 桶）加 anchor 的**唯一入口是 lora_ckpt 轴 picker**，而它**只 push 不 prune**（`SidebarXYAxes.commitPicks`）：

- 切项目/版本时 `InlineLoraPicker` 的 live-clear effect 发 `onPick([])`，只清**轴绑定**（注释明写「loras[] 里之前那条 entry 不动」）；
- 切轴类型、删 Y 轴同理。

旧 anchor 全留在桶里成**孤儿**，且 XY 侧栏没有 base-LoRA 列表 UI，用户**看不到也删不掉**。`handleGenerate` 旧逻辑 `lora_configs: loras.filter(...)` 把**整桶当 base LoRA 发**，后端 `anima_daemon._run_xy` 把 `lora_configs` 全部叠到**每个 cell**，只 mutate 轴引用的那条 path → 孤儿恒定叠加到所有图。

日志铁证：两条不同 topology 的 LoRA 在 `"XY 共享种子"`（XY 循环开始）**之前**就都 `已加载 LoRA`，即基础 apply 阶段就注入了两条，不是逐格替换。

> 历次「修复」（#159 双桶 split 等）只解了**跨 mode 串味**，从没碰**桶内孤儿沉积 + 整桶当 base 发**这一层 —— 这就是为什么修了几次仍复现。

## 改动
- `generate/xy.ts`：抽纯函数 `buildXYMatrix(xDraft, yDraft, loras)` —— 只保留被 X/Y 轴 `loraIndex` 引用的 anchor，按出现序重映射索引，孤儿丢弃；非 lora_ckpt 轴 → `lora_configs` 为空。
- `Generate.tsx`：XY 分支改调 `buildXYMatrix`，不再整桶发。后端无需改（前端不发孤儿即干净）。
- `xy.test.ts`：+5 纯单测（孤儿丢弃 / 索引重映射 / X·Y 引用不同 anchor / X·Y 去重 / 越界抛错）。
- `Generate.test.tsx`：修正一个把 bug 行为固化成预期的用例（steps 轴 + `xyLoras=[B]` 却断言发 `[B]`）；DOM 测试不再 seed lora_ckpt 轴（无 projects 的 mock 下 picker mount 即清空它）。

## 验证
- `tsc --noEmit` 干净；
- 全套 web vitest 301 passed（含本次 30）。

## 备注
- 残留（对生成已无害，未在本 PR 处理）：`xyLoras` 持久层仍会沉积孤儿；persisted lora_ckpt 轴 reload 被 picker mount-clear 抹掉是另一独立 quirk。可后续单开「切轴/删轴时 prune 孤儿 + 侧栏显示桶内全部 anchor」清理。
- master（v0.10.3）尚无 #159 也无本修复，缺陷更重（叠加 + 跨 mode 串味皆在）。按讨论结论：随下次 dev→master 发版带完整修复，不单开 master hotfix。