### PR TITLE
fix(inference): 对齐 ComfyUI 出图 + 修 LoRA DoRA/rs_lora 静默失效

### DIFF
--- a/models/anima_modeling.py
+++ b/models/anima_modeling.py
@@ -229,18 +229,27 @@ class Anima(MiniTrainDIT):
             layer_norm=False,
         )
 
-    def preprocess_text_embeds(self, text_embeds, text_ids):
+    def preprocess_text_embeds(self, text_embeds, text_ids, t5xxl_weights=None):
         """
         Process text embeddings through the LLM adapter.
 
         Args:
             text_embeds: Qwen3 embeddings (B, seq_len, 1024)
             text_ids: T5 token IDs (B, seq_len)
+            t5xxl_weights: 每 token 权重 (B, seq_len) 或 (B, seq_len, 1)；
+                对应 `(tag:1.3)` 类语法。漏传 → 权重失效（与 ComfyUI 原生
+                `comfy/ldm/anima/model.py:198-206` 对齐）。
 
         Returns:
             Processed embeddings for cross-attention
         """
         if text_ids is not None:
-            return self.llm_adapter(text_embeds, text_ids)
+            out = self.llm_adapter(text_embeds, text_ids)
+            if t5xxl_weights is not None:
+                w = t5xxl_weights
+                if w.dim() == out.dim() - 1:
+                    w = w.unsqueeze(-1)
+                out = out * w.to(dtype=out.dtype)
+            return out
         else:
             return text_embeds

--- a/models/anima_modeling_core.py
+++ b/models/anima_modeling_core.py
@@ -1363,18 +1363,27 @@ class Anima(MiniTrainDIT):
             layer_norm=False,
         )
 
-    def preprocess_text_embeds(self, text_embeds, text_ids):
+    def preprocess_text_embeds(self, text_embeds, text_ids, t5xxl_weights=None):
         """
         Process text embeddings through the LLM adapter.
 
         Args:
             text_embeds: Qwen3 embeddings (B, seq_len, 1024)
             text_ids: T5 token IDs (B, seq_len)
+            t5xxl_weights: 每 token 权重 (B, seq_len) 或 (B, seq_len, 1)；
+                对应 `(tag:1.3)` 类语法。漏传 → 权重失效（与 ComfyUI 原生
+                `comfy/ldm/anima/model.py:198-206` 对齐）。
 
         Returns:
             Processed embeddings for cross-attention
         """
         if text_ids is not None:
-            return self.llm_adapter(text_embeds, text_ids)
+            out = self.llm_adapter(text_embeds, text_ids)
+            if t5xxl_weights is not None:
+                w = t5xxl_weights
+                if w.dim() == out.dim() - 1:
+                    w = w.unsqueeze(-1)
+                out = out * w.to(dtype=out.dtype)
+            return out
         else:
             return text_embeds

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -91,8 +91,10 @@ def _emit_for(req_id: str, kind: str, **extra: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _lora_topology(meta: LoRAMeta) -> tuple[int, float, str, int]:
-    return (meta.rank, meta.alpha, meta.algo, meta.factor)
+def _lora_topology(meta: LoRAMeta) -> tuple[int, float, str, int, bool, bool]:
+    # weight_decompose / rs_lora 改了网络结构（前者加 dora_scale 张量、后者改
+    # effective alpha 公式），不同设置不能走热换权重路径，必须重新 inject。
+    return (meta.rank, meta.alpha, meta.algo, meta.factor, meta.weight_decompose, meta.rs_lora)
 
 
 def _load_lora_state_dict(path: str, device: str, dtype: Any) -> dict[str, Any]:

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -661,6 +661,7 @@ def _run_generate(
                     device=CACHE.device,
                     dtype=CACHE.dtype,
                     step_callback=preview_callback,
+                    seed=seed,
                 )
                 fname = f"gen_{img_idx:04d}_p{pi}_c{ci}_s{seed}.png"
                 vpath = _virtual_path(task_id, fname)
@@ -785,6 +786,7 @@ def _run_xy(
                     scheduler=scheduler,
                     device=CACHE.device,
                     dtype=CACHE.dtype,
+                    seed=cur_seed,
                 )
                 fname = f"xy_x{xi:02d}_y{yi:02d}_s{cur_seed}.png"
                 vpath = _virtual_path(task_id, fname)

--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -200,6 +200,7 @@ def main() -> None:
                     scheduler=scheduler,
                     device=device,
                     dtype=dtype,
+                    seed=seed,
                 )
                 fname = f"gen_{img_idx:04d}_p{pi}_c{ci}_s{seed}.png"
                 out_path = output_dir / fname
@@ -365,6 +366,7 @@ def _run_xy_matrix(
                     scheduler=scheduler,
                     device=device,
                     dtype=dtype,
+                    seed=cur_seed,
                 )
                 fname = f"xy_x{xi:02d}_y{yi:02d}_s{cur_seed}.png"
                 out_path = output_dir / fname

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -78,7 +78,9 @@ def run(ctx: TrainingContext) -> None:
                 t5_ids = t5_ids.to(ctx.device)
                 t5_attn = t5_attn.to(ctx.device)
                 t5_w = t5_w.to(ctx.device, dtype=torch.float32)
-                cross = ctx.model.preprocess_text_embeds(qwen_emb, t5_ids)
+                # t5_w 透传到 preprocess_text_embeds 内乘到 LLMAdapter 输出上（与
+                # ComfyUI 原生 `comfy/ldm/anima/model.py:198-206` 对齐）。
+                cross = ctx.model.preprocess_text_embeds(qwen_emb, t5_ids, t5xxl_weights=t5_w)
                 if cross.shape[1] < 512:
                     cross = F.pad(cross, (0, 0, 0, 512 - cross.shape[1]))
                 # KV trim：把 padding 截到最近有效 token bucket（64/128/256/512）

--- a/runtime/training/sampling.py
+++ b/runtime/training/sampling.py
@@ -72,6 +72,7 @@ def sample_image(
     device="cuda",
     dtype=torch.bfloat16,
     step_callback=None,
+    seed: int | None = None,
 ):
     """训练时采样预览（尽量对齐 ComfyUI KSampler）
 
@@ -92,9 +93,10 @@ def sample_image(
         logger.info(f"[Debug] VAE scale: mean_shape={m.shape}, std_inv_shape={s.shape}")
         logger.info(f"[Debug] VAE scale values: mean={m.mean().item():.4f}, std_inv={s.mean().item():.4f}")
 
-    # 默认负面提示词 (参考 Anima Prompt Guide)
+    # negative_prompt=None 时用空字符串（与 ComfyUI 一致：用户没填就是空）。
+    # 之前硬编码一长串默认负面会和 ComfyUI 出图对不上（CFG 锚点不同）。
     if negative_prompt is None:
-        negative_prompt = "worst quality, low quality, score_1, score_2, score_3, blurry, jpeg artifacts, bad anatomy, bad hands, bad feet, missing fingers, extra fingers, text, watermark, logo, signature, username, artist name, copyright name"
+        negative_prompt = ""
 
     # 文本编码
     try:
@@ -107,7 +109,9 @@ def sample_image(
         t5_ids = t5_ids.to(device)
         t5_attn = t5_attn.to(device)
         t5_w = t5_w.to(device, dtype=torch.float32)
-        cross_cond = model.preprocess_text_embeds(qwen_embeds, t5_ids)
+        # t5_w 透传到 preprocess_text_embeds 内乘到 LLMAdapter 输出上（与 ComfyUI 原生
+        # `comfy/ldm/anima/model.py:198-206` 对齐）。漏传 → `(tag:w)` 语法静默失效。
+        cross_cond = model.preprocess_text_embeds(qwen_embeds, t5_ids, t5xxl_weights=t5_w)
         if cross_cond.shape[1] < 512:
             cross_cond = F.pad(cross_cond, (0, 0, 0, 512 - cross_cond.shape[1]))
 
@@ -118,7 +122,7 @@ def sample_image(
         t5_ids_uncond = t5_ids_uncond.to(device)
         t5_attn_uncond = t5_attn_uncond.to(device)
         t5_w_uncond = t5_w_uncond.to(device, dtype=torch.float32)
-        cross_uncond = model.preprocess_text_embeds(qwen_embeds_uncond, t5_ids_uncond)
+        cross_uncond = model.preprocess_text_embeds(qwen_embeds_uncond, t5_ids_uncond, t5xxl_weights=t5_w_uncond)
         if cross_uncond.shape[1] < 512:
             cross_uncond = F.pad(cross_uncond, (0, 0, 0, 512 - cross_uncond.shape[1]))
 
@@ -133,7 +137,15 @@ def sample_image(
     sigmas = _flow_sigmas_simple(steps, shift=3.0, device=device)
 
     # 初始化噪声（ComfyUI CONST.noise_scaling: x = sigma*noise + (1-sigma)*latent_image；txt2img latent_image=0）
-    x = torch.randn(1, 16, 1, lat_h, lat_w, device=device, dtype=torch.float32) * float(sigmas[0])
+    # 与 ComfyUI `comfy/sample.prepare_noise` 对齐：CPU 上 torch.randn(generator=seed) 再 to(device)，
+    # 保证不同 GPU / CUDA 版本下同 seed 出同图（旧版 device=cuda 走 cuRAND，跨硬件不一致）。
+    noise_gen = None
+    if seed is not None:
+        noise_gen = torch.Generator(device="cpu").manual_seed(int(seed))
+    x = torch.randn(
+        1, 16, 1, lat_h, lat_w,
+        device="cpu", dtype=torch.float32, generator=noise_gen,
+    ).to(device) * float(sigmas[0])
     logger.info(f"[Debug] Latents init: {x.shape}, mean={x.mean().item():.4f}, std={x.std().item():.4f}")
 
     pad_mask = torch.zeros(1, 1, lat_h, lat_w, device=device, dtype=dtype)
@@ -165,7 +177,7 @@ def sample_image(
     if sampler_fn is not None:
         x = sampler_fn(
             denoise_fn, x, sigmas,
-            seed=None, s_noise=1.0, max_stage=3,
+            seed=seed, s_noise=1.0, max_stage=3,
             step_callback=step_callback,
         )
     else:

--- a/studio/services/inference/core.py
+++ b/studio/services/inference/core.py
@@ -53,21 +53,29 @@ class LoRASpec:
 
 @dataclass
 class LoRAMeta:
-    """从 safetensors metadata 解析出来的 LoRA 训练参数。"""
+    """从 safetensors metadata 解析出来的 LoRA 训练参数。
+
+    weight_decompose / rs_lora 必须忠实回放训练侧设置 —— 否则推理网络结构
+    与文件不匹配：DoRA 漏 dora_scale 张量（unexpected keys），RS-LoRA 把
+    effective alpha 从 α/√rank 错算成 α/rank，强度被砍 √rank 倍。
+    """
     rank: int
     alpha: float
     algo: str
     factor: int
+    weight_decompose: bool = False
+    rs_lora: bool = False
 
 
 def read_lora_meta(path: str) -> LoRAMeta:
     """从 safetensors 顶层 metadata 读 LoRA 训练参数。
 
-    AnimaLycorisAdapter.save() 写入约定（utils/lycoris_adapter.py:178）：
+    AnimaLycorisAdapter.save() 写入约定（utils/lycoris_adapter.py）：
       - 顶层 metadata: ss_network_dim (rank), ss_network_alpha (alpha)
-      - ss_network_args JSON 内: algo, factor, dropout, ...
+      - ss_network_args JSON 内: algo, factor, weight_decompose, rs_lora, ...
 
-    缺字段或解析失败时回退到默认值（rank=32, alpha=rank, algo=lokr, factor=8）。
+    缺字段或解析失败时回退到默认值（rank=32, alpha=rank, algo=lokr, factor=8,
+    weight_decompose=False, rs_lora=False）。
     """
     from safetensors import safe_open
 
@@ -108,7 +116,17 @@ def read_lora_meta(path: str) -> LoRAMeta:
         except (ValueError, TypeError):
             pass
 
-    return LoRAMeta(rank=rank, alpha=alpha, algo=algo, factor=factor)
+    weight_decompose = bool(ss_args.get("weight_decompose", False))
+    rs_lora = bool(ss_args.get("rs_lora", False))
+
+    return LoRAMeta(
+        rank=rank,
+        alpha=alpha,
+        algo=algo,
+        factor=factor,
+        weight_decompose=weight_decompose,
+        rs_lora=rs_lora,
+    )
 
 
 def apply_loras(
@@ -144,6 +162,8 @@ def apply_loras(
             rank=meta.rank,
             alpha=meta.alpha,
             factor=meta.factor,
+            weight_decompose=meta.weight_decompose,
+            rs_lora=meta.rs_lora,
         )
         adapter.inject(model)
 

--- a/tests/test_inference_core.py
+++ b/tests/test_inference_core.py
@@ -40,7 +40,14 @@ def _patched_adapter(factory: object) -> Iterator[None]:
 
 
 def _write_lora_safetensors(
-    path: Path, *, rank: int, alpha: float, algo: str, factor: int,
+    path: Path,
+    *,
+    rank: int,
+    alpha: float,
+    algo: str,
+    factor: int,
+    weight_decompose: bool = False,
+    rs_lora: bool = False,
 ) -> None:
     """写一个伪 LoRA safetensors，带 ss_* metadata；tensor 内容空。"""
     sd = {"lora_unet_dummy.lokr_w1": torch.zeros(2, 2)}
@@ -52,6 +59,8 @@ def _write_lora_safetensors(
             "algo": algo,
             "factor": factor,
             "preset": "anima_full",
+            "weight_decompose": weight_decompose,
+            "rs_lora": rs_lora,
         }),
     }
     save_file(sd, str(path), metadata=meta)
@@ -101,6 +110,61 @@ def test_read_lora_meta_invalid_fields(tmp_path: Path) -> None:
     assert meta.rank == 32
     assert meta.alpha == 32.0  # alpha fallback to rank
     assert meta.algo == "lokr"
+
+
+def test_read_lora_meta_dora_and_rs_lora(tmp_path: Path) -> None:
+    """DoRA / RS-LoRA 训练标志必须从 ss_network_args 读回。
+
+    回归 bug：训练侧开 weight_decompose=True 写入文件 dora_scale 张量；
+    推理侧若漏读，构造的 LycorisNetwork 不带 DoRA → dora_scale 全部
+    unexpected、forward 缺归一化项 → LoRA 效果错位。
+    RS-LoRA 同理：α/√rank vs α/rank 强度差 √rank 倍。
+    """
+    p = tmp_path / "dora_rs.safetensors"
+    _write_lora_safetensors(
+        p, rank=64, alpha=8.0, algo="lokr", factor=4,
+        weight_decompose=True, rs_lora=True,
+    )
+    meta = read_lora_meta(str(p))
+    assert meta.weight_decompose is True
+    assert meta.rs_lora is True
+
+
+def test_read_lora_meta_defaults_without_dora_rs(tmp_path: Path) -> None:
+    """不显式设置时 weight_decompose / rs_lora 默认 False。"""
+    p = tmp_path / "plain.safetensors"
+    _write_lora_safetensors(p, rank=16, alpha=8.0, algo="lokr", factor=8)
+    meta = read_lora_meta(str(p))
+    assert meta.weight_decompose is False
+    assert meta.rs_lora is False
+
+
+def test_apply_loras_propagates_dora_and_rs_lora(tmp_path: Path) -> None:
+    """apply_loras 必须把 weight_decompose / rs_lora 透传到 AnimaLycorisAdapter，
+    否则 inject 出的网络结构与文件不匹配。"""
+    p = tmp_path / "dora.safetensors"
+    _write_lora_safetensors(
+        p, rank=64, alpha=8.0, algo="lokr", factor=4,
+        weight_decompose=True, rs_lora=True,
+    )
+
+    created: list[MagicMock] = []
+
+    def _fake_adapter(*args: object, **kwargs: object) -> MagicMock:
+        m = MagicMock()
+        m.init_kwargs = dict(kwargs)
+        m.network = MagicMock()
+        m.network.loras = []
+        m.load_state_dict.return_value = MagicMock(missing_keys=[], unexpected_keys=[])
+        created.append(m)
+        return m
+
+    model = MagicMock()
+    with _patched_adapter(_fake_adapter):
+        apply_loras(model, [LoRASpec(path=str(p), scale=1.0)], device="cpu", dtype=torch.float32)
+
+    assert created[0].init_kwargs["weight_decompose"] is True
+    assert created[0].init_kwargs["rs_lora"] is True
 
 
 def test_apply_loras_each_lora_injects_separately(tmp_path: Path) -> None:


### PR DESCRIPTION
## 背景

用户反映两个独立现象：

1. **Studio Test 页出图 LoRA "完全没生效"** — 日志里 LoRA 加载提示 `unexpected=280`（正好等于注入的 LOKR 层数）
2. **同样配置下 Studio 出图与 ComfyUI 出图差别明显**（即便排除 seed 因素）

逐项排查 ComfyUI 原生 Anima 实现（`comfy/ldm/anima/model.py`、`comfy/text_encoders/anima.py`、`comfy/sample.py`、`comfy/ldm/cosmos/predict2.py`、`comfy/supported_models.py:1027`）后确认是 4 个不同层面的对齐 bug，分两块修。

## Commit 1: LoRA DoRA/rs_lora metadata 透传

`read_lora_meta` 漏读 `ss_network_args` 里的 `weight_decompose` 和 `rs_lora` 两个字段，`apply_loras` 构造的 LycorisNetwork 网络结构与训练时不一致：

| 字段 | 训练 | 推理（旧）| 后果 |
|---|---|---|---|
| `weight_decompose=True` (DoRA) | 文件含 280 个 `dora_scale` 张量 | 网络没有该参数 | 280 keys unexpected，DoRA 归一化项全部跳过 |
| `rs_lora=True` | effective α = α/√rank（rank=64 时 = 1.0）| α/rank（= 0.125）| **LoRA 强度被砍到训练时的 1/8** |

两者叠加 → 用户感知"LoRA 完全没生效"。

**修复**：
- `LoRAMeta` 扩展两字段；`read_lora_meta` 从 ss_network_args 读
- `apply_loras` 透传给 `AnimaLycorisAdapter`
- `_lora_topology` 加入这两字段，避免不同 DoRA/rs_lora 设置走错误的热换权重路径
- 3 个回归测试覆盖 metadata 读出 / 默认值 / apply_loras 透传

## Commit 2: 对齐 ComfyUI 出图三处

| 项 | Studio 旧 | ComfyUI | 影响 |
|---|---|---|---|
| **T5 token 权重 `(tag:1.3)`** | `tokenize_t5_weighted` 算出 `t5_w` 但调 `preprocess_text_embeds(qwen, t5_ids)` 时丢弃 | `comfy/ldm/anima/model.py:198-206` 在 LLMAdapter 输出后 `out * t5xxl_weights` | 权重语法对训练/出图都无效 |
| **初始噪声** | `torch.randn(device='cuda')` 走 cuRAND（跨硬件不一致）| `comfy/sample.prepare_noise` CPU generator + `.to(device)` | 同 seed 不同卡出不同噪声，无法跨平台复现 |
| **默认负面 prompt** | `None` 时偷塞 `"worst quality, low quality, score_1, ..."` 一长串 | 用户填什么用什么，空就是空 | CFG 锚点不同，构图直接两样 |

**修复**：
- `preprocess_text_embeds` 加 `t5xxl_weights` 参数，LLMAdapter 输出后乘；`sampling.py` + `loop.py` 调用透传 `t5_w`
- `sample_image` 加 `seed` 参数，noise 改 CPU generator → `.to(device)`；ER-SDE 调用也传 seed（旧版写死 `seed=None`）；4 个 caller（`anima_daemon.py` ×2、`anima_generate.py` ×2）传 seed 上来
- `negative_prompt is None` 时改为空字符串

## 不做的项

对比中还发现几个差异，按影响排序后决定**不在本 PR 修**：

- **shift=3.0 vs 6.0**：ComfyUI 原生 Anima `supported_models.py:1027` 就是 3.0，与 Studio 一致；6.0 是另一个独立模型 (NewBie plugin) 的节点默认值，与本项目无关
- **sigma 输入 dtype bf16 vs fp32**：Studio Timesteps 第一步就 `.float()` 算 sin/cos，sigma 的 bf16 quantize 影响在 (0,1) 区间约 1/256 精度；ComfyUI 也支持 bf16 unet，整体精度可配置
- **weighted tag 跨逗号括号解析**：常规 `(tag:w), other` 写法两边一致；嵌套 `(a, b, c:1.3)` 共享权重的写法 Studio 会拆错，但常见 booru 风格 prompt 不触发
- **Qwen/T5 max_length=512 截断**：prompt < 512 token 不触发（用户日志里 prompt = 333 token）
- **cross_cond pad 不传 attention mask**：Cosmos cross-attn 架构层就不接收 mask，两边都是裸 pad，对齐

## 模型架构 / VAE / Sampler 已确认对齐（不必担心）

并行用多个 agent 逐文件对比 ComfyUI 原生 Anima 与 Studio：

- **VAE**：Wan21 latent_format mean/std 完全一致，decode 公式 `z*std+mean→decoder→(+1)/2` 等价
- **DiT 架构**：685/688 key 完全命中；hidden=2048/blocks=28/heads=16/cross_emb=1024/patch=2/adaln_lora_dim=256 全对齐；AdaLN 3 参 modulation、self/cross/mlp 三段、分离 qkv MHA、SDPA 后端、GPT2 MLP、LLMAdapter 6 层逐行对齐
- **RoPE 3D**：亲自代数验证 Studio half-rotate + `[t,h,w]*2` 布局与 ComfyUI `stack 2x2 + reshape(2,-1)` 数学完全等价（都是 channel `(i, i+D/2)` 配对，角度一致）
- **Sampler / Scheduler**：simple_scheduler、`time_snr_shift`、offset_first_sigma、ER-SDE stage 1/2/3、`noise_scaler = λ*(exp(λ^0.3)+10)`、末步 `sigma_next==0` 处理全等价
- **CFG / Denoise**：`v = v_un + s*(v_c-v_un)` 等价于 ComfyUI 在 x0 上的 CFG；CONST `denoised = x - σ*v`、`noise_scaling = σ*noise + (1-σ)*latent` 等价

## Test plan

- [x] `pytest tests/test_inference_core.py tests/test_anima_generate_xy.py` → 27/27 pass
- [x] `pytest -k "sample or sampling or anima or text_encod or preprocess"` → 172 pass, 4 skipped
- [x] dev baseline 上的 44 个 fail / 10 error 全是 Python 3.10+ 兼容（`types.UnionType`）、`ModuleNotFoundError`、`flash_attn` 没装等环境问题，跟本 PR 改的代码无关
- [ ] 用户手测：重启 daemon 跑 Test 页出图，确认 LoRA 效果回来 + 同 seed 跟 ComfyUI 出图明显更接近

🤖 Generated with [Claude Code](https://claude.com/claude-code)