### PR TITLE
feat(reg): find_best_match 归一化加权 + Caption 策略文档

### DIFF
--- a/docs/user-guide/training-tips.md
+++ b/docs/user-guide/training-tips.md
@@ -23,6 +23,30 @@
 - 删除明显错误的标签
 - 保持标签风格一致（全小写，空格分隔）
 
+### Caption 策略与正则集配合
+
+想要训完的 LoRA 有「trigger off → 退回 base 默认 / trigger on → 出训练学的画风或角色」这种**开关式**控制效果，caption 必须把「要被 trigger 吸收的特征 tag」从 train caption 里删掉；正则集再去掉触发词，两边配合才能让 trigger 成为真正的 on/off 开关。
+
+#### 核心原则
+
+| LoRA 类型 | train caption 保留 | train caption 删掉 | 正则集排除 |
+|---|---|---|---|
+| **画风 LoRA** | 内容 tag（角色 / 场景 / 物体） | —（保持原样） | 触发词 + 画师名 |
+| **人物 LoRA** | 触发词（人物） + 环境（场景 / 动作） | 角色特征（发色 / 眼睛 / 体型 / 标志性服饰） | 触发词（角色名） |
+| **人物 + 衣服 LoRA** | 触发词（人物 + 衣服） + 环境 | 角色特征 + 衣服细节 | 触发词（角色名 + 衣服名） |
+
+#### 为什么这样配合
+
+- train 集 caption 删了特征 tag → 模型把这些特征**绑定到 trigger** 上
+- 正则集 caption 不含 trigger（builder 自动排除 `based_on_version`；正则集排除列表里再手动加触发词 / 角色名 / 衣服名）
+- 正则集图片来自 booru 自然分布或 base 模型自生成，发色 / 眼睛 / 衣服**随机分布**
+- 训练时正则集提供「trigger 不在时这组环境 tag 该长什么样」的监督信号
+- 结果：trigger off 时输出退向 base 模型的自然分布；trigger on 时才出训练学到的角色 / 画风
+
+#### 不遵守的后果
+
+如果 caption 里残留了本来应被吸收的特征 tag（如训角色没删 `silver_hair`），那 trigger off 时 prompt 写 `silver_hair` 仍会 leak 出训练集风格 —— trigger 不再是干净的 on/off 开关，更接近「加权融合」，且 LoRA 容易在「不写 silver_hair 反而劣化」上踩坑。
+
 ---
 
 ## 参数调优

--- a/studio/services/reg/analysis.py
+++ b/studio/services/reg/analysis.py
@@ -239,7 +239,25 @@ def calculate_tag_similarity(
     current_weights: dict[str, float],
     target_count: int,
 ) -> float:
-    """与源脚本一致：负 MSE。"""
+    """与源脚本一致：负 MSE。
+
+    `target_weights` 和 `current_weights` 都按 **文档频率**（doc frequency）测量：
+    某个 tag 出现在多少张图里 / 总图数 ∈ [0, 1]。`target_weights` 来自 train caption
+    分析；`current_weights` 来自 reg 集已下图，跟 `target_weights` 同公式（每图每
+    tag 累加 `1/target_count`）—— 拉够 `target_count` 张后，含某 tag 的 K 张图会让
+    `current_weights[tag]` 累加到 `K / target_count`，恰好等于该 tag 在 reg 集里的
+    doc frequency，跟 `target_weights` 的量级对称匹配。
+
+    这**不是** reverse-IDF：它跟 target 测的量级一致，所以累加没有非对称偏向。
+    副作用：密集打标的图（如 50-tag 的 booru post）单图贡献的 MSE 项更多，候选
+    选择会略偏向 tag 数多的图 —— 但这跟 train 的 doc frequency 分布一致，所以
+    没产生失配（target 也是按 doc frequency 算的）。
+
+    若改成「归一化分布匹配」（候选侧用 `1/(target_count * len(post_tags))`），
+    `target_weights` 也必须按同样方式重算 —— 否则会产生不对称的 IDF 偏置。
+    本 PR 不动 contract，仅文档化（见 `tmp/reg_algorithm_research.md` Smell D
+    + 用户讨论 2026-05-30）。
+    """
     new_weights = dict(current_weights)
     for tag in candidate_tags:
         new_weights[tag] = new_weights.get(tag, 0) + (1 / target_count)
@@ -309,6 +327,20 @@ def check_aspect_ratio(
     return min_ar <= ar <= max_ar
 
 
+# PR-3 (Smell C 修法)：tag_score 跟 res_score 归一到同量级再加权。
+# - tag_score = -MSE，量级 ~ [-len(target_weights), 0]
+# - res_score ∈ [0, 1]
+# 旧公式 `tag_score + res_score * 0.1` 让 tag 主导但又给 res 一个无依据
+# 0.1 系数 —— 实际行为：tag 差 0.001 即可被 res 反转，跟 docstring 的
+# "tie-breaker" 不一致。新公式把 tag_score / len(target_weights) 归一到
+# ~[-1, 0]，跟 res_score 同量级，按 0.7:0.3 加权。0.7 沿用 tag 主导，
+# 0.3 让 res 真能影响排序（用户在意 ARB 桶一致性）。
+# 见 `tmp/reg_algorithm_research.md` Smell C + 用户 caption-disentanglement
+# 讨论决策（2026-05-30）。
+TAG_SCORE_WEIGHT = 0.7
+RES_SCORE_WEIGHT = 0.3
+
+
 def find_best_match(
     posts: list[dict[str, Any]],
     target_weights: dict[str, float],
@@ -332,6 +364,11 @@ def find_best_match(
     best_post = None
     best_score = float("-inf")
 
+    # tag_score 归一化分母：参与 MSE 的 tag 集大小近似为 target_weights 的
+    # 大小（candidate_tags 在不重叠部分占小头）。除以它把 tag_score 归一到
+    # ~[-1, 0]，再跟 [0, 1] 的 res_score 加权。
+    tag_denom = max(1, len(target_weights))
+
     for post in candidates:
         post_id, _, _, _ = booru_api.post_fields(post, api_source)
         if post_id and post_id in source_image_ids:
@@ -348,12 +385,13 @@ def find_best_match(
         tag_score = calculate_tag_similarity(
             target_weights, post_tags, current_weights, target_count
         )
+        tag_norm = tag_score / tag_denom
         res_score = 0.0
         if target_resolution and target_aspect_ratio and pw and ph:
             res_score = calculate_resolution_similarity(
                 pw, ph, target_resolution, target_aspect_ratio, resolution_std
             )
-        final_score = tag_score + res_score * 0.1
+        final_score = TAG_SCORE_WEIGHT * tag_norm + RES_SCORE_WEIGHT * res_score
         if final_score > best_score:
             best_score = final_score
             best_post = post

--- a/tests/test_reg_builder.py
+++ b/tests/test_reg_builder.py
@@ -234,6 +234,40 @@ def test_check_aspect_ratio_enabled_filters() -> None:
     ) is False  # ar=3.0 > 2.0
 
 
+def test_find_best_match_new_formula_prefers_aspect_bucket_match() -> None:
+    """PR-3 Smell C 修法：res_score 在新公式下真能影响排序，对齐用户
+    「reg 集要跟 train 落同一个 ARB 桶」的诉求。
+
+    对比两个候选：
+    - A：tag 完美匹配 + aspect 差（4.0 vs target 1.0）
+    - B：tag 缺 1 个 + aspect 完美（1.0 = target 1.0）
+
+    旧公式 `tag + 0.1*res`：A 胜（res 加成不足以抵 tag 差距）。
+    新公式 `0.7*tag_norm + 0.3*res`：B 胜（aspect 完美抵过 tag 略差）。
+    """
+    target = {f"t{i}": 1.0 for i in range(5)}
+    posts = [
+        # A：5 tag 完美 + aspect 4.0（差）
+        {"@attributes": {
+            "id": "1", "file_url": "u", "tags": "t0 t1 t2 t3 t4",
+            "width": 1024, "height": 256,
+        }},
+        # B：缺 1 tag + aspect 1.0（完美匹配 ARB 桶）
+        {"@attributes": {
+            "id": "2", "file_url": "u", "tags": "t0 t1 t2 t3",
+            "width": 800, "height": 800,
+        }},
+    ]
+    best, _ = reg_builder.find_best_match(
+        posts, target, {}, target_count=5,
+        api_source="gelbooru", skip_similar=False,
+        target_resolution=(800, 800),
+        target_aspect_ratio=1.0,
+    )
+    assert best is not None
+    assert best["@attributes"]["id"] == "2"
+
+
 def test_find_best_match_skips_source_ids(tmp_path: Path) -> None:
     posts = [
         {"@attributes": {"id": "10", "file_url": "u", "tags": "1girl solo", "width": 512, "height": 512}},


### PR DESCRIPTION
## 背景

PR-1 (#171) + PR-2 (#172) 把 reg 集变成可编辑 / mirror + flat / AI 先验默认 / 设计稿 restyle 后，剩 deep-research 报告（`tmp/reg_algorithm_research.md`）里几个算法 smell 没动。本 PR 是 plan C 阶段的收窄落地 — 经用户讨论后只做有价值的两条，其他三条经讨论决定不做或仅文档化。

## 改动

### (b) Smell C 修法：`find_best_match` 归一化加权

原 `final = tag_score + res_score * 0.1`（`analysis.py:356`）：
- `tag_score` 是 -MSE，量级 ~`[-len(target_weights), 0]`
- `res_score` ∈ `[0, 1]`
- `0.1` 系数让 res 加成（最多 +0.1）经常被 tag 的小差距（0.01 级别）反转 — docstring 自称「resolution 作 tie-breaker」但实现是 weighted sum，实际 res 主导排序

新公式：

```python
tag_denom = max(1, len(target_weights))
tag_norm = tag_score / tag_denom           # 归一到 ~[-1, 0]
final = 0.7 * tag_norm + 0.3 * res_score   # 跟 res_score 同量级再加权
```

用户决策：tag 仍主导（0.7），但 res 真能影响排序（0.3）— 对齐「reg 集要跟 train 落同一个 ARB 桶」的实际诉求（aspect 一致 = 同 bucket）。

### (c) Smell D 判决：保留 + 文档化

`calculate_tag_similarity` 的 `+= 1/target_count` 看似 reverse-IDF（密集打标的图贡献多），但与 `target_weights = count/total_images` 数学对称 — 两边都按 doc frequency 测量，没有非对称偏置。本 PR 不动逻辑，仅扩写 docstring 说明 contract，避免未来 reviewer 想"修正"它（也避免 deep-research 报告里误判）。

### (f) docs：Caption 策略与正则集配合

`docs/user-guide/training-tips.md` 加新章节，固化用户在 100+ LoRA 上摸出的方法论：

| LoRA 类型 | train caption 保留 | train caption 删掉 | 正则集排除 |
|---|---|---|---|
| 画风 LoRA | 内容 tag | — | 触发词 + 画师名 |
| 人物 LoRA | 触发词 + 环境 | 角色特征（发色 / 眼睛 / 体型 / 标志性服饰） | 触发词（角色名） |
| 人物 + 衣服 | 触发词 + 环境 | 角色特征 + 衣服细节 | 触发词（角色名 + 衣服名） |

加「为什么这样配合」和「不遵守的后果」两节，让用户知道 reg 集为什么以及怎么跟 caption 策略配合实现 trigger-as-switch 效果。

## 不做的项（PR-3 plan 里有但用户讨论后决定砍）

- **(a) `target_weights` 剔除 blacklist**：用户指出会破坏「我排除某 tag = 图不含」的细粒度控制；排除高频 tag 时反而让评分跑偏（例：排 `1girl` 95% → target 只剩低频 tag → 选到完全不像 train 的杂图）
- **(d) Smell D 双侧 normalize**：plan 已定不动；本 PR 仅文档化
- **(e) C1 phash 事前过滤**：PR-1 的 A4 build-pipeline 内置 dedup 已覆盖；事前过滤的带宽节省收益小，不抵新 surface area（缩略图下载 + phash 状态维护 + 跟 incremental / consecutive_failures 协调）

## 测试

- 后端 81 reg 套件 passed，含新增：
  - `test_find_best_match_new_formula_prefers_aspect_bucket_match`：构造 tag 完美但 aspect 差的候选 vs tag 缺 1 个但 aspect 完美的候选，验证新公式选后者（aspect 完美抵过 tag 略差），旧公式选前者
- `calculate_tag_similarity` docstring 改动零代码影响，不需要新测试