### PR TITLE
fix(launcher): studio.sh 错误退出时也 pause 别闪退

### DIFF
--- a/studio.sh
+++ b/studio.sh
@@ -43,6 +43,25 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR" || { echo "studio.sh: cannot cd to $SCRIPT_DIR" >&2; exit 1; }
 
+# Mirror studio.bat's `pause` on error: when launched from a file manager
+# (double-click) the terminal closes on exit and the user can't read the
+# error (e.g. missing Node.js / Python). EXIT trap covers every `exit N`
+# path (setup-time `exit 1`, main-loop non-zero rc) uniformly; only pause
+# when stdin is a TTY so CI / piped invocations don't hang.
+_pause_if_tty_on_error() {
+    local rc=$?
+    # 130 = SIGINT (Ctrl+C), 143 = SIGTERM — user wanted to kill, don't make
+    # them press Enter to dismiss.
+    if [ "$rc" -eq 0 ] || [ "$rc" -eq 130 ] || [ "$rc" -eq 143 ]; then
+        return
+    fi
+    if [ -t 0 ] && [ -t 1 ]; then
+        printf "[studio] Press Enter to close..." >&2
+        read -r _ || true
+    fi
+}
+trap _pause_if_tty_on_error EXIT
+
 # Force Python UTF-8 output so cli.py messages with non-ASCII characters are
 # not mangled on non-UTF-8 locales.
 export PYTHONUTF8=1


### PR DESCRIPTION
## 背景

`studio.sh` 在没装 Node.js 时 `cli.py::_print_npm_install_hint()` 打 stderr → `cmd_run` 返回 2 → studio.sh 只打一行 `Exit code 2` 就 exit。从文件管理器双击或非持久终端启动的用户看不到错误就闪退。

`studio.bat` 早就有 `pause >nul` 兜底，studio.sh 缺对应处理。

## 改动

加 `trap _pause_if_tty_on_error EXIT` 一把覆盖所有 exit 路径（setup 阶段的 `exit 1` + 主循环非零 rc）：
- 非零 rc + stdin/stdout 都是 TTY → 提示按 Enter 后退出
- rc=0/130/143（正常 / Ctrl+C / SIGTERM）→ skip，不让用户 kill 时还要再按 Enter
- 非 TTY（CI / 管道）→ skip，避免误卡

## 测试

- `bash -n studio.sh` 语法检查通过
- 现有 cli 流程 / 自更新 exit 42 路径不受影响（trap 在 exec 之前清掉）