### PR TITLE
fix(schema): noise_offset 与金字塔噪声互斥，对齐 kohya 上游

### DIFF
--- a/docs/user-guide/training-tips.md
+++ b/docs/user-guide/training-tips.md
@@ -205,9 +205,12 @@ EDM/Karras 论文里 δ=0.15 是常用经验值。
 
 | 字段 | 默认 | 用途 |
 |------|------|------|
-| `noise_offset` | `0.0` | 给噪声加常数偏置；`0.05~0.1` 能改善超暗 / 超亮场景的对比度 |
-| `pyramid_noise_iters` | `0` | 金字塔噪声层数；`>0` 在多尺度叠加噪声，纹理多样性更好 |
-| `pyramid_noise_discount` | `0.35` | 金字塔每层衰减系数（仅 `pyramid_noise_iters>0` 用） |
+| `noise_enhancement_type` | `none` | `none` / `offset` / `pyramid` 三选一，互斥（见下） |
+| `noise_offset` | `0.0` | 给噪声加常数偏置；`0.05~0.1` 能改善超暗 / 超亮场景的对比度。仅 `type=offset` 生效 |
+| `pyramid_noise_iters` | `0` | 金字塔噪声层数；多尺度叠加噪声，纹理多样性更好。仅 `type=pyramid` 生效 |
+| `pyramid_noise_discount` | `0.35` | 金字塔每层衰减系数。仅 `type=pyramid` 生效 |
+
+**互斥约束**：`noise_offset` 与金字塔噪声**不能同时启用**。两者都在给噪声注入低频成分（pyramid 最低分辨率那层 ≈ `noise_offset` 等价物），叠加会让低频成分双倍灌入，训练目标失真。这跟 kohya 上游 [sd-scripts PR #477](https://github.com/kohya-ss/sd-scripts/pull/477) 的硬约束一致。Anima 的 schema 校验会强制清零反组字段，老 yaml 同开会按 `pyramid_noise_iters > 0` 优先映射到 pyramid。
 
 `pyramid_noise` 来自 Mistoline / Diffusion 社区实验，画风 LoRA 受益明显，角色 LoRA 一般。
 

--- a/runtime/training/bootstrap.py
+++ b/runtime/training/bootstrap.py
@@ -92,8 +92,15 @@ def apply_yaml_config(args, config):
     所以这里显式做一次。
     """
     from studio.infrastructure.argparse_bridge import merge_yaml_into_namespace
-    from studio.schema import TrainingConfig, migrate_legacy_attention, migrate_legacy_save_keys
-    config = migrate_legacy_save_keys(migrate_legacy_attention(dict(config or {})))
+    from studio.schema import (
+        TrainingConfig,
+        migrate_legacy_attention,
+        migrate_legacy_save_keys,
+        migrate_noise_enhancement_type,
+    )
+    config = migrate_noise_enhancement_type(
+        migrate_legacy_save_keys(migrate_legacy_attention(dict(config or {})))
+    )
     return merge_yaml_into_namespace(args, config, TrainingConfig)
 
 

--- a/studio/domain/__init__.py
+++ b/studio/domain/__init__.py
@@ -15,7 +15,11 @@
 from .common import AttentionBackend, GROUP_ORDER, _meta
 from .generate import GenerateConfig
 from .lora import LoraEntry
-from .migrations import migrate_legacy_attention, migrate_legacy_save_keys
+from .migrations import (
+    migrate_legacy_attention,
+    migrate_legacy_save_keys,
+    migrate_noise_enhancement_type,
+)
 from .reg import RegAiConfig
 from .training import TrainingConfig
 from .xy_matrix import XYAxisSpec, XYAxisType, XYMatrixSpec, _check_axis_values
@@ -34,4 +38,5 @@ __all__ = [
     "_meta",
     "migrate_legacy_attention",
     "migrate_legacy_save_keys",
+    "migrate_noise_enhancement_type",
 ]

--- a/studio/domain/migrations.py
+++ b/studio/domain/migrations.py
@@ -70,3 +70,54 @@ def migrate_legacy_save_keys(data: Any) -> Any:
             else:
                 data[new] = data.pop(legacy)
     return data
+
+
+def migrate_noise_enhancement_type(data: Any) -> Any:
+    """对齐 kohya: `noise_offset` 与金字塔噪声互斥；用单一 type 字段管控。
+
+    两步：
+      1. 老 yaml 没有 `noise_enhancement_type` 时按现状字段推导：
+            pyramid_noise_iters > 0   → "pyramid"
+            noise_offset > 0          → "offset"
+            都为 0                    → "none"
+         历史 bug 配置（两者都 > 0）：选 "pyramid"。理由：Anima 旧 `make_noise`
+         实现末尾 `noise = cur / cur.std().clamp(...)` 归一化会稀释 noise_offset
+         的常数偏移，实际生效的主要是 pyramid，所以推导到 pyramid 跟用户主观
+         观察最接近。
+      2. 反组字段强制清零 —— kohya_ss issue #2599 教训：序列化层就要互斥，
+         UI 隐藏字段不等于清值，否则 yaml 残值会进训练。
+         注意：argparse_bridge 路径绕开 pydantic validator，清零必须在
+         migration 里做（不能只在 schema validator 里做）。
+
+    Idempotent：已显式给了 `noise_enhancement_type` 就直接尊重。
+    """
+    if not isinstance(data, dict):
+        return data
+    if "noise_enhancement_type" not in data:
+        pyramid = _coerce_num(data.get("pyramid_noise_iters", 0))
+        offset = _coerce_num(data.get("noise_offset", 0.0))
+        if pyramid > 0:
+            data["noise_enhancement_type"] = "pyramid"
+        elif offset > 0:
+            data["noise_enhancement_type"] = "offset"
+        else:
+            data["noise_enhancement_type"] = "none"
+    t = data["noise_enhancement_type"]
+    if t == "offset":
+        data["pyramid_noise_iters"] = 0
+    elif t == "pyramid":
+        data["noise_offset"] = 0.0
+    elif t == "none":
+        data["noise_offset"] = 0.0
+        data["pyramid_noise_iters"] = 0
+    return data
+
+
+def _coerce_num(v: Any) -> float:
+    """yaml 可能把数字读成 str / None；为 type 推导宽容地转 float。"""
+    if v is None:
+        return 0.0
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return 0.0

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -18,7 +18,11 @@ from typing import Any, Literal, Optional
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .common import AttentionBackend, _meta
-from .migrations import migrate_legacy_attention, migrate_legacy_save_keys
+from .migrations import (
+    migrate_legacy_attention,
+    migrate_legacy_save_keys,
+    migrate_noise_enhancement_type,
+)
 
 
 class TrainingConfig(BaseModel):
@@ -303,20 +307,25 @@ class TrainingConfig(BaseModel):
         description="【性能】Cross-attention KV trim：按实际 token 数裁到最近 bucket（64/128/256/512），减少 padding 计算量",
         json_schema_extra=_meta("system", advanced=True),
     )
+    noise_enhancement_type: Literal["none", "offset", "pyramid"] = Field(
+        "none",
+        description="【噪声增强】二选一：offset 给噪声加常数低频偏移（亮暗对比）；pyramid 多尺度叠加低频（构图/光照）。kohya 上游同样禁止同开。",
+        json_schema_extra=_meta("noise_schedule", advanced=True),
+    )
     noise_offset: float = Field(
         0.0, ge=0.0, le=0.2,
-        description="【噪声增强】低频偏移强度，缓解亮度均值偏差（0=禁用，推荐 0.05-0.1）",
-        json_schema_extra=_meta("noise_schedule", advanced=True),
+        description="【噪声增强】低频偏移强度，缓解亮度均值偏差（推荐 0.05-0.1）",
+        json_schema_extra=_meta("noise_schedule", show_when="noise_enhancement_type==offset", advanced=True),
     )
     pyramid_noise_iters: int = Field(
         0, ge=0, le=6,
-        description="【噪声增强】多尺度噪声叠加层数（0=禁用；2-3 帮助全局光照构图学习）",
-        json_schema_extra=_meta("noise_schedule", advanced=True),
+        description="【噪声增强】多尺度噪声叠加层数（2-3 帮助全局光照构图学习）",
+        json_schema_extra=_meta("noise_schedule", show_when="noise_enhancement_type==pyramid", advanced=True),
     )
     pyramid_noise_discount: float = Field(
         0.35, ge=0.1, le=0.9,
-        description="【噪声增强】金字塔每层衰减系数（仅 pyramid_noise_iters > 0）",
-        json_schema_extra=_meta("noise_schedule", show_when="pyramid_noise_iters!=0", advanced=True),
+        description="【噪声增强】金字塔每层衰减系数",
+        json_schema_extra=_meta("noise_schedule", show_when="noise_enhancement_type==pyramid", advanced=True),
     )
     timestep_sampling: Literal[
         "logit_normal",
@@ -473,6 +482,11 @@ class TrainingConfig(BaseModel):
     @classmethod
     def _migrate_save_keys(cls, data: Any) -> Any:
         return migrate_legacy_save_keys(data)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_noise_enhancement(cls, data: Any) -> Any:
+        return migrate_noise_enhancement_type(data)
 
     @model_validator(mode="after")
     def _validate_prodigy_scheduler(self) -> "TrainingConfig":

--- a/studio/schema.py
+++ b/studio/schema.py
@@ -19,6 +19,7 @@ from .domain import (
     _meta,
     migrate_legacy_attention,
     migrate_legacy_save_keys,
+    migrate_noise_enhancement_type,
 )
 
 __all__ = [
@@ -35,4 +36,5 @@ __all__ = [
     "_meta",
     "migrate_legacy_attention",
     "migrate_legacy_save_keys",
+    "migrate_noise_enhancement_type",
 ]

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -312,6 +312,11 @@
         "none": "PyTorch SDPA",
         "xformers": "xFormers",
         "flashAttn": "Flash Attention"
+      },
+      "noiseEnhancementType": {
+        "none": "Disabled",
+        "offset": "Noise Offset",
+        "pyramid": "Pyramid noise"
       }
     },
     "disableHints": {
@@ -369,9 +374,10 @@
       "ppsf_use_stableadamw": "Use stable AdamW normalization in PPSF (recommended)",
       "weight_decay": "Weight decay (0 disables)",
       "kv_trim": "[Performance] Cross-attention KV trim: crop to nearest bucket (64/128/256/512) by actual token count to reduce padding compute",
-      "noise_offset": "[Noise augmentation] Low-frequency offset strength, helps brightness mean bias (0 disables, recommended 0.05-0.1)",
-      "pyramid_noise_iters": "[Noise augmentation] Multi-scale noise layers (0 disables; 2-3 helps global lighting/composition learning)",
-      "pyramid_noise_discount": "[Noise augmentation] Per-layer pyramid decay (only when pyramid_noise_iters > 0)",
+      "noise_enhancement_type": "[Noise augmentation] Pick one: offset injects a constant low-frequency bias (light/dark contrast); pyramid stacks multi-scale low-frequency noise (composition/lighting). Mutually exclusive — kohya enforces the same constraint.",
+      "noise_offset": "[Noise augmentation] Low-frequency offset strength, helps brightness mean bias (recommended 0.05-0.1)",
+      "pyramid_noise_iters": "[Noise augmentation] Multi-scale noise layers (2-3 helps global lighting/composition learning)",
+      "pyramid_noise_discount": "[Noise augmentation] Per-layer pyramid decay",
       "timestep_sampling": "[Timestep sampling] Distribution (logit_normal is the SD3/Anima default; mixed_* modes blend uniform with a biased end using timestep_mix_low_prob)",
       "timestep_shift": "[Timestep sampling] logit-normal / mode shift (>1 biases high-noise end, <1 biases detail end)",
       "timestep_mix_low_prob": "[Timestep sampling] Sample ratio sent to the biased end in mixed_* modes (0 = all uniform; typical 0.15-0.30)",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -312,6 +312,11 @@
         "none": "PyTorch SDPA",
         "xformers": "xFormers",
         "flashAttn": "Flash Attention"
+      },
+      "noiseEnhancementType": {
+        "none": "不启用",
+        "offset": "Noise Offset",
+        "pyramid": "金字塔噪声"
       }
     },
     "disableHints": {
@@ -369,9 +374,10 @@
       "ppsf_use_stableadamw": "PPSF 用 stable AdamW 归一化（推荐开启）",
       "weight_decay": "权重衰减（0=禁用）",
       "kv_trim": "【性能】Cross-attention KV trim：按实际 token 数裁到最近 bucket（64/128/256/512），减少 padding 计算量",
-      "noise_offset": "【噪声增强】低频偏移强度，缓解亮度均值偏差（0=禁用，推荐 0.05-0.1）",
-      "pyramid_noise_iters": "【噪声增强】多尺度噪声叠加层数（0=禁用；2-3 帮助全局光照构图学习）",
-      "pyramid_noise_discount": "【噪声增强】金字塔每层衰减系数（仅 pyramid_noise_iters > 0）",
+      "noise_enhancement_type": "【噪声增强】二选一：offset 给噪声加常数低频偏移（亮暗对比）；pyramid 多尺度叠加低频（构图/光照）。kohya 上游同样禁止同开。",
+      "noise_offset": "【噪声增强】低频偏移强度，缓解亮度均值偏差（推荐 0.05-0.1）",
+      "pyramid_noise_iters": "【噪声增强】多尺度噪声叠加层数（2-3 帮助全局光照构图学习）",
+      "pyramid_noise_discount": "【噪声增强】金字塔每层衰减系数",
       "timestep_sampling": "【时间步采样】分布（logit_normal 为 SD3/Anima 默认；mixed_* 模式混合 uniform 与偏置端，按 timestep_mix_low_prob 控制比例）",
       "timestep_shift": "【时间步采样】logit-normal / mode shift（>1 偏向高噪声端，<1 偏向细节端）",
       "timestep_mix_low_prob": "【时间步采样】mixed_* 模式下走偏置端的样本比例（0 = 全 uniform；典型 0.15-0.30）",

--- a/studio/web/src/lib/schema.ts
+++ b/studio/web/src/lib/schema.ts
@@ -126,6 +126,11 @@ export const SCHEMA_ENUM_LABEL_KEYS: Record<string, Record<string, string>> = {
     xformers: 'schema.enums.attentionBackend.xformers',
     flash_attn: 'schema.enums.attentionBackend.flashAttn',
   },
+  noise_enhancement_type: {
+    none: 'schema.enums.noiseEnhancementType.none',
+    offset: 'schema.enums.noiseEnhancementType.offset',
+    pyramid: 'schema.enums.noiseEnhancementType.pyramid',
+  },
 }
 
 export function schemaGroupLabel(key: string, fallback: string, t: TFunction): string {

--- a/tests/test_noise_enhancement_schema.py
+++ b/tests/test_noise_enhancement_schema.py
@@ -1,0 +1,194 @@
+"""schema.noise_enhancement_type + migrate_noise_enhancement_type 回归。
+
+对齐 kohya-ss/sd-scripts PR #477（raise error when both noise_offset and
+multires）：noise_offset 与金字塔噪声在 Anima 这边走单一 type 字段管控，
+schema / migration 层强制清零反组字段（kohya_ss issue #2599 教训：UI 隐藏
+不等于清值，序列化层要互斥）。
+"""
+from __future__ import annotations
+
+import pytest
+
+from studio.schema import TrainingConfig, migrate_noise_enhancement_type
+
+
+# ---------------------------------------------------------------------------
+# migrate_noise_enhancement_type（dict 层 helper）
+# ---------------------------------------------------------------------------
+
+
+def test_migrate_legacy_only_offset() -> None:
+    """只设 noise_offset > 0 → type=offset。"""
+    out = migrate_noise_enhancement_type({"noise_offset": 0.05})
+    assert out["noise_enhancement_type"] == "offset"
+    assert out["pyramid_noise_iters"] == 0
+
+
+def test_migrate_legacy_only_pyramid() -> None:
+    """只设 pyramid_noise_iters > 0 → type=pyramid，noise_offset 清零。"""
+    out = migrate_noise_enhancement_type({"pyramid_noise_iters": 3})
+    assert out["noise_enhancement_type"] == "pyramid"
+    assert out["noise_offset"] == 0.0
+
+
+def test_migrate_legacy_neither() -> None:
+    """两者都 0 / 未设 → type=none。"""
+    out = migrate_noise_enhancement_type({})
+    assert out["noise_enhancement_type"] == "none"
+
+
+def test_migrate_legacy_both_set_pyramid_wins() -> None:
+    """历史 bug 配置：两者都 > 0 → pyramid 优先，offset 清零。
+
+    理由：Anima 旧 make_noise 末尾归一化稀释了 noise_offset 的常数偏移，
+    实际生效的主要是 pyramid。
+    """
+    out = migrate_noise_enhancement_type({
+        "noise_offset": 0.05,
+        "pyramid_noise_iters": 3,
+    })
+    assert out["noise_enhancement_type"] == "pyramid"
+    assert out["noise_offset"] == 0.0
+
+
+def test_migrate_explicit_type_offset_clears_pyramid() -> None:
+    """显式 type=offset → pyramid_noise_iters 强制清零（issue #2599 教训）。"""
+    out = migrate_noise_enhancement_type({
+        "noise_enhancement_type": "offset",
+        "noise_offset": 0.05,
+        "pyramid_noise_iters": 3,  # 残值，必须清掉
+    })
+    assert out["noise_enhancement_type"] == "offset"
+    assert out["noise_offset"] == 0.05
+    assert out["pyramid_noise_iters"] == 0
+
+
+def test_migrate_explicit_type_pyramid_clears_offset() -> None:
+    out = migrate_noise_enhancement_type({
+        "noise_enhancement_type": "pyramid",
+        "noise_offset": 0.05,  # 残值
+        "pyramid_noise_iters": 3,
+    })
+    assert out["noise_enhancement_type"] == "pyramid"
+    assert out["noise_offset"] == 0.0
+    assert out["pyramid_noise_iters"] == 3
+
+
+def test_migrate_explicit_type_none_clears_both() -> None:
+    out = migrate_noise_enhancement_type({
+        "noise_enhancement_type": "none",
+        "noise_offset": 0.05,
+        "pyramid_noise_iters": 3,
+    })
+    assert out["noise_enhancement_type"] == "none"
+    assert out["noise_offset"] == 0.0
+    assert out["pyramid_noise_iters"] == 0
+
+
+def test_migrate_idempotent() -> None:
+    once = migrate_noise_enhancement_type({"pyramid_noise_iters": 3})
+    twice = migrate_noise_enhancement_type(dict(once))
+    assert once == twice
+
+
+def test_migrate_non_dict_passthrough() -> None:
+    """非 dict 直接 return 不动（pydantic model_validator(mode='before') 兼容）。"""
+    assert migrate_noise_enhancement_type(None) is None
+    assert migrate_noise_enhancement_type("notadict") == "notadict"
+    assert migrate_noise_enhancement_type(42) == 42
+
+
+def test_migrate_str_number_coerced() -> None:
+    """yaml 偶尔把数字读成 str；不能崩，按 0 处理。"""
+    out = migrate_noise_enhancement_type({"noise_offset": "0.05"})
+    assert out["noise_enhancement_type"] == "offset"
+
+
+def test_migrate_invalid_number_treated_as_zero() -> None:
+    """坏值（非数字 str / None）→ 当作 0 处理，不抛。"""
+    out = migrate_noise_enhancement_type({
+        "noise_offset": "abc",
+        "pyramid_noise_iters": None,
+    })
+    assert out["noise_enhancement_type"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# pydantic schema —— TrainingConfig 走 migrate 后能正确构造 + 互斥
+# ---------------------------------------------------------------------------
+
+
+def test_schema_default_is_none() -> None:
+    t = TrainingConfig()
+    assert t.noise_enhancement_type == "none"
+    assert t.noise_offset == 0.0
+    assert t.pyramid_noise_iters == 0
+
+
+def test_schema_legacy_offset_yaml() -> None:
+    """老 yaml { noise_offset: 0.05 } → type=offset，pyramid 清零。"""
+    t = TrainingConfig(noise_offset=0.05)  # type: ignore[call-arg]
+    assert t.noise_enhancement_type == "offset"
+    assert t.noise_offset == 0.05
+    assert t.pyramid_noise_iters == 0
+
+
+def test_schema_legacy_pyramid_yaml() -> None:
+    t = TrainingConfig(pyramid_noise_iters=3)  # type: ignore[call-arg]
+    assert t.noise_enhancement_type == "pyramid"
+    assert t.noise_offset == 0.0
+    assert t.pyramid_noise_iters == 3
+
+
+def test_schema_legacy_both_set_pyramid_wins() -> None:
+    """老 yaml 两者都设 → pyramid 优先，offset 清零（issue #2599 同款防御）。"""
+    t = TrainingConfig(noise_offset=0.05, pyramid_noise_iters=3)  # type: ignore[call-arg]
+    assert t.noise_enhancement_type == "pyramid"
+    assert t.noise_offset == 0.0
+    assert t.pyramid_noise_iters == 3
+
+
+def test_schema_explicit_offset_clears_pyramid() -> None:
+    """显式 type=offset 但 yaml 残留 pyramid 字段 → 清掉。"""
+    t = TrainingConfig(
+        noise_enhancement_type="offset",
+        noise_offset=0.05,
+        pyramid_noise_iters=3,  # 残值
+    )
+    assert t.noise_enhancement_type == "offset"
+    assert t.noise_offset == 0.05
+    assert t.pyramid_noise_iters == 0
+
+
+def test_schema_explicit_pyramid_clears_offset() -> None:
+    t = TrainingConfig(
+        noise_enhancement_type="pyramid",
+        noise_offset=0.05,  # 残值
+        pyramid_noise_iters=3,
+    )
+    assert t.noise_enhancement_type == "pyramid"
+    assert t.noise_offset == 0.0
+    assert t.pyramid_noise_iters == 3
+
+
+def test_schema_explicit_none_clears_both() -> None:
+    t = TrainingConfig(
+        noise_enhancement_type="none",
+        noise_offset=0.05,
+        pyramid_noise_iters=3,
+    )
+    assert t.noise_enhancement_type == "none"
+    assert t.noise_offset == 0.0
+    assert t.pyramid_noise_iters == 0
+
+
+def test_schema_invalid_type_rejected() -> None:
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        TrainingConfig(noise_enhancement_type="multires")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("t_value", ["none", "offset", "pyramid"])
+def test_schema_all_types_validate(t_value: str) -> None:
+    t = TrainingConfig(noise_enhancement_type=t_value)  # type: ignore[arg-type]
+    assert t.noise_enhancement_type == t_value


### PR DESCRIPTION
## 背景

kohya-ss/sd-scripts [PR #477](https://github.com/kohya-ss/sd-scripts/pull/477)（2023-05 merged）在 `verify_training_args` 加 raise 禁止 `noise_offset + multires_noise_iterations` 同开 —— **SD1/SDXL/SD3/Flux 全模型层面，不是 SDXL 专属**。理由：两者都给噪声注入低频成分，pyramid 最低分辨率那层 ≈ noise_offset 等价物，叠加导致低频双倍灌入、训练目标失真。

Anima 旧实现没禁，且 `make_noise` 末尾 `noise = cur / cur.std().clamp(...)` 归一化会稀释先加的 noise_offset 常数偏移 —— 用户以为两者都生效，实际等效"只 pyramid 在跑、offset 被吃掉"，比 kohya 报错更隐蔽。

## 改动

走 kohya_ss GUI 的「单选 + 反组隐藏」模式（`class_advanced_training.py` 的 `noise_offset_type` Dropdown），但学 [issue #2599](https://github.com/bmaltais/kohya_ss/issues/2599) 的教训：**UI 隐藏字段不等于清值，序列化层就要互斥**，否则 yaml 残值会进训练。

- 加 `noise_enhancement_type: Literal["none", "offset", "pyramid"]` 字段
- `migrate_noise_enhancement_type` 两步：老 yaml 推导 type（两者都 > 0 时 pyramid 优先，因为 Anima 旧实现里 pyramid 才是实际生效的）+ 反组字段强制清零
- `TrainingConfig` before validator 调 migration（pydantic 路径）
- `apply_yaml_config` 也调 migration（argparse_bridge 路径绕开 validator，需显式调）
- `noise_offset` / `pyramid_*` 字段的 `show_when` 改成按 type 联动
- 前端 schema-driven 自动渲染 Literal 为 Dropdown；i18n 加 type 描述 + 选项标签
- 文档 `training-tips.md` 噪声章节加互斥说明 + kohya PR #477 引用

## 测试

- `tests/test_noise_enhancement_schema.py` 22 用例覆盖 migration / schema 互斥 / 历史 bug 配置（两者都 > 0 → pyramid 优先 + offset 清零）/ pydantic enum 校验
- 回归 68/68 ✓（attention / studio_configs / version_config / lokr）
- 前端 schema/SchemaForm 16/16 ✓