### PR TITLE
fix(dataset): cache_latents + flip_augment 同开按 kohya 双份 latent 模式

### DIFF
--- a/docs/user-guide/training-tips.md
+++ b/docs/user-guide/training-tips.md
@@ -211,6 +211,17 @@ EDM/Karras 论文里 δ=0.15 是常用经验值。
 
 `pyramid_noise` 来自 Mistoline / Diffusion 社区实验，画风 LoRA 受益明显，角色 LoRA 一般。
 
+### Flip Augment + Cache Latents（双份缓存）
+
+`flip_augment` 与 `cache_latents` 同开时，Anima 按 kohya 上游 `latents` / `latents_flipped` 模式存**双份 latent**：
+
+- cache 阶段对每张图 encode 两次（原图 + 镜像），分别存到 npz 的 `latent` / `latent_flipped` 键
+- 训练时 `__getitem__` 50% 概率取 flipped 版本，跟非 cache 路径行为对齐
+- 代价：**编码时间和 cache 大小都 ×2**（小数据集无感知，大数据集要权衡）
+- 老 cache（只有 `latent`）+ `flip_augment=true` → 自动判失效，重 encode 补全；切回 `flip_augment=false` 不会反复重 encode（双份是单份的超集）
+
+历史 bug：旧版 0.11.x 之前同开两者会让 cache 阶段那一次随机翻转 baked 进 npz，**flip_augment 永久失效 + 50% 数据被永久镜像污染**。0.11.x 起按双份方案修复，已有的污染 cache 通过 `_is_cache_valid` 自动检测重 encode。
+
 ---
 
 ## Schema 简单/高级模式 与 字段位置（0.7.1 改动）

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -271,22 +271,35 @@ class ImageDataset(Dataset):
         return len(self.samples)
 
     def __getitem__(self, idx):
+        # 默认 path：DataLoader 不能传额外参数，所以由 flip_augment 决定是否随机翻转。
+        # CachedLatentDataset 想显式控制 flip 时直接调 get_with_flip(idx, flip=...)，
+        # 在 cache 阶段对每张图各 encode 一次 flip=False / flip=True，避免随机性 baked
+        # 进 npz（kohya 风格双份 latent）。
+        flip = self.flip_augment and random.random() > 0.5
+        return self.get_with_flip(idx, flip=flip)
+
+    def get_with_flip(self, idx, *, flip: bool):
+        """带显式 flip 控制的 __getitem__。
+
+        flip=True/False：强制翻 / 不翻，调用方负责决策；用于 cache 双份编码。
+        flip 与 self.flip_augment 解耦，不读 self.flip_augment 也不掷随机数。
+        """
         import numpy as np
         from PIL import Image
         sample = self.samples[idx]
         img = Image.open(sample["image"]).convert("RGB")
-        
+
         # 获取 caption（正则集可用 caption_override 统一覆盖）
         caption = None
         if self.caption_override is not None:
             caption = self.caption_override
         elif sample.get("json_path"):
             caption = self._process_caption_json(sample["json_path"])
-        
+
         if caption is None and sample.get("txt_path"):
             caption = sample["txt_path"].read_text(encoding="utf-8").strip()
             caption = self._process_caption_txt(caption)
-        
+
         if caption is None:
             caption = ""
 
@@ -305,8 +318,7 @@ class ImageDataset(Dataset):
         top = (nh - th) // 2
         img = img.crop((left, top, left + tw, top + th))
 
-        # 水平翻转增强
-        if self.flip_augment and random.random() > 0.5:
+        if flip:
             img = img.transpose(Image.FLIP_LEFT_RIGHT)
 
         # 转 tensor [-1, 1]
@@ -462,7 +474,16 @@ class BucketBatchSampler:
 
 
 class CachedLatentDataset(Dataset):
-    """Kohya 风格 npz 文件缓存的数据集"""
+    """Kohya 风格 npz 文件缓存的数据集。
+
+    flip_augment + cache_latents 同开时按 kohya 双份 latent 模式：
+      - cache 阶段对每张图 encode 两次（flip=False / flip=True），分别存到
+        npz 的 `latent` / `latent_flipped` 键
+      - 训练时 __getitem__ 50% 概率取 flipped 版本
+    旧版本静默把"cache 阶段那次随机翻转"baked 进 npz，导致 flip 永久失效 +
+    50% 数据被永久镜像污染；新版通过 _is_cache_valid 检测缺 latent_flipped
+    键，自动重 encode 修复。
+    """
     def __init__(self, base_dataset, vae, device, dtype, cache_dir=None):
         import numpy as np
         self.base_dataset = base_dataset
@@ -472,6 +493,10 @@ class CachedLatentDataset(Dataset):
         self.samples = self._get_base_samples(base_dataset)
         self.cache_dir = Path(cache_dir) if cache_dir else None
         self.bucket_for_index = []
+        # cache 是否需要双份 latent —— 取决于底层 ImageDataset.flip_augment
+        self.flip_augment = bool(
+            getattr(self.base_image_dataset, "flip_augment", False)
+        )
         self._build_cache(vae, device, dtype)
 
     def _get_base_samples(self, dataset):
@@ -509,8 +534,15 @@ class CachedLatentDataset(Dataset):
         return img_path.with_suffix(".npz")
 
     def _is_cache_valid(self, img_path, npz_path):
-        """检查缓存是否有效（图像未修改，且格式含 latent 键）。
-        若为其他模型的不兼容缓存，则删除并返回 False。"""
+        """检查缓存是否有效（图像未修改，且格式兼容当前 flip_augment 设置）。
+
+        - 缺 `latent` 键 / 其他模型的不兼容缓存 → 删除重 encode
+        - flip_augment=True 且 npz 缺 `latent_flipped` 键 → 失效重 encode（旧
+          单份 cache 即"flip 永久 baked"的污染状态，必须重 encode 修复）
+        - flip_augment=False 且 npz 有 `latent_flipped` → 仍视为有效（双份
+          cache 是 flip 模式的超集，关 flip 后只读 latent 不浪费）
+        - bucket 尺寸不匹配 → 失效
+        """
         if not npz_path.exists():
             return False
         if npz_path.stat().st_mtime < img_path.stat().st_mtime:
@@ -520,6 +552,8 @@ class CachedLatentDataset(Dataset):
                 if "latent" not in data.files:
                     npz_path.unlink()
                     logger.debug(f"已删除不兼容缓存: {npz_path.name}")
+                    return False
+                if getattr(self, "flip_augment", False) and "latent_flipped" not in data.files:
                     return False
                 expected_bucket = self._expected_bucket_size(img_path)
                 if expected_bucket is not None:
@@ -571,18 +605,38 @@ class CachedLatentDataset(Dataset):
             self.bucket_for_index[i] = (int(h), int(w))
 
     def _encode_and_save(self, indices, vae, device, dtype):
-        """编码图像并保存为 npz"""
+        """编码图像并保存为 npz。
+
+        flip_augment=True 时对每张图编码两次（flip=False / flip=True）分别存到
+        `latent` / `latent_flipped` 键；训练时 __getitem__ 随机选其一。
+        flip_augment=False 时只编码一次，存 `latent`。
+        """
+        base_img = self.base_image_dataset
+        want_flip = self.flip_augment and base_img is not None
         for count, i in enumerate(indices):
-            item = self.base_dataset[i]
+            npz_kwargs = {}
+            if base_img is not None:
+                # 显式控制 flip，避免随机性 baked 进 npz
+                item = base_img.get_with_flip(i, flip=False)
+            else:
+                item = self.base_dataset[i]
             pixels = item["pixel_values"].unsqueeze(0).to(device, dtype=dtype)
             _, _, ph, pw = pixels.shape
             bucket_w, bucket_h = pw, ph
             with torch.no_grad():
                 pixels_5d = pixels.unsqueeze(2)
                 latent = vae.model.encode(pixels_5d, vae.scale)
-            latent_np = latent.squeeze(0).cpu().float().numpy()
+            npz_kwargs["latent"] = latent.squeeze(0).cpu().float().numpy()
+
+            if want_flip:
+                item_f = base_img.get_with_flip(i, flip=True)
+                pixels_f = item_f["pixel_values"].unsqueeze(0).to(device, dtype=dtype)
+                with torch.no_grad():
+                    latent_f = vae.model.encode(pixels_f.unsqueeze(2), vae.scale)
+                npz_kwargs["latent_flipped"] = latent_f.squeeze(0).cpu().float().numpy()
+
             npz_path = self._get_npz_path(self.samples[i]["image"])
-            self.np.savez(npz_path, latent=latent_np, bucket_w=bucket_w, bucket_h=bucket_h)
+            self.np.savez(npz_path, bucket_w=bucket_w, bucket_h=bucket_h, **npz_kwargs)
             if (count + 1) % 10 == 0 or count == len(indices) - 1:
                 logger.info(f"  编码进度: {count + 1}/{len(indices)}")
 
@@ -593,8 +647,17 @@ class CachedLatentDataset(Dataset):
         sample = self.samples[idx]
         npz_path = self._get_npz_path(sample["image"])
         data = self.np.load(npz_path)
-        latent = torch.from_numpy(data["latent"])
-        
+        # flip_augment=True 且 npz 有 latent_flipped 时 50% 概率取镜像版本，
+        # 跟非 cache 路径 ImageDataset.__getitem__ 的 flip 概率一致。
+        # 没有 latent_flipped 键（flip_augment=False 时的单份 cache）就只读 latent。
+        use_flip = (
+            self.flip_augment
+            and "latent_flipped" in data.files
+            and random.random() > 0.5
+        )
+        latent_key = "latent_flipped" if use_flip else "latent"
+        latent = torch.from_numpy(data[latent_key])
+
         # 获取 base_dataset 的引用（处理可能的嵌套）
         base = self.base_dataset
         while hasattr(base, "dataset"):

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -96,7 +96,7 @@ class TrainingConfig(BaseModel):
     )
     flip_augment: bool = Field(
         True,
-        description="水平翻转增强",
+        description="水平翻转增强（与 cache_latents 同开时 VAE 缓存自动存原图+镜像两份 latent，训练时随机取，编码时间和缓存大小 ×2）",
         json_schema_extra=_meta("caption"),
     )
     tag_dropout: float = Field(

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -332,7 +332,7 @@
       "reg_weight": "Regularization loss weight",
       "shuffle_caption": "Shuffle tags (JSON mode shuffles within categories, TXT mode shuffles all tags)",
       "keep_tokens": "Protect the first N tags from shuffling (TXT mode only)",
-      "flip_augment": "Horizontal flip augmentation",
+      "flip_augment": "Horizontal flip augmentation (when combined with cache_latents, the VAE cache stores both original and flipped latents per image; encoding time and cache size both 2×)",
       "tag_dropout": "Random tag dropout probability",
       "prefer_json": "Prefer JSON tag files (recommended; supports category shuffle)",
       "cache_latents": "Cache VAE latents to speed up training",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -332,7 +332,7 @@
       "reg_weight": "正则集 loss 权重",
       "shuffle_caption": "启用标签打乱（JSON 模式分类内打乱，TXT 模式全部打乱）",
       "keep_tokens": "保护前 N 个标签不打乱（仅 TXT 模式）",
-      "flip_augment": "水平翻转增强",
+      "flip_augment": "水平翻转增强（与 cache_latents 同开时 VAE 缓存自动存原图+镜像两份 latent，训练时随机取，编码时间和缓存大小 ×2）",
       "tag_dropout": "标签随机丢弃概率",
       "prefer_json": "优先使用 JSON 标签文件（推荐，支持分类 shuffle）",
       "cache_latents": "缓存 VAE latent 加速训练",

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -49,6 +49,263 @@ def test_cached_latent_invalidates_when_resolution_bucket_changes(tmp_path: Path
     assert cached._is_cache_valid(img_path, npz_path) is True
 
 
+def test_cached_latent_invalidates_when_flip_augment_added(tmp_path: Path) -> None:
+    """老 cache（只有 latent，无 latent_flipped）+ flip_augment=True → 失效重 encode。
+
+    旧版本静默把 cache 阶段那次随机翻转 baked 进 npz，导致 50% 数据被永久镜像
+    污染；新版要求 flip_augment=True 时 npz 必须同时有 latent + latent_flipped。
+    """
+    pytest.importorskip("torch")
+    from PIL import Image
+    import numpy as np
+
+    from runtime.training.dataset import BucketManager, CachedLatentDataset, ImageDataset
+
+    img_path = tmp_path / "0001.png"
+    Image.new("RGB", (1024, 1024), color=(127, 127, 127)).save(img_path)
+    img_path.with_suffix(".txt").write_text("1girl", encoding="utf-8")
+    npz_path = img_path.with_suffix(".npz")
+    # 老格式 cache：只有 latent，无 latent_flipped
+    np.savez(
+        npz_path,
+        latent=np.zeros((16, 1, 128, 128), dtype=np.float32),
+        bucket_w=1024,
+        bucket_h=1024,
+    )
+
+    bucket_mgr = BucketManager(1024)
+    dataset = ImageDataset(tmp_path, 1024, bucket_mgr, flip_augment=True)
+    cached = object.__new__(CachedLatentDataset)
+    cached.base_dataset = dataset
+    cached.base_image_dataset = dataset
+    cached.np = np
+    cached.samples = dataset.samples
+    cached.cache_dir = None
+    cached.bucket_for_index = []
+    cached.flip_augment = True
+
+    # flip_augment=True 但 npz 缺 latent_flipped → 失效（强制重 encode）
+    assert cached._is_cache_valid(img_path, npz_path) is False
+
+    # 补全 latent_flipped → 有效
+    np.savez(
+        npz_path,
+        latent=np.zeros((16, 1, 128, 128), dtype=np.float32),
+        latent_flipped=np.zeros((16, 1, 128, 128), dtype=np.float32),
+        bucket_w=1024,
+        bucket_h=1024,
+    )
+    assert cached._is_cache_valid(img_path, npz_path) is True
+
+
+def test_cached_latent_accepts_double_cache_with_flip_off(tmp_path: Path) -> None:
+    """双份 cache + flip_augment=False → 仍有效（不强制再 encode；只读 latent）。
+
+    避免用户切 flip 开关时反复重 encode；双份是单份的超集。
+    """
+    pytest.importorskip("torch")
+    from PIL import Image
+    import numpy as np
+
+    from runtime.training.dataset import BucketManager, CachedLatentDataset, ImageDataset
+
+    img_path = tmp_path / "0001.png"
+    Image.new("RGB", (1024, 1024), color=(127, 127, 127)).save(img_path)
+    img_path.with_suffix(".txt").write_text("1girl", encoding="utf-8")
+    npz_path = img_path.with_suffix(".npz")
+    np.savez(
+        npz_path,
+        latent=np.zeros((16, 1, 128, 128), dtype=np.float32),
+        latent_flipped=np.zeros((16, 1, 128, 128), dtype=np.float32),
+        bucket_w=1024,
+        bucket_h=1024,
+    )
+
+    bucket_mgr = BucketManager(1024)
+    dataset = ImageDataset(tmp_path, 1024, bucket_mgr, flip_augment=False)
+    cached = object.__new__(CachedLatentDataset)
+    cached.base_dataset = dataset
+    cached.base_image_dataset = dataset
+    cached.np = np
+    cached.samples = dataset.samples
+    cached.cache_dir = None
+    cached.bucket_for_index = []
+    cached.flip_augment = False
+
+    assert cached._is_cache_valid(img_path, npz_path) is True
+
+
+class _FakeVAEModel:
+    """Mock VAE：encode 把 pixel mean / first-pixel signature 写进 latent，
+    让测试能区分『原图 latent』vs『flipped latent』。"""
+    def encode(self, pixels_5d, scale):
+        import torch
+        # pixels_5d: [B, C, T=1, H, W]
+        b, c, t, h, w = pixels_5d.shape
+        # 签名：取第一行的第一个像素值 + 最后一个像素值，写进 latent 头两个 channel
+        # flip 后这俩会对调 → 区分有无 flip
+        first = pixels_5d[:, 0:1, :, :, 0:1].mean(dim=(2, 3, 4), keepdim=True)
+        last = pixels_5d[:, 0:1, :, :, -1:].mean(dim=(2, 3, 4), keepdim=True)
+        latent = torch.zeros(b, 16, 1, h // 8, w // 8, dtype=pixels_5d.dtype)
+        latent[:, 0, 0, 0, 0] = first.squeeze()
+        latent[:, 1, 0, 0, 0] = last.squeeze()
+        return latent
+
+
+class _FakeVAE:
+    def __init__(self):
+        self.model = _FakeVAEModel()
+        self.scale = 1.0
+
+
+def test_cached_latent_encodes_both_flipped_and_unflipped_when_flip_aug(tmp_path: Path) -> None:
+    """flip_augment=True → cache 阶段对每张图 encode 两次，npz 同时有 latent + latent_flipped。
+
+    用 mock VAE 把图像第一列/最后一列 mean 编进 latent 签名，验证两份 latent 是
+    精确镜像对（latent[0,0,0,0,0] / latent[0,1,0,0,0] 在 flipped 版本里对调）。
+    """
+    pytest.importorskip("torch")
+    import torch
+    import numpy as np
+    from PIL import Image
+
+    from runtime.training.dataset import BucketManager, CachedLatentDataset, ImageDataset
+
+    img_path = tmp_path / "asym.png"
+    # 第一列纯红 (255,0,0)，最后一列纯蓝 (0,0,255)，区分明显
+    img = Image.new("RGB", (256, 256), color=(127, 127, 127))
+    for y in range(256):
+        img.putpixel((0, y), (255, 0, 0))
+        img.putpixel((255, y), (0, 0, 255))
+    img.save(img_path)
+    img_path.with_suffix(".txt").write_text("test", encoding="utf-8")
+
+    bucket_mgr = BucketManager(256, min_reso=256, max_reso=256, step=64)
+    dataset = ImageDataset(tmp_path, 256, bucket_mgr, flip_augment=True)
+    cached = CachedLatentDataset(dataset, _FakeVAE(), device="cpu", dtype=torch.float32)
+
+    npz_path = img_path.with_suffix(".npz")
+    with np.load(npz_path) as data:
+        assert "latent" in data.files
+        assert "latent_flipped" in data.files
+        # 原图：第一列红（pixel→[-1, 1] 范围内 R 通道高），最后一列蓝（B 通道高）
+        # mock encode 用 channel-0 mean 当签名；R=1.0/G=B=-1.0 → mean = -1/3
+        # 翻转后第一列变蓝、最后一列变红，签名对调
+        sig_orig_first = float(data["latent"][0, 0, 0, 0])
+        sig_orig_last = float(data["latent"][1, 0, 0, 0])
+        sig_flip_first = float(data["latent_flipped"][0, 0, 0, 0])
+        sig_flip_last = float(data["latent_flipped"][1, 0, 0, 0])
+        # flipped 的 first 应当等于 orig 的 last（左右调换），反之亦然
+        assert abs(sig_flip_first - sig_orig_last) < 1e-5
+        assert abs(sig_flip_last - sig_orig_first) < 1e-5
+        # 且 first ≠ last（确保签名真的有区分性，不是 mock 永远写 0）
+        assert abs(sig_orig_first - sig_orig_last) > 1e-3
+
+
+def test_cached_latent_encodes_single_when_flip_aug_off(tmp_path: Path) -> None:
+    """flip_augment=False → npz 只有 latent，不浪费时间编 flipped 版本。"""
+    pytest.importorskip("torch")
+    import torch
+    import numpy as np
+    from PIL import Image
+
+    from runtime.training.dataset import BucketManager, CachedLatentDataset, ImageDataset
+
+    img_path = tmp_path / "x.png"
+    Image.new("RGB", (256, 256), color=(127, 127, 127)).save(img_path)
+    img_path.with_suffix(".txt").write_text("t", encoding="utf-8")
+
+    bucket_mgr = BucketManager(256, min_reso=256, max_reso=256, step=64)
+    dataset = ImageDataset(tmp_path, 256, bucket_mgr, flip_augment=False)
+    cached = CachedLatentDataset(dataset, _FakeVAE(), device="cpu", dtype=torch.float32)
+
+    npz_path = img_path.with_suffix(".npz")
+    with np.load(npz_path) as data:
+        assert "latent" in data.files
+        assert "latent_flipped" not in data.files
+
+
+def test_cached_latent_getitem_picks_flipped_per_random(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """flip_augment=True 时 __getitem__ 按 random 50% 取 latent_flipped；
+    flip_augment=False 时永远取 latent（即使 npz 有 flipped 也忽略）。
+    """
+    pytest.importorskip("torch")
+    import torch
+    import numpy as np
+    from PIL import Image
+
+    from runtime.training.dataset import BucketManager, CachedLatentDataset, ImageDataset
+    from runtime.training import dataset as dataset_mod
+
+    img_path = tmp_path / "y.png"
+    Image.new("RGB", (256, 256), color=(127, 127, 127)).save(img_path)
+    img_path.with_suffix(".txt").write_text("t", encoding="utf-8")
+
+    bucket_mgr = BucketManager(256, min_reso=256, max_reso=256, step=64)
+    dataset = ImageDataset(tmp_path, 256, bucket_mgr, flip_augment=True)
+    cached = CachedLatentDataset(dataset, _FakeVAE(), device="cpu", dtype=torch.float32)
+
+    # 注入显式的 latent / latent_flipped 值便于分辨
+    npz_path = img_path.with_suffix(".npz")
+    latent_orig = np.full((16, 1, 32, 32), 1.0, dtype=np.float32)
+    latent_flip = np.full((16, 1, 32, 32), 2.0, dtype=np.float32)
+    np.savez(npz_path, latent=latent_orig, latent_flipped=latent_flip, bucket_w=256, bucket_h=256)
+
+    # random.random() > 0.5 控制选 flipped；patch 成 0.9 (>0.5) → flipped
+    monkeypatch.setattr(dataset_mod.random, "random", lambda: 0.9)
+    item = cached[0]
+    assert float(item["latent"][0, 0, 0, 0]) == 2.0  # flipped
+
+    # patch 成 0.1 (<0.5) → 原图
+    monkeypatch.setattr(dataset_mod.random, "random", lambda: 0.1)
+    item = cached[0]
+    assert float(item["latent"][0, 0, 0, 0]) == 1.0  # 原图
+
+    # flip_augment=False 时永远取原图（即使 npz 有 flipped 和 random=0.9）
+    cached.flip_augment = False
+    monkeypatch.setattr(dataset_mod.random, "random", lambda: 0.9)
+    item = cached[0]
+    assert float(item["latent"][0, 0, 0, 0]) == 1.0
+
+
+def test_image_dataset_get_with_flip_independent_of_random_state(tmp_path: Path) -> None:
+    """get_with_flip 不读 self.flip_augment，也不掷骰子 —— 用于 cache 双份编码。
+
+    flip=False / flip=True 必须得到精确镜像对，否则 cache 会写入随机性，污染数据。
+    """
+    pytest.importorskip("torch")
+    import random as _random
+    from PIL import Image
+
+    from runtime.training.dataset import ImageDataset
+
+    img_path = tmp_path / "asymmetric.png"
+    # 非对称图：左半红 右半蓝，flip 后左蓝右红
+    img = Image.new("RGB", (256, 256), color=(255, 0, 0))
+    for x in range(128, 256):
+        for y in range(256):
+            img.putpixel((x, y), (0, 0, 255))
+    img.save(img_path)
+    img_path.with_suffix(".txt").write_text("test", encoding="utf-8")
+
+    dataset = ImageDataset(tmp_path, 256, flip_augment=True)
+
+    _random.seed(0)
+    item_no_flip = dataset.get_with_flip(0, flip=False)
+    _random.seed(99)  # 不同 seed
+    item_no_flip_2 = dataset.get_with_flip(0, flip=False)
+    # flip=False 在任何 random 状态下结果一致
+    assert (item_no_flip["pixel_values"] == item_no_flip_2["pixel_values"]).all()
+
+    item_flipped = dataset.get_with_flip(0, flip=True)
+    # flip=True 与 flip=False 应当左右镜像（取一行验证 pixel 顺序反过来）
+    row_no_flip = item_no_flip["pixel_values"][:, 100, :]  # CxHxW，取 H=100 行
+    row_flipped = item_flipped["pixel_values"][:, 100, :]
+    # flipped 的最后一列等于原图的第一列（左右翻）
+    assert (row_no_flip[:, 0] == row_flipped[:, -1]).all()
+    assert (row_no_flip[:, -1] == row_flipped[:, 0]).all()
+
+
 def test_image_dataset_loads_caption_utils_when_prefer_json(tmp_path: Path) -> None:
     """Regression: dataset.py 算 caption_utils.py 路径时少回溯一层 parent 会让
     JSON caption 模式静默 fallback 到 TXT（utils/ 在仓库根，不在 runtime/utils/）。"""


### PR DESCRIPTION
## 背景

`CachedLatentDataset._encode_and_save` 调 `base_dataset[i]` 拿 pixel，而 `ImageDataset.__getitem__` 里 `if flip_augment and random.random() > 0.5: img.transpose(...)` 在 cache 阶段就掷骰子 → **cache 那一次随机决定每张图永久存为翻转 / 不翻转**，之后训练 `CachedLatentDataset.__getitem__` 只读 npz 不再 invoke base flip。

后果：
- flip_augment 静默失效（用户以为有，实际没有）
- 50% 数据被永久镜像污染（每次启训随机一半图被翻成镜像）

## 改动

按 kohya-ss/sd-scripts `ImageInfo.latents / latents_flipped` 双份 latent 方案修复：

1. `ImageDataset.get_with_flip(idx, *, flip: bool)` 抽出 flip 控制，与 `self.flip_augment` / random 解耦。`__getitem__` 调它传随机决策，`CachedLatentDataset` cache 阶段显式传 `flip=False` / `flip=True`
2. `CachedLatentDataset._encode_and_save` 按 `self.flip_augment` 决定单 / 双份编码；双份存 npz 的 `latent` + `latent_flipped` 两键
3. `_is_cache_valid` 新增校验：`flip_augment=True` 且 npz 缺 `latent_flipped` 键 → 失效重 encode（**自动修复历史污染 cache**）；反向 `flip_augment=False` 时双份仍有效（超集），切开关不反复重 encode
4. `__getitem__` 读 npz 时按 `random.random() > 0.5` 选 `latent` / `latent_flipped`，跟非 cache 路径 `ImageDataset` flip 概率一致

代价：`flip_augment=True` 时编码时间和 cache 大小都 ×2，但训练里 flip 真生效。

## 测试

`tests/test_datasets.py` 加 6 用例：

- 老 cache + `flip_augment=True` 触发失效重 encode
- 双份 cache + `flip_augment=False` 仍有效（避免来回重编码）
- `get_with_flip` 不读 random state，`flip=False` / `True` 是精确镜像对
- `flip_augment=True` build 后 npz 同时有 `latent` + `latent_flipped`（用 `_FakeVAE` 把图像 first-col / last-col mean 编进 latent 签名严格验证）
- `flip_augment=False` build 后 npz 只有 `latent`，不浪费时间
- `__getitem__` 在 random > 0.5 时取 `latent_flipped`、< 0.5 时取 `latent`；`flip_augment=False` 时永远取 `latent`

回归：dataset + bucket 21/21 ✓；schema 套（attention/noise/lokr/...）139/139 ✓