### PR TITLE
fix(tests): preprocess fixture 不再砸真 upscaler 权重

### DIFF
--- a/tests/test_preprocess_endpoints.py
+++ b/tests/test_preprocess_endpoints.py
@@ -26,9 +26,14 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(secrets, "SECRETS_FILE", tmp_path / "secrets.json")
 
-    # 让 upscaler_target 指到 tmp 内的"假权重"，避免端点检查 409
+    # 让 upscaler_target 指到 tmp 内的"假权重"，避免端点检查 409。
+    # 必须 patch `paths.models_root` 而不是 `model_downloader.models_root` —
+    # 后者只是 __init__ 的 re-export，而 upscaler_target 在 paths.py 内部用
+    # 本模块的 models_root 调用；patch re-export 不会改到调用点，会让 dummy
+    # 权重写到 REPO_ROOT/models/upscalers/ 把真模型干掉。
+    from studio.services.models import paths as _paths
     models_root = tmp_path / "models"
-    monkeypatch.setattr(model_downloader, "models_root", lambda: models_root)
+    monkeypatch.setattr(_paths, "models_root", lambda: models_root)
     weight = model_downloader.upscaler_target("4x-AnimeSharp")
     weight.parent.mkdir(parents=True, exist_ok=True)
     weight.write_bytes(b"dummy-weights")


### PR DESCRIPTION
## Summary

`tests/test_preprocess_endpoints.py` 的 `isolated` fixture 想把
`upscaler_target("4x-AnimeSharp")` 指到 tmp_path 然后写 `b"dummy-weights"`
当假权重。但 monkeypatch 打错了对象 — patch 的是
`studio.services.models.__init__` 里 re-export 的 `models_root` 别名，
而 `upscaler_target` 在 `paths.py` 内部用本模块的 `models_root()` 调用，
patch 不传播。

后果：每次跑 pytest 都把 13 字节 ASCII `dummy-weights` 写进
**真实** `REPO_ROOT/models/upscalers/4x-AnimeSharp.pth`，把 64MB 的
真权重盖掉。下次开预处理 worker 调 `torch.load` 解 13 字节 pickle，
抛 `_pickle.UnpicklingError: could not find MARK`，所有图 fail。

## Fix

改 patch `studio.services.models.paths.models_root`（实际调用点），
patch 立刻生效。加了一段注释说明这个 re-export vs source 的坑，
防再次踩。

## Test plan

- [x] `pytest tests/test_preprocess_endpoints.py -q` → 18 passed
- [x] 测试跑完后 `models/upscalers/4x-AnimeSharp.pth` 不再被覆盖

## Notes

- 本地真权重已被砸过，需要用户在 Settings 页重新下载（我已经做了）
- scope 限定 tests，不动 production 代码

🤖 Generated with [Claude Code](https://claude.com/claude-code)