### PR TITLE
Fix/reg prior caption format

### DIFF
--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -11,9 +11,10 @@
 
 逻辑：
   1. 扫 train 目录所有图 + caption
-  2. 每张图 → tag 去除 excluded → ", " 拼成 prompt → 生成 1 张正则图
-  3. 输出到 reg/{对应子文件夹}/{stem}_ai_{seed}.png（镜像 train 子目录结构）
-  4. 同名 .txt 写入用过的 prompt
+  2. 每张图先把训练图同名 tag 文件复制为 reg 输出图的同名 tag 文件
+  3. 从 reg 侧 tag 文件读取 tags，去除 excluded，按 Anima 空格 tag 规范拼 prompt
+     并把 reg 侧 tag 文件重写为实际 prompt（JSON 保持标准 JSON 形态）
+  4. 输出到 reg/{对应子文件夹}/{stem}_ai_{seed}.png（镜像 train 子目录结构）
   5. reg/meta.json 写 generation_method="ai_base", api_source=""
      （与 booru 拉取共用 reg_builder.RegMeta schema，不再撞名重写）
 
@@ -25,6 +26,7 @@ import argparse
 import json
 import logging
 import random
+import shutil
 import sys
 import time
 from collections import Counter
@@ -44,6 +46,10 @@ import anima_train as _T  # noqa: E402
 
 # 复用 reg_builder.RegMeta（PR-9 commit 2 加了 generation_method 字段）
 from studio.services.reg.builder import RegMeta, read_meta, write_meta  # noqa: E402
+from studio.services.tagging.caption_format import (  # noqa: E402
+    caption_json_to_tags,
+    caption_json_to_text,
+)
 
 logging.basicConfig(
     level=logging.INFO,
@@ -62,17 +68,341 @@ def parse_args() -> argparse.Namespace:
     return p.parse_args()
 
 
-def _read_tags(img_path: Path) -> list[str]:
-    """读图片旁边的 .txt caption，返回 raw tag 列表（不归一化）。"""
-    txt = img_path.with_suffix(".txt")
-    if not txt.exists():
+CAPTION_SUFFIXES = (".json", ".txt", ".caption")
+
+
+def _tag_key(tag: str) -> str:
+    """Canonical key for matching/excluding tags.
+
+    Anima prompts should use spaces, not underscores.  We still treat spaces and
+    underscores as equivalent for exclude matching so older UI/booru-style
+    excluded tags continue to work.
+    """
+    return " ".join(str(tag or "").strip().lower().replace("_", " ").split())
+
+
+def _dedupe_tags(tags: list[str]) -> list[str]:
+    """去重但保留原始 tag 文本与顺序。"""
+    out: list[str] = []
+    seen: set[str] = set()
+    for tag in tags:
+        text = str(tag or "").strip()
+        key = _tag_key(text)
+        if not text or key in seen:
+            continue
+        seen.add(key)
+        out.append(text)
+    return out
+
+
+def _prompt_tag(tag: str) -> str:
+    """Normalize one tag for Anima text encoders: lowercase, spaces, no underscores."""
+    return _tag_key(tag)
+
+
+def _read_json_tags(json_path: Path) -> list[str]:
+    data = json.loads(json_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
         return []
-    raw = txt.read_text(encoding="utf-8", errors="ignore").strip()
-    return [t.strip() for t in raw.split(",") if t.strip()]
+
+    tags: list[str] = []
+    meta = data.get("meta")
+    if isinstance(meta, dict):
+        trigger = meta.get("trigger")
+        if isinstance(trigger, str) and trigger.strip():
+            tags.append(trigger.strip())
+    tags.extend(caption_json_to_tags(data))
+    return _dedupe_tags(tags)
+
+
+def _read_text_tags(caption_path: Path) -> list[str]:
+    raw = caption_path.read_text(encoding="utf-8", errors="ignore").strip()
+    if not raw:
+        return []
+    if "," in raw:
+        return [t.strip() for t in raw.split(",") if t.strip()]
+    return [t.strip() for t in raw.split() if t.strip()]
+
+
+def _caption_candidates_for_image(img_path: Path) -> list[Path]:
+    return [
+        p for suffix in CAPTION_SUFFIXES
+        if (p := img_path.with_suffix(suffix)).exists()
+    ]
+
+
+def _read_tags_from_caption(caption_path: Path) -> list[str]:
+    if caption_path.suffix == ".json":
+        return _read_json_tags(caption_path)
+    return _read_text_tags(caption_path)
+
+
+def _caption_path_for_image(img_path: Path) -> Path | None:
+    """Return the first readable sidecar caption path, preferring JSON."""
+    for p in _caption_candidates_for_image(img_path):
+        try:
+            _read_tags_from_caption(p)
+            return p
+        except Exception as e:
+            logger.warning("caption 读取失败 %s: %s", p, e)
+    return None
+
+
+def _read_tags(img_path: Path) -> list[str]:
+    """读图片旁边的 caption，返回 raw tag 列表（不归一化）。
+
+    JSON caption 优先，TXT/CAPTION 作为回退；与训练数据集 / 标签编辑器保持
+    同一套 JSON 语义，避免先验生成在 Step 4 选择 JSON 打标时拿不到 prompt。
+    """
+    caption_path = _caption_path_for_image(img_path)
+    if caption_path is None:
+        return []
+    return _read_tags_from_caption(caption_path)
+
+
+def _copy_caption_for_reg(train_img_path: Path, out_img_path: Path) -> Path | None:
+    """Copy train sidecar caption to the generated reg image sidecar path."""
+    src = _caption_path_for_image(train_img_path)
+    if src is None:
+        return None
+    suffix = ".txt" if src.suffix == ".caption" else src.suffix
+    dst = out_img_path.with_suffix(suffix)
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(src, dst)
+    return dst
+
+
+def _build_prompt_from_caption(caption_path: Path, excluded_tags: set[str]) -> str:
+    """Build an Anima prior prompt from a reg-side caption file."""
+    return ", ".join(_prompt_tags_from_caption(caption_path, excluded_tags))
+
+
+def _prompt_tags_from_caption(caption_path: Path, excluded_tags: set[str]) -> list[str]:
+    """Return normalized prompt tags from a caption file."""
+    prompt_tags: list[str] = []
+    seen: set[str] = set()
+    for raw_tag in _read_tags_from_caption(caption_path):
+        tag = _prompt_tag(raw_tag)
+        if not tag or tag in excluded_tags or tag in seen:
+            continue
+        seen.add(tag)
+        prompt_tags.append(tag)
+    return prompt_tags
+
+
+def _take_prompt_tag(
+    raw_tag: object,
+    excluded_tags: set[str],
+    seen: set[str],
+) -> str | None:
+    tag = _prompt_tag(str(raw_tag or ""))
+    if not tag or tag in excluded_tags or tag in seen:
+        return None
+    seen.add(tag)
+    return tag
+
+
+def _split_tag_value(value: object) -> list[object]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return value.split(",")
+    if isinstance(value, (list, tuple, set)):
+        return list(value)
+    return [value]
+
+
+def _filter_prompt_tag_list(
+    raw_tags: object,
+    excluded_tags: set[str],
+    seen: set[str],
+) -> list[str]:
+    out: list[str] = []
+    for raw_tag in _split_tag_value(raw_tags):
+        tag = _take_prompt_tag(raw_tag, excluded_tags, seen)
+        if tag:
+            out.append(tag)
+    return out
+
+
+def _filter_tag_collection(
+    value: object,
+    excluded_tags: set[str],
+    seen: set[str],
+) -> str | list[str]:
+    tags = _filter_prompt_tag_list(value, excluded_tags, seen)
+    if isinstance(value, str):
+        return ", ".join(tags)
+    return tags
+
+
+def _filter_scalar_tag(
+    value: object,
+    excluded_tags: set[str],
+    seen: set[str],
+) -> str:
+    return _take_prompt_tag(value, excluded_tags, seen) or ""
+
+
+def _character_text(value: object) -> str:
+    if isinstance(value, dict):
+        full = str(value.get("full") or "").strip()
+        if full:
+            return full
+        parts = [
+            str(value.get("name") or "").strip(),
+            str(value.get("variant") or "").strip(),
+        ]
+        return ", ".join(p for p in parts if p)
+    return str(value or "").strip()
+
+
+def _filter_character_value(
+    value: object,
+    excluded_tags: set[str],
+    seen: set[str],
+) -> object:
+    tag = _take_prompt_tag(_character_text(value), excluded_tags, seen)
+    if not isinstance(value, dict):
+        return tag or ""
+
+    out = dict(value)
+    if not tag:
+        for key in ("name", "variant", "full"):
+            if key in out:
+                out[key] = ""
+        return out
+
+    if "full" in out or not ("name" in out or "variant" in out):
+        out["full"] = tag
+    if "name" in out and not str(out.get("variant") or "").strip():
+        out["name"] = tag
+    return out
+
+
+def _filter_meta_trigger(data: dict, excluded_tags: set[str], seen: set[str]) -> None:
+    meta = data.get("meta") if isinstance(data.get("meta"), dict) else None
+    if meta is None:
+        return
+    trigger = _take_prompt_tag(meta.get("trigger"), excluded_tags, seen)
+    if trigger:
+        meta["trigger"] = trigger
+    else:
+        meta.pop("trigger", None)
+
+
+def _filter_standard_json(data: dict, excluded_tags: set[str]) -> dict:
+    out = dict(data)
+    tags = dict(out.get("tags") if isinstance(out.get("tags"), dict) else {})
+    out["tags"] = tags
+    seen: set[str] = set()
+    _filter_meta_trigger(out, excluded_tags, seen)
+
+    tags["quality"] = _filter_prompt_tag_list(tags.get("quality"), excluded_tags, seen)
+    for key in ("count", "character", "series", "artist"):
+        tags[key] = _filter_scalar_tag(tags.get(key), excluded_tags, seen)
+    for key in ("appearance", "tags", "environment"):
+        tags[key] = _filter_prompt_tag_list(tags.get(key), excluded_tags, seen)
+    tags["nl"] = str(tags.get("nl") or "").strip()
+    return out
+
+
+def _filter_documented_full_json(data: dict, excluded_tags: set[str]) -> dict:
+    out = dict(data)
+    fixed = dict(out.get("fixed") if isinstance(out.get("fixed"), dict) else {})
+    character = out.get("character")
+    ai = dict(out.get("ai_output") if isinstance(out.get("ai_output"), dict) else {})
+    from_path = dict(out.get("from_path") if isinstance(out.get("from_path"), dict) else {})
+    out["fixed"] = fixed
+    out["character"] = character
+    out["ai_output"] = ai
+    if "from_path" in out:
+        out["from_path"] = from_path
+
+    seen: set[str] = set()
+    _filter_meta_trigger(out, excluded_tags, seen)
+
+    fixed["quality"] = _filter_tag_collection(fixed.get("quality"), excluded_tags, seen)
+    ai["count"] = _filter_scalar_tag(ai.get("count"), excluded_tags, seen)
+    out["character"] = _filter_character_value(character, excluded_tags, seen)
+    fixed["series"] = _filter_scalar_tag(fixed.get("series"), excluded_tags, seen)
+    fixed["artist"] = _filter_scalar_tag(fixed.get("artist"), excluded_tags, seen)
+
+    ai["appearance"] = _filter_prompt_tag_list(ai.get("appearance"), excluded_tags, seen)
+    for key in ("appearance", "extra_appearance"):
+        if key in from_path:
+            from_path[key] = _filter_prompt_tag_list(from_path.get(key), excluded_tags, seen)
+
+    ai["tags"] = _filter_prompt_tag_list(ai.get("tags"), excluded_tags, seen)
+    for key in ("tags", "extra_tags"):
+        if key in from_path:
+            from_path[key] = _filter_prompt_tag_list(from_path.get(key), excluded_tags, seen)
+
+    ai["environment"] = _filter_prompt_tag_list(ai.get("environment"), excluded_tags, seen)
+    ai["nl"] = str(ai.get("nl") or "").strip()
+    return out
+
+
+def _filter_simple_tags_json(data: dict, excluded_tags: set[str]) -> dict:
+    out = dict(data)
+    seen: set[str] = set()
+    _filter_meta_trigger(out, excluded_tags, seen)
+    out["tags"] = _filter_prompt_tag_list(out.get("tags"), excluded_tags, seen)
+    return out
+
+
+def _filter_simplified_json(data: dict, excluded_tags: set[str]) -> dict:
+    out = dict(data)
+    seen: set[str] = set()
+    _filter_meta_trigger(out, excluded_tags, seen)
+    if "quality" in out:
+        out["quality"] = _filter_tag_collection(out.get("quality"), excluded_tags, seen)
+    for key in ("count", "character", "series", "artist"):
+        if key in out:
+            out[key] = _filter_scalar_tag(out.get(key), excluded_tags, seen)
+    for key in ("appearance", "tags", "environment"):
+        if key in out:
+            out[key] = _filter_prompt_tag_list(out.get(key), excluded_tags, seen)
+    if "nl" in out:
+        out["nl"] = str(out.get("nl") or "").strip()
+    return out
+
+
+def _filter_json_caption(raw: dict, excluded_tags: set[str]) -> dict:
+    tags_obj = raw.get("tags")
+    if isinstance(tags_obj, dict):
+        return _filter_standard_json(raw, excluded_tags)
+    if "ai_output" in raw or "fixed" in raw or "from_path" in raw:
+        return _filter_documented_full_json(raw, excluded_tags)
+    if isinstance(tags_obj, list):
+        return _filter_simple_tags_json(raw, excluded_tags)
+    return _filter_simplified_json(raw, excluded_tags)
+
+
+def _rewrite_json_caption_for_prompt(caption_path: Path, excluded_tags: set[str]) -> str:
+    """Rewrite a reg JSON sidecar while preserving its source JSON shape."""
+    raw = json.loads(caption_path.read_text(encoding="utf-8"))
+    filtered = _filter_json_caption(raw if isinstance(raw, dict) else {}, excluded_tags)
+    prompt = caption_json_to_text(filtered)
+    caption_path.write_text(
+        json.dumps(filtered, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return prompt
+
+
+def _rewrite_caption_for_prompt(caption_path: Path, excluded_tags: set[str]) -> str:
+    """Persist the reg sidecar caption that corresponds to the generated image."""
+    if caption_path.suffix == ".json":
+        return _rewrite_json_caption_for_prompt(caption_path, excluded_tags)
+
+    prompt = _build_prompt_from_caption(caption_path, excluded_tags)
+    caption_path.write_text(prompt, encoding="utf-8")
+    return prompt
 
 
 def _normalize(tag: str) -> str:
-    return tag.lower().strip().replace(" ", "_")
+    return _tag_key(tag)
 
 
 def _scan_train(train_dir: Path) -> list[dict]:
@@ -113,6 +443,17 @@ def _already_has_reg(reg_sub: Path, train_stem: str) -> bool:
         ):
             return True
     return False
+
+
+def _clear_reg_dir(reg_dir: Path) -> None:
+    """Clear old reg outputs before a full AI prior generation run."""
+    if not reg_dir.exists():
+        return
+    for child in reg_dir.iterdir():
+        if child.is_dir():
+            shutil.rmtree(child)
+        else:
+            child.unlink()
 
 
 def _write_meta_final(
@@ -252,19 +593,15 @@ def main() -> None:
 
     model.eval()
 
+    if not incremental:
+        logger.info("full 模式：清空旧 reg 内容")
+        _clear_reg_dir(reg_dir)
+
     # 生成循环
     total = len(to_generate)
     actual_count = 0
 
     for idx, entry in enumerate(to_generate):
-        tags = [_normalize(t) for t in entry["tags"]]
-        tags = [t for t in tags if t and t not in excluded_tags]
-
-        if not tags:
-            logger.warning(f"[{idx + 1}/{total}] {entry['img'].name} 过滤后无 tag，跳过")
-            continue
-
-        prompt = ", ".join(tags)
         seed = (base_seed + idx) if base_seed != 0 else random.randint(0, 2**31 - 1)
         torch.manual_seed(seed)
         random.seed(seed)
@@ -275,8 +612,25 @@ def main() -> None:
 
         out_name = f"{entry['stem']}_ai_{seed}.png"
         out_path = reg_sub / out_name
+        caption_path = _copy_caption_for_reg(entry["img"], out_path)
+        if caption_path is None:
+            logger.warning(f"[{idx + 1}/{total}] {entry['img'].name} 无 tag 文件，跳过")
+            continue
+
+        try:
+            prompt = _rewrite_caption_for_prompt(caption_path, excluded_tags)
+        except Exception as e:
+            logger.warning(f"[{idx + 1}/{total}] {caption_path.name} 读取失败，跳过: {e}")
+            caption_path.unlink(missing_ok=True)
+            continue
+
+        if not prompt:
+            logger.warning(f"[{idx + 1}/{total}] {entry['img'].name} 过滤后无 tag，跳过")
+            caption_path.unlink(missing_ok=True)
+            continue
 
         logger.info(f"[{idx + 1}/{total}] {entry['img'].name} -> {out_name}")
+        logger.info(f"  caption: {caption_path.name}")
         logger.info(f"  prompt: {prompt[:80]}")
 
         try:
@@ -294,13 +648,14 @@ def main() -> None:
                 dtype=dtype,
             )
             img.save(out_path)
-            out_path.with_suffix(".txt").write_text(prompt, encoding="utf-8")
             actual_count += 1
             logger.info(f"  已保存: {out_path}")
             if _update_monitor:
                 _update_monitor(sample_path=str(out_path), step=idx + 1)
         except Exception as e:
             logger.error(f"  生成失败: {e}")
+            if not out_path.exists():
+                caption_path.unlink(missing_ok=True)
 
     _write_meta_final(reg_dir, entries, excluded_tags, incremental, actual_count)
     logger.info(f"完成: {actual_count}/{total} 张")


### PR DESCRIPTION
  ## 背景

  AI 先验生成之前只读取 `.txt` caption，并且会把 tag 里的空格转换成下划线。

  这会导致两个问题：

  - 使用 JSON caption 打标的训练集无法被 AI 先验生成正确读取
  - Anima prompt 会变成 `brown_hair` 这类下划线格式，而项目文档和训练路径都使用 `brown hair` 这种空格格
  式

  ## 改动

  - 支持 AI 先验生成读取 `.json/.txt/.caption` 训练集 caption
  - 生成前先把训练图同名 tag 文件复制到 reg 输出图的同名 sidecar
    - `.json` 保持为 `.json`
    - `.txt` 保持为 `.txt`
    - `.caption` 复制为 `.txt`
  - 从 reg 侧 sidecar 读取 tags 后再构造生成 prompt
  - prompt 保留 Anima 推荐的空格 tag 格式，不再转换为下划线
  - `excluded_tags` 会同步写回 reg sidecar
    - TXT：删除后写回 `.txt`
    - JSON：结构化删除 tag 字段，同时保留原 JSON 形态和 `nl` 自然语言
  - full 模式会先清空旧 reg 输出，避免旧 caption 混入训练；incremental 模式只补新图
  - excluded tag 匹配时兼容空格和下划线，避免旧的 booru/UI 风格排除项失效

  ## 测试

  - [x] 本地断言验证：
    - TXT caption 会写回删除 excluded 后的内容
    - JSON caption 会保留原字段形态并删除 excluded tag
    - JSON `nl` 自然语言会保留
    - 训练读取 JSON 的 caption 与生成 prompt 一致
    - full 模式会清空旧 reg 输出
  - [ ] `pytest` 未运行：当前本地 venv 未安装 pytest

  ## 备注

  这是一个窄范围 bugfix，只改 AI 先验生成 caption 处理逻辑，不涉及前端、训练主循环、模型加载或 booru 正
  则构建逻辑。