### PR TITLE
fix(deps): 补 SOCKS5 代理依赖 — httpx[socks] + requests[socks]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,13 @@ psutil>=5.9.0
 # 两者都导出 `import pynvml` 模块名，但老 pynvml 已 unmaintained 会打 deprecation 警告。
 nvidia-ml-py>=12.0
 rich>=13.7.0
-requests>=2.31.0
+# requests[socks] / httpx[socks]：SOCKS5 代理支持。
+# 用户在 Settings → 代理 配 socks5:// URL 时，requests 走 PySocks（booru/modelscope
+# 下载链），huggingface_hub 1.x 走 httpx + socksio（HF 下载链）。两个 extras 都不装
+# 时，下载报 `'socksio' package is not installed` / `Missing dependencies for SOCKS`，
+# 安装本身无 C 扩展、跨平台。
+requests[socks]>=2.31.0
+httpx[socks]>=0.27
 
 # PP4 — WD14 打标
 # onnxruntime 由 studio 启动期按 GPU 检测自动安装（services/onnxruntime_setup.py）：


### PR DESCRIPTION
## 背景 / 动机

用户在 Settings → 代理 配 `socks5://...` 后下载主模型报：

```
✗ anima-base-v1.0.safetensors: Using SOCKS proxy, but the 'socksio' package is not installed.
  Make sure to install httpx using pip install httpx[socks].
```

根因：`requirements.txt` 没声明 SOCKS5 所需的两个 extras。

两条下载链路用不同 HTTP 客户端，各自需要不同的 SOCKS backend：

| 链路 | HTTP 客户端 | SOCKS 依赖 |
|---|---|---|
| `huggingface_hub.hf_hub_download`（HF 下载） | httpx | `socksio` |
| `proxy_manager.patch_requests_session` + `requests.Session.proxies`（booru / modelscope 链） | requests | `PySocks` |

> 注：`huggingface_hub` **1.0.0** 开始把下载 transport 从 requests 换成 httpx。我们 `requirements.txt` 钉的 `>=0.20.0` 是敞口的，pip 拉到 1.14.0 后这条报错从「`Missing dependencies for SOCKS support`（PySocks 缺）」变成现在的「`'socksio' package is not installed`」。底层「我们从未声明 SOCKS extras」的漏洞 0.x 时代就有，只是当时几乎没人碰 socks5:// 链路所以没暴露。

## 改动

`requirements.txt`：

```diff
-requests>=2.31.0
+requests[socks]>=2.31.0
+httpx[socks]>=0.27
```

并加一段中文注释说明两个 extras 各自服务于哪条链路、装它们不引入 C 扩展、跨平台 OK。

`httpx` 此前是 `huggingface_hub` 的传递依赖，本次显式列出 + `[socks]` extra，让"装这条 line 等于打开 SOCKS 支持"在 requirements 里看得见，避免下一次再被传递依赖隐性变更搅动。

## 测试方式

- 本地 `pip install 'httpx[socks]' 'requests[socks]'` 确认两个 extras 在干净环境里确实缺失（输出装上了 `socksio-1.0.0` + `PySocks-1.7.1`）
- 没跑 `python -m studio test`：纯 deps 改动不动 Python 代码，pytest 覆盖不到 requirements.txt 内容；CI 在干净环境装 requirements 才是真验证

## 范围外（不在本 PR）

`huggingface_hub>=0.20.0` 这种敞口 pin 让 0.x → 1.x major 跳变直接落用户机器；1.x 除 transport 切换外还可能有别的 API surface 破坏性变更（xet / HfFileSystem 行为）。建议另开 issue 做一次 1.x 兼容性 audit + 收紧 pin（如 `>=0.20.0,<2`），不在本 hotfix 范围。