### PR TITLE
feat(ui): 代理改名为 "Booru 代理" 移到数据集 tab — 删网络 tab

### DIFF
--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -674,11 +674,10 @@
     "tabGenerate": "Generate",
     "tabAppearance": "Appearance",
     "tabSystem": "System",
-    "tabNetwork": "Network",
     "proxy": {
-      "sectionTitle": "Network Proxy (HTTP/HTTPS)",
+      "sectionTitle": "Booru Proxy",
       "enableLabel": "Enable Proxy",
-      "enableDesc": "After enabling, some backend network requests (model downloads, Booru scraping) will go through the proxy  configured below.",
+      "enableDesc": "When enabled, Booru scraping requests go through the proxy configured below. Only covers the Booru download path; model downloads (HuggingFace / ModelScope) do not use this proxy.",
       "httpLabel": "HTTP Proxy Address",
       "httpDesc": "e.g. http://127.0.0.1:7890 or http://proxy.example.com:8080",
       "httpsLabel": "HTTPS Proxy Address",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -674,11 +674,10 @@
     "tabGenerate": "测试",
     "tabAppearance": "页面",
     "tabSystem": "系统",
-    "tabNetwork": "网络",
     "proxy": {
-      "sectionTitle": "网络代理 (HTTP/HTTPS)",
+      "sectionTitle": "Booru 代理",
       "enableLabel": "启用代理",
-      "enableDesc": "开启后，部分后端网络请求（模型下载、Booru 抓图）将经过下方配置的代理。",
+      "enableDesc": "开启后，Booru 抓图请求将经过下方配置的代理。仅覆盖 Booru 下载链路，模型下载（HuggingFace / ModelScope）不走此代理。",
       "httpLabel": "HTTP 代理地址",
       "httpDesc": "例如 http://127.0.0.1:7890 或 http://proxy.example.com:8080",
       "httpsLabel": "HTTPS 代理地址",

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -60,7 +60,7 @@ type Section =
   | 'generate'
   | 'proxy'
 
-type Tab = 'dataset' | 'tagging' | 'preprocess' | 'training' | 'monitor' | 'testing' | 'appearance' | 'system' | 'network'
+type Tab = 'dataset' | 'tagging' | 'preprocess' | 'training' | 'monitor' | 'testing' | 'appearance' | 'system'
 
 // 外部页面通过 `?section=<id>` 跳转到 SettingsPage 的特定 section 时，用这个
 // 反向映射决定要先切到哪个 tab。只列出能从外部链接到的 sections。
@@ -80,7 +80,6 @@ const TAB_LIST: { id: Tab; labelKey: string }[] = [
   { id: 'testing', labelKey: 'settings.tabGenerate' },
   { id: 'appearance', labelKey: 'settings.tabAppearance' },
   { id: 'system', labelKey: 'settings.tabSystem' },
-  { id: 'network', labelKey: 'settings.tabNetwork' },
 ]
 
 // 每个 tab 的 section index — 用于右侧 sticky 导航。id 与各 section 的 DOM id
@@ -90,6 +89,7 @@ const TAB_SECTIONS: Record<Tab, { id: string; labelKey: string }[]> = {
     { id: 'gelbooru', labelKey: 'settings.gelbooru' },
     { id: 'danbooru', labelKey: 'settings.danbooru' },
     { id: 'download-global', labelKey: 'settings.downloadGlobal' },
+    { id: 'proxy', labelKey: 'settings.proxy.sectionTitle' },
   ],
   preprocess: [
     { id: 'upscalers', labelKey: 'settings.upscalers' },
@@ -120,9 +120,6 @@ const TAB_SECTIONS: Record<Tab, { id: string; labelKey: string }[]> = {
   system: [
     { id: 'version', labelKey: 'settings.version' },
     { id: 'service', labelKey: 'settings.service' },
-  ],
-  network: [
-    { id: 'proxy', labelKey: 'settings.proxy.sectionTitle' },
   ],
 }
 
@@ -178,7 +175,7 @@ function getStoredTab(): Tab {
     if (
       v === 'dataset' || v === 'tagging' || v === 'preprocess' || v === 'training'
       || v === 'monitor' || v === 'testing' || v === 'appearance'
-      || v === 'system' || v === 'network'
+      || v === 'system'
     ) return v
   } catch {
     /* ignore localStorage errors */
@@ -701,6 +698,72 @@ export default function SettingsPage() {
           </div>
         </div>
       </SettingsSection>
+
+      <SettingsSection id="proxy" title={t('settings.proxy.sectionTitle')}>
+        <SettingsField label={t('settings.proxy.enableLabel')}>
+          <Bool
+            value={draft.proxy.enabled}
+            onChange={(v) => update('proxy', 'enabled', v)}
+          />
+          <p className="text-xs text-fg-tertiary mt-1">
+            {t('settings.proxy.enableDesc')}
+          </p>
+        </SettingsField>
+
+        <SettingsField
+          label={t('settings.proxy.httpLabel')}
+          desc={t('settings.proxy.httpDesc')}
+        >
+          <input
+            type="text"
+            value={draft.proxy.http_proxy}
+            onChange={(e) => update('proxy', 'http_proxy', e.target.value)}
+            placeholder="http://127.0.0.1:7890"
+            className={textInputClass}
+            disabled={!draft.proxy.enabled}
+          />
+        </SettingsField>
+
+        <SettingsField
+          label={t('settings.proxy.httpsLabel')}
+          desc={t('settings.proxy.httpsDesc')}
+        >
+          <input
+            type="text"
+            value={draft.proxy.https_proxy}
+            onChange={(e) => update('proxy', 'https_proxy', e.target.value)}
+            placeholder="http://127.0.0.1:7890"
+            className={textInputClass}
+            disabled={!draft.proxy.enabled}
+          />
+        </SettingsField>
+
+        <SettingsField
+          label={t('settings.proxy.noProxyLabel')}
+          desc={t('settings.proxy.noProxyDesc')}
+        >
+          <input
+            type="text"
+            value={draft.proxy.no_proxy}
+            onChange={(e) => update('proxy', 'no_proxy', e.target.value)}
+            placeholder="localhost,127.0.0.1"
+            className={textInputClass}
+            disabled={!draft.proxy.enabled}
+          />
+        </SettingsField>
+
+        <div className="text-xs text-fg-tertiary border-t border-subtle pt-3 mt-1">
+          <p className="m-0">{t('settings.proxy.tipsTitle')}</p>
+          <ul className="list-disc pl-4 m-0 mt-1 space-y-0.5">
+            <li>{t('settings.proxy.tips1')}</li>
+            <li>
+              {t('settings.proxy.tips2')}
+              <code className="text-fg-primary">http://user:pass@host:port</code>
+            </li>
+            <li>{t('settings.proxy.tips3')}</li>
+          </ul>
+        </div>
+      </SettingsSection>
       </>)}
 
       {tab === 'tagging' && (<>
@@ -1055,73 +1118,6 @@ export default function SettingsPage() {
         <SystemSection />
       )}
 
-      {tab === 'network' && (
-        <SettingsSection title={t('settings.proxy.sectionTitle')}>
-          <SettingsField label={t('settings.proxy.enableLabel')}>
-            <Bool
-              value={draft.proxy.enabled}
-              onChange={(v) => update('proxy', 'enabled', v)}
-            />
-            <p className="text-xs text-fg-tertiary mt-1">
-              {t('settings.proxy.enableDesc')}
-            </p>
-          </SettingsField>
-      
-          <SettingsField
-            label={t('settings.proxy.httpLabel')}
-            desc={t('settings.proxy.httpDesc')}
-          >
-            <input
-              type="text"
-              value={draft.proxy.http_proxy}
-              onChange={(e) => update('proxy', 'http_proxy', e.target.value)}
-              placeholder="http://127.0.0.1:7890"
-              className={textInputClass}
-              disabled={!draft.proxy.enabled}
-            />
-          </SettingsField>
-      
-          <SettingsField
-            label={t('settings.proxy.httpsLabel')}
-            desc={t('settings.proxy.httpsDesc')}
-          >
-            <input
-              type="text"
-              value={draft.proxy.https_proxy}
-              onChange={(e) => update('proxy', 'https_proxy', e.target.value)}
-              placeholder="http://127.0.0.1:7890"
-              className={textInputClass}
-              disabled={!draft.proxy.enabled}
-            />
-          </SettingsField>
-      
-          <SettingsField
-            label={t('settings.proxy.noProxyLabel')}
-            desc={t('settings.proxy.noProxyDesc')}
-          >
-            <input
-              type="text"
-              value={draft.proxy.no_proxy}
-              onChange={(e) => update('proxy', 'no_proxy', e.target.value)}
-              placeholder="localhost,127.0.0.1"
-              className={textInputClass}
-              disabled={!draft.proxy.enabled}
-            />
-          </SettingsField>
-      
-          <div className="text-xs text-fg-tertiary border-t border-subtle pt-3 mt-1">
-            <p className="m-0">{t('settings.proxy.tipsTitle')}</p>
-            <ul className="list-disc pl-4 m-0 mt-1 space-y-0.5">
-              <li>{t('settings.proxy.tips1')}</li>
-              <li>
-                {t('settings.proxy.tips2')}
-                <code className="text-fg-primary">http://user:pass@host:port</code>
-              </li>
-              <li>{t('settings.proxy.tips3')}</li>
-            </ul>
-          </div>
-        </SettingsSection>
-      )}
     </div>
 
     <SectionIndex sections={TAB_SECTIONS[tab]} scrollContainer={scrollContainerRef} />


### PR DESCRIPTION
## 背景 / 动机

调查 PR #190（补 `httpx[socks]` / `requests[socks]`）时发现的相关 UX bug。

PR #162 (`feat: 添加全局代理配置支持`) 在 UI 上叫"全局代理"，但实际数据流：

| 链路 | HTTP 客户端 | proxy_manager 是否注入 |
|---|---|---|
| Booru pool / downloader | requests | ✓ `patch_requests_session` |
| ModelScope SDK | requests | ✗ |
| HuggingFace 下载 | httpx（hf_hub 1.x） | ✗ |

PR #162 原版本里有个 `setup_global_httpx_client()` 想把 socks5:// 灌进 hf_hub 的 httpx client，但它 import 了 `huggingface_hub.set_client_factory` —— 这个符号 hf_hub 里根本不存在。hotfix #165 (`dd6b8dd`) 把整段代码删了。

结果就是：UI 上叫"全局代理"，代码注释里写"当前只覆盖 booru 下载链路"。用户填了 `socks5://...` 以为 HF 下载也走代理，实际啥也没发生。

## 改动

- 删独立的"网络" tab（`tabNetwork` i18n key、`Tab` 联合类型成员、TAB_LIST 条目、`TAB_SECTIONS.network`、`getStoredTab` whitelist）
- 把代理 section 移到「数据集」tab 末尾，顺序：`gelbooru` / `danbooru` / `download-global` / `proxy`
- Section title `"网络代理 (HTTP/HTTPS)"` → `"Booru 代理"` / `"Booru Proxy"`
- `enableDesc` 删掉 `"模型下载"` 这条不实陈述，明确说明"仅覆盖 Booru 下载链路，模型下载（HuggingFace / ModelScope）不走此代理"

不动 `secrets.proxy` schema，后端 API 完全兼容；用户存的代理配置不丢。

## 反向兼容性

- 之前在 localStorage 存了 `studio.settings.activeTab = "network"` 的用户：`getStoredTab` 不再匹配，自动降级到默认 `'dataset'` tab —— 无感
- 不动 `secrets.proxy` 字段名（http_proxy / https_proxy / no_proxy / enabled），后端读取链路完全无改动

## 测试方式

- worktree 里没装 node_modules，跳本地 `npm run lint` / `tsc`；改动是纯机械搬迁 + 字符串替换 + tab 路由删除，CI 跑 lint/typecheck 是真验证
- 手动核查：grep `tabNetwork` / `'network'` / `网络代理` / `Network Proxy` 全仓库无残留
- JSX 闭合手动验证（最后一个 tab gate 是 `system`，包装 div 闭合不变）

## 范围外

`proxy_manager` 当前只接 booru、不接 ModelScope/HF 的事，不在本 PR 改 —— 那是真正"扩大代理覆盖范围"的功能性改动，需要单独 PR 处理 httpx client 的 monkeypatch（且需要 `socksio` 已通过 PR #190 装好）。