### PR TITLE
refactor(studio): task 档案搬出 version 子树到 tasks/<id>/

### DIFF
--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -162,11 +162,14 @@ def run(ctx: TrainingContext) -> None:
     # 创建输出目录
     ctx.output_dir = Path(args.output_dir)
     ctx.output_dir.mkdir(parents=True, exist_ok=True)
-    # 采样图落到 monitor state 同级 samples/。监控 state file 由 supervisor 按
-    # task 注入（--monitor-state-file），采样图随之按 task 隔离；samples.py 优先
-    # 在 monitor_dir/samples 解析。没传（纯 CLI 训练）退回 output_dir/samples。
+    # 采样图落到 task 档案根的 samples/。supervisor 按 task 注入
+    # `--monitor-state-file <studio_data>/tasks/<id>/monitor/state.json`，
+    # sample_dir 取其上跳一层的 `samples/` —— `tasks/<id>/samples/`，跟 monitor/
+    # 同级，整组（snapshot/ monitor/ samples/ run.log）就是 task 完整档案。
+    # 没传 --monitor-state-file（纯 CLI 训练 / 兼容老版本注入路径）退回
+    # output_dir/samples，samples.py 仍可在 monitor_dir 周围多候选搜回。
     _msf = getattr(args, "monitor_state_file", None)
-    ctx.sample_dir = (Path(_msf).parent / "samples") if _msf else (ctx.output_dir / "samples")
+    ctx.sample_dir = (Path(_msf).parent.parent / "samples") if _msf else (ctx.output_dir / "samples")
     ctx.sample_dir.mkdir(parents=True, exist_ok=True)
     # supervisor 启动训练时通过 env LORA_TASK_ID 注入 queue task id（ADR 0006）。
     # 用于 ctx.state_dir() 计算 per-task state 子目录；env 不存在时 fallback unknown。

--- a/studio/api/routers/logs.py
+++ b/studio/api/routers/logs.py
@@ -1,7 +1,8 @@
 """任务日志读取（PR-6 commit 1 从 server.py 抽出）。
 
 1 route：
-    GET /api/logs/{task_id}    读 LOGS_DIR/{task_id}.log，去掉 worker EVENT 行
+    GET /api/logs/{task_id}    读 tasks/<id>/run.log（老 task fallback
+                               LOGS_DIR/<id>.log），去掉 worker EVENT 行
 """
 from __future__ import annotations
 
@@ -9,14 +10,18 @@ from typing import Any
 
 from fastapi import APIRouter
 
-from ...paths import LOGS_DIR
+from ...paths import LOGS_DIR, task_log_path
 
 router = APIRouter()
 
 
 @router.get("/api/logs/{task_id}")
 def get_log(task_id: int) -> dict[str, Any]:
-    p = LOGS_DIR / f"{task_id}.log"
+    # 新 task 走 tasks/<id>/run.log；老 task 在 studio_data/logs/<id>.log，
+    # 不写迁移脚本（DB 里也没记 log 路径，看哪个存在），按存在性 fallback。
+    p = task_log_path(task_id)
+    if not p.exists():
+        p = LOGS_DIR / f"{task_id}.log"
     if not p.exists():
         return {"task_id": task_id, "content": "", "size": 0}
     raw = p.read_text(encoding="utf-8", errors="replace")

--- a/studio/api/routers/queue/lifecycle.py
+++ b/studio/api/routers/queue/lifecycle.py
@@ -25,7 +25,7 @@ from ...deps import _supervisor
 from ...schemas.queue import EnqueueRequest, ReorderRequest
 from .... import db
 from ....infrastructure.event_bus import bus
-from ....paths import USER_PRESETS_DIR
+from ....paths import USER_PRESETS_DIR, task_dir
 
 router = APIRouter()
 
@@ -257,4 +257,12 @@ def delete_queue_item(task_id: int) -> dict[str, Any]:
         if task["status"] not in db.TERMINAL_STATUSES:
             raise HTTPException(400, "only terminal tasks can be deleted")
         db.delete_task(conn, task_id)
+    # task-scoped 档案（snapshot/config.yaml / monitor/state.json / samples/ /
+    # run.log）跟 task DB 行同生命周期 —— 删 task 一并清。老 task 散在
+    # studio_data/logs/<id>.log / studio_data/monitors/task_<id>/ 的不动
+    # （不写迁移脚本，留作老版本兼容性测试数据）。
+    import shutil
+    tdir = task_dir(task_id)
+    if tdir.exists():
+        shutil.rmtree(tdir, ignore_errors=True)
     return {"deleted": task_id}

--- a/studio/api/routers/samples.py
+++ b/studio/api/routers/samples.py
@@ -16,7 +16,7 @@ from fastapi.responses import FileResponse
 from .. import errors as _errors
 from ..responses import _thumb_response
 from ... import db
-from ...paths import OUTPUT_DIR
+from ...paths import OUTPUT_DIR, task_samples_dir
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -30,9 +30,11 @@ def get_sample(
 ) -> FileResponse:
     """采样图代理。
 
-    `?task_id=N` 给了 → 在该任务 monitor_state_path 周围按多个候选目录查找：
-    - `monitor_state.json` 同级 `samples/`（PP6.1 当初约定）
-    - `monitor_state.json` 同级 `output/samples/`（anima_train 实际写法 ——
+    `?task_id=N` 给了 → 按多个候选目录查找：
+    - **新（task-scoped）** `studio_data/tasks/<task_id>/samples/`
+    - `monitor_state.json` 同级 `samples/`（PP6.1 v0.5.0+ 老 task 兼容；
+      state file 在 versions/<v>/monitor/task_<id>/ 时，samples 也在那）
+    - `monitor_state.json` 同级 `output/samples/`（pre-PP6.1 老 task；
       sample_dir = output_dir/samples，output_dir 通常是 versions/{label}/output）
     - 同级 `output/<任意子目录>/samples/`（兜底防 anima_train 用别的 output 名）
 
@@ -55,7 +57,12 @@ def get_sample(
             raise HTTPException(404)
         monitor_dir = Path(row["monitor_state_path"]).parent
         candidates = [
+            # task-scoped 档案 —— 新 task 写在这（migration 之后唯一目标）
+            task_samples_dir(task_id) / filename,
+            # 老 task 兼容：state.json 同级 samples/（PP6.1 v0.5.0+ +
+            # c3961d9 unreleased dev 期间的过渡布局）
             monitor_dir / "samples" / filename,
+            # 老 task 兼容：output/samples/（pre-PP6.1）
             monitor_dir / "output" / "samples" / filename,
         ]
         # 再扫一层 output/<sub>/samples/ 兜底（用户改 output_dir 名字时仍能找到）

--- a/studio/infrastructure/paths.py
+++ b/studio/infrastructure/paths.py
@@ -21,8 +21,20 @@ STUDIO_DATA = REPO_ROOT / "studio_data"
 STUDIO_DB = STUDIO_DATA / "studio.db"
 USER_PRESETS_DIR = STUDIO_DATA / "presets"
 USER_CONFIGS_DIR = USER_PRESETS_DIR  # 兼容别名（PP0 后将随 configs_io 一起移除）
+# LOGS_DIR：pre-task-scoped layout 时所有 task 日志的扁平目录。
+# 新 task 走 `tasks/<id>/run.log`（见 task_log_path）；这个目录仅保留给
+# 老 task 兼容读取（不写新）。
 LOGS_DIR = STUDIO_DATA / "logs"
 THUMB_CACHE_DIR = STUDIO_DATA / "thumb_cache"
+
+# Task-scoped 档案根目录。每个 task 独立子目录，跟 version 解耦，
+# 删 version 不会带走 task 历史（loss / 参数 / sample / 日志）。
+# 子目录约定（snapshot/ 已由 task_snapshot.py 引入 ADR-0007 §11.7）：
+#   tasks/<id>/snapshot/config.yaml   ← task 启动时 freeze 的 config
+#   tasks/<id>/monitor/state.json     ← 训练监控状态（loss/LR/sample 索引）
+#   tasks/<id>/samples/*.png          ← 训练采样图
+#   tasks/<id>/run.log                ← worker 子进程 stdout/stderr
+TASKS_DIR = STUDIO_DATA / "tasks"
 
 # React 前端
 WEB_DIR = REPO_ROOT / "studio" / "web"
@@ -43,6 +55,49 @@ def ensure_dirs() -> None:
     migrate_configs_to_presets()
     for d in (USER_PRESETS_DIR, LOGS_DIR, DATA_EXPORTS):
         d.mkdir(parents=True, exist_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Task-scoped 路径 helper
+# ---------------------------------------------------------------------------
+#
+# 所有 helper 都不 mkdir —— 调用方按需 mkdir(parents=True, exist_ok=True)。
+# 跟 task_snapshot.snapshot_dir 已有约定保持一致：snapshot_dir(id) 也是
+# `tasks/<id>/snapshot/` 一个子目录，本组 helper 提供 monitor/samples/log 三个
+# sibling，组合起来就是 task 完整档案。
+
+def task_dir(task_id: int) -> Path:
+    """`studio_data/tasks/<task_id>/` —— task 档案根。"""
+    return TASKS_DIR / str(int(task_id))
+
+
+def task_monitor_state_path(task_id: int) -> Path:
+    """`tasks/<task_id>/monitor/state.json` —— 训练监控状态文件。
+
+    取代旧路径：
+    - `versions/<v>/monitor/task_<id>/state.json`（PP6.1，v0.5.0+，仍兼容读）
+    - `versions/<v>/monitor_state.json`（pre-PP6.1，仍兼容读）
+    - `studio_data/monitors/task_<id>/state.json`（无 version_id 兜底，仍兼容读）
+    """
+    return task_dir(task_id) / "monitor" / "state.json"
+
+
+def task_samples_dir(task_id: int) -> Path:
+    """`tasks/<task_id>/samples/` —— 训练采样图。
+
+    runtime 写：`runtime/training/phases/bootstrap.py` 把 ctx.sample_dir 指向这里。
+    API 读：`studio/api/routers/samples.py` 候选首位。
+    """
+    return task_dir(task_id) / "samples"
+
+
+def task_log_path(task_id: int) -> Path:
+    """`tasks/<task_id>/run.log` —— worker 子进程 stdout/stderr。
+
+    取代旧路径 `studio_data/logs/<task_id>.log`（仍兼容读）。
+    `project_jobs` 的日志（`studio_data/jobs/<job_id>.log`）是另一套，不动。
+    """
+    return task_dir(task_id) / "run.log"
 
 
 # ---------------------------------------------------------------------------

--- a/studio/services/task_snapshot.py
+++ b/studio/services/task_snapshot.py
@@ -21,19 +21,19 @@ from typing import Any, Optional
 
 import yaml
 
-from ..paths import STUDIO_DATA
+from ..paths import task_dir
 
 SNAPSHOT_CONFIG_FILENAME = "config.yaml"
 
 
-def snapshot_root() -> Path:
-    """所有 task snapshot 落到 ``studio_data/tasks/``。"""
-    return STUDIO_DATA / "tasks"
-
-
 def snapshot_dir(task_id: int) -> Path:
-    """``studio_data/tasks/{task_id}/snapshot/``。"""
-    return snapshot_root() / str(int(task_id)) / "snapshot"
+    """``studio_data/tasks/{task_id}/snapshot/``。
+
+    跟 monitor/ samples/ run.log sibling，整组是 task 完整档案。
+    路径由 `paths.task_dir` 派生，跟其他 task-scoped helper 同源；
+    测试只需 monkeypatch `paths.TASKS_DIR` 一次即可隔离全部。
+    """
+    return task_dir(task_id) / "snapshot"
 
 
 def snapshot_config_path(task_id: int) -> Path:

--- a/studio/supervisor/cmd_builder.py
+++ b/studio/supervisor/cmd_builder.py
@@ -10,8 +10,7 @@ import sys
 from pathlib import Path
 from typing import Any, Callable
 
-from .. import db
-from ..paths import REPO_ROOT, STUDIO_DATA
+from ..paths import REPO_ROOT, task_monitor_state_path
 
 # PP10.2.b：哪些 job kind 吃 GPU。这些 kind 在训练运行中默认会被推迟，
 # 除非 secrets.queue.allow_gpu_during_train=True 显式允许并行。
@@ -67,41 +66,19 @@ def _default_cmd_builder(task: dict[str, Any], config_path: Path) -> list[str]:
 
 
 def _resolve_monitor_state_path(task: dict[str, Any]) -> Path:
-    """PP6.1 — 决定 task 的 monitor_state.json 落盘路径（按 task 隔离）。
+    """决定 task 的 monitor_state.json 落盘路径。
 
-    每个 task 落到独立子目录，避免同一 version 下多个 task 互相覆盖监控曲线
-    与采样图。旧实现按 version 落 `versions/{label}/monitor_state.json`，同
-    version 第二个 task 一跑就盖掉第一个，监控页查 task1 看到的却是 task2。
+    一律落 `studio_data/tasks/<id>/monitor/state.json`，跟 version 解耦：
+    - 删 version 不再带走 task 历史（loss 曲线 / 采样图）
+    - 同一 version 多次跑的 task 各自独立档案，用户可以拉出来对比
 
-    有 version_id：`versions/{label}/monitor/task_{id}/state.json` —— 仍挂在
-    version 目录下（删 version 时一并清理），但按 task 分目录。采样图由 runtime
-    写到 state.json 同级 `samples/`（见 bootstrap.py），samples.py 按
-    `monitor_dir/samples` 解析，于是采样图也随之按 task 隔离。
-    没有 version_id（PP1 之前的旧任务）：兜底到
-    `studio_data/monitors/task_{id}/state.json`。
-
-    兼容老任务：已跑过的老任务 monitor_state_path 早存进 DB（指向旧的 version
-    级文件），读取走存量值不受影响；samples.py 仍保留 `monitor_dir/output/samples`
-    候选，旧采样图照常可见。本改动只影响此后新启动的 task。
+    历史路径仅保留**读**兼容（老 task DB monitor_state_path 列保留旧值，
+    读端按值取，新 task 不再写这些路径）：
+    - `versions/<label>/monitor/task_<id>/state.json` —— PP6.1（v0.5.0+）
+    - `versions/<label>/monitor_state.json` —— pre-PP6.1
+    - `studio_data/monitors/task_<id>/state.json` —— 无 version_id 兜底
     """
-    vid = task.get("version_id")
-    pid = task.get("project_id")
-    if vid and pid:
-        # 不在这里 import projects/versions（避免循环）；直接通过 db 查
-        with db.connection_for() as conn:
-            row = conn.execute(
-                "SELECT projects.slug AS slug, versions.label AS label "
-                "FROM versions JOIN projects ON versions.project_id = projects.id "
-                "WHERE versions.id = ?",
-                (vid,),
-            ).fetchone()
-        if row:
-            return (
-                STUDIO_DATA / "projects" / f"{pid}-{row['slug']}"
-                / "versions" / row["label"] / "monitor" / f"task_{task['id']}"
-                / "state.json"
-            )
-    return STUDIO_DATA / "monitors" / f"task_{task['id']}" / "state.json"
+    return task_monitor_state_path(task["id"])
 
 
 def _default_job_cmd_builder(job: dict[str, Any]) -> list[str]:

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -34,7 +34,15 @@ from typing import Any, Callable, Optional
 from .. import db, secrets as _secrets
 from ..services.projects import jobs as project_jobs
 from ..infrastructure.log_tail import LogTailer, MonitorStatePoller
-from ..paths import LOGS_DIR, REPO_ROOT, STUDIO_DATA, STUDIO_DB, USER_PRESETS_DIR
+from ..paths import (
+    LOGS_DIR,
+    REPO_ROOT,
+    STUDIO_DATA,
+    STUDIO_DB,
+    USER_PRESETS_DIR,
+    task_dir,
+    task_log_path,
+)
 from ..services.inference.daemon import (
     InferenceDaemon,
     STATE_STOPPED as _DAEMON_STOPPED,
@@ -517,16 +525,19 @@ class Supervisor:
 
             self._freeze_task_snapshot(int(task["id"]), cfg_path)
 
-            # PP6.1 — 计算 per-task monitor 状态文件路径
-            # 有 version_id：versions/{label}/monitor_state.json
-            # 没有：studio_data/monitors/task_{id}/state.json（兜底）
+            # task-scoped 档案：monitor state 一律落 tasks/<id>/monitor/state.json，
+            # 跟 version 解耦（之前在 versions/<label>/monitor/task_<id>/state.json，
+            # 删 version 会一并丢掉 task 历史）
             monitor_state_path = _resolve_monitor_state_path(task)
             # 提前注入到 task dict 供 cmd_builder 用，以及落库
             task = dict(task)
             task["monitor_state_path"] = str(monitor_state_path)
 
-            self._logs_dir.mkdir(parents=True, exist_ok=True)
-            log_path = self._logs_dir / f"{task['id']}.log"
+            # task-scoped 档案：日志落 tasks/<id>/run.log，跟 monitor / samples /
+            # snapshot 同根。老 task 跑过的 studio_data/logs/<id>.log 由 logs.py
+            # fallback 读，不再写新文件到那。
+            log_path = task_log_path(task["id"])
+            log_path.parent.mkdir(parents=True, exist_ok=True)
             log_fp = open(log_path, "wb")
 
             cmd = self._cmd_builder(task, cfg_path)
@@ -1159,9 +1170,12 @@ class Supervisor:
                     "pid": None,
                 }
                 if status == "failed":
-                    # B-1.6: tail jobs/<id>.log 末 12 行（含 Traceback 优先）
-                    # 拼到 error_msg，UI Task 列表能直接看到根因，不必每次翻 trace
-                    tail = _tail_log_for_error_msg(self._logs_dir / f"{cid}.log")
+                    # B-1.6: tail task run.log 末 12 行（含 Traceback 优先）
+                    # 拼到 error_msg，UI Task 列表能直接看到根因，不必每次翻 trace。
+                    # 新 task 走 tasks/<id>/run.log；老 task fallback 到旧 logs/<id>.log。
+                    new_log = task_log_path(cid)
+                    tail_src = new_log if new_log.exists() else self._logs_dir / f"{cid}.log"
+                    tail = _tail_log_for_error_msg(tail_src)
                     fields["error_msg"] = (
                         f"exit code {rc}\n{tail}" if tail else f"exit code {rc}"
                     )

--- a/tests/test_daemon_gpu_yield.py
+++ b/tests/test_daemon_gpu_yield.py
@@ -16,14 +16,18 @@ from studio.supervisor import Supervisor
 
 
 @pytest.fixture
-def env(tmp_path: Path):
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from studio.infrastructure import paths as _paths
     db_path = tmp_path / "studio.db"
     db.init_db(db_path)
     logs = tmp_path / "logs"
     configs = tmp_path / "configs"
+    tasks = tmp_path / "tasks"
     logs.mkdir()
     configs.mkdir()
-    return {"db": db_path, "logs": logs, "configs": configs}
+    monkeypatch.setattr(_paths, "TASKS_DIR", tasks)
+    monkeypatch.setattr(_paths, "LOGS_DIR", logs)
+    return {"db": db_path, "logs": logs, "configs": configs, "tasks": tasks}
 
 
 @pytest.fixture

--- a/tests/test_inference_daemon.py
+++ b/tests/test_inference_daemon.py
@@ -221,14 +221,18 @@ def _patch_singleton(d: InferenceDaemon, monkeypatch) -> None:
 
 
 @pytest.fixture
-def env(tmp_path: Path):
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from studio.infrastructure import paths as _paths
     db_path = tmp_path / "studio.db"
     db.init_db(db_path)
     logs = tmp_path / "logs"
     configs = tmp_path / "configs"
+    tasks = tmp_path / "tasks"
     logs.mkdir()
     configs.mkdir()
-    return {"db": db_path, "logs": logs, "configs": configs}
+    monkeypatch.setattr(_paths, "TASKS_DIR", tasks)
+    monkeypatch.setattr(_paths, "LOGS_DIR", logs)
+    return {"db": db_path, "logs": logs, "configs": configs, "tasks": tasks}
 
 
 def _task_status(db_path: Path, task_id: int) -> str:

--- a/tests/test_resume_path.py
+++ b/tests/test_resume_path.py
@@ -83,43 +83,61 @@ def test_cmd_builder_resume_after_monitor_state_file(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# _resolve_monitor_state_path —— per-task 隔离（同 version 多 task 串台修复）
+# _resolve_monitor_state_path —— task-scoped 档案（跟 version 解耦）
 # ---------------------------------------------------------------------------
 
 
 def test_monitor_state_path_isolated_per_task_same_version(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """同一 version 下两个 task 的 monitor_state_path 必须互不相同、各含自己的
-    task id。回归：旧实现按 version 落 monitor_state.json，第二个 task 跑起来
-    盖掉第一个的曲线 / 采样图 → 监控页查 task1 显示的是 task2。"""
-    from studio.services.projects import projects, versions
+    """同 version 下两个 task 的 monitor_state_path 互不相同、各含自己的
+    task id；都落 tasks/<id>/monitor/state.json，跟 version 标签无关。
+    回归 1：旧 pre-PP6.1 实现按 version 落 monitor_state.json，第二个 task
+    覆盖第一个 → 监控页 task1 看到 task2。
+    回归 2：PP6.1 (v0.5.0+) 仍把 task 子目录挂在 versions/<v>/monitor/ 下，
+    删 version 一并丢历史，task 之间无法对比 → 现在搬出 version 子树。"""
     from studio.supervisor.cmd_builder import _resolve_monitor_state_path
 
-    dbfile = tmp_path / "studio.db"
-    db.init_db(dbfile)
-    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
-    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
-    with db.connection_for(dbfile) as conn:
-        p = projects.create_project(conn, title="P")
-        v = versions.create_version(conn, project_id=p["id"], label="baseline")
-
-    base = {"version_id": v["id"], "project_id": p["id"]}
+    # version_id / project_id 现在不再参与路径计算（task-scoped）
+    base = {"version_id": 999, "project_id": 1}
     p1 = _resolve_monitor_state_path({**base, "id": 1})
     p2 = _resolve_monitor_state_path({**base, "id": 2})
 
     assert p1 != p2
-    assert "task_1" in p1.parts and "task_2" in p2.parts
-    assert "baseline" in p1.parts        # 仍挂在 version 目录下（删 version 一并清）
-    assert p1.name == "state.json"
+    assert p1.parts[-4:] == ("tasks", "1", "monitor", "state.json")
+    assert p2.parts[-4:] == ("tasks", "2", "monitor", "state.json")
 
 
-def test_monitor_state_path_old_task_without_version_fallback() -> None:
-    """PP1 之前的老任务（无 version_id）兜底到 monitors/task_{id}/state.json。"""
+def test_monitor_state_path_no_version_still_task_scoped() -> None:
+    """没 version_id 也走 tasks/<id>/monitor/state.json（之前是兜底
+    monitors/task_<id>/state.json，老 task DB 列保留旧值由读端兼容）。"""
     from studio.supervisor.cmd_builder import _resolve_monitor_state_path
 
     pth = _resolve_monitor_state_path({"id": 7})
-    assert pth.parts[-3:] == ("monitors", "task_7", "state.json")
+    assert pth.parts[-4:] == ("tasks", "7", "monitor", "state.json")
+
+
+def test_task_paths_helpers_form_a_consistent_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """task_monitor_state_path / task_samples_dir / task_log_path 必须落同一个
+    tasks/<id>/ 根 —— 调用方依赖这点（监控页 SSE / 删除清理）。"""
+    from studio.infrastructure import paths as _paths
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "tasks")
+
+    msp = _paths.task_monitor_state_path(42)
+    samples = _paths.task_samples_dir(42)
+    log = _paths.task_log_path(42)
+    snapshot = _paths.task_dir(42) / "snapshot" / "config.yaml"
+
+    root = tmp_path / "tasks" / "42"
+    assert msp == root / "monitor" / "state.json"
+    assert samples == root / "samples"
+    assert log == root / "run.log"
+    # 跟 task_snapshot.snapshot_dir 拼出来的路径完全一致，确保 task 档案
+    # 不被 snapshot/ 单独的 helper 拉到别处。
+    from studio.services.task_snapshot import snapshot_dir
+    assert snapshot_dir(42) == root / "snapshot"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -25,16 +25,24 @@ def _wait_for(predicate, timeout=5.0, interval=0.05):
 
 
 @pytest.fixture
-def env(tmp_path: Path):
-    """初始化 db + 目录，并提供一个有效 config 文件。"""
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """初始化 db + 目录，并提供一个有效 config 文件。
+
+    task-scoped 档案（tasks/<id>/run.log + monitor/state.json + samples/）
+    会落到 STUDIO_DATA/tasks/，测试里 monkeypatch TASKS_DIR 到 tmp 隔离。
+    """
+    from studio.infrastructure import paths as _paths
     db_path = tmp_path / "studio.db"
     db.init_db(db_path)
     logs = tmp_path / "logs"
     configs = tmp_path / "configs"
+    tasks = tmp_path / "tasks"
     logs.mkdir()
     configs.mkdir()
+    monkeypatch.setattr(_paths, "TASKS_DIR", tasks)
+    monkeypatch.setattr(_paths, "LOGS_DIR", logs)
     (configs / "fake.yaml").write_text("epochs: 1\n", encoding="utf-8")
-    return {"db": db_path, "logs": logs, "configs": configs}
+    return {"db": db_path, "logs": logs, "configs": configs, "tasks": tasks}
 
 
 def _events_collector():
@@ -289,7 +297,9 @@ def test_monitor_state_path_passed_to_cmd_and_db(env, monkeypatch) -> None:
 
     # cmd_builder 收到的 task dict 含 monitor_state_path
     assert captured.get("cmd_msp"), "cmd_builder 没拿到 monitor_state_path"
-    assert "task_" in captured["cmd_msp"]  # 兜底路径含 task_{id}
+    # task-scoped 档案：tasks/<id>/monitor/state.json
+    msp_parts = Path(captured["cmd_msp"]).parts
+    assert msp_parts[-4:] == ("tasks", str(tid), "monitor", "state.json")
 
     # db 也写入了
     with db.connection_for(env["db"]) as conn:

--- a/tests/test_supervisor_jobs.py
+++ b/tests/test_supervisor_jobs.py
@@ -14,12 +14,15 @@ from studio.supervisor import Supervisor
 
 @pytest.fixture
 def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from studio.infrastructure import paths as _paths
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
     monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
-    return {"db": dbfile, "logs": tmp_path / "logs"}
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(_paths, "LOGS_DIR", tmp_path / "logs")
+    return {"db": dbfile, "logs": tmp_path / "logs", "tasks": tmp_path / "tasks"}
 
 
 def _wait_until(pred, timeout: float = 5.0, step: float = 0.05) -> bool:

--- a/tests/test_supervisor_version_status.py
+++ b/tests/test_supervisor_version_status.py
@@ -26,12 +26,15 @@ def _wait_for(predicate, timeout: float = 8.0, interval: float = 0.05) -> bool:
 @pytest.fixture
 def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     """初始化 db + 目录 + 项目 + version + valid config 文件。"""
+    from studio.infrastructure import paths as _paths
     db_path = tmp_path / "studio.db"
     db.init_db(db_path)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
     monkeypatch.setattr(db, "STUDIO_DB", db_path)
-    # snapshot 落 tmp_path 避免污染真实 studio_data
-    monkeypatch.setattr(task_snapshot, "STUDIO_DATA", tmp_path / "studio_data")
+    # task-scoped 档案（snapshot / monitor / samples / log）共享 paths.TASKS_DIR；
+    # 一处 monkeypatch 整组落 tmp_path 避免污染真实 studio_data。
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "studio_data" / "tasks")
+    monkeypatch.setattr(_paths, "LOGS_DIR", tmp_path / "logs")
 
     logs = tmp_path / "logs"
     configs = tmp_path / "configs"

--- a/tests/test_task_snapshot.py
+++ b/tests/test_task_snapshot.py
@@ -14,13 +14,15 @@ from studio.services.projects import projects
 
 @pytest.fixture
 def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from studio.infrastructure import paths as _paths
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
-    # task_snapshot 用 STUDIO_DATA：mock 到 tmp_path / studio_data
-    monkeypatch.setattr(task_snapshot, "STUDIO_DATA", tmp_path / "studio_data")
+    # task_snapshot 走 paths.task_dir → 共享 paths.TASKS_DIR；
+    # 整组 task-scoped helper（snapshot / monitor / samples / log）一并隔离。
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "studio_data" / "tasks")
     return {"db": dbfile, "data": tmp_path / "studio_data"}
 
 
@@ -30,8 +32,7 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 
 
 def test_snapshot_paths_under_studio_data(isolated) -> None:
-    root = task_snapshot.snapshot_root()
-    assert root == isolated["data"] / "tasks"
+    root = isolated["data"] / "tasks"
     assert task_snapshot.snapshot_dir(42) == root / "42" / "snapshot"
     assert task_snapshot.snapshot_config_path(42) == root / "42" / "snapshot" / "config.yaml"
 

--- a/tests/test_trace_id_subprocess.py
+++ b/tests/test_trace_id_subprocess.py
@@ -139,6 +139,9 @@ def test_spawn_task_injects_trace_env_to_subprocess(tmp_path: Path,
                         lambda *a, **kw: MagicMock(start=lambda: None))
     monkeypatch.setattr("studio.supervisor.core._resolve_monitor_state_path",
                         lambda t: tmp_path / "monitor.json")
+    # task_log_path 走 paths.TASKS_DIR；改到 tmp 不污染 studio_data/
+    from studio.infrastructure import paths as _paths
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "tasks")
 
     # 假 config 文件存在
     (tmp_path / "cfg.yaml").write_text("dummy", encoding="utf-8")
@@ -190,6 +193,9 @@ def test_spawn_task_generates_bg_trace_when_task_has_none(
                         lambda *a, **kw: MagicMock(start=lambda: None))
     monkeypatch.setattr("studio.supervisor.core._resolve_monitor_state_path",
                         lambda t: tmp_path / "monitor.json")
+    # task_log_path 走 paths.TASKS_DIR；改到 tmp 不污染 studio_data/
+    from studio.infrastructure import paths as _paths
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "tasks")
     (tmp_path / "cfg.yaml").write_text("dummy", encoding="utf-8")
 
     sup = Supervisor(on_event=lambda evt: None)

--- a/tests/test_worker_event_baseline.py
+++ b/tests/test_worker_event_baseline.py
@@ -33,6 +33,12 @@ def test_event_marker_string_is_double_underscore_event_colon() -> None:
 def test_logs_router_filters_event_lines(tmp_path: Path,
                                           monkeypatch: pytest.MonkeyPatch) -> None:
     """logs router 必须去掉 `__EVENT__:` 行，只返人读日志。"""
+    # logs.py 先查 task_log_path(id)（task-scoped 新路径），不存在 fallback
+    # LOGS_DIR/<id>.log。本测试断老 task fallback 路径，需 patch 两边：
+    # TASKS_DIR 指 tmp（避开真实 studio_data/tasks/42 万一存在），
+    # LOGS_DIR 指 tmp/legacy 收老 log。
+    from studio.infrastructure import paths as _paths
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "tasks")
     monkeypatch.setattr(_logs_router, "LOGS_DIR", tmp_path)
 
     # 写一个混合 log：业务行 + EVENT 行 + 业务行
@@ -63,9 +69,47 @@ def test_logs_router_filters_event_lines(tmp_path: Path,
     assert "progress" not in content
 
 
+def test_logs_router_prefers_task_scoped_path(tmp_path: Path,
+                                               monkeypatch: pytest.MonkeyPatch) -> None:
+    """新路径 tasks/<id>/run.log 优先；老 LOGS_DIR/<id>.log 仅 fallback。"""
+    from studio.infrastructure import paths as _paths
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(_logs_router, "LOGS_DIR", tmp_path / "legacy_logs")
+
+    (tmp_path / "tasks" / "99" / "run.log").parent.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "tasks" / "99" / "run.log").write_text("NEW\n", encoding="utf-8")
+    (tmp_path / "legacy_logs").mkdir()
+    (tmp_path / "legacy_logs" / "99.log").write_text("OLD\n", encoding="utf-8")
+
+    monkeypatch.setattr(server.db, "STUDIO_DB", tmp_path / "studio.db")
+    db.init_db(tmp_path / "studio.db")
+    client = TestClient(server.app)
+    body = client.get("/api/logs/99").json()
+    assert body["content"] == "NEW\n"
+
+
+def test_logs_router_falls_back_to_legacy_logs_dir(tmp_path: Path,
+                                                    monkeypatch: pytest.MonkeyPatch) -> None:
+    """老 task 未迁移，DB 列也没 log 路径 —— 落 LOGS_DIR/<id>.log 仍然读得到。"""
+    from studio.infrastructure import paths as _paths
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(_logs_router, "LOGS_DIR", tmp_path / "legacy_logs")
+
+    (tmp_path / "legacy_logs").mkdir()
+    (tmp_path / "legacy_logs" / "55.log").write_text("OLD_ONLY\n", encoding="utf-8")
+
+    monkeypatch.setattr(server.db, "STUDIO_DB", tmp_path / "studio.db")
+    db.init_db(tmp_path / "studio.db")
+    client = TestClient(server.app)
+    body = client.get("/api/logs/55").json()
+    assert body["content"] == "OLD_ONLY\n"
+
+
 def test_event_marker_unused_task_returns_empty_not_error(tmp_path: Path,
                                                             monkeypatch: pytest.MonkeyPatch) -> None:
     """unknown task_id 返 200 empty，不是 404；前端 polling 依赖这个不抛错。"""
+    from studio.infrastructure import paths as _paths
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "tasks")
     monkeypatch.setattr(_logs_router, "LOGS_DIR", tmp_path)
     monkeypatch.setattr(server.db, "STUDIO_DB", tmp_path / "studio.db")
     db.init_db(tmp_path / "studio.db")


### PR DESCRIPTION
## 背景 / 动机

monitor state / 采样图 / 日志原来跟着 version 走，PP6.1 (v0.5.0+) 后路径是 `versions/<v>/monitor/task_<id>/...`。两个问题：

1. **删 version 会一并丢 task 历史** —— 用户回头想看「上次跑这套配置的 loss 曲线 / 采样图」必须保留对应 version；想清理 version 又会顺带丢档案
2. **task 之间对比不直观** —— 同一 version 多次实验的 task 散落 `monitor/task_*` 子目录，跨 version 对比更要绕路径

## 改动概要

task-scoped 档案从 version 子树搬到 `studio_data/tasks/<id>/`，跟 ADR-0007 §11.7 已有的 task config snapshot 同根：

```
tasks/<id>/snapshot/config.yaml   ← 已有（task 启动 freeze 的 config）
tasks/<id>/monitor/state.json     ← 新：loss / LR / sample 索引
tasks/<id>/samples/*.png          ← 新：训练采样图
tasks/<id>/run.log                ← 新：worker stdout/stderr
```

**留在 version 级**：`reg/`（reg 数据集是 version 的训练资源，多个 task 复用）、`output/*.safetensors`（训练产物 = version 交付物）、`config.yaml`、`train/{N}_data/`、`caption_snapshots/`、`version.json`。

**不动**：`studio_data/jobs/<id>.log` —— `project_jobs`（download / preprocess / tag / reg_build）跟训练 task 是两套调度对象，已 job 隔离，没有 version 串台问题。

### 关键代码点

| 文件 | 改动 |
|---|---|
| `studio/infrastructure/paths.py` | 加 `TASKS_DIR` + `task_dir/task_monitor_state_path/task_samples_dir/task_log_path` 4 helper |
| `studio/services/task_snapshot.py` | `snapshot_dir` 改用 `paths.task_dir`，跟新 helper 同源 |
| `studio/supervisor/cmd_builder.py` | `_resolve_monitor_state_path` 三分支（有 vid / 无 vid / 兜底）塌成一条 `task_monitor_state_path(id)` |
| `studio/supervisor/core.py` | `_spawn_task` 日志走 `task_log_path(tid)`；error tail 先查新路径，老 task fallback |
| `runtime/training/phases/bootstrap.py` | `sample_dir = state_path.parent.parent / "samples"`（落 `tasks/<id>/samples/`，跟 `monitor/` sibling） |
| `studio/api/routers/samples.py` | 候选首位加 `task_samples_dir(id)`；PP6.1 + pre-PP6.1 候选保留兼容 |
| `studio/api/routers/logs.py` | 先查 `task_log_path(id)`，老 task fallback `LOGS_DIR/<id>.log` |
| `studio/api/routers/queue/lifecycle.py` | `delete_queue_item` 末尾 `rmtree(task_dir(id))` |

### 老 task 兼容

**不写迁移脚本**（按 user 决定，留作老版本兼容性回归数据）：

- DB `monitor_state_path` 列保留旧值不动；新启动 task 写新路径
- `samples.py` 保留 `monitor_dir/{samples,output/samples,output/*/samples}` 候选 → PP6.1 (v0.5.0+) 的 `versions/<v>/monitor/task_<id>/samples/` 和 pre-PP6.1 的 `versions/<v>/{samples,output/samples}/` 都能命中
- `logs.py` task_log_path 不存在则 fallback `LOGS_DIR/<id>.log`
- supervisor error tail 同样的 fallback 链

兼容矩阵（DB 列 `monitor_state_path` 值 → 实际 sample/log 位置 → 读端命中）：

| Task 启动版本 | DB 列值 | sample 实际位置 | 读端候选 |
|---|---|---|---|
| **新（本 PR 后）** | `tasks/<id>/monitor/state.json` | `tasks/<id>/samples/` | 新候选首位 ✓ |
| PP6.1 (v0.5.0–dev) | `versions/<v>/monitor/task_<id>/state.json` | `versions/<v>/monitor/task_<id>/samples/` 或 `versions/<v>/output/samples/` | `monitor_dir/samples` + `monitor_dir/output/samples` ✓ |
| pre-PP6.1 (< v0.5.0) | `versions/<v>/monitor_state.json` | `versions/<v>/{samples,output/samples}/` | `monitor_dir/samples` + `monitor_dir/output/samples` ✓ |

## 测试方式

- env fixture 改用 `monkeypatch _paths.TASKS_DIR + LOGS_DIR` 单点隔离
- `test_resume_path`：加 `_resolve_monitor_state_path` 新路径断言 + `task_paths_helpers_form_a_consistent_archive`（保 4 helper 落同根）
- `test_worker_event_baseline`：加 `prefers_task_scoped_path`（同 task id 新老两份 log 都在，必须返新内容）+ `falls_back_to_legacy_logs_dir`（仅老存在时仍读得到）
- `test_supervisor.test_monitor_state_path_passed_to_cmd_and_db`：断言路径形态改成 `tasks/<id>/monitor/state.json`

后端 pytest 全过（touched 136 个 + 周边 1811 个 pass；剩 10 个失败是 pre-existing 跟本 PR 无关 —— downloader / cltagger 模块加载、test_logging_bootstrap studio.log handler，已 stash 验证）。无前端改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)