### PR TITLE
fix(train): sample_seed=0 训练开始时 resolve 保证跨 epoch 同 seed

### DIFF
--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -62,6 +62,23 @@ def _maybe_apply_pause_snapshot(args, resume_state_path: Path) -> None:
         args.sample_prompts = sp
 
 
+def _resolve_sample_seed(args) -> None:
+    """sample_seed=0 → 训练开始时随机抽一次写回 args，并 log。
+
+    Why：sample_seed=0 走 sample_runner 时不调 torch.manual_seed，整批
+    采样跟着 global RNG 漂移，跨 epoch 同 prompt 出图不同 → 看不出是
+    模型收敛还是噪声变了。抽一次固定下来，整轮训练同 prompt 同 seed。
+
+    与 pause snapshot 协作：snapshot 写整份 args.dict()，resolved 值会
+    被 freeze；resume 经 _maybe_apply_pause_snapshot 灌回，跨 pause 仍
+    用同一 seed。用户重新起 task 时若 yaml 还是 0，启动重抽一次新随机。
+    """
+    if int(getattr(args, "sample_seed", 0) or 0):
+        return
+    args.sample_seed = random.randint(1, 2**31 - 1)
+    logger.info(f"sample_seed=0 → 训练用随机种子: {args.sample_seed}")
+
+
 def _prepend_trigger_to_sample_prompts(args) -> None:
     """trigger_word 非空 → prepend 到 sample_prompt / sample_prompts 每条。
 
@@ -155,6 +172,8 @@ def run(ctx: TrainingContext) -> None:
     torch.manual_seed(args.seed)
     random.seed(args.seed)
     np.random.seed(args.seed)
+
+    _resolve_sample_seed(args)
 
     ctx.device = "cuda" if torch.cuda.is_available() else "cpu"
     ctx.dtype = torch.bfloat16 if args.mixed_precision == "bf16" else torch.float32

--- a/tests/test_resume_path.py
+++ b/tests/test_resume_path.py
@@ -297,6 +297,51 @@ def test_trigger_skips_empty_prompt_strings() -> None:
 
 
 # ---------------------------------------------------------------------------
+# bootstrap_phase: _resolve_sample_seed
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_sample_seed_zero_is_replaced_with_random_positive() -> None:
+    """sample_seed=0 → 抽一个 [1, 2**31-1] 范围的具体 seed 写回 args。"""
+    from runtime.training.phases.bootstrap import _resolve_sample_seed
+
+    args = argparse.Namespace(sample_seed=0)
+    _resolve_sample_seed(args)
+    assert isinstance(args.sample_seed, int)
+    assert 1 <= args.sample_seed <= 2**31 - 1
+
+
+def test_resolve_sample_seed_explicit_value_kept() -> None:
+    """用户显式给的非 0 seed → 不动，保证 reproducibility。"""
+    from runtime.training.phases.bootstrap import _resolve_sample_seed
+
+    args = argparse.Namespace(sample_seed=42)
+    _resolve_sample_seed(args)
+    assert args.sample_seed == 42
+
+
+def test_resolve_sample_seed_idempotent_after_resolve() -> None:
+    """二次调用不再覆盖已 resolved 的 seed（pause/resume 路径关键）。"""
+    from runtime.training.phases.bootstrap import _resolve_sample_seed
+
+    args = argparse.Namespace(sample_seed=0)
+    _resolve_sample_seed(args)
+    first = args.sample_seed
+    _resolve_sample_seed(args)
+    assert args.sample_seed == first
+
+
+def test_resolve_sample_seed_missing_attr_treated_as_zero() -> None:
+    """args 没有 sample_seed 字段 → 当成 0 抽一个具体值塞进去。"""
+    from runtime.training.phases.bootstrap import _resolve_sample_seed
+
+    args = argparse.Namespace()
+    _resolve_sample_seed(args)
+    assert isinstance(args.sample_seed, int)
+    assert args.sample_seed > 0
+
+
+# ---------------------------------------------------------------------------
 # supervisor._clear_pause_artifacts
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 背景

`sample_seed=0` 的语义是"随机种子"（schema description 明示），但当前实现走 `runtime/training/sample_runner.py:62-63`：

```python
if s_seed:
    torch.manual_seed(s_seed + seed_offset)
```

`s_seed=0` 时 `if` 整段跳过 — 不 set seed，也没往 `sample_image()` 传 `seed=`，所以全程靠 global torch RNG。global RNG 在每个训练 step 里都被消耗（dropout / timestep / noise / dataloader），不同 epoch 落到采样点时 state 完全不同 → **同 prompt 不同 epoch 出图不一样**。

后果：跨 epoch 采样图本来是看「收敛过程 / 过拟合趋势」的，前提是噪声固定只看模型变化。0 的行为把噪声也一起变了，对比就废了。

## 改动

参考 kohya-ss/sd-scripts 的标准做法：训练 bootstrap 阶段，若 `sample_seed` 是 0 / 缺省，调 `random.randint(1, 2**31-1)` 抽一次写回 `args.sample_seed`，并 log 出来让用户知道用的什么 seed。整轮训练同 prompt 同 seed，跨 epoch 可对比。

### Pause / resume 兼容性

`runtime/training/snapshot.py:write_config_snapshot` 写整份 `vars(args)`，resolved 值会被 freeze；resume 经 `_maybe_apply_pause_snapshot` 灌回 args → 跨 pause/resume 仍用同一 seed。

用户重新起 task 时若 yaml 仍为 0，下次 bootstrap 重抽一次新随机（不挂死在第一次 task 的 seed 上）。

## 测试

- 新增 4 个 unit test 覆盖：
  - `test_resolve_sample_seed_zero_is_replaced_with_random_positive` — 0 → [1, 2**31-1] 内随机
  - `test_resolve_sample_seed_explicit_value_kept` — 非 0 不动（reproducibility 保留）
  - `test_resolve_sample_seed_idempotent_after_resolve` — 二次调用不再覆盖（resume 路径关键）
  - `test_resolve_sample_seed_missing_attr_treated_as_zero` — 缺字段当 0
- `tests/test_resume_path.py` 26 passed
- 手测：grep 全仓 `sample_seed` 只有 schema 定义 + sample_runner 读取两处，无第三方副作用

## 截图

无 UI 改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)