### PR TITLE
perf(train): lora algo 默认 bypass_mode 消除 ΔW rebuild (#182)

### DIFF
--- a/tests/test_lycoris_bypass.py
+++ b/tests/test_lycoris_bypass.py
@@ -1,0 +1,177 @@
+"""lora algo 默认走 bypass_mode 的等价性 + DoRA / LoKr / LoHa 仍走 rebuild 的 guard。
+
+背景：lycoris LoConModule 默认 forward 会 rebuild ΔW=up@down 全矩阵再多跑一次
+F.linear——对普通 LoRA 是每层 ~2× FLOPs 的浪费（issue #182）。bypass_mode=True 路径
+是经典 `org_forward(x) + lora_up(lora_down(x)) * scale`，等价于 sd-scripts/PEFT 的 LoRA forward。
+
+本文件验证：
+1) lora algo (LoCon) 下，bypass=True 与 bypass=False 的 forward / backward 数值等价
+2) AnimaLycorisAdapter(algo='lora') 默认 bypass_mode=True
+3) DoRA(weight_decompose=True) 强制 bypass_mode=False，避免 lycoris bypass 路径
+   不走 wd 分支导致的静默失效
+4) LoKr / LoHa 保持 bypass_mode=False（默认 rebuild，行为不变）
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from utils.lycoris_adapter import AnimaLycorisAdapter
+
+pytest.importorskip("lycoris")
+
+
+class MockDiT(nn.Module):
+    """对齐 ANIMA_PRESET 的 target_name（*q_proj/*k_proj/*v_proj/*output_proj/*mlp.layer1/2）"""
+
+    def __init__(self, d: int = 64):
+        super().__init__()
+        self.q_proj = nn.Linear(d, d, bias=False)
+        self.k_proj = nn.Linear(d, d, bias=False)
+        self.v_proj = nn.Linear(d, d, bias=False)
+        self.output_proj = nn.Linear(d, d, bias=False)
+
+
+def _bypass_modes(adapter: AnimaLycorisAdapter) -> list[bool]:
+    return [bool(getattr(m, "bypass_mode", False)) for m in adapter.network.loras]
+
+
+# ─── (1) LoCon 数值等价：bypass=True vs bypass=False ──────────────────────────
+
+
+def _build_lora_module(bypass: bool, seed: int = 0):
+    """直接造一个 LoConModule，避开 LycorisNetwork 的 preset/target 匹配"""
+    from lycoris.modules.locon import LoConModule
+
+    torch.manual_seed(seed)
+    linear = nn.Linear(64, 64, bias=False)
+    mod = LoConModule(
+        lora_name="test",
+        org_module=linear,
+        multiplier=1.0,
+        lora_dim=8,
+        alpha=8,
+        dropout=0.0,
+        rank_dropout=0.0,
+        module_dropout=0.0,
+        bypass_mode=bypass,
+    )
+    mod.apply_to()
+    return linear, mod
+
+
+def _copy_lora_weights(src, dst) -> None:
+    """把 src 的 lora_up/down 权重塞进 dst（同 shape）"""
+    dst.lora_up.weight.data.copy_(src.lora_up.weight.data)
+    dst.lora_down.weight.data.copy_(src.lora_down.weight.data)
+
+
+def test_locon_bypass_vs_rebuild_forward_equivalent() -> None:
+    """同样权重、同样输入：bypass 路径与 rebuild 路径 forward 输出数值一致。
+
+    LoRA paper 的 W'X = WX + BAX，bypass 是直接算右式；rebuild 是先 W'=W+BA 再算 W'X。
+    fp32 下应严格一致到 ~1e-5 量级。
+    """
+    linear_a, mod_bypass = _build_lora_module(bypass=True, seed=0)
+    linear_b, mod_rebuild = _build_lora_module(bypass=False, seed=0)
+    # base linear 权重已经因为 seed=0 一致；同步 lora 部分
+    _copy_lora_weights(mod_bypass, mod_rebuild)
+    # 让 lora_up 不为 0（默认 init 是 0）才能真正测到 lora 路径
+    with torch.no_grad():
+        mod_bypass.lora_up.weight.normal_(std=0.1)
+        mod_rebuild.lora_up.weight.copy_(mod_bypass.lora_up.weight)
+
+    # 同步 base linear 权重以防 seed 之外有差异
+    with torch.no_grad():
+        linear_b.weight.copy_(linear_a.weight)
+
+    mod_bypass.eval()
+    mod_rebuild.eval()
+    x = torch.randn(2, 16, 64)
+    out_bypass = linear_a(x)
+    out_rebuild = linear_b(x)
+    assert torch.allclose(out_bypass, out_rebuild, atol=1e-5, rtol=1e-5)
+
+
+def test_locon_bypass_vs_rebuild_backward_equivalent() -> None:
+    """同样 loss：两条路径在 lora_up/lora_down 上的梯度数值一致。"""
+    linear_a, mod_bypass = _build_lora_module(bypass=True, seed=1)
+    linear_b, mod_rebuild = _build_lora_module(bypass=False, seed=1)
+    _copy_lora_weights(mod_bypass, mod_rebuild)
+    with torch.no_grad():
+        mod_bypass.lora_up.weight.normal_(std=0.1)
+        mod_rebuild.lora_up.weight.copy_(mod_bypass.lora_up.weight)
+        linear_b.weight.copy_(linear_a.weight)
+
+    mod_bypass.train()
+    mod_rebuild.train()
+    x = torch.randn(2, 16, 64, requires_grad=False)
+    target = torch.randn(2, 16, 64)
+
+    loss_bypass = (linear_a(x) - target).pow(2).mean()
+    loss_rebuild = (linear_b(x) - target).pow(2).mean()
+    assert torch.allclose(loss_bypass, loss_rebuild, atol=1e-5)
+
+    loss_bypass.backward()
+    loss_rebuild.backward()
+
+    assert torch.allclose(
+        mod_bypass.lora_up.weight.grad,
+        mod_rebuild.lora_up.weight.grad,
+        atol=1e-5, rtol=1e-5,
+    )
+    assert torch.allclose(
+        mod_bypass.lora_down.weight.grad,
+        mod_rebuild.lora_down.weight.grad,
+        atol=1e-5, rtol=1e-5,
+    )
+
+
+# ─── (2-4) AnimaLycorisAdapter 按 algo + DoRA 自动选 bypass_mode ──────────────
+
+
+def test_adapter_lora_defaults_to_bypass_mode() -> None:
+    """algo='lora' 不开 DoRA → 全部模块 bypass_mode=True（issue #182 默认快路径）"""
+    torch.manual_seed(0)
+    model = MockDiT()
+    adapter = AnimaLycorisAdapter(algo="lora", rank=8, alpha=8)
+    adapter.inject(model)
+    modes = _bypass_modes(adapter)
+    assert modes, "preset 应该至少匹配一个 q/k/v/output_proj"
+    assert all(modes), f"lora algo 全部模块应走 bypass，但得到 {modes}"
+
+
+def test_adapter_lora_with_dora_forces_rebuild() -> None:
+    """algo='lora' + lora_dora=True：DoRA 数学上必须 rebuild，guard 不能让 bypass 静默吞掉 wd 分支"""
+    torch.manual_seed(0)
+    model = MockDiT()
+    adapter = AnimaLycorisAdapter(
+        algo="lora", rank=8, alpha=8, weight_decompose=True,
+    )
+    adapter.inject(model)
+    modes = _bypass_modes(adapter)
+    assert modes
+    assert not any(modes), f"DoRA 必须走 rebuild，但 bypass_mode={modes}"
+
+
+def test_adapter_lokr_keeps_rebuild() -> None:
+    """algo='lokr' 行为不变（LoKr 的 bypass 数值等价但路径相当绕，本 PR 不动）"""
+    torch.manual_seed(0)
+    model = MockDiT()
+    adapter = AnimaLycorisAdapter(algo="lokr", rank=8, alpha=8, factor=8)
+    adapter.inject(model)
+    modes = _bypass_modes(adapter)
+    assert modes
+    assert not any(modes), f"lokr 应保持 rebuild，但 bypass_mode={modes}"
+
+
+def test_adapter_loha_keeps_rebuild() -> None:
+    """algo='loha' 行为不变（LoHa bypass 内部仍 rebuild，开了反而慢；lycoris changelog 原话）"""
+    torch.manual_seed(0)
+    model = MockDiT()
+    adapter = AnimaLycorisAdapter(algo="loha", rank=8, alpha=8)
+    adapter.inject(model)
+    modes = _bypass_modes(adapter)
+    assert modes
+    assert not any(modes), f"loha 应保持 rebuild，但 bypass_mode={modes}"

--- a/utils/lycoris_adapter.py
+++ b/utils/lycoris_adapter.py
@@ -94,6 +94,15 @@ class AnimaLycorisAdapter:
         if self.rs_lora:
             extra["rs_lora"] = True
 
+        # algo='lora' (LoCon) 默认走 bypass_mode：lycoris LoConModule 默认 forward 会
+        # rebuild ΔW=up@down (out,in) 再多跑一次 F.linear，等于每层 ~2× FLOPs。
+        # bypass_mode=True 走 bypass_forward_diff = org_forward(x) + lora_up(lora_down(x))，
+        # 是 LoRA 论文 + sd-scripts + PEFT 的标准 forward；对外行为完全等价但 ~2× 快。
+        # DoRA(weight_decompose) 路径数学上必须 rebuild —— lycoris bypass forward 不走 wd
+        # 分支，会让 DoRA 静默失效；这里 guard。参考 lycoris docs/Network-Args.md "Bypass Mode"。
+        if self.algo == "lora" and not self.weight_decompose:
+            extra["bypass_mode"] = True
+
         self.network = LycorisNetwork(
             model,
             multiplier=1.0,
@@ -137,7 +146,8 @@ class AnimaLycorisAdapter:
         self._injected_model = model
 
         n = len(self.network.loras)
-        logger.info(f"注入 {self.algo.upper()} 到 {n} 层（lycoris-lora）")
+        forward_path = "bypass (low-rank)" if extra.get("bypass_mode") else "rebuild (ΔW)"
+        logger.info(f"注入 {self.algo.upper()} 到 {n} 层（lycoris-lora, forward={forward_path}）")
         if self.use_lokr:
             full_matrix = [lora for lora in self.network.loras if getattr(lora, "use_w2", False)]
             if full_matrix:


### PR DESCRIPTION
## 背景 / 动机

Issue #182 报告：同样模型 / 同样配置（rank=8, batch=1, RTX 5070 Ti, Anima 1024）下，AnimaLoraStudio **0.11 it/s** 比 sd-scripts 的 **0.19 it/s** 慢约 1.8x。

排查后定位根因在 lycoris `LoConModule.forward` 的默认路径：

```python
# lycoris/modules/locon.py 默认 bypass_mode=False 时：
base = self.org_forward(x)
diff_weight = self.make_weight(device)   # rebuild ΔW = up @ down，shape (out, in)
delta = F.linear(x, diff_weight)         # 再跑一次全 rank F.linear
return base + delta
```

对每个被 patch 的 Linear（Anima 一共 ~280 层），相当于每 step 多干了一遍 full-rank 矩阵乘 + 重建 (out, in) 大矩阵的开销。

lycoris 自带 `bypass_mode=True` 走的是 `bypass_forward_diff`：

```python
return org_forward(x) + lora_up(lora_down(x)) * scale
```

这是 **LoRA 论文 + sd-scripts `networks/lora_flux.py` + PEFT + diffusers** 全部采用的标准 forward，数学完全等价。

`bypass_mode` 在官方 [Network-Args.md](https://github.com/KohakuBlueleaf/LyCORIS/blob/main/docs/Network-Args.md) 里设计目的是给 QLyCORIS（bnb 量化层）用 —— 量化的 W 没法 `W + ΔW`，所以必须拆开算 —— 但同样的拆法对普通 LoCon 顺手把 rebuild 浪费消掉了。lycoris 作者从未在文档里指出它对普通 LoRA 是 ~2× 加速，因此默认值是 None / False。

## 改动

**`utils/lycoris_adapter.py`** —— inject() 时按 algo + DoRA 选 forward 路径：

| algo | DoRA | bypass_mode | 原因 |
|---|---|---|---|
| `lora` | off | **True**（新默认） | LoConModule bypass = 标准 LoRA forward，~2× 快 |
| `lora` | on | False | DoRA 数学上必须 rebuild；lycoris bypass 路径不走 wd 分支，会让 DoRA 静默失效 |
| `lokr` | * | False | bypass 路径数值等价但实现复杂，留后续单独评估 + 测试 |
| `loha` | * | False | lycoris changelog 原话：LoHa bypass 内部仍 rebuild，开了反而慢 |

注入 log 增加 forward path 标注，方便后续诊断：`注入 LORA 到 N 层（lycoris-lora, forward=bypass (low-rank)）`

state_dict 键名（`lora_up.weight` / `lora_down.weight`）独立于 bypass_mode，**ComfyUI 加载流程不受影响**。

## 测试

新增 `tests/test_lycoris_bypass.py`（6 个用例）：

- LoCon `bypass=True` vs `bypass=False` 直接构造 LoConModule、同权重 同输入：
  - forward 输出数值等价（fp32 ~1e-5）
  - backward 在 `lora_up` / `lora_down` 上的梯度数值等价
- adapter wiring 校验（防回归）：
  - `algo='lora'` 默认 → 全部模块 `bypass_mode=True`
  - `algo='lora' + lora_dora=True` → 强制 `bypass_mode=False`
  - `algo='lokr'` / `algo='loha'` → 保持 `bypass_mode=False`

`python -m studio test` 跑过：1882 passed（11 个 dev 既有 failures 与本 PR 无关：FakeSession 缺 proxies attr / lifespan studio.log env-specific，分别属于 #190 follow-up 和测试 fixture 问题）。

新测试 6/6 全绿；原有 5 个 lycoris 相关测试文件 24 个用例无回归。

## 预期收益

issue #182 报告人配置（algo='lora', rank=8, RTX 5070 Ti, Anima 1024 batch=1）：
- 理论上 0.11 → ~0.18-0.20 it/s（消除每层 ~2× FLOPs + Python overhead）
- 接近 sd-scripts 0.19-0.20 it/s baseline

LoKr / LoHa / DoRA 用户：零变化。