### PR TITLE
refactor(reg): JSON caption filter 复用 normalize_caption_json + clear_reg_dir

### DIFF
--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -44,11 +44,18 @@ for _p in (_THIS_DIR, _REPO_ROOT):
 
 import anima_train as _T  # noqa: E402
 
-# 复用 reg_builder.RegMeta（PR-9 commit 2 加了 generation_method 字段）
-from studio.services.reg.builder import RegMeta, read_meta, write_meta  # noqa: E402
+# 复用 reg_builder.RegMeta（PR-9 commit 2 加了 generation_method 字段）+ clear_reg_dir
+# （booru full-mode build 入口同款实现，行为/语义跟 booru reg 路径绑定一致）。
+from studio.services.reg.builder import (  # noqa: E402
+    RegMeta,
+    clear_reg_dir,
+    read_meta,
+    write_meta,
+)
 from studio.services.tagging.caption_format import (  # noqa: E402
     caption_json_to_tags,
     caption_json_to_text,
+    normalize_caption_json,
 )
 
 logging.basicConfig(
@@ -190,199 +197,59 @@ def _prompt_tags_from_caption(caption_path: Path, excluded_tags: set[str]) -> li
     return prompt_tags
 
 
-def _take_prompt_tag(
-    raw_tag: object,
-    excluded_tags: set[str],
-    seen: set[str],
-) -> str | None:
-    tag = _prompt_tag(str(raw_tag or ""))
-    if not tag or tag in excluded_tags or tag in seen:
-        return None
-    seen.add(tag)
-    return tag
+def _filter_normalized_caption(
+    data: dict, excluded_tags: set[str]
+) -> dict:
+    """Drop excluded tags + meta.trigger from a normalized standard-shape caption.
 
+    Reg 端不带 trigger：base prior 不认识 LoRA handle；同时避免 reg sidecar 被
+    训练侧 caption_utils.load_and_build_caption 再次读到 trigger 注入。
 
-def _split_tag_value(value: object) -> list[object]:
-    if value is None:
-        return []
-    if isinstance(value, str):
-        return value.split(",")
-    if isinstance(value, (list, tuple, set)):
-        return list(value)
-    return [value]
+    Scalar 字段（count/character/series/artist）按逗号拆开后逐 tag 过 excluded
+    再 join 回，让 "1girl, 1boy" 这种合并值的单项 exclude 可以命中。
+    """
+    src_tags = data.get("tags") or {}
 
+    def _keep_list(values: list[str]) -> list[str]:
+        return [t for t in values if _tag_key(t) not in excluded_tags]
 
-def _filter_prompt_tag_list(
-    raw_tags: object,
-    excluded_tags: set[str],
-    seen: set[str],
-) -> list[str]:
-    out: list[str] = []
-    for raw_tag in _split_tag_value(raw_tags):
-        tag = _take_prompt_tag(raw_tag, excluded_tags, seen)
-        if tag:
-            out.append(tag)
-    return out
-
-
-def _filter_tag_collection(
-    value: object,
-    excluded_tags: set[str],
-    seen: set[str],
-) -> str | list[str]:
-    tags = _filter_prompt_tag_list(value, excluded_tags, seen)
-    if isinstance(value, str):
-        return ", ".join(tags)
-    return tags
-
-
-def _filter_scalar_tag(
-    value: object,
-    excluded_tags: set[str],
-    seen: set[str],
-) -> str:
-    return _take_prompt_tag(value, excluded_tags, seen) or ""
-
-
-def _character_text(value: object) -> str:
-    if isinstance(value, dict):
-        full = str(value.get("full") or "").strip()
-        if full:
-            return full
-        parts = [
-            str(value.get("name") or "").strip(),
-            str(value.get("variant") or "").strip(),
+    def _keep_scalar(value: str) -> str:
+        kept = [
+            t.strip() for t in str(value or "").split(",")
+            if t.strip() and _tag_key(t) not in excluded_tags
         ]
-        return ", ".join(p for p in parts if p)
-    return str(value or "").strip()
+        return ", ".join(kept)
 
-
-def _filter_character_value(
-    value: object,
-    excluded_tags: set[str],
-    seen: set[str],
-) -> object:
-    tag = _take_prompt_tag(_character_text(value), excluded_tags, seen)
-    if not isinstance(value, dict):
-        return tag or ""
-
-    out = dict(value)
-    if not tag:
-        for key in ("name", "variant", "full"):
-            if key in out:
-                out[key] = ""
-        return out
-
-    if "full" in out or not ("name" in out or "variant" in out):
-        out["full"] = tag
-    if "name" in out and not str(out.get("variant") or "").strip():
-        out["name"] = tag
-    return out
-
-
-def _filter_meta_trigger(data: dict, excluded_tags: set[str], seen: set[str]) -> None:
-    meta = data.get("meta") if isinstance(data.get("meta"), dict) else None
-    if meta is None:
-        return
-    trigger = _take_prompt_tag(meta.get("trigger"), excluded_tags, seen)
-    if trigger:
-        meta["trigger"] = trigger
-    else:
-        meta.pop("trigger", None)
-
-
-def _filter_standard_json(data: dict, excluded_tags: set[str]) -> dict:
-    out = dict(data)
-    tags = dict(out.get("tags") if isinstance(out.get("tags"), dict) else {})
-    out["tags"] = tags
-    seen: set[str] = set()
-    _filter_meta_trigger(out, excluded_tags, seen)
-
-    tags["quality"] = _filter_prompt_tag_list(tags.get("quality"), excluded_tags, seen)
-    for key in ("count", "character", "series", "artist"):
-        tags[key] = _filter_scalar_tag(tags.get(key), excluded_tags, seen)
-    for key in ("appearance", "tags", "environment"):
-        tags[key] = _filter_prompt_tag_list(tags.get(key), excluded_tags, seen)
-    tags["nl"] = str(tags.get("nl") or "").strip()
-    return out
-
-
-def _filter_documented_full_json(data: dict, excluded_tags: set[str]) -> dict:
-    out = dict(data)
-    fixed = dict(out.get("fixed") if isinstance(out.get("fixed"), dict) else {})
-    character = out.get("character")
-    ai = dict(out.get("ai_output") if isinstance(out.get("ai_output"), dict) else {})
-    from_path = dict(out.get("from_path") if isinstance(out.get("from_path"), dict) else {})
-    out["fixed"] = fixed
-    out["character"] = character
-    out["ai_output"] = ai
-    if "from_path" in out:
-        out["from_path"] = from_path
-
-    seen: set[str] = set()
-    _filter_meta_trigger(out, excluded_tags, seen)
-
-    fixed["quality"] = _filter_tag_collection(fixed.get("quality"), excluded_tags, seen)
-    ai["count"] = _filter_scalar_tag(ai.get("count"), excluded_tags, seen)
-    out["character"] = _filter_character_value(character, excluded_tags, seen)
-    fixed["series"] = _filter_scalar_tag(fixed.get("series"), excluded_tags, seen)
-    fixed["artist"] = _filter_scalar_tag(fixed.get("artist"), excluded_tags, seen)
-
-    ai["appearance"] = _filter_prompt_tag_list(ai.get("appearance"), excluded_tags, seen)
-    for key in ("appearance", "extra_appearance"):
-        if key in from_path:
-            from_path[key] = _filter_prompt_tag_list(from_path.get(key), excluded_tags, seen)
-
-    ai["tags"] = _filter_prompt_tag_list(ai.get("tags"), excluded_tags, seen)
-    for key in ("tags", "extra_tags"):
-        if key in from_path:
-            from_path[key] = _filter_prompt_tag_list(from_path.get(key), excluded_tags, seen)
-
-    ai["environment"] = _filter_prompt_tag_list(ai.get("environment"), excluded_tags, seen)
-    ai["nl"] = str(ai.get("nl") or "").strip()
-    return out
-
-
-def _filter_simple_tags_json(data: dict, excluded_tags: set[str]) -> dict:
-    out = dict(data)
-    seen: set[str] = set()
-    _filter_meta_trigger(out, excluded_tags, seen)
-    out["tags"] = _filter_prompt_tag_list(out.get("tags"), excluded_tags, seen)
-    return out
-
-
-def _filter_simplified_json(data: dict, excluded_tags: set[str]) -> dict:
-    out = dict(data)
-    seen: set[str] = set()
-    _filter_meta_trigger(out, excluded_tags, seen)
-    if "quality" in out:
-        out["quality"] = _filter_tag_collection(out.get("quality"), excluded_tags, seen)
-    for key in ("count", "character", "series", "artist"):
-        if key in out:
-            out[key] = _filter_scalar_tag(out.get(key), excluded_tags, seen)
-    for key in ("appearance", "tags", "environment"):
-        if key in out:
-            out[key] = _filter_prompt_tag_list(out.get(key), excluded_tags, seen)
-    if "nl" in out:
-        out["nl"] = str(out.get("nl") or "").strip()
-    return out
-
-
-def _filter_json_caption(raw: dict, excluded_tags: set[str]) -> dict:
-    tags_obj = raw.get("tags")
-    if isinstance(tags_obj, dict):
-        return _filter_standard_json(raw, excluded_tags)
-    if "ai_output" in raw or "fixed" in raw or "from_path" in raw:
-        return _filter_documented_full_json(raw, excluded_tags)
-    if isinstance(tags_obj, list):
-        return _filter_simple_tags_json(raw, excluded_tags)
-    return _filter_simplified_json(raw, excluded_tags)
+    meta = {
+        k: v for k, v in (data.get("meta") or {}).items() if k != "trigger"
+    }
+    return {
+        "meta": meta,
+        "tags": {
+            "quality": _keep_list(src_tags.get("quality") or []),
+            "count": _keep_scalar(src_tags.get("count") or ""),
+            "character": _keep_scalar(src_tags.get("character") or ""),
+            "series": _keep_scalar(src_tags.get("series") or ""),
+            "artist": _keep_scalar(src_tags.get("artist") or ""),
+            "appearance": _keep_list(src_tags.get("appearance") or []),
+            "tags": _keep_list(src_tags.get("tags") or []),
+            "environment": _keep_list(src_tags.get("environment") or []),
+            "nl": str(src_tags.get("nl") or "").strip(),
+        },
+    }
 
 
 def _rewrite_json_caption_for_prompt(caption_path: Path, excluded_tags: set[str]) -> str:
-    """Rewrite a reg JSON sidecar while preserving its source JSON shape."""
+    """Normalize → filter excluded + drop trigger → write back standard shape.
+
+    Reg sidecar 是派生产物，统一写 caption_format.normalize_caption_json 输出的
+    标准 shape；训练侧 caption_utils.load_and_build_caption 读 reg JSON 也走同一
+    个 normalize 入口，不需要保留 user-side 原始 documented_full / simplified
+    形态，反而消掉了 4 套 shape filter 的镜像维护成本。
+    """
     raw = json.loads(caption_path.read_text(encoding="utf-8"))
-    filtered = _filter_json_caption(raw if isinstance(raw, dict) else {}, excluded_tags)
+    normalized = normalize_caption_json(raw if isinstance(raw, dict) else {})
+    filtered = _filter_normalized_caption(normalized, excluded_tags)
     prompt = caption_json_to_text(filtered)
     caption_path.write_text(
         json.dumps(filtered, ensure_ascii=False, indent=2) + "\n",
@@ -443,17 +310,6 @@ def _already_has_reg(reg_sub: Path, train_stem: str) -> bool:
         ):
             return True
     return False
-
-
-def _clear_reg_dir(reg_dir: Path) -> None:
-    """Clear old reg outputs before a full AI prior generation run."""
-    if not reg_dir.exists():
-        return
-    for child in reg_dir.iterdir():
-        if child.is_dir():
-            shutil.rmtree(child)
-        else:
-            child.unlink()
 
 
 def _write_meta_final(
@@ -595,7 +451,7 @@ def main() -> None:
 
     if not incremental:
         logger.info("full 模式：清空旧 reg 内容")
-        _clear_reg_dir(reg_dir)
+        clear_reg_dir(reg_dir)
 
     # 生成循环
     total = len(to_generate)

--- a/tests/test_anima_reg_caption.py
+++ b/tests/test_anima_reg_caption.py
@@ -1,0 +1,231 @@
+"""anima_reg_ai 的 JSON caption filter + sidecar 重写单测（PR #185 follow-up）。
+
+校验 _rewrite_json_caption_for_prompt 走 normalize_caption_json + 单层过滤后：
+- meta.trigger 永远从 reg sidecar + prompt 里去掉（base prior 不带 LoRA handle）
+- excluded_tags 在 space/underscore 两种形态下都能命中
+- documented_full / 简化 shape 全部折叠成标准 shape 写回（reg 是派生产物）
+- scalar 字段含逗号时按单 tag 过 excluded
+- nl 自然语言保留到 prompt 末尾
+- _clear_reg_dir 复用自 reg_builder.clear_reg_dir（不再本地复刻）
+
+不跑 GPU，不触发 anima_train 真 import — top-level stub。
+"""
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def reg_module():
+    """import runtime.anima_reg_ai 一次复用，stub 掉 anima_train 重依赖。"""
+    if "anima_train" not in sys.modules or not hasattr(sys.modules["anima_train"], "sample_image"):
+        at = types.ModuleType("anima_train")
+        at.sample_image = lambda *a, **k: None
+        at.find_diffusion_pipe_root = lambda: Path(".")
+        at.resolve_path_best_effort = lambda p, bases: p
+        at.load_anima_model = lambda *a, **k: None
+        at.load_vae = lambda *a, **k: None
+        at.load_text_encoders = lambda *a, **k: (None, None, None)
+        at.enable_xformers = lambda *a, **k: None
+        sys.modules["anima_train"] = at
+
+    import importlib
+    if "anima_reg_ai" in sys.modules:
+        del sys.modules["anima_reg_ai"]
+    return importlib.import_module("anima_reg_ai")
+
+
+def _write(tmp_path: Path, data: dict) -> Path:
+    p = tmp_path / "cap.json"
+    p.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    return p
+
+
+def _read(p: Path) -> dict:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# trigger 不进 reg
+# ---------------------------------------------------------------------------
+
+def test_drops_meta_trigger_from_prompt_and_sidecar(reg_module, tmp_path: Path) -> None:
+    src = _write(tmp_path, {
+        "meta": {"trigger": "aoirikko"},
+        "tags": {
+            "quality": ["masterpiece"],
+            "appearance": ["brown hair"],
+        },
+    })
+    prompt = reg_module._rewrite_json_caption_for_prompt(src, set())
+    assert "aoirikko" not in prompt.lower()
+    assert "brown hair" in prompt
+    on_disk = _read(src)
+    assert on_disk["meta"].get("trigger") in (None, "")
+
+
+def test_drops_trigger_even_when_other_meta_kept(reg_module, tmp_path: Path) -> None:
+    src = _write(tmp_path, {
+        "meta": {"trigger": "aoirikko", "tagger_version": "v2"},
+        "tags": {"appearance": ["smile"]},
+    })
+    reg_module._rewrite_json_caption_for_prompt(src, set())
+    on_disk = _read(src)
+    assert "trigger" not in on_disk["meta"]
+    assert on_disk["meta"].get("tagger_version") == "v2"
+
+
+# ---------------------------------------------------------------------------
+# excluded space / underscore 等价
+# ---------------------------------------------------------------------------
+
+def test_excluded_underscore_matches_space_form(reg_module, tmp_path: Path) -> None:
+    src = _write(tmp_path, {
+        "tags": {"appearance": ["brown hair", "blue eyes"]},
+    })
+    # excluded_tags 传 underscore，命中 JSON 里的 space 形态
+    excluded = {reg_module._tag_key("brown_hair")}
+    prompt = reg_module._rewrite_json_caption_for_prompt(src, excluded)
+    assert "brown hair" not in prompt
+    assert "blue eyes" in prompt
+
+
+def test_excluded_space_matches_underscore_form(reg_module, tmp_path: Path) -> None:
+    src = _write(tmp_path, {
+        "tags": {"appearance": ["brown_hair", "blue_eyes"]},
+    })
+    excluded = {reg_module._tag_key("brown hair")}
+    prompt = reg_module._rewrite_json_caption_for_prompt(src, excluded)
+    assert "brown" not in prompt or "hair" not in prompt
+    # blue_eyes 经 normalize 会被 split_tags 收敛到 "blue_eyes" 一项；
+    # 取一个轻断言：另一个 tag 仍在
+    assert "blue" in prompt
+
+
+# ---------------------------------------------------------------------------
+# shape 折叠：documented_full → standard
+# ---------------------------------------------------------------------------
+
+def test_documented_full_shape_folds_to_standard_on_disk(reg_module, tmp_path: Path) -> None:
+    src = _write(tmp_path, {
+        "fixed": {"quality": "masterpiece, best quality", "series": "kaguya", "artist": ""},
+        "character": {"name": "Misaka", "variant": "Sisters", "full": "Misaka Mikoto"},
+        "ai_output": {
+            "count": "1girl",
+            "appearance": ["brown hair"],
+            "tags": ["sitting"],
+            "environment": ["indoors"],
+            "nl": "She is reading a book.",
+        },
+        "from_path": {"appearance": ["smile"], "extra_tags": ["solo"]},
+    })
+    prompt = reg_module._rewrite_json_caption_for_prompt(src, set())
+    on_disk = _read(src)
+
+    # 落盘 shape：标准 shape，原 fixed/character/ai_output/from_path 顶层 key 全没了
+    assert isinstance(on_disk.get("tags"), dict)
+    assert "fixed" not in on_disk
+    assert "ai_output" not in on_disk
+    assert "from_path" not in on_disk
+    assert "character" not in on_disk  # character 折到 tags.character
+
+    # prompt：character 折成 full、appearance / tags 合并 from_path 部分、nl 接在末尾
+    assert "misaka mikoto" in prompt.lower()
+    assert "brown hair" in prompt
+    assert "smile" in prompt
+    assert "sitting" in prompt
+    assert "solo" in prompt
+    assert "She is reading a book." in prompt
+
+
+def test_simplified_tags_list_top_level_shape(reg_module, tmp_path: Path) -> None:
+    src = _write(tmp_path, {
+        "tags": ["1girl", "brown hair", "smile"],
+        "meta": {"trigger": "aoirikko"},
+    })
+    prompt = reg_module._rewrite_json_caption_for_prompt(src, set())
+    assert "aoirikko" not in prompt.lower()
+    assert "1girl" in prompt
+    assert "brown hair" in prompt
+    on_disk = _read(src)
+    assert isinstance(on_disk["tags"], dict)  # 折成标准 shape
+    assert "1girl" in on_disk["tags"]["tags"]
+
+
+# ---------------------------------------------------------------------------
+# character / scalar 字段
+# ---------------------------------------------------------------------------
+
+def test_character_dict_full_name_excluded_drops_character(reg_module, tmp_path: Path) -> None:
+    """character 是 dict 形态时折叠到 full 字符串，excluded 命中 full 名直接清空。"""
+    src = _write(tmp_path, {
+        "fixed": {"quality": "best quality"},
+        "character": {"name": "Misaka", "variant": "", "full": "Misaka Mikoto"},
+        "ai_output": {"tags": [], "appearance": [], "environment": []},
+    })
+    excluded = {reg_module._tag_key("Misaka Mikoto")}
+    prompt = reg_module._rewrite_json_caption_for_prompt(src, excluded)
+    assert "misaka" not in prompt.lower()
+    assert "best quality" in prompt
+
+
+def test_scalar_field_with_comma_per_tag_exclude(reg_module, tmp_path: Path) -> None:
+    """count="1girl, 1boy" 里 exclude="1boy" 只删 1boy 一个 token。"""
+    src = _write(tmp_path, {
+        "tags": {"count": "1girl, 1boy", "appearance": []},
+    })
+    excluded = {reg_module._tag_key("1boy")}
+    prompt = reg_module._rewrite_json_caption_for_prompt(src, excluded)
+    assert "1girl" in prompt
+    assert "1boy" not in prompt
+    on_disk = _read(src)
+    assert "1boy" not in on_disk["tags"]["count"]
+    assert "1girl" in on_disk["tags"]["count"]
+
+
+# ---------------------------------------------------------------------------
+# nl 自然语言保留
+# ---------------------------------------------------------------------------
+
+def test_nl_preserved_at_prompt_tail(reg_module, tmp_path: Path) -> None:
+    src = _write(tmp_path, {
+        "tags": {
+            "appearance": ["brown hair"],
+            "nl": "She is wearing a school uniform.",
+        },
+    })
+    prompt = reg_module._rewrite_json_caption_for_prompt(src, set())
+    assert prompt.endswith("She is wearing a school uniform.")
+    assert "brown hair" in prompt
+
+
+# ---------------------------------------------------------------------------
+# 复用：clear_reg_dir 来自 reg_builder
+# ---------------------------------------------------------------------------
+
+def test_clear_reg_dir_is_reused_from_reg_builder(reg_module) -> None:
+    from studio.services.reg.builder import clear_reg_dir as upstream
+    assert reg_module.clear_reg_dir is upstream
+    # 同时确认本地不再定义私有复制
+    assert not hasattr(reg_module, "_clear_reg_dir")
+
+
+# ---------------------------------------------------------------------------
+# txt 路径不退化：单 .txt caption 仍按 space-form 写回，trigger 由 .txt 内容决定
+# ---------------------------------------------------------------------------
+
+def test_txt_caption_path_unchanged(reg_module, tmp_path: Path) -> None:
+    src = tmp_path / "cap.txt"
+    src.write_text("brown_hair, blue eyes, 1girl", encoding="utf-8")
+    excluded = {reg_module._tag_key("1girl")}
+    prompt = reg_module._rewrite_caption_for_prompt(src, excluded)
+    assert "brown hair" in prompt  # underscore → space 归一
+    assert "blue eyes" in prompt
+    assert "1girl" not in prompt
+    on_disk = src.read_text(encoding="utf-8")
+    assert on_disk == prompt


### PR DESCRIPTION
## 背景

PR #185（fix/reg-prior-caption-format）合到 dev 后 review 发现两处与上游公共实现不必要的并行复刻：

1. **`_clear_reg_dir`** 字字复刻 `studio.services.reg.builder.clear_reg_dir`（booru full-mode build 同款入口）— 行为/语义本应跟 booru reg 路径绑定。
2. **`_filter_standard_json` / `_filter_documented_full_json` / `_filter_simple_tags_json` / `_filter_simplified_json`** 4 个 shape filter 加 8 个 helper（共 ~200 行）整套镜像了 `studio.services.tagging.caption_format.normalize_caption_json` 的 shape 派发和字段语义，只为「保留原 JSON 形态写回」。未来 caption JSON 加第 5 种 shape，两边都必须同步改，否则 reg-side 和训练侧对同一份 JSON 的理解会悄悄分裂。

## 改动

### 1. `clear_reg_dir` 复用

删本地 `_clear_reg_dir`，直接 `from studio.services.reg.builder import clear_reg_dir`。和 `reg_build_worker.py:227-229` 走同一入口。

### 2. JSON shape filter 走 normalize → 标准 shape 写回

`_rewrite_json_caption_for_prompt` 改成：

1. `normalize_caption_json(raw)` — 4 种 shape 收敛到标准 shape
2. `_filter_normalized_caption(normalized, excluded)` — 单层过滤（excluded tags + 永远去掉 `meta.trigger`）
3. `caption_json_to_text(filtered)` → prompt
4. 写回**标准 shape**（不再保留原 documented_full / simplified 形态）

reg sidecar 是派生产物；训练侧 `utils.caption_utils.load_and_build_caption` 读 reg JSON 也走同一个 `normalize_caption_json` 入口，所以 reg-side 写哪种 shape 训练侧都能读 — 没保形必要，反而消掉 4 套 shape filter 的镜像维护成本。

### 3. 顺手修两个 PR #185 自带的小坑

- **`from_path.tags / extra_tags` 同 `seen` 池**：旧代码两个字段共享 `seen` set → `ai.tags` 和 `from_path.tags` 有交集时让 `from_path` 那份静默清空。走 normalize 后两边合并到 `tags.tags` 单字段，问题消失。
- **scalar 字段单逗号 exclude 失效**：`count = \"1girl, 1boy\"` 这种合并值，旧代码当一个整 key 去 excluded set 查 → 永远 miss。新 `_keep_scalar` 按逗号 split 后逐 tag 过 excluded。

### 4. 代码量

- `runtime/anima_reg_ai.py`: 666 → 522 行（-14 helper / +1 `_filter_normalized_caption`）
- `tests/test_anima_reg_caption.py`: 新增 11 个表驱动单测

## 测试

\`\`\`
$ pytest tests/test_anima_reg_caption.py -v
11 passed in 1.99s
\`\`\`

覆盖：

- `meta.trigger` 永远从 reg sidecar + prompt 去掉（其它 meta 字段如 `tagger_version` 保留）
- excluded space ↔ underscore 双向匹配
- documented_full / 简化 shape 都折叠到标准 shape 写回
- character dict 折成 full 字符串后 exclude 命中全清空
- scalar 字段含逗号时按单 tag 过 excluded（修上述小坑）
- nl 自然语言保留到 prompt 末尾
- `clear_reg_dir` 是 reg_builder 同一实例（不是本地复刻）
- .txt 路径行为不变（仍归一到 space form）

整套 `pytest tests/`（去掉 PR #194 / dev 既有的 10 个无关 fail）1853 pass。

## 范围外（留 P2 跟进）

- **incremental 续跑老 reg 集时跳过的图，sidecar 不刷新**：用户改 `excluded_tags` 后 incremental 续跑，老图配旧 sidecar、新图配新 sidecar，同 reg 集两种 caption 共存。
- PR #185 主体行为（JSON caption 读取支持 / space canonical 切换 / full 模式清空）保留不动；只动了实现复用。