### PR TITLE
fix(updater): 0.10.2 用户检查更新 + preflight 双重失败修复（hotfix v0.11.1）

### DIFF
--- a/studio/services/runtime/updater.py
+++ b/studio/services/runtime/updater.py
@@ -441,7 +441,12 @@ def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheck
     cur = current_version()
     checked_at = time.time()
 
-    rc, _, stderr = _git("fetch", "origin", channel, timeout=GIT_FETCH_TIMEOUT)
+    # `--tags` 必须显式：git 在带显式 refspec 时关闭"auto follow tags"，
+    # 导致新 release tag（如 v0.11.0）永远不进 refs/tags/。下面 describe
+    # --exact-match 会失败，--abbrev=0 fallback 返回上一个 release tag，
+    # 被错当成 latest_version → installed_version == latest_version →
+    # 状态机误报 up_to_date（0.10.2 用户实测撞到，删 .git 重 bootstrap 才好）。
+    rc, _, stderr = _git("fetch", "origin", channel, "--tags", timeout=GIT_FETCH_TIMEOUT)
     if rc != 0:
         return UpdateCheckResult(
             channel=channel, current_commit=cur.commit, latest_commit="",
@@ -475,12 +480,14 @@ def check_update(channel: str = "master", use_cache: bool = True) -> UpdateCheck
         if _RELEASE_TAG_RE.match(tag_at_remote):
             latest_version = tag_at_remote
     if not latest_tag:
-        # describe 精确匹配失败 → fallback：取最近 reachable tag（保留兼容）
+        # describe 精确匹配失败 → fallback：取最近 reachable tag 仅用于 UI 显示。
+        # **不要**赋给 latest_version：「最近 reachable tag」≠「远端最新 release」。
+        # 远端 master 在两个 release 之间时（HEAD 比上次 tag 多几个 commit）
+        # --abbrev=0 仍返回上次 release tag，赋给 latest_version 会让状态机错判
+        # installed_version == latest_version → up_to_date，丢掉中间的更新提示。
         rc, tag_near, _ = _git("describe", "--tags", "--abbrev=0", latest)
         if rc == 0:
             latest_tag = tag_near
-            if channel == "master" and _RELEASE_TAG_RE.match(tag_near):
-                latest_version = tag_near
 
     installed_version = cur.stable_version
 

--- a/studio/services/updater.py
+++ b/studio/services/updater.py
@@ -1,0 +1,17 @@
+"""Backward-compat shim — 真正的 updater 已搬到 studio.services.runtime.updater。
+
+**保留此文件的目的（不要删！）**：
+0.10.2 及更早的 client 在 preflight 阶段调 `target_has_self_update()` 只检查
+一条 `_SELF_UPDATE_MARKER = "studio/services/updater.py"` 路径。v0.11.0 PR #143
+services/ 重构把 updater.py 搬到 `services/runtime/` 之后，v0.10.2 用户的
+client 跑 `git cat-file -e origin/master:studio/services/updater.py` 永远失败
+→ preflight 误报"目标版本早于 webui 自更新 feature" → 阻断确认按钮 → 用户
+没法用 webui 升级。保留此 shim 让旧 client 的存在性检查能通过。
+
+只要还有 0.10.2- 用户存在升级路径，就**不要删**此文件。删之前 grep 一遍
+发布版历史里 `_SELF_UPDATE_MARKER` / `_SELF_UPDATE_MARKERS` 的值，确认所有
+有人可能装的旧版本 client 都已经识别新路径，再考虑废弃。
+
+新代码请直接 `from studio.services.runtime.updater import ...`。
+"""
+from .runtime.updater import *  # noqa: F401, F403

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -248,6 +248,124 @@ def test_check_update_invalid_channel_raises() -> None:
         updater.check_update(channel="weird-branch")
 
 
+def test_check_update_master_fetch_uses_tags(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """git fetch 必须带 --tags：显式 refspec 关闭 auto-follow-tags，缺 --tags
+    会让新 release tag 进不来，下游 describe fallback 错把旧 tag 当 latest。
+    （0.10.2 用户报"已是最新"实测撞到的根因）"""
+    git_calls: list[tuple] = []
+    def _fake_git(*args, **kwargs):
+        git_calls.append(args)
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/master"):
+            return 0, "remote_sha", ""
+        if args[0] == "rev-list":
+            return 0, "0", ""
+        if args[:2] == ("rev-parse", "HEAD"):
+            return 0, "remote_sha", ""
+        if args[0] == "describe":
+            return 1, "", ""
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.10.2", commit="remote_sha", commit_short="remote_s",
+            commit_time_iso="", branch="master", tag=None, is_dirty=False,
+            installed_kind="stable", installed_label="v0.10.2",
+            stable_version="v0.10.2",
+        ),
+    )
+
+    updater.check_update(channel="master", use_cache=False)
+    fetch_calls = [c for c in git_calls if c[:2] == ("fetch", "origin")]
+    assert fetch_calls, "应当调 git fetch"
+    assert any("--tags" in c for c in fetch_calls), \
+        "git fetch 必须带 --tags 才能拉新 release tag"
+
+
+def test_check_update_returns_update_available_when_new_release_tag(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """0.10.2 用户，远端发了 v0.11.0：fetch 带 --tags 后 describe --exact-match
+    成功，latest_version=v0.11.0，状态机正确报 update_available。"""
+    def _fake_git(*args, **kwargs):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/master"):
+            return 0, "v0_11_0_sha", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/master"):
+            return 0, "37", ""
+        if args[:3] == ("rev-list", "--count", "origin/master..HEAD"):
+            return 0, "0", ""
+        if args[:2] == ("rev-parse", "HEAD"):
+            return 0, "v0_10_2_sha", ""
+        if args[:3] == ("describe", "--tags", "--exact-match"):
+            return 0, "v0.11.0", ""
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.10.2", commit="v0_10_2_sha", commit_short="v0_10_2_",
+            commit_time_iso="", branch="master", tag="v0.10.2", is_dirty=False,
+            installed_kind="stable", installed_label="v0.10.2",
+            stable_version="v0.10.2",
+        ),
+    )
+
+    result = updater.check_update(channel="master", use_cache=False)
+    assert result.state == "update_available"
+    assert result.installed_version == "v0.10.2"
+    assert result.latest_version == "v0.11.0"
+    assert result.behind_count == 37
+
+
+def test_check_update_does_not_use_abbrev0_tag_as_latest_version(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """defense in depth：远端 master 处于「上次 release 之后、下次 release 之前」
+    时（HEAD 没打 tag，--exact-match 失败），--abbrev=0 fallback 返回上次 release
+    tag。这个 tag 只能用于 UI 显示（latest_tag），**不能**赋给 latest_version —
+    否则状态机会把 installed_version == latest_version 误判成 up_to_date，
+    丢掉 release 后 dev 合到 master 的中间更新。"""
+    def _fake_git(*args, **kwargs):
+        if args[:2] == ("fetch", "origin"):
+            return 0, "", ""
+        if args[:2] == ("rev-parse", "origin/master"):
+            return 0, "mid_release_sha", ""
+        if args[:3] == ("rev-list", "--count", "HEAD..origin/master"):
+            return 0, "5", ""
+        if args[:3] == ("rev-list", "--count", "origin/master..HEAD"):
+            return 0, "0", ""
+        if args[:2] == ("rev-parse", "HEAD"):
+            return 0, "v0_10_2_sha", ""
+        if args[:3] == ("describe", "--tags", "--exact-match"):
+            return 1, "", "fatal: no exact match"
+        if args[:3] == ("describe", "--tags", "--abbrev=0"):
+            return 0, "v0.10.2", ""
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+    monkeypatch.setattr(
+        updater, "current_version",
+        lambda: updater.VersionInfo(
+            version="0.10.2", commit="v0_10_2_sha", commit_short="v0_10_2_",
+            commit_time_iso="", branch="master", tag="v0.10.2", is_dirty=False,
+            installed_kind="stable", installed_label="v0.10.2",
+            stable_version="v0.10.2",
+        ),
+    )
+
+    result = updater.check_update(channel="master", use_cache=False)
+    assert result.latest_tag == "v0.10.2"
+    assert result.latest_version is None, \
+        "--abbrev=0 fallback 不应赋给 latest_version，避免误报 up_to_date"
+    assert result.state == "update_available"
+    assert result.behind_count == 5
+
+
 # ---------------------------------------------------------------------------
 # requirements / package.json stale 检测
 # ---------------------------------------------------------------------------
@@ -813,6 +931,33 @@ def test_self_update_markers_track_real_file() -> None:
         f"_SELF_UPDATE_MARKERS 没有一个指向真实文件：{updater._SELF_UPDATE_MARKERS}"
         "——updater.py 搬家后忘了更新 marker 路径？"
     )
+
+
+def test_legacy_updater_shim_present_for_0_10_2_clients() -> None:
+    """studio/services/updater.py 兼容 shim 必须保留。
+
+    0.10.2 及更早的 client 在 preflight 里只检查这一条单路径 marker
+    （`_SELF_UPDATE_MARKER = "studio/services/updater.py"`）。v0.11.0 (PR #143)
+    services/ 重构把文件搬到 `runtime/` 之后，旧路径如果**真的**被删，
+    v0.10.2 client 升到 origin/master 会被 preflight 误判"目标版本早于
+    webui 自更新 feature"并阻断按钮。shim 文件本身存在性就够（git cat-file
+    只检查 blob 存在），但必须可正常 import 防止外部脚本误用。
+
+    删除条件：grep 历史所有发布版的 `_SELF_UPDATE_MARKER*` 值，确认每个有人
+    可能装的旧版本都已识别新路径 `studio/services/runtime/updater.py`。
+    """
+    from studio.paths import REPO_ROOT
+    shim = REPO_ROOT / "studio" / "services" / "updater.py"
+    assert shim.exists(), (
+        f"backward-compat shim {shim} 缺失！"
+        "0.10.2- client 的 target_has_self_update 检查这条单路径，"
+        "删了会让旧用户没法通过 webui 升级。"
+    )
+    # 能 import 且暴露关键符号（让外部脚本 from studio.services.updater import 不挂）
+    from studio.services import updater as legacy
+    assert hasattr(legacy, "check_update")
+    assert hasattr(legacy, "current_version")
+    assert hasattr(legacy, "target_has_self_update")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

0.10.2 用户在 webui 点「检查新版本」一直显示「已是最新」，把 `.git/` 删掉重启走 bootstrap 才能升上来；升到一半还会被 preflight 「目标版本早于 webui 自更新 feature」错误阻断。两个 bug 串成完整封死路径，已发布的 0.10.2 client 没法热修，必须服务端补救才能让现存的 0.10.2 安装能自更新。属于 release flow 文档里 hotfix 的典型场景。

## Bug 1：`check_update` 漏 `--tags`，新 release tag 永远进不来

### 复现链

1. `studio/services/runtime/updater.py:check_update` 调 `git fetch origin master`（无 `--tags`）。
2. git 的行为：带显式 refspec 时**关闭** auto-follow-tags。新发布的 `v0.11.0` tag 永远不会进本地 `refs/tags/`。
3. 接下来 `git describe --tags --exact-match origin/master` 失败（tag 不在本地）。
4. Fallback 到 `git describe --tags --abbrev=0 origin/master` 返回**最近 reachable tag** = `v0.10.2`。
5. 这条路径把 `v0.10.2` 既赋给 `latest_tag` 又赋给 `latest_version`。
6. 状态机第一条 \`installed_version == latest_version\` 命中 → `state = "up_to_date"`。
7. UI 显示「已是最新版本」，按钮置灰。

删 `.git` 触发 `bootstrap_git_repo()` 重新 init 的路径用了 `git fetch origin master --tags`（259 行），所以一次性能拉到新 tag，绕过 bug。但下一轮 release 又会撞。

### 修复

- `check_update` 的 fetch 加 `--tags`。
- `--abbrev=0` fallback 只赋给 `latest_tag`（UI 显示用），**不再**赋给 `latest_version`。防御性 —— 远端处于「上次 release 之后、下次 release 之前」时（HEAD 没打 tag），`--abbrev=0` 仍返回上次 tag，再赋给 `latest_version` 会让"中间 commit"误报 `up_to_date`。

## Bug 2：0.10.2 client `_SELF_UPDATE_MARKER` 单一旧路径，preflight 误报

### 复现链

1. 0.10.2 的 client 代码定义 `_SELF_UPDATE_MARKER = \"studio/services/updater.py\"`（单数）。`target_has_self_update` 只检查这一条路径。
2. v0.11.0 PR #143 services/ 重构把 `updater.py` 搬到 `studio/services/runtime/updater.py`，**删除了**旧路径。
3. 0.10.2 client 跑 `git cat-file -e origin/master:studio/services/updater.py` → rc≠0 → `target_has_self_update=False`。
4. Preflight 报 `self_update_compat` err level → `blocking=True` → 确认按钮 disabled。

已发布的 0.10.2 client 没法回追修这条 marker 路径，但服务端可以保留旧路径作为存在性 marker —— git `cat-file -e` 只检查 blob 存在，不读内容。

### 修复

新建 `studio/services/updater.py` 作为 backward-compat shim：

\`\`\`python
\"\"\"Backward-compat shim — 真正的 updater 已搬到 studio.services.runtime.updater。

**保留此文件的目的（不要删！）**：
0.10.2 及更早的 client 在 preflight 阶段调 \`target_has_self_update()\` 只检查
一条 \`_SELF_UPDATE_MARKER = \"studio/services/updater.py\"\` 路径。...
\"\"\"
from .runtime.updater import *  # noqa: F401, F403
\`\`\`

文件 docstring 显式写明删除条件：grep 历史所有发布版的 `_SELF_UPDATE_MARKER*` 值，确认所有有人可能装的旧版本 client 都已识别新路径，再考虑废弃。

## 修复后的实际效果

| 用户场景 | 修复前 | 修复后 |
|---|---|---|
| 0.10.2 用户点「检查更新」 | 「已是最新」（误报） | 「有新稳定版 v0.11.0」 |
| 0.10.2 用户点「确认更新 → v0.11.0」 | preflight 报 X 「目标版本早于自更新 feature」阻断 | preflight 全 ✓，按钮可点 |
| v0.11.0 用户点「检查更新」 | 正确，本来就工作 | 同上 |
| 未来 v0.12.0 释出后 0.10.2 用户 | 又得删 .git | 直接看到新版本 |
| 未来 v0.12.0 释出后 0.11.x 用户 | 正确 | 同上 |

## 测试

新增 4 条回归测试（`tests/test_updater.py`）：

- `test_check_update_master_fetch_uses_tags`：守住 fetch 调用必须含 `--tags`
- `test_check_update_returns_update_available_when_new_release_tag`：完整模拟 0.10.2 → v0.11.0 场景
- `test_check_update_does_not_use_abbrev0_tag_as_latest_version`：远端在两次 release 之间时，`latest_version=None` + state=update_available
- `test_legacy_updater_shim_present_for_0_10_2_clients`：shim 文件存在 + 关键公共 API（`check_update` / `current_version` / `target_has_self_update`）可正常 import

通过：66 个 updater 测试 + 112 个 server/version 相关测试全绿。

## Hotfix 接力清单（合并后请做）

按 CONTRIBUTING.md hotfix 流程剩余步骤：

1. ☐ 在 master 上 commit version bump（直接，不走 PR）：
   - `release_notes.yaml` 顶部 prepend 新 block（草案见下）
   - `python tools/bump_version.py validate`
   - `python tools/bump_version.py bump --version 0.11.1 --date 2026-06-01`
   - 手改 `README.md` + `README.en.md` 顶部 shields.io badge 和「当前版本」段到 `0.11.1`
   - `git add ... && git commit -m \"chore(release): v0.11.1\"`
2. ☐ 打 tag：`git tag -a v0.11.1 -m \"v0.11.1 — 0.10.2 用户自更新链路修复\" && git push origin v0.11.1`
3. ☐ GitHub Release：title 用 `v0.11.1`，body 复制 CHANGELOG 对应段，勾 Set as latest release
4. ☐ Sync 回 dev：`git checkout dev && git merge master && git push origin dev`（CONTRIBUTING 警告：这一步**必须**做，否则下次 release 这个 fix 会回归）

### `release_notes.yaml` 建议草案

\`\`\`yaml
- version: \"0.11.1\"
  date: \"2026-06-01\"
  summary: \"0.10.2 用户 webui 自更新链路修复\"
  entries:
    - kind: fixed
      summary: \"0.10.2 用户检查更新永远显示「已是最新」，无法看到新版本\"
      pr_refs: [<本 PR>]
      detail: |
        修复 `check_update` 漏带 `--tags`，导致新发布的 release tag 永远进不来。
        症状：装了 v0.10.2 的用户点「检查新版本」，明明 v0.11.0 已经发了，
        仍然显示「已是最新版本」，按钮置灰。

        绕过办法（修复前需要走这一步）：删除安装目录的 `.git/` 文件夹然后重启
        Studio，启动期会自动重新 bootstrap 仓库并把所有 tag 拉齐，再点检查
        就能看到新版本。**0.11.1 起不再需要这一步**。
    - kind: fixed
      summary: \"0.10.2 用户点确认更新时 preflight 误报「目标版本早于自更新 feature」阻断按钮\"
      pr_refs: [<本 PR>]
      detail: |
        v0.11.0 重构把 `studio/services/updater.py` 搬到 `studio/services/runtime/updater.py`，
        0.10.2 client 在 preflight 检查时只认旧路径，结果误判每个新版本都"早于
        自更新 feature"。本版本在 master 上保留 `studio/services/updater.py`
        兼容文件，让旧 client 的存在性检查能通过。
\`\`\`

## 风险评估

- shim 文件加 `from .runtime.updater import *`，所有现有 import path
  （`from studio.services.runtime.updater import ...`）不变，无 import 回归
- fetch 加 `--tags` 只影响首次 fetch（后续 tag 已在本地）；带宽影响可忽略
- `--abbrev=0` fallback 不再赋 `latest_version`：UI `latest_tag` 仍正常显示，
  只是状态机不再依赖这条 fallback。已加测试覆盖

🤖 Generated with [Claude Code](https://claude.com/claude-code)