### PR TITLE
fix(train): cache_latents 按 npz_path 去重避免 repeat 重复 VAE 编码

### DIFF
--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -570,20 +570,32 @@ class CachedLatentDataset(Dataset):
         return True
 
     def _build_cache(self, vae, device, dtype):
-        """构建/加载 npz 缓存"""
+        """构建/加载 npz 缓存。
+
+        per-folder repeat（5_concept 前缀）让 ImageDataset.samples 里同一张图重复 N 次，
+        但 npz 落点是 img_path.with_suffix(".npz") — 每张唯一图只对应一个 npz。
+        按 npz_path 去重，每张图最多 encode 一次；否则同 npz 会被反复覆盖写 N 次
+        （flip_augment 模式下再乘 2），首次构建 cache 时 80% 的 VAE encode 都是浪费。
+        """
         logger.info("检查 VAE latent 缓存...")
         to_encode = []
+        seen_npz = set()
+        unique_total = 0
         for i, sample in enumerate(self.samples):
             img_path = sample["image"]
             npz_path = self._get_npz_path(img_path)
+            if npz_path in seen_npz:
+                continue
+            seen_npz.add(npz_path)
+            unique_total += 1
             if not self._is_cache_valid(img_path, npz_path):
                 to_encode.append(i)
 
         if to_encode:
-            logger.info(f"需要编码 {len(to_encode)}/{len(self.samples)} 张图像...")
+            logger.info(f"需要编码 {len(to_encode)}/{unique_total} 张图像...")
             self._encode_and_save(to_encode, vae, device, dtype)
         else:
-            logger.info(f"所有 {len(self.samples)} 张图像已缓存")
+            logger.info(f"所有 {unique_total} 张图像已缓存")
 
         self._fill_bucket_for_index()
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -225,6 +225,87 @@ def test_cached_latent_encodes_single_when_flip_aug_off(tmp_path: Path) -> None:
         assert "latent_flipped" not in data.files
 
 
+class _CountingVAEModel:
+    """Mock VAE：每次 encode 把调用次数 +1，让测试能数 VAE 实际被调用了几次。"""
+    def __init__(self):
+        self.encode_calls = 0
+
+    def encode(self, pixels_5d, scale):
+        import torch
+        self.encode_calls += 1
+        b, _, _, h, w = pixels_5d.shape
+        return torch.zeros(b, 16, 1, h // 8, w // 8, dtype=pixels_5d.dtype)
+
+
+class _CountingVAE:
+    def __init__(self):
+        self.model = _CountingVAEModel()
+        self.scale = 1.0
+
+
+def test_cached_latent_dedupes_repeats_in_encode_pass(tmp_path: Path) -> None:
+    """per-folder repeat (5_concept) 让 samples 列表里同一张图重复 N 次；
+    cache 阶段必须按 npz_path 去重 — 每张唯一图只 encode 一次，
+    而不是按 repeat 倍数反复 VAE encode 同一张图、反复覆盖同一 npz。
+    """
+    pytest.importorskip("torch")
+    import torch
+    from PIL import Image
+
+    from runtime.training.dataset import BucketManager, CachedLatentDataset, ImageDataset
+
+    folder = tmp_path / "5_concept"
+    folder.mkdir()
+    for i in range(2):
+        img_path = folder / f"img{i}.png"
+        Image.new("RGB", (256, 256), color=(127 + i, 127, 127)).save(img_path)
+        img_path.with_suffix(".txt").write_text("tag", encoding="utf-8")
+
+    bucket_mgr = BucketManager(256, min_reso=256, max_reso=256, step=64)
+    dataset = ImageDataset(tmp_path, 256, bucket_mgr)
+    # repeat 展开：2 张图 × 5 = 10 个 samples
+    assert len(dataset.samples) == 10
+
+    vae = _CountingVAE()
+    CachedLatentDataset(dataset, vae, device="cpu", dtype=torch.float32)
+
+    # 唯一图 2 张 × flip_augment=False → 2 次 VAE encode（不是 10 次）
+    assert vae.model.encode_calls == 2, (
+        f"期望 2 次 encode（唯一图数）,实际 {vae.model.encode_calls} 次 — "
+        "_build_cache 没按 npz_path 去重，对同一张图按 repeat 倍数重复编码"
+    )
+    # 唯一 npz 文件 = 2
+    assert len(list(folder.glob("*.npz"))) == 2
+
+
+def test_cached_latent_dedupes_repeats_with_flip_aug(tmp_path: Path) -> None:
+    """repeat + flip_augment：唯一图 × 2（flip/不 flip 各一次），不是 repeat × 2。"""
+    pytest.importorskip("torch")
+    import torch
+    from PIL import Image
+
+    from runtime.training.dataset import BucketManager, CachedLatentDataset, ImageDataset
+
+    folder = tmp_path / "3_concept"
+    folder.mkdir()
+    for i in range(2):
+        img_path = folder / f"img{i}.png"
+        Image.new("RGB", (256, 256), color=(127 + i, 127, 127)).save(img_path)
+        img_path.with_suffix(".txt").write_text("tag", encoding="utf-8")
+
+    bucket_mgr = BucketManager(256, min_reso=256, max_reso=256, step=64)
+    dataset = ImageDataset(tmp_path, 256, bucket_mgr, flip_augment=True)
+    assert len(dataset.samples) == 6  # 2 × 3
+
+    vae = _CountingVAE()
+    CachedLatentDataset(dataset, vae, device="cpu", dtype=torch.float32)
+
+    # 2 张唯一图 × 2 (flip/不 flip) = 4 次，不是 6 × 2 = 12 次
+    assert vae.model.encode_calls == 4, (
+        f"期望 4 次 encode（2 唯一 × flip/不 flip）,实际 {vae.model.encode_calls} 次"
+    )
+
+
 def test_cached_latent_getitem_picks_flipped_per_random(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """flip_augment=True 时 __getitem__ 按 random 50% 取 latent_flipped；
     flip_augment=False 时永远取 latent（即使 npz 有 flipped 也忽略）。


### PR DESCRIPTION
## 背景 / 动机

per-folder repeat（Kohya 风格 `5_concept` 前缀文件夹）会把同一张图按 N 倍展开到 `ImageDataset.samples` 里。`CachedLatentDataset._build_cache` 直接遍历 `samples` 收集 `to_encode`，**没按 npz_path 去重**，结果同一张图被 VAE encode N 次、反复覆盖同一个 `xxx.npz`；`flip_augment` 模式下还要再乘 2。

举例：`5_concept` 文件夹 3 张图 + `flip_augment=True` + `cache_latents=True`：
- 旧行为：首次建 cache 跑 **30 次** VAE encode（15 个 samples × flip/不 flip 各 1），产出 3 个 npz，每个被覆盖 5 次
- 实际只需要 **6 次** encode（3 张唯一图 × 2）

二次运行（npz 已存在）不受影响 —— `_is_cache_valid` 命中后 `to_encode` 本来就是空。问题集中在**首次构建**或**改了分辨率/flip 触发失效后**。

## 改动概要

`runtime/training/dataset.py:_build_cache`：

1. 收 `to_encode` 时用 `seen_npz` set 按 `npz_path` 去重，每张唯一图最多入选一次
2. `unique_total` 替代 `len(self.samples)` 当日志分母，跟实际工作量对齐

`_encode_and_save` / `_fill_bucket_for_index` / `__getitem__` / `_is_cache_valid` 都不动，npz 文件格式不变，向后兼容。

`_fill_bucket_for_index` 也会按 sample 数遍历 npz 读 header，存在类似冗余 open，但开销小（不调 VAE）；本 PR 不动，留给后续如果有需要再优化。

## 测试方式

`tests/test_datasets.py` 加 2 个 regression test，用计数 mock VAE 验证 `encode` 调用次数：

- `test_cached_latent_dedupes_repeats_in_encode_pass`：`5_concept` × 2 图，`flip=False` → 期望 2 次 encode（不是 `len(samples)=10`）
- `test_cached_latent_dedupes_repeats_with_flip_aug`：`3_concept` × 2 图，`flip=True` → 期望 4 次 encode（不是 `len(samples)=6` × 2 = 12）

```bash
python -m pytest tests/test_datasets.py -q
# 23 passed
```

## 不在范围内

- `_fill_bucket_for_index` 的冗余 npz read（开销远小于 VAE，不调 VAE 模型）
- 不改 npz 格式 / `_is_cache_valid` / `__getitem__` 行为
- 不改 UI / CLI / schema