### PR TITLE
fix(cli): argparse_bridge 兼容 py3.13+ 且兜底 description 裸 %

### DIFF
--- a/studio/infrastructure/argparse_bridge.py
+++ b/studio/infrastructure/argparse_bridge.py
@@ -81,7 +81,12 @@ def add_argument_for(parser: argparse.ArgumentParser, name: str, field: FieldInf
     flag = _flag_for(name, field)
     annotation, is_optional = _unwrap_optional(field.annotation)
     default = _default_value(field)
-    help_text = (field.description or "").strip()
+    # argparse format_help 把 description 当 printf 模板做 `% params` 展开，
+    # description 里裸 `%`（如 "占 90%"）会让 --help 直接 ValueError。
+    # 项目里 schema description 同时给 Web UI / i18n 用，不应被 argparse 语义污染，
+    # 因此在 bridge 一层把所有裸 `%` 转义 —— 全项目无人使用 %(default)s 这类
+    # argparse named substitution，escape 不会破坏既有用法。
+    help_text = (field.description or "").strip().replace("%", "%%")
 
     # bool ----------------------------------------------------------------
     if annotation is bool:
@@ -94,13 +99,29 @@ def add_argument_for(parser: argparse.ArgumentParser, name: str, field: FieldInf
             actual_default = default  # keep None
         else:
             actual_default = bool(default) if default is not None else False
-        parser.add_argument(
-            flag,
-            dest=name,
-            action=argparse.BooleanOptionalAction,
-            default=actual_default,
-            help=help_text or None,
-        )
+        # Python 3.13+ 的 argparse 拒绝把 --no-X 形式的 flag 传给
+        # BooleanOptionalAction（会自动衍生 --no-no-X 与字段重名）。
+        # 字段名以 no_ 开头时退化为一对互斥 store_true/store_false：
+        #   --no-X    → store_true  (no_X = True)
+        #   --X       → store_false (no_X = False)
+        if name.startswith("no_") and len(name) > 3:
+            positive = "--" + name[3:].replace("_", "-")
+            parser.add_argument(
+                flag,
+                dest=name,
+                action="store_true",
+                default=actual_default,
+                help=help_text or None,
+            )
+            parser.add_argument(positive, dest=name, action="store_false", help=None)
+        else:
+            parser.add_argument(
+                flag,
+                dest=name,
+                action=argparse.BooleanOptionalAction,
+                default=actual_default,
+                help=help_text or None,
+            )
         return
 
     # Literal -------------------------------------------------------------

--- a/tests/test_argparse_bridge.py
+++ b/tests/test_argparse_bridge.py
@@ -48,6 +48,40 @@ def test_bool_uses_paired_flag() -> None:
     assert parser.parse_args(["--enabled"]).enabled is True
 
 
+def test_bool_field_named_no_x_uses_paired_store_actions() -> None:
+    """字段名以 no_ 开头时退化成两个互斥 store_true/store_false flag。
+
+    py3.13+ argparse 拒绝把 --no-X 塞给 BooleanOptionalAction（issue #170）。
+    本用例 codify 退化路径：默认值保留 / --no-X 设 True / --X 设 False。
+    """
+    from studio.schema import TrainingConfig
+
+    parser = bridge.build_parser(TrainingConfig, add_config_arg=False)
+    # 默认 True（schema 里 no_progress 默认 True）
+    assert parser.parse_args([]).no_progress is True
+    # --no-progress 显式打开（向后兼容旧 CLI 习惯）
+    assert parser.parse_args(["--no-progress"]).no_progress is True
+    # --progress 关闭 → no_progress=False
+    assert parser.parse_args(["--progress"]).no_progress is False
+
+
+def test_help_tolerates_percent_in_description() -> None:
+    """description 含裸 `%` 时 format_help 不应崩，且输出仍是单个 `%`。
+
+    argparse 把 description 当 printf 模板做 `% params` 展开，未 escape 的
+    `%` 会触发 ValueError。Schema description 同时供 Web UI / i18n 使用，
+    不应被 argparse 语义污染 —— bridge 一层兜底转义。
+    """
+    class _PctSample(BaseModel):
+        ratio: float = Field(0.5, description="新值占 90%；越大响应越快")
+
+    parser = bridge.build_parser(_PctSample, add_config_arg=False)
+    text = parser.format_help()  # 修复前在 py3.10+ 直接 ValueError
+    # 用户看到的仍是单个 %（不是 %%）
+    assert "占 90%；" in text
+    assert "%%" not in text
+
+
 def test_literal_emits_choices() -> None:
     parser = bridge.build_parser(_Sample, add_config_arg=False)
     assert parser.parse_args(["--mode", "b"]).mode == "b"


### PR DESCRIPTION
## 背景

issue #170 中用户在 Python 3.14 上跑 `anima_train.py` 撞到：

```
ValueError: invalid option name '--no-progress' for BooleanOptionalAction
```

根因：py3.13 起 argparse 收紧了 `BooleanOptionalAction` 的命名校验 —— 不允许 flag 本身就以 `--no-` 开头（它会自动衍生 `--no-no-progress` 与字段同名冲突）。schema 里 `no_progress: bool` 字段被 bridge 编成 `--no-progress` + `BooleanOptionalAction`，于是 build_parser 直接抛错。

顺手在 3.13 真机跑全量回归还发现另一条同支线 pre-existing fail：`infonoise_beta` description 含 `占 90%；`，argparse `format_help()` 把 description 当 printf 模板 `% params` 展开 → `unsupported format character '?' (0xff1b)`，让 `--help` 在 py3.10+ 直接崩。两件都是 CLI 入口稳定性问题，合并为一个 unit。

## 改动

`studio/infrastructure/argparse_bridge.py`：

1. **bool 字段名以 `no_` 开头时退化为一对 `--no-X` / `--X`** —— store_true / store_false 分别注册，dest 仍为字段原名。绕过 BooleanOptionalAction 的校验，行为与之前一致：
   - `--no-progress` → `no_progress=True`（向后兼容旧 CLI 习惯）
   - `--progress` → `no_progress=False`
   - 默认值取字段默认（保留 PR #146 对 `Optional[bool]` 默认 `None` 的处理）
2. **description 里裸 `%` 自动转义成 `%%`** —— bridge 一层兜底；schema 作者 / Web UI / i18n 不再需要关心 argparse 的 % 语义。全项目无人使用 `%(default)s` 这类 named substitution，escape 不会破坏既有用法。

## 测试

`tests/test_argparse_bridge.py` 新增两条 codify：

- `test_bool_field_named_no_x_uses_paired_store_actions` —— 用 schema 真实字段 `no_progress` 验证三态
- `test_help_tolerates_percent_in_description` —— 验证 `format_help()` 不崩、用户看到的仍是单个 `%`

| | 改前 | 改后 |
|---|---|---|
| **Python 3.13** | 21 pass / 1 fail (`help_does_not_crash`) | **24 pass / 0 fail** |
| **Python 3.11** | 21 pass / 1 fail | **24 pass / 0 fail** |

issue #170 报告者所述场景（裸跑 `anima_train.py` 在 3.13+ 直接 build_parser 失败）在改后不再触发。

Closes #170 (第 2 项 Python 3.13/3.14 兼容性部分)

🤖 Generated with [Claude Code](https://claude.com/claude-code)