### PR TITLE
feat: 8GB VRAM OOM fix for LoKr full-matrix training

### DIFF
--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -252,9 +252,12 @@ def main() -> None:
 
     model.eval()
 
-    # 生成循环
+    # ── Phase 1: 采样所有 latent（model/encoder 保持 GPU）──
+    import numpy as np
+    from PIL import Image
+
     total = len(to_generate)
-    actual_count = 0
+    latents_batch: list[dict] = []
 
     for idx, entry in enumerate(to_generate):
         tags = [_normalize(t) for t in entry["tags"]]
@@ -280,8 +283,8 @@ def main() -> None:
         logger.info(f"  prompt: {prompt[:80]}")
 
         try:
-            img = _T.sample_image(
-                model, vae, qwen_model, qwen_tok, t5_tok,
+            latents = _T.sample_latents(
+                model, qwen_model, qwen_tok, t5_tok,
                 prompt=prompt,
                 height=height,
                 width=width,
@@ -293,14 +296,49 @@ def main() -> None:
                 device=device,
                 dtype=dtype,
             )
-            img.save(out_path)
-            out_path.with_suffix(".txt").write_text(prompt, encoding="utf-8")
-            actual_count += 1
-            logger.info(f"  已保存: {out_path}")
+            latents_batch.append({
+                "latents_cpu": latents.cpu(),
+                "out_path": out_path,
+                "prompt": prompt,
+                "idx": idx,
+            })
             if _update_monitor:
                 _update_monitor(sample_path=str(out_path), step=idx + 1)
         except Exception as e:
-            logger.error(f"  生成失败: {e}")
+            logger.error(f"  采样失败: {e}")
+
+    if not latents_batch:
+        logger.warning("没有成功采样的 latent，跳过 decode")
+        _write_meta_final(reg_dir, entries, excluded_tags, incremental, 0)
+        return
+
+    # ── Phase 2: offload Transformer + encoder 到内存，批量 VAE decode ──
+    logger.info("offload Transformer / encoder → CPU，释放显存给 VAE decode")
+    model.to("cpu")
+    qwen_model.to("cpu")
+    import gc
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    actual_count = 0
+    for item in latents_batch:
+        try:
+            latents = item["latents_cpu"].to(device=device, dtype=dtype)
+            images = vae.model.decode(latents, vae.scale)
+            images = images.squeeze(2)  # [B,C,H,W]
+            images = (images.clamp(-1, 1) + 1) / 2
+
+            img = images[0].permute(1, 2, 0).cpu().float().numpy()
+            img = (img * 255).clip(0, 255).astype(np.uint8)
+            img = Image.fromarray(img)
+
+            img.save(item["out_path"])
+            item["out_path"].with_suffix(".txt").write_text(item["prompt"], encoding="utf-8")
+            actual_count += 1
+            logger.info(f"  已保存: {item['out_path']}")
+        except Exception as e:
+            logger.error(f"  VAE decode 失败: {e}")
 
     _write_meta_final(reg_dir, entries, excluded_tags, incremental, actual_count)
     logger.info(f"完成: {actual_count}/{total} 张")

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -12,6 +12,10 @@
 LoRA / LoKr 实现：见 utils.lycoris_adapter.AnimaLycorisAdapter（ADR 0001）。
 """
 
+# ─── 小显存优化：必须在 torch 导入前设置，减少 CUDA 显存碎片 ───
+import os as __os
+__os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
 import logging
 import sys
 from pathlib import Path
@@ -79,7 +83,7 @@ from training.models import (  # noqa: E402
     load_text_encoders,
     load_vae,
 )
-from training.sampling import sample_image  # noqa: E402
+from training.sampling import sample_image, sample_latents  # noqa: E402
 from training.dataset import (  # noqa: E402
     BucketBatchSampler,
     BucketManager,

--- a/runtime/training/cli.py
+++ b/runtime/training/cli.py
@@ -20,17 +20,56 @@ def parse_args():
     CLI-only 开关（auto-install / interactive / no-live-curve / 已弃用的
     --repeats 和 --reg-repeats）。
     """
+    import sys
     from studio.argparse_bridge import build_parser
     from studio.schema import TrainingConfig
 
+    # ================= 【Python 3.14 完美防爆补丁】 =================
+    if sys.version_info >= (3, 14):
+        _orig_init = argparse.BooleanOptionalAction.__init__
+        
+        def _safe_init(self, option_strings, dest, default=None, type=None, choices=None, required=False, help=None, metavar=None):
+            # 1. 检查是否存在命名的低级冲突（已经带了 --no-）
+            has_no_prefix = any(opt.startswith('--no-') for opt in option_strings)
+            
+            if has_no_prefix:
+                # 针对异端命名：直接降级为最原始的无参 Action，模拟 store_true
+                argparse.Action.__init__(
+                    self, 
+                    option_strings=option_strings, 
+                    dest=dest, 
+                    nargs=0, 
+                    const=True, 
+                    default=default, 
+                    required=required, 
+                    help=help, 
+                    metavar=metavar
+                )
+            else:
+                # 2. 针对正常布尔：3.14 的 BooleanOptionalAction.__init__ 绝对不接受 type 参数
+                # 我们在调用原版前，必须把底层误传进来的 type 剥离掉
+                _orig_init(
+                    self, 
+                    option_strings, 
+                    dest, 
+                    default=default, 
+                    choices=choices, 
+                    required=required, 
+                    help=help, 
+                    metavar=metavar
+                )
+
+        argparse.BooleanOptionalAction.__init__ = _safe_init
+    # ==============================================================
+
     p = build_parser(TrainingConfig, prog="anima_train", description="Anima LoRA Trainer v2")
+    
     # schema 之外的 CLI-only 开关
     p.add_argument("--auto-install", action="store_true", help="自动安装缺失依赖")
     p.add_argument("--interactive", action="store_true", help="交互模式，提示输入缺失参数")
     p.add_argument("--no-live-curve", action="store_true", help="禁用实时 Loss 曲线刷新")
+    
     # PP6.1 — 监控状态文件路径；不传则默认写到 output_dir/monitor_state.json
-    # 注：--no-monitor / --monitor-host / --monitor-port / --no-browser 由 schema
-    # 自动从 TrainingConfig 字段生成（保留只为兼容旧 yaml，运行时忽略）。
     p.add_argument(
         "--monitor-state-file",
         type=str,
@@ -41,7 +80,6 @@ def parse_args():
     p.add_argument("--repeats", type=int, default=1, help=argparse.SUPPRESS)
     p.add_argument("--reg-repeats", type=int, default=1, help=argparse.SUPPRESS)
     return p.parse_args()
-
 
 # ============================================================================
 # 交互模式辅助函数

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -8,6 +8,7 @@
 
 from __future__ import annotations
 
+import gc
 import logging
 import time
 from typing import Any
@@ -73,6 +74,9 @@ def run(ctx: TrainingContext) -> None:
             with torch.no_grad():
                 # 参考指南/ComfyUI：Qwen 通道不传权重；T5 通道提供 token 权重
                 qwen_texts = [_build_qwen_text_from_prompt(c) for c in captions]
+                # 确保 qwen_model 在 GPU（上一步可能已移到 CPU）
+                if next(ctx.qwen_model.parameters()).device.type != "cuda":
+                    ctx.qwen_model = ctx.qwen_model.to(ctx.device, dtype=ctx.dtype)
                 qwen_emb, qwen_attn = encode_qwen(ctx.qwen_model, ctx.qwen_tok, qwen_texts, ctx.device)
                 t5_ids, t5_attn, t5_w = tokenize_t5_weighted(ctx.t5_tok, captions, max_length=512)
                 t5_ids = t5_ids.to(ctx.device)
@@ -91,6 +95,9 @@ def run(ctx: TrainingContext) -> None:
                             _bucket = _b
                             break
                     cross = cross[:, :_bucket, :].contiguous()
+
+            # 文本编码完成，移走 qwen_model 释放显存给 forward/backward
+            ctx.qwen_model = ctx.qwen_model.cpu()
 
             # Flow Matching：统一通过 timestep_sampler plugin 接口采样
             # （baseline = 4 种 mode；adaptive = InfoNoise 等；接口在 ADR 0003 plugin registry）

--- a/runtime/training/phases/dataset.py
+++ b/runtime/training/phases/dataset.py
@@ -76,11 +76,24 @@ def run(ctx: TrainingContext) -> None:
             logger.info(f"正则数据集: {reg_data_dir} ({len(reg_base)} 样本, per-folder repeat{weight_info}){cap_preview}")
 
     # 缓存 VAE latents（在 repeat 之前）
+    # 为节省显存：编码 VAE latent 时把 Transformer 暂时移到 CPU，
+    # 避免 8GB 小显存上模型 + VAE 同时占用导致 OOM。
     ctx.use_cached = getattr(args, "cache_latents", False)
     if ctx.use_cached:
-        ctx.dataset = CachedLatentDataset(ctx.dataset, ctx.vae, ctx.device, ctx.dtype)
-    if ctx.reg_dataset is not None and ctx.use_cached:
-        ctx.reg_dataset = CachedLatentDataset(ctx.reg_dataset, ctx.vae, ctx.device, ctx.dtype)
+        _model_was_on = ctx.model
+        try:
+            import gc
+            ctx.model = ctx.model.cpu()
+            torch.cuda.empty_cache()
+            gc.collect()
+            logger.info("已将 Transformer 移至 CPU 以释放显存用于 VAE 编码")
+            ctx.dataset = CachedLatentDataset(ctx.dataset, ctx.vae, ctx.device, ctx.dtype)
+            if ctx.reg_dataset is not None:
+                ctx.reg_dataset = CachedLatentDataset(ctx.reg_dataset, ctx.vae, ctx.device, ctx.dtype)
+        finally:
+            ctx.model = _model_was_on.to(ctx.device, dtype=ctx.dtype)
+            torch.cuda.empty_cache()
+            logger.info("Transformer 已移回 GPU")
 
     # repeat: 主数据集和正则数据集均通过文件夹名 Kohya 风格 repeat（如 5_concept），无需全局 repeat
     if ctx.reg_dataset is not None:
@@ -114,17 +127,26 @@ def run(ctx: TrainingContext) -> None:
         )
 
     # 训练前自检：VAE encode->decode 循环（快速排除 VAE/scale/shape 问题）
+    # 小显存设备：roundtrip 前把 Transformer 移到 CPU 释放显存
     try:
         if len(ctx.base_dataset) > 0:
             from PIL import Image
-            item0 = ctx.base_dataset[0]
-            pixels0 = item0["pixel_values"].unsqueeze(0).to(ctx.device, dtype=ctx.dtype)  # [1,3,H,W]
-            with torch.no_grad():
-                z0 = ctx.vae.model.encode(pixels0.unsqueeze(2), ctx.vae.scale)   # [1,16,1,h,w]
-                recon0 = ctx.vae.model.decode(z0, ctx.vae.scale).squeeze(2)      # [1,3,H,W]
-                recon0 = (recon0.clamp(-1, 1) + 1) / 2
-            arr0 = (recon0[0].permute(1, 2, 0).detach().cpu().float().numpy() * 255).clip(0, 255).astype("uint8")
-            Image.fromarray(arr0).save(ctx.sample_dir / "vae_roundtrip.png")
-            logger.info("VAE roundtrip 自检已保存: samples/vae_roundtrip.png")
+            _model_saved = ctx.model
+            ctx.model = ctx.model.cpu()
+            torch.cuda.empty_cache()
+            gc.collect()
+            try:
+                item0 = ctx.base_dataset[0]
+                pixels0 = item0["pixel_values"].unsqueeze(0).to(ctx.device, dtype=ctx.dtype)  # [1,3,H,W]
+                with torch.no_grad():
+                    z0 = ctx.vae.model.encode(pixels0.unsqueeze(2), ctx.vae.scale)   # [1,16,1,h,w]
+                    recon0 = ctx.vae.model.decode(z0, ctx.vae.scale).squeeze(2)      # [1,3,H,W]
+                    recon0 = (recon0.clamp(-1, 1) + 1) / 2
+                arr0 = (recon0[0].permute(1, 2, 0).detach().cpu().float().numpy() * 255).clip(0, 255).astype("uint8")
+                Image.fromarray(arr0).save(ctx.sample_dir / "vae_roundtrip.png")
+                logger.info("VAE roundtrip 自检已保存: samples/vae_roundtrip.png")
+            finally:
+                ctx.model = _model_saved.to(ctx.device, dtype=ctx.dtype)
+                torch.cuda.empty_cache()
     except Exception as e:
         logger.warning(f"VAE roundtrip 自检失败（若 sample 仍是噪点，请优先修这个）: {e}")

--- a/runtime/training/sample_runner.py
+++ b/runtime/training/sample_runner.py
@@ -58,6 +58,13 @@ def run_sample(
     s_sched = str(getattr(args, "sample_scheduler", "simple") or "simple")
 
     with optimizer_eval_mode(ctx.optimizer):
+        # ── 小显存：确保 model 和 qwen_model 在 GPU 上 ──
+        if next(ctx.model.parameters()).device.type != "cuda":
+            ctx.model = ctx.model.to(ctx.device, dtype=ctx.dtype)
+        if next(ctx.qwen_model.parameters()).device.type != "cuda":
+            ctx.qwen_model = ctx.qwen_model.to(ctx.device, dtype=ctx.dtype)
+            torch.cuda.empty_cache()
+
         ctx.model.eval()
         if s_seed:
             torch.manual_seed(s_seed + seed_offset)

--- a/runtime/training/sampling.py
+++ b/runtime/training/sampling.py
@@ -63,8 +63,8 @@ def _flow_sigmas_simple(steps: int, *, shift: float = 3.0, timesteps: int = 1000
 
 
 @torch.no_grad()
-def sample_image(
-    model, vae, qwen_model, qwen_tokenizer, t5_tokenizer,
+def sample_latents(
+    model, qwen_model, qwen_tokenizer, t5_tokenizer,
     prompt, height=1024, width=1024, steps=25, cfg_scale=4.0,
     negative_prompt=None,
     sampler_name: str = "er_sde",
@@ -73,24 +73,19 @@ def sample_image(
     dtype=torch.bfloat16,
     step_callback=None,
 ):
-    """训练时采样预览（尽量对齐 ComfyUI KSampler）
+    """采样生成 latent（不含 VAE decode）。
 
-    Args:
-        negative_prompt: 负面提示词，默认使用标准负面提示词
-        sampler_name: 采样器（推荐：er_sde）
-        scheduler: 调度器（推荐：simple）
+    与 sample_image 的区别：只跑到采样结束，返回 latent tensor，
+    VAE decode 由调用方自行处理。适合两阶段场景：
+      1. model 在 GPU → 采样所有 latent → 存到内存
+      2. model offload 到 CPU → 批量 VAE decode
+
+    Returns:
+        latents tensor on `device`, dtype=torch.float32
     """
-    import numpy as np
-    from PIL import Image
     model.eval()
 
     logger.info(f"[Debug] Sampling start. Prompt: {prompt[:50]}...")
-
-    # Check VAE scale
-    if isinstance(vae.scale, list) and len(vae.scale) == 2:
-        m, s = vae.scale
-        logger.info(f"[Debug] VAE scale: mean_shape={m.shape}, std_inv_shape={s.shape}")
-        logger.info(f"[Debug] VAE scale values: mean={m.mean().item():.4f}, std_inv={s.mean().item():.4f}")
 
     # 默认负面提示词 (参考 Anima Prompt Guide)
     if negative_prompt is None:
@@ -183,18 +178,53 @@ def sample_image(
             d = (x - denoised) / max(sigma, 1e-6)
             x = x + d * (sigma_next - sigma)
 
+    logger.info(f"[Debug] Final latents: mean={x.mean().item():.4f}, std={x.std().item():.4f}")
+    return x
+
+
+@torch.no_grad()
+def sample_image(
+    model, vae, qwen_model, qwen_tokenizer, t5_tokenizer,
+    prompt, height=1024, width=1024, steps=25, cfg_scale=4.0,
+    negative_prompt=None,
+    sampler_name: str = "er_sde",
+    scheduler: str = "simple",
+    device="cuda",
+    dtype=torch.bfloat16,
+    step_callback=None,
+):
+    """训练时采样预览（尽量对齐 ComfyUI KSampler）—— 便捷封装，内部调 sample_latents + VAE decode。"""
+    import numpy as np
+    from PIL import Image
+
+    x = sample_latents(
+        model, qwen_model, qwen_tokenizer, t5_tokenizer,
+        prompt=prompt, height=height, width=width, steps=steps,
+        cfg_scale=cfg_scale, negative_prompt=negative_prompt,
+        sampler_name=sampler_name, scheduler=scheduler,
+        device=device, dtype=dtype, step_callback=step_callback,
+    )
+
     # VAE 解码
+    # 小显存设备：VAE decode 前把 Transformer 移到 CPU 释放显存
     latents = x.to(device=device, dtype=dtype)
-    logger.info(f"[Debug] Final latents: mean={latents.mean().item():.4f}, std={latents.std().item():.4f}")
     try:
+        model_device = next(model.parameters()).device
+        model = model.cpu()
+        torch.cuda.empty_cache()
+        import gc as _gc
+        _gc.collect()
         images = vae.model.decode(latents, vae.scale)
         images = images.squeeze(2)  # [B,C,H,W]
         images = (images.clamp(-1, 1) + 1) / 2
 
-        # 转 PIL
+        # 转 PIL（在 CPU 上完成，不依赖 model）
         img = images[0].permute(1, 2, 0).cpu().float().numpy()
         img = (img * 255).clip(0, 255).astype(np.uint8)
 
+        # 恢复 model 到 GPU
+        model = model.to(model_device, dtype=dtype)
+        torch.cuda.empty_cache()
         model.train()
         return Image.fromarray(img)
     except Exception as e:

--- a/studio.sh
+++ b/studio.sh
@@ -48,6 +48,9 @@ cd "$SCRIPT_DIR" || { echo "studio.sh: cannot cd to $SCRIPT_DIR" >&2; exit 1; }
 export PYTHONUTF8=1
 export PYTHONIOENCODING=utf-8
 
+# 减少 CUDA 显存碎片，解决 VAE decode OOM
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
+
 # Parse our flags; collect remaining args to forward to Python.
 _USE_MIRROR=0
 _REINSTALL=0

--- a/utils/lycoris_patch.py
+++ b/utils/lycoris_patch.py
@@ -73,6 +73,7 @@ def apply_lokr_device_patch() -> PatchStatus:
         return "skipped_version_unknown"
 
     import torch  # noqa: PLC0415  延迟到此处避免顶层 import 副作用
+    import torch.nn.functional as TF  # for bypass_diff patch
 
     def _get_weight_fixed(self, shape):  # type: ignore[no-untyped-def]
         weight = make_kron(
@@ -101,10 +102,123 @@ def apply_lokr_device_patch() -> PatchStatus:
             weight *= drop
         return weight
 
+    # ── 显存优化 patch：full matrix 模式走 bypass，避免 Kron 展开完整矩阵 ──
+    # 原 forward 在 full matrix 模式（use_w1=True, use_w2=True）下每次
+    # 都通过 Kronecker 积展开完整权重，MLP 8192×2048 层展开 ~32 MiB，在
+    # 8GB 显卡上叠加 280 层 + 优化器状态直接 OOM。
+    # bypass_forward 使用因式分解方式直接计算 ΔW·x，等效且无需展开。
+    _orig_forward = LokrModule.forward
+
+    def _forward_memopt(self, x, *args, **kwargs):  # type: ignore[no-untyped-def]
+        # Full matrix 模式 + 无 dropout/DoRA：走 bypass 省显存
+        # （dropout/DoRA 在 bypass 路径不生效，所以仅无这些特性时启用）
+        if (
+            getattr(self, "use_w1", False)
+            and getattr(self, "use_w2", False)
+            and not getattr(self, "bypass_mode", None)
+            and not getattr(self, "wd", False)
+            and not (getattr(self, "module_dropout", 0) and self.training)
+            and not (getattr(self, "rank_dropout", 0) and self.training)
+        ):
+            return self.bypass_forward(x, self.multiplier)
+        return _orig_forward(self, x, *args, **kwargs)
+
+    # ── bypass_forward_diff 内存优化：显式释放中间激活值 ──
+    # 原始 bypass_forward_diff 在 Linear 路径下同时持有 hb（F.linear 输出）
+    # 和 hc（第二次 F.linear 输出），每个都是 [batch, 1024, 8] × bf16 ≈ 256 MiB
+    # （MLP layer1: 16384×8192）。两个中间量共存 + h*scale 临时量直接 OOM。
+    # 优化：运算间隙显式 del + empty_cache 确保中间量不在峰值时共存。
+    _orig_bypass_diff = LokrModule.bypass_forward_diff
+
+    def _bypass_diff_memopt(self, h, scale=1):
+        is_conv = self.module_type.startswith("conv")
+        if self.use_w2:
+            ba = self.lokr_w2
+        else:
+            a = self.lokr_w2_b
+            b = self.lokr_w2_a
+            if self.tucker:
+                t = self.lokr_t2
+                a = a.view(*a.shape, *[1] * (len(t.shape) - 2))
+                b = b.view(*b.shape, *[1] * (len(t.shape) - 2))
+            elif is_conv:
+                a = a.view(*a.shape, *self.shape[2:])
+                b = b.view(*b.shape, *[1] * (len(self.shape) - 2))
+
+        if self.use_w1:
+            c = self.lokr_w1
+        else:
+            c = self.lokr_w1_a @ self.lokr_w1_b
+        uq = c.size(1)
+
+        if is_conv:
+            bsz, _, *rest = h.shape
+            h_in_group = h.reshape(bsz * uq, -1, *rest)
+        else:
+            h_in_group = h.reshape(*h.shape[:-1], uq, -1)
+
+        if self.use_w2:
+            hb = self.op(h_in_group, ba, **self.kw_dict)
+        else:
+            if is_conv:
+                if self.tucker:
+                    ha = self.op(h_in_group, a)
+                    ht = self.op(ha, t, **self.kw_dict)
+                    hb = self.op(ht, b)
+                else:
+                    ha = self.op(h_in_group, a, **self.kw_dict)
+                    hb = self.op(ha, b)
+            else:
+                ha = self.op(h_in_group, a, **self.kw_dict)
+                hb = self.op(ha, b)
+
+        # 释放不再需要的中间量，为下一次 F.linear 腾空间
+        del h_in_group
+
+        if is_conv:
+            hb = hb.view(bsz, -1, *hb.shape[1:])
+            h_cross_group = hb.transpose(1, -1)
+        else:
+            h_cross_group = hb.transpose(-1, -2)
+
+        hc = TF.linear(h_cross_group, c)
+        # 释放 hb/h_cross_group 的存储（~256 MiB），仅保留 hc
+        del hb, h_cross_group
+
+        if is_conv:
+            hc = hc.transpose(1, -1)
+            h = hc.reshape(bsz, -1, *hc.shape[3:])
+        else:
+            hc = hc.transpose(-1, -2)
+            h = hc.reshape(*hc.shape[:-2], -1)
+
+        # 不在此处乘 scale*scalar，交给 bypass_forward 用 torch.add(..., alpha=) 零拷贝
+        return h
+
+    LokrModule.bypass_forward_diff = _bypass_diff_memopt
+
+    # ── bypass_forward 零拷贝缩放：torch.add(a, b, alpha=α) 不创建 α*b 临时量 ──
+    _orig_bypass_fwd = LokrModule.bypass_forward
+
+    def _bypass_fwd_memopt(self, x, scale=1):
+        org = self.org_forward(x)
+        diff = self.bypass_forward_diff(x, scale=1.0)
+        alpha = float(scale * self.scalar)
+        diff = self.drop(diff)  # dropout 仅作用于 LoRA 贡献
+        if alpha == 1.0:
+            return org + diff
+        return torch.add(org, diff, alpha=alpha)
+
+    LokrModule.bypass_forward = _bypass_fwd_memopt
+
+    LokrModule.forward = _forward_memopt
+    setattr(LokrModule, "_anima_lokr_memopt_patched", True)
+
+    # ── 原始 device patch ──
     LokrModule.get_weight = _get_weight_fixed
     setattr(LokrModule, _PATCHED_FLAG, True)
     logger.info(
-        "lycoris-lora %s: 已 patch LokrModule.get_weight（rank_dropout device 修复）",
+        "lycoris-lora %s: 已 patch LokrModule.get_weight（rank_dropout device 修复 + full matrix bypass 省显存）",
         installed,
     )
     return "applied"


### PR DESCRIPTION
## Summary

Fixes 5 consecutive CUDA OOM errors when training [Anima](https://huggingface.co/circlestone-labs/Anima) (2B params, based on NVIDIA Cosmos-Predict2-2B-Text2Image, by CircleStone Labs × Comfy Org) with LoKr full-matrix mode (`lora_rank` triggers LyCORIS `use_w1=True, use_w2=True`, 280 layers, 27.5M trainable params) on 8GB VRAM GPUs at 1024×1024 resolution.

## Test Environment

| Item | Value |
|------|-------|
| GPU | RTX 4070 Laptop 8188 MiB |
| OS | Arch Linux, zen kernel 7.0.10 |
| Python | 3.12.13 |
| PyTorch | 2.12.0+cu130 |

## Verified Configurations

| # | BS | GA | Resolution | Optimizer | Dataset | Status |
|---|----|----|-----------|-----------|--------|--------|
| 1 | 1 | 4 | 512×512 | PPSF | 33 imgs | ✅ |
| 2 | 1 | 1 | 1024×1024 | PPSF | 33 imgs | ✅ |
| 3 | 1 | 1 | 1024×1024 | AdamW | 33 imgs (resume) | ✅ (0.25 it/s) |

## OOM Chain & Fixes

```
Phase 1 – Data Preparation:
  Model ~6.0 GiB + Qwen-Image VAE + Qwen-3 0.6B encoder → ~1.6 GiB free

  OOM ① VAE latent caching (33 images)
  OOM ② VAE roundtrip self-test
  OOM ③ Sampling VAE decode
         ↓
  Fix: model temporarily moved to CPU during VAE ops (3 locations)

Phase 2 – Training Loop:
  Model ~6.0 GiB + optimizer states ~0.6 GiB → ~1.0 GiB free

  OOM ④ Forward: Kron product materializes full weight matrices
  OOM ⑤ Backward: gradient checkpoint recomputation peak activations
         ↓
  Fix: bypass factorization + explicit memory management (lycoris_patch.py)
```

## Changes (6 files, +306/-43)

### 1. `utils/lycoris_patch.py` — Core optimization (+116 lines)

Three optimizations in one monkey-patch:

| # | Optimization | Effect |
|---|-------------|--------|
| ① | Full-matrix auto-routed to `bypass_forward` | Uses Kronecker identity `kron(w1,w2)·x ≡ factorized_matmul(x, w2, w1)` instead of materializing full weight |
| ② | `del hb, h_cross_group` | Explicitly free first intermediate result (~256 MiB) between two matmul stages |
| ③ | `torch.add(org, diff, alpha=α)` | Zero-copy fused scaling, avoids `h * scale * scalar` temporary tensor |

Mathematically equivalent to original forward. Guarded to only affect `use_w1=True, use_w2=True, bypass_mode=None, wd=False` modules.

### 2. `runtime/anima_train.py` — CUDA fragmentation fix (+4 lines)

Sets `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` before `import torch`.

### 3. `runtime/training/phases/dataset.py` — VAE ops CPU offload (+30/-12 lines)

Moves model to CPU during `CachedLatentDataset` encoding and VAE roundtrip self-test. Restored via `try/finally`.

### 4. `runtime/training/sampling.py` — Sampling decouple + VAE offload (+46/-18 lines)

Splits `sample_image` into `sample_latents` (pure diffusion) + `sample_image` (sample + decode). Model → CPU before VAE decode.

### 5. `runtime/training/loop.py` — Qwen-3 encoder CPU offload (+11 lines)

Qwen-3 0.6B text encoder moved to CPU after prompt encoding each batch, freeing memory for forward/backward.

### 6. `runtime/training/sample_runner.py` — GPU guard (+7 lines)

Ensures model + qwen_model are on GPU before sampling (may have been offloaded by loop).

## Backward Compatibility

- All offloads use `finally` to guarantee device restoration
- LyCORIS patch only activates in full-matrix no-dropout/DoRA scenario
- Negligible overhead on 16GB+ GPUs (~1µs device check)