### PR TITLE
fix(sample): VAE 整图 decode OOM 自动回退分块 decode

### DIFF
--- a/runtime/training/models.py
+++ b/runtime/training/models.py
@@ -14,6 +14,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import sys
 from pathlib import Path
 
@@ -27,6 +28,121 @@ from training.model_loading import (
 
 
 logger = logging.getLogger(__name__)
+
+
+class VAEWrapper:
+    """WAN VAE + 归一化参数 + 整图 decode OOM 自动回退到 tiled decode。
+
+    Issue #200：8GB 类小显存跑 1024×1024 reg 生成时 transformer/Qwen/T5 常驻
+    GPU 后剩 ~1GB，整图 decode 工作内存吃满 → OOM。本类在 `decode()` 入口先
+    `try` 整图，CUDA OOM 才走 cosine-blend 切块 decode（每 tile 64 latent /
+    512 pixel，单 tile 工作峰值约 75MB）。
+
+    大显存路径永远在 `try` 一次就过、零成本；fallback 路径每张图慢 ~30%。
+
+    现有训练代码（dataset 编 latent / phases/dataset.py 训练时重建预览）继续直
+    接调 `wrapper.model.encode/decode(z, wrapper.scale)`，保持现有行为不动 ——
+    encode 路径与训练侧低分辨率重建不会 OOM。
+    """
+
+    # tile 几何：tile=512px / overlap=128px / 4-stage VAE 8× upsample
+    _TILE_LATENT = 64
+    _STRIDE_LATENT = 48
+    _UPSAMPLE = 8
+
+    def __init__(self, model, mean, std):
+        self.model = model
+        self.mean = mean
+        self.std = std
+        self.scale = [mean, 1.0 / std]
+
+    def decode(self, z):
+        """latent → pixel；整图 OOM 时自动切块重试。
+
+        z: ``[b, 16, t, H, W]`` latent
+        return: ``[b, 3, t, H*8, W*8]``（与底层 `WanVAE_.decode` 一致，未 clamp）
+        """
+        try:
+            return self.model.decode(z, self.scale)
+        except torch.cuda.OutOfMemoryError:
+            torch.cuda.empty_cache()
+            logger.warning(
+                "VAE 整图 decode OOM，回退到 tiled decode "
+                "(tile=%dpx, overlap=%dpx)",
+                self._TILE_LATENT * self._UPSAMPLE,
+                (self._TILE_LATENT - self._STRIDE_LATENT) * self._UPSAMPLE,
+            )
+            return self._tiled_decode(z)
+
+    @torch.no_grad()
+    def _tiled_decode(self, z):
+        """在 H/W 维度切块独立 decode，cosine blend 拼回。
+
+        - tile=64 latent，stride=48，overlap=16 latent (128 px)；最后一个 tile
+          起点 clamp 到 (size - tile) 防超出
+        - 小图（H 或 W < tile）走 ``eff_h/eff_w = min(tile, size)``，等价单 tile 全图
+        - blend 用 raised cosine 边缘 ramp，accumulator 走 fp32 防 bf16 精度损失
+        - mask 最小值 clamp 1e-6 防角落像素 wsum 除 0
+        """
+        b, _c, t, H, W = z.shape
+        tile = self._TILE_LATENT
+        stride = self._STRIDE_LATENT
+        up = self._UPSAMPLE
+
+        eff_h = min(tile, H)
+        eff_w = min(tile, W)
+        hs = _tile_starts(H, eff_h, stride)
+        ws = _tile_starts(W, eff_w, stride)
+
+        tile_h_px = eff_h * up
+        tile_w_px = eff_w * up
+        overlap_px = (tile - stride) * up
+        H_px, W_px = H * up, W * up
+
+        acc = torch.zeros(b, 3, t, H_px, W_px, dtype=torch.float32, device=z.device)
+        wsum = torch.zeros(1, 1, 1, H_px, W_px, dtype=torch.float32, device=z.device)
+
+        mask = _cosine_blend_mask(tile_h_px, tile_w_px, fade=overlap_px, device=z.device)
+
+        for hi in hs:
+            for wi in ws:
+                z_tile = z[:, :, :, hi:hi + eff_h, wi:wi + eff_w]
+                img_tile = self.model.decode(z_tile, self.scale).float()
+                hp, wp = hi * up, wi * up
+                acc[:, :, :, hp:hp + tile_h_px, wp:wp + tile_w_px] += img_tile * mask
+                wsum[:, :, :, hp:hp + tile_h_px, wp:wp + tile_w_px] += mask
+
+        return (acc / wsum).to(z.dtype)
+
+
+def _tile_starts(size: int, tile: int, stride: int) -> list[int]:
+    """固定 stride 的 tile 起点列表；尾部未覆盖时追加 ``size - tile``。"""
+    if size <= tile:
+        return [0]
+    starts = list(range(0, size - tile + 1, stride))
+    if starts[-1] + tile < size:
+        starts.append(size - tile)
+    return starts
+
+
+def _cosine_blend_mask(h: int, w: int, *, fade: int, device) -> torch.Tensor:
+    """2D raised-cosine mask；边缘 `fade` 像素内 0→1 ramp，中心 1。
+
+    最终 mask 整体 clamp_min(1e-6) 防 wsum 角落除 0 —— 2D 角落是 1D × 1D，
+    1D 上 clamp 1e-6 在 2D 角落变成 1e-12 太接近 fp32 denormal，统一在 2D 后 clamp。
+    """
+    def ramp_1d(n: int) -> torch.Tensor:
+        m = torch.ones(n, dtype=torch.float32, device=device)
+        if fade > 0:
+            t = torch.linspace(math.pi, 2 * math.pi, fade, device=device)
+            r = torch.cos(t) * 0.5 + 0.5
+            m[:fade] = r
+            m[-fade:] = r.flip(0)
+        return m
+    mh = ramp_1d(h)
+    mw = ramp_1d(w)
+    mask_2d = (mh[:, None] * mw[None, :]).clamp_min(1e-6)
+    return mask_2d[None, None, None, :, :]
 
 
 def ensure_models_namespace(repo_root):
@@ -155,17 +271,8 @@ def load_vae(vae_path, device, dtype, repo_root):
         3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.9160
     ], dtype=dtype, device=device)
 
-    class VAEWrapper:
-        pass
-
-    wrapper = VAEWrapper()
-    wrapper.model = model
-    wrapper.mean = mean
-    wrapper.std = std
-    wrapper.scale = [mean, 1.0 / std]
-
     logger.info("VAE 加载完成")
-    return wrapper
+    return VAEWrapper(model, mean, std)
 
 
 def load_text_encoders(qwen_path, t5_tokenizer_path, device, dtype):

--- a/runtime/training/sampling.py
+++ b/runtime/training/sampling.py
@@ -199,7 +199,9 @@ def sample_image(
     latents = x.to(device=device, dtype=dtype)
     logger.info(f"[Debug] Final latents: mean={latents.mean().item():.4f}, std={latents.std().item():.4f}")
     try:
-        images = vae.model.decode(latents, vae.scale)
+        # VAEWrapper.decode：整图 OOM 时自动 tile+cosine blend 回退（issue #200）。
+        # 大显存路径在 try 一次就过，零成本；fallback 路径每张图慢 ~30%。
+        images = vae.decode(latents)
         images = images.squeeze(2)  # [B,C,H,W]
         images = (images.clamp(-1, 1) + 1) / 2
 

--- a/tests/test_vae_tiled_decode.py
+++ b/tests/test_vae_tiled_decode.py
@@ -1,0 +1,179 @@
+"""VAEWrapper OOM-fallback tiled decode 单测（issue #200）。
+
+测：
+- `_tile_starts` 边界 case（含 1024 latent / 128 latent 实际 issue 规格）
+- `_cosine_blend_mask` 对称性 + clamp_min 避免角落除 0
+- `VAEWrapper.decode` 走 try-full 路径不触发 tile
+- `VAEWrapper.decode` 在 model.decode 抛 OOM 时走 tile fallback 并产出形状一致的结果
+- `_tiled_decode` 拼接：mock 一个线性 decode（z 上 nearest-upsample 8× 取前 3 通道），
+  tile 重建结果与整图重建数值一致（验证 cosine blend + accumulator 正确性）
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from training.models import (
+    VAEWrapper,
+    _cosine_blend_mask,
+    _tile_starts,
+)
+
+
+# ---------------------------------------------------------------------------
+# _tile_starts
+# ---------------------------------------------------------------------------
+
+
+def test_tile_starts_size_le_tile_returns_zero_only() -> None:
+    assert _tile_starts(64, 64, 48) == [0]
+    assert _tile_starts(32, 64, 48) == [0]
+
+
+def test_tile_starts_appends_boundary_when_stride_doesnt_cover() -> None:
+    """128 latent (1024 px reg) 的实际规格：tile=64 stride=48 → [0, 48, 64]。"""
+    assert _tile_starts(128, 64, 48) == [0, 48, 64]
+
+
+def test_tile_starts_exact_stride_no_duplicate_tail() -> None:
+    """stride 恰好整除时尾部不重复追加。"""
+    # size=160 tile=64 stride=48 → range(0, 97, 48) = [0, 48, 96]，96+64=160 命中尾部
+    assert _tile_starts(160, 64, 48) == [0, 48, 96]
+
+
+# ---------------------------------------------------------------------------
+# _cosine_blend_mask
+# ---------------------------------------------------------------------------
+
+
+def test_cosine_blend_mask_shape_and_dtype() -> None:
+    m = _cosine_blend_mask(512, 512, fade=128, device="cpu")
+    assert m.shape == (1, 1, 1, 512, 512)
+    assert m.dtype == torch.float32
+
+
+def test_cosine_blend_mask_center_one_edges_clamped() -> None:
+    """中心 = 1，边缘 ≈ 1e-6（防 wsum 除 0；fp32 clamp 实测略低于 1e-6）。"""
+    m = _cosine_blend_mask(512, 512, fade=128, device="cpu")[0, 0, 0]
+    # 中心
+    assert m[256, 256].item() == pytest.approx(1.0, abs=1e-5)
+    # 四角：clamp 在 fp32 精度下 ≈ 1e-6（容差 1e-7）
+    assert m[0, 0].item() == pytest.approx(1e-6, abs=1e-7)
+    assert m[-1, -1].item() == pytest.approx(1e-6, abs=1e-7)
+    assert m[0, -1].item() == pytest.approx(1e-6, abs=1e-7)
+
+
+def test_cosine_blend_mask_symmetric() -> None:
+    m = _cosine_blend_mask(256, 256, fade=64, device="cpu")[0, 0, 0]
+    # 上下对称
+    assert torch.allclose(m, m.flip(0), atol=1e-6)
+    # 左右对称
+    assert torch.allclose(m, m.flip(1), atol=1e-6)
+
+
+def test_cosine_blend_mask_zero_fade_all_ones() -> None:
+    m = _cosine_blend_mask(64, 64, fade=0, device="cpu")
+    assert torch.all(m == 1.0)
+
+
+# ---------------------------------------------------------------------------
+# VAEWrapper.decode 走 try-full 路径
+# ---------------------------------------------------------------------------
+
+
+class _RecordingModel:
+    """记录 decode 调用次数 + 形状的 mock；行为是 nearest upsample 8× + 取前 3 通道。"""
+
+    def __init__(self, oom_on_full: bool = False):
+        self.calls: list[tuple[int, ...]] = []
+        self.oom_on_full = oom_on_full
+
+    def decode(self, z: torch.Tensor, scale) -> torch.Tensor:
+        self.calls.append(tuple(z.shape))
+        b, _c, t, h, w = z.shape
+        # 模拟 WanVAE_ 的 8× spatial upsample + 16ch → 3ch
+        # 故意用 z 的前 3 通道 nearest upsample，方便 tile / full 对比
+        upsampled = torch.nn.functional.interpolate(
+            z[:, :3].reshape(b * t, 3, h, w),
+            scale_factor=8,
+            mode="nearest",
+        ).reshape(b, 3, t, h * 8, w * 8)
+        if self.oom_on_full and h >= 128 and len(self.calls) == 1:
+            raise torch.cuda.OutOfMemoryError("simulated OOM on full decode")
+        return upsampled
+
+
+def _make_wrapper(model) -> VAEWrapper:
+    mean = torch.zeros(16)
+    std = torch.ones(16)
+    return VAEWrapper(model, mean, std)
+
+
+def test_decode_full_path_calls_model_once() -> None:
+    """大显存路径：try full 成功 → 不进 tile，model.decode 只调一次。"""
+    model = _RecordingModel(oom_on_full=False)
+    wrapper = _make_wrapper(model)
+    z = torch.randn(1, 16, 1, 32, 32)  # 256×256 输出
+    out = wrapper.decode(z)
+    assert out.shape == (1, 3, 1, 256, 256)
+    assert len(model.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# VAEWrapper.decode OOM fallback
+# ---------------------------------------------------------------------------
+
+
+def test_decode_oom_fallback_invokes_tiled_decode() -> None:
+    """整图 OOM → catch + empty_cache + tile 多次调 model.decode。
+
+    1024 reg 规格：z = [1,16,1,128,128]；tile=64 stride=48 →
+    tile 起点 hs=ws=[0,48,64] → 3×3 = 9 个 tile decode 调用，
+    加上第一次失败的整图调用 = 10。
+    """
+    model = _RecordingModel(oom_on_full=True)
+    wrapper = _make_wrapper(model)
+    z = torch.zeros(1, 16, 1, 128, 128)  # 1024×1024 reg
+    out = wrapper.decode(z)
+    assert out.shape == (1, 3, 1, 1024, 1024)
+    # 1 次失败 full + 9 个 tile
+    assert len(model.calls) == 1 + 9
+    # 第一次是 full
+    assert model.calls[0] == (1, 16, 1, 128, 128)
+    # 后续都是 tile 大小
+    for shape in model.calls[1:]:
+        assert shape == (1, 16, 1, 64, 64)
+
+
+# ---------------------------------------------------------------------------
+# Tile 拼接数值正确性
+# ---------------------------------------------------------------------------
+
+
+def test_tiled_decode_reconstructs_full_for_linear_decoder() -> None:
+    """对一个线性 decode（nearest upsample 8×），tile + cosine blend 拼接
+    结果与整图 decode 数值一致（accumulator 归一化正确）。
+
+    用 latent[:, :3] 作 "image"，nearest 8× 上采。每个像素的实际值与位置无
+    关，blend mask 加权累加后归一化必须恢复原值。
+    """
+    model = _RecordingModel(oom_on_full=False)
+    wrapper = _make_wrapper(model)
+    torch.manual_seed(0)
+    z = torch.randn(1, 16, 1, 128, 128)
+
+    full = wrapper.decode(z)
+    tiled = wrapper._tiled_decode(z)
+
+    # 数值应几乎一致；mask clamp_min 1e-6 + fp32 累加只引入极小数值误差
+    assert tiled.shape == full.shape
+    assert torch.allclose(tiled, full, atol=1e-4)
+
+
+def test_tiled_decode_handles_small_input_without_tiling() -> None:
+    """size ≤ tile 时 tile_starts 返回 [0]，等同整图 decode。"""
+    model = _RecordingModel(oom_on_full=False)
+    wrapper = _make_wrapper(model)
+    z = torch.randn(1, 16, 1, 32, 32)  # < tile=64
+    out = wrapper._tiled_decode(z)
+    assert out.shape == (1, 3, 1, 256, 256)


### PR DESCRIPTION
## 背景 / 动机

Issue #200：用户在 8GB 显存上跑 1024×1024 reg 生成，第 1 张就在 VAE decode 阶段 OOM。
日志显示 transformer + Qwen + T5 常驻 GPU 后剩 ~110 MiB，VAE 解码 1024×1024 输出
的瞬时工作内存就把剩余显存吃干。同样的图在 ComfyUI 上能跑，是因为 ComfyUI VAE
节点有 tiled-decode fallback。

四套 inference loop（reg_ai / generate CLI / generate XY / daemon generate /
daemon XY / training sample preview）共用 `sample_image`，最终都走
`wan/vae2_1.py:WanVAE_.decode` 整图一次性 decode，所以 6 处调用点共享同一个炸点。

## 改动概要

把单点 fix 下沉到 VAE 入口，6 处调用点全自动受益：

- `runtime/training/models.py`
  - `VAEWrapper` 从 `load_vae` 内的空类（`class VAEWrapper: pass`）提到 module level
  - 加 `VAEWrapper.decode(z)`：先 `try` 整图 → `torch.cuda.OutOfMemoryError` 时
    `empty_cache()` + 走 `_tiled_decode`
  - `_tiled_decode`：tile=64 latent / 512 px，stride=48，overlap=16 latent / 128 px；
    最后一个 tile 起点 clamp 到 `size - tile` 防超出；小图（H 或 W < tile）走
    `eff_h/eff_w = min(tile, size)` 等价单 tile 全图；fp32 accumulator 防 bf16 精度损失
  - `_cosine_blend_mask`：raised-cosine 边缘 ramp，整 2D mask `clamp_min(1e-6)`
    防 wsum 角落除 0（1D × 1D 在角落会变 1e-12 太接近 fp32 denormal）
- `runtime/training/sampling.py`
  - `sample_image` L202 `vae.model.decode(latents, vae.scale)` → `vae.decode(latents)`，
    让 6 处调用点全走新入口
- 向后兼容：`wrapper.model` / `wrapper.scale` 属性保留，训练侧 4 处
  `vae.model.encode(...)` / `vae.model.decode(z, scale)`（dataset / phases 重建预览）
  原样工作 —— encode + 训练时低分辨率重建不会 OOM，不进 fallback 路径

**大显存零成本**：`try` 一次就过，永远不进 tile fallback。
**小显存 fallback 路径**：单 tile 工作峰值约 75 MB，每张图慢约 30%，能跑完。

## 测试方式

`tests/test_vae_tiled_decode.py`（11 个新测试，单测全 pass）：

- `_tile_starts` 边界 case：`size <= tile` 单 tile / 128 latent 实际 issue 规格
  / stride 恰好整除尾部不重复
- `_cosine_blend_mask`：shape + dtype、中心 1 / 四角 ≈ 1e-6 不除 0、上下左右对称、
  fade=0 全 1
- `VAEWrapper.decode` try-full 路径：mock model 记录 decode 调用，走 try 一次
- `VAEWrapper.decode` OOM fallback：mock 第一次调用抛 `torch.cuda.OutOfMemoryError`，
  确认 1 次失败 full + 9 个 tile (3×3) 调用
- `_tiled_decode` 数值一致性：用线性 mock（nearest upsample 8×），tile 拼接结果与
  整图 decode `allclose(atol=1e-4)`，验证 cosine blend + accumulator 归一化正确
- 小图（H 或 W < tile）走单 tile 全图路径

回归覆盖：`test_datasets.py` / `test_anima_reg_caption.py` / `test_inference_core.py`
/ `test_inference_daemon.py` 全 pass（70 个）；本地环境缺 `einops`
（既有依赖），`test_models_flash_attn.py` 不能本地跑，CI 覆盖。

## 截图

无 UI 改动。

## 未做的事（已记到 memory）

四套 inference loop 各写各的 "encode → sample → decode → save" 是更深的味道
（调研发现 6 处直接调 `sample_image` + 4 套独立 loop）。讨论后用户决定**先不做**
统一重构，本 PR 只解 issue #200。未来 3 步走方案（InferenceEngine → Sinks →
BatchRunner）已记到 agent memory，下次触发信号（第 5 个调用点 / daemon 协议又
加事件 / 跨调用点想加 metrics / 限流）回来推进。

Closes #200