### PR TITLE
perf(web): optimize SettingsDrawer mounting, backdrop blur, and text input lag

### DIFF
--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -29,6 +29,29 @@ const ANIM_MS = 220
 export default function SettingsDrawer() {
   const { isOpen, close } = useSettingsDrawer()
   const [contentReady, setContentReady] = useState(false)
+  const [shouldRender, setShouldRender] = useState(isOpen)
+  const [active, setActive] = useState(isOpen)
+
+  useEffect(() => {
+    if (isOpen) {
+      setShouldRender(true)
+    } else {
+      setActive(false)
+      const timer = setTimeout(() => {
+        setShouldRender(false)
+      }, ANIM_MS)
+      return () => clearTimeout(timer)
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (shouldRender && isOpen) {
+      const id = requestAnimationFrame(() => {
+        setActive(true)
+      })
+      return () => cancelAnimationFrame(id)
+    }
+  }, [shouldRender, isOpen])
 
   // open: 让外壳先滑进来（GPU 动画），下一帧再 mount Settings
   // close: 立刻卸 Settings，外壳的 slide-out 在空骨架上跑
@@ -41,10 +64,12 @@ export default function SettingsDrawer() {
     return () => cancelAnimationFrame(id)
   }, [isOpen])
 
+  if (!shouldRender) return null
+
   return (
     <div
       aria-hidden={!isOpen}
-      className={`absolute inset-0 z-30 ${isOpen ? '' : 'pointer-events-none'}`}
+      className={`absolute inset-0 z-30 ${active ? '' : 'pointer-events-none'}`}
     >
       {/* backdrop：absolute 铺满 viewport，让 panel slide-in 中途不会从右边露出底页。
        *  之前用 flex + flex-1 时 backdrop 只占 panel 左边那条，panel 滑动期间右侧
@@ -52,7 +77,7 @@ export default function SettingsDrawer() {
       <div
         onClick={() => void close()}
         className={`absolute inset-0 transition-[background-color,backdrop-filter,-webkit-backdrop-filter] ease-out ${
-          isOpen ? 'bg-black/25 backdrop-blur-sm' : 'bg-black/0 backdrop-blur-0'
+          active ? 'bg-black/25 backdrop-blur-sm' : 'bg-black/0 backdrop-blur-0'
         }`}
         style={{ transitionDuration: `${ANIM_MS}ms` }}
         aria-label="close settings"
@@ -61,7 +86,7 @@ export default function SettingsDrawer() {
         role="dialog"
         aria-modal="true"
         className={`absolute top-0 right-0 bottom-0 flex flex-col bg-canvas border-l border-subtle shadow-2xl transition-transform ease-out ${DRAWER_WIDTH_CLASS} ${
-          isOpen ? 'translate-x-0' : 'translate-x-full'
+          active ? 'translate-x-0' : 'translate-x-full'
         }`}
         style={{ transitionDuration: `${ANIM_MS}ms` }}
       >

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -76,8 +76,8 @@ export default function SettingsDrawer() {
        *  panel 槽位无人覆盖 → 看见底层页面 / 出现黑白闪屏。 */}
       <div
         onClick={() => void close()}
-        className={`absolute inset-0 transition-[background-color,backdrop-filter,-webkit-backdrop-filter] ease-out ${
-          active ? 'bg-black/25 backdrop-blur-sm' : 'bg-black/0 backdrop-blur-0'
+        className={`absolute inset-0 transition-colors ease-out ${
+          active ? 'bg-black/35' : 'bg-black/0'
         }`}
         style={{ transitionDuration: `${ANIM_MS}ms` }}
         aria-label="close settings"

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -125,6 +125,11 @@ const initialServerState = {
   },
   models: { root: null, selected_anima: '1.0', selected_upscaler: '4x-AnimeSharp', auto_sync_paths: true },
   queue: { allow_gpu_during_train: false },
+  download_source: 'huggingface',
+  modelscope: { token: '' },
+  generate: { preview_every_n_steps: 0, attention_backend: 'sdpa' },
+  system: { update_channel: 'stable', show_dev_channel: false },
+  proxy: { enabled: false, http_proxy: '', https_proxy: '', no_proxy: '' },
 }
 
 const emptyModelsCatalog = {

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -599,15 +599,16 @@ export default function SettingsPage() {
       {tab === 'dataset' && (<>
       <SettingsSection id="gelbooru" title="Gelbooru">
         <SettingsField label="user_id">
-          <input
+          <SettingsInput
             type="text"
             value={draft.gelbooru.user_id}
-            onChange={(e) => update('gelbooru', 'user_id', e.target.value)}
+            onChange={(v) => update('gelbooru', 'user_id', v)}
             autoComplete="off"
             data-lpignore="true"
             data-1p-ignore
             data-form-type="other"
-            className={textInputClass}                                  />
+            className={textInputClass}
+          />
         </SettingsField>
         <SettingsField label="api_key">
           <SensitiveInput
@@ -629,16 +630,17 @@ export default function SettingsPage() {
 
       <SettingsSection id="danbooru" title="Danbooru">
         <SettingsField label="username">
-          <input
+          <SettingsInput
             type="text"
             value={draft.danbooru.username}
-            onChange={(e) => update('danbooru', 'username', e.target.value)}
+            onChange={(v) => update('danbooru', 'username', v)}
             placeholder={t('settings.danbooruUsernamePlaceholder')}
             autoComplete="off"
             data-lpignore="true"
             data-1p-ignore
             data-form-type="other"
-            className={textInputClass}                                  />
+            className={textInputClass}
+          />
         </SettingsField>
         <SettingsField label="api_key">
           <SensitiveInput
@@ -665,42 +667,46 @@ export default function SettingsPage() {
           desc={t('settings.commaSeparated')}
           helpTooltip={<p><Trans i18nKey="settings.excludeTagsHelp" components={{ code: <code /> }} /></p>}
         >
-          <input
+          <SettingsInput
             type="text"
             value={draft.download.exclude_tags.join(', ')}
-            onChange={(e) =>
+            onChange={(v) =>
               update('download', 'exclude_tags',
-                e.target.value.split(',').map((t) => t.trim().replace(/^-+/, '')).filter(Boolean)
+                v.split(',').map((t) => t.trim().replace(/^-+/, '')).filter(Boolean)
               )
             }
             placeholder={t('settings.excludeTagsPlaceholder')}
-            className={textInputClass}                                  />
+            className={textInputClass}
+          />
         </SettingsField>
 
         <div className="grid grid-cols-3 gap-3 pt-2 border-t border-subtle">
           <div className="flex flex-col gap-1">
             <label className="text-xs text-fg-secondary font-mono">parallel_workers</label>
-            <input
+            <SettingsInput
               type="number" min={1} max={16}
               value={draft.download.parallel_workers}
-              onChange={(e) => update('download', 'parallel_workers', Math.max(1, Number(e.target.value) || 1))}
-              className={`${textInputClass} max-w-24`}                              />
+              onChange={(v) => update('download', 'parallel_workers', Math.max(1, Number(v) || 1))}
+              className={`${textInputClass} max-w-24`}
+            />
           </div>
           <div className="flex flex-col gap-1">
             <label className="text-xs text-fg-secondary font-mono">api_rate_per_sec</label>
-            <input
+            <SettingsInput
               type="number" step="0.5" min={0.5} max={10}
               value={draft.download.api_rate_per_sec}
-              onChange={(e) => update('download', 'api_rate_per_sec', Math.max(0.5, Number(e.target.value) || 0.5))}
-              className={`${textInputClass} max-w-24`}                              />
+              onChange={(v) => update('download', 'api_rate_per_sec', Math.max(0.5, Number(v) || 0.5))}
+              className={`${textInputClass} max-w-24`}
+            />
           </div>
           <div className="flex flex-col gap-1">
             <label className="text-xs text-fg-secondary font-mono">cdn_rate_per_sec</label>
-            <input
+            <SettingsInput
               type="number" step="1" min={1} max={20}
               value={draft.download.cdn_rate_per_sec}
-              onChange={(e) => update('download', 'cdn_rate_per_sec', Math.max(1, Number(e.target.value) || 1))}
-              className={`${textInputClass} max-w-24`}                              />
+              onChange={(v) => update('download', 'cdn_rate_per_sec', Math.max(1, Number(v) || 1))}
+              className={`${textInputClass} max-w-24`}
+            />
           </div>
         </div>
       </SettingsSection>
@@ -720,10 +726,10 @@ export default function SettingsPage() {
           label={t('settings.proxy.httpLabel')}
           desc={t('settings.proxy.httpDesc')}
         >
-          <input
+          <SettingsInput
             type="text"
             value={draft.proxy.http_proxy}
-            onChange={(e) => update('proxy', 'http_proxy', e.target.value)}
+            onChange={(v) => update('proxy', 'http_proxy', v)}
             placeholder="http://127.0.0.1:7890"
             className={textInputClass}
             disabled={!draft.proxy.enabled}
@@ -734,10 +740,10 @@ export default function SettingsPage() {
           label={t('settings.proxy.httpsLabel')}
           desc={t('settings.proxy.httpsDesc')}
         >
-          <input
+          <SettingsInput
             type="text"
             value={draft.proxy.https_proxy}
-            onChange={(e) => update('proxy', 'https_proxy', e.target.value)}
+            onChange={(v) => update('proxy', 'https_proxy', v)}
             placeholder="http://127.0.0.1:7890"
             className={textInputClass}
             disabled={!draft.proxy.enabled}
@@ -748,10 +754,10 @@ export default function SettingsPage() {
           label={t('settings.proxy.noProxyLabel')}
           desc={t('settings.proxy.noProxyDesc')}
         >
-          <input
+          <SettingsInput
             type="text"
             value={draft.proxy.no_proxy}
-            onChange={(e) => update('proxy', 'no_proxy', e.target.value)}
+            onChange={(v) => update('proxy', 'no_proxy', v)}
             placeholder="localhost,127.0.0.1"
             className={textInputClass}
             disabled={!draft.proxy.enabled}
@@ -807,26 +813,29 @@ export default function SettingsPage() {
           t={t}
         />
         <SettingsField label="local_dir" desc={t('settings.blankAutoHfDownload')}>
-          <input
+          <SettingsInput
             type="text"
             value={draft.wd14.local_dir ?? ''}
-            onChange={(e) => update('wd14', 'local_dir', e.target.value || null)}
-            className={textInputClass}                                  />
+            onChange={(v) => update('wd14', 'local_dir', v || null)}
+            className={textInputClass}
+          />
         </SettingsField>
         <div className="grid grid-cols-2 gap-3">
           <SettingsField label="threshold_general">
-            <input
+            <SettingsInput
               type="number" step="0.01" min={0} max={1}
               value={draft.wd14.threshold_general}
-              onChange={(e) => update('wd14', 'threshold_general', Number(e.target.value))}
-              className={`${textInputClass} max-w-32`}                              />
+              onChange={(v) => update('wd14', 'threshold_general', Number(v))}
+              className={`${textInputClass} max-w-32`}
+            />
           </SettingsField>
           <SettingsField label="threshold_character">
-            <input
+            <SettingsInput
               type="number" step="0.01" min={0} max={1}
               value={draft.wd14.threshold_character}
-              onChange={(e) => update('wd14', 'threshold_character', Number(e.target.value))}
-              className={`${textInputClass} max-w-32`}                              />
+              onChange={(v) => update('wd14', 'threshold_character', Number(v))}
+              className={`${textInputClass} max-w-32`}
+            />
           </SettingsField>
         </div>
         <SettingsField label="blacklist_tags" desc={t('settings.commaSeparated')}>
@@ -837,11 +846,12 @@ export default function SettingsPage() {
           />
         </SettingsField>
         <SettingsField label="batch_size" desc={t('settings.batchSizeHint')}>
-          <input
+          <SettingsInput
             type="number" min={1} max={64}
             value={draft.wd14.batch_size}
-            onChange={(e) => update('wd14', 'batch_size', Math.max(1, Number(e.target.value) || 1))}
-            className={`${textInputClass} max-w-24`}                              />
+            onChange={(v) => update('wd14', 'batch_size', Math.max(1, Number(v) || 1))}
+            className={`${textInputClass} max-w-24`}
+          />
         </SettingsField>
       </SettingsSection>
 
@@ -861,26 +871,29 @@ export default function SettingsPage() {
           t={t}
         />
         <SettingsField label="local_dir" desc={t('settings.blankAutoHfDownload')}>
-          <input
+          <SettingsInput
             type="text"
             value={draft.cltagger.local_dir ?? ''}
-            onChange={(e) => update('cltagger', 'local_dir', e.target.value || null)}
-            className={textInputClass}                                  />
+            onChange={(v) => update('cltagger', 'local_dir', v || null)}
+            className={textInputClass}
+          />
         </SettingsField>
         <div className="grid grid-cols-2 gap-3">
           <SettingsField label="threshold_general">
-            <input
+            <SettingsInput
               type="number" step="0.01" min={0} max={1}
               value={draft.cltagger.threshold_general}
-              onChange={(e) => update('cltagger', 'threshold_general', Number(e.target.value))}
-              className={`${textInputClass} max-w-32`}                                      />
+              onChange={(v) => update('cltagger', 'threshold_general', Number(v))}
+              className={`${textInputClass} max-w-32`}
+            />
           </SettingsField>
           <SettingsField label="threshold_character">
-            <input
+            <SettingsInput
               type="number" step="0.01" min={0} max={1}
               value={draft.cltagger.threshold_character}
-              onChange={(e) => update('cltagger', 'threshold_character', Number(e.target.value))}
-              className={`${textInputClass} max-w-32`}                                      />
+              onChange={(v) => update('cltagger', 'threshold_character', Number(v))}
+              className={`${textInputClass} max-w-32`}
+            />
           </SettingsField>
         </div>
         <div className="grid grid-cols-2 gap-3">
@@ -908,11 +921,12 @@ export default function SettingsPage() {
           />
         </SettingsField>
         <SettingsField label="batch_size" desc={t('settings.batchSizeHint')}>
-          <input
+          <SettingsInput
             type="number" min={1} max={64}
             value={draft.cltagger.batch_size}
-            onChange={(e) => update('cltagger', 'batch_size', Math.max(1, Number(e.target.value) || 1))}
-            className={`${textInputClass} max-w-24`}                              />
+            onChange={(v) => update('cltagger', 'batch_size', Math.max(1, Number(v) || 1))}
+            className={`${textInputClass} max-w-24`}
+          />
         </SettingsField>
       </SettingsSection>
 
@@ -1018,27 +1032,27 @@ export default function SettingsPage() {
           />
         </SettingsField>
         <SettingsField label="project">
-          <input
+          <SettingsInput
             type="text"
             value={draft.wandb.project}
-            onChange={(e) => update('wandb', 'project', e.target.value)}
+            onChange={(v) => update('wandb', 'project', v)}
             placeholder="AnimaLoraStudio"
             className={textInputClass}
           />
         </SettingsField>
         <SettingsField label="entity" desc={t('settings.wandbEntityHint')}>
-          <input
+          <SettingsInput
             type="text"
             value={draft.wandb.entity}
-            onChange={(e) => update('wandb', 'entity', e.target.value)}
+            onChange={(v) => update('wandb', 'entity', v)}
             className={textInputClass}
           />
         </SettingsField>
         <SettingsField label="base_url" desc={t('settings.wandbBaseUrlHint')}>
-          <input
+          <SettingsInput
             type="text"
             value={draft.wandb.base_url}
-            onChange={(e) => update('wandb', 'base_url', e.target.value)}
+            onChange={(v) => update('wandb', 'base_url', v)}
             placeholder="https://api.wandb.ai"
             className={textInputClass}
           />
@@ -1070,12 +1084,12 @@ export default function SettingsPage() {
               label={t('settings.sampleMaxSide')}
               helpTooltip={<p>{t('settings.sampleMaxSideHelp')}</p>}
             >
-              <input
+              <SettingsInput
                 type="number"
                 min={64}
                 step={64}
                 value={draft.wandb.sample_max_side}
-                onChange={(e) => update('wandb', 'sample_max_side', Math.max(64, parseInt(e.target.value) || 1216))}
+                onChange={(v) => update('wandb', 'sample_max_side', Math.max(64, parseInt(v) || 1216))}
                 className={textInputClass}
               />
             </SettingsField>
@@ -1085,12 +1099,12 @@ export default function SettingsPage() {
                 <p><Trans i18nKey="settings.sampleEveryNStepsHelp" components={{ code: <code /> }} /></p>
               }
             >
-              <input
+              <SettingsInput
                 type="number"
                 min={0}
                 step={50}
                 value={draft.wandb.sample_every_n_steps}
-                onChange={(e) => update('wandb', 'sample_every_n_steps', Math.max(0, parseInt(e.target.value) || 0))}
+                onChange={(v) => update('wandb', 'sample_every_n_steps', Math.max(0, parseInt(v) || 0))}
                 className={textInputClass}
               />
             </SettingsField>
@@ -1334,18 +1348,76 @@ function SensitiveInput({ value, serverValue, onChange }: {
   value: string; serverValue: string; onChange: (v: string) => void
 }) {
   const { t } = useTranslation()
-  const masked = value === MASK
+  const [localValue, setLocalValue] = useState(value)
+
+  useEffect(() => {
+    setLocalValue(value)
+  }, [value])
+
+  const masked = localValue === MASK
+
+  const handleBlur = () => {
+    if (localValue !== value) {
+      onChange(localValue)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.currentTarget.blur()
+    }
+  }
+
   return (
     <input
       type="password"
-      value={masked ? '' : value}
+      value={masked ? '' : localValue}
       placeholder={serverValue === MASK ? t('settings.sensitiveSavedPlaceholder') : ''}
-      onChange={(e) => onChange(e.target.value || MASK)}
+      onChange={(e) => setLocalValue(e.target.value || MASK)}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
       autoComplete="new-password"
       data-lpignore="true"
       data-1p-ignore
       data-form-type="other"
-      className={textInputClass}                />
+      className={textInputClass}
+    />
+  )
+}
+
+interface SettingsInputProps extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange'> {
+  value: string | number
+  onChange: (v: string) => void
+}
+
+function SettingsInput({ value, onChange, type = 'text', ...props }: SettingsInputProps) {
+  const [localValue, setLocalValue] = useState(value)
+
+  useEffect(() => {
+    setLocalValue(value)
+  }, [value])
+
+  const handleBlur = () => {
+    if (String(localValue) !== String(value)) {
+      onChange(String(localValue))
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.currentTarget.blur()
+    }
+  }
+
+  return (
+    <input
+      type={type}
+      {...props}
+      value={localValue}
+      onChange={(e) => setLocalValue(e.target.value)}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
+    />
   )
 }
 


### PR DESCRIPTION
### 变更背景 / Background
主要解决设置抽屉（SettingsDrawer）以及设置页面（Settings Page）存在的几处严重的前端渲染与交互性能问题：
1. **未关闭彻底的合成层**：在关闭状态下，抽屉依旧在 DOM 中渲染并保留 `backdrop-filter: blur(0px)`，导致浏览器为整个 viewport 维持无意义的合成层（Composition Layer）。
2. **GPU 实时模糊开销过大**：开启抽屉时，遮罩层（backdrop）采用 `backdrop-blur-sm` 会迫使 GPU 实时对全屏进行高斯模糊。在 2K/4K 高分屏、核显或缩放场景下，造成显著的页面滚动掉帧与滞后。
3. **高频打字重绘延迟**：在 4200+ 行的大组件 `SettingsPage` 中，几乎所有输入框都在键盘每敲击一次时同步更新全局 `draft` 状态，触发整个设置组件的重绘，造成了极其明显的打字交互卡顿。
4. **单元测试报错**：`Settings.test.tsx` 里的 Server Mock 数据缺失了近年来新增加的部分配置属性，导致组件在测试环境中实例化报错。

This PR addresses several critical frontend rendering and interaction bottlenecks:
1. **Idle Composition Layers**: The drawer remained in the DOM when closed, keeping `backdrop-filter: blur(0px)` which forced the browser to maintain an idle composition layer.
2. **Backdrop Filter GPU Overhead**: The `backdrop-blur-sm` filter on the full-screen overlay required heavy GPU resource to recalculate blurs during transitions and page scrolling, leading to severe lag on 2K/4K screens or integrated GPUs.
3. **Typing Lag due to High-frequency Re-renders**: Keystrokes in form fields triggered synchronous updates to the top-level `draft` state in the 4200-line `SettingsPage`, causing the entire page to re-render on every character.
4. **Broken Unit Tests**: Missing configuration fields in `initialServerState` within `Settings.test.tsx` caused runtime type errors.

---

### 变更内容 / Changes
1. **动态挂载管理 (Dynamic Mounting)**:
   - 抽屉关闭过渡完成后自动从 DOM 彻底卸载。
   - 采用 `requestAnimationFrame` 延迟挂载激活类名，确保初次挂载时顺利触发滑入 CSS 动画，避免动画闪烁。
2. **消除 GPU 模糊瓶颈 (Remove Backdrop Blur)**:
   - 移除了 `backdrop-blur-sm` 高斯模糊滤镜，遮罩统一为纯半透明颜色过渡（从 `bg-black/0` 平滑过渡到 `bg-black/35`），彻底消除了 GPU 实时模糊的计算延迟，使滚动极为流畅。
3. **本地状态输入组件 (Local Stateful Inputs)**:
   - 新增 `SettingsInput` 并重构了 `SensitiveInput` 组件。在打字时仅维护输入框内部的 localState，仅在失去焦点 (`onBlur`) 或按回车 (`onKeyDown`) 时，才一次性向父组件同步 `draft` 状态，实现零延迟的顺畅输入。
4. **Mock 数据补全 (Test Fixes)**:
   - 补齐了 `Settings.test.tsx` 中缺失的字段（`proxy`、`system`、`generate`、`modelscope` 和 `download_source`）。

---

### 验证情况 / Verification
- 运行 `npm run test`，所有 34 个测试文件、308 个测试用例全部绿灯通过。
- 运行 `npm run build`，编译打包无 TS 及 Eslint 静态检查报错。
- All 308 vitest unit tests passed successfully.
- Web package built successfully with zero TS/Eslint errors.