### PR TITLE
feat(preprocess): add train-scope backend API (PR-2)

### DIFF
--- a/docs/adr/0010-preprocess-train-scope.md
+++ b/docs/adr/0010-preprocess-train-scope.md
@@ -108,15 +108,26 @@ projects/{id}-{slug}/
 **字段语义**：
 
 - `version` (int): schema 版本，当前固定 `2`
-- `images` (map): key = train 内**实际文件名**（含扩展名），value = entry
-- `entry.origin` (string): `download/` 下对应原图的**文件名**，用于 restore 反查
+- `images` (map): key = train 内**POSIX 相对路径** `"{N_label}/{image}"`（LoRA
+  repeat folder 结构：`train/1_data/X.png` → entry key `"1_data/X.png"`），
+  value = entry
+- `entry.origin` (string): `download/` 下对应原图的**平铺文件名**（download/
+  无 sub-folder 结构），用于 restore 反查
 - `entry.mtime` / `entry.size` (number): 产物文件元数据，可检测外部修改
+
+**为什么 rel path 而不是平铺**：LoRA 训练 dataset config 把 `train/{N_label}/`
+当 repeat folder（N = 重复次数）；同一张图可在多个 folder 出现（罕见但合法）。
+平铺 entry key 无法表达跨 folder 唯一性 + 同名歧义。POSIX 形式 `/` 跨平台一致。
+
+`train/` 根目录直接放的图**被忽略**（LoRA 训练只读 sub-folder 内）；validator
+`_validate_rel_name` 强制 `folder/image` 两段格式，防 path traversal。
 
 **状态从字段差异隐含推断**（承袭 ADR 0004 极简原则）：
 
-- `name="X.png"` + `origin="X.jpg"` → 处理过（扩展名变 = upscale / crop / 转码之一）
-- `name="X.jpg"` + `origin="X.jpg"` + mtime/size 匹配 → 原样未处理
-- `name="X.jpg"` + `origin="X.jpg"` + mtime/size 不匹配 → 外部修改
+- entry key rel path 末段 `"X.png"` + `origin="X.jpg"` → 处理过（扩展名变 =
+  upscale / crop / 转码之一）
+- 末段 `"X.jpg"` + `origin="X.jpg"` + mtime/size 匹配 → 原样未处理
+- 末段 `"X.jpg"` + `origin="X.jpg"` + mtime/size 不匹配 → 外部修改
 
 **不存的字段**（明确否定项，跟 ADR 0004 Addendum 1 一致）：
 
@@ -134,9 +145,14 @@ projects/{id}-{slug}/
 **重建规则**（按优先级）：
 
 1. 目标 `versions/{label}/train/manifest.json` 已存在 → 直接返回（O(1) stat，热路径 0 开销）
-2. 不存在 + 老 `projects/{id}/preprocess/manifest.json` 存在 → 按 `train/` 实际文件名集合（仅 `.png/.jpg/.jpeg/.webp`）与老 entry 的 `origin` 反查匹配 → 重建 v2 schema
+2. 不存在 + 老 `projects/{id}/preprocess/manifest.json` 存在 → 递归扫
+   `train/` 一级 sub-folder 收集图片相对路径集合（仅图像后缀；根目录直接放
+   的图忽略）；按文件名（rel path 末段）匹配老平铺 entry name → 重建 v2
+   schema，entry key 用 rel path
 3. 老 manifest 不存在 / 损坏（非 dict / 非法 JSON） → 写空 v2 manifest（`{"version": 2, "images": {}}`）
 4. 老 entry 标 `kind: duplicate_removed` → **跳过**（人工去重审核状态不跨模型迁移，新模型下用户在 train scope 重新去重）
+5. 跨 sub-folder 同名图（罕见但合法，如 `1_data/X.png` + `5_extra/X.png`） →
+   各自独立 entry，都继承同一老 origin
 
 并发：`threading.Lock` 串行 + 原子 `tmp+rename` 落盘 + 双检查防竞态。
 

--- a/docs/design/preprocess-train-scope-plan.md
+++ b/docs/design/preprocess-train-scope-plan.md
@@ -84,9 +84,9 @@ projects/{id}-{slug}/
 {
   "version": 2,
   "images": {
-    "X.png":    { "origin": "X.jpg", "mtime": 1731000000, "size": 1234567 },
-    "Y_c0.png": { "origin": "Y.jpg", "mtime": 1731000000, "size": 800000 },
-    "Y_c1.png": { "origin": "Y.jpg", "mtime": 1731000000, "size": 850000 }
+    "1_data/X.png":    { "origin": "X.jpg", "mtime": 1731000000, "size": 1234567 },
+    "1_data/Y_c0.png": { "origin": "Y.jpg", "mtime": 1731000000, "size": 800000 },
+    "1_data/Y_c1.png": { "origin": "Y.jpg", "mtime": 1731000000, "size": 850000 }
   }
 }
 ```
@@ -94,10 +94,16 @@ projects/{id}-{slug}/
 **字段语义**：
 
 - `version` (int): schema 版本，当前固定 `2`。未来再变 schema 用这个判断
-- `images` (map): key = train 内**实际文件名**（含扩展名），value = entry
-- `entry.origin` (string): `download/` 下对应原图的**文件名**（含扩展名）。用于 restore 反查
+- `images` (map): key = **POSIX 相对路径** `"{N_label}/{image}"`（LoRA repeat
+  folder：`train/1_data/X.png` → entry key `"1_data/X.png"`），value = entry
+- `entry.origin` (string): `download/` 下对应原图的**平铺文件名**（download/
+  无 sub-folder 结构）。用于 restore 反查
 - `entry.mtime` (number): 产物文件 mtime（秒级 Unix timestamp）。差异可推断"用户在外部改过"
 - `entry.size` (number): 产物文件大小（字节）
+
+**为什么 rel path 而不是平铺**：LoRA dataset config 把 `train/{N_label}/` 当
+repeat folder，同名图可在多个 folder 出现（罕见但合法）。`train/` 根目录直接
+放的图被忽略；`core.py:_validate_rel_name` 强制 `folder/image` 两段防 path traversal。
 
 **状态从字段差异隐含推断**：
 

--- a/studio/services/dataset/curation.py
+++ b/studio/services/dataset/curation.py
@@ -275,6 +275,74 @@ def copy_to_train(
     return {"copied": copied, "skipped": skipped, "missing": missing}
 
 
+def copy_download_to_train(
+    conn,
+    project_id: int,
+    version_id: int,
+    files: list[str],
+    dest_folder: str,
+) -> dict[str, list[str]]:
+    """ADR 0010 train scope（PR-2 step C）：纯 download → train 复制 + 写
+    train manifest entry。简化版替代 `copy_to_train`，PR-3 删老的。
+
+    跟老 `copy_to_train` 的差异：
+
+    - **取消 preprocess 派生分支** — bytes 始终从 `download/{name}` 拿
+    - 写 train manifest entry，key = `f"{dest_folder}/{name}"`，
+      origin = name（curate 阶段图是原图未处理；后续 preprocess 在 train/
+      原地处理时再 update entry）
+    - caption (.txt/.json) 仍从 `download/{stem}.{ext}` 复制到
+      `train/{dest_folder}/{stem}.{ext}`
+    - 不消费 / 不感知 preprocess 派生（multi-crop fan-out 在新模型下发生在
+      curate 之后的 preprocess phase）
+
+    `files` 是 download 池里的图名（平铺），不带 folder 前缀。
+    """
+    _validate_folder(dest_folder)
+    p, v, train = _version_train_dir(conn, project_id, version_id)
+    pdir = projects.project_dir(p["id"], p["slug"])
+    download_dir = pdir / "download"
+    dst_dir = train / dest_folder
+    dst_dir.mkdir(parents=True, exist_ok=True)
+    preprocess_manifest.ensure_train_manifest(pdir, v["label"])
+
+    copied: list[str] = []
+    skipped: list[str] = []
+    missing: list[str] = []
+    for name in files:
+        _validate_filename(name)
+        src = download_dir / name
+        if not src.exists():
+            missing.append(name)
+            continue
+        dst = dst_dir / name
+        if dst.exists():
+            skipped.append(name)
+            continue
+        shutil.copy2(src, dst)
+        # caption metadata 跟随
+        stem = Path(name).stem
+        for ext in _META_EXTS:
+            sm = download_dir / f"{stem}{ext}"
+            if sm.exists():
+                try:
+                    shutil.copy2(sm, dst_dir / f"{stem}{ext}")
+                except OSError:
+                    pass
+        # 写 train manifest entry，key = "{folder}/{name}"
+        rel = f"{dest_folder}/{name}"
+        meta: dict[str, Any] = {"origin": name}
+        try:
+            st = dst.stat()
+            meta["mtime"] = st.st_mtime
+            meta["size"] = st.st_size
+        except OSError:
+            pass
+        preprocess_manifest.train_add_processed(pdir, v["label"], rel, meta)
+        copied.append(name)
+    return {"copied": copied, "skipped": skipped, "missing": missing}
+
+
 def remove_from_train(
     conn,
     project_id: int,

--- a/studio/services/preprocess/core.py
+++ b/studio/services/preprocess/core.py
@@ -564,3 +564,350 @@ def restore_products(
 
 # 旧 API 兼容别名（v1 完整下线 sidecar 后可删；前端调用点已替换为 /restore）
 delete_products = restore_products
+
+
+# ---------------------------------------------------------------------------
+# ADR 0010 — train-scope 列表 / 状态 / job（PR-2 step B）
+#
+# 老 list_pending / list_processed / list_*_workspace / summary / resolve_targets
+# / start_job / start_crop_job / restore_products 暂留作 backward-compat 给老
+# endpoint 用，PR-3 删。新代码请用 *_train 系列：
+#
+# - list_train_images:   列 train/ 全部图 + manifest 元数据（替代 pending+processed 二元）
+# - summary_train:       train scope 简短统计
+# - resolve_targets_train / start_job_train / start_crop_job_train: job 创建
+# - list_crop_workspace_train / list_duplicate_removed_workspace_train: 子页工作集
+# - restore_products_train: 调 manifest.train_restore（语义：copy download → train）
+# ---------------------------------------------------------------------------
+
+
+def version_train_dir(p: dict[str, Any], version_label: str) -> Path:
+    return project_root(p) / "versions" / version_label / "train"
+
+
+def _train_images_listing(train_dir: Path) -> list[Path]:
+    if not train_dir.exists():
+        return []
+    return sorted([f for f in train_dir.iterdir() if _is_image(f)])
+
+
+def list_train_images(
+    p: dict[str, Any], version_label: str
+) -> list[dict[str, Any]]:
+    """列 `versions/{vlabel}/train/` 全部图 + manifest entry 元数据。
+
+    替代老 `list_pending + list_processed` 二元概念——新模型下 train/ 即"训练集
+    grid"，无 pending/processed 区分（状态从字段差异隐含推断，详 ADR 0010
+    §Manifest schema v2）。
+
+    返回 `[{name, mtime, size, w, h, origin, source, orphan, duplicate_removed,
+    model, scale, action, target_area, src_size, dst_size, elapsed_seconds}]`：
+    - `origin / source`：都填 `entry.origin`（兼容老前端字段名 source）
+    - `orphan`：`download/{origin}` 缺失（restore 会落 no_origin）
+    - `duplicate_removed`：bool（默认 False；UI 区分"训练参与" vs "审核跳过"）
+    - 老 schema 透传字段（model/scale/...）新 entry 一律 None；前端容忍
+
+    极端情况：manifest 标 duplicate_removed 但 train/ 物理已删（用户外部删）→
+    仍报告一条 stale 项，UI 容忍 w/h 为 None。
+    """
+    from PIL import Image
+
+    pdir = project_root(p)
+    download_dir = pdir / "download"
+    train_dir = version_train_dir(p, version_label)
+
+    m = preprocess_manifest.train_load(pdir, version_label)
+    entries = m["images"]
+
+    download_names = (
+        {f.name for f in _download_images(download_dir)}
+        if download_dir.exists() else set()
+    )
+
+    items: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for f in _train_images_listing(train_dir):
+        seen.add(f.name)
+        entry = entries.get(f.name, {})
+        origin = preprocess_manifest.entry_origin(entry, f.name)
+        st = f.stat()
+        w: Optional[int] = None
+        h: Optional[int] = None
+        try:
+            with Image.open(f) as im:
+                w, h = im.size
+        except (OSError, ValueError):
+            pass
+        items.append({
+            "name": f.name,
+            "mtime": st.st_mtime,
+            "size": st.st_size,
+            "w": w, "h": h,
+            "origin": origin,
+            "source": origin,
+            "orphan": origin not in download_names,
+            "duplicate_removed": preprocess_manifest.is_duplicate_removed_entry(entry),
+            "model": entry.get("model"),
+            "scale": entry.get("scale"),
+            "action": entry.get("action"),
+            "target_area": entry.get("target_area"),
+            "src_size": entry.get("src_size"),
+            "dst_size": entry.get("dst_size"),
+            "elapsed_seconds": entry.get("elapsed_seconds"),
+        })
+
+    # stale duplicate_removed entry（manifest 有 + train/ 物理无）
+    for name, entry in sorted(entries.items()):
+        if name in seen:
+            continue
+        if not preprocess_manifest.is_duplicate_removed_entry(entry):
+            continue
+        origin = preprocess_manifest.entry_origin(entry, name)
+        items.append({
+            "name": name,
+            "mtime": float(entry.get("mtime", 0.0) or 0.0),
+            "size": int(entry.get("size", 0) or 0),
+            "w": None, "h": None,
+            "origin": origin,
+            "source": origin,
+            "orphan": origin not in download_names,
+            "duplicate_removed": True,
+            "model": None, "scale": None, "action": None,
+            "target_area": None, "src_size": None, "dst_size": None,
+            "elapsed_seconds": None,
+        })
+
+    return items
+
+
+def summary_train(p: dict[str, Any], version_label: str) -> dict[str, Any]:
+    """train scope 简短统计。
+
+    `image_count` = train/ 里物理图像数 + 仅 manifest 标记 duplicate_removed
+    且物理已删的数（罕见 stale entry，仍计入展示）。
+    """
+    pdir = project_root(p)
+    train_dir = version_train_dir(p, version_label)
+    m = preprocess_manifest.train_load(pdir, version_label)
+    physical = {f.name for f in _train_images_listing(train_dir)}
+    soft_removed_only = {
+        name for name, entry in m["images"].items()
+        if preprocess_manifest.is_duplicate_removed_entry(entry)
+        and name not in physical
+    }
+    return {"image_count": len(physical) + len(soft_removed_only)}
+
+
+def resolve_targets_train(
+    p: dict[str, Any], version_label: str, *,
+    mode: str, names: Optional[Iterable[str]] = None,
+) -> list[str]:
+    """根据 mode + names 返回当前 train/ grid 中要处理的图名列表。
+
+    mode='all' / 'all_force' → train/ 全部图
+    mode='selected'          → 名单与 train/ 实存交集
+    """
+    train_dir = version_train_dir(p, version_label)
+    if not train_dir.exists() and mode != "selected":
+        return []
+    existing = {f.name for f in _train_images_listing(train_dir)}
+
+    if mode in ("all", "all_force"):
+        return sorted(existing)
+    if mode == "selected":
+        if not names:
+            raise PreprocessError("mode=selected 时 names 不能为空")
+        chosen: list[str] = []
+        for n in names:
+            _validate_name(n)
+            if n in existing:
+                chosen.append(n)
+        return sorted(set(chosen))
+    raise PreprocessError(f"未知 mode: {mode!r}")
+
+
+def start_job_train(
+    conn, *,
+    project_id: int,
+    version_id: int,
+    mode: str = "all",
+    names: Optional[list[str]] = None,
+    model: str = DEFAULT_MODEL,
+    tile_size: int = DEFAULT_TILE_SIZE,
+    tile_pad: int = DEFAULT_TILE_PAD,
+    device: str = DEFAULT_DEVICE,
+    target_area: Optional[int] = DEFAULT_TARGET_AREA,
+) -> dict[str, Any]:
+    """train scope preprocess job。worker 通过 job.version_id 拿 version label
+    后从 `versions/{label}/train/` 列源 + 写产物（PR-2 step D 改 worker）。
+    """
+    p = projects.get_project(conn, project_id)
+    if not p:
+        raise PreprocessError(f"项目不存在: id={project_id}")
+    if mode not in ("all", "selected", "all_force"):
+        raise PreprocessError(f"未知 mode: {mode!r}")
+    if mode == "selected" and not names:
+        raise PreprocessError("mode=selected 必须给 names")
+    if names:
+        for n in names:
+            _validate_name(n)
+
+    params: dict[str, Any] = {
+        "stage": STAGE_UPSCALE,
+        "mode": mode,
+        "model": model,
+        "tile_size": int(tile_size),
+        "tile_pad": int(tile_pad),
+        "device": device,
+        "target_area": int(target_area) if target_area else None,
+    }
+    if names:
+        params["names"] = list(names)
+
+    return project_jobs.create_job(
+        conn,
+        project_id=project_id,
+        version_id=version_id,
+        kind=PREPROCESS_KIND,
+        params=params,
+    )
+
+
+def start_crop_job_train(
+    conn, *,
+    project_id: int,
+    version_id: int,
+    crops: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    """train scope crop job。`crops` 的源文件名为 `train/` 下当前文件名。"""
+    p = projects.get_project(conn, project_id)
+    if not p:
+        raise PreprocessError(f"项目不存在: id={project_id}")
+    if not isinstance(crops, dict) or not crops:
+        raise PreprocessError("crops 不能为空")
+    sanitized: dict[str, list[dict[str, Any]]] = {}
+    for name, rects in crops.items():
+        _validate_name(name)
+        if not isinstance(rects, list) or not rects:
+            raise PreprocessError(f"{name!r} 的 rects 为空")
+        out_rects: list[dict[str, Any]] = []
+        for r in rects:
+            if not isinstance(r, dict):
+                raise PreprocessError(f"{name!r} 含非法 rect: {r!r}")
+            clean = _validate_rect(r)
+            label = r.get("label")
+            if label is not None:
+                clean["label"] = str(label)[:64]
+            out_rects.append(clean)
+        sanitized[name] = out_rects
+
+    params = {"stage": STAGE_CROP, "crops": sanitized}
+    return project_jobs.create_job(
+        conn,
+        project_id=project_id,
+        version_id=version_id,
+        kind=PREPROCESS_KIND,
+        params=params,
+    )
+
+
+def list_crop_workspace_train(
+    p: dict[str, Any], version_label: str
+) -> list[dict[str, Any]]:
+    """裁剪页工作集（train scope）：train/ 里所有图，附像素尺寸 + processed 标记。
+
+    `processed` 推断：`name != origin`（扩展名变 = 经过 upscale/crop/转码之一）。
+    duplicate_removed 的图跳过（不让用户对软删除图再裁）。
+    """
+    from PIL import Image
+
+    pdir = project_root(p)
+    train_dir = version_train_dir(p, version_label)
+    m = preprocess_manifest.train_load(pdir, version_label)
+    entries = m["images"]
+    removed_origins = preprocess_manifest.train_duplicate_removed_origins(
+        pdir, version_label
+    )
+
+    items: list[dict[str, Any]] = []
+    for f in _train_images_listing(train_dir):
+        entry = entries.get(f.name, {})
+        if preprocess_manifest.is_duplicate_removed_entry(entry):
+            continue
+        origin = preprocess_manifest.entry_origin(entry, f.name)
+        if origin in removed_origins:
+            continue
+        try:
+            with Image.open(f) as im:
+                w, h = im.size
+        except (OSError, ValueError):
+            continue
+        st = f.stat()
+        items.append({
+            "name": f.name,
+            "source": origin,
+            "w": w, "h": h,
+            "mtime": st.st_mtime,
+            "size": st.st_size,
+            "processed": f.name != origin,
+        })
+    return items
+
+
+def list_duplicate_removed_workspace_train(
+    p: dict[str, Any], version_label: str
+) -> list[dict[str, Any]]:
+    """train scope 软删除工作集。物理文件仍在 train/{name}（mark_duplicate_removed
+    不删文件），缩略图按 train bucket 取（thumb endpoint PR-3 改）。
+    """
+    from PIL import Image
+
+    pdir = project_root(p)
+    train_dir = version_train_dir(p, version_label)
+    removed = preprocess_manifest.train_duplicate_removed(pdir, version_label)
+
+    items: list[dict[str, Any]] = []
+    for name in sorted(removed.keys()):
+        entry = removed[name]
+        origin = preprocess_manifest.entry_origin(entry, name)
+        src = train_dir / name
+        if not src.is_file():
+            items.append({
+                "name": name,
+                "source": origin,
+                "w": None, "h": None,
+                "mtime": float(entry.get("mtime", 0.0) or 0.0),
+                "size": int(entry.get("size", 0) or 0),
+            })
+            continue
+        try:
+            with Image.open(src) as im:
+                w, h = im.size
+        except (OSError, ValueError):
+            w, h = None, None
+        st = src.stat()
+        items.append({
+            "name": name,
+            "source": origin,
+            "w": w, "h": h,
+            "mtime": st.st_mtime,
+            "size": st.st_size,
+        })
+    return items
+
+
+def restore_products_train(
+    p: dict[str, Any], version_label: str, names: Iterable[str],
+) -> dict[str, list[str]]:
+    """train scope 还原：从 `download/{entry.origin}` 复制覆盖 `train/{name}`。
+
+    返回 `{restored, missing, no_origin}` 三组。详 ADR 0010 §Restore 语义。
+    `no_origin` = download 物理缺失，UI 应该给用户三选项（拖入替换 / 保留 /
+    从 train 移除）而不是隐瞒失败。
+    """
+    pdir = project_root(p)
+    name_list: list[str] = []
+    for raw in names:
+        _validate_name(raw)
+        name_list.append(raw)
+    return preprocess_manifest.train_restore(pdir, version_label, name_list)

--- a/studio/services/preprocess/core.py
+++ b/studio/services/preprocess/core.py
@@ -257,6 +257,20 @@ def _validate_name(name: str) -> None:
         raise PreprocessError(f"非法文件名: {name!r}")
 
 
+def _validate_rel_name(name: str) -> None:
+    """ADR 0010 train-scope name 校验：必须形如 `"folder/image"`（POSIX 形式）。
+
+    严格 2 段 + 拒 `..` / 反斜杠 / 绝对路径 / 空段，防 path traversal。
+    """
+    if not name:
+        raise PreprocessError(f"非法 rel name: {name!r}")
+    if "\\" in name or name.startswith("/"):
+        raise PreprocessError(f"非法 rel name: {name!r}")
+    parts = name.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1] or ".." in parts:
+        raise PreprocessError(f"非法 rel name（要求 folder/image）: {name!r}")
+
+
 def resolve_targets(
     p: dict[str, Any], *, mode: str, names: Optional[Iterable[str]] = None
 ) -> list[str]:
@@ -585,10 +599,25 @@ def version_train_dir(p: dict[str, Any], version_label: str) -> Path:
     return project_root(p) / "versions" / version_label / "train"
 
 
-def _train_images_listing(train_dir: Path) -> list[Path]:
+def _train_images_listing(train_dir: Path) -> list[tuple[str, Path]]:
+    """递归 train_dir 一级 sub-folder（LoRA repeat folder）收集 `(rel_path, full_path)`。
+
+    rel_path = POSIX 形式 `"{folder}/{image}"`，跟 manifest entry key 一致。
+    train_dir 根目录直接放的图忽略（LoRA 训练只读 sub-folder 内）。
+    按 rel_path 字典序稳定输出。
+    """
     if not train_dir.exists():
         return []
-    return sorted([f for f in train_dir.iterdir() if _is_image(f)])
+    out: list[tuple[str, Path]] = []
+    for sub in train_dir.iterdir():
+        if not sub.is_dir():
+            continue
+        for f in sub.iterdir():
+            if not _is_image(f):
+                continue
+            out.append((f"{sub.name}/{f.name}", f))
+    out.sort(key=lambda t: t[0])
+    return out
 
 
 def list_train_images(
@@ -626,10 +655,10 @@ def list_train_images(
 
     items: list[dict[str, Any]] = []
     seen: set[str] = set()
-    for f in _train_images_listing(train_dir):
-        seen.add(f.name)
-        entry = entries.get(f.name, {})
-        origin = preprocess_manifest.entry_origin(entry, f.name)
+    for rel, f in _train_images_listing(train_dir):
+        seen.add(rel)
+        entry = entries.get(rel, {})
+        origin = preprocess_manifest.entry_origin(entry, rel)
         st = f.stat()
         w: Optional[int] = None
         h: Optional[int] = None
@@ -639,7 +668,7 @@ def list_train_images(
         except (OSError, ValueError):
             pass
         items.append({
-            "name": f.name,
+            "name": rel,
             "mtime": st.st_mtime,
             "size": st.st_size,
             "w": w, "h": h,
@@ -689,7 +718,7 @@ def summary_train(p: dict[str, Any], version_label: str) -> dict[str, Any]:
     pdir = project_root(p)
     train_dir = version_train_dir(p, version_label)
     m = preprocess_manifest.train_load(pdir, version_label)
-    physical = {f.name for f in _train_images_listing(train_dir)}
+    physical = {rel for rel, _ in _train_images_listing(train_dir)}
     soft_removed_only = {
         name for name, entry in m["images"].items()
         if preprocess_manifest.is_duplicate_removed_entry(entry)
@@ -710,7 +739,7 @@ def resolve_targets_train(
     train_dir = version_train_dir(p, version_label)
     if not train_dir.exists() and mode != "selected":
         return []
-    existing = {f.name for f in _train_images_listing(train_dir)}
+    existing = {rel for rel, _ in _train_images_listing(train_dir)}
 
     if mode in ("all", "all_force"):
         return sorted(existing)
@@ -719,7 +748,7 @@ def resolve_targets_train(
             raise PreprocessError("mode=selected 时 names 不能为空")
         chosen: list[str] = []
         for n in names:
-            _validate_name(n)
+            _validate_rel_name(n)
             if n in existing:
                 chosen.append(n)
         return sorted(set(chosen))
@@ -750,7 +779,7 @@ def start_job_train(
         raise PreprocessError("mode=selected 必须给 names")
     if names:
         for n in names:
-            _validate_name(n)
+            _validate_rel_name(n)
 
     params: dict[str, Any] = {
         "stage": STAGE_UPSCALE,
@@ -787,7 +816,7 @@ def start_crop_job_train(
         raise PreprocessError("crops 不能为空")
     sanitized: dict[str, list[dict[str, Any]]] = {}
     for name, rects in crops.items():
-        _validate_name(name)
+        _validate_rel_name(name)
         if not isinstance(rects, list) or not rects:
             raise PreprocessError(f"{name!r} 的 rects 为空")
         out_rects: list[dict[str, Any]] = []
@@ -830,11 +859,11 @@ def list_crop_workspace_train(
     )
 
     items: list[dict[str, Any]] = []
-    for f in _train_images_listing(train_dir):
-        entry = entries.get(f.name, {})
+    for rel, f in _train_images_listing(train_dir):
+        entry = entries.get(rel, {})
         if preprocess_manifest.is_duplicate_removed_entry(entry):
             continue
-        origin = preprocess_manifest.entry_origin(entry, f.name)
+        origin = preprocess_manifest.entry_origin(entry, rel)
         if origin in removed_origins:
             continue
         try:
@@ -843,13 +872,15 @@ def list_crop_workspace_train(
         except (OSError, ValueError):
             continue
         st = f.stat()
+        # processed 推断：origin 文件名 != rel 文件名（扩展名变 or 含 _c0 后缀等）
+        rel_filename = rel.rsplit("/", 1)[-1]
         items.append({
-            "name": f.name,
+            "name": rel,
             "source": origin,
             "w": w, "h": h,
             "mtime": st.st_mtime,
             "size": st.st_size,
-            "processed": f.name != origin,
+            "processed": rel_filename != origin,
         })
     return items
 
@@ -908,6 +939,6 @@ def restore_products_train(
     pdir = project_root(p)
     name_list: list[str] = []
     for raw in names:
-        _validate_name(raw)
+        _validate_rel_name(raw)
         name_list.append(raw)
     return preprocess_manifest.train_restore(pdir, version_label, name_list)

--- a/studio/services/preprocess/duplicates.py
+++ b/studio/services/preprocess/duplicates.py
@@ -427,6 +427,176 @@ def options_to_json(options: DuplicateOptions) -> dict[str, Any]:
     }
 
 
+# ---------------------------------------------------------------------------
+# ADR 0010 — train-scope duplicates API (PR-2 step E)
+#
+# 老 _resolve_download_sources / scan_project_duplicates / apply_duplicate_removals
+# 暂留作 backward-compat 给老 endpoint 用，PR-3 删。新代码 / 新 endpoint 请用
+# *_train 系列：scope 收窄到 versions/{label}/train/，每个 version 独立审核。
+# ---------------------------------------------------------------------------
+
+
+def _resolve_train_sources(
+    conn,
+    project_id: int,
+    version_id: int,
+    project_dir: Path,
+) -> list[tuple[str, Path]]:
+    """ADR 0010 train scope: 列 `versions/{label}/train/{folder}/` 全部图作
+    duplicate-scan sources。
+
+    跳过 train manifest 已标 `duplicate_removed` 的（用户审核过的不再 dup-scan）。
+    name 用 POSIX rel path 形式（`"1_data/X.png"`）跟 train manifest entry key
+    一致；下游 group/report/apply 走同一形式。
+    """
+    from ..projects import versions as ver
+
+    version = ver.get_version(conn, version_id)
+    if not version or version["project_id"] != project_id:
+        raise DuplicateFinderError(
+            f"version not found / mismatch: id={version_id}"
+        )
+    label = version["label"]
+    train_dir = project_dir / "versions" / label / "train"
+    if not train_dir.exists():
+        return []
+    removed_rels = set(
+        preprocess_manifest.train_duplicate_removed(project_dir, label).keys()
+    )
+    sources: list[tuple[str, Path]] = []
+    for sub in sorted(train_dir.iterdir()):
+        if not sub.is_dir():
+            continue
+        for f in sorted(sub.iterdir()):
+            if not f.is_file():
+                continue
+            if f.suffix.lower() not in IMAGE_EXTS:
+                continue
+            rel = f"{sub.name}/{f.name}"
+            if rel in removed_rels:
+                continue
+            sources.append((rel, f))
+    return sources
+
+
+def scan_train_duplicates(
+    conn,
+    project_id: int,
+    version_id: int,
+    options: DuplicateOptions,
+    on_progress: Callable[[dict[str, Any]], None] | None = None,
+) -> dict[str, Any]:
+    """ADR 0010 train-scope 重复扫描。主流程跟 scan_project_duplicates 一致，
+    只是 sources 解析改成 `_resolve_train_sources`。
+
+    返回结构跟老版本相同（前端契约不变；PR-3 改 endpoint 后才换前端），仅
+    `target` 字段改成 `"train"` 表明 scope。
+    """
+    _require_imagehash()
+    project, project_dir = curation._project_dir(conn, project_id)  # noqa: SLF001
+    sources = _resolve_train_sources(conn, project_id, version_id, project_dir)
+    if on_progress:
+        on_progress({
+            "stage": "hashing",
+            "idx": 0,
+            "total": len(sources),
+            "text": f"Preparing hashes for {len(sources)} images...",
+        })
+    started = time.monotonic()
+    infos = build_all_image_infos(sources, options, on_progress=on_progress)
+    if on_progress:
+        total_pairs = len(infos) * (len(infos) - 1) // 2
+        on_progress({
+            "stage": "comparing",
+            "idx": 0,
+            "total": total_pairs,
+            "text": f"Comparing {total_pairs} image pairs...",
+        })
+    groups, pair_metrics, stats = group_similar_images(
+        infos, options, on_progress=on_progress,
+    )
+    blur_candidates = (
+        find_blur_candidates(infos, options) if options.detect_blur else []
+    )
+    crop_relations: list[CropRelation] = []
+    if options.detect_crops:
+        if on_progress:
+            total_pairs = len(infos) * (len(infos) - 1) // 2
+            on_progress({
+                "stage": "crop_relations",
+                "idx": 0,
+                "total": total_pairs,
+                "text": f"Checking {total_pairs} crop/scale relation pairs...",
+            })
+        crop_relations = find_crop_relations(infos, options, on_progress=on_progress)
+    elapsed = time.monotonic() - started
+
+    return {
+        "target": "train",
+        "match_scope": options.match_scope,
+        "total_images": len(sources),
+        "readable_images": len(infos),
+        "group_count": len(groups),
+        "candidate_count": sum(max(0, len(g) - 1) for g in groups),
+        "blur_candidate_count": len(blur_candidates),
+        "crop_relation_count": len(crop_relations),
+        "elapsed_seconds": round(elapsed, 3),
+        "options": options_to_json(options),
+        "stats": stats,
+        "groups": [
+            _group_to_json(index, group, pair_metrics)
+            for index, group in enumerate(groups, start=1)
+        ],
+        "blur_candidates": [
+            _blur_candidate_to_json(candidate)
+            for candidate in blur_candidates
+        ],
+        "crop_relations": [
+            _crop_relation_to_json(relation)
+            for relation in crop_relations
+        ],
+    }
+
+
+def apply_train_duplicate_removals(
+    conn,
+    project_id: int,
+    version_id: int,
+    *,
+    names: list[str],
+) -> dict[str, Any]:
+    """ADR 0010 train scope: 把 names 标记 duplicate_removed（per-version 审核
+    状态，写到 train manifest）。
+
+    `names` 是 train rel path 形式（`"1_data/X.png"`）。物理文件不动——保留
+    作"已审核但跳过"标记，跟老 mark_duplicate_removed 一致。
+    """
+    from ..projects import versions as ver
+
+    project = projects.get_project(conn, project_id)
+    if not project:
+        raise DuplicateFinderError(f"project not found: id={project_id}")
+    version = ver.get_version(conn, version_id)
+    if not version or version["project_id"] != project_id:
+        raise DuplicateFinderError(
+            f"version not found / mismatch: id={version_id}"
+        )
+
+    project_dir = projects.project_dir(project["id"], project["slug"])
+    # 校验 rel path 形式（跟 core._validate_rel_name 一致：两段、无 ..）
+    for raw_name in names:
+        if not raw_name or "\\" in raw_name or raw_name.startswith("/"):
+            raise DuplicateFinderError(f"非法 rel name: {raw_name!r}")
+        parts = raw_name.split("/")
+        if len(parts) != 2 or not parts[0] or not parts[1] or ".." in parts:
+            raise DuplicateFinderError(
+                f"非法 rel name（要求 folder/image）: {raw_name!r}"
+            )
+    return preprocess_manifest.train_mark_duplicate_removed(
+        project_dir, version["label"], names,
+    )
+
+
 def _resolve_download_sources(
     conn,
     project_id: int,

--- a/studio/services/preprocess/manifest.py
+++ b/studio/services/preprocess/manifest.py
@@ -473,34 +473,72 @@ def ensure_manifest(project_dir: Path) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 TRAIN_MANIFEST_VERSION = 2
-_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".webp"})
 
 
 def train_manifest_path(project_dir: Path, version_label: str) -> Path:
     return project_dir / "versions" / version_label / "train" / MANIFEST_NAME
 
 
+def _scan_train_images(train_dir: Path) -> set[str]:
+    """递归 train_dir 一级 sub-folder 收集图片相对路径（POSIX 形式）。
+
+    LoRA 训练用 repeat folder 结构：`train/1_data/X.png` 而不是 `train/X.png`
+    （`{N_label}/{image}` 由 dataset_config.toml 解析）。manifest entry key
+    用 POSIX 相对路径表达跨 folder 唯一性（同名图可在多个 folder 重复出现）。
+
+    根目录直接放的图忽略（不该有，但防御）；非 image 文件（caption .txt /
+    arbitrary）也忽略。
+    """
+    from ..dataset.scan import IMAGE_EXTS
+
+    if not train_dir.exists():
+        return set()
+    rel_paths: set[str] = set()
+    for sub in train_dir.iterdir():
+        if not sub.is_dir():
+            continue
+        for f in sub.iterdir():
+            if f.is_file() and f.suffix.lower() in IMAGE_EXTS:
+                rel_paths.add(f"{sub.name}/{f.name}")
+    return rel_paths
+
+
 def _build_train_manifest_from_legacy(
-    legacy: dict[str, Any], train_files: set[str]
+    legacy: dict[str, Any], train_rel_paths: set[str]
 ) -> dict[str, Any]:
     """从老 project 级 manifest 抽出 train/ 里实际存在的图的 origin 关系。
 
-    跳过：(1) train/ 里没有的 entry、(2) 老 entry 标 duplicate_removed 的（人工
-    去重审核记录，跟 train manifest 无关，新模型走 version 级独立记录）。
+    老 manifest entry name 是平铺产物名（如 `X.png`，不含 folder 前缀）。
+    新 train/ 实际位置在 sub-folder 里（如 `1_data/X.png`）。匹配规则：
+
+    - 按文件名（rel path 的末段）建索引
+    - 老 entry name 找到任意同名 train 文件 → 用该 train rel path 作新 key
+    - 跨 sub-folder 同名 → 给每个匹配的 rel path 各加一条 entry（保守，让
+      用户在 UI 自决；罕见但合法）
+
+    跳过：(1) train/ 没匹配文件名的 entry、(2) duplicate_removed 老 entry
+    （人工去重审核状态不跨模型迁移；新模型走 version 级独立记录）。
     """
+    by_filename: dict[str, list[str]] = {}
+    for rel in train_rel_paths:
+        nm = rel.rsplit("/", 1)[-1]
+        by_filename.setdefault(nm, []).append(rel)
+
     images: dict[str, Any] = {}
     for name, entry in legacy.get("images", {}).items():
         if not isinstance(entry, dict):
             continue
-        if name not in train_files:
-            continue
         if is_duplicate_removed_entry(entry):
             continue
-        images[name] = {
-            "origin": entry_origin(entry, name),
-            "mtime": entry.get("mtime", 0),
-            "size": entry.get("size", 0),
-        }
+        rels = by_filename.get(name)
+        if not rels:
+            continue
+        for rel in rels:
+            images[rel] = {
+                "origin": entry_origin(entry, name),
+                "mtime": entry.get("mtime", 0),
+                "size": entry.get("size", 0),
+            }
     return {"version": TRAIN_MANIFEST_VERSION, "images": images}
 
 
@@ -537,12 +575,8 @@ def ensure_train_manifest(project_dir: Path, version_label: str) -> Path:
 
         train_dir.mkdir(parents=True, exist_ok=True)
 
-        # 收集 train/ 里的图（一级目录，不递归；按图像后缀过滤避免把 .txt 算进来）
-        train_files: set[str] = set()
-        if train_dir.exists():
-            for entry in train_dir.iterdir():
-                if entry.is_file() and entry.suffix.lower() in _IMAGE_SUFFIXES:
-                    train_files.add(entry.name)
+        # 收集 train/ 里的图（递归一级 sub-folder，LoRA repeat folder 结构）
+        train_rel_paths = _scan_train_images(train_dir)
 
         # 读老 manifest（不存在 / 损坏 → 空，跟 load() 一致语义）
         legacy: dict[str, Any]
@@ -555,7 +589,7 @@ def ensure_train_manifest(project_dir: Path, version_label: str) -> Path:
         else:
             legacy = {}
 
-        manifest = _build_train_manifest_from_legacy(legacy, train_files)
+        manifest = _build_train_manifest_from_legacy(legacy, train_rel_paths)
         _atomic_write(target, manifest)
         return target
 
@@ -570,6 +604,8 @@ def ensure_train_manifest(project_dir: Path, version_label: str) -> Path:
 #
 # 关键语义差异（vs ADR 0004 老 API）：
 # - manifest 落 `versions/{label}/train/manifest.json`（PR-1 已加 ensure 路径）
+# - entry key 用 **POSIX 相对路径**（如 `"1_data/X.png"`），表达 LoRA repeat
+#   folder 结构（`train/{N_label}/{image}`）；跨 folder 同名图各自独立 entry
 # - `train_restore(name)` = 从 `download/{entry.origin}` 复制覆盖回 `train/{name}`
 #   （不是删 entry；详 ADR 0010 §Restore 语义）；缺 origin 文件时 → no_origin 列表
 # - `train_add_processed` size 兜底 stat `train/{name}`（不是老 `preprocess/{name}`）

--- a/studio/services/preprocess/manifest.py
+++ b/studio/services/preprocess/manifest.py
@@ -558,3 +558,326 @@ def ensure_train_manifest(project_dir: Path, version_label: str) -> Path:
         manifest = _build_train_manifest_from_legacy(legacy, train_files)
         _atomic_write(target, manifest)
         return target
+
+
+# ---------------------------------------------------------------------------
+# ADR 0010 — train-scope manifest API（PR-2 step A）
+#
+# 老的 project-scope API（load / add_processed / restore / mark_duplicate_removed /
+# clear_all / replace_with_crops / get_entry / all_processed / duplicate_removed*）
+# 暂留作 backward-compat 给老 endpoint 用，PR-3 删。新代码 / 新调用方请用
+# `train_xxx` 系列。
+#
+# 关键语义差异（vs ADR 0004 老 API）：
+# - manifest 落 `versions/{label}/train/manifest.json`（PR-1 已加 ensure 路径）
+# - `train_restore(name)` = 从 `download/{entry.origin}` 复制覆盖回 `train/{name}`
+#   （不是删 entry；详 ADR 0010 §Restore 语义）；缺 origin 文件时 → no_origin 列表
+# - `train_add_processed` size 兜底 stat `train/{name}`（不是老 `preprocess/{name}`）
+# - 所有 train_xxx 进 mutation 前先调 ensure_train_manifest（防御性，幂等）
+#
+# 锁仍用模块单 `_LOCK`（plan §12.2.1 推荐：version 写不频繁，单锁可接受）。
+# ---------------------------------------------------------------------------
+
+
+def _train_dir(project_dir: Path, version_label: str) -> Path:
+    return project_dir / "versions" / version_label / "train"
+
+
+def _empty_train_manifest() -> dict[str, Any]:
+    return {"version": TRAIN_MANIFEST_VERSION, "images": {}}
+
+
+def _read_train_target(target: Path) -> dict[str, Any]:
+    """读 train manifest 文件（target 已知存在）；损坏 → 空 v2 manifest。
+
+    设计跟老 `load()` 一致——损坏不抛，下次写时覆盖。callers 内部用，跟
+    `ensure_train_manifest` 配套（callers 已 ensure 过 target 存在）。
+    """
+    try:
+        raw = json.loads(target.read_text(encoding="utf-8"))
+        if isinstance(raw, dict) and isinstance(raw.get("images"), dict):
+            return raw
+    except (OSError, json.JSONDecodeError):
+        pass
+    return _empty_train_manifest()
+
+
+# ---- read ----------------------------------------------------------------
+
+
+def train_load(project_dir: Path, version_label: str) -> dict[str, Any]:
+    """读 train manifest；不存在则 fallback 重建（详 ADR 0010 §Fallback 重建机制）。
+
+    返回完整 manifest dict `{"version": 2, "images": {...}}`。
+    """
+    target = ensure_train_manifest(project_dir, version_label)
+    return _read_train_target(target)
+
+
+def train_get_entry(
+    project_dir: Path, version_label: str, name: str
+) -> Optional[dict[str, Any]]:
+    return train_load(project_dir, version_label)["images"].get(name)
+
+
+def train_all_processed(
+    project_dir: Path, version_label: str
+) -> dict[str, dict[str, Any]]:
+    """非 duplicate_removed 的 entry 视为"已处理"——对新 schema 是 entry 存在
+    即视为已处理（隐含状态推断；详 ADR 0010 §Manifest schema v2）。
+    """
+    m = train_load(project_dir, version_label)
+    return {
+        name: entry
+        for name, entry in m["images"].items()
+        if entry.get("kind", "processed") == "processed"
+    }
+
+
+def train_duplicate_removed(
+    project_dir: Path, version_label: str
+) -> dict[str, dict[str, Any]]:
+    m = train_load(project_dir, version_label)
+    return {
+        name: entry
+        for name, entry in m["images"].items()
+        if is_duplicate_removed_entry(entry)
+    }
+
+
+def train_duplicate_removed_origins(
+    project_dir: Path, version_label: str
+) -> set[str]:
+    return {
+        entry_origin(entry, name)
+        for name, entry in train_duplicate_removed(
+            project_dir, version_label
+        ).items()
+    }
+
+
+# ---- mutation（必须 with _LOCK）-----------------------------------------
+
+
+def train_add_processed(
+    project_dir: Path,
+    version_label: str,
+    name: str,
+    meta: dict[str, Any],
+) -> None:
+    """记录一张已处理图（train scope）。
+
+    schema 跟老 `add_processed` 一致——只采纳 `origin / mtime / size`，其他
+    字段（model/scale/action/...）丢弃。size 兜底 stat `train/{name}`。
+    """
+    ensure_train_manifest(project_dir, version_label)
+    target = train_manifest_path(project_dir, version_label)
+    with _LOCK:
+        m = _read_train_target(target)
+        origin = meta.get("origin") or meta.get("source") or name
+        entry: dict[str, Any] = {
+            "origin": origin,
+            "mtime": meta.get("mtime", time.time()),
+        }
+        if "size" in meta:
+            entry["size"] = meta["size"]
+        else:
+            png = _train_dir(project_dir, version_label) / name
+            try:
+                entry["size"] = png.stat().st_size
+            except OSError:
+                entry["size"] = 0
+        m["images"][name] = entry
+        _atomic_write(target, m)
+
+
+def train_replace_with_crops(
+    project_dir: Path,
+    version_label: str,
+    *,
+    source_name: str,
+    outputs: list[dict[str, Any]],
+) -> None:
+    """multi-crop fan-out：把 `source_name` 替换成 N 个 crop 产物 entry。
+
+    操作跟老 `replace_with_crops` 一致——找出所有 origin 与 source_name 匹配
+    的旧 entry + source_name 自身全部删除，写入 N 个新 entry（origin 沿用
+    旧 entry origin 或回退 source_name）。
+
+    磁盘文件（train/{name}.png 等）由调用方负责，本函数只动 manifest。
+    """
+    ensure_train_manifest(project_dir, version_label)
+    target = train_manifest_path(project_dir, version_label)
+    with _LOCK:
+        m = _read_train_target(target)
+        to_remove = {source_name}
+        for nm, entry in m["images"].items():
+            if entry_origin(entry, nm) == source_name:
+                to_remove.add(nm)
+        for nm in to_remove:
+            m["images"].pop(nm, None)
+        now = time.time()
+        for o in outputs:
+            entry = {
+                "origin": o.get("origin") or source_name,
+                "mtime": o.get("mtime", now),
+                "size": int(o.get("size", 0)),
+            }
+            m["images"][o["name"]] = entry
+        _atomic_write(target, m)
+
+
+def train_mark_duplicate_removed(
+    project_dir: Path,
+    version_label: str,
+    names: list[str],
+) -> dict[str, list[str]]:
+    """标记人工审核去重移除（train scope）。
+
+    不动磁盘文件——保留 train/{name} 作"已审核但跳过"标记。下游 curate /
+    training 通过查 manifest 判断该图是否参与训练。
+
+    每个 version 独立审核（manifest 是 version 级）。fork 时整树复制
+    （ADR 0007 `_copytree("train")`）会把 duplicate_removed 状态带过去。
+    """
+    removed: list[str] = []
+    missing: list[str] = []
+    skipped: list[str] = []
+    now = time.time()
+    ensure_train_manifest(project_dir, version_label)
+    target = train_manifest_path(project_dir, version_label)
+    train_dir = _train_dir(project_dir, version_label)
+    with _LOCK:
+        m = _read_train_target(target)
+        for name in names:
+            entry = m["images"].get(name)
+            if is_duplicate_removed_entry(entry):
+                skipped.append(name)
+                continue
+            if entry is not None:
+                if entry.get("kind", "processed") != "processed":
+                    skipped.append(name)
+                    continue
+                origin = entry_origin(entry, name)
+                size = int(entry.get("size", 0) or 0)
+            else:
+                src = train_dir / name
+                if not src.is_file():
+                    missing.append(name)
+                    continue
+                origin = name
+                try:
+                    size = src.stat().st_size
+                except OSError:
+                    size = 0
+            m["images"][name] = {
+                "kind": DUPLICATE_REMOVED_KIND,
+                "origin": origin,
+                "mtime": now,
+                "size": size,
+            }
+            removed.append(name)
+        _atomic_write(target, m)
+    return {"removed": removed, "missing": missing, "skipped": skipped}
+
+
+def train_restore_duplicate_removed(
+    project_dir: Path,
+    version_label: str,
+    names: list[str],
+) -> dict[str, list[str]]:
+    """撤销去重移除标记——只删 duplicate_removed entry，不动 train/ 物理文件。
+
+    跟老 `restore_duplicate_removed` 同语义，train scope 版。
+    """
+    restored: list[str] = []
+    missing: list[str] = []
+    ensure_train_manifest(project_dir, version_label)
+    target = train_manifest_path(project_dir, version_label)
+    with _LOCK:
+        m = _read_train_target(target)
+        for name in names:
+            entry = m["images"].get(name)
+            if is_duplicate_removed_entry(entry):
+                del m["images"][name]
+                restored.append(name)
+            else:
+                missing.append(name)
+        _atomic_write(target, m)
+    return {"restored": restored, "missing": missing}
+
+
+def train_restore(
+    project_dir: Path,
+    version_label: str,
+    names: list[str],
+) -> dict[str, list[str]]:
+    """复原：从 `download/{entry.origin}` 复制覆盖回 `train/{name}`。
+
+    跟老 `restore` 语义完全不同——老的是"删 manifest entry + 删 preprocess
+    PNG"靠 resolver fallback；新模型下 train/ 是 self-contained 没 fallback，
+    必须显式从 download 复制（详 ADR 0010 §Restore 语义）。
+
+    返回三组：
+    - `restored`：成功复原（download 原图存在并已复制覆盖）
+    - `missing`：name 在 manifest 没 entry（也不复制；调用方决定怎么提示）
+    - `no_origin`：entry 存在但 `download/{origin}` 物理文件缺失——UI 应该
+      给用户三选项（拖入替换 / 保留处理后版本 / 从 train 移除）
+    """
+    import shutil
+
+    restored: list[str] = []
+    missing: list[str] = []
+    no_origin: list[str] = []
+    ensure_train_manifest(project_dir, version_label)
+    target = train_manifest_path(project_dir, version_label)
+    download_dir = project_dir / "download"
+    train_dir = _train_dir(project_dir, version_label)
+    with _LOCK:
+        m = _read_train_target(target)
+        for name in names:
+            entry = m["images"].get(name)
+            if entry is None:
+                missing.append(name)
+                continue
+            origin = entry_origin(entry, name)
+            src = download_dir / origin
+            if not src.is_file():
+                no_origin.append(name)
+                continue
+            dst = train_dir / name
+            try:
+                shutil.copy2(src, dst)
+            except OSError:
+                no_origin.append(name)
+                continue
+            try:
+                st = src.stat()
+                m["images"][name] = {
+                    "origin": origin,
+                    "mtime": int(st.st_mtime),
+                    "size": st.st_size,
+                }
+            except OSError:
+                # 极端：copy2 成功但 stat 失败 — 保守只更 origin
+                m["images"][name] = {**entry, "origin": origin}
+            restored.append(name)
+        _atomic_write(target, m)
+    return {"restored": restored, "missing": missing, "no_origin": no_origin}
+
+
+def train_clear_all(project_dir: Path, version_label: str) -> None:
+    """清空本 version 的 train manifest 状态——只清 manifest 文件，**不动**
+    train/ 物理文件。
+
+    跟老 `clear_all` 语义不同——老的删 preprocess/ PNG 物理产物；新模型下
+    train/ 是训练数据本身，删物理文件 = 删训练集，不该由"清空预处理状态"
+    引发。调用方如果想完全重做预处理，应该改成"对每张图调 train_restore"
+    （复原到 download 原图），不调本函数。
+
+    本函数提供给极端场景（manifest 损坏到不可读）做"清零重建"用。
+    """
+    ensure_train_manifest(project_dir, version_label)
+    target = train_manifest_path(project_dir, version_label)
+    with _LOCK:
+        _atomic_write(target, _empty_train_manifest())

--- a/studio/services/preprocess/manifest.py
+++ b/studio/services/preprocess/manifest.py
@@ -902,6 +902,43 @@ def train_restore(
     return {"restored": restored, "missing": missing, "no_origin": no_origin}
 
 
+def train_swap_entry(
+    project_dir: Path,
+    version_label: str,
+    old_name: str,
+    new_name: str,
+    meta: dict[str, Any],
+) -> None:
+    """原子替换 train manifest entry：删 `old_name`，写 `new_name`。
+
+    给 worker 在 upscale 输出扩展名变化时用（如 src=`1_data/X.jpg` →
+    dst=`1_data/X.png`），避免 manifest 残留 dangling 老 entry。
+
+    `meta` 跟 `train_add_processed` 一致——只采纳 origin/mtime/size，其他丢弃。
+    size 兜底 stat `train/{new_name}`。
+    """
+    ensure_train_manifest(project_dir, version_label)
+    target = train_manifest_path(project_dir, version_label)
+    with _LOCK:
+        m = _read_train_target(target)
+        m["images"].pop(old_name, None)
+        origin = meta.get("origin") or meta.get("source") or new_name
+        entry: dict[str, Any] = {
+            "origin": origin,
+            "mtime": meta.get("mtime", time.time()),
+        }
+        if "size" in meta:
+            entry["size"] = meta["size"]
+        else:
+            png = _train_dir(project_dir, version_label) / new_name
+            try:
+                entry["size"] = png.stat().st_size
+            except OSError:
+                entry["size"] = 0
+        m["images"][new_name] = entry
+        _atomic_write(target, m)
+
+
 def train_clear_all(project_dir: Path, version_label: str) -> None:
     """清空本 version 的 train manifest 状态——只清 manifest 文件，**不动**
     train/ 物理文件。

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 from studio import db
 from studio.services.preprocess import core as preprocess
-from studio.services.projects import jobs as project_jobs, projects
+from studio.services.projects import jobs as project_jobs, projects, versions
 from studio.services import models as model_downloader
 from studio.services.preprocess import manifest as preprocess_manifest
 from studio.services.inference import upscaler
@@ -81,6 +81,24 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
             project = projects.get_project(conn, job["project_id"])
         if not project:
             log(f"[error] project {job['project_id']} missing")
+            return 1
+
+        # ADR 0010 train-scope 分发：job.version_id 非空 → 新 train scope 路径；
+        # None → 老 project scope 路径（backward-compat，PR-3 删）
+        version_id = job.get("version_id")
+        if version_id is not None:
+            with db.connection_for() as conn:
+                version = versions.get_version(conn, version_id)
+            if not version:
+                log(f"[error] version {version_id} missing")
+                return 1
+            if stage == preprocess.STAGE_CROP:
+                return _run_crop_train(project, version, params, log, emit_event)
+            if stage == preprocess.STAGE_UPSCALE:
+                return _run_upscale_train(
+                    project, version, params, log, emit_event,
+                )
+            log(f"[error] 未知 stage: {stage!r}")
             return 1
 
         if stage == preprocess.STAGE_CROP:
@@ -427,6 +445,340 @@ def _run_crop(
             emit_throttled(
                 force=True,
                 idx=idx, total=total, name=src_name, status="fail",
+                error=str(exc)[:200],
+                succeeded=succeeded, failed=failed, skipped=skipped,
+            )
+
+    log(f"[done] succeeded={succeeded} failed={failed} skipped={skipped}")
+    return 0
+
+
+def _run_upscale_train(
+    project: dict[str, Any],
+    version: dict[str, Any],
+    params: dict[str, Any],
+    log: Callable[[str], None],
+    emit_event: Callable[..., None],
+) -> int:
+    """ADR 0010 train-scope upscale。
+
+    源 + 产物都在 `versions/{label}/train/{folder}/`，manifest 写到
+    `versions/{label}/train/manifest.json`。PNG 输出 stem 不变但扩展名可能
+    改（X.jpg → X.png）—— `train_swap_entry` 原子替换 manifest，物理 src
+    单独 unlink 避免训练集 stem 冲突；caption (.txt) 同 stem 保留不动。
+    """
+    mode = params.get("mode", "all")
+    names = params.get("names") or None
+    model_label = params.get("model", preprocess.DEFAULT_MODEL)
+    tile_size = int(params.get("tile_size", preprocess.DEFAULT_TILE_SIZE))
+    tile_pad = int(params.get("tile_pad", preprocess.DEFAULT_TILE_PAD))
+    device = params.get("device", preprocess.DEFAULT_DEVICE)
+    target_area_raw = params.get("target_area", preprocess.DEFAULT_TARGET_AREA)
+    target_area = int(target_area_raw) if target_area_raw else None
+
+    project_dir = projects.project_dir(project["id"], project["slug"])
+    train_dir = preprocess.version_train_dir(project, version["label"])
+    train_dir.mkdir(parents=True, exist_ok=True)
+
+    model_path = model_downloader.upscaler_target(model_label)
+    if not model_path.exists():
+        log(
+            f"[error] 模型权重不存在：{model_path}（请先在设置页下载 {model_label}）"
+        )
+        return 1
+
+    try:
+        sources = preprocess.resolve_targets_train(
+            project, version["label"], mode=mode, names=names
+        )
+    except preprocess.PreprocessError as exc:
+        log(f"[error] 解析目标失败: {exc}")
+        return 1
+
+    total = len(sources)
+    if total == 0:
+        log("[done] 没有需要处理的图")
+        return 0
+
+    target_desc = (
+        f"{int(math.sqrt(target_area))}²={target_area}px"
+        if target_area else "off (直接 4×)"
+    )
+    log(
+        f"[start] mode={mode} model={model_label} tile={tile_size}+{tile_pad} "
+        f"device={device} target={target_desc} total={total} scope=train"
+    )
+
+    try:
+        import torch
+        resolved_dev = upscaler.resolve_device(device)
+        resolved_dtype = upscaler.resolve_dtype("auto", resolved_dev)
+        gpu_name = (
+            torch.cuda.get_device_name(0)
+            if resolved_dev.type == "cuda" and torch.cuda.is_available()
+            else "—"
+        )
+        log(
+            f"[device] resolved={resolved_dev} dtype={str(resolved_dtype).replace('torch.', '')} "
+            f"gpu={gpu_name} cuda_available={torch.cuda.is_available()}"
+        )
+        upscaler.load_model(model_path, device=resolved_dev, dtype=resolved_dtype)
+        log(f"[model] {model_label} loaded → {resolved_dev}")
+    except Exception as exc:  # noqa: BLE001
+        log(f"[device] diagnostic failed: {exc}（继续，但可能跑在 CPU 上）")
+
+    succeeded = 0
+    failed = 0
+    skipped = 0
+
+    for idx, src_rel in enumerate(sources, start=1):
+        if _stop_requested:
+            log(f"[cancel] 收到取消信号，已处理 {idx - 1}/{total}")
+            break
+        src_path = train_dir / src_rel
+        if not src_path.exists():
+            log(f"[skip] ({idx}/{total}) {src_rel}: 源已不存在")
+            skipped += 1
+            emit_event(
+                "preprocess_progress",
+                idx=idx, total=total, name=src_rel, status="skip",
+                succeeded=succeeded, failed=failed, skipped=skipped,
+            )
+            continue
+
+        # origin 沿用 manifest 已有 entry（multi-crop 派生 root），否则用 rel
+        # path 末段（curate 复制图时写的就是 file name == origin）
+        existing = preprocess_manifest.train_get_entry(
+            project_dir, version["label"], src_rel
+        )
+        src_filename = src_rel.rsplit("/", 1)[-1]
+        if existing is not None:
+            origin_name = preprocess_manifest.entry_origin(existing, src_filename)
+        else:
+            origin_name = src_filename
+
+        # dst rel：同 folder 同 stem，扩展名固定 .png（upscaler 输出 PNG）
+        folder, _ = src_rel.split("/", 1)
+        src_stem = Path(src_filename).stem
+        dst_rel = f"{folder}/{src_stem}.png"
+        dst_path = train_dir / dst_rel
+
+        log(f"[upscale] ({idx}/{total}) {src_rel} → {dst_rel}")
+        try:
+            meta = upscaler.upscale_file(
+                src_path,
+                dst_path,
+                model_path=model_path,
+                label=model_label,
+                tile_size=tile_size,
+                tile_pad=tile_pad,
+                device=device,
+                target_area=target_area,
+                on_log=log,
+                prewarm_thumb_sizes=[256, 768],
+            )
+            meta["origin"] = origin_name
+            if dst_rel != src_rel:
+                # 扩展名变 → 原子 swap entry + 删 src 物理文件
+                preprocess_manifest.train_swap_entry(
+                    project_dir, version["label"],
+                    old_name=src_rel, new_name=dst_rel, meta=meta,
+                )
+                try:
+                    src_path.unlink()
+                except OSError as exc:
+                    log(f"   ⚠ 删旧 {src_rel} 失败: {exc}")
+            else:
+                # 覆盖原文件（src == dst rel path）→ 普通 add_processed
+                preprocess_manifest.train_add_processed(
+                    project_dir, version["label"], dst_rel, meta,
+                )
+            succeeded += 1
+            emit_event(
+                "preprocess_progress",
+                idx=idx, total=total, name=src_rel, status="done",
+                action=meta.get("action"),
+                succeeded=succeeded, failed=failed, skipped=skipped,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log(f"[fail] {src_rel}: {exc}")
+            failed += 1
+            emit_event(
+                "preprocess_progress",
+                idx=idx, total=total, name=src_rel, status="fail",
+                error=str(exc)[:200],
+                succeeded=succeeded, failed=failed, skipped=skipped,
+            )
+
+    log(f"[done] succeeded={succeeded} failed={failed} skipped={skipped}")
+    return 0
+
+
+def _run_crop_train(
+    project: dict[str, Any],
+    version: dict[str, Any],
+    params: dict[str, Any],
+    log: Callable[[str], None],
+    emit_event: Callable[..., None],
+) -> int:
+    """ADR 0010 train-scope crop。
+
+    `params['crops']` = `{rel_path: [rects]}`，rel_path 形如 `1_data/X.png`。
+    crop 产物输出到同 folder 内：N=1 覆盖源文件名（`folder/stem.png`），
+    N>1 fan-out 成 `folder/stem_c0.png` / `folder/stem_c1.png` / ...；
+    train_replace_with_crops 原子替换 manifest。
+    """
+    project_dir = projects.project_dir(project["id"], project["slug"])
+    train_dir = preprocess.version_train_dir(project, version["label"])
+    train_dir.mkdir(parents=True, exist_ok=True)
+
+    crops_param = params.get("crops") or {}
+    if not crops_param:
+        log("[done] crops 为空，无事可做")
+        return 0
+    sources = sorted(crops_param.keys())
+
+    _last_emit_at = [0.0]
+
+    def emit_throttled(*, force: bool, **payload) -> None:
+        now = time.monotonic()
+        if not force and (now - _last_emit_at[0]) < 1.0:
+            return
+        _last_emit_at[0] = now
+        emit_event("crop_progress", **payload)
+
+    total = len(sources)
+    log(f"[start] stage=crop total={total} scope=train")
+
+    succeeded = 0
+    failed = 0
+    skipped = 0
+
+    for idx, src_rel in enumerate(sources, start=1):
+        if _stop_requested:
+            log(f"[cancel] 收到取消信号，已处理 {idx - 1}/{total}")
+            break
+        is_last = idx == total
+        try:
+            preprocess._validate_rel_name(src_rel)
+        except preprocess.PreprocessError as exc:
+            log(f"[skip] {src_rel}: {exc}")
+            skipped += 1
+            emit_throttled(
+                force=True,
+                idx=idx, total=total, name=src_rel, status="skip",
+                succeeded=succeeded, failed=failed, skipped=skipped,
+            )
+            continue
+
+        src_path = train_dir / src_rel
+        if not src_path.is_file():
+            log(f"[skip] ({idx}/{total}) {src_rel}: 源不存在")
+            skipped += 1
+            emit_throttled(
+                force=True,
+                idx=idx, total=total, name=src_rel, status="skip",
+                succeeded=succeeded, failed=failed, skipped=skipped,
+            )
+            continue
+
+        # origin 沿用 manifest 已有 entry root，否则用 src filename
+        existing = preprocess_manifest.train_get_entry(
+            project_dir, version["label"], src_rel
+        )
+        src_filename = src_rel.rsplit("/", 1)[-1]
+        if existing is not None:
+            origin = preprocess_manifest.entry_origin(existing, src_filename)
+        else:
+            origin = src_filename
+
+        rects = crops_param[src_rel]
+        n = len(rects)
+        folder, _ = src_rel.split("/", 1)
+        src_stem = Path(src_filename).stem
+        out_rels = (
+            [f"{folder}/{src_stem}.png"] if n == 1
+            else [f"{folder}/{src_stem}_c{i}.png" for i in range(n)]
+        )
+
+        log(f"[crop] ({idx}/{total}) {src_rel} → {n} 个产物")
+        try:
+            t0 = time.monotonic()
+            with Image.open(src_path) as raw:
+                raw.load()
+                src_img = raw.convert("RGB") if raw.mode != "RGB" else raw.copy()
+            sw, sh = src_img.size
+            outputs: list[dict[str, Any]] = []
+            for r, out_rel in zip(rects, out_rels):
+                left = int(round(r["x"] * sw))
+                top = int(round(r["y"] * sh))
+                right = int(round((r["x"] + r["w"]) * sw))
+                bottom = int(round((r["y"] + r["h"]) * sh))
+                right = max(left + 1, right)
+                bottom = max(top + 1, bottom)
+                piece = src_img.crop((left, top, right, bottom))
+                out_path = train_dir / out_rel
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+                piece.save(tmp_path, format="PNG", optimize=False)
+                import os as _os
+                _os.replace(tmp_path, out_path)
+                try:
+                    st = out_path.stat()
+                    sz, mt = st.st_size, st.st_mtime
+                except OSError:
+                    sz, mt = 0, time.time()
+                outputs.append({
+                    "name": out_rel,
+                    "origin": origin,
+                    "size": sz,
+                    "mtime": mt,
+                })
+
+            # N>1：原 src 物理文件（如果不在 outputs 列表里）应当删
+            if n > 1:
+                stale_rel = f"{folder}/{src_stem}.png"
+                stale_path = train_dir / stale_rel
+                if stale_path.is_file() and stale_rel not in out_rels:
+                    try:
+                        stale_path.unlink()
+                    except OSError as exc:
+                        log(f"   ⚠ 删旧 {stale_rel} 失败: {exc}")
+
+            preprocess_manifest.train_replace_with_crops(
+                project_dir, version["label"],
+                source_name=src_rel,
+                outputs=outputs,
+            )
+            # thumb prewarm
+            try:
+                from studio.services.dataset import thumb_cache
+                for out_rel in out_rels:
+                    out_path = train_dir / out_rel
+                    with Image.open(out_path) as piece:
+                        piece.load()
+                        thumb_cache.prewarm_from_image(out_path, piece, [256, 768])
+            except Exception as exc:  # noqa: BLE001
+                log(f"   ⚠ thumb prewarm failed: {exc}")
+
+            elapsed = time.monotonic() - t0
+            succeeded += 1
+            log(
+                f"   ✓ {src_rel} → {', '.join(out_rels)}  "
+                f"({sw}×{sh} → {n} 块, {elapsed:.2f}s)"
+            )
+            emit_throttled(
+                force=(idx == 1 or is_last),
+                idx=idx, total=total, name=src_rel, status="done",
+                n_out=n, outputs=out_rels,
+                succeeded=succeeded, failed=failed, skipped=skipped,
+            )
+        except Exception as exc:  # noqa: BLE001
+            log(f"[fail] {src_rel}: {exc}")
+            failed += 1
+            emit_throttled(
+                force=True,
+                idx=idx, total=total, name=src_rel, status="fail",
                 error=str(exc)[:200],
                 succeeded=succeeded, failed=failed, skipped=skipped,
             )

--- a/tests/test_curation_train_scope.py
+++ b/tests/test_curation_train_scope.py
@@ -1,0 +1,170 @@
+"""ADR 0010 — curation `copy_download_to_train` (PR-2 step C)。
+
+跟老 `copy_to_train` 的差异（独立单测在 test_curation.py 不重叠）：
+- 取消 preprocess 派生分支（bytes 始终从 download/{name}）
+- 写 train manifest entry，key = "{folder}/{name}"，origin = name
+- caption 仍从 download/{stem}.* 复制
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from studio import db
+from studio.services.dataset import curation
+from studio.services.preprocess import manifest as preprocess_manifest
+from studio.services.projects import projects, versions
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    with db.connection_for(dbfile) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label="v1")
+    return {"db": dbfile, "p": p, "v": v}
+
+
+def _pdir(env) -> Path:
+    return projects.project_dir(env["p"]["id"], env["p"]["slug"])
+
+
+def _dl(env, name: str, blob: bytes = b"img") -> Path:
+    f = _pdir(env) / "download" / name
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_bytes(blob)
+    return f
+
+
+def _train(env, folder: str = "1_data") -> Path:
+    return _pdir(env) / "versions" / env["v"]["label"] / "train" / folder
+
+
+# ---------------------------------------------------------------------------
+# 基础：复制 + manifest entry
+# ---------------------------------------------------------------------------
+
+
+def test_copy_download_to_train_writes_manifest_entry(env) -> None:
+    _dl(env, "X.jpg", blob=b"orig" * 10)
+    with db.connection_for(env["db"]) as conn:
+        result = curation.copy_download_to_train(
+            conn, env["p"]["id"], env["v"]["id"],
+            files=["X.jpg"], dest_folder="1_data",
+        )
+    assert result == {"copied": ["X.jpg"], "skipped": [], "missing": []}
+    # bytes 复制
+    assert (_train(env) / "X.jpg").read_bytes() == b"orig" * 10
+    # manifest entry key = "1_data/X.jpg"，origin = "X.jpg"
+    entry = preprocess_manifest.train_get_entry(
+        _pdir(env), env["v"]["label"], "1_data/X.jpg"
+    )
+    assert entry is not None
+    assert entry["origin"] == "X.jpg"
+    assert entry["size"] == 40
+
+
+def test_copy_download_to_train_copies_caption(env) -> None:
+    _dl(env, "Y.jpg")
+    (_pdir(env) / "download" / "Y.txt").write_text("a tag, b tag")
+    (_pdir(env) / "download" / "Y.json").write_text('{"k":1}')
+    with db.connection_for(env["db"]) as conn:
+        curation.copy_download_to_train(
+            conn, env["p"]["id"], env["v"]["id"],
+            files=["Y.jpg"], dest_folder="1_data",
+        )
+    assert (_train(env) / "Y.txt").read_text() == "a tag, b tag"
+    assert (_train(env) / "Y.json").read_text() == '{"k":1}'
+
+
+def test_copy_download_to_train_skips_existing(env) -> None:
+    _dl(env, "Z.jpg")
+    dst = _train(env)
+    dst.mkdir(parents=True, exist_ok=True)
+    (dst / "Z.jpg").write_bytes(b"existing")
+
+    with db.connection_for(env["db"]) as conn:
+        result = curation.copy_download_to_train(
+            conn, env["p"]["id"], env["v"]["id"],
+            files=["Z.jpg"], dest_folder="1_data",
+        )
+    assert result == {"copied": [], "skipped": ["Z.jpg"], "missing": []}
+    # 内容没被覆盖
+    assert (dst / "Z.jpg").read_bytes() == b"existing"
+
+
+def test_copy_download_to_train_missing(env) -> None:
+    with db.connection_for(env["db"]) as conn:
+        result = curation.copy_download_to_train(
+            conn, env["p"]["id"], env["v"]["id"],
+            files=["ghost.jpg"], dest_folder="1_data",
+        )
+    assert result == {"copied": [], "skipped": [], "missing": ["ghost.jpg"]}
+
+
+def test_copy_download_to_train_multiple_folders_indep_entries(env) -> None:
+    """同一张图复制到两个 folder → manifest 两个独立 entry。"""
+    _dl(env, "shared.jpg", blob=b"s")
+    with db.connection_for(env["db"]) as conn:
+        curation.copy_download_to_train(
+            conn, env["p"]["id"], env["v"]["id"],
+            files=["shared.jpg"], dest_folder="1_data",
+        )
+        curation.copy_download_to_train(
+            conn, env["p"]["id"], env["v"]["id"],
+            files=["shared.jpg"], dest_folder="5_extra",
+        )
+    m = preprocess_manifest.train_load(_pdir(env), env["v"]["label"])
+    assert "1_data/shared.jpg" in m["images"]
+    assert "5_extra/shared.jpg" in m["images"]
+    # 两个 entry origin 都指向同一 download
+    assert m["images"]["1_data/shared.jpg"]["origin"] == "shared.jpg"
+    assert m["images"]["5_extra/shared.jpg"]["origin"] == "shared.jpg"
+
+
+def test_copy_download_to_train_no_preprocess_branch(env) -> None:
+    """ADR 0010：copy_download_to_train 不消费 preprocess 派生，即使老 manifest
+    标 X.jpg 已经处理过（preprocess/X.png），新函数仍只从 download 复制原图。"""
+    _dl(env, "X.jpg", blob=b"raw")
+    # 模拟老项目残留 preprocess/X.png + 项目级 manifest entry
+    pre = _pdir(env) / "preprocess"
+    pre.mkdir(parents=True, exist_ok=True)
+    (pre / "X.png").write_bytes(b"upscaled-residue")
+    preprocess_manifest.add_processed(_pdir(env), "X.png", {"source": "X.jpg"})
+
+    with db.connection_for(env["db"]) as conn:
+        curation.copy_download_to_train(
+            conn, env["p"]["id"], env["v"]["id"],
+            files=["X.jpg"], dest_folder="1_data",
+        )
+
+    # train 收到的是 download bytes（"raw"），不是 preprocess 派生
+    assert (_train(env) / "X.jpg").read_bytes() == b"raw"
+    # 新 manifest entry key 是 "1_data/X.jpg"，origin = name 本身
+    entry = preprocess_manifest.train_get_entry(
+        _pdir(env), env["v"]["label"], "1_data/X.jpg"
+    )
+    assert entry["origin"] == "X.jpg"
+
+
+def test_copy_download_to_train_invalid_folder_rejected(env) -> None:
+    _dl(env, "X.jpg")
+    with db.connection_for(env["db"]) as conn:
+        with pytest.raises(curation.CurationError):
+            curation.copy_download_to_train(
+                conn, env["p"]["id"], env["v"]["id"],
+                files=["X.jpg"], dest_folder="../escape",
+            )
+
+
+def test_copy_download_to_train_invalid_filename_rejected(env) -> None:
+    with db.connection_for(env["db"]) as conn:
+        with pytest.raises(curation.CurationError):
+            curation.copy_download_to_train(
+                conn, env["p"]["id"], env["v"]["id"],
+                files=["../../etc/passwd"], dest_folder="1_data",
+            )

--- a/tests/test_duplicates_train_scope.py
+++ b/tests/test_duplicates_train_scope.py
@@ -1,0 +1,184 @@
+"""ADR 0010 — duplicates train-scope API（PR-2 step E）。
+
+覆盖 `_resolve_train_sources`、`apply_train_duplicate_removals` 行为。
+`scan_train_duplicates` 主体跟 `scan_project_duplicates` 共享，只是 sources
+来源不同 — sources 解析正确即可信任主流程（无需重测 hash/compare/group）。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from studio import db
+from studio.services.preprocess import duplicates as duplicate_finder
+from studio.services.preprocess import manifest as preprocess_manifest
+from studio.services.projects import projects, versions
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    with db.connection_for(dbfile) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label="v1")
+    pdir = projects.project_dir(p["id"], p["slug"])
+    sub = pdir / "versions" / "v1" / "train" / "1_data"
+    sub.mkdir(parents=True, exist_ok=True)
+    return {"db": dbfile, "p": p, "v": v, "pdir": pdir, "sub": sub}
+
+
+def _png(path: Path, color: tuple[int, int, int] = (255, 0, 0)) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (32, 32), color).save(path, "PNG")
+
+
+# ---------------------------------------------------------------------------
+# _resolve_train_sources
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_train_sources_lists_subfolder_images(env) -> None:
+    _png(env["sub"] / "X.png")
+    _png(env["sub"] / "Y.png")
+    with db.connection_for(env["db"]) as conn:
+        out = duplicate_finder._resolve_train_sources(
+            conn, env["p"]["id"], env["v"]["id"], env["pdir"],
+        )
+    names = [n for n, _ in out]
+    assert names == ["1_data/X.png", "1_data/Y.png"]
+
+
+def test_resolve_train_sources_skips_duplicate_removed(env) -> None:
+    _png(env["sub"] / "X.png")
+    _png(env["sub"] / "Y.png")
+    preprocess_manifest.train_mark_duplicate_removed(
+        env["pdir"], env["v"]["label"], ["1_data/Y.png"],
+    )
+    with db.connection_for(env["db"]) as conn:
+        out = duplicate_finder._resolve_train_sources(
+            conn, env["p"]["id"], env["v"]["id"], env["pdir"],
+        )
+    names = [n for n, _ in out]
+    assert names == ["1_data/X.png"]
+
+
+def test_resolve_train_sources_skips_non_image(env) -> None:
+    _png(env["sub"] / "X.png")
+    (env["sub"] / "X.txt").write_text("caption")
+    with db.connection_for(env["db"]) as conn:
+        out = duplicate_finder._resolve_train_sources(
+            conn, env["p"]["id"], env["v"]["id"], env["pdir"],
+        )
+    names = [n for n, _ in out]
+    assert names == ["1_data/X.png"]
+
+
+def test_resolve_train_sources_empty_when_no_train(env) -> None:
+    import shutil
+    shutil.rmtree(env["pdir"] / "versions")
+    with db.connection_for(env["db"]) as conn:
+        out = duplicate_finder._resolve_train_sources(
+            conn, env["p"]["id"], env["v"]["id"], env["pdir"],
+        )
+    assert out == []
+
+
+def test_resolve_train_sources_mismatched_version_raises(env) -> None:
+    """version_id 跟 project_id 不一致 → DuplicateFinderError。"""
+    # 另开一个 project + version
+    with db.connection_for(env["db"]) as conn:
+        other_p = projects.create_project(conn, title="Other")
+        other_v = versions.create_version(
+            conn, project_id=other_p["id"], label="v1"
+        )
+    with db.connection_for(env["db"]) as conn:
+        with pytest.raises(duplicate_finder.DuplicateFinderError):
+            duplicate_finder._resolve_train_sources(
+                conn, env["p"]["id"], other_v["id"], env["pdir"],
+            )
+
+
+# ---------------------------------------------------------------------------
+# apply_train_duplicate_removals
+# ---------------------------------------------------------------------------
+
+
+def test_apply_train_duplicate_marks_manifest(env) -> None:
+    _png(env["sub"] / "A.png")
+    _png(env["sub"] / "B.png")
+    with db.connection_for(env["db"]) as conn:
+        result = duplicate_finder.apply_train_duplicate_removals(
+            conn, env["p"]["id"], env["v"]["id"],
+            names=["1_data/A.png", "1_data/B.png"],
+        )
+    assert sorted(result["removed"]) == ["1_data/A.png", "1_data/B.png"]
+    # 物理文件保留
+    assert (env["sub"] / "A.png").exists()
+    assert (env["sub"] / "B.png").exists()
+    # manifest 标记
+    entry = preprocess_manifest.train_get_entry(
+        env["pdir"], env["v"]["label"], "1_data/A.png"
+    )
+    assert entry["kind"] == preprocess_manifest.DUPLICATE_REMOVED_KIND
+
+
+def test_apply_train_duplicate_rejects_invalid_rel_name(env) -> None:
+    with db.connection_for(env["db"]) as conn:
+        with pytest.raises(duplicate_finder.DuplicateFinderError):
+            duplicate_finder.apply_train_duplicate_removals(
+                conn, env["p"]["id"], env["v"]["id"],
+                names=["../etc/passwd"],
+            )
+
+
+def test_apply_train_duplicate_rejects_flat_name(env) -> None:
+    """rel path 必须含 folder 前缀（两段格式）。"""
+    with db.connection_for(env["db"]) as conn:
+        with pytest.raises(duplicate_finder.DuplicateFinderError):
+            duplicate_finder.apply_train_duplicate_removals(
+                conn, env["p"]["id"], env["v"]["id"],
+                names=["X.png"],  # 平铺，缺 folder
+            )
+
+
+def test_apply_train_duplicate_mismatched_version_raises(env) -> None:
+    with db.connection_for(env["db"]) as conn:
+        other_p = projects.create_project(conn, title="Other")
+        other_v = versions.create_version(
+            conn, project_id=other_p["id"], label="v1"
+        )
+    with db.connection_for(env["db"]) as conn:
+        with pytest.raises(duplicate_finder.DuplicateFinderError):
+            duplicate_finder.apply_train_duplicate_removals(
+                conn, env["p"]["id"], other_v["id"],
+                names=["1_data/A.png"],
+            )
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat：老 _resolve_download_sources / apply_duplicate_removals 不动
+# ---------------------------------------------------------------------------
+
+
+def test_train_apis_dont_affect_legacy_apis(env) -> None:
+    """train-scope API 写 train manifest，不影响项目级 manifest（PR-3 才删
+    老 API）。"""
+    _png(env["sub"] / "A.png")
+    # 老 manifest 先准备一条
+    preprocess_manifest.add_processed(env["pdir"], "X.png", {"source": "X.png"})
+
+    with db.connection_for(env["db"]) as conn:
+        duplicate_finder.apply_train_duplicate_removals(
+            conn, env["p"]["id"], env["v"]["id"],
+            names=["1_data/A.png"],
+        )
+
+    # 项目级 manifest 没动
+    legacy = preprocess_manifest.get_entry(env["pdir"], "X.png")
+    assert legacy is not None  # 老条目仍在
+    assert legacy.get("kind", "processed") == "processed"

--- a/tests/test_preprocess_train_core.py
+++ b/tests/test_preprocess_train_core.py
@@ -4,7 +4,8 @@
 / start_crop_job_train / list_crop_workspace_train /
 list_duplicate_removed_workspace_train / restore_products_train`。
 
-老 project-scope API 单测在 test_preprocess.py，本文件不覆盖。
+train/ 是 LoRA repeat folder 结构（`train/{N_label}/{image}`）；manifest entry
+key 和这些函数的 `name` 参数都用 POSIX 相对路径（`"1_data/X.png"`）。
 """
 from __future__ import annotations
 
@@ -19,9 +20,16 @@ from studio.services.preprocess import manifest as preprocess_manifest
 from studio.services.projects import jobs as project_jobs, projects, versions
 
 
+DEFAULT_FOLDER = "1_data"
+
+
+def _rel(name: str, folder: str = DEFAULT_FOLDER) -> str:
+    return f"{folder}/{name}"
+
+
 @pytest.fixture
 def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
-    """复用 test_preprocess.py 的 isolated 模式 + 自动创建 v1 version。"""
+    """isolated 项目 + 自动创建 v1 version + `versions/v1/train/1_data/` sub-folder。"""
     dbfile = tmp_path / "studio.db"
     db.init_db(dbfile)
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
@@ -30,16 +38,14 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     with db.connection_for(dbfile) as conn:
         p = projects.create_project(conn, title="PP")
         v = versions.create_version(conn, project_id=p["id"], label="v1")
-    return {"db": dbfile, "project": p, "version": v}
+    sub = preprocess.version_train_dir(p, "v1") / DEFAULT_FOLDER
+    sub.mkdir(parents=True, exist_ok=True)
+    return {"db": dbfile, "project": p, "version": v, "sub": sub}
 
 
 def _write_png(path: Path, size: tuple[int, int] = (10, 10)) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     Image.new("RGB", size, color="red").save(path, "PNG")
-
-
-def _train_dir(p: dict, label: str = "v1") -> Path:
-    return preprocess.version_train_dir(p, label)
 
 
 def _download_dir(p: dict) -> Path:
@@ -53,43 +59,44 @@ def _download_dir(p: dict) -> Path:
 
 
 def test_list_train_images_empty_when_no_train(isolated) -> None:
+    # 删 fixture 预建的 sub-folder
+    import shutil
+    shutil.rmtree(isolated["sub"])
     items = preprocess.list_train_images(isolated["project"], "v1")
     assert items == []
 
 
 def test_list_train_images_basic_entry(isolated) -> None:
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "X.png", (100, 80))
+    sub = isolated["sub"]
+    _write_png(sub / "X.png", (100, 80))
     download = _download_dir(p)
     download.mkdir(parents=True, exist_ok=True)
     (download / "X.jpg").write_bytes(b"orig")
     preprocess_manifest.train_add_processed(
-        preprocess.project_root(p), "v1", "X.png", {"origin": "X.jpg"}
+        preprocess.project_root(p), "v1", _rel("X.png"), {"origin": "X.jpg"}
     )
 
     items = preprocess.list_train_images(p, "v1")
     assert len(items) == 1
     item = items[0]
-    assert item["name"] == "X.png"
+    assert item["name"] == _rel("X.png")
     assert item["origin"] == "X.jpg"
     assert item["source"] == "X.jpg"
     assert item["w"] == 100 and item["h"] == 80
     assert item["orphan"] is False
     assert item["duplicate_removed"] is False
-    # 老 schema 透传字段应为 None
     assert item["model"] is None
     assert item["scale"] is None
 
 
 def test_list_train_images_orphan_when_download_missing(isolated) -> None:
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "Y.png")
+    sub = isolated["sub"]
+    _write_png(sub / "Y.png")
     preprocess_manifest.train_add_processed(
-        preprocess.project_root(p), "v1", "Y.png", {"origin": "Y.jpg"}
+        preprocess.project_root(p), "v1", _rel("Y.png"), {"origin": "Y.jpg"}
     )
-    # 不创建 download/Y.jpg
 
     items = preprocess.list_train_images(p, "v1")
     assert len(items) == 1
@@ -98,52 +105,49 @@ def test_list_train_images_orphan_when_download_missing(isolated) -> None:
 
 def test_list_train_images_marks_duplicate_removed(isolated) -> None:
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "A.png")
+    sub = isolated["sub"]
+    _write_png(sub / "A.png")
     preprocess_manifest.train_mark_duplicate_removed(
-        preprocess.project_root(p), "v1", ["A.png"]
+        preprocess.project_root(p), "v1", [_rel("A.png")]
     )
 
     items = preprocess.list_train_images(p, "v1")
-    # 物理文件 + manifest 都在，只是 kind=duplicate_removed
     assert len(items) == 1
     assert items[0]["duplicate_removed"] is True
 
 
 def test_list_train_images_includes_stale_duplicate_removed(isolated) -> None:
-    """manifest 有 duplicate_removed entry 但 train/ 物理已删 → 仍报告（stale）。"""
+    """manifest 有 duplicate_removed entry 但 train/ 物理已删 → 仍报告 stale。"""
     p = isolated["project"]
-    train = _train_dir(p)
-    train.mkdir(parents=True, exist_ok=True)
-    _write_png(train / "S.png")
+    sub = isolated["sub"]
+    _write_png(sub / "S.png")
     preprocess_manifest.train_mark_duplicate_removed(
-        preprocess.project_root(p), "v1", ["S.png"]
+        preprocess.project_root(p), "v1", [_rel("S.png")]
     )
-    # 模拟用户外部删 train/S.png
-    (train / "S.png").unlink()
+    (sub / "S.png").unlink()
 
     items = preprocess.list_train_images(p, "v1")
     assert len(items) == 1
-    assert items[0]["name"] == "S.png"
+    assert items[0]["name"] == _rel("S.png")
     assert items[0]["duplicate_removed"] is True
-    assert items[0]["w"] is None  # stale 不读图头
+    assert items[0]["w"] is None
 
 
 def test_list_train_images_processed_state_from_origin_diff(isolated) -> None:
-    """名字 != origin → 隐含"处理过"（新 schema 状态推断）。"""
+    """name (rel path 末段) != origin → 隐含"处理过"。"""
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "P.png")
+    sub = isolated["sub"]
+    _write_png(sub / "P.png")
     download = _download_dir(p)
     download.mkdir(parents=True, exist_ok=True)
     (download / "P.jpg").write_bytes(b"o")
     preprocess_manifest.train_add_processed(
-        preprocess.project_root(p), "v1", "P.png", {"origin": "P.jpg"}
+        preprocess.project_root(p), "v1", _rel("P.png"), {"origin": "P.jpg"}
     )
 
     items = preprocess.list_train_images(p, "v1")
-    # name "P.png" vs origin "P.jpg" 后缀不同 → 处理过；UI 看 source != name 推断
-    assert items[0]["origin"] != items[0]["name"]
+    # rel path "1_data/P.png" vs origin "P.jpg" → 处理过（origin 是平铺 download 名）
+    assert items[0]["origin"] != items[0]["name"].rsplit("/", 1)[-1]
 
 
 # ---------------------------------------------------------------------------
@@ -153,18 +157,18 @@ def test_list_train_images_processed_state_from_origin_diff(isolated) -> None:
 
 def test_summary_train_counts_physical_plus_stale(isolated) -> None:
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "A.png")
-    _write_png(train / "B.png")
-    # stale duplicate_removed（manifest 有 + 物理无）
-    _write_png(train / "C.png")
+    sub = isolated["sub"]
+    _write_png(sub / "A.png")
+    _write_png(sub / "B.png")
+    # stale duplicate_removed
+    _write_png(sub / "C.png")
     preprocess_manifest.train_mark_duplicate_removed(
-        preprocess.project_root(p), "v1", ["C.png"]
+        preprocess.project_root(p), "v1", [_rel("C.png")]
     )
-    (train / "C.png").unlink()
+    (sub / "C.png").unlink()
 
     s = preprocess.summary_train(p, "v1")
-    assert s["image_count"] == 3  # A + B 物理 + C stale
+    assert s["image_count"] == 3
 
 
 # ---------------------------------------------------------------------------
@@ -174,23 +178,23 @@ def test_summary_train_counts_physical_plus_stale(isolated) -> None:
 
 def test_resolve_targets_all_lists_train(isolated) -> None:
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "z.png")
-    _write_png(train / "a.png")
+    sub = isolated["sub"]
+    _write_png(sub / "z.png")
+    _write_png(sub / "a.png")
 
     out = preprocess.resolve_targets_train(p, "v1", mode="all")
-    assert out == ["a.png", "z.png"]  # 字典序
+    assert out == [_rel("a.png"), _rel("z.png")]
 
 
 def test_resolve_targets_selected_intersects_train(isolated) -> None:
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "X.png")
+    sub = isolated["sub"]
+    _write_png(sub / "X.png")
 
     out = preprocess.resolve_targets_train(
-        p, "v1", mode="selected", names=["X.png", "ghost.png"]
+        p, "v1", mode="selected", names=[_rel("X.png"), _rel("ghost.png")]
     )
-    assert out == ["X.png"]
+    assert out == [_rel("X.png")]
 
 
 def test_resolve_targets_selected_empty_names_raises(isolated) -> None:
@@ -206,10 +210,11 @@ def test_resolve_targets_unknown_mode_raises(isolated) -> None:
         )
 
 
-def test_resolve_targets_name_with_slash_rejected(isolated) -> None:
+def test_resolve_targets_name_with_traversal_rejected(isolated) -> None:
+    """`..` 在 name 里被 _validate_name 拒。folder/file POSIX 形式 OK。"""
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "X.png")
+    sub = isolated["sub"]
+    _write_png(sub / "X.png")
     with pytest.raises(preprocess.PreprocessError):
         preprocess.resolve_targets_train(
             p, "v1", mode="selected", names=["../etc/passwd"]
@@ -258,14 +263,13 @@ def test_start_crop_job_train_validates_rects(isolated) -> None:
             conn,
             project_id=p["id"],
             version_id=v["id"],
-            crops={"X.png": [{"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}]},
+            crops={_rel("X.png"): [{"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}]},
         )
         assert job["version_id"] == v["id"]
-        # 非法 rect 拒
         with pytest.raises(preprocess.PreprocessError):
             preprocess.start_crop_job_train(
                 conn, project_id=p["id"], version_id=v["id"],
-                crops={"X.png": [{"x": 0, "y": 0, "w": 0.001, "h": 0.5}]},
+                crops={_rel("X.png"): [{"x": 0, "y": 0, "w": 0.001, "h": 0.5}]},
             )
 
 
@@ -276,36 +280,38 @@ def test_start_crop_job_train_validates_rects(isolated) -> None:
 
 def test_list_crop_workspace_excludes_duplicate_removed(isolated) -> None:
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "ok.png", (50, 40))
-    _write_png(train / "dup.png", (60, 50))
+    sub = isolated["sub"]
+    _write_png(sub / "ok.png", (50, 40))
+    _write_png(sub / "dup.png", (60, 50))
     preprocess_manifest.train_mark_duplicate_removed(
-        preprocess.project_root(p), "v1", ["dup.png"]
+        preprocess.project_root(p), "v1", [_rel("dup.png")]
     )
 
     out = preprocess.list_crop_workspace_train(p, "v1")
     names = [it["name"] for it in out]
-    assert names == ["ok.png"]
+    assert names == [_rel("ok.png")]
     assert out[0]["w"] == 50 and out[0]["h"] == 40
 
 
 def test_list_crop_workspace_processed_flag(isolated) -> None:
-    """name != origin → processed=True；name == origin → processed=False。"""
+    """rel path 末段 != origin → processed=True；相等 → False。"""
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "proc.png")
-    _write_png(train / "raw.jpg")
+    sub = isolated["sub"]
+    _write_png(sub / "proc.png")
+    _write_png(sub / "raw.jpg")
     preprocess_manifest.train_add_processed(
-        preprocess.project_root(p), "v1", "proc.png", {"origin": "proc.jpg"}
+        preprocess.project_root(p), "v1", _rel("proc.png"),
+        {"origin": "proc.jpg"},
     )
     preprocess_manifest.train_add_processed(
-        preprocess.project_root(p), "v1", "raw.jpg", {"origin": "raw.jpg"}
+        preprocess.project_root(p), "v1", _rel("raw.jpg"),
+        {"origin": "raw.jpg"},
     )
 
     out = preprocess.list_crop_workspace_train(p, "v1")
     by_name = {it["name"]: it for it in out}
-    assert by_name["proc.png"]["processed"] is True
-    assert by_name["raw.jpg"]["processed"] is False
+    assert by_name[_rel("proc.png")]["processed"] is True
+    assert by_name[_rel("raw.jpg")]["processed"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -315,27 +321,26 @@ def test_list_crop_workspace_processed_flag(isolated) -> None:
 
 def test_list_duplicate_removed_workspace_returns_marked(isolated) -> None:
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "Q.png", (40, 30))
+    sub = isolated["sub"]
+    _write_png(sub / "Q.png", (40, 30))
     preprocess_manifest.train_mark_duplicate_removed(
-        preprocess.project_root(p), "v1", ["Q.png"]
+        preprocess.project_root(p), "v1", [_rel("Q.png")]
     )
 
     out = preprocess.list_duplicate_removed_workspace_train(p, "v1")
     assert len(out) == 1
-    assert out[0]["name"] == "Q.png"
+    assert out[0]["name"] == _rel("Q.png")
     assert out[0]["w"] == 40 and out[0]["h"] == 30
 
 
 def test_list_duplicate_removed_workspace_stale_entry(isolated) -> None:
-    """物理已删 → 仍返回 stale entry，w/h None。"""
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "R.png")
+    sub = isolated["sub"]
+    _write_png(sub / "R.png")
     preprocess_manifest.train_mark_duplicate_removed(
-        preprocess.project_root(p), "v1", ["R.png"]
+        preprocess.project_root(p), "v1", [_rel("R.png")]
     )
-    (train / "R.png").unlink()
+    (sub / "R.png").unlink()
 
     out = preprocess.list_duplicate_removed_workspace_train(p, "v1")
     assert len(out) == 1
@@ -348,33 +353,31 @@ def test_list_duplicate_removed_workspace_stale_entry(isolated) -> None:
 
 
 def test_restore_products_train_copies_download_to_train(isolated) -> None:
-    """完整 restore 流程：download/X.jpg → train/X.png 覆盖。"""
     p = isolated["project"]
-    train = _train_dir(p)
+    sub = isolated["sub"]
     download = _download_dir(p)
     download.mkdir(parents=True, exist_ok=True)
     (download / "X.jpg").write_bytes(b"original" * 5)
-    _write_png(train / "X.png")
+    _write_png(sub / "X.png")
     preprocess_manifest.train_add_processed(
-        preprocess.project_root(p), "v1", "X.png", {"origin": "X.jpg"}
+        preprocess.project_root(p), "v1", _rel("X.png"), {"origin": "X.jpg"}
     )
 
-    result = preprocess.restore_products_train(p, "v1", ["X.png"])
-    assert result == {"restored": ["X.png"], "missing": [], "no_origin": []}
-    assert (train / "X.png").read_bytes() == b"original" * 5
+    result = preprocess.restore_products_train(p, "v1", [_rel("X.png")])
+    assert result == {"restored": [_rel("X.png")], "missing": [], "no_origin": []}
+    assert (sub / "X.png").read_bytes() == b"original" * 5
 
 
 def test_restore_products_train_no_origin_when_download_missing(isolated) -> None:
     p = isolated["project"]
-    train = _train_dir(p)
-    _write_png(train / "Y.png")
+    sub = isolated["sub"]
+    _write_png(sub / "Y.png")
     preprocess_manifest.train_add_processed(
-        preprocess.project_root(p), "v1", "Y.png", {"origin": "Y.jpg"}
+        preprocess.project_root(p), "v1", _rel("Y.png"), {"origin": "Y.jpg"}
     )
-    # 不创建 download/Y.jpg
 
-    result = preprocess.restore_products_train(p, "v1", ["Y.png"])
-    assert result == {"restored": [], "missing": [], "no_origin": ["Y.png"]}
+    result = preprocess.restore_products_train(p, "v1", [_rel("Y.png")])
+    assert result == {"restored": [], "missing": [], "no_origin": [_rel("Y.png")]}
 
 
 def test_restore_products_train_validates_name(isolated) -> None:

--- a/tests/test_preprocess_train_core.py
+++ b/tests/test_preprocess_train_core.py
@@ -1,0 +1,383 @@
+"""ADR 0010 — train-scope core API（PR-2 step B）。
+
+覆盖 `list_train_images / summary_train / resolve_targets_train / start_job_train
+/ start_crop_job_train / list_crop_workspace_train /
+list_duplicate_removed_workspace_train / restore_products_train`。
+
+老 project-scope API 单测在 test_preprocess.py，本文件不覆盖。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from studio import db
+from studio.services.preprocess import core as preprocess
+from studio.services.preprocess import manifest as preprocess_manifest
+from studio.services.projects import jobs as project_jobs, projects, versions
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """复用 test_preprocess.py 的 isolated 模式 + 自动创建 v1 version。"""
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
+    with db.connection_for(dbfile) as conn:
+        p = projects.create_project(conn, title="PP")
+        v = versions.create_version(conn, project_id=p["id"], label="v1")
+    return {"db": dbfile, "project": p, "version": v}
+
+
+def _write_png(path: Path, size: tuple[int, int] = (10, 10)) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", size, color="red").save(path, "PNG")
+
+
+def _train_dir(p: dict, label: str = "v1") -> Path:
+    return preprocess.version_train_dir(p, label)
+
+
+def _download_dir(p: dict) -> Path:
+    d, _ = preprocess.project_paths(p)
+    return d
+
+
+# ---------------------------------------------------------------------------
+# list_train_images
+# ---------------------------------------------------------------------------
+
+
+def test_list_train_images_empty_when_no_train(isolated) -> None:
+    items = preprocess.list_train_images(isolated["project"], "v1")
+    assert items == []
+
+
+def test_list_train_images_basic_entry(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "X.png", (100, 80))
+    download = _download_dir(p)
+    download.mkdir(parents=True, exist_ok=True)
+    (download / "X.jpg").write_bytes(b"orig")
+    preprocess_manifest.train_add_processed(
+        preprocess.project_root(p), "v1", "X.png", {"origin": "X.jpg"}
+    )
+
+    items = preprocess.list_train_images(p, "v1")
+    assert len(items) == 1
+    item = items[0]
+    assert item["name"] == "X.png"
+    assert item["origin"] == "X.jpg"
+    assert item["source"] == "X.jpg"
+    assert item["w"] == 100 and item["h"] == 80
+    assert item["orphan"] is False
+    assert item["duplicate_removed"] is False
+    # 老 schema 透传字段应为 None
+    assert item["model"] is None
+    assert item["scale"] is None
+
+
+def test_list_train_images_orphan_when_download_missing(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "Y.png")
+    preprocess_manifest.train_add_processed(
+        preprocess.project_root(p), "v1", "Y.png", {"origin": "Y.jpg"}
+    )
+    # 不创建 download/Y.jpg
+
+    items = preprocess.list_train_images(p, "v1")
+    assert len(items) == 1
+    assert items[0]["orphan"] is True
+
+
+def test_list_train_images_marks_duplicate_removed(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "A.png")
+    preprocess_manifest.train_mark_duplicate_removed(
+        preprocess.project_root(p), "v1", ["A.png"]
+    )
+
+    items = preprocess.list_train_images(p, "v1")
+    # 物理文件 + manifest 都在，只是 kind=duplicate_removed
+    assert len(items) == 1
+    assert items[0]["duplicate_removed"] is True
+
+
+def test_list_train_images_includes_stale_duplicate_removed(isolated) -> None:
+    """manifest 有 duplicate_removed entry 但 train/ 物理已删 → 仍报告（stale）。"""
+    p = isolated["project"]
+    train = _train_dir(p)
+    train.mkdir(parents=True, exist_ok=True)
+    _write_png(train / "S.png")
+    preprocess_manifest.train_mark_duplicate_removed(
+        preprocess.project_root(p), "v1", ["S.png"]
+    )
+    # 模拟用户外部删 train/S.png
+    (train / "S.png").unlink()
+
+    items = preprocess.list_train_images(p, "v1")
+    assert len(items) == 1
+    assert items[0]["name"] == "S.png"
+    assert items[0]["duplicate_removed"] is True
+    assert items[0]["w"] is None  # stale 不读图头
+
+
+def test_list_train_images_processed_state_from_origin_diff(isolated) -> None:
+    """名字 != origin → 隐含"处理过"（新 schema 状态推断）。"""
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "P.png")
+    download = _download_dir(p)
+    download.mkdir(parents=True, exist_ok=True)
+    (download / "P.jpg").write_bytes(b"o")
+    preprocess_manifest.train_add_processed(
+        preprocess.project_root(p), "v1", "P.png", {"origin": "P.jpg"}
+    )
+
+    items = preprocess.list_train_images(p, "v1")
+    # name "P.png" vs origin "P.jpg" 后缀不同 → 处理过；UI 看 source != name 推断
+    assert items[0]["origin"] != items[0]["name"]
+
+
+# ---------------------------------------------------------------------------
+# summary_train
+# ---------------------------------------------------------------------------
+
+
+def test_summary_train_counts_physical_plus_stale(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "A.png")
+    _write_png(train / "B.png")
+    # stale duplicate_removed（manifest 有 + 物理无）
+    _write_png(train / "C.png")
+    preprocess_manifest.train_mark_duplicate_removed(
+        preprocess.project_root(p), "v1", ["C.png"]
+    )
+    (train / "C.png").unlink()
+
+    s = preprocess.summary_train(p, "v1")
+    assert s["image_count"] == 3  # A + B 物理 + C stale
+
+
+# ---------------------------------------------------------------------------
+# resolve_targets_train
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_targets_all_lists_train(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "z.png")
+    _write_png(train / "a.png")
+
+    out = preprocess.resolve_targets_train(p, "v1", mode="all")
+    assert out == ["a.png", "z.png"]  # 字典序
+
+
+def test_resolve_targets_selected_intersects_train(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "X.png")
+
+    out = preprocess.resolve_targets_train(
+        p, "v1", mode="selected", names=["X.png", "ghost.png"]
+    )
+    assert out == ["X.png"]
+
+
+def test_resolve_targets_selected_empty_names_raises(isolated) -> None:
+    p = isolated["project"]
+    with pytest.raises(preprocess.PreprocessError):
+        preprocess.resolve_targets_train(p, "v1", mode="selected", names=[])
+
+
+def test_resolve_targets_unknown_mode_raises(isolated) -> None:
+    with pytest.raises(preprocess.PreprocessError):
+        preprocess.resolve_targets_train(
+            isolated["project"], "v1", mode="bogus"
+        )
+
+
+def test_resolve_targets_name_with_slash_rejected(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "X.png")
+    with pytest.raises(preprocess.PreprocessError):
+        preprocess.resolve_targets_train(
+            p, "v1", mode="selected", names=["../etc/passwd"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# start_job_train
+# ---------------------------------------------------------------------------
+
+
+def test_start_job_train_creates_job_with_version_id(isolated) -> None:
+    p = isolated["project"]
+    v = isolated["version"]
+    with db.connection_for(isolated["db"]) as conn:
+        job = preprocess.start_job_train(
+            conn,
+            project_id=p["id"],
+            version_id=v["id"],
+            mode="all",
+        )
+    assert job["version_id"] == v["id"]
+    assert job["kind"] == preprocess.PREPROCESS_KIND
+    import json
+    params = json.loads(job["params"]) if isinstance(job["params"], str) else job["params"]
+    assert params["stage"] == preprocess.STAGE_UPSCALE
+    assert params["mode"] == "all"
+
+
+def test_start_job_train_selected_requires_names(isolated) -> None:
+    p = isolated["project"]
+    v = isolated["version"]
+    with db.connection_for(isolated["db"]) as conn:
+        with pytest.raises(preprocess.PreprocessError):
+            preprocess.start_job_train(
+                conn, project_id=p["id"], version_id=v["id"],
+                mode="selected",
+            )
+
+
+def test_start_crop_job_train_validates_rects(isolated) -> None:
+    p = isolated["project"]
+    v = isolated["version"]
+    with db.connection_for(isolated["db"]) as conn:
+        job = preprocess.start_crop_job_train(
+            conn,
+            project_id=p["id"],
+            version_id=v["id"],
+            crops={"X.png": [{"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}]},
+        )
+        assert job["version_id"] == v["id"]
+        # 非法 rect 拒
+        with pytest.raises(preprocess.PreprocessError):
+            preprocess.start_crop_job_train(
+                conn, project_id=p["id"], version_id=v["id"],
+                crops={"X.png": [{"x": 0, "y": 0, "w": 0.001, "h": 0.5}]},
+            )
+
+
+# ---------------------------------------------------------------------------
+# list_crop_workspace_train
+# ---------------------------------------------------------------------------
+
+
+def test_list_crop_workspace_excludes_duplicate_removed(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "ok.png", (50, 40))
+    _write_png(train / "dup.png", (60, 50))
+    preprocess_manifest.train_mark_duplicate_removed(
+        preprocess.project_root(p), "v1", ["dup.png"]
+    )
+
+    out = preprocess.list_crop_workspace_train(p, "v1")
+    names = [it["name"] for it in out]
+    assert names == ["ok.png"]
+    assert out[0]["w"] == 50 and out[0]["h"] == 40
+
+
+def test_list_crop_workspace_processed_flag(isolated) -> None:
+    """name != origin → processed=True；name == origin → processed=False。"""
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "proc.png")
+    _write_png(train / "raw.jpg")
+    preprocess_manifest.train_add_processed(
+        preprocess.project_root(p), "v1", "proc.png", {"origin": "proc.jpg"}
+    )
+    preprocess_manifest.train_add_processed(
+        preprocess.project_root(p), "v1", "raw.jpg", {"origin": "raw.jpg"}
+    )
+
+    out = preprocess.list_crop_workspace_train(p, "v1")
+    by_name = {it["name"]: it for it in out}
+    assert by_name["proc.png"]["processed"] is True
+    assert by_name["raw.jpg"]["processed"] is False
+
+
+# ---------------------------------------------------------------------------
+# list_duplicate_removed_workspace_train
+# ---------------------------------------------------------------------------
+
+
+def test_list_duplicate_removed_workspace_returns_marked(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "Q.png", (40, 30))
+    preprocess_manifest.train_mark_duplicate_removed(
+        preprocess.project_root(p), "v1", ["Q.png"]
+    )
+
+    out = preprocess.list_duplicate_removed_workspace_train(p, "v1")
+    assert len(out) == 1
+    assert out[0]["name"] == "Q.png"
+    assert out[0]["w"] == 40 and out[0]["h"] == 30
+
+
+def test_list_duplicate_removed_workspace_stale_entry(isolated) -> None:
+    """物理已删 → 仍返回 stale entry，w/h None。"""
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "R.png")
+    preprocess_manifest.train_mark_duplicate_removed(
+        preprocess.project_root(p), "v1", ["R.png"]
+    )
+    (train / "R.png").unlink()
+
+    out = preprocess.list_duplicate_removed_workspace_train(p, "v1")
+    assert len(out) == 1
+    assert out[0]["w"] is None
+
+
+# ---------------------------------------------------------------------------
+# restore_products_train
+# ---------------------------------------------------------------------------
+
+
+def test_restore_products_train_copies_download_to_train(isolated) -> None:
+    """完整 restore 流程：download/X.jpg → train/X.png 覆盖。"""
+    p = isolated["project"]
+    train = _train_dir(p)
+    download = _download_dir(p)
+    download.mkdir(parents=True, exist_ok=True)
+    (download / "X.jpg").write_bytes(b"original" * 5)
+    _write_png(train / "X.png")
+    preprocess_manifest.train_add_processed(
+        preprocess.project_root(p), "v1", "X.png", {"origin": "X.jpg"}
+    )
+
+    result = preprocess.restore_products_train(p, "v1", ["X.png"])
+    assert result == {"restored": ["X.png"], "missing": [], "no_origin": []}
+    assert (train / "X.png").read_bytes() == b"original" * 5
+
+
+def test_restore_products_train_no_origin_when_download_missing(isolated) -> None:
+    p = isolated["project"]
+    train = _train_dir(p)
+    _write_png(train / "Y.png")
+    preprocess_manifest.train_add_processed(
+        preprocess.project_root(p), "v1", "Y.png", {"origin": "Y.jpg"}
+    )
+    # 不创建 download/Y.jpg
+
+    result = preprocess.restore_products_train(p, "v1", ["Y.png"])
+    assert result == {"restored": [], "missing": [], "no_origin": ["Y.png"]}
+
+
+def test_restore_products_train_validates_name(isolated) -> None:
+    p = isolated["project"]
+    with pytest.raises(preprocess.PreprocessError):
+        preprocess.restore_products_train(p, "v1", ["../etc"])

--- a/tests/test_preprocess_worker_train.py
+++ b/tests/test_preprocess_worker_train.py
@@ -1,0 +1,270 @@
+"""ADR 0010 — preprocess_worker train-scope path（PR-2 step D）。
+
+直接调 `_run_crop_train` / `train_swap_entry` 行为，不通过 supervisor 子进程。
+不跑真 upscaler（torch 模型加载耗时）—— upscale 主流程由 _run_upscale_train
+仅做 path/manifest 派生测试，模型调用在端到端手测。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from studio.services.projects import projects
+from studio.services.preprocess import manifest as pm
+from studio.workers import preprocess_worker as worker
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
+    """最小 project + version dict + 目录结构（不依赖 db）。"""
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    pdir = tmp_path / "projects" / "1-test"
+    (pdir / "download").mkdir(parents=True)
+    (pdir / "preprocess").mkdir(parents=True)
+    train_root = pdir / "versions" / "v1" / "train"
+    sub = train_root / "1_data"
+    sub.mkdir(parents=True)
+    return {
+        "project": {"id": 1, "slug": "test"},
+        "version": {"id": 10, "label": "v1"},
+        "pdir": pdir,
+        "sub": sub,
+    }
+
+
+def _silence(*_args, **_kwargs) -> None:
+    pass
+
+
+def _make_image(path: Path, size: tuple[int, int] = (200, 100), color=(255, 0, 0)) -> None:
+    Image.new("RGB", size, color).save(path, format="PNG")
+
+
+# ---------------------------------------------------------------------------
+# train_swap_entry (Step D 配套 helper)
+# ---------------------------------------------------------------------------
+
+
+def test_swap_entry_removes_old_writes_new(env) -> None:
+    """upscale 改扩展名（X.jpg → X.png）场景：swap entry 原子替换。"""
+    sub = env["sub"]
+    (sub / "X.jpg").write_bytes(b"jpg")
+    (sub / "X.png").write_bytes(b"png" * 100)
+    # 老 entry "1_data/X.jpg"
+    pm.train_add_processed(
+        env["pdir"], "v1", "1_data/X.jpg", {"origin": "X.jpg"},
+    )
+
+    pm.train_swap_entry(
+        env["pdir"], "v1",
+        old_name="1_data/X.jpg",
+        new_name="1_data/X.png",
+        meta={"origin": "X.jpg"},  # origin 不变（仍指向 download/X.jpg）
+    )
+
+    m = pm.train_load(env["pdir"], "v1")
+    assert "1_data/X.jpg" not in m["images"]
+    assert m["images"]["1_data/X.png"]["origin"] == "X.jpg"
+    assert m["images"]["1_data/X.png"]["size"] == 300
+
+
+# ---------------------------------------------------------------------------
+# _run_crop_train: N=1 覆盖
+# ---------------------------------------------------------------------------
+
+
+def test_crop_train_single_rect_overwrites_source(env) -> None:
+    sub = env["sub"]
+    _make_image(sub / "X.png", size=(200, 100))
+    pm.train_add_processed(env["pdir"], "v1", "1_data/X.png", {"origin": "X.png"})
+
+    rc = worker._run_crop_train(
+        env["project"], env["version"],
+        {"crops": {"1_data/X.png": [{"x": 0.2, "y": 0.0, "w": 0.5, "h": 1.0}]}},
+        _silence, _silence,
+    )
+    assert rc == 0
+    # 覆盖在原 path
+    assert (sub / "X.png").is_file()
+    with Image.open(sub / "X.png") as out:
+        assert out.size == (100, 100)  # 0.5×200 = 100
+    # manifest entry 仍是 1_data/X.png，origin 保持
+    entry = pm.train_get_entry(env["pdir"], "v1", "1_data/X.png")
+    assert entry is not None
+    assert entry["origin"] == "X.png"
+
+
+# ---------------------------------------------------------------------------
+# _run_crop_train: N>1 fan-out
+# ---------------------------------------------------------------------------
+
+
+def test_crop_train_fan_out_writes_multiple(env) -> None:
+    sub = env["sub"]
+    _make_image(sub / "Y.png", size=(200, 100))
+    pm.train_add_processed(env["pdir"], "v1", "1_data/Y.png", {"origin": "Y.png"})
+
+    rc = worker._run_crop_train(
+        env["project"], env["version"],
+        {"crops": {"1_data/Y.png": [
+            {"x": 0.0, "y": 0.0, "w": 0.4, "h": 1.0},
+            {"x": 0.5, "y": 0.0, "w": 0.4, "h": 1.0},
+        ]}},
+        _silence, _silence,
+    )
+    assert rc == 0
+    # fan-out 派生 c0 / c1
+    assert (sub / "Y_c0.png").is_file()
+    assert (sub / "Y_c1.png").is_file()
+    # 原 Y.png 物理被删（fan-out > 1）
+    assert not (sub / "Y.png").is_file()
+    # manifest 派生
+    m = pm.train_load(env["pdir"], "v1")
+    assert "1_data/Y.png" not in m["images"]
+    assert "1_data/Y_c0.png" in m["images"]
+    assert "1_data/Y_c1.png" in m["images"]
+    # 多 crop 共享 origin
+    assert m["images"]["1_data/Y_c0.png"]["origin"] == "Y.png"
+    assert m["images"]["1_data/Y_c1.png"]["origin"] == "Y.png"
+
+
+# ---------------------------------------------------------------------------
+# _run_crop_train: 源不存在
+# ---------------------------------------------------------------------------
+
+
+def test_crop_train_skips_when_source_missing(env) -> None:
+    rc = worker._run_crop_train(
+        env["project"], env["version"],
+        {"crops": {"1_data/ghost.png": [{"x": 0, "y": 0, "w": 0.5, "h": 0.5}]}},
+        _silence, _silence,
+    )
+    assert rc == 0  # job 仍完成；单图 skip
+
+
+# ---------------------------------------------------------------------------
+# _run_crop_train: 拒非法 rel name
+# ---------------------------------------------------------------------------
+
+
+def test_crop_train_rejects_invalid_rel_name(env) -> None:
+    rc = worker._run_crop_train(
+        env["project"], env["version"],
+        {"crops": {"../escape/X.png": [{"x": 0, "y": 0, "w": 0.5, "h": 0.5}]}},
+        _silence, _silence,
+    )
+    # 路径校验 fail → skip 该项；job 仍 return 0
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# _run_crop_train: multi-crop 链式 origin 保持
+# ---------------------------------------------------------------------------
+
+
+def test_crop_train_origin_inherited_from_existing_entry(env) -> None:
+    """老 entry 标 X_c0.png 的 origin=X.jpg；对 X_c0.png 再切 → 派生应继承
+    origin=X.jpg（链式不丢 root）。"""
+    sub = env["sub"]
+    _make_image(sub / "X_c0.png", size=(100, 100))
+    pm.train_add_processed(
+        env["pdir"], "v1", "1_data/X_c0.png", {"origin": "X.jpg"},
+    )
+
+    worker._run_crop_train(
+        env["project"], env["version"],
+        {"crops": {"1_data/X_c0.png": [
+            {"x": 0.0, "y": 0.0, "w": 0.5, "h": 1.0},
+            {"x": 0.5, "y": 0.0, "w": 0.5, "h": 1.0},
+        ]}},
+        _silence, _silence,
+    )
+    m = pm.train_load(env["pdir"], "v1")
+    assert m["images"]["1_data/X_c0_c0.png"]["origin"] == "X.jpg"
+    assert m["images"]["1_data/X_c0_c1.png"]["origin"] == "X.jpg"
+
+
+# ---------------------------------------------------------------------------
+# _run_upscale_train: path 派生（不调真 upscaler）
+# ---------------------------------------------------------------------------
+
+
+def test_upscale_train_dispatches_to_train_paths(env, monkeypatch) -> None:
+    """mock upscaler.upscale_file 验证 src/dst path + manifest 更新逻辑。"""
+    sub = env["sub"]
+    (sub / "X.jpg").write_bytes(b"raw")
+    pm.train_add_processed(env["pdir"], "v1", "1_data/X.jpg", {"origin": "X.jpg"})
+
+    called: dict = {}
+
+    def fake_upscale(src, dst, **kwargs):
+        called["src"] = src
+        called["dst"] = dst
+        # mock 产物：往 dst 写一个 PNG
+        Image.new("RGB", (400, 200), (0, 255, 0)).save(dst, format="PNG")
+        return {
+            "model": "fake",
+            "scale": 4,
+            "src_size": [200, 100],
+            "dst_size": [400, 200],
+            "action": "upscale",
+        }
+
+    monkeypatch.setattr(worker.upscaler, "upscale_file", fake_upscale)
+    monkeypatch.setattr(worker.upscaler, "load_model", lambda *a, **k: None)
+    monkeypatch.setattr(worker.upscaler, "resolve_device", lambda d: type("Dev", (), {"type": "cpu"})())
+    monkeypatch.setattr(worker.upscaler, "resolve_dtype", lambda *a, **k: "float32")
+
+    # mock model_downloader.upscaler_target → 返回一个存在的路径
+    fake_model = env["pdir"] / "fake-model.pth"
+    fake_model.write_bytes(b"weight")
+    monkeypatch.setattr(
+        worker.model_downloader, "upscaler_target", lambda label: fake_model,
+    )
+
+    rc = worker._run_upscale_train(
+        env["project"], env["version"],
+        {"mode": "all"},
+        _silence, _silence,
+    )
+    assert rc == 0
+    # src/dst path 对
+    assert called["src"] == sub / "X.jpg"
+    assert called["dst"] == sub / "X.png"
+    # src 物理被删（扩展名变）
+    assert not (sub / "X.jpg").is_file()
+    assert (sub / "X.png").is_file()
+    # manifest swap：old key 走，new key 入
+    m = pm.train_load(env["pdir"], "v1")
+    assert "1_data/X.jpg" not in m["images"]
+    assert m["images"]["1_data/X.png"]["origin"] == "X.jpg"
+
+
+def test_upscale_train_overwrites_when_extension_same(env, monkeypatch) -> None:
+    """src 已是 .png（已处理过的图再上调）→ src == dst path → 普通 add_processed。"""
+    sub = env["sub"]
+    (sub / "X.png").write_bytes(b"old")
+    pm.train_add_processed(env["pdir"], "v1", "1_data/X.png", {"origin": "X.png"})
+
+    def fake_upscale(src, dst, **kwargs):
+        Image.new("RGB", (400, 200), (0, 255, 0)).save(dst, format="PNG")
+        return {"model": "fake", "scale": 4, "action": "upscale"}
+
+    monkeypatch.setattr(worker.upscaler, "upscale_file", fake_upscale)
+    monkeypatch.setattr(worker.upscaler, "load_model", lambda *a, **k: None)
+    monkeypatch.setattr(worker.upscaler, "resolve_device", lambda d: type("Dev", (), {"type": "cpu"})())
+    monkeypatch.setattr(worker.upscaler, "resolve_dtype", lambda *a, **k: "float32")
+    fake_model = env["pdir"] / "fake.pth"
+    fake_model.write_bytes(b"w")
+    monkeypatch.setattr(worker.model_downloader, "upscaler_target", lambda label: fake_model)
+
+    rc = worker._run_upscale_train(
+        env["project"], env["version"], {"mode": "all"}, _silence, _silence,
+    )
+    assert rc == 0
+    # 仅 X.png（dst 覆盖 src）
+    m = pm.train_load(env["pdir"], "v1")
+    assert set(m["images"].keys()) == {"1_data/X.png"}
+    assert (sub / "X.png").is_file()

--- a/tests/test_train_manifest_fallback.py
+++ b/tests/test_train_manifest_fallback.py
@@ -2,17 +2,25 @@
 
 设计见 docs/adr/0010-preprocess-train-scope.md + docs/design/preprocess-train-scope-plan.md §3.2。
 
+train/ 是 LoRA repeat folder 结构（`train/{N_label}/{image}`），manifest entry
+key 用 POSIX 相对路径表达跨 folder 唯一性。fallback 把老 project 级 manifest
+的平铺 entry name（如 `"X.png"`）按文件名匹配到 train 里实际的相对路径
+（如 `"1_data/X.png"`）。
+
 覆盖：
 - 目标已存在 → 直接返回（不动现有 manifest 内容）
 - 老 manifest 不存在 → 写空 v2 manifest
-- 老 manifest 存在 + train/ 完全匹配
-- 老 manifest 存在 + train/ 部分图（不在老 manifest 的不迁）
+- 老 manifest 存在 + train/{folder}/{image} 完全匹配
+- 老 manifest 存在 + train/{folder}/ 部分图（不在老 manifest 的不迁）
 - 老 manifest 存在 + 老 entry 在 train/ 不存在（不迁该 entry）
 - multi-crop fan-out 派生匹配（Y_c0.png + Y_c1.png 共享 origin）
 - duplicate_removed 老 entry 不进新 manifest
 - 老 manifest 损坏 → 按不存在处理
 - 幂等：调 2 次结果一致 + 不重写已有 manifest
 - 仅识别图像后缀（.txt 等不算 train 图）
+- train/ 根目录直接放的图忽略（LoRA 只读 sub-folder 内）
+- 跨 sub-folder 同名图分别 entry
+- 多 version 独立
 """
 from __future__ import annotations
 
@@ -25,16 +33,20 @@ import pytest
 from studio.services.preprocess import manifest as pm
 
 
+DEFAULT_FOLDER = "1_data"
+
+
 @pytest.fixture
 def project_dir(tmp_path: Path) -> Path:
-    """模拟项目目录：download/ + preprocess/ 存在，versions/v1/ 可按需建。"""
     (tmp_path / "download").mkdir()
     (tmp_path / "preprocess").mkdir()
     return tmp_path
 
 
-def _train_dir(project_dir: Path, label: str = "v1") -> Path:
-    d = project_dir / "versions" / label / "train"
+def _train_subfolder(
+    project_dir: Path, label: str = "v1", folder: str = DEFAULT_FOLDER
+) -> Path:
+    d = project_dir / "versions" / label / "train" / folder
     d.mkdir(parents=True, exist_ok=True)
     return d
 
@@ -52,20 +64,25 @@ def _read_train_manifest(project_dir: Path, label: str = "v1") -> dict:
     )
 
 
+def _rel(name: str, folder: str = DEFAULT_FOLDER) -> str:
+    return f"{folder}/{name}"
+
+
 # ---------------------------------------------------------------------------
 # Case 1: 目标已存在 → 直接返回，不动内容
 # ---------------------------------------------------------------------------
 
 
 def test_ensure_returns_existing_without_rewrite(project_dir: Path) -> None:
-    train_dir = _train_dir(project_dir)
+    _train_subfolder(project_dir)
     existing = {
         "version": 2,
-        "images": {"keep.png": {"origin": "keep.jpg", "mtime": 999, "size": 42}},
+        "images": {
+            _rel("keep.png"): {"origin": "keep.jpg", "mtime": 999, "size": 42}
+        },
     }
     target = pm.train_manifest_path(project_dir, "v1")
     target.write_text(json.dumps(existing), encoding="utf-8")
-    # 老 manifest 也存在但内容不同 — 不应该污染 target
     _write_legacy(project_dir, {"keep.png": {"origin": "DIFFERENT.jpg"}})
 
     returned = pm.ensure_train_manifest(project_dir, "v1")
@@ -84,14 +101,13 @@ def test_no_legacy_no_train_writes_empty(project_dir: Path) -> None:
     target = pm.ensure_train_manifest(project_dir, "v1")
     assert target.exists()
     assert _read_train_manifest(project_dir) == {"version": 2, "images": {}}
-    # 目录被建出来
     assert target.parent.exists()
 
 
 def test_no_legacy_with_train_files_writes_empty(project_dir: Path) -> None:
-    """train/ 有图但老 manifest 不存在 → 写空 manifest（无 origin 信息可继承）。"""
-    train_dir = _train_dir(project_dir)
-    (train_dir / "foo.png").write_bytes(b"\x89PNG")
+    """train/{folder}/ 有图但老 manifest 不存在 → 写空 manifest（无 origin 可继承）。"""
+    sub = _train_subfolder(project_dir)
+    (sub / "foo.png").write_bytes(b"\x89PNG")
 
     pm.ensure_train_manifest(project_dir, "v1")
     assert _read_train_manifest(project_dir) == {"version": 2, "images": {}}
@@ -103,9 +119,9 @@ def test_no_legacy_with_train_files_writes_empty(project_dir: Path) -> None:
 
 
 def test_legacy_full_match_rebuilds(project_dir: Path) -> None:
-    train_dir = _train_dir(project_dir)
-    (train_dir / "X.png").write_bytes(b"x")
-    (train_dir / "Y.png").write_bytes(b"y")
+    sub = _train_subfolder(project_dir)
+    (sub / "X.png").write_bytes(b"x")
+    (sub / "Y.png").write_bytes(b"y")
     _write_legacy(project_dir, {
         "X.png": {"origin": "X.jpg", "mtime": 100, "size": 1000},
         "Y.png": {"origin": "Y.jpg", "mtime": 200, "size": 2000},
@@ -115,16 +131,15 @@ def test_legacy_full_match_rebuilds(project_dir: Path) -> None:
     data = _read_train_manifest(project_dir)
     assert data["version"] == 2
     assert data["images"] == {
-        "X.png": {"origin": "X.jpg", "mtime": 100, "size": 1000},
-        "Y.png": {"origin": "Y.jpg", "mtime": 200, "size": 2000},
+        _rel("X.png"): {"origin": "X.jpg", "mtime": 100, "size": 1000},
+        _rel("Y.png"): {"origin": "Y.jpg", "mtime": 200, "size": 2000},
     }
 
 
 def test_legacy_entry_missing_in_train_is_skipped(project_dir: Path) -> None:
     """老 entry 在 train/ 没对应文件 → 不进新 manifest。"""
-    train_dir = _train_dir(project_dir)
-    (train_dir / "X.png").write_bytes(b"x")
-    # Y.png 在老 manifest 但不在 train/
+    sub = _train_subfolder(project_dir)
+    (sub / "X.png").write_bytes(b"x")
     _write_legacy(project_dir, {
         "X.png": {"origin": "X.jpg", "mtime": 100, "size": 1000},
         "Y.png": {"origin": "Y.jpg", "mtime": 200, "size": 2000},
@@ -132,22 +147,21 @@ def test_legacy_entry_missing_in_train_is_skipped(project_dir: Path) -> None:
 
     pm.ensure_train_manifest(project_dir, "v1")
     data = _read_train_manifest(project_dir)
-    assert set(data["images"].keys()) == {"X.png"}
+    assert set(data["images"].keys()) == {_rel("X.png")}
 
 
 def test_train_file_not_in_legacy_is_skipped(project_dir: Path) -> None:
-    """train/ 里有图但老 manifest 没记 → 不写 entry（用户手动拖入 / curate 复制
-    的原图；新模型下这种图默认 origin = name，但本 fallback 不假设这点）。"""
-    train_dir = _train_dir(project_dir)
-    (train_dir / "X.png").write_bytes(b"x")
-    (train_dir / "Z.png").write_bytes(b"z")  # 老 manifest 没记
+    """train/ 里有图但老 manifest 没记 → 不写 entry。"""
+    sub = _train_subfolder(project_dir)
+    (sub / "X.png").write_bytes(b"x")
+    (sub / "Z.png").write_bytes(b"z")
     _write_legacy(project_dir, {
         "X.png": {"origin": "X.jpg", "mtime": 100, "size": 1000},
     })
 
     pm.ensure_train_manifest(project_dir, "v1")
     data = _read_train_manifest(project_dir)
-    assert set(data["images"].keys()) == {"X.png"}
+    assert set(data["images"].keys()) == {_rel("X.png")}
 
 
 # ---------------------------------------------------------------------------
@@ -156,9 +170,9 @@ def test_train_file_not_in_legacy_is_skipped(project_dir: Path) -> None:
 
 
 def test_multi_crop_fan_out_preserved(project_dir: Path) -> None:
-    train_dir = _train_dir(project_dir)
-    (train_dir / "Y_c0.png").write_bytes(b"c0")
-    (train_dir / "Y_c1.png").write_bytes(b"c1")
+    sub = _train_subfolder(project_dir)
+    (sub / "Y_c0.png").write_bytes(b"c0")
+    (sub / "Y_c1.png").write_bytes(b"c1")
     _write_legacy(project_dir, {
         "Y_c0.png": {"origin": "Y.jpg", "mtime": 200, "size": 800},
         "Y_c1.png": {"origin": "Y.jpg", "mtime": 200, "size": 850},
@@ -166,8 +180,8 @@ def test_multi_crop_fan_out_preserved(project_dir: Path) -> None:
 
     pm.ensure_train_manifest(project_dir, "v1")
     data = _read_train_manifest(project_dir)
-    assert data["images"]["Y_c0.png"]["origin"] == "Y.jpg"
-    assert data["images"]["Y_c1.png"]["origin"] == "Y.jpg"
+    assert data["images"][_rel("Y_c0.png")]["origin"] == "Y.jpg"
+    assert data["images"][_rel("Y_c1.png")]["origin"] == "Y.jpg"
 
 
 # ---------------------------------------------------------------------------
@@ -176,21 +190,17 @@ def test_multi_crop_fan_out_preserved(project_dir: Path) -> None:
 
 
 def test_duplicate_removed_legacy_entry_skipped(project_dir: Path) -> None:
-    """duplicate_removed 是人工去重审核记录（kind="duplicate_removed"），
-    跟 train ↔ download 关系无关，不应进新 train manifest。"""
-    train_dir = _train_dir(project_dir)
-    (train_dir / "X.png").write_bytes(b"x")
-    # 模拟用户清过去重，dup.jpg 在老 manifest 标了 duplicate_removed
+    sub = _train_subfolder(project_dir)
+    (sub / "X.png").write_bytes(b"x")
     _write_legacy(project_dir, {
         "X.png": {"origin": "X.jpg", "mtime": 100, "size": 1000},
         "dup.jpg": {"kind": pm.DUPLICATE_REMOVED_KIND, "origin": "dup.jpg"},
     })
-    # 即使 dup.jpg 物理存在于 train/（罕见但可能），也不该被写进
-    (train_dir / "dup.jpg").write_bytes(b"dup")
+    (sub / "dup.jpg").write_bytes(b"dup")
 
     pm.ensure_train_manifest(project_dir, "v1")
     data = _read_train_manifest(project_dir)
-    assert set(data["images"].keys()) == {"X.png"}
+    assert set(data["images"].keys()) == {_rel("X.png")}
 
 
 # ---------------------------------------------------------------------------
@@ -199,8 +209,8 @@ def test_duplicate_removed_legacy_entry_skipped(project_dir: Path) -> None:
 
 
 def test_corrupted_legacy_treated_as_missing(project_dir: Path) -> None:
-    train_dir = _train_dir(project_dir)
-    (train_dir / "X.png").write_bytes(b"x")
+    sub = _train_subfolder(project_dir)
+    (sub / "X.png").write_bytes(b"x")
     pm.manifest_path(project_dir).write_text("not json", encoding="utf-8")
 
     pm.ensure_train_manifest(project_dir, "v1")
@@ -209,9 +219,8 @@ def test_corrupted_legacy_treated_as_missing(project_dir: Path) -> None:
 
 
 def test_legacy_invalid_shape_treated_as_missing(project_dir: Path) -> None:
-    """非 dict 形状 → 当损坏处理（跟现有 `load()` 一致）。"""
-    train_dir = _train_dir(project_dir)
-    (train_dir / "X.png").write_bytes(b"x")
+    sub = _train_subfolder(project_dir)
+    (sub / "X.png").write_bytes(b"x")
     pm.manifest_path(project_dir).write_text(json.dumps(["array"]), encoding="utf-8")
 
     pm.ensure_train_manifest(project_dir, "v1")
@@ -225,8 +234,8 @@ def test_legacy_invalid_shape_treated_as_missing(project_dir: Path) -> None:
 
 
 def test_idempotent_second_call_no_rewrite(project_dir: Path) -> None:
-    train_dir = _train_dir(project_dir)
-    (train_dir / "X.png").write_bytes(b"x")
+    sub = _train_subfolder(project_dir)
+    (sub / "X.png").write_bytes(b"x")
     _write_legacy(project_dir, {
         "X.png": {"origin": "X.jpg", "mtime": 100, "size": 1000},
     })
@@ -235,31 +244,40 @@ def test_idempotent_second_call_no_rewrite(project_dir: Path) -> None:
     target = pm.train_manifest_path(project_dir, "v1")
     first_mtime = target.stat().st_mtime_ns
 
-    # 第二次调用应该 short-circuit（O(1) stat），不动文件
     pm.ensure_train_manifest(project_dir, "v1")
     assert target.stat().st_mtime_ns == first_mtime
 
 
 # ---------------------------------------------------------------------------
-# Case 10: 仅识别图像后缀
+# Case 10: 仅识别图像后缀 + train/ 根目录直接放的图忽略
 # ---------------------------------------------------------------------------
 
 
 def test_non_image_files_in_train_ignored(project_dir: Path) -> None:
-    """train/ 里 .txt / .json 不算图像，不影响重建逻辑。"""
-    train_dir = _train_dir(project_dir)
-    (train_dir / "X.png").write_bytes(b"x")
-    (train_dir / "X.txt").write_text("caption")  # caption 不应被当作图
-    (train_dir / "manifest.json.tmp").write_text("{}")  # tmp 文件残留
+    sub = _train_subfolder(project_dir)
+    (sub / "X.png").write_bytes(b"x")
+    (sub / "X.txt").write_text("caption")
+    (sub / "manifest.json.tmp").write_text("{}")
     _write_legacy(project_dir, {
         "X.png": {"origin": "X.jpg", "mtime": 100, "size": 1000},
-        "X.txt": {"origin": "X.txt", "mtime": 100, "size": 5},  # 老 manifest 误存（不会发生但防御）
+        "X.txt": {"origin": "X.txt"},
     })
 
     pm.ensure_train_manifest(project_dir, "v1")
     data = _read_train_manifest(project_dir)
-    # X.txt 老 entry 跟 train_files 集合（仅图像）不匹配 → 不迁
-    assert set(data["images"].keys()) == {"X.png"}
+    assert set(data["images"].keys()) == {_rel("X.png")}
+
+
+def test_train_root_files_ignored(project_dir: Path) -> None:
+    """train/ 根目录直接放的图忽略（LoRA 训练只读 sub-folder 内）。"""
+    train_root = project_dir / "versions" / "v1" / "train"
+    train_root.mkdir(parents=True)
+    (train_root / "stray.png").write_bytes(b"stray")
+    _write_legacy(project_dir, {"stray.png": {"origin": "stray.jpg"}})
+
+    pm.ensure_train_manifest(project_dir, "v1")
+    data = _read_train_manifest(project_dir)
+    assert data == {"version": 2, "images": {}}
 
 
 # ---------------------------------------------------------------------------
@@ -268,9 +286,8 @@ def test_non_image_files_in_train_ignored(project_dir: Path) -> None:
 
 
 def test_concurrent_ensure_yields_single_manifest(project_dir: Path) -> None:
-    """多线程同时调 → `_LOCK` 双检查保证只重建一次，结果一致。"""
-    train_dir = _train_dir(project_dir)
-    (train_dir / "X.png").write_bytes(b"x")
+    sub = _train_subfolder(project_dir)
+    (sub / "X.png").write_bytes(b"x")
     _write_legacy(project_dir, {
         "X.png": {"origin": "X.jpg", "mtime": 100, "size": 1000},
     })
@@ -294,7 +311,7 @@ def test_concurrent_ensure_yields_single_manifest(project_dir: Path) -> None:
     assert len(set(map(str, results))) == 1
     data = _read_train_manifest(project_dir)
     assert data["version"] == 2
-    assert data["images"]["X.png"]["origin"] == "X.jpg"
+    assert data["images"][_rel("X.png")]["origin"] == "X.jpg"
 
 
 # ---------------------------------------------------------------------------
@@ -303,11 +320,10 @@ def test_concurrent_ensure_yields_single_manifest(project_dir: Path) -> None:
 
 
 def test_multiple_versions_independent(project_dir: Path) -> None:
-    """两个 version 各自重建独立 manifest，互不干扰。"""
-    v1_train = _train_dir(project_dir, "v1")
-    v2_train = _train_dir(project_dir, "v2")
-    (v1_train / "X.png").write_bytes(b"x")
-    (v2_train / "Y.png").write_bytes(b"y")
+    v1_sub = _train_subfolder(project_dir, "v1")
+    v2_sub = _train_subfolder(project_dir, "v2")
+    (v1_sub / "X.png").write_bytes(b"x")
+    (v2_sub / "Y.png").write_bytes(b"y")
     _write_legacy(project_dir, {
         "X.png": {"origin": "X.jpg", "mtime": 100, "size": 1000},
         "Y.png": {"origin": "Y.jpg", "mtime": 200, "size": 2000},
@@ -318,5 +334,30 @@ def test_multiple_versions_independent(project_dir: Path) -> None:
 
     v1_data = _read_train_manifest(project_dir, "v1")
     v2_data = _read_train_manifest(project_dir, "v2")
-    assert set(v1_data["images"].keys()) == {"X.png"}
-    assert set(v2_data["images"].keys()) == {"Y.png"}
+    assert set(v1_data["images"].keys()) == {_rel("X.png")}
+    assert set(v2_data["images"].keys()) == {_rel("Y.png")}
+
+
+# ---------------------------------------------------------------------------
+# Case 13: 跨 sub-folder 同名图（罕见但合法 — 多个 repeat folder 同图）
+# ---------------------------------------------------------------------------
+
+
+def test_cross_subfolder_same_filename_both_entry(project_dir: Path) -> None:
+    """同名图在 1_data 和 5_extra 都有 → 各自独立 entry（key 含 folder 前缀）。"""
+    sub_a = _train_subfolder(project_dir, folder="1_data")
+    sub_b = _train_subfolder(project_dir, folder="5_extra")
+    (sub_a / "shared.png").write_bytes(b"a")
+    (sub_b / "shared.png").write_bytes(b"b")
+    _write_legacy(project_dir, {
+        "shared.png": {"origin": "shared.jpg", "mtime": 100, "size": 500},
+    })
+
+    pm.ensure_train_manifest(project_dir, "v1")
+    data = _read_train_manifest(project_dir)
+    assert set(data["images"].keys()) == {
+        "1_data/shared.png",
+        "5_extra/shared.png",
+    }
+    assert data["images"]["1_data/shared.png"]["origin"] == "shared.jpg"
+    assert data["images"]["5_extra/shared.png"]["origin"] == "shared.jpg"

--- a/tests/test_train_manifest_mutations.py
+++ b/tests/test_train_manifest_mutations.py
@@ -1,0 +1,382 @@
+"""ADR 0010 — train-scope manifest mutation API（PR-2 step A）。
+
+覆盖 `train_load / train_get_entry / train_all_processed / train_duplicate_removed*
+/ train_add_processed / train_replace_with_crops / train_mark_duplicate_removed /
+train_restore_duplicate_removed / train_restore / train_clear_all`。
+
+老 project-scope API（`add_processed / restore / mark_duplicate_removed / etc.`）
+独立测试在 `test_preprocess_manifest.py`，本文件不覆盖。
+
+关键语义点（vs 老 API）：
+- manifest 落 `versions/{label}/train/manifest.json`
+- `train_restore` = 从 `download/{entry.origin}` 复制覆盖 `train/{name}`
+  （老的是"删 entry"，依赖 resolver fallback）
+- size 兜底 stat `train/{name}`（老的 stat preprocess/{name}）
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+from studio.services.preprocess import manifest as pm
+
+
+@pytest.fixture
+def project_dir(tmp_path: Path) -> Path:
+    """模拟项目目录 + 一个 version v1。"""
+    (tmp_path / "download").mkdir()
+    (tmp_path / "preprocess").mkdir()
+    (tmp_path / "versions" / "v1" / "train").mkdir(parents=True)
+    return tmp_path
+
+
+def _train_path(project_dir: Path, name: str, label: str = "v1") -> Path:
+    return project_dir / "versions" / label / "train" / name
+
+
+def _download_path(project_dir: Path, name: str) -> Path:
+    return project_dir / "download" / name
+
+
+def _read(p: Path) -> dict:
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+# ---------------------------------------------------------------------------
+# train_load / train_get_entry / train_all_processed
+# ---------------------------------------------------------------------------
+
+
+def test_load_creates_empty_via_ensure(project_dir: Path) -> None:
+    """train_load 触发 fallback 重建（无 legacy → 空 manifest）。"""
+    m = pm.train_load(project_dir, "v1")
+    assert m == {"version": 2, "images": {}}
+    # 已落盘
+    assert pm.train_manifest_path(project_dir, "v1").exists()
+
+
+def test_get_entry_missing_returns_none(project_dir: Path) -> None:
+    assert pm.train_get_entry(project_dir, "v1", "missing.png") is None
+
+
+def test_all_processed_filters_duplicate_removed(project_dir: Path) -> None:
+    pm.train_add_processed(project_dir, "v1", "A.png", {"origin": "A.jpg"})
+    _train_path(project_dir, "B.png").write_bytes(b"b")
+    pm.train_mark_duplicate_removed(project_dir, "v1", ["B.png"])
+
+    processed = pm.train_all_processed(project_dir, "v1")
+    assert set(processed) == {"A.png"}
+
+
+def test_duplicate_removed_origins_collects_all(project_dir: Path) -> None:
+    _train_path(project_dir, "X.png").write_bytes(b"x")
+    _train_path(project_dir, "Y.png").write_bytes(b"y")
+    pm.train_mark_duplicate_removed(project_dir, "v1", ["X.png", "Y.png"])
+
+    origins = pm.train_duplicate_removed_origins(project_dir, "v1")
+    assert origins == {"X.png", "Y.png"}
+
+
+# ---------------------------------------------------------------------------
+# train_add_processed
+# ---------------------------------------------------------------------------
+
+
+def test_add_processed_stores_minimal_schema(project_dir: Path) -> None:
+    """新 schema 只采纳 origin/mtime/size；过程字段全丢。"""
+    _train_path(project_dir, "X.png").write_bytes(b"\x89PNG" + b"x" * 100)
+    pm.train_add_processed(project_dir, "v1", "X.png", {
+        "origin": "X.jpg",
+        "model": "RealESRGAN_x4",  # 过程信息，应被丢
+        "scale": 4,                # 过程信息
+        "action": "upscale",       # 过程信息
+        "src_size": [512, 512],    # 过程信息
+        "mtime": 1731000000,
+    })
+
+    m = pm.train_load(project_dir, "v1")
+    entry = m["images"]["X.png"]
+    assert entry["origin"] == "X.jpg"
+    assert entry["mtime"] == 1731000000
+    assert entry["size"] == 104  # stat'd train/X.png
+    # 过程字段不应进 entry
+    assert "model" not in entry
+    assert "scale" not in entry
+    assert "action" not in entry
+
+
+def test_add_processed_size_fallback_stat_train(project_dir: Path) -> None:
+    """size 缺失时从 train/{name} stat（不是 preprocess/）。"""
+    _train_path(project_dir, "Y.png").write_bytes(b"y" * 42)
+    # preprocess/Y.png 不存在 — 防御老逻辑误用
+    pm.train_add_processed(project_dir, "v1", "Y.png", {"origin": "Y.jpg"})
+
+    entry = pm.train_get_entry(project_dir, "v1", "Y.png")
+    assert entry is not None
+    assert entry["size"] == 42
+
+
+def test_add_processed_origin_fallback_to_name(project_dir: Path) -> None:
+    """meta 没 origin/source → 用 name 自身（1:1 同名场景）。"""
+    _train_path(project_dir, "Z.jpg").write_bytes(b"z")
+    pm.train_add_processed(project_dir, "v1", "Z.jpg", {})
+
+    entry = pm.train_get_entry(project_dir, "v1", "Z.jpg")
+    assert entry is not None
+    assert entry["origin"] == "Z.jpg"
+
+
+# ---------------------------------------------------------------------------
+# train_replace_with_crops
+# ---------------------------------------------------------------------------
+
+
+def test_replace_with_crops_removes_source_and_writes_fan_out(
+    project_dir: Path,
+) -> None:
+    # 老 entry：X.png 是 X.jpg 的 upscale 产物
+    _train_path(project_dir, "X.png").write_bytes(b"x" * 10)
+    pm.train_add_processed(project_dir, "v1", "X.png", {"origin": "X.jpg"})
+
+    # multi-crop: X.png → X_c0.png / X_c1.png
+    pm.train_replace_with_crops(
+        project_dir, "v1",
+        source_name="X.png",
+        outputs=[
+            {"name": "X_c0.png", "origin": "X.jpg", "mtime": 1, "size": 100},
+            {"name": "X_c1.png", "origin": "X.jpg", "mtime": 1, "size": 110},
+        ],
+    )
+
+    m = pm.train_load(project_dir, "v1")
+    assert "X.png" not in m["images"]
+    assert m["images"]["X_c0.png"]["origin"] == "X.jpg"
+    assert m["images"]["X_c1.png"]["origin"] == "X.jpg"
+    assert m["images"]["X_c1.png"]["size"] == 110
+
+
+def test_replace_with_crops_origin_fallback_to_source(
+    project_dir: Path,
+) -> None:
+    """outputs 没 origin 字段时回退到 source_name。"""
+    _train_path(project_dir, "raw.png").write_bytes(b"r")
+    pm.train_add_processed(project_dir, "v1", "raw.png", {"origin": "raw.png"})
+
+    pm.train_replace_with_crops(
+        project_dir, "v1",
+        source_name="raw.png",
+        outputs=[{"name": "raw_c0.png", "size": 50}],
+    )
+
+    entry = pm.train_get_entry(project_dir, "v1", "raw_c0.png")
+    assert entry is not None
+    assert entry["origin"] == "raw.png"
+
+
+# ---------------------------------------------------------------------------
+# train_mark_duplicate_removed
+# ---------------------------------------------------------------------------
+
+
+def test_mark_duplicate_removed_on_existing_processed(project_dir: Path) -> None:
+    _train_path(project_dir, "A.png").write_bytes(b"a")
+    pm.train_add_processed(project_dir, "v1", "A.png", {"origin": "A.jpg"})
+
+    result = pm.train_mark_duplicate_removed(project_dir, "v1", ["A.png"])
+    assert result == {"removed": ["A.png"], "missing": [], "skipped": []}
+
+    entry = pm.train_get_entry(project_dir, "v1", "A.png")
+    assert entry is not None
+    assert entry["kind"] == pm.DUPLICATE_REMOVED_KIND
+    assert entry["origin"] == "A.jpg"
+    # train/A.png 物理文件**不删**——保留作"已审核但跳过"标记
+    assert _train_path(project_dir, "A.png").exists()
+
+
+def test_mark_duplicate_removed_on_unrecorded_train_file(
+    project_dir: Path,
+) -> None:
+    """name 不在 manifest 但物理在 train/ → 标记 + origin = name。"""
+    _train_path(project_dir, "B.png").write_bytes(b"b" * 5)
+
+    result = pm.train_mark_duplicate_removed(project_dir, "v1", ["B.png"])
+    assert result == {"removed": ["B.png"], "missing": [], "skipped": []}
+
+    entry = pm.train_get_entry(project_dir, "v1", "B.png")
+    assert entry is not None
+    assert entry["origin"] == "B.png"  # 没 manifest 时 origin = name
+    assert entry["size"] == 5
+
+
+def test_mark_duplicate_removed_missing_returns_missing(project_dir: Path) -> None:
+    """name 不在 manifest 且 train/{name} 物理也不在 → missing。"""
+    result = pm.train_mark_duplicate_removed(project_dir, "v1", ["ghost.png"])
+    assert result["missing"] == ["ghost.png"]
+    assert result["removed"] == []
+
+
+def test_mark_duplicate_removed_already_marked_skipped(project_dir: Path) -> None:
+    _train_path(project_dir, "C.png").write_bytes(b"c")
+    pm.train_mark_duplicate_removed(project_dir, "v1", ["C.png"])
+
+    result = pm.train_mark_duplicate_removed(project_dir, "v1", ["C.png"])
+    assert result["skipped"] == ["C.png"]
+    assert result["removed"] == []
+
+
+# ---------------------------------------------------------------------------
+# train_restore_duplicate_removed
+# ---------------------------------------------------------------------------
+
+
+def test_restore_duplicate_removed_unwinds_mark(project_dir: Path) -> None:
+    _train_path(project_dir, "D.png").write_bytes(b"d")
+    pm.train_mark_duplicate_removed(project_dir, "v1", ["D.png"])
+
+    result = pm.train_restore_duplicate_removed(project_dir, "v1", ["D.png"])
+    assert result == {"restored": ["D.png"], "missing": []}
+    assert pm.train_get_entry(project_dir, "v1", "D.png") is None
+
+
+def test_restore_duplicate_removed_missing_when_not_marked(
+    project_dir: Path,
+) -> None:
+    _train_path(project_dir, "E.png").write_bytes(b"e")
+    pm.train_add_processed(project_dir, "v1", "E.png", {"origin": "E.jpg"})
+
+    result = pm.train_restore_duplicate_removed(project_dir, "v1", ["E.png"])
+    assert result == {"restored": [], "missing": ["E.png"]}
+    # processed entry 不动
+    entry = pm.train_get_entry(project_dir, "v1", "E.png")
+    assert entry is not None
+    assert entry.get("kind", "processed") == "processed"
+
+
+# ---------------------------------------------------------------------------
+# train_restore — 新语义：从 download/{origin} 复制覆盖到 train/{name}
+# ---------------------------------------------------------------------------
+
+
+def test_restore_copies_from_download_overwriting_train(
+    project_dir: Path,
+) -> None:
+    """已 upscale 产物 train/X.png ← 从 download/X.jpg 复制覆盖。"""
+    _download_path(project_dir, "X.jpg").write_bytes(b"orig" * 10)
+    _train_path(project_dir, "X.png").write_bytes(b"upscaled" * 100)
+    pm.train_add_processed(project_dir, "v1", "X.png", {"origin": "X.jpg"})
+
+    result = pm.train_restore(project_dir, "v1", ["X.png"])
+
+    assert result == {"restored": ["X.png"], "missing": [], "no_origin": []}
+    # train/X.png 内容被替换成 download 原图
+    assert _train_path(project_dir, "X.png").read_bytes() == b"orig" * 10
+    # manifest entry 保留 origin，mtime/size 更新到 download 文件
+    entry = pm.train_get_entry(project_dir, "v1", "X.png")
+    assert entry is not None
+    assert entry["origin"] == "X.jpg"
+    assert entry["size"] == 40
+
+
+def test_restore_missing_when_no_manifest_entry(project_dir: Path) -> None:
+    result = pm.train_restore(project_dir, "v1", ["ghost.png"])
+    assert result == {"restored": [], "missing": ["ghost.png"], "no_origin": []}
+
+
+def test_restore_no_origin_when_download_missing(project_dir: Path) -> None:
+    """ADR 0010 §Restore 语义：download/{origin} 缺失 → no_origin（不是
+    missing），UI 给三选项 [拖入替换 / 保留 / 移除]。"""
+    _train_path(project_dir, "Y.png").write_bytes(b"y")
+    pm.train_add_processed(project_dir, "v1", "Y.png", {"origin": "Y.jpg"})
+    # 不创建 download/Y.jpg
+
+    result = pm.train_restore(project_dir, "v1", ["Y.png"])
+
+    assert result == {"restored": [], "missing": [], "no_origin": ["Y.png"]}
+    # train/Y.png 内容**不动**
+    assert _train_path(project_dir, "Y.png").read_bytes() == b"y"
+
+
+def test_restore_mixed_results(project_dir: Path) -> None:
+    """三类结果同时返回。"""
+    _download_path(project_dir, "OK.jpg").write_bytes(b"ok")
+    _train_path(project_dir, "OK.png").write_bytes(b"old-ok")
+    _train_path(project_dir, "NoOrig.png").write_bytes(b"x")
+    pm.train_add_processed(project_dir, "v1", "OK.png", {"origin": "OK.jpg"})
+    pm.train_add_processed(
+        project_dir, "v1", "NoOrig.png", {"origin": "missing.jpg"}
+    )
+
+    result = pm.train_restore(
+        project_dir, "v1", ["OK.png", "NoOrig.png", "Ghost.png"]
+    )
+
+    assert result["restored"] == ["OK.png"]
+    assert result["no_origin"] == ["NoOrig.png"]
+    assert result["missing"] == ["Ghost.png"]
+
+
+# ---------------------------------------------------------------------------
+# train_clear_all
+# ---------------------------------------------------------------------------
+
+
+def test_clear_all_empties_manifest_keeps_train_files(project_dir: Path) -> None:
+    """clear_all **不动** train/ 物理文件——它们是训练数据，不该被预处理清空
+    操作引发删除。详 ADR 0010 §train_clear_all。"""
+    _train_path(project_dir, "P.png").write_bytes(b"p")
+    pm.train_add_processed(project_dir, "v1", "P.png", {"origin": "P.jpg"})
+
+    pm.train_clear_all(project_dir, "v1")
+
+    m = pm.train_load(project_dir, "v1")
+    assert m == {"version": 2, "images": {}}
+    # 物理文件保留
+    assert _train_path(project_dir, "P.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# 多 version 隔离
+# ---------------------------------------------------------------------------
+
+
+def test_multi_version_isolation(project_dir: Path) -> None:
+    """v1 / v2 各自 manifest 独立，mutation 不串。"""
+    (project_dir / "versions" / "v2" / "train").mkdir(parents=True)
+    (project_dir / "versions" / "v2" / "train" / "Q.png").write_bytes(b"q")
+
+    pm.train_add_processed(project_dir, "v1", "v1-only.png", {"origin": "x.jpg"})
+    pm.train_add_processed(project_dir, "v2", "Q.png", {"origin": "Q.jpg"})
+
+    v1 = pm.train_load(project_dir, "v1")
+    v2 = pm.train_load(project_dir, "v2")
+    assert set(v1["images"]) == {"v1-only.png"}
+    assert set(v2["images"]) == {"Q.png"}
+
+
+# ---------------------------------------------------------------------------
+# 老 project-scope manifest 不动（PR-2 backward-compat 保障）
+# ---------------------------------------------------------------------------
+
+
+def test_train_mutations_dont_touch_project_manifest(project_dir: Path) -> None:
+    """train_xxx 函数只动 train manifest；老 project-scope manifest 完全不动
+    （PR-3 才删，PR-2 阶段必须保持向后兼容）。"""
+    pm.manifest_path(project_dir).write_text(
+        json.dumps({"images": {"legacy.png": {"origin": "legacy.jpg"}}}),
+        encoding="utf-8",
+    )
+    legacy_mtime = pm.manifest_path(project_dir).stat().st_mtime_ns
+
+    _train_path(project_dir, "X.png").write_bytes(b"x")
+    pm.train_add_processed(project_dir, "v1", "X.png", {"origin": "X.jpg"})
+    pm.train_mark_duplicate_removed(project_dir, "v1", ["X.png"])
+    pm.train_clear_all(project_dir, "v1")
+
+    # 老 manifest 文件 mtime 没变（PR-2 train_xxx 函数从不动它）
+    assert pm.manifest_path(project_dir).stat().st_mtime_ns == legacy_mtime
+    # 老 manifest 内容也没变
+    legacy = _read(pm.manifest_path(project_dir))
+    assert legacy == {"images": {"legacy.png": {"origin": "legacy.jpg"}}}


### PR DESCRIPTION
## 背景 / 动机

ADR 0010 PR-2 — 后端 manifest / core / worker / curation / duplicates 全套
**train-scope API 加新**，老 project-scope API 暂留作 backward-compat，
PR-3 删。本 PR 完全**不动现有 endpoint / worker 路径**，老行为 100% 兼容。

详细决策见 [ADR 0010](docs/adr/0010-preprocess-train-scope.md) +
[实施计划](docs/design/preprocess-train-scope-plan.md)（PR-1 #209 加的）。

## 走法：渐进 deprecation

跟 lifecycle `_v8 add-only → _v9 destructive` 同 pattern：

- **PR-2（本 PR）**：加新 \`train_*\` API + worker train scope 分发（按
  \`job.version_id\` 路由），老 API 不动
- **PR-3**：API endpoint URL pid → (pid, vid) + \`_v11\` migration +
  \`preprocessing\` phase + 删老 \`load / resolve / list_pending /
  list_processed / mark_duplicate_removed / restore / clear_all\` 等
- **PR-4**：前端 + Sidebar

PR-2 内部 7 个 commit（每个 step 独立 self-contained，最后 squash 落 dev）：

| Commit | Step | 范围 |
|---|---|---|
| 9c9e137 | A | manifest train-scope API：\`train_load / train_get_entry / train_all_processed / train_duplicate_removed* / train_add_processed / train_replace_with_crops / train_mark_duplicate_removed / train_restore_duplicate_removed / train_restore / train_clear_all\` |
| 9de8eaa | B | core train-scope API：\`list_train_images / summary_train / resolve_targets_train / start_job_train / start_crop_job_train / list_crop_workspace_train / list_duplicate_removed_workspace_train / restore_products_train\` |
| 6e8e658 | (fix) | 修正 PR-1 + step A/B 设计错误：train/ 是 LoRA repeat folder 结构，entry key 改用 POSIX rel path \`\"1_data/X.png\"\` |
| a7124a6 | (docs) | ADR 0010 + plan 同步反映 rel path 设计 |
| f51fda7 | C | curation：\`copy_download_to_train\` 简化版（删 \"preprocess 派生 vs download 原图\" 双分支） |
| 0b6cc06 | D | worker：\`_run_upscale_train\` / \`_run_crop_train\` + manifest helper \`train_swap_entry\`；主 \`run()\` 按 \`job.version_id\` 分发 |
| b83e4d2 | E | duplicates：\`_resolve_train_sources / scan_train_duplicates / apply_train_duplicate_removals\` |

## 关键语义点（ADR 0010 落地细节）

1. **manifest entry key = POSIX 相对路径** \`\"{folder}/{image}\"\`（LoRA
   repeat folder：\`train/1_data/X.png\` → key \`\"1_data/X.png\"\`）。
   train 根目录直接放的图被忽略；\`_validate_rel_name\` 强制 \`folder/image\`
   两段格式防 path traversal。

2. **\`train_restore\` 语义新**：从 \`download/{entry.origin}\` 复制覆盖回
   \`train/{name}\`（不是删 entry）。download 缺失返 \`no_origin\` 列表（UI
   给三选项 [拖入替换 / 保留 / 移除]）。详 ADR 0010 §Restore 语义。

3. **\`train_clear_all\` 不动物理文件**：train/ 是训练数据本身，不该被预处理
   清空操作引发删除。

4. **worker \`job.version_id\` 分发**：非空 → 新 train scope 路径
   （\`_run_upscale_train\` / \`_run_crop_train\`）；None → 老 project scope
   路径（backward-compat）。两条路径独立，老路径行为完全不变。

5. **\`copy_download_to_train\` 简化**：纯 download → train 复制 + 写
   manifest entry \`{origin: name}\`；不消费 preprocess 派生（预处理在
   新模型下是 curate 之后的事）。

6. **去重 scope 跟随下沉**：\`_resolve_train_sources\` 扫 train/{folder}/，
   \`scan_train_duplicates\` / \`apply_train_duplicate_removals\` per-version
   独立审核（fork 时跟随整树复制带过去）。**不拆模块**。

## 测试

新增 6 个测试文件（72 个 case）：

| 文件 | case 数 | 范围 |
|---|---|---|
| test_train_manifest_mutations.py | 22 | step A 行为 + 多 version 隔离 + 不动 legacy manifest |
| test_preprocess_train_core.py | 22 | step B 行为 + rel path + duplicate_removed flag |
| test_curation_train_scope.py | 8 | step C 行为 + 跨 folder 独立 entry + preprocess 残留隔离 |
| test_preprocess_worker_train.py | 8 | step D 行为：swap_entry / crop N=1/N>1 / source missing / 非法 rel name / multi-crop chain origin / upscale path 派生（mock upscaler）|
| test_duplicates_train_scope.py | 10 | step E 行为 + rel name 校验 + legacy 不受影响 |
| test_train_manifest_fallback.py | +2 | PR-1 fallback 测试改造（sub-folder fixture）+ 新增 cross-subfolder 同名 entry / train root 文件忽略 case |

### \`python -m studio test\`

**1986 passed, 12 failed** —— 12 fail 跟 PR-1 时是同一批 pre-existing
failures（\`test_cltagger\` / \`test_downloader\` / \`test_logging_bootstrap\`
/ \`test_train_endpoints\` / \`test_xy_matrix_schema\`），在 \`origin/dev\` 上
同样 fail，跟本 PR 改动 0 关联。本 PR 不引入任何回归。

PR-1 当时 1914 passed → PR-2 1986 passed，新增 72 测试对得上。

### 老 worker / endpoint 套件全过

- test_preprocess.py（老 list_pending / list_processed / summary）
- test_preprocess_crop_worker.py（老 \`_run_crop\` 端到端）
- test_curation.py（老 \`copy_to_train\` 双分支）
- test_preprocess_endpoints.py / test_curation_endpoints.py（老 URL）

证明 backward-compat 完整。

## 后续

| PR | 范围 | 依赖 |
|---|---|---|
| **PR-1 #209** ✅ merged | ADR 0010 + \`ensure_train_manifest\` fallback | 独立 |
| **PR-2（本 PR）** | 后端 train-scope API + worker 分发 | PR-1 合 dev |
| PR-3 | endpoint URL pid → (pid, vid) + \`preprocessing\` phase + \`_v11\` migration + 删老 API | PR-2 合 dev |
| PR-4 | 前端 Preprocess 子页 + Sidebar 重排 + i18n \"（可选）\" | PR-3 合 dev |