### PR TITLE
feat(preprocess): preprocessing phase + train-scope endpoints (PR-3)

### DIFF
--- a/studio/api/routers/projects/curation.py
+++ b/studio/api/routers/projects/curation.py
@@ -36,7 +36,7 @@ from ...schemas.curation import (
 )
 from ._shared import _publish_project_state
 from .... import db
-from ....services.projects import jobs as project_jobs, projects
+from ....services.projects import jobs as project_jobs, projects, versions
 from ....services.dataset import curation, scan as datasets
 from ....infrastructure.event_bus import bus
 from ....services.preprocess import duplicates as duplicate_finder, manifest as preprocess_manifest
@@ -374,6 +374,127 @@ def apply_project_duplicates(
 ) -> dict[str, Any]:
     """Backward-compatible alias; now marks manifest duplicate_removed."""
     return apply_preprocess_duplicates(pid, body)
+
+
+# ---------------------------------------------------------------------------
+# ADR 0010 — train-scope duplicates endpoint（PR-3 step 2）
+#
+# scope 收窄到 versions/{label}/train/，对应 PR-2 加的 scan_train_duplicates
+# / apply_train_duplicate_removals。老 endpoint 暂留作 backward-compat，PR-4
+# 改前端用新 URL，之后单独 PR 删老路径。
+# ---------------------------------------------------------------------------
+
+
+def _resolve_pv_or_404_dup(
+    pid: int, vid: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    with db.connection_for() as conn:
+        p = projects.get_project(conn, pid)
+        if not p:
+            raise HTTPException(404, f"项目不存在: id={pid}")
+        v = versions.get_version(conn, vid)
+        if not v or v["project_id"] != pid:
+            raise HTTPException(404, f"版本不存在: id={vid}")
+    return p, v
+
+
+@router.post("/api/projects/{pid}/versions/{vid}/preprocess/duplicates/scan")
+def scan_preprocess_duplicates_train(
+    pid: int, vid: int, body: DuplicateScanRequest,
+) -> dict[str, Any]:
+    """ADR 0010 train scope 重复扫描。sources = versions/{label}/train/
+    （跳过 manifest 已标 duplicate_removed 的）；返回结构跟老 endpoint 一致，
+    `target` 字段从 `"preprocess"` 改成 `"train"`。"""
+    _resolve_pv_or_404_dup(pid, vid)
+    with db.connection_for() as conn:
+        try:
+            options = duplicate_finder.options_from_payload(body.model_dump())
+            last_progress_at = 0.0
+
+            def publish_progress(payload: dict[str, Any]) -> None:
+                nonlocal last_progress_at
+                now = time.monotonic()
+                if now - last_progress_at < 1.0:
+                    return
+                last_progress_at = now
+                bus.publish({
+                    "type": "duplicate_scan_progress",
+                    "project_id": pid,
+                    "version_id": vid,
+                    "status": "running",
+                    **payload,
+                })
+
+            bus.publish({
+                "type": "duplicate_scan_progress",
+                "project_id": pid,
+                "version_id": vid,
+                "status": "running",
+                "text": "Scanning duplicate candidates in train set...",
+            })
+            result = duplicate_finder.scan_train_duplicates(
+                conn, pid, vid, options, on_progress=publish_progress,
+            )
+            bus.publish({
+                "type": "duplicate_scan_progress",
+                "project_id": pid,
+                "version_id": vid,
+                "status": "done",
+                "total_images": result["total_images"],
+                "group_count": result["group_count"],
+                "candidate_count": result["candidate_count"],
+                "blur_candidate_count": result.get("blur_candidate_count", 0),
+                "crop_relation_count": result.get("crop_relation_count", 0),
+                "elapsed_seconds": result["elapsed_seconds"],
+                "text": (
+                    f"Scanned {result['total_images']} train images; "
+                    f"found {result['group_count']} groups / "
+                    f"{result['candidate_count']} candidates, "
+                    f"{result.get('blur_candidate_count', 0)} blur candidates, "
+                    f"{result.get('crop_relation_count', 0)} crop relations."
+                ),
+            })
+            return result
+        except curation.CurationError as exc:
+            bus.publish({
+                "type": "duplicate_scan_progress",
+                "project_id": pid,
+                "version_id": vid,
+                "status": "failed",
+                "text": str(exc),
+            })
+            _curation_err_code(exc); raise
+        except duplicate_finder.DuplicateFinderError as exc:
+            bus.publish({
+                "type": "duplicate_scan_progress",
+                "project_id": pid,
+                "version_id": vid,
+                "status": "failed",
+                "text": str(exc),
+            })
+            _duplicate_err_code(exc); raise
+
+
+@router.post("/api/projects/{pid}/versions/{vid}/preprocess/duplicates/apply")
+def apply_preprocess_duplicates_train(
+    pid: int, vid: int, body: DuplicateApplyRequest,
+) -> dict[str, Any]:
+    """ADR 0010 train scope: 标记 per-version 审核状态到 train manifest。
+    `names` 是 train rel path（`"1_data/X.png"`）。物理文件不动。"""
+    _resolve_pv_or_404_dup(pid, vid)
+    with db.connection_for() as conn:
+        try:
+            result = duplicate_finder.apply_train_duplicate_removals(
+                conn, pid, vid, names=body.names,
+            )
+            project = projects.get_project(conn, pid)
+        except curation.CurationError as exc:
+            _curation_err_code(exc); raise
+        except duplicate_finder.DuplicateFinderError as exc:
+            _duplicate_err_code(exc); raise
+    if project:
+        _publish_project_state(project)
+    return result
 
 
 @router.post("/api/projects/{pid}/versions/{vid}/curation/copy")

--- a/studio/api/routers/projects/ingestion.py
+++ b/studio/api/routers/projects/ingestion.py
@@ -44,7 +44,7 @@ from ...schemas.ingestion import (
 )
 from ._shared import _publish_job_state, _publish_project_state
 from .... import db, secrets
-from ....services.projects import jobs as project_jobs, projects
+from ....services.projects import jobs as project_jobs, projects, versions
 from ....services.dataset import scan as datasets
 from ....paths import REPO_ROOT
 from ....services.preprocess import core as preprocess_svc
@@ -411,6 +411,193 @@ def restore_preprocess_files(
         raise HTTPException(404, f"项目不存在: id={pid}")
     try:
         res = preprocess_svc.restore_products(p, body.names)
+    except preprocess_svc.PreprocessError as exc:
+        raise HTTPException(400, str(exc)) from exc
+    if res["restored"]:
+        _publish_project_state(p)
+    return res
+
+
+# ---------------------------------------------------------------------------
+# ADR 0010 — train-scope preprocess endpoint 群（PR-3 step 2）
+#
+# `/api/projects/{pid}/versions/{vid}/preprocess/*` —— scope 收窄到 train 集合，
+# 调 *_train 服务函数（PR-2 加的）。老的 `/api/projects/{pid}/preprocess/*`
+# 暂留作 backward-compat 给老前端用，PR-4 改前端用新 URL，之后单独 PR 删老路径。
+# ---------------------------------------------------------------------------
+
+
+def _resolve_pv_or_404(pid: int, vid: int) -> tuple[dict[str, Any], dict[str, Any]]:
+    """拿 (project, version) 校验项目+版本存在且 vid 属于 pid。"""
+    with db.connection_for() as conn:
+        p = projects.get_project(conn, pid)
+        if not p:
+            raise HTTPException(404, f"项目不存在: id={pid}")
+        v = versions.get_version(conn, vid)
+        if not v or v["project_id"] != pid:
+            raise HTTPException(404, f"版本不存在: id={vid}")
+    return p, v
+
+
+@router.post("/api/projects/{pid}/versions/{vid}/preprocess/start")
+def start_preprocess_train(
+    pid: int, vid: int, body: PreprocessStartRequest,
+) -> dict[str, Any]:
+    """ADR 0010 train scope: 对 versions/{label}/train/{folder}/ 跑 upscale。
+
+    跟老 `start_preprocess` 同样的 body schema + validation；worker 看
+    job.version_id 派发到 _run_upscale_train。
+    """
+    if body.mode not in ("all", "selected", "all_force"):
+        raise HTTPException(400, f"未知 mode: {body.mode}")
+    if body.tile_size <= 0:
+        raise HTTPException(400, "tile_size 必须 > 0")
+    if body.device not in ("auto", "cuda", "cpu"):
+        raise HTTPException(400, f"未知 device: {body.device}")
+    if body.target_area is not None and (
+        body.target_area < 256 * 256 or body.target_area > 4096 * 4096
+    ):
+        raise HTTPException(400, f"target_area 超出范围: {body.target_area}")
+    try:
+        target = model_downloader.upscaler_target(body.model)
+    except ValueError as exc:
+        raise HTTPException(400, f"未知放大器: {body.model}") from exc
+    if not target.exists():
+        raise HTTPException(
+            409,
+            f"放大器权重未下载: {body.model}（请先到「设置 → 预处理」下载）",
+        )
+
+    p, v = _resolve_pv_or_404(pid, vid)
+    with db.connection_for() as conn:
+        try:
+            job = preprocess_svc.start_job_train(
+                conn,
+                project_id=pid,
+                version_id=vid,
+                mode=body.mode,
+                names=body.names,
+                model=body.model,
+                tile_size=body.tile_size,
+                tile_pad=body.tile_pad,
+                device=body.device,
+                target_area=body.target_area,
+            )
+        except preprocess_svc.PreprocessError as exc:
+            raise HTTPException(400, str(exc)) from exc
+    _publish_job_state(job)
+    return job
+
+
+@router.get("/api/projects/{pid}/versions/{vid}/preprocess/status")
+def preprocess_status_train(pid: int, vid: int) -> dict[str, Any]:
+    """最新 train-scope preprocess job + 日志尾 + train summary。"""
+    p, v = _resolve_pv_or_404(pid, vid)
+    with db.connection_for() as conn:
+        job = project_jobs.latest_for(
+            conn, project_id=pid, version_id=vid,
+            kind=preprocess_svc.PREPROCESS_KIND,
+        )
+    log_tail = ""
+    if job:
+        log_path = Path(job.get("log_path") or "")
+        if log_path.exists():
+            try:
+                text = log_path.read_text(encoding="utf-8", errors="replace")
+                log_tail = "\n".join(text.splitlines()[-50:])
+            except Exception:  # noqa: BLE001
+                log_tail = ""
+    return {
+        "job": job,
+        "log_tail": log_tail,
+        "summary": preprocess_svc.summary_train(p, v["label"]),
+    }
+
+
+@router.get("/api/projects/{pid}/versions/{vid}/preprocess/files")
+def list_preprocess_files_train(pid: int, vid: int) -> dict[str, Any]:
+    """train scope: 列 versions/{label}/train/ 全部图 + manifest 元数据。
+
+    新模型下 list_pending / list_processed 二元概念消失（详 ADR 0010
+    §Manifest schema v2）；统一返回 `images` 列表，前端按 entry 字段差异
+    渲染状态徽章。response 仍含 `summary` 跟老 endpoint 一致。
+    """
+    p, v = _resolve_pv_or_404(pid, vid)
+    return {
+        "images": preprocess_svc.list_train_images(p, v["label"]),
+        "summary": preprocess_svc.summary_train(p, v["label"]),
+    }
+
+
+@router.get("/api/projects/{pid}/versions/{vid}/preprocess/duplicates/removed")
+def list_duplicate_removed_train(pid: int, vid: int) -> dict[str, Any]:
+    """train scope: 「已删除」tab 列被去重审核标记的 manifest entries。"""
+    p, v = _resolve_pv_or_404(pid, vid)
+    return {
+        "images": preprocess_svc.list_duplicate_removed_workspace_train(
+            p, v["label"]
+        ),
+    }
+
+
+@router.get("/api/projects/{pid}/versions/{vid}/preprocess/crop/workspace")
+def list_crop_workspace_train_endpoint(pid: int, vid: int) -> dict[str, Any]:
+    """train scope: 裁剪页工作集 = train/{folder}/{image} 全部 + 像素尺寸 +
+    processed 标记。"""
+    p, v = _resolve_pv_or_404(pid, vid)
+    return {"images": preprocess_svc.list_crop_workspace_train(p, v["label"])}
+
+
+@router.post("/api/projects/{pid}/versions/{vid}/preprocess/crop")
+def start_preprocess_crop_train(
+    pid: int, vid: int, body: PreprocessCropRequest,
+) -> dict[str, Any]:
+    """train scope: 创建 crop job。`crops` 的源文件名是 train rel path
+    （`"1_data/X.png"`，跟 list_crop_workspace_train 返回 `name` 一致）。"""
+    if not body.crops:
+        raise HTTPException(400, "crops 不能为空")
+    _resolve_pv_or_404(pid, vid)
+    crops_payload: dict[str, list[dict[str, Any]]] = {
+        name: [r.model_dump() for r in rects]
+        for name, rects in body.crops.items()
+    }
+    with db.connection_for() as conn:
+        try:
+            job = preprocess_svc.start_crop_job_train(
+                conn, project_id=pid, version_id=vid, crops=crops_payload,
+            )
+        except preprocess_svc.PreprocessError as exc:
+            raise HTTPException(400, str(exc)) from exc
+    _publish_job_state(job)
+    return job
+
+
+@router.post("/api/projects/{pid}/versions/{vid}/preprocess/files/reset")
+def reset_preprocess_files_train(pid: int, vid: int) -> dict[str, Any]:
+    """train scope: 清空 train manifest 状态（**不动** train/ 物理文件，详
+    ADR 0010 §train_clear_all 决策）。下游 list_train_images 仍能列物理图，
+    只是 entry 元数据没了；UI 走未处理状态徽章。
+    """
+    p, v = _resolve_pv_or_404(pid, vid)
+    pdir = projects.project_dir(p["id"], p["slug"])
+    preprocess_manifest.train_clear_all(pdir, v["label"])
+    _publish_project_state(p)
+    return {"ok": True}
+
+
+@router.post("/api/projects/{pid}/versions/{vid}/preprocess/files/restore")
+def restore_preprocess_files_train(
+    pid: int, vid: int, body: PreprocessRestoreRequest,
+) -> dict[str, Any]:
+    """train scope restore: 从 `download/{entry.origin}` 复制覆盖回
+    `train/{name}`。返回 `{restored, missing, no_origin}` 三组（详 ADR 0010
+    §Restore 语义）；`no_origin` 给前端三选项 UI [拖入替换 / 保留 / 移除] 用。
+    """
+    if not body.names:
+        return {"restored": [], "missing": [], "no_origin": []}
+    p, v = _resolve_pv_or_404(pid, vid)
+    try:
+        res = preprocess_svc.restore_products_train(p, v["label"], body.names)
     except preprocess_svc.PreprocessError as exc:
         raise HTTPException(400, str(exc)) from exc
     if res["restored"]:

--- a/studio/infrastructure/migrations/__init__.py
+++ b/studio/infrastructure/migrations/__init__.py
@@ -25,6 +25,7 @@ from ._v7_version_trigger_word import migrate as _migrate_v7
 from ._v8_version_status_phase import migrate as _migrate_v8
 from ._v9_drop_legacy_stage import migrate as _migrate_v9
 from ._v10_request_trace import migrate as _migrate_v10
+from ._v11_preprocessing_phase import migrate as _migrate_v11
 
 Migration = Callable[[sqlite3.Connection], None]
 
@@ -39,6 +40,7 @@ MIGRATIONS: list[Migration] = [
     _migrate_v8,  # v8: versions.status / phase / last_failure_reason（ADR-0007）
     _migrate_v9,  # v9: 删 projects.stage + versions.stage（ADR-0007 PR-5 destructive）
     _migrate_v10, # v10: tasks.request_trace_id（ADR-0009 PR-1 C6 trace_id 跨进程贯穿）
+    _migrate_v11, # v11: versions.phase 加 preprocessing 值（ADR-0010 配套，回填 curating+train 非空 → preprocessing）
 ]
 
 

--- a/studio/infrastructure/migrations/_v11_preprocessing_phase.py
+++ b/studio/infrastructure/migrations/_v11_preprocessing_phase.py
@@ -1,0 +1,74 @@
+"""v10 → v11: ADR 0010 加 `preprocessing` phase 到 VersionPhase.ORDER。
+
+VersionPhase 从 5 → 6：
+
+    curating → preprocessing → tagging → editing → regularizing → ready
+
+新 phase 介于 curating / tagging 之间；可跳过（跟 regularizing 一致）。
+
+回填策略（all silent, add-only — 跟 _v8 同 pattern）：
+
+  - phase = curating + `versions/{label}/train/{sub-folder}/` 有图 →
+    推进到 preprocessing（用户已经 curate 完，train 集合现存）
+  - phase = curating + train 空 → 保持 curating
+  - 其他 phase（tagging / editing / regularizing / ready） → 保持不变
+
+依据：ADR 0010 §Migration —— 用户原话 "preprocessing 的图片已经复制到现有
+train 的图片了"，train/ 非空意味着 curate 实质完成；提供"silent advance to
+preprocessing"让升级后用户进入项目直接看到新 phase。
+
+零 schema 改动：phase 列已是 TEXT（_v8 加的），新值无需扩字段；旧的
+phase 字段约束在 backend code（VersionPhase.VALUES）维护，DB 层只是 TEXT。
+
+跟 _v9 destructive 的关系：本 migration 不动 stage 列（_v9 已删）；只 UPDATE
+phase 列。顺序保证 (`MIGRATIONS[10]` 在 `_v9` 之后) 不需要特殊处理。
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+
+# 跟 dataset.scan.IMAGE_EXTS 一致；这里 inline 是为了避免 migration 模块依赖
+# services/ 层（migrations 应该 self-contained，让 cold-start 顺序灵活）。
+_IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif"})
+
+
+def _train_has_image(project_dir: Path, version_label: str) -> bool:
+    """跟 manifest._scan_train_images 一致逻辑：扫 train/{sub-folder}/{image}。
+    train 根目录直接放的图忽略（LoRA 训练只读 sub-folder 内）。
+    """
+    train_dir = project_dir / "versions" / version_label / "train"
+    if not train_dir.exists():
+        return False
+    for sub in train_dir.iterdir():
+        if not sub.is_dir():
+            continue
+        for f in sub.iterdir():
+            if f.is_file() and f.suffix.lower() in _IMAGE_EXTS:
+                return True
+    return False
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    # Lazy import：避免 migration 模块加载时强依赖 services 层；测试 monkeypatch
+    # services.projects.PROJECTS_DIR 后跑 migrate 会拿到正确路径。
+    from ...services.projects import projects as _projects
+
+    rows = conn.execute(
+        "SELECT v.id, v.label, p.id, p.slug "
+        "FROM versions v "
+        "JOIN projects p ON v.project_id = p.id "
+        "WHERE v.phase = 'curating'"
+    ).fetchall()
+    for vid, label, pid, slug in rows:
+        try:
+            project_dir = _projects.project_dir(int(pid), str(slug))
+        except (TypeError, ValueError):
+            continue
+        if _train_has_image(project_dir, str(label)):
+            conn.execute(
+                "UPDATE versions SET phase = 'preprocessing' WHERE id = ?",
+                (vid,),
+            )
+    conn.commit()

--- a/studio/services/projects/phase.py
+++ b/studio/services/projects/phase.py
@@ -80,6 +80,26 @@ def check_regularizing(
     return CheckResult(True)
 
 
+def check_preprocessing(
+    conn: sqlite3.Connection, version_id: int
+) -> CheckResult:
+    """无 preprocess job 处于 pending/running（ADR 0010；可跳过 = 不强求处理过）。
+
+    跟 `check_regularizing` 同 pattern——预处理是可选 phase（upscale / crop /
+    去重等都可跳过，接受训练时默认放大算法）；校验仅防 concurrent job 撞车。
+    """
+    row = conn.execute(
+        "SELECT COUNT(*) FROM project_jobs "
+        "WHERE version_id = ? "
+        "  AND kind = 'preprocess' "
+        "  AND status IN ('pending', 'running')",
+        (version_id,),
+    ).fetchone()
+    if int(row[0]) > 0:
+        return CheckResult(False, "预处理任务进行中，请等待完成")
+    return CheckResult(True)
+
+
 def check_ready(
     project: dict[str, Any], version: dict[str, Any]
 ) -> CheckResult:
@@ -110,6 +130,8 @@ def check_phase(
     P = _versions.VersionPhase
     if phase == P.CURATING:
         return check_curating(_versions.stats_for_version(p, v))
+    if phase == P.PREPROCESSING:
+        return check_preprocessing(conn, version_id)
     if phase == P.TAGGING:
         return check_tagging(_versions.stats_for_version(p, v))
     if phase == P.EDITING:
@@ -164,10 +186,11 @@ def advance_phase(
 def skip_phase(
     conn: sqlite3.Connection, version_id: int
 ) -> tuple[bool, CheckResult, Optional[str]]:
-    """跳过当前 phase（仅 ``SKIPPABLE`` 集合允许；当前 = regularizing）。
+    """跳过当前 phase（仅 ``SKIPPABLE`` 集合允许；当前 = preprocessing /
+    regularizing）。
 
-    与 ``advance_phase`` 区别：不要求"完成条件"满足（如不要求生成正则集），
-    仅校验"无 concurrent job"防止状态错乱。
+    与 ``advance_phase`` 区别：不要求"完成条件"满足（如不要求生成正则集 /
+    不要求每张图都预处理过），仅校验"无 concurrent job"防止状态错乱。
     """
     v = _versions.get_version(conn, version_id)
     if not v:
@@ -177,9 +200,13 @@ def skip_phase(
     if current_phase not in _versions.VersionPhase.SKIPPABLE:
         return False, CheckResult(False, f"phase {current_phase} 不可跳过"), None
 
-    # regularizing 跳过也要 no job running
+    # skip 时仍校验"无 concurrent job"防止状态错乱
     if current_phase == _versions.VersionPhase.REGULARIZING:
         result = check_regularizing(conn, version_id)
+        if not result.ok:
+            return False, result, None
+    elif current_phase == _versions.VersionPhase.PREPROCESSING:
+        result = check_preprocessing(conn, version_id)
         if not result.ok:
             return False, result, None
 

--- a/studio/services/projects/versions.py
+++ b/studio/services/projects/versions.py
@@ -41,21 +41,25 @@ class VersionStatus:
 class VersionPhase:
     """版本准备 cursor，仅 status=preparing 时有业务语义（ADR-0007 §11.3-B / §11.5-A）。
 
-    顺序：curating → tagging → editing → regularizing → ready。
-    regularizing 可跳过（SKIPPABLE），其余必经。
+    顺序：curating → preprocessing → tagging → editing → regularizing → ready。
+    preprocessing / regularizing 可跳过（SKIPPABLE），其余必经。
+
+    ADR 0010 加 preprocessing phase（curating 之后）：用户筛选完图后对 train
+    集做 upscale / crop / 去重等精细处理；可跳过 = 接受训练时默认放大算法。
     """
 
     CURATING = "curating"
+    PREPROCESSING = "preprocessing"
     TAGGING = "tagging"
     EDITING = "editing"
     REGULARIZING = "regularizing"
     READY = "ready"
 
     ORDER: tuple[str, ...] = (
-        CURATING, TAGGING, EDITING, REGULARIZING, READY,
+        CURATING, PREPROCESSING, TAGGING, EDITING, REGULARIZING, READY,
     )
     VALUES: frozenset[str] = frozenset(ORDER)
-    SKIPPABLE: frozenset[str] = frozenset({REGULARIZING})
+    SKIPPABLE: frozenset[str] = frozenset({PREPROCESSING, REGULARIZING})
 
 
 def get_status(v: dict[str, Any]) -> str:

--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 163,
+  "count": 173,
   "routes": [
     {
       "path": "/",
@@ -791,6 +791,86 @@
         "GET"
       ],
       "name": "list_version_lora_ckpts",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/crop",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_preprocess_crop_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/crop/workspace",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_crop_workspace_train_endpoint",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/duplicates/apply",
+      "methods": [
+        "POST"
+      ],
+      "name": "apply_preprocess_duplicates_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/duplicates/removed",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_duplicate_removed_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/duplicates/scan",
+      "methods": [
+        "POST"
+      ],
+      "name": "scan_preprocess_duplicates_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/files",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_preprocess_files_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/files/reset",
+      "methods": [
+        "POST"
+      ],
+      "name": "reset_preprocess_files_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/files/restore",
+      "methods": [
+        "POST"
+      ],
+      "name": "restore_preprocess_files_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/start",
+      "methods": [
+        "POST"
+      ],
+      "name": "start_preprocess_train",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/preprocess/status",
+      "methods": [
+        "GET"
+      ],
+      "name": "preprocess_status_train",
       "type": "APIRoute"
     },
     {

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -106,3 +106,144 @@ def test_apply_all_is_idempotent(tmp_path: Path) -> None:
         first = apply_all(c)
         again = apply_all(c)
     assert first == again == len(MIGRATIONS) + 1
+
+
+# ---------------------------------------------------------------------------
+# v11 — ADR 0010 加 preprocessing phase + 回填 curating+train 非空
+# ---------------------------------------------------------------------------
+
+
+def _setup_v11_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """init db + monkeypatch PROJECTS_DIR → 让 _v11 能找到 train/ 物理图。"""
+    from studio.services.projects import projects
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    return dbfile
+
+
+def test_v11_advances_curating_with_train_image_to_preprocessing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """curating + train/{folder}/{image} 存在 → 推进到 preprocessing。"""
+    from studio.infrastructure.migrations._v11_preprocessing_phase import migrate as v11
+    from studio.services.projects import projects, versions
+    dbfile = _setup_v11_env(tmp_path, monkeypatch)
+
+    with db.connection_for(dbfile) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label="v1")
+    sub = projects.project_dir(p["id"], p["slug"]) / "versions" / "v1" / "train" / "1_data"
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / "X.png").write_bytes(b"img")
+    with db.connection_for(dbfile) as conn:
+        conn.execute("UPDATE versions SET phase = 'curating' WHERE id = ?", (v["id"],))
+        conn.commit()
+        v11(conn)
+        new_phase = conn.execute(
+            "SELECT phase FROM versions WHERE id = ?", (v["id"],)
+        ).fetchone()[0]
+    assert new_phase == "preprocessing"
+
+
+def test_v11_keeps_curating_when_train_empty(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """curating + train 空 → 保持 curating。"""
+    from studio.infrastructure.migrations._v11_preprocessing_phase import migrate as v11
+    from studio.services.projects import projects, versions
+    dbfile = _setup_v11_env(tmp_path, monkeypatch)
+
+    with db.connection_for(dbfile) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label="v1")
+        conn.execute("UPDATE versions SET phase = 'curating' WHERE id = ?", (v["id"],))
+        conn.commit()
+        v11(conn)
+        new_phase = conn.execute(
+            "SELECT phase FROM versions WHERE id = ?", (v["id"],)
+        ).fetchone()[0]
+    assert new_phase == "curating"
+
+
+def test_v11_ignores_other_phases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """tagging / editing / regularizing / ready 不动，无论 train 状态。"""
+    from studio.infrastructure.migrations._v11_preprocessing_phase import migrate as v11
+    from studio.services.projects import projects, versions
+    dbfile = _setup_v11_env(tmp_path, monkeypatch)
+
+    with db.connection_for(dbfile) as conn:
+        p = projects.create_project(conn, title="P")
+        for label, phase in [
+            ("v1", "tagging"), ("v2", "editing"),
+            ("v3", "regularizing"), ("v4", "ready"),
+        ]:
+            v = versions.create_version(conn, project_id=p["id"], label=label)
+            conn.execute(
+                "UPDATE versions SET phase = ? WHERE id = ?", (phase, v["id"])
+            )
+        conn.commit()
+        # train 有图也不该被推
+        for label in ["v1", "v2", "v3", "v4"]:
+            sub = projects.project_dir(p["id"], p["slug"]) / "versions" / label / "train" / "1_data"
+            sub.mkdir(parents=True, exist_ok=True)
+            (sub / "X.png").write_bytes(b"x")
+        v11(conn)
+        phases = dict(conn.execute(
+            "SELECT label, phase FROM versions WHERE project_id = ?", (p["id"],)
+        ).fetchall())
+    assert phases == {
+        "v1": "tagging", "v2": "editing",
+        "v3": "regularizing", "v4": "ready",
+    }
+
+
+def test_v11_ignores_train_root_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """train/ 根目录直接放的图忽略 → phase 保持 curating。"""
+    from studio.infrastructure.migrations._v11_preprocessing_phase import migrate as v11
+    from studio.services.projects import projects, versions
+    dbfile = _setup_v11_env(tmp_path, monkeypatch)
+
+    with db.connection_for(dbfile) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label="v1")
+        conn.execute("UPDATE versions SET phase = 'curating' WHERE id = ?", (v["id"],))
+        conn.commit()
+    train_root = projects.project_dir(p["id"], p["slug"]) / "versions" / "v1" / "train"
+    train_root.mkdir(parents=True, exist_ok=True)
+    (train_root / "stray.png").write_bytes(b"x")
+
+    with db.connection_for(dbfile) as conn:
+        v11(conn)
+        new_phase = conn.execute(
+            "SELECT phase FROM versions WHERE id = ?", (v["id"],)
+        ).fetchone()[0]
+    assert new_phase == "curating"
+
+
+def test_v11_idempotent_second_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from studio.infrastructure.migrations._v11_preprocessing_phase import migrate as v11
+    from studio.services.projects import projects, versions
+    dbfile = _setup_v11_env(tmp_path, monkeypatch)
+
+    with db.connection_for(dbfile) as conn:
+        p = projects.create_project(conn, title="P")
+        v = versions.create_version(conn, project_id=p["id"], label="v1")
+    sub = projects.project_dir(p["id"], p["slug"]) / "versions" / "v1" / "train" / "1_data"
+    sub.mkdir(parents=True, exist_ok=True)
+    (sub / "X.png").write_bytes(b"x")
+    with db.connection_for(dbfile) as conn:
+        conn.execute("UPDATE versions SET phase = 'curating' WHERE id = ?", (v["id"],))
+        conn.commit()
+        v11(conn)
+        v11(conn)
+        new_phase = conn.execute(
+            "SELECT phase FROM versions WHERE id = ?", (v["id"],)
+        ).fetchone()[0]
+    assert new_phase == "preprocessing"

--- a/tests/test_phase_endpoints.py
+++ b/tests/test_phase_endpoints.py
@@ -71,7 +71,8 @@ def test_advance_fails_with_empty_train(client: TestClient) -> None:
     assert body["new_phase"] is None
 
 
-def test_advance_curating_to_tagging_with_image(client: TestClient) -> None:
+def test_advance_curating_to_preprocessing_with_image(client: TestClient) -> None:
+    """ADR 0010 加 preprocessing phase（curating 之后）。"""
     p, v = _make_pv(client)
     vdir = versions.version_dir(p["id"], p["slug"], v["label"])
     _put_image(vdir / "train" / "5_concept", "001", with_caption=False)
@@ -80,8 +81,8 @@ def test_advance_curating_to_tagging_with_image(client: TestClient) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["advanced"] is True
-    assert body["new_phase"] == "tagging"
-    assert body["version"]["phase"] == "tagging"
+    assert body["new_phase"] == "preprocessing"
+    assert body["version"]["phase"] == "preprocessing"
 
 
 def test_advance_tagging_fails_with_missing_caption(client: TestClient) -> None:

--- a/tests/test_train_scope_endpoints.py
+++ b/tests/test_train_scope_endpoints.py
@@ -1,0 +1,335 @@
+"""ADR 0010 — train-scope preprocess endpoint smoke tests（PR-3 step 2）。
+
+老 endpoint 测试在 test_preprocess_endpoints.py / test_curation_endpoints.py，
+本文件只覆盖新 `/api/projects/{pid}/versions/{vid}/preprocess/*` 路径。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+from fastapi.testclient import TestClient
+
+from studio import db, secrets, server
+from studio.services.preprocess import manifest as preprocess_manifest
+from studio.services.projects import jobs as project_jobs, projects, versions
+from studio.services import models as model_downloader
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(project_jobs, "JOB_LOGS_DIR", tmp_path / "jobs")
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
+    monkeypatch.setattr(secrets, "SECRETS_FILE", tmp_path / "secrets.json")
+
+    from studio.services.models import paths as _paths
+    models_root = tmp_path / "models"
+    monkeypatch.setattr(_paths, "models_root", lambda: models_root)
+    weight = model_downloader.upscaler_target("4x-AnimeSharp")
+    weight.parent.mkdir(parents=True, exist_ok=True)
+    weight.write_bytes(b"dummy-weights")
+    return {"db": dbfile}
+
+
+class _StubSupervisor:
+    def cancel_job(self, _jid: int) -> bool:
+        return True
+
+
+@pytest.fixture
+def client(isolated) -> TestClient:
+    server.app.state.supervisor = _StubSupervisor()
+    return TestClient(server.app)
+
+
+def _make_pv(client: TestClient) -> tuple[dict, dict]:
+    p = client.post(
+        "/api/projects", json={"title": "P", "initial_version_label": "v1"}
+    ).json()
+    with db.connection_for() as conn:
+        v = versions.list_versions(conn, project_id=p["id"])[0]
+    return p, v
+
+
+def _train_sub(p: dict, label: str = "v1", folder: str = "1_data") -> Path:
+    d = projects.project_dir(p["id"], p["slug"]) / "versions" / label / "train" / folder
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _write_png(path: Path, size: tuple[int, int] = (40, 40)) -> None:
+    Image.new("RGB", size, "red").save(path, "PNG")
+
+
+# ---------------------------------------------------------------------------
+# 404 path validation
+# ---------------------------------------------------------------------------
+
+
+def test_404_for_unknown_project(client: TestClient) -> None:
+    resp = client.get("/api/projects/99999/versions/1/preprocess/files")
+    assert resp.status_code == 404
+
+
+def test_404_for_unknown_version(client: TestClient) -> None:
+    p, _ = _make_pv(client)
+    resp = client.get(f"/api/projects/{p['id']}/versions/99999/preprocess/files")
+    assert resp.status_code == 404
+
+
+def test_404_for_version_belonging_to_other_project(client: TestClient) -> None:
+    p1, _ = _make_pv(client)
+    p2 = client.post(
+        "/api/projects", json={"title": "P2", "initial_version_label": "v1"}
+    ).json()
+    with db.connection_for() as conn:
+        v2 = versions.list_versions(conn, project_id=p2["id"])[0]
+    resp = client.get(
+        f"/api/projects/{p1['id']}/versions/{v2['id']}/preprocess/files"
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# list_preprocess_files_train
+# ---------------------------------------------------------------------------
+
+
+def test_files_endpoint_returns_train_images_and_summary(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    sub = _train_sub(p)
+    _write_png(sub / "X.png")
+    _write_png(sub / "Y.png")
+    preprocess_manifest.train_add_processed(
+        projects.project_dir(p["id"], p["slug"]),
+        v["label"], "1_data/X.png", {"origin": "X.jpg"},
+    )
+
+    resp = client.get(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/files"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    names = sorted(it["name"] for it in body["images"])
+    assert names == ["1_data/X.png", "1_data/Y.png"]
+    assert body["summary"]["image_count"] == 2
+
+
+# ---------------------------------------------------------------------------
+# preprocess_status_train
+# ---------------------------------------------------------------------------
+
+
+def test_status_endpoint_returns_null_job_when_none(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    resp = client.get(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/status"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["job"] is None
+    assert body["log_tail"] == ""
+    assert body["summary"]["image_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# start_preprocess_train
+# ---------------------------------------------------------------------------
+
+
+def test_start_endpoint_creates_job_with_version_id(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    resp = client.post(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/start",
+        json={"mode": "all"},
+    )
+    assert resp.status_code == 200
+    job = resp.json()
+    assert job["version_id"] == v["id"]
+    assert job["kind"] == "preprocess"
+
+
+def test_start_endpoint_rejects_unknown_mode(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    resp = client.post(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/start",
+        json={"mode": "bogus"},
+    )
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# duplicate_removed_train
+# ---------------------------------------------------------------------------
+
+
+def test_duplicates_removed_endpoint(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    sub = _train_sub(p)
+    _write_png(sub / "dup.png")
+    preprocess_manifest.train_mark_duplicate_removed(
+        projects.project_dir(p["id"], p["slug"]),
+        v["label"], ["1_data/dup.png"],
+    )
+
+    resp = client.get(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/duplicates/removed"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    names = [it["name"] for it in body["images"]]
+    assert names == ["1_data/dup.png"]
+
+
+# ---------------------------------------------------------------------------
+# crop workspace + crop start
+# ---------------------------------------------------------------------------
+
+
+def test_crop_workspace_endpoint(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    sub = _train_sub(p)
+    _write_png(sub / "A.png", (30, 30))
+
+    resp = client.get(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/crop/workspace"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body["images"]) == 1
+    assert body["images"][0]["name"] == "1_data/A.png"
+    assert body["images"][0]["w"] == 30
+
+
+def test_crop_start_endpoint_creates_job(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    resp = client.post(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/crop",
+        json={"crops": {"1_data/X.png": [
+            {"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}
+        ]}},
+    )
+    assert resp.status_code == 200
+    job = resp.json()
+    assert job["version_id"] == v["id"]
+
+
+# ---------------------------------------------------------------------------
+# reset (clear_all)
+# ---------------------------------------------------------------------------
+
+
+def test_reset_endpoint_clears_manifest_keeps_files(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    sub = _train_sub(p)
+    _write_png(sub / "X.png")
+    pdir = projects.project_dir(p["id"], p["slug"])
+    preprocess_manifest.train_add_processed(
+        pdir, v["label"], "1_data/X.png", {"origin": "X.jpg"},
+    )
+
+    resp = client.post(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/files/reset"
+    )
+    assert resp.status_code == 200
+    # manifest 空，物理文件保留
+    m = preprocess_manifest.train_load(pdir, v["label"])
+    assert m["images"] == {}
+    assert (sub / "X.png").exists()
+
+
+# ---------------------------------------------------------------------------
+# restore — 3 组返回
+# ---------------------------------------------------------------------------
+
+
+def test_restore_endpoint_copies_from_download(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    pdir = projects.project_dir(p["id"], p["slug"])
+    sub = _train_sub(p)
+    _write_png(sub / "X.png")  # 假设上调过
+    # download/X.jpg 是 origin
+    (pdir / "download").mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (10, 10), "blue").save(pdir / "download" / "X.jpg", "JPEG")
+    preprocess_manifest.train_add_processed(
+        pdir, v["label"], "1_data/X.png", {"origin": "X.jpg"},
+    )
+
+    resp = client.post(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/files/restore",
+        json={"names": ["1_data/X.png"]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["restored"] == ["1_data/X.png"]
+    assert body["missing"] == []
+    assert body["no_origin"] == []
+
+
+def test_restore_endpoint_no_origin_when_download_missing(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    pdir = projects.project_dir(p["id"], p["slug"])
+    sub = _train_sub(p)
+    _write_png(sub / "Y.png")
+    preprocess_manifest.train_add_processed(
+        pdir, v["label"], "1_data/Y.png", {"origin": "Y.jpg"},
+    )
+    # 不创建 download/Y.jpg
+    resp = client.post(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/files/restore",
+        json={"names": ["1_data/Y.png"]},
+    )
+    body = resp.json()
+    assert body["no_origin"] == ["1_data/Y.png"]
+
+
+def test_restore_endpoint_empty_names_returns_three_groups(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    resp = client.post(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/files/restore",
+        json={"names": []},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body == {"restored": [], "missing": [], "no_origin": []}
+
+
+# ---------------------------------------------------------------------------
+# duplicates scan / apply
+# ---------------------------------------------------------------------------
+
+
+def test_duplicates_scan_endpoint_returns_train_target(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    sub = _train_sub(p)
+    _write_png(sub / "X.png")
+    _write_png(sub / "Y.png")
+
+    resp = client.post(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/duplicates/scan",
+        json={},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["target"] == "train"
+    assert body["total_images"] == 2
+
+
+def test_duplicates_apply_endpoint_marks_manifest(client: TestClient) -> None:
+    p, v = _make_pv(client)
+    sub = _train_sub(p)
+    _write_png(sub / "X.png")
+    resp = client.post(
+        f"/api/projects/{p['id']}/versions/{v['id']}/preprocess/duplicates/apply",
+        json={"names": ["1_data/X.png"]},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["removed"] == ["1_data/X.png"]
+    # 物理文件保留
+    assert (sub / "X.png").exists()

--- a/tests/test_version_status_phase.py
+++ b/tests/test_version_status_phase.py
@@ -99,11 +99,14 @@ def test_version_status_enum_values() -> None:
 
 
 def test_version_phase_order_and_skippable() -> None:
+    # ADR 0010 加 preprocessing phase（curating 之后，可跳过跟 regularizing 一致）
     assert versions.VersionPhase.ORDER == (
-        "curating", "tagging", "editing", "regularizing", "ready",
+        "curating", "preprocessing", "tagging", "editing", "regularizing", "ready",
     )
-    assert len(versions.VersionPhase.VALUES) == 5
-    assert versions.VersionPhase.SKIPPABLE == frozenset({"regularizing"})
+    assert len(versions.VersionPhase.VALUES) == 6
+    assert versions.VersionPhase.SKIPPABLE == frozenset(
+        {"preprocessing", "regularizing"}
+    )
 
 
 def test_get_status_fallback_to_preparing() -> None:

--- a/tests/test_versions_phase.py
+++ b/tests/test_versions_phase.py
@@ -167,13 +167,9 @@ def test_advance_phase_blocked_by_failed_check(isolated) -> None:
     assert versions.get_phase(v2) == "curating"
 
 
-def test_advance_phase_curating_to_tagging(isolated) -> None:
-    """curating phase + train 有图 → 推进到 tagging。"""
+def test_advance_phase_curating_to_preprocessing(isolated) -> None:
+    """curating phase + train 有图 → 推进到 preprocessing（ADR 0010 加新 phase）。"""
     v = _make_version(isolated)
-    vdir = versions.version_dir(v["project_id"],
-                                 projects.PROJECTS_DIR.name and v["label"] or v["label"],
-                                 v["label"])
-    # 用真正的 project slug
     with db.connection_for(isolated["db"]) as conn:
         p = projects.get_project(conn, v["project_id"])
     vdir = versions.version_dir(p["id"], p["slug"], v["label"])
@@ -183,10 +179,10 @@ def test_advance_phase_curating_to_tagging(isolated) -> None:
         advanced, result, new_phase = versions_phase.advance_phase(conn, v["id"])
     assert advanced
     assert result.ok
-    assert new_phase == "tagging"
+    assert new_phase == "preprocessing"
     with db.connection_for(isolated["db"]) as conn:
         v2 = versions.get_version(conn, v["id"])
-    assert versions.get_phase(v2) == "tagging"
+    assert versions.get_phase(v2) == "preprocessing"
 
 
 def test_advance_phase_tagging_blocked_by_missing_caption(isolated) -> None:
@@ -213,6 +209,41 @@ def test_skip_phase_only_works_for_skippable(isolated) -> None:
         advanced, result, _ = versions_phase.skip_phase(conn, v["id"])
     assert not advanced
     assert "不可跳过" in result.reason
+
+
+def test_skip_phase_preprocessing_jumps_to_tagging(isolated) -> None:
+    """ADR 0010：preprocessing 可跳过（无 preprocess job running） → cursor 跳到 tagging。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        versions.update_version(conn, v["id"], phase="preprocessing")
+        advanced, result, new_phase = versions_phase.skip_phase(conn, v["id"])
+    assert advanced
+    assert result.ok
+    assert new_phase == "tagging"
+
+
+def test_skip_phase_preprocessing_blocked_by_running_job(isolated) -> None:
+    """有 preprocess job pending/running → 拒跳过（防 concurrent job 撞车）。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        versions.update_version(conn, v["id"], phase="preprocessing")
+        conn.execute(
+            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
+            "VALUES (?, ?, 'preprocess', '{}', 'running')",
+            (v["project_id"], v["id"]),
+        )
+        conn.commit()
+        advanced, result, _ = versions_phase.skip_phase(conn, v["id"])
+    assert not advanced
+    assert "预处理" in result.reason
+
+
+def test_check_preprocessing_ok_without_running_job(isolated) -> None:
+    """无 concurrent preprocess job → OK（preprocessing 可跳过不强求完成度）。"""
+    v = _make_version(isolated)
+    with db.connection_for(isolated["db"]) as conn:
+        result = versions_phase.check_preprocessing(conn, v["id"])
+    assert result.ok
 
 
 def test_skip_phase_regularizing_jumps_to_ready(isolated) -> None:


### PR DESCRIPTION
## 背景 / 动机

ADR 0010 PR-3 — 把 ADR 0007 phase 状态机加新值 \`preprocessing\`（curating
之后，可跳过跟 regularizing 一致），并加 train-scope preprocess endpoint
群（10 个）调 PR-2 加的 *_train 服务函数。

老 endpoint \`/api/projects/{pid}/preprocess/*\` 暂留作 backward-compat，
PR-4 改前端用新 URL 后单独 PR 删老路径 / 老 service API。

## Commits

| # | 范围 |
|---|---|
| c34a725 | step 1: VersionPhase.ORDER 加 PREPROCESSING + SKIPPABLE 加 + check_preprocessing + _v11 隐式 migration |
| 0f83375 | step 2: 10 个新 vid-aware endpoint + 16 个 endpoint smoke test |
| ad2d304 | test(route-snapshot): regenerate（10 个新 routes） |

## 关键设计点

### 1. VersionPhase 加 \`preprocessing\`

```python
# 改前 (ADR 0007 §132):
ORDER = (curating, tagging, editing, regularizing, ready)         # 5
SKIPPABLE = {regularizing}

# 改后 (ADR 0010 amendment):
ORDER = (curating, preprocessing, tagging, editing, regularizing, ready)   # 6
SKIPPABLE = {preprocessing, regularizing}
```

\`check_preprocessing(conn, version_id)\` 跟 \`check_regularizing\` 同 pattern：
无 preprocess job pending/running → OK；可跳过 = 不强求处理过任何图。

### 2. \`_v11\` 隐式 DB migration

零 schema 改动——phase 列已是 TEXT（_v8 加的）；migration 只 UPDATE。

回填规则（all silent add-only，跟 _v8 同 pattern）：

| 现存 phase | train/{sub-folder}/{image} | 新 phase |
|---|---|---|
| curating | 非空 | **preprocessing** |
| curating | 空 | curating（保持） |
| tagging / editing / regularizing / ready | 任意 | 保持不变 |

依据 ADR 0010 §Migration："preprocessing 的图片已经复制到现有 train 的图
片了"——train/ 非空意味着用户 curate 实质完成。

### 3. 10 个新 vid-aware endpoint

ingestion.py 8 个 + curation.py 2 个：

| 旧 URL | 新 URL | 服务函数 |
|---|---|---|
| POST /preprocess/start | POST /versions/{vid}/preprocess/start | start_job_train |
| GET /preprocess/status | GET /versions/{vid}/preprocess/status | summary_train + latest_for(version_id) |
| GET /preprocess/files | GET /versions/{vid}/preprocess/files | list_train_images + summary_train |
| GET /preprocess/duplicates/removed | GET /versions/{vid}/preprocess/duplicates/removed | list_duplicate_removed_workspace_train |
| GET /preprocess/crop/workspace | GET /versions/{vid}/preprocess/crop/workspace | list_crop_workspace_train |
| POST /preprocess/crop | POST /versions/{vid}/preprocess/crop | start_crop_job_train |
| POST /preprocess/files/reset | POST /versions/{vid}/preprocess/files/reset | train_clear_all |
| POST /preprocess/files/restore | POST /versions/{vid}/preprocess/files/restore | restore_products_train |
| POST /preprocess/duplicates/scan | POST /versions/{vid}/preprocess/duplicates/scan | scan_train_duplicates |
| POST /preprocess/duplicates/apply | POST /versions/{vid}/preprocess/duplicates/apply | apply_train_duplicate_removals |

### 4. Response 契约变化（新 endpoint vs 老 endpoint）

- **files endpoint**: 返 \`{images, summary}\` 替代老 \`{processed, pending,
  summary}\` 双 grid。新模型 train 即"训练集 grid"，状态从字段差异隐含推断
  （ADR 0010 §Manifest schema v2）
- **restore endpoint**: 返 \`{restored, missing, no_origin}\` 三组（老的只
  \`{restored, missing}\`）。\`no_origin\` 给前端三选项 UI [拖入替换 / 保留
  / 移除]（ADR 0010 §Restore 语义）
- **reset endpoint**: train_clear_all 只清 manifest **不动 train/ 物理
  文件**（train 是训练数据本身，不该被预处理清空操作引发删除）
- **duplicates scan**: \`target\` 字段从 \`\"preprocess\"\` 改 \`\"train\"\`
  标识 scope

## 测试

新增 24 个 case：

| 文件 | case 数 |
|---|---|
| test_train_scope_endpoints.py | 16 |
| test_migrations.py (新增 _v11) | +5 |
| test_versions_phase.py (新增 preprocessing skip/check) | +3 |

改 3 个老测试反映新 6 phase ORDER：
- test_version_status_phase.py::test_version_phase_order_and_skippable
- test_versions_phase.py::test_advance_phase_curating_to_preprocessing（原 to_tagging）
- test_phase_endpoints.py::test_advance_curating_to_preprocessing_with_image（原 to_tagging）

### \`python -m studio test\`

**2011 passed, 12 failed** —— 12 fail 跟 PR-2 当时是同一批 pre-existing
failures（test_cltagger / test_downloader / test_logging_bootstrap /
test_train_endpoints / test_xy_matrix_schema），跟本 PR 改动 0 关联。零
新增回归。

PR-2 时 1986 → PR-3 2011 = +25 passed 对应新增 24 + route_snapshot
regenerated +1。

### 老 endpoint 套件全过

- test_preprocess_endpoints.py / test_curation_endpoints.py 28 case
  全过 — 老 URL backward-compat 完整

## 后续

| PR | 范围 | 状态 |
|---|---|---|
| PR-1 #209 ✅ | ADR 0010 + ensure_train_manifest fallback | merged |
| PR-2 #210 ✅ | 后端 train-scope API + worker 分发 | merged |
| **PR-3（本 PR）** | preprocessing phase + 10 vid-aware endpoint | 本 PR |
| PR-4 | 前端 Preprocess 子页 + Sidebar 重排 + i18n "（可选）" | 待 |
| PR-5（清理） | 删老 endpoint + 老 service API（manifest.load/resolve/list_pending/list_processed/mark_duplicate_removed/restore/clear_all + worker 老 upscale 路径 + curation 老 copy_to_train） | 待 PR-4 后 |