### PR TITLE
fix(ui): symmetric InfoNoise mutex + backend compat for old configs

### DIFF
--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -351,7 +351,13 @@ class TrainingConfig(BaseModel):
     noise_enhancement_type: Literal["none", "offset", "pyramid"] = Field(
         "none",
         description="噪声增强机制（默认 none）。offset 在噪声上加 per-sample DC 偏置；pyramid 在多个尺度叠加低频噪声。两者机制不同，但都改变低频成分，互斥防双倍叠加。LoRA 训练默认保持 none",
-        json_schema_extra=_meta("noise_augmentation", advanced=True),
+        json_schema_extra=_meta(
+            "noise_augmentation",
+            advanced=True,
+            disable_when="infonoise_enabled==true",
+            disable_value="none",
+            disable_hint="InfoNoise 启用时禁用噪声增强（schema 互斥）",
+        ),
     )
     noise_offset: float = Field(
         0.0, ge=0.0, le=0.2,

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -355,7 +355,6 @@ class TrainingConfig(BaseModel):
             "noise_augmentation",
             advanced=True,
             disable_when="infonoise_enabled==true",
-            disable_value="none",
             disable_hint="InfoNoise 启用时禁用噪声增强（schema 互斥）",
         ),
     )
@@ -421,6 +420,8 @@ class TrainingConfig(BaseModel):
             alt_description="【InfoNoise 热身期】InfoNoise 开启时仅热身期生效；正式阶段由自适应 CDF 接管",
             alt_description_when="infonoise_enabled==true",
             advanced=True,
+            disable_when="infonoise_enabled==true",
+            disable_hint="InfoNoise 启用时禁用 schedule shift（schema 互斥，仅 1.0 兼容）",
         ),
     )
     infonoise_enabled: bool = Field(
@@ -466,7 +467,11 @@ class TrainingConfig(BaseModel):
     loss_type: Literal["mse", "huber"] = Field(
         "mse",
         description="训练 loss 类型。mse 经典；huber 对 outlier 鲁棒（在 |x|<δ 时用二次，|x|≥δ 时用线性）",
-        json_schema_extra=_meta("loss"),
+        json_schema_extra=_meta(
+            "loss",
+            disable_when="infonoise_enabled==true",
+            disable_hint="InfoNoise 启用时禁用 loss 类型切换（schema 互斥，仅 mse 兼容）",
+        ),
     )
     huber_c: float = Field(
         0.15, ge=0.01, le=5.0,
@@ -476,7 +481,11 @@ class TrainingConfig(BaseModel):
     loss_weighting: Literal["none", "min_snr", "detail_inv_t", "cosmap"] = Field(
         "none",
         description="loss 加权方案：none 不加权；min_snr 抑制极端时步的权重；detail_inv_t 强化低 t 细节；cosmap 用 SD3 cosine 映射",
-        json_schema_extra=_meta("loss"),
+        json_schema_extra=_meta(
+            "loss",
+            disable_when="infonoise_enabled==true",
+            disable_hint="InfoNoise 启用时禁用 loss 加权（schema 互斥，仅 none 兼容）",
+        ),
     )
     min_snr_gamma: float = Field(
         5.0, ge=0.1, le=20.0,

--- a/studio/web/src/components/SchemaForm.test.tsx
+++ b/studio/web/src/components/SchemaForm.test.tsx
@@ -201,4 +201,33 @@ describe('SchemaForm takeover behavior', () => {
     expect(screen.getByText('InfoNoise takes over timestep sampling')).toBeInTheDocument()
     expect(screen.queryByText('Normal timestep description')).not.toBeInTheDocument()
   })
+
+  it('disable_when without disable_value preserves the existing value (no silent reset)', async () => {
+    const onChange = vi.fn()
+    // timestep_sampling has disable_when='infonoise_enabled==true' but NO disable_value
+    // in the mock schema. Old behavior reset to prop.default; new behavior keeps the
+    // user's value so the backend model_validator surfaces the real conflict combo.
+    render(
+      <SchemaForm
+        schema={schema}
+        values={{
+          optimizer_type: 'adamw',
+          learning_rate: 0.0001,
+          lr_scheduler: 'none',
+          infonoise_enabled: true,
+          timestep_sampling: 'uniform',
+        }}
+        onChange={onChange}
+        advancedMode
+      />,
+    )
+
+    // Yield once to let the disable-takeover useEffect run (it would have called
+    // onChange under the old behavior).
+    await new Promise((r) => setTimeout(r, 0))
+    expect(onChange).not.toHaveBeenCalled()
+    const timestepSelect = screen.getAllByRole('combobox').find((el) => (el as HTMLSelectElement).value === 'uniform') as HTMLSelectElement
+    expect(timestepSelect.value).toBe('uniform')
+    expect(timestepSelect).toBeDisabled()
+  })
 })

--- a/studio/web/src/components/SchemaForm.tsx
+++ b/studio/web/src/components/SchemaForm.tsx
@@ -54,12 +54,15 @@ export default function SchemaForm({
   }
   const takeoverValueForField = (name: string, prop: typeof props[string]) => {
     if (name === 'lr_scheduler' && isProdigyOptimizer) return 'none'
-    return prop.disable_value ?? prop.default
+    return prop.disable_value
   }
 
-  // disable_when 触发时把字段值强制回到 default。避免「切换 optimizer 到
-  // prodigy_plus_schedulefree 之后 lr_scheduler 还停在 cosine，保存时被 pydantic
-  // model_validator 拒绝」这种死锁 UX。
+  // disable_when 触发时：
+  //   - 显式带 disable_value（或 lr_scheduler 特例）→ 强制改值，避免「切到 prodigy
+  //     之后 lr_scheduler 还停在 cosine 保存被 pydantic 拒」的死锁 UX
+  //   - 只 disable_when 不带 disable_value → 保留用户当前值，把冲突交给后端
+  //     model_validator 报错（InfoNoise 互斥四件套走这条：让用户看到原始冲突
+  //     值 + toast 告知是哪个组合炸，而不是 silent 抹掉用户的 detail_inv_t / huber）
   useEffect(() => {
     let nextValues = values
     let changed = false

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -341,7 +341,8 @@
       "learning_rate": "Prodigy controls the learning rate",
       "lr_scheduler": "Adaptive optimizers use a constant learning rate",
       "timestep_sampling": "InfoNoise controls timestep sampling",
-      "timestep_shift": "InfoNoise controls timestep sampling"
+      "timestep_shift": "InfoNoise controls timestep sampling",
+      "noise_enhancement_type": "Disabled while InfoNoise is enabled (schema mutex)"
     },
     "descriptions": {
       "transformer_path": "Main diffusion model weights (.safetensors)",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -342,7 +342,10 @@
       "lr_scheduler": "Adaptive optimizers use a constant learning rate",
       "timestep_sampling": "InfoNoise controls timestep sampling",
       "timestep_shift": "InfoNoise controls timestep sampling",
-      "noise_enhancement_type": "Disabled while InfoNoise is enabled (schema mutex)"
+      "noise_enhancement_type": "Disabled while InfoNoise is enabled (schema mutex)",
+      "loss_weighting": "Disabled while InfoNoise is enabled (schema mutex, only `none` compatible)",
+      "loss_type": "Disabled while InfoNoise is enabled (schema mutex, only `mse` compatible)",
+      "timestep_schedule_shift": "Disabled while InfoNoise is enabled (schema mutex, only `1.0` compatible)"
     },
     "descriptions": {
       "transformer_path": "Main diffusion model weights (.safetensors)",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -341,7 +341,8 @@
       "learning_rate": "Prodigy 接管学习率",
       "lr_scheduler": "自适应优化器固定为常数学习率",
       "timestep_sampling": "InfoNoise 接管时间步采样",
-      "timestep_shift": "InfoNoise 接管时间步采样"
+      "timestep_shift": "InfoNoise 接管时间步采样",
+      "noise_enhancement_type": "InfoNoise 启用时禁用噪声增强（schema 互斥）"
     },
     "descriptions": {
       "transformer_path": "主扩散模型权重（.safetensors）",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -342,7 +342,10 @@
       "lr_scheduler": "自适应优化器固定为常数学习率",
       "timestep_sampling": "InfoNoise 接管时间步采样",
       "timestep_shift": "InfoNoise 接管时间步采样",
-      "noise_enhancement_type": "InfoNoise 启用时禁用噪声增强（schema 互斥）"
+      "noise_enhancement_type": "InfoNoise 启用时禁用噪声增强（schema 互斥）",
+      "loss_weighting": "InfoNoise 启用时禁用 loss 加权（schema 互斥，仅 none 兼容）",
+      "loss_type": "InfoNoise 启用时禁用 loss 类型切换（schema 互斥，仅 mse 兼容）",
+      "timestep_schedule_shift": "InfoNoise 启用时禁用 schedule shift（schema 互斥，仅 1.0 兼容）"
     },
     "descriptions": {
       "transformer_path": "主扩散模型权重（.safetensors）",


### PR DESCRIPTION
## 背景

InfoNoise 一共有 4 对 schema-level 互斥（`TrainingConfig.model_validator`s）：

| 控制方 | 被控字段 | 冲突值 |
|---|---|---|
| `infonoise_enabled=true` | `noise_enhancement_type` | `!= none` |
| `infonoise_enabled=true` | `loss_weighting` | `!= none` |
| `infonoise_enabled=true` | `loss_type` | `== huber` |
| `infonoise_enabled=true` | `timestep_schedule_shift` | `!= 1.0` |

后端 validator 4 条全在，但前端表单 4 个字段都没装 `disable_when`。结果：用户可以随便切，等 Train 页 600 ms debounce auto-save 才弹一个 `train.saveFailed` toast，表单状态仍 dirty —— 视觉就是「互斥没生效」。

参考 Prodigy → `lr_scheduler` 已经在用 schema-driven UI mutex（`SchemaForm.tsx:51`），把这套铺到 InfoNoise 4 件套。

## 设计迭代历程

本 PR 走过 3 稿才定型，分别对应 commit `dae3c45` / `d99f665` / `9e336a4`。

### Round 1 (`dae3c45`)：只锁 `noise_enhancement_type` + auto-reset

给 `noise_enhancement_type` 加 `disable_when=infonoise_enabled==true` + `disable_value=\"none\"`。开 InfoNoise → 噪声增强自动 reset 到 none。

问题：1）只覆盖了 1 对（剩 3 对没动）；2）老 config 进来会被 silent 抹掉用户原投入。

### Round 2 (`d99f665`)：4 对全装 + 保留值 + 让后端 toast 报错

去掉 `disable_value`，加给 4 对全装 `disable_when`。`SchemaForm` 改 `takeoverValueForField` 不再 fallback 到 default。

问题：老 config（infonoise=on + loss_weighting=detail_inv_t）进来 → loss_weighting 灰显但仍是 detail_inv_t → 保存触发后端拒 → toast 报错 → **但 loss_weighting 也是灰的，用户改不了**。死锁。

### Round 3 (`9e336a4`，本 PR 最终态)：「先开的赢」对称锁 + 后端 compat

经用户盘点后明确：

- **实时切换**：先把某侧切到非默认的赢，另一侧灰显 + reset 到 default
- **老 config**：进入后由**后端**容错关掉 InfoNoise，保留用户原值，前端顶部 banner 提示

具体实施：

1. **`SchemaForm.tsx`**：恢复 `disable_value ?? prop.default` fallback（round 1 行为）
2. **`domain/training.py`**：
   - 4 个被控字段保留 round 2 的 `disable_when=infonoise_enabled==true`
   - **新增 `infonoise_enabled` 反向 `disable_when`**（复合 OR）：
     ```
     noise_enhancement_type!=none||loss_weighting!=none||loss_type==huber||timestep_schedule_shift!=1
     ```
   - 两侧都装 `disable_when` 形成**对称锁**，谁先非默认谁赢
3. **`services/presets/io.py`**：`_tolerant_validate` 加 InfoNoise compat 分支。当 model_validator 报错（loc=()）且 raw 里 `infonoise_enabled=True`，自动设 False + append `\"infonoise_enabled\"` 到 `defaulted_fields`，重试。一次性把 4 对冲突全清。`write_preset` 严格路径**不**走 compat（前端绕过 disable_when 直接 PUT 应该报错）。
4. **`api/routers/projects/training.py` + `services/version_config.py`**：GET 端点新增 `defaulted_fields` / `dropped_fields` 字段；`read_version_config_with_warnings` 拆出来供 GET 用，老 `read_version_config` 保留兼容
5. **`pages/project/steps/Train.tsx`**：`refreshConfig` 调用 `applyPresetWarnings(r)`，让现有顶部 banner 在初次 load 也亮起（之前只在 fork preset / save as preset 路径亮）
6. **i18n**：新增 `disableHints.infonoise_enabled` 描述反向锁

## 4 对 user case 矩阵

| Case | state | 动作 | 行为 |
|---|---|---|---|
| 实时-A | infonoise=off + 4 字段都默认 | 点 InfoNoise on | InfoNoise 上勾；4 字段灰显（已经全是 default，无 reset 动作） |
| 实时-B | infonoise=off + loss_weighting=detail_inv_t | 点 loss_weighting=none | loss_weighting=none；InfoNoise checkbox 解锁 |
| 实时-C | infonoise=on | 点 InfoNoise off | 4 字段解锁 |
| 实时-D | loss_weighting=detail_inv_t | 切 weighting=none | InfoNoise 解锁 |
| 老 config | infonoise=on + weighting=detail_inv_t | 进入 Train 页 | 后端关 InfoNoise + 保留 detail_inv_t；顶部 banner: \"已重置：infonoise_enabled\" |
| 老 config 多冲突 | infonoise=on + 4 字段全非默认 | 进入 | 一刀关 InfoNoise，4 字段全保留；banner 同上 |

## 测试

- `tests/test_presets_io.py` 新增 **3 个 case**：
  - `test_tolerant_validate_infonoise_mutex_disables_infonoise`：4 对单冲突分别覆盖
  - `test_tolerant_validate_infonoise_mutex_multi_conflict_one_pass`：4 对同冲突一次清，defaulted_fields 只 append 一次
  - `test_write_preset_strict_path_still_rejects_infonoise_mutex`：严格保存路径不走 compat
- 后端：61 InfoNoise/timestep + 85 presets+infonoise+timestep 全过
- 前端：SchemaForm.test.tsx 4/4 + npx tsc --noEmit clean + npm run lint clean

`python -m studio test` 全量在本机有一批 pre-existing 失败（pydantic + `typing._SpecialForm` AttributeError 4 条 + test_version_config 4 条 stale Lion-invalid 断言），stash 本 PR 改动后同样失败，与本 PR 无关。

## 手测路径

**case A — 4 字段灰显对称**
1. Train 页进阶模式 → 时间步采样组
2. 打开 `infonoise_enabled` → 4 字段同时灰显（noise_enhancement / loss_weighting / loss_type / timestep_schedule_shift），各显 disable hint
3. 关 `infonoise_enabled` → 4 字段解锁
4. 切 `loss_weighting=detail_inv_t` → `infonoise_enabled` checkbox 反向灰显，hint: \"需先把 noise_enhancement / loss_weighting / loss_type / schedule_shift 全部置默认才能启用\"

**case B — 老 config 兼容 + banner**
1. 准备冲突 yaml：`infonoise_enabled: true` + `loss_weighting: detail_inv_t`
2. 进入 Train 页
3. 顶部黄色 banner 显: \"已重置：infonoise_enabled\"
4. 表单：`infonoise_enabled=false` + `loss_weighting=detail_inv_t` 保留
5. 用户保留 detail_inv_t 直接保存 OK；或者改 weighting=none 后再开 InfoNoise

🤖 Generated with [Claude Code](https://claude.com/claude-code)