### PR TITLE
fix(upload): apply convert_to_png + stem-collision suffix to dataset uploads

### DIFF
--- a/studio/api/routers/projects/ingestion.py
+++ b/studio/api/routers/projects/ingestion.py
@@ -150,6 +150,10 @@ async def upload_local_files(
 
     与 booru 下载共用同一份「全量备份」目录；上传不走 job 系统，端点同步处理
     并返回 added / skipped 列表。任一文件成功即把项目 stage 推到 downloading。
+
+    复用 `gelbooru.convert_to_png` / `remove_alpha_channel` 设置：开启时上传图
+    也归一到 PNG（同 stem 加 `_1` 后缀避免 caption 撞车），与 booru 下载链路
+    保持一致。
     """
     if not files:
         raise HTTPException(400, "没有上传文件")
@@ -165,7 +169,12 @@ async def upload_local_files(
     for f in files:
         data = await f.read()
         pairs.append((f.filename or "", io.BytesIO(data)))
-    result = uploads_svc.accept_many(pairs, pdir)
+    sec = secrets.load()
+    result = uploads_svc.accept_many(
+        pairs, pdir,
+        convert_to_png=sec.gelbooru.convert_to_png,
+        remove_alpha_channel=sec.gelbooru.remove_alpha_channel,
+    )
     return _apply_project_upload_result(pid, result)
 
 
@@ -186,8 +195,13 @@ def upload_local_file_from_path(pid: int, body: UploadFromPathBody) -> dict[str,
     if not src.is_file():
         raise HTTPException(400, "请选择文件")
     pdir = projects.project_dir(p["id"], p["slug"]) / "download"
+    sec = secrets.load()
     with src.open("rb") as fh:
-        result = uploads_svc.accept_many([(src.name, fh)], pdir)
+        result = uploads_svc.accept_many(
+            [(src.name, fh)], pdir,
+            convert_to_png=sec.gelbooru.convert_to_png,
+            remove_alpha_channel=sec.gelbooru.remove_alpha_channel,
+        )
     return _apply_project_upload_result(pid, result)
 
 

--- a/studio/services/dataset/uploads.py
+++ b/studio/services/dataset/uploads.py
@@ -5,19 +5,31 @@
 
 约束：
 - 接受 IMAGE_EXTS 里所有格式的单图（png / jpg / jpeg / webp / bmp / gif）；
-  zip 包内同样按这套白名单提取，原样落盘（不做格式转换）。
+  zip 包内同样按这套白名单提取。
 - zip 内的子目录结构会被拍平（取 basename）。
-- 文件名冲突保守跳过，不覆盖、不自动重命名 —— 让用户知道哪里跳过了。
 - zip 损坏时整包跳过并报告，不影响其它文件。
+
+`convert_to_png` 模式（与 booru 下载共用的 `gelbooru.convert_to_png` 设置）：
+- 所有图片经 PIL 解码后统一重编码为 .png，文件名 stem 不变后缀改 .png；
+- 同 stem 冲突（含 `1.jpg` + `1.png` 同上传一次的场景）改加 `_1`/`_2` 后缀
+  落盘，避免 caption `1.txt` 被两张不同图共用；
+- `remove_alpha_channel=True` 时按白底压平 alpha，与 booru 下载一致；
+- PIL 解码失败按 skipped 上报「图片损坏」。
+
+`convert_to_png=False`（默认）保持历史行为：原扩展名拷贝、目标已存在则跳过。
 """
 from __future__ import annotations
 
 import shutil
 import zipfile
 from dataclasses import dataclass, field
+from io import BytesIO
 from pathlib import Path
 from typing import BinaryIO, Iterable
 
+from PIL import Image
+
+from ..booru.api import flatten_alpha, has_alpha
 from .scan import IMAGE_EXTS
 
 # PP10 起复用全链路白名单：上传 / 下载 / curation / 训练共用一份。
@@ -49,13 +61,82 @@ def _is_image_ext(name: str) -> bool:
     return Path(name).suffix.lower() in ALLOWED_IMAGE_EXTS
 
 
+def _unique_target(dest_dir: Path, name: str) -> Path:
+    """目标已存在时加 `_1` / `_2` ... 后缀直到不冲突。
+
+    用于 convert_to_png 模式：用户的本意是「这张图也进来」，文件名冲突时
+    用后缀保住第二张，而不是丢弃。caption 文件按落盘后的实际 stem 配对，
+    所以后缀化的 `1_1.png` 会拿到独立的 `1_1.txt`，不再与 `1.png` 共用。
+    """
+    target = dest_dir / name
+    if not target.exists():
+        return target
+    stem = Path(name).stem
+    suffix = Path(name).suffix
+    i = 1
+    while True:
+        cand = dest_dir / f"{stem}_{i}{suffix}"
+        if not cand.exists():
+            return cand
+        i += 1
+
+
+def _write_image_entry(
+    src_name: str,
+    src_stream: BinaryIO,
+    dest_dir: Path,
+    *,
+    convert_to_png: bool,
+    remove_alpha_channel: bool,
+    report_name: str,
+    result: UploadResult,
+) -> None:
+    """落盘单张图。"""
+    if not convert_to_png:
+        target = dest_dir / src_name
+        if target.exists():
+            result.skipped.append(
+                {"name": report_name, "reason": "已存在，跳过"}
+            )
+            return
+        with target.open("wb") as fh:
+            shutil.copyfileobj(src_stream, fh)
+        result.added.append(src_name)
+        return
+
+    raw = src_stream.read()
+    try:
+        img = Image.open(BytesIO(raw))
+        img.load()
+    except Exception as exc:  # noqa: BLE001 — PIL 抛多种类型，整体当损坏
+        result.skipped.append(
+            {"name": report_name, "reason": f"图片损坏: {exc}"}
+        )
+        return
+    target = _unique_target(dest_dir, Path(src_name).stem + ".png")
+    if remove_alpha_channel and has_alpha(img):
+        img = flatten_alpha(img)
+    out = (
+        img.convert("RGBA")
+        if has_alpha(img) and not remove_alpha_channel
+        else img.convert("RGB")
+    )
+    out.save(target, "PNG", optimize=True)
+    result.added.append(target.name)
+
+
 def accept_one(
-    src_name: str, src_stream: BinaryIO, dest_dir: Path
+    src_name: str,
+    src_stream: BinaryIO,
+    dest_dir: Path,
+    *,
+    convert_to_png: bool = False,
+    remove_alpha_channel: bool = False,
 ) -> UploadResult:
     """处理单个上传文件。
 
-    - IMAGE_EXTS 内任一格式 → 直接拷到 dest_dir（不做格式转换）
-    - zip → 解压所有图片格式（拍平）
+    - IMAGE_EXTS 内任一格式 → 落盘（按 convert_to_png 决定是否重编码 PNG）
+    - zip → 解压所有图片格式（拍平、内层 entry 同样按 convert_to_png 处理）
     - 其他 / 没扩展名 → 拒绝
     """
     base = _safe_basename(src_name or "")
@@ -68,13 +149,13 @@ def accept_one(
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     if suffix in ALLOWED_IMAGE_EXTS:
-        target = dest_dir / base
-        if target.exists():
-            result.skipped.append({"name": base, "reason": "已存在，跳过"})
-        else:
-            with target.open("wb") as fh:
-                shutil.copyfileobj(src_stream, fh)
-            result.added.append(base)
+        _write_image_entry(
+            base, src_stream, dest_dir,
+            convert_to_png=convert_to_png,
+            remove_alpha_channel=remove_alpha_channel,
+            report_name=base,
+            result=result,
+        )
         return result
 
     if suffix == ZIP_EXT:
@@ -92,15 +173,14 @@ def accept_one(
                             {"name": label, "reason": "格式不支持"}
                         )
                         continue
-                    target = dest_dir / inner_base
-                    if target.exists():
-                        result.skipped.append(
-                            {"name": label, "reason": "已存在，跳过"}
+                    with zf.open(info) as entry:
+                        _write_image_entry(
+                            inner_base, entry, dest_dir,
+                            convert_to_png=convert_to_png,
+                            remove_alpha_channel=remove_alpha_channel,
+                            report_name=label,
+                            result=result,
                         )
-                        continue
-                    with zf.open(info) as src, target.open("wb") as dst:
-                        shutil.copyfileobj(src, dst)
-                    result.added.append(inner_base)
         except zipfile.BadZipFile:
             result.skipped.append({"name": base, "reason": "zip 损坏"})
         return result
@@ -113,10 +193,20 @@ def accept_one(
 
 
 def accept_many(
-    files: Iterable[tuple[str, BinaryIO]], dest_dir: Path
+    files: Iterable[tuple[str, BinaryIO]],
+    dest_dir: Path,
+    *,
+    convert_to_png: bool = False,
+    remove_alpha_channel: bool = False,
 ) -> UploadResult:
     """批量处理；汇总 added / skipped。"""
     out = UploadResult()
     for name, stream in files:
-        out.merge(accept_one(name, stream, dest_dir))
+        out.merge(
+            accept_one(
+                name, stream, dest_dir,
+                convert_to_png=convert_to_png,
+                remove_alpha_channel=remove_alpha_channel,
+            )
+        )
     return out

--- a/tests/test_download_endpoints.py
+++ b/tests/test_download_endpoints.py
@@ -19,7 +19,18 @@ def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(server.db, "STUDIO_DB", dbfile)
     monkeypatch.setattr(secrets, "SECRETS_FILE", tmp_path / "secrets.json")
-    secrets.update({"gelbooru": {"user_id": "u", "api_key": "k"}})
+    # 上传 endpoint 默认会按 gelbooru.convert_to_png 走 PIL 重编码；这里关掉，让
+    # 现有用 raw bytes 的上传测试继续验证原始拷贝分支。convert 路径用专门测试。
+    secrets.update(
+        {
+            "gelbooru": {
+                "user_id": "u",
+                "api_key": "k",
+                "convert_to_png": False,
+                "remove_alpha_channel": False,
+            }
+        }
+    )
     return {"db": dbfile}
 
 
@@ -365,6 +376,48 @@ def test_upload_skip_existing(client: TestClient) -> None:
     assert body["added"] == []
     assert body["skipped"][0]["reason"] == "已存在，跳过"
     assert (pdir / "x.png").read_bytes() == b"old"
+
+
+def test_upload_convert_to_png_renames_and_dedups(
+    client: TestClient,
+) -> None:
+    """gelbooru.convert_to_png=True：上传 1.png + 1.jpg（不同图）→ 1.png + 1_1.png。
+
+    解决 caption `1.txt` 被 jpg/png 两张不同图共用的问题；同 stem 加 `_N` 后缀
+    保住第二张而不是跳过。
+    """
+    import io as _io
+
+    from PIL import Image
+    from studio import secrets
+
+    secrets.update({"gelbooru": {"convert_to_png": True}})
+
+    def _png(color):
+        buf = _io.BytesIO()
+        Image.new("RGB", (4, 4), color).save(buf, "PNG")
+        return buf.getvalue()
+
+    def _jpg(color):
+        buf = _io.BytesIO()
+        Image.new("RGB", (4, 4), color).save(buf, "JPEG", quality=90)
+        return buf.getvalue()
+
+    p = _make_project(client)
+    r = client.post(
+        f"/api/projects/{p['id']}/upload",
+        files=[
+            ("files", ("1.png", _png((0, 0, 0)), "image/png")),
+            ("files", ("1.jpg", _jpg((255, 255, 255)), "image/jpeg")),
+        ],
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert sorted(body["added"]) == ["1.png", "1_1.png"]
+    assert body["skipped"] == []
+    pdir = projects.project_dir(p["id"], p["slug"]) / "download"
+    assert (pdir / "1.png").exists()
+    assert (pdir / "1_1.png").exists()
 
 
 def test_upload_404_for_unknown_project(client: TestClient) -> None:

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -6,8 +6,27 @@ import zipfile
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 from studio.services.dataset import uploads
+
+
+def _png_bytes(size: tuple[int, int] = (4, 4), color: tuple[int, int, int] = (255, 0, 0)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, "PNG")
+    return buf.getvalue()
+
+
+def _jpg_bytes(size: tuple[int, int] = (4, 4), color: tuple[int, int, int] = (0, 128, 255)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGB", size, color).save(buf, "JPEG", quality=90)
+    return buf.getvalue()
+
+
+def _rgba_png_bytes(size: tuple[int, int] = (4, 4)) -> bytes:
+    buf = io.BytesIO()
+    Image.new("RGBA", size, (10, 20, 30, 100)).save(buf, "PNG")
+    return buf.getvalue()
 
 
 def _zip_bytes(entries: dict[str, bytes]) -> bytes:
@@ -133,3 +152,100 @@ def test_dest_dir_created(tmp_path: Path) -> None:
     out = uploads.accept_one("x.jpg", io.BytesIO(b"x"), target)
     assert out.added == ["x.jpg"]
     assert (target / "x.jpg").exists()
+
+
+# ---------------------------------------------------------------------------
+# convert_to_png 模式：与 booru 下载共用的 gelbooru.convert_to_png 设置
+# ---------------------------------------------------------------------------
+
+
+def test_convert_jpg_renamed_to_png(tmp_path: Path) -> None:
+    out = uploads.accept_one(
+        "photo.jpg", io.BytesIO(_jpg_bytes()), tmp_path,
+        convert_to_png=True,
+    )
+    assert out.added == ["photo.png"]
+    assert (tmp_path / "photo.png").exists()
+    # 已重编码为合法 PNG
+    with Image.open(tmp_path / "photo.png") as im:
+        assert im.format == "PNG"
+
+
+def test_convert_same_stem_collision_gets_suffix(tmp_path: Path) -> None:
+    """1.png + 1.jpg 同一次上传：第二张转完撞名 → 加 _1 后缀，避免 caption 共用。"""
+    files = [
+        ("1.png", io.BytesIO(_png_bytes(color=(0, 0, 0)))),
+        ("1.jpg", io.BytesIO(_jpg_bytes(color=(255, 255, 255)))),
+    ]
+    out = uploads.accept_many(files, tmp_path, convert_to_png=True)
+    assert sorted(out.added) == ["1.png", "1_1.png"]
+    assert out.skipped == []
+    assert (tmp_path / "1.png").exists()
+    assert (tmp_path / "1_1.png").exists()
+
+
+def test_convert_collision_in_zip_gets_suffix(tmp_path: Path) -> None:
+    blob = _zip_bytes(
+        {
+            "a.png": _png_bytes(color=(10, 10, 10)),
+            "a.jpg": _jpg_bytes(color=(200, 200, 200)),
+        }
+    )
+    out = uploads.accept_one(
+        "pack.zip", io.BytesIO(blob), tmp_path,
+        convert_to_png=True,
+    )
+    assert sorted(out.added) == ["a.png", "a_1.png"]
+    assert (tmp_path / "a.png").exists()
+    assert (tmp_path / "a_1.png").exists()
+
+
+def test_convert_collision_against_existing_file(tmp_path: Path) -> None:
+    """目标目录已经有 a.png，新上传 a.jpg 在 convert 模式下落 a_1.png（不跳过）。"""
+    (tmp_path / "a.png").write_bytes(_png_bytes())
+    out = uploads.accept_one(
+        "a.jpg", io.BytesIO(_jpg_bytes()), tmp_path,
+        convert_to_png=True,
+    )
+    assert out.added == ["a_1.png"]
+    assert (tmp_path / "a_1.png").exists()
+
+
+def test_convert_corrupt_image_skipped(tmp_path: Path) -> None:
+    out = uploads.accept_one(
+        "broken.jpg", io.BytesIO(b"not-a-real-image"), tmp_path,
+        convert_to_png=True,
+    )
+    assert out.added == []
+    assert len(out.skipped) == 1
+    assert "图片损坏" in out.skipped[0]["reason"]
+
+
+def test_convert_remove_alpha_channel_flattens(tmp_path: Path) -> None:
+    out = uploads.accept_one(
+        "rgba.png", io.BytesIO(_rgba_png_bytes()), tmp_path,
+        convert_to_png=True,
+        remove_alpha_channel=True,
+    )
+    assert out.added == ["rgba.png"]
+    with Image.open(tmp_path / "rgba.png") as im:
+        assert im.mode == "RGB"  # alpha 已被白底压平
+
+
+def test_convert_keeps_alpha_when_flag_off(tmp_path: Path) -> None:
+    out = uploads.accept_one(
+        "rgba.png", io.BytesIO(_rgba_png_bytes()), tmp_path,
+        convert_to_png=True,
+        remove_alpha_channel=False,
+    )
+    assert out.added == ["rgba.png"]
+    with Image.open(tmp_path / "rgba.png") as im:
+        assert im.mode == "RGBA"
+
+
+def test_convert_off_preserves_raw_bytes(tmp_path: Path) -> None:
+    """convert_to_png=False（默认）继续走原扩展名拷贝、目标已存在跳过。"""
+    raw = b"\xff\xd8not-decoded"
+    out = uploads.accept_one("photo.jpg", io.BytesIO(raw), tmp_path)
+    assert out.added == ["photo.jpg"]
+    assert (tmp_path / "photo.jpg").read_bytes() == raw


### PR DESCRIPTION
## 背景 / 动机

当 `gelbooru.convert_to_png` 设置开启时，booru 下载路径会把所有图归一为
`.png`，但 **dataset 上传 / 服务端路径导入** 路径之前是 raw bytes 透传，
没经过 PIL。结果：用户既下载又上传时，`download/` 目录下会同时出现 `.png`
和 `.jpg`/`.webp` 的图。后续训练用 `{stem}.txt` 配对 caption，`1.png` 和
`1.jpg`（两张**不同**图）会共用 `1.txt`，捕捉不到。

## 改动概要

### `studio/services/dataset/uploads.py`
- `accept_one` / `accept_many` 加 `convert_to_png` + `remove_alpha_channel` kwarg（默认 False，保留旧行为）
- 抽 `_write_image_entry` helper：convert 模式 PIL 解码 + PNG 重编码，复用 `services/booru/api.has_alpha` / `flatten_alpha` 与 booru 下载链路对齐
- 抽 `_unique_target`：同 stem 冲突加 `_1` / `_2` ... 后缀，避免丢图；用户的本意是「这张图也进来」，而不是因撞名被跳过
- PIL 解码失败按 `skipped` 上报「图片损坏: ...」
- zip 内部 entry 同样走 helper

### `studio/api/routers/projects/ingestion.py`
- `upload_local_files` + `upload_local_file_from_path` 都从 `secrets.load().gelbooru.*` 读两个设置传给 `accept_many`

### 设置命名

暂复用 `gelbooru.convert_to_png` / `gelbooru.remove_alpha_channel`。语义已扩展到所有 ingestion 路径，但避免本 PR 牵动 secrets schema 迁移；搬家（例如 `ingestion.convert_to_png`）单独开 PR。

## 测试方式

`tests/test_uploads.py` 新增 8 个 convert-mode 单测（用真实 PIL 生成的 png/jpg bytes）：
- jpg → png 重命名
- 同传 \`1.png\` + \`1.jpg\`（不同图）→ \`1.png\` + \`1_1.png\`
- zip 内 \`a.png\` + \`a.jpg\` → \`a.png\` + \`a_1.png\`
- 目标目录已有 \`a.png\` → 上传 \`a.jpg\` 落盘为 \`a_1.png\`（不跳过）
- 损坏 bytes → skipped 上报「图片损坏」
- `remove_alpha_channel=True` → alpha 压平为 RGB
- `remove_alpha_channel=False` → 保留 RGBA
- `convert_to_png=False`（默认）→ 原 bytes 拷贝

`tests/test_download_endpoints.py`：
- `isolated` fixture 显式设 `convert_to_png=False`，让现有 raw-bytes 上传测试继续覆盖原始拷贝分支
- 新增 `test_upload_convert_to_png_renames_and_dedups` 验证整链路：上传 \`1.png\` + \`1.jpg\`（不同图）→ \`download/1.png\` + \`download/1_1.png\`

```
pytest tests/test_uploads.py tests/test_download_endpoints.py   # 47/47 ✓
pytest tests/ -k 'upload or dataset or ingestion or project_routes' \
  --ignore=tests/test_downloader.py                              # 61/61 ✓
```

`tests/test_downloader.py` 上的 8 个 fail 与本 PR 无关，是 `FakeSession` 缺 `proxies` 属性的 pre-existing harness 问题；在 dev base 上 stash 出我的改动也复现。

🤖 Generated with [Claude Code](https://claude.com/claude-code)