### PR TITLE
fix(infonoise): mask reg samples by is_reg flag, decouple from loss_weight

### DIFF
--- a/docs/todo/infonoise-reg-policy-reeval.md
+++ b/docs/todo/infonoise-reg-policy-reeval.md
@@ -1,0 +1,100 @@
+# InfoNoise reg 集 record 策略重评估清单
+
+**创建于** 2026-06-05
+**触发** PR #216 commit `cfbfd218` 阈值方案的 follow-up；用户在 review 中发现 `loss_weight >= 0.99` 阈值在 `reg_weight=1.0` 边界有内部矛盾，三方算法分析后改为按 `is_reg` flag 硬过滤。
+**当前状态** 🟢 路线 1（is_reg hard exclude）已落地于 `runtime/training/loop.py:141-152` + `runtime/training/dataset.py`。本文档记录路线 2（loss_weight soft weighting）延后的依据 + 何时重评估。
+
+---
+
+## 当前实现（路线 1：is_reg 硬过滤）
+
+```python
+# runtime/training/loop.py
+if "is_reg" in batch:
+    _main_mask = ~batch["is_reg"].to(t.device)
+    if _main_mask.any():
+        ctx.timestep_sampler.record(t.detach()[_main_mask], _raw_mse[_main_mask])
+else:
+    ctx.timestep_sampler.record(t.detach(), _raw_mse)
+```
+
+- `MergedDataset.__getitem__` 给 main 样本写 `is_reg=False`，reg 样本写 `is_reg=True`
+- `collate_fn` / `collate_fn_cached` 透传 `is_reg` 为 `torch.bool` tensor
+- InfoNoise 的 FIFO/EMA 只看 main 样本的 (t, raw_mse)，CDF 学 mmse_main(t)
+- reg 样本仍照常进梯度，按 `reg_weight` 加权（loop.py:154-156 那段不动）
+- 对 `reg_weight` 任何取值（0.3 / 0.7 / 1.0 / 任意）都是同一种 mask 行为
+
+## 备选路线 2（已延后：loss_weight soft 加权）
+
+不过滤，按 loss_weight 加权 record 进 FIFO/EMA：
+
+```python
+ctx.timestep_sampler.record(t, raw_mse, weights=batch["loss_weight"])
+# InfoNoise 内部 bucket aggregation 改为 weighted: sum(w*mse) / sum(w)
+```
+
+数学性质：对真实目标 `L = E_main[ℓ] + λ E_reg[ℓ]` 的 min-variance importance sampling proposal（Katharopoulos-Fleuret 等），λ 连续 unbiased。
+
+## 选路线 1 而非路线 2 的依据（2026-06-05 三 agent 分析）
+
+三个独立 lens：
+
+| Lens | Q1 | 置信度 |
+|---|---|---|
+| 信息论 / I-MMSE | exclude_all | 72% |
+| weighted ERM / IS | soft_weight_by_loss_weight | 78% |
+| 训练动力学 / 用户目标 | exclude_all | 78% |
+
+**多数（2/3）支持 hard exclude**。三方一致拒绝 `loss_weight >= 0.99` 旧方案（A: type error / B: arbitrary θ / C: identity vs weight 错配）。
+
+**核心争点**：InfoNoise 工具的 job 是什么？
+- 路线 1（A+C）："main 分布的 MMSE 估计器"，reg 是 means 不是 ends
+- 路线 2（B）："你写下的 weighted ERM 的 min-variance IS proposal"
+
+路线 1 胜出的现实依据：
+1. InfoNoise 论文契约（I-MMSE）严格依赖单分布；mixture 推广未证（Lens B 自承盲点 #1）
+2. 当前 AnimaLoraStudio 用户群 99% 是单角色 / 单画风 LoRA + 通用图 reg，reg 是辅助 prior 而非 co-training target
+3. `reg_weight=1.0` 在社区实际语义是"强正则"，不是"multi-task 平衡训练"
+4. 工程成本低（1 字段 + 1 行 mask）；路线 2 要改 InfoNoise sampler 内部 FIFO/EMA 累加器
+
+## 重评估触发条件
+
+**满足以下任一条件时重新评估是否切到路线 2 或混合方案**：
+
+1. **数据规模触发**：用户群中 reg 集与 main 集"分布相似"的比例显著上升（如出现大量"用同 booru tag 范围作 reg"或"同画师其他作品作 reg"的训练 config）。判定方法：在社区调研或 wandb 上抽样近 N 个 reg 集，看其 caption 分布跟 main 集的 KL 距离分布。
+
+2. **多 main 分布场景出现**：multi-concept LoRA / 同时训多个角色 / 同时训角色+画风 等场景成为主流。这时"单 main 分布"假设破裂，路线 1 的"hard exclude reg"也不再够用，需要 per-distribution CDF（每个分布维护一个 entropy curve）或路线 2 的 weighted aggregation。
+
+3. **`reg_weight ≥ 0.7` 高占比**：社区调研发现用户大量配 `reg_weight ≥ 0.7`（接近 1.0），说明用户语义已经从"辅助 prior"转向"co-training"，此时路线 2 的 λ-连续 semantics 更贴合用户意图。
+
+4. **InfoNoise 论文 / 学术界进展**：出现 I-MMSE 在 mixture distribution 下的正式推广（如 mixture-MMSE + weighted ERM 联合分析），或 Katharopoulos-Fleuret 风格 IS 与扩散 schedule 优化的对接论文。这时路线 2 有了缺失的数学保证。
+
+5. **实测路线 1 sub-optimal**：用户反馈或对照实验显示，开 reg 集 + InfoNoise 时收敛速度 / 最终质量明显劣于路线 2 模拟（即便 reg 集分布不同）。需要 A/B 实验设计（同 config 跑两套 record 策略对比 main 任务 metric）。
+
+## 重评估时的具体动作
+
+- **判定继续路线 1**：本文档归档到 `docs/todo/archive/`，CHANGELOG 加一条说明重评估结论 + 数据
+- **判定切换路线 2**：
+  1. InfoNoise sampler 加 `record(t, mse, weights=None)` 接口
+  2. FIFO bucket 改 weighted streaming average（注意数值稳定性、低权重 sample 不被掩盖）
+  3. EMA 累加器同步加权
+  4. loop.py:141 改为 `ctx.timestep_sampler.record(t, raw_mse, weights=batch["loss_weight"])`
+  5. dataset.py 的 `is_reg` 字段保留（多 main 分布场景可能仍需要 identity label）
+  6. training-tips.md reg 行重写
+  7. 加测试：(a) λ=0 时 reg 样本对 schedule 影响→0；(b) λ=1 时 reg 跟 main 平权进 record；(c) weighted streaming average 数值稳定性
+- **判定混合方案**（per-distribution CDF）：单独开 ADR
+
+## 引用 / 上下文
+
+- 触发本次讨论的 commit: `cfbfd218` (PR #216 follow-up to e7ac3e3)
+- 3 agent workflow run: `wf_42e355a5-f01`（2026-06-05）
+- 完整三方分析 transcript: `tmp/infonoise/` 下任何归档 + memory `infonoise-reg-policy-open.md`
+- 当前实现: `runtime/training/loop.py:141-152` + `runtime/training/dataset.py` MergedDataset / collate_fn
+- 相关测试: `tests/test_infonoise.py::test_record_accepts_partial_batch_after_reg_mask`
+- 关联 memory: `infonoise_reg_policy_open.md`、`reg_dreambooth_alignment.md`（reg 集在现代 DiT 训练里整体定位）
+
+## 复查节奏
+
+- **半年一次**（2026-12-05 / 2027-06-05 ...）：抽样近 6 个月社区 / wandb 的 reg 集 config，看分布是否仍以"通用图 reg"为主
+- **触发性复查**：上面 5 个触发条件任一命中
+- **3 年仍无 multi-concept LoRA 主流化**（2029-06-05 后）：路线 1 可视为长期稳定方案，本文档可降级为 archive

--- a/docs/user-guide/training-tips.md
+++ b/docs/user-guide/training-tips.md
@@ -210,7 +210,7 @@ EDM/Karras 论文里 δ=0.15 是常用经验值。
 | `loss_type=huber` | huber 削峰让 outlier 区间不学，但 InfoNoise 用 raw MSE 看到 outlier 仍高 → 推 mass 进去 → 反馈环 | schema 互斥 |
 | `timestep_schedule_shift != 1.0` | shift 只在 baseline 路径生效；CDF 接管后静默失效 | schema 互斥 |
 | `noise_enhancement_type != none` (`offset` / `pyramid`) | 噪声增强改变 noise 形状，InfoNoise 学到的不再是 clean entropy rate profile（I-MMSE 推导假设标准高斯 noise）| schema 互斥 |
-| 正则集（`reg_data_dir != null` + `reg_weight < 1`） | reg 集分布跟 train 集不同；InfoNoise 自动跳过 reg 集样本仅学 train 集分布（loop 内 mask 处理） | 透明处理，无需用户操作 |
+| 正则集（`reg_data_dir != null`，任意 `reg_weight`） | reg 集与 main 集分布不同（典型 booru 通用图 vs LoRA 主题）；I-MMSE 假设单分布，混入会让 schedule 学到 mixture MMSE 而非 mmse_main。InfoNoise 按 batch 内 `is_reg` flag 硬过滤 reg 样本，仅 main 样本进 schedule 学习；reg 样本仍参与梯度（按 `reg_weight` 加权） | 透明处理，无需用户操作。未来若主流用法转向多 main 分布（multi-concept LoRA），按 `docs/todo/infonoise-reg-policy-reeval.md` 重评估 |
 | LoRA dropout（`lora_dropout` / `lora_rank_dropout` / `lora_module_dropout`） | 加梯度噪声，不改 mse 形状的系统性偏移 | 可同开，FIFO + EMA 双层平滑能 absorb |
 
 ### 噪声增强

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -387,9 +387,11 @@ class MergedDataset(Dataset):
         if idx < self._main_len:
             item = self.main_dataset[idx]
             item["loss_weight"] = 1.0
+            item["is_reg"] = False
             return item
         item = self.reg_dataset[idx - self._main_len]
         item["loss_weight"] = self.reg_weight
+        item["is_reg"] = True
         return item
 
 
@@ -700,6 +702,7 @@ def collate_fn(batch):
     result = {"pixel_values": pixels, "captions": captions}
     if "loss_weight" in batch[0]:
         result["loss_weight"] = torch.tensor([b["loss_weight"] for b in batch], dtype=torch.float32)
+        result["is_reg"] = torch.tensor([b["is_reg"] for b in batch], dtype=torch.bool)
     return result
 
 
@@ -710,4 +713,5 @@ def collate_fn_cached(batch):
     result = {"latents": latents, "captions": captions}
     if "loss_weight" in batch[0]:
         result["loss_weight"] = torch.tensor([b["loss_weight"] for b in batch], dtype=torch.float32)
+        result["is_reg"] = torch.tensor([b["is_reg"] for b in batch], dtype=torch.bool)
     return result

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -138,14 +138,14 @@ def run(ctx: TrainingContext) -> None:
                     _raw_mse = _raw_mse_per_sample.mean(
                         dim=list(range(1, _raw_mse_per_sample.dim()))
                     )
-                # 仅 main 集样本进 InfoNoise schedule 学习：论文 entropy rate 假设单一
-                # 数据分布；reg 集典型 reg_weight=0.3 跟 train 集分布差距通常很大（booru
-                # 通用图 vs LoRA 主题），混入 record 会让 schedule 被 reg 集 unweighted 影响
-                # （违反 reg_weight<1 想表达的"仅微弱影响"意图）。MergedDataset 给 main 集
-                # set loss_weight=1.0、reg 集 set =reg_weight；无 reg 时整个 batch 没这个 key。
-                if "loss_weight" in batch:
-                    _lw = batch["loss_weight"].to(_raw_mse.device)
-                    _main_mask = _lw >= 0.99
+                # 仅 main 集样本进 InfoNoise schedule 学习：I-MMSE 假设单一数据分布，
+                # reg 集典型是通用图（booru）vs main 集是单一主题，混入 record 学到的是
+                # mixture MMSE 不是 mmse_main(t)。用 is_reg flag 而非 loss_weight 阈值
+                # 是因为 distribution identity 跟 gradient 权重是两条独立轴
+                # （reg_weight=1.0 时 loss_weight=1.0 但 reg 仍是不同分布）。
+                # 见 docs/todo/infonoise-reg-policy-reeval.md 未来重评估条件。
+                if "is_reg" in batch:
+                    _main_mask = ~batch["is_reg"].to(t.device)
                     if _main_mask.any():
                         ctx.timestep_sampler.record(t.detach()[_main_mask], _raw_mse[_main_mask])
                 else:

--- a/tests/test_infonoise.py
+++ b/tests/test_infonoise.py
@@ -331,17 +331,17 @@ def test_state_dict_round_trip_v2():
 
 
 def test_record_accepts_partial_batch_after_reg_mask():
-    """模拟 loop.py 用 loss_weight≥0.99 mask 跳过 reg 集样本后再 record。
+    """模拟 loop.py 用 ~is_reg mask 跳过 reg 集样本后再 record。
 
     InfoNoise 不应假定每次 record 都收到固定 batch size — main+reg 混合 batch
     经 mask 后样本数变少，scheduler 必须能正确处理。
     """
     s = InfoNoiseScheduler(K=4, N_warm=1, M=1, B=4, N_min=1, beta=0.5)
-    # 模拟 batch=4: 2 个 main (loss_weight=1.0) + 2 个 reg (loss_weight=0.3)
+    # 模拟 batch=4: 2 个 main (is_reg=False) + 2 个 reg (is_reg=True)
     t_full = torch.tensor([0.1, 0.5, 0.9, 0.5])
     mse_full = torch.tensor([10.0, 5.0, 1.0, 5.0])
-    lw = torch.tensor([1.0, 0.3, 0.3, 1.0])
-    main_mask = lw >= 0.99
+    is_reg = torch.tensor([False, True, True, False])
+    main_mask = ~is_reg
     # 应取 idx 0 + 3 = 2 个样本进 record
     s.record(t_full[main_mask], mse_full[main_mask])
     assert s._internal_step == 1  # 1 次调用


### PR DESCRIPTION
## 背景 / 动机

PR #216 commit `cfbfd218` 给 InfoNoise record 加了 `loss_weight >= 0.99` 阈值跳过 reg 集样本。代码 review 时发现这个阈值方案在 `reg_weight=1.0` 边界有内部矛盾：

| reg_weight | 分布纯净论证适用 | 当前 mask 行为 |
|---|---|---|
| 0.3（社区默认）| 是 | 跳过 reg ✅ |
| 0.7 | 是 | 跳过 reg ✅ |
| **1.0** | **仍是** | **reg 进 record ❌** |

分布纯净的理由（reg 集与 main 集分布不同 → 不该污染 schedule 学习）不依赖 reg_weight 取值，但 `loss_weight=1.0` 既覆盖 main 也覆盖 `reg_weight=1.0` 的 reg。本质上 distribution identity 跟 gradient weight 是两条独立的语义轴，不该用同一字段当 proxy。

为决定改 hard exclude（is_reg flag）还是 soft weight by loss_weight，跑了 3 个独立无上下文 agent 从信息论 / weighted ERM / 训练动力学三个角度独立推演，2:1 倾向 hard exclude（lens 详细推导见提交里的 `docs/todo/infonoise-reg-policy-reeval.md`）。

## 改动概要

- `runtime/training/dataset.py`：MergedDataset 给 main 样本写 `is_reg=False`、reg 样本写 `is_reg=True`；两个 `collate_fn` 透传为 `torch.bool` tensor
- `runtime/training/loop.py:141-152`：InfoNoise record mask 来源由 `loss_weight >= 0.99` 改为 `~batch[\"is_reg\"]`，跟 `loss_weight` 解耦；无 reg 集时仍 fallback 全收（行为不变）
- `tests/test_infonoise.py`：`test_record_accepts_partial_batch_after_reg_mask` 模拟改用 `is_reg`
- `docs/user-guide/training-tips.md`：reg + InfoNoise 那行去掉 `reg_weight < 1` 限定，明确"任意 reg_weight 都 hard exclude"
- `docs/todo/infonoise-reg-policy-reeval.md`（新）：路线 2 (soft weighting) 延后理由 + 5 条重评估触发条件 + 切换时具体动作清单

reg 样本仍照常进梯度按 `reg_weight` 加权（`loop.py:154-156` 不动），只是不进 InfoNoise schedule 学习。

## 路线 2 为什么延后而非现在做

soft weighting 数学上是对真实 weighted ERM \`L = E_main + λE_reg\` 的 min-variance IS proposal，但：
1. InfoNoise 论文 I-MMSE 推导假设单分布，mixture 推广未证（Lens B 自承盲点）
2. 当前 AnimaLoraStudio 用户群 99% 是单 main 分布 LoRA + 通用图 reg，路线 1 够用
3. 实现成本：路线 2 要改 InfoNoise sampler 内部 FIFO/EMA 累加器为 weighted streaming average，改动面大

完整 5 条重评估触发条件（multi-concept LoRA / 高 reg_weight 占比 / I-MMSE mixture 推广 / 实测 sub-optimal / 数据规模）写在 `docs/todo/infonoise-reg-policy-reeval.md`，未来触发任一条时按那个清单评估是否切路线 2。

## 测试方式

- `tests/test_datasets.py` + `tests/test_losses.py` + `tests/test_loss_weighting.py` + `tests/test_infonoise.py`：**93 passed**
- `tests/test_infonoise.py::test_record_accepts_partial_batch_after_reg_mask`：mask 模拟改用 is_reg 后通过
- 其余测试套件（200+）未受影响