### PR TITLE
feat(web): 训练 / 预设页右栏加章节锚点 nav + outputs 删除按钮去高亮

### DIFF
--- a/studio/web/src/components/SchemaForm.tsx
+++ b/studio/web/src/components/SchemaForm.tsx
@@ -23,6 +23,25 @@ interface Props {
   advancedMode?: boolean
 }
 
+/** 计算当前 advancedMode 下哪些 group 至少有一个可见字段（用于侧栏锚点导航）。
+ * 与下面的 buckets 逻辑保持一致：跳过 hidden / 跳过 advanced（简单模式下）。
+ * 不考虑 show_when —— 那是 per-field 动态，section header 仍按 bucket 渲染。 */
+export function visibleSchemaGroups(
+  schema: SchemaResponse,
+  advancedMode: boolean,
+): Array<{ key: string; label: string }> {
+  const counts = new Map<string, number>()
+  for (const [, prop] of Object.entries(schema.schema.properties)) {
+    if (prop.hidden) continue
+    if (prop.advanced && !advancedMode) continue
+    const g = prop.group ?? 'misc'
+    counts.set(g, (counts.get(g) ?? 0) + 1)
+  }
+  return schema.groups
+    .filter((g) => (counts.get(g.key) ?? 0) > 0)
+    .map((g) => ({ key: g.key, label: g.label }))
+}
+
 /**
  * 按 schema.groups 分区渲染表单；分组可折叠。
  * show_when 用 evalShowWhen 做条件显示，依赖当前 values。
@@ -119,7 +138,8 @@ export default function SchemaForm({
         return (
           <section
             key={key}
-            className="rounded-md border border-subtle bg-surface"
+            id={`schema-group-${key}`}
+            className="rounded-md border border-subtle bg-surface scroll-mt-4"
           >
             <button
               type="button"

--- a/studio/web/src/components/SchemaSectionIndex.tsx
+++ b/studio/web/src/components/SchemaSectionIndex.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useState, type RefObject } from 'react'
+import { useTranslation } from 'react-i18next'
+import { schemaGroupLabel } from '../lib/schema'
+
+/** SchemaForm 各分区的右侧锚点导航。
+ *
+ * active 判定走 scroll 监听：找滚动容器视口顶端下方 50px 处之上、DOM 顺序最后
+ * 一个 section 作为 active。比 IntersectionObserver + rootMargin "激活带" 稳，
+ * 不会出现多个 section 同时在带内时 active 来回跳。 */
+export default function SchemaSectionIndex({
+  groups,
+  scrollContainer,
+}: {
+  groups: Array<{ key: string; label: string }>
+  scrollContainer: RefObject<HTMLElement | null>
+}) {
+  const { t } = useTranslation()
+  const [active, setActive] = useState<string>(groups[0]?.key ?? '')
+
+  useEffect(() => {
+    setActive(groups[0]?.key ?? '')
+  }, [groups])
+
+  useEffect(() => {
+    const root = scrollContainer.current
+    if (!root || groups.length === 0) return
+
+    const compute = () => {
+      const rootTop = root.getBoundingClientRect().top
+      // 容器顶端往下 50px 当判定线 —— 这条线上方的最后一个 section 就是 active。
+      // 50 是经验值：太小（如 0）切换太晚，section 头已经露出来才 active；太大
+      // section 还远着就 active 上了。
+      const probe = rootTop + 50
+      let next = groups[0].key
+      for (const g of groups) {
+        const el = document.getElementById(`schema-group-${g.key}`)
+        if (!el) continue
+        if (el.getBoundingClientRect().top <= probe) {
+          next = g.key
+        } else {
+          break
+        }
+      }
+      setActive((prev) => (prev === next ? prev : next))
+    }
+
+    compute()
+    root.addEventListener('scroll', compute, { passive: true })
+    // 折叠 / 展开 section 会改变高度但不触发 scroll，靠 ResizeObserver 兜底。
+    let ro: ResizeObserver | null = null
+    if (typeof ResizeObserver !== 'undefined') {
+      ro = new ResizeObserver(compute)
+      ro.observe(root)
+    }
+    return () => {
+      root.removeEventListener('scroll', compute)
+      ro?.disconnect()
+    }
+  }, [groups, scrollContainer])
+
+  const onJump = (key: string) => {
+    const el = document.getElementById(`schema-group-${key}`)
+    if (!el) return
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    setActive(key)
+  }
+
+  if (groups.length === 0) return null
+
+  return (
+    <nav className="flex flex-col gap-0.5">
+      <div className="caption mb-2 px-2">{t('settings.pageIndex')}</div>
+      {groups.map((g) => (
+        <button
+          key={g.key}
+          onClick={() => onJump(g.key)}
+          className={`text-left text-xs px-2 py-1.5 rounded-sm transition-colors border-l-2 bg-transparent ${
+            active === g.key
+              ? 'border-accent text-accent bg-accent-soft/40'
+              : 'border-transparent text-fg-tertiary hover:text-fg-secondary hover:bg-overlay/40'
+          }`}
+        >
+          {schemaGroupLabel(g.key, g.label, t)}
+        </button>
+      ))}
+    </nav>
+  )
+}

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -767,7 +767,7 @@ export function OutputsTab({ taskId }: { taskId: number }) {
                 <button
                   onClick={handleDelete}
                   disabled={deleting || noneSelected}
-                  className="btn btn-danger btn-sm"
+                  className="btn btn-ghost btn-sm text-err"
                 >
                   {t('queueDetail.deleteSelected', { n: selected.size })}
                 </button>

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -13,7 +13,8 @@ import {
 } from '../../../api/client'
 import ConfigSkeleton from '../../../components/ConfigSkeleton'
 import { useDialog } from '../../../components/Dialog'
-import SchemaForm from '../../../components/SchemaForm'
+import SchemaForm, { visibleSchemaGroups } from '../../../components/SchemaForm'
+import SchemaSectionIndex from '../../../components/SchemaSectionIndex'
 import StepShell from '../../../components/StepShell'
 import { useToast } from '../../../components/Toast'
 import { useSettingsDrawer } from '../../../lib/SettingsDrawer'
@@ -254,6 +255,13 @@ export default function TrainPage() {
     [presets, pickerSearch],
   )
 
+  // 右侧 SchemaSectionIndex 的 IntersectionObserver root + 跳转目标
+  const schemaScrollRef = useRef<HTMLDivElement | null>(null)
+  const visibleGroups = useMemo(
+    () => (schema ? visibleSchemaGroups(schema, advancedMode) : []),
+    [schema, advancedMode],
+  )
+
   // popover 关闭：点外面 / Esc
   useEffect(() => {
     if (!pickerOpen) return
@@ -463,7 +471,7 @@ export default function TrainPage() {
       <div className="flex flex-col h-full gap-3">
 
         {/* 两栏布局：左（预设 + config 编辑） / 右（估算面板） */}
-        <div className="grid grid-cols-[1.5fr_1fr] gap-3 flex-1 min-h-0">
+        <div className="grid grid-cols-[3fr_1fr] gap-3 flex-1 min-h-0">
 
           {/* 左栏 */}
           <div className="flex flex-col gap-3 min-h-0 min-w-0 overflow-y-auto">
@@ -595,7 +603,7 @@ export default function TrainPage() {
                 {t('train.noConfigHint')}
               </div>
             ) : config ? (
-              <section className="flex-1 min-h-0 overflow-y-auto pr-1">
+              <section ref={schemaScrollRef} className="flex-1 min-h-0 overflow-y-auto pr-1">
                 <div className="flex justify-end mb-2">
                   <div className="inline-flex rounded-md border border-subtle overflow-hidden text-xs">
                     <button
@@ -641,12 +649,22 @@ export default function TrainPage() {
             )}
           </div>
 
-        {/* 右栏：训练集 + 正则集分布 */}
-        <DatasetStatsPanel
-          activeVersion={activeVersion}
-          reg={reg}
-          config={config}
-        />
+        {/* 右栏：训练集 + 正则集分布 + 章节锚点导航 */}
+        <div className="flex flex-col min-h-0 min-w-0 overflow-y-auto">
+          <DatasetStatsPanel
+            activeVersion={activeVersion}
+            reg={reg}
+            config={config}
+          />
+          {configResp?.has_config && config && visibleGroups.length > 0 && (
+            <div className="mt-8">
+              <SchemaSectionIndex
+                groups={visibleGroups}
+                scrollContainer={schemaScrollRef}
+              />
+            </div>
+          )}
+        </div>
       </div>
     </div>
     </StepShell>

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -10,7 +10,8 @@ import {
 import ConfigSkeleton from '../../components/ConfigSkeleton'
 import { useDialog } from '../../components/Dialog'
 import PathPicker from '../../components/PathPicker'
-import SchemaForm from '../../components/SchemaForm'
+import SchemaForm, { visibleSchemaGroups } from '../../components/SchemaForm'
+import SchemaSectionIndex from '../../components/SchemaSectionIndex'
 import { useToast } from '../../components/Toast'
 import { useSettingsDrawer } from '../../lib/SettingsDrawer'
 import { useAdvancedMode } from '../../lib/useAdvancedMode'
@@ -282,6 +283,14 @@ export default function PresetsPage() {
     }
     return out
   }, [autoSyncPaths, modelPathDefaults, config, t, MODEL_PATH_FIELDS])
+
+  // 右侧 SchemaSectionIndex 的 IntersectionObserver root + 跳转目标。
+  // 这里的 root 是整个内容滚动区，跟 Settings 页一致。
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null)
+  const visibleGroups = useMemo(
+    () => (schema ? visibleSchemaGroups(schema, advancedMode) : []),
+    [schema, advancedMode],
+  )
 
   // ── popover 关闭：点外面关 ──
   useEffect(() => {
@@ -684,8 +693,12 @@ export default function PresetsPage() {
       </div>
 
       {/* ── content（scroll） ── */}
-      <div className="flex-1 min-h-0 overflow-auto p-4">
-        <div className="flex flex-col gap-3">
+      <div ref={scrollContainerRef} className="flex-1 min-h-0 overflow-auto p-4">
+        <div
+          className="grid gap-10"
+          style={{ gridTemplateColumns: '3fr 1fr' }}
+        >
+        <div className="flex flex-col gap-3 min-w-0">
 
           {/* 名称 / 描述 */}
           <section className="rounded-md border border-subtle bg-surface px-3.5 py-2.5">
@@ -811,6 +824,19 @@ export default function PresetsPage() {
               )}
             </section>
           )}
+        </div>
+
+        {/* 右侧锚点导航：跟 Settings 页一个套路，sticky 跟随滚动 */}
+        <aside className="hidden lg:block">
+          <div className="sticky top-0">
+            {schema && config && visibleGroups.length > 0 && (
+              <SchemaSectionIndex
+                groups={visibleGroups}
+                scrollContainer={scrollContainerRef}
+              />
+            )}
+          </div>
+        </aside>
         </div>
       </div>
 


### PR DESCRIPTION
## 背景

集中处理三个 UI/UX 问题：

1. 训练 / 预设页 SchemaForm 字段动辄十几个 group，找特定 section 要滚一阵；两边右栏（训练页 stats 之下、预设页本身没右栏）有大块空白可以利用。
2. 训练页 stats 之下的空白浪费，希望参照设置页右侧「本页索引」加章节快速跳转。
3. Queue Detail 输出页 toolbar 里「删除所选」是 `btn-danger`（填红），跟同行的 ghost 按钮（复制路径 / 打开文件夹 / 刷新 / 退出批量）风格不统一，对一个"批量删除"动作高亮太刺眼。

## 改动概要

### 章节锚点 nav

- 新组件 `SchemaSectionIndex.tsx`：按 schema.groups 列出可见 group，点击平滑滚动到对应 section，当前 section 高亮
- `SchemaForm.tsx`：
  - 每个 group `<section>` 加 \`id=\"schema-group-{key}\"\` + `scroll-mt-4` 当锚点目标
  - 导出 `visibleSchemaGroups(schema, advancedMode)` helper，跟 buckets 用同一份「过滤 hidden / advanced」逻辑算可见 group

**active 判定方案**：scroll 监听 +「容器顶部 + 50px 判定线之上、DOM 顺序最后一个 section」逻辑，比 IntersectionObserver + rootMargin「激活带」稳。激活带方案在 group 短时会有多个 section 同时落在带内、`groups.find` 拿到的 active 来回跳；scroll-driven 全确定式。

ResizeObserver 兜底折叠 / 展开 group 时高度变化但没触发 scroll 的情况。

### 布局调整

- 训练页 `Train.tsx`：右栏 stats panel + 32px 间距 + section nav；左右比例 `1.5fr:1fr` → `3fr:1fr`，给 SchemaForm 字段输入框舒展
- 预设页 `Presets.tsx`：内容区从单列改 `3fr:1fr` grid，右侧 sticky aside 放 nav

### 删除按钮

`QueueDetail.tsx` toolbar 的「删除所选」：`btn btn-danger btn-sm` → `btn btn-ghost btn-sm text-err`。红色只留在文字上做"危险"提示，不再背景填充。

## 测试

- \`npx tsc --noEmit\` ✅
- \`npm run lint\` ✅
- \`npx vitest run\` ✅ 309/309（无新增 / 修改 test，纯 UI 视觉改动）

手测：
- 训练页右栏锚点点击 → 左栏 SchemaForm 平滑滚到对应 group
- 滚动 SchemaForm 时 active 高亮跟随、不闪
- 预设页 ditto
- 输出页删除按钮新样式跟周围 ghost 按钮一致

## 截图

待补（HMR 模式下截）。原 issue 截图见对应讨论。