### PR TITLE
fix(ui): symmetric InfoNoise mutex + backend compat for old configs

### DIFF
--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -567,7 +567,7 @@ def get_version_config_endpoint(pid: int, vid: int) -> dict[str, Any]:
             "project_specific_defaults": psd,
         }
     try:
-        cfg = version_config.read_version_config(project, ver)
+        cfg, dropped, defaulted = version_config.read_version_config_with_warnings(project, ver)
     except version_config.VersionConfigError as exc:
         raise HTTPException(422, str(exc)) from exc
     return {
@@ -575,6 +575,8 @@ def get_version_config_endpoint(pid: int, vid: int) -> dict[str, Any]:
         "config": cfg,
         "project_specific_fields": psf,
         "project_specific_defaults": psd,
+        "dropped_fields": dropped,
+        "defaulted_fields": defaulted,
     }
 
 

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -427,7 +427,17 @@ class TrainingConfig(BaseModel):
     infonoise_enabled: bool = Field(
         False,
         description="【InfoNoise】启用自适应时间步采样：训练中根据信息量自动调整 t 分布，聚焦更有效的训练区间",
-        json_schema_extra=_meta("timestep_sampling", advanced=True),
+        json_schema_extra=_meta(
+            "timestep_sampling",
+            advanced=True,
+            disable_when=(
+                "noise_enhancement_type!=none"
+                "||loss_weighting!=none"
+                "||loss_type==huber"
+                "||timestep_schedule_shift!=1"
+            ),
+            disable_hint="互斥字段（noise_enhancement / loss_weighting / loss_type / schedule_shift）非默认时不可启用（schema 互斥）",
+        ),
     )
     infonoise_K: int = Field(
         64, ge=16, le=256,

--- a/studio/services/presets/io.py
+++ b/studio/services/presets/io.py
@@ -150,7 +150,9 @@ def _tolerant_validate(raw: dict[str, Any]) -> tuple[TrainingConfig, list[str], 
 
     defaults = TrainingConfig()
     defaulted: list[str] = []
-    max_rounds = len(data)
+    # loop bound = data fields + 1 extra round for the InfoNoise compat shim
+    # below (which doesn't consume a field-level slot).
+    max_rounds = len(data) + 1
     for _ in range(max_rounds):
         try:
             cfg = TrainingConfig.model_validate(data)
@@ -160,6 +162,15 @@ def _tolerant_validate(raw: dict[str, Any]) -> tuple[TrainingConfig, list[str], 
                 e["loc"][0] for e in exc.errors() if e.get("loc")
             }
             if not bad_fields:
+                # Model-level validator (loc=()) — for the InfoNoise mutex set
+                # (4 _validate_infonoise_*_exclusive), prefer to disable InfoNoise
+                # and preserve the user's investment in loss_weighting / loss_type /
+                # timestep_schedule_shift / noise_enhancement_type. Frontend shows
+                # this as a compat banner via defaulted_fields.
+                if data.get("infonoise_enabled") is True:
+                    data["infonoise_enabled"] = False
+                    defaulted.append("infonoise_enabled")
+                    continue
                 raise PresetError(f"预设校验失败: {exc}") from exc
             for f in bad_fields:
                 data[f] = getattr(defaults, f)

--- a/studio/services/version_config.py
+++ b/studio/services/version_config.py
@@ -106,6 +106,19 @@ def read_version_config(
     project: dict[str, Any], version: dict[str, Any]
 ) -> dict[str, Any]:
     """读 version 私有 config；不存在抛 VersionConfigError。"""
+    cfg, _, _ = read_version_config_with_warnings(project, version)
+    return cfg
+
+
+def read_version_config_with_warnings(
+    project: dict[str, Any], version: dict[str, Any]
+) -> tuple[dict[str, Any], list[str], list[str]]:
+    """读 version 私有 config 同时返回容错校验产出的 (dropped, defaulted) 字段列表。
+
+    用于 GET 端点把 compat 信息透传给前端（顶部 banner 提示）。InfoNoise 老 config
+    互斥被 _tolerant_validate 自动关 InfoNoise 时，"infonoise_enabled" 会出现在
+    defaulted 里。
+    """
     p = version_config_path(project, version)
     if not p.exists():
         raise VersionConfigError(
@@ -114,8 +127,8 @@ def read_version_config(
     raw = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
     if not isinstance(raw, dict):
         raise VersionConfigError("config.yaml 顶层不是 mapping")
-    cfg, _, _ = _tolerant_validate(raw)
-    return _absolutize_model_paths(cfg.model_dump(mode="python"))
+    cfg, dropped, defaulted = _tolerant_validate(raw)
+    return _absolutize_model_paths(cfg.model_dump(mode="python")), dropped, defaulted
 
 
 def write_version_config(

--- a/studio/web/src/components/SchemaForm.test.tsx
+++ b/studio/web/src/components/SchemaForm.test.tsx
@@ -202,32 +202,4 @@ describe('SchemaForm takeover behavior', () => {
     expect(screen.queryByText('Normal timestep description')).not.toBeInTheDocument()
   })
 
-  it('disable_when without disable_value preserves the existing value (no silent reset)', async () => {
-    const onChange = vi.fn()
-    // timestep_sampling has disable_when='infonoise_enabled==true' but NO disable_value
-    // in the mock schema. Old behavior reset to prop.default; new behavior keeps the
-    // user's value so the backend model_validator surfaces the real conflict combo.
-    render(
-      <SchemaForm
-        schema={schema}
-        values={{
-          optimizer_type: 'adamw',
-          learning_rate: 0.0001,
-          lr_scheduler: 'none',
-          infonoise_enabled: true,
-          timestep_sampling: 'uniform',
-        }}
-        onChange={onChange}
-        advancedMode
-      />,
-    )
-
-    // Yield once to let the disable-takeover useEffect run (it would have called
-    // onChange under the old behavior).
-    await new Promise((r) => setTimeout(r, 0))
-    expect(onChange).not.toHaveBeenCalled()
-    const timestepSelect = screen.getAllByRole('combobox').find((el) => (el as HTMLSelectElement).value === 'uniform') as HTMLSelectElement
-    expect(timestepSelect.value).toBe('uniform')
-    expect(timestepSelect).toBeDisabled()
-  })
 })

--- a/studio/web/src/components/SchemaForm.tsx
+++ b/studio/web/src/components/SchemaForm.tsx
@@ -73,15 +73,17 @@ export default function SchemaForm({
   }
   const takeoverValueForField = (name: string, prop: typeof props[string]) => {
     if (name === 'lr_scheduler' && isProdigyOptimizer) return 'none'
-    return prop.disable_value
+    return prop.disable_value ?? prop.default
   }
 
-  // disable_when 触发时：
-  //   - 显式带 disable_value（或 lr_scheduler 特例）→ 强制改值，避免「切到 prodigy
-  //     之后 lr_scheduler 还停在 cosine 保存被 pydantic 拒」的死锁 UX
-  //   - 只 disable_when 不带 disable_value → 保留用户当前值，把冲突交给后端
-  //     model_validator 报错（InfoNoise 互斥四件套走这条：让用户看到原始冲突
-  //     值 + toast 告知是哪个组合炸，而不是 silent 抹掉用户的 detail_inv_t / huber）
+  // disable_when 触发 → 字段灰显 + 值 reset 到 disable_value（缺省回到 default）。
+  // 「先开的赢」语义：当 InfoNoise 与 loss_weighting / loss_type / schedule_shift /
+  // noise_enhancement_type 任一互斥，先把状态切到非默认的那一侧赢，另一侧灰显且
+  // reset 到 default。两侧都装 disable_when 形成对称锁。
+  //
+  // 老 config 同开（infonoise=on + 互斥字段非默认）由后端 _tolerant_validate 反向
+  // 处理：关掉 infonoise 保留用户原投入的 weighting / huber / shift / enhancement，
+  // 把 "infonoise_enabled" 写进 defaulted_fields，前端顶部 banner 提示。
   useEffect(() => {
     let nextValues = values
     let changed = false

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -345,7 +345,8 @@
       "noise_enhancement_type": "Disabled while InfoNoise is enabled (schema mutex)",
       "loss_weighting": "Disabled while InfoNoise is enabled (schema mutex, only `none` compatible)",
       "loss_type": "Disabled while InfoNoise is enabled (schema mutex, only `mse` compatible)",
-      "timestep_schedule_shift": "Disabled while InfoNoise is enabled (schema mutex, only `1.0` compatible)"
+      "timestep_schedule_shift": "Disabled while InfoNoise is enabled (schema mutex, only `1.0` compatible)",
+      "infonoise_enabled": "Reset noise_enhancement / loss_weighting / loss_type / schedule_shift to defaults to enable (schema mutex)"
     },
     "descriptions": {
       "transformer_path": "Main diffusion model weights (.safetensors)",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -345,7 +345,8 @@
       "noise_enhancement_type": "InfoNoise 启用时禁用噪声增强（schema 互斥）",
       "loss_weighting": "InfoNoise 启用时禁用 loss 加权（schema 互斥，仅 none 兼容）",
       "loss_type": "InfoNoise 启用时禁用 loss 类型切换（schema 互斥，仅 mse 兼容）",
-      "timestep_schedule_shift": "InfoNoise 启用时禁用 schedule shift（schema 互斥，仅 1.0 兼容）"
+      "timestep_schedule_shift": "InfoNoise 启用时禁用 schedule shift（schema 互斥，仅 1.0 兼容）",
+      "infonoise_enabled": "需先把 noise_enhancement / loss_weighting / loss_type / schedule_shift 全部置默认才能启用（schema 互斥）"
     },
     "descriptions": {
       "transformer_path": "主扩散模型权重（.safetensors）",

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -93,6 +93,11 @@ export default function TrainPage() {
 
   const vid = activeVersion?.id ?? null
 
+  const applyPresetWarnings = useCallback((r: { dropped_fields?: string[]; defaulted_fields?: string[] }) => {
+    setDroppedFields(r.dropped_fields ?? [])
+    setDefaultedFields(r.defaulted_fields ?? [])
+  }, [])
+
   const refreshConfig = useCallback(async () => {
     if (!vid) return
     try {
@@ -100,15 +105,13 @@ export default function TrainPage() {
       setConfigResp(r)
       setConfigSync(r.config)
       savedJsonRef.current = JSON.stringify(r.config)
+      // 老 config 兼容（InfoNoise 互斥被后端自动关掉等）由后端写进 r.defaulted_fields，
+      // 顶部 banner 渲染。dropped_fields 兜底 schema 演进时丢弃的旧字段。
+      applyPresetWarnings(r)
     } catch (e) {
       toast(t('train.loadConfigFailed', { error: e }), 'error')
     }
-  }, [project.id, vid, toast, setConfigSync, t])
-
-  const applyPresetWarnings = useCallback((r: { dropped_fields?: string[]; defaulted_fields?: string[] }) => {
-    setDroppedFields(r.dropped_fields ?? [])
-    setDefaultedFields(r.defaulted_fields ?? [])
-  }, [])
+  }, [project.id, vid, toast, setConfigSync, t, applyPresetWarnings])
 
   useEffect(() => {
     api.schema().then(setSchema).catch((e) => toast(t('train.loadSchemaFailed', { error: e }), 'error'))

--- a/tests/test_presets_io.py
+++ b/tests/test_presets_io.py
@@ -165,6 +165,63 @@ def test_preset_path_is_public_alias() -> None:
 
 
 # ---------------------------------------------------------------------------
+# InfoNoise 老 config 互斥兼容：_tolerant_validate 自动关 InfoNoise 保住用户原值
+# ---------------------------------------------------------------------------
+
+
+def test_tolerant_validate_infonoise_mutex_disables_infonoise() -> None:
+    """老 yaml 同时 infonoise=on + 4 互斥字段任一非默认 → 自动关 InfoNoise
+    保留用户原投入字段，"infonoise_enabled" 进 defaulted_fields 让前端 banner。
+    """
+    cases = [
+        {"infonoise_enabled": True, "noise_enhancement_type": "offset"},
+        {"infonoise_enabled": True, "loss_weighting": "detail_inv_t"},
+        {"infonoise_enabled": True, "loss_type": "huber"},
+        {"infonoise_enabled": True, "timestep_schedule_shift": 2.0},
+    ]
+    for overrides in cases:
+        cfg, _, defaulted = presets_io._tolerant_validate(overrides)
+        assert cfg.infonoise_enabled is False, overrides
+        assert "infonoise_enabled" in defaulted, overrides
+        # 用户原投入字段全保留
+        for k, v in overrides.items():
+            if k == "infonoise_enabled":
+                continue
+            assert getattr(cfg, k) == v, overrides
+
+
+def test_tolerant_validate_infonoise_mutex_multi_conflict_one_pass() -> None:
+    """同时 4 条互斥全冲突 → 一刀关 InfoNoise，4 字段全保留，defaulted 只有
+    "infonoise_enabled"（一次性处理，不重复 append）。"""
+    cfg, _, defaulted = presets_io._tolerant_validate({
+        "infonoise_enabled": True,
+        "noise_enhancement_type": "offset",
+        "loss_weighting": "detail_inv_t",
+        "loss_type": "huber",
+        "timestep_schedule_shift": 2.0,
+    })
+    assert cfg.infonoise_enabled is False
+    assert cfg.noise_enhancement_type == "offset"
+    assert cfg.loss_weighting == "detail_inv_t"
+    assert cfg.loss_type == "huber"
+    assert cfg.timestep_schedule_shift == 2.0
+    assert defaulted == ["infonoise_enabled"]
+
+
+def test_write_preset_strict_path_still_rejects_infonoise_mutex(
+    presets_dir: Path,
+) -> None:
+    """write_preset 走严格 model_validate（非 tolerant）—— 互斥配置直接拒，
+    防 UI 绕过 disable_when 锁直接发 PUT 提交 silent 改值。"""
+    with pytest.raises(presets_io.PresetError):
+        presets_io.write_preset("conflict", {
+            **_payload(),
+            "infonoise_enabled": True,
+            "loss_type": "huber",
+        })
+
+
+# ---------------------------------------------------------------------------
 # 路径规范化（PP10.5）：yaml 写盘 / 读取统一绝对路径
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 背景

PR #221 把 4 对 InfoNoise schema 互斥（`noise_enhancement_type` / `loss_weighting` / `loss_type=huber` / `timestep_schedule_shift`）的前端 mutex 落了一半 —— 只装了**单向** disable_when（开 InfoNoise → 锁 4 个字段），且采用「保留值不 reset」的方案，让后端 validator 在保存时报错。

两个问题：

1. **没有反向锁**：现状只有 4 个被控字段灰显，`infonoise_enabled` checkbox 不被反向锁。如果先把 `loss_weighting=detail_inv_t`，再点 `infonoise_enabled`，前端没拦截；要等保存才被后端拒
2. **老 config 死锁**：旧 yaml 同时 `infonoise=on` + `loss_weighting=detail_inv_t` 进 Train 页后，`loss_weighting` 灰显 + 仍是 detail_inv_t → 保存触发后端拒 → toast 报错 → **但 loss_weighting 也是灰的，用户改不了**

## 设计

「**先开的赢**」+「**老 config 优先关 InfoNoise + banner**」：

| 场景 | 行为 |
|---|---|
| 实时切换：先开 InfoNoise → 4 字段灰显 | InfoNoise 上勾；4 字段灰显并 reset 到各自 default（none/none/mse/1.0） |
| 实时切换：先把 `loss_weighting=detail_inv_t` → `infonoise_enabled` checkbox 反向灰显 | 锁住 InfoNoise 不让点（直到 weighting 回到 none） |
| 老 config：`infonoise=on + loss_weighting=detail_inv_t` 加载 | 后端 `_tolerant_validate` 自动关 InfoNoise，保留 weighting=detail_inv_t；顶部 banner 提示「已重置：infonoise_enabled」|

## 改动

1. **`SchemaForm.tsx`** —— `takeoverValueForField` 恢复 `?? prop.default` 回退（PR #221 round-2 把这条改成 \"只返回 disable_value\"，本 PR 反过来）。实时勾上互斥字段 → 另一侧 reset 到 default。

2. **`domain/training.py`** —— 4 个被控字段保留 PR #221 的 `disable_when=infonoise_enabled==true`；**新增 `infonoise_enabled` 反向 `disable_when`**（复合 OR）：
   ```
   noise_enhancement_type!=none||loss_weighting!=none||loss_type==huber||timestep_schedule_shift!=1
   ```
   两侧都装 `disable_when` 形成**对称锁**，谁先非默认谁赢。

3. **`services/presets/io.py`** —— `_tolerant_validate` 加 InfoNoise compat 分支。当 model_validator 报错（`loc=()`）且 raw 里 `infonoise_enabled=True`，自动设 False + append `\"infonoise_enabled\"` 到 `defaulted_fields`，重试。一次性把 4 对冲突全清（关掉 infonoise 让 4 个 `_validate_infonoise_*_exclusive` 全过）。

   `write_preset` 严格路径**不**走 compat —— 前端绕过 disable_when 锁直接 PUT 应该报错，防 silent 改值。

4. **`api/routers/projects/training.py` + `services/version_config.py`** —— GET `/api/projects/{pid}/versions/{vid}/config` 新增 `defaulted_fields` / `dropped_fields`；`read_version_config_with_warnings` 拆出来供 GET 用，老 `read_version_config` 保留兼容。`VersionConfigResponse` TS 接口已有这两个字段，前端类型不动。

5. **`pages/project/steps/Train.tsx`** —— `refreshConfig` 调用 `applyPresetWarnings(r)`，让现有顶部 banner（之前只在 fork preset / save as preset 路径亮）在初次 config load 也亮起。

6. **i18n** —— `disableHints.infonoise_enabled` 新增反向锁文案。

## 测试

- `tests/test_presets_io.py` **3 个新 case**：
  - `test_tolerant_validate_infonoise_mutex_disables_infonoise`：4 对单冲突分别覆盖
  - `test_tolerant_validate_infonoise_mutex_multi_conflict_one_pass`：4 对同冲突一次清，`defaulted_fields` 只 append 一次
  - `test_write_preset_strict_path_still_rejects_infonoise_mutex`：严格保存路径不走 compat
- `SchemaForm.test.tsx` 移除 PR #221 那条「保留值不 reset」契约 pin（语义已被本 PR 推翻），保留 4 个原有测试
- 后端：85 presets+infonoise+timestep 全过
- 前端：SchemaForm vitest 4/4 + `npx tsc --noEmit` clean + `npm run lint` clean

## 手测路径

**case A — 反向锁**
1. Train 页进阶模式
2. 把 `loss_weighting=detail_inv_t` → `infonoise_enabled` checkbox 立刻灰显，hint 显「需先把 noise_enhancement / loss_weighting / loss_type / schedule_shift 全部置默认才能启用」
3. 切 `loss_weighting=none` → checkbox 解锁可点

**case B — 老 config 兼容 banner**
1. 准备冲突 yaml：`infonoise_enabled: true` + `loss_weighting: detail_inv_t`
2. 进入 Train 页
3. 顶部黄色 banner 显: 「已重置：infonoise_enabled」
4. 表单：`infonoise_enabled=false` + `loss_weighting=detail_inv_t` 保留
5. 用户保留 detail_inv_t 直接保存 OK；或者改 weighting=none 后再开 InfoNoise

🤖 Generated with [Claude Code](https://claude.com/claude-code)