### PR TITLE
feat(generate): daemon 闲置自动卸载模型释放 VRAM

### DIFF
--- a/studio/api/routers/secrets.py
+++ b/studio/api/routers/secrets.py
@@ -6,12 +6,14 @@
 """
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from fastapi import APIRouter
 
 from ... import secrets
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
@@ -23,4 +25,12 @@ def get_secrets() -> dict[str, Any]:
 @router.put("/api/secrets")
 def put_secrets(body: dict[str, Any]) -> dict[str, Any]:
     new = secrets.update(body)
+    # 用户在 Settings 里改了 generate.idle_timeout_minutes 后，立即同步给跑着的
+    # daemon —— 不然要等下次出图 dispatch 才生效。daemon 还没起的话 set 也安全
+    # （走 noop 分支，下次 dispatch 时一并应用）。
+    try:
+        from ...services.inference.daemon import get_daemon
+        get_daemon().sync_idle_timeout_from_secrets()
+    except Exception:
+        logger.warning("failed to sync idle_timeout to daemon", exc_info=True)
     return secrets.to_masked_dict(new)

--- a/studio/infrastructure/secrets.py
+++ b/studio/infrastructure/secrets.py
@@ -433,9 +433,13 @@ class GenerateConfig(BaseModel):
     - `attention_backend`：注意力后端选择。`'auto'`（默认）→ 装了什么用什么
       （优先级 flash_attn > xformers > none/SDPA）；显式值（flash_attn/
       xformers/none）则强制 —— 想 debug 或对比时手动指定。
+    - `idle_timeout_minutes`：daemon 闲置 N 分钟自动卸载模型释放 VRAM。
+      0 = 关闭，模型常驻直到用户手动清。计时只在 daemon idle + 模型已 load
+      时跑；进 busy / 已 unload 时取消。
     """
     preview_every_n_steps: int = 3
     attention_backend: str = "auto"
+    idle_timeout_minutes: int = 10
 
 
 class SystemConfig(BaseModel):

--- a/studio/services/inference/daemon.py
+++ b/studio/services/inference/daemon.py
@@ -97,6 +97,11 @@ class InferenceDaemon:
         self._log_buffer: collections.deque[dict[str, Any]] = collections.deque(maxlen=2000)
         self._log_seq = 0
         self._log_listeners: list[EventCallback] = []
+        # idle timeout：daemon 闲 N 秒（模型已 load）自动 unload 释放 VRAM。
+        # 0 = 关闭。supervisor 在 spawn 后通过 sync_idle_timeout_from_secrets() 注入；
+        # PUT /api/secrets 后 router 也会调一次同步。
+        self._idle_timeout_seconds: float = 0.0
+        self._idle_timer: Optional[threading.Timer] = None
 
     # ---------------------------------------------------------------- 状态
     @property
@@ -122,6 +127,83 @@ class InferenceDaemon:
     def add_global_listener(self, cb: EventCallback) -> None:
         with self._lock:
             self._global_listeners.append(cb)
+
+    # --------------------------------------------------------------- idle 自动卸载
+    def set_idle_timeout_seconds(self, seconds: float) -> None:
+        """设置 daemon 闲置自动 unload 的超时（秒）。0 = 关闭。
+
+        定时器只在 daemon idle + 模型已 load + 进程存活 时跑；进 busy / 模型卸了 /
+        进程死了 都会自动 cancel。无需调用方关心。
+        """
+        secs = max(0.0, float(seconds))
+        with self._lock:
+            if self._idle_timeout_seconds == secs:
+                return
+            self._idle_timeout_seconds = secs
+            self._reschedule_idle_timer_locked()
+
+    def sync_idle_timeout_from_secrets(self) -> None:
+        """从 secrets.generate.idle_timeout_minutes 读出并应用。
+
+        失败（文件坏 / 字段缺）走 fallback：不改当前值，记一行 warning。
+        """
+        try:
+            # 局部 import 避免 services/inference → infrastructure 模块层循环
+            from ...infrastructure import secrets as _secrets
+            minutes = int(_secrets.load().generate.idle_timeout_minutes)
+        except Exception:
+            logger.warning(
+                "failed to read idle_timeout_minutes from secrets; keeping current value",
+                exc_info=True,
+            )
+            return
+        self.set_idle_timeout_seconds(max(0, minutes) * 60.0)
+
+    def _reschedule_idle_timer_locked(self) -> None:
+        """根据当前状态重置 idle timer。**必须持 self._lock 调用。**
+
+        cancel 旧 timer；当 timeout>0 + IDLE + 模型 loaded + 进程存活 时起新 timer。
+        其余情况只 cancel 不重启（包括 BUSY / UNLOADING / STOPPED / 模型未 load）。
+        """
+        old = self._idle_timer
+        if old is not None:
+            try:
+                old.cancel()
+            except Exception:
+                pass
+            self._idle_timer = None
+        if (
+            self._idle_timeout_seconds > 0
+            and self._state == STATE_IDLE
+            and self._model_loaded
+            and self._proc is not None
+        ):
+            timer = threading.Timer(self._idle_timeout_seconds, self._on_idle_timeout)
+            timer.daemon = True
+            timer.name = "inference-daemon-idle-timer"
+            self._idle_timer = timer
+            timer.start()
+
+    def _on_idle_timeout(self) -> None:
+        """idle timer 到期回调：仍 idle+loaded 时触发 unload。
+
+        触发瞬间状态可能已变（其他线程刚 submit_task / 手动 unload）；
+        重新检查再走 request_unload，避免冗余协议消息。
+        """
+        with self._lock:
+            should_unload = (
+                self._state == STATE_IDLE
+                and self._model_loaded
+                and self._proc is not None
+            )
+            timeout = self._idle_timeout_seconds
+        if not should_unload:
+            return
+        logger.info("daemon idle for %.0fs; auto-unloading model", timeout)
+        try:
+            self.request_unload()
+        except Exception:
+            logger.exception("auto unload from idle timer failed")
 
     # --------------------------------------------------------------- 生命周期
     def start(self) -> None:
@@ -223,6 +305,7 @@ class InferenceDaemon:
             self._state = STATE_STOPPED
             self._model_loaded = False
             self._active = None
+            self._reschedule_idle_timer_locked()
 
     # ----------------------------------------------------------------- 提交
     def submit_task(
@@ -248,6 +331,7 @@ class InferenceDaemon:
                 task_id=task_id, request_id=req_id, on_event=on_event,
             )
             self._state = STATE_BUSY
+            self._reschedule_idle_timer_locked()
             assert self._proc is not None and self._proc.stdin is not None
             stdin = self._proc.stdin
 
@@ -266,6 +350,7 @@ class InferenceDaemon:
             with self._lock:
                 self._state = STATE_IDLE
                 self._active = None
+                self._reschedule_idle_timer_locked()
             raise RuntimeError(f"daemon write failed: {e}") from e
         return req_id
 
@@ -305,6 +390,7 @@ class InferenceDaemon:
             assert self._proc is not None and self._proc.stdin is not None
             stdin = self._proc.stdin
             self._state = STATE_UNLOADING
+            self._reschedule_idle_timer_locked()
         try:
             stdin.write(json.dumps({"id": "_unload", "action": "unload"}) + "\n")
             stdin.flush()
@@ -428,6 +514,9 @@ class InferenceDaemon:
                 elif kind == "unloaded":
                     self._state = STATE_IDLE
                     self._model_loaded = False
+                # `loaded` 进入 idle+loaded → 启动 idle timer；`unloaded` 模型走 → cancel
+                if kind in ("ready", "loaded", "unloaded"):
+                    self._reschedule_idle_timer_locked()
             for cb in list(self._global_listeners):
                 try:
                     cb(msg)
@@ -462,6 +551,8 @@ class InferenceDaemon:
             with self._lock:
                 self._active = None
                 self._state = STATE_IDLE
+                # task 完成回 idle；模型还在 → 重启 idle 倒计时
+                self._reschedule_idle_timer_locked()
 
         try:
             active.on_event({**forward_msg, "task_id": active.task_id})
@@ -480,6 +571,7 @@ class InferenceDaemon:
             active = self._active
             self._active = None
             listeners = list(self._global_listeners)
+            self._reschedule_idle_timer_locked()
 
         if active is not None and prev_state != STATE_UNLOADING:
             try:

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -866,6 +866,10 @@ class Supervisor:
                 self._fail_daemon_task(task_id, f"daemon start failed: {e}")
                 return
 
+        # spawn 后立刻把 idle timeout 从 secrets 同步进 daemon，避免首个 task 出图后
+        # 模型常驻；用户在 settings 改值后下一次 dispatch 也会重新读取。
+        daemon.sync_idle_timeout_from_secrets()
+
         if not self._daemon_listener_registered:
             daemon.add_global_listener(self._on_daemon_global_event)
             daemon.add_log_listener(self._on_daemon_log_line)

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -371,6 +371,9 @@ export interface GenerateSecretsConfig {
   /** 注意力后端默认值（design 决策：用户配置一次，不每次出图都改）。
    * Generate 页 enqueue 自动注入；Settings 训练 tab 切换。 */
   attention_backend: AttentionBackend
+  /** 测试出图 daemon 闲置 N 分钟自动卸载模型释放 VRAM。0 = 关闭，模型常驻
+   * 直到手动点"清理显存"。计时只在 idle + 模型 loaded 时跑。 */
+  idle_timeout_minutes: number
 }
 
 /** 系统级偏好（ADR 0002 / 0005）。update_channel 是用户视图偏好（"stable" /

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -989,6 +989,14 @@
     "previewThrottle": "Throttle (preview every N steps)",
     "previewThrottleDesc": "0 = off; recommended 3-5",
     "taeFluxHelp": "The TAEFlux decode model is downloaded in the background when the server starts; no separate UI action is needed.",
+    "idleTimeout": {
+      "title": "Auto-unload VRAM",
+      "label": "Unload after idle (minutes)",
+      "desc": "Default: 10 minutes",
+      "help": "The generate daemon keeps the model in VRAM after the first run so you can quickly retry with different params. If no new generation arrives within this window, the model is auto-unloaded to free VRAM (next run reloads, ~30-60s). 0 = off, keep the model resident until you manually click \"Free VRAM\". Recommended: 10 minutes.",
+      "minutesSuffix": "min",
+      "offHint": "Off: model stays resident until manually freed"
+    },
     "theme": "Theme",
     "themeLight": "☀ Light",
     "themeDark": "☾ Dark",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -989,6 +989,14 @@
     "previewThrottle": "节流（每 N 步推一次预览）",
     "previewThrottleDesc": "0 = 关闭；推荐 3-5",
     "taeFluxHelp": "TAEFlux 解码模型 server 启动时已后台下载，UI 不需要单独操作。",
+    "idleTimeout": {
+      "title": "显存自动清理",
+      "label": "闲置自动卸载（分钟）",
+      "desc": "默认 10 分钟",
+      "help": "测试出图模型加载后会常驻显存，方便重复调参。超过指定时长没出图就自动卸载释放显存（下次出图重新加载约 30-60 秒）。0 = 关闭，模型常驻直到手动点\"清理显存\"。推荐 10 分钟。",
+      "minutesSuffix": "分",
+      "offHint": "已关闭：模型常驻直到手动清理"
+    },
     "theme": "主题",
     "themeLight": "☀ 日间",
     "themeDark": "☾ 暗色",

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -115,6 +115,7 @@ const TAB_SECTIONS: Record<Tab, { id: string; labelKey: string }[]> = {
     { id: 'wandb', labelKey: 'settings.wandb' },
   ],
   testing: [
+    { id: 'idle-timeout', labelKey: 'settings.idleTimeout.title' },
     { id: 'preview', labelKey: 'settings.intermediatePreview' },
   ],
   appearance: [
@@ -251,7 +252,7 @@ const EMPTY: Secrets = {
   },
   models: { root: null, selected_anima: '1.0', selected_upscaler: '4x-AnimeSharp', auto_sync_paths: true },
   queue: { allow_gpu_during_train: false },
-  generate: { preview_every_n_steps: 3, attention_backend: 'auto' },
+  generate: { preview_every_n_steps: 3, attention_backend: 'auto', idle_timeout_minutes: 10 },
   system: { update_channel: 'stable', show_dev_channel: false },
   proxy: {
     enabled: false,
@@ -1189,6 +1190,7 @@ export default function SettingsPage() {
         {/* attention 后端走全局 auto-detect，UI 不暴露切换；想强制覆盖
             的高级用户改 secrets.json 的 generate.attention_backend
             （flash_attn / xformers / none）。安装管理在『训练』tab。 */}
+        <IdleTimeoutSection draft={draft} update={update} />
         <TaeFluxSection draft={draft} update={update} />
       </>)}
 
@@ -2943,6 +2945,45 @@ function XformersSection() {
 //
 // TAEFlux 模型 server 启动时后台下载（lifespan startup）；UI 只暴露用户必须
 // 控制的「节流 N」一个输入，其他状态/下载/帮助文字全删（用户决策）。
+
+function IdleTimeoutSection({
+  draft, update,
+}: {
+  draft: Secrets
+  update: <S extends Section, K extends keyof Secrets[S]>(
+    section: S, key: K, value: Secrets[S][K],
+  ) => void
+}) {
+  const { t } = useTranslation()
+  const minutes = draft.generate.idle_timeout_minutes
+  return (
+    <SettingsSection id="idle-timeout" title={t('settings.idleTimeout.title')}>
+      <SettingsField
+        label={t('settings.idleTimeout.label')}
+        desc={t('settings.idleTimeout.desc')}
+        helpTooltip={<p>{t('settings.idleTimeout.help')}</p>}
+      >
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            min={0}
+            max={240}
+            value={minutes}
+            onChange={(e) => update('generate', 'idle_timeout_minutes', Math.max(0, Number(e.target.value) || 0))}
+            className="input"
+            style={{ width: 80 }}
+          />
+          <span className="text-xs text-fg-tertiary">
+            {minutes === 0
+              ? t('settings.idleTimeout.offHint')
+              : t('settings.idleTimeout.minutesSuffix')}
+          </span>
+        </div>
+      </SettingsField>
+    </SettingsSection>
+  )
+}
+
 
 function TaeFluxSection({
   draft, update,

--- a/tests/test_inference_daemon_idle_timeout.py
+++ b/tests/test_inference_daemon_idle_timeout.py
@@ -1,0 +1,270 @@
+"""InferenceDaemon idle timeout 自动 unload 测试。
+
+策略：不真启 daemon 子进程，直接对 InferenceDaemon 实例做白盒测试 —
+- 用 SimpleNamespace 伪造 `_proc`（非 None 满足 reschedule 检查）
+- 手动设 state / model_loaded 模拟各状态
+- 用极短 timeout（0.05-0.1s）等真实 Timer 触发；不用 sleep 长时间
+
+覆盖：
+- timeout=0 时不启动 timer
+- model 未 load 时不启动
+- state=BUSY 时不启动
+- IDLE + loaded + timeout>0 → 启动；到期调 request_unload
+- 状态切换（BUSY→IDLE / unloaded / stopped）正确 cancel / 重启 timer
+- sync_idle_timeout_from_secrets 从 settings 读
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from studio.services.inference.daemon import (
+    InferenceDaemon,
+    STATE_BUSY,
+    STATE_IDLE,
+    STATE_STOPPED,
+    STATE_UNLOADING,
+)
+
+
+# 让 `_proc is not None` 满足，但不真发协议（reschedule 只看 is None；request_unload
+# 会拿 _proc.stdin —— 测试里用 spy 替换 request_unload 不走到那一步）。
+def _fake_proc() -> SimpleNamespace:
+    return SimpleNamespace(stdin=None, poll=lambda: None)
+
+
+def _make_daemon_in_state(
+    *,
+    state: str = STATE_IDLE,
+    model_loaded: bool = True,
+    with_proc: bool = True,
+) -> InferenceDaemon:
+    d = InferenceDaemon()
+    if with_proc:
+        d._proc = _fake_proc()  # type: ignore[assignment]
+    d._state = state
+    d._model_loaded = model_loaded
+    return d
+
+
+def _wait_until(predicate, timeout=2.0, interval=0.01) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return False
+
+
+# ---------- arming 条件 -------------------------------------------------------
+
+
+def test_timer_does_not_arm_when_timeout_zero() -> None:
+    d = _make_daemon_in_state()
+    d.set_idle_timeout_seconds(0)
+    assert d._idle_timer is None
+
+
+def test_timer_does_not_arm_when_model_not_loaded() -> None:
+    d = _make_daemon_in_state(model_loaded=False)
+    d.set_idle_timeout_seconds(5.0)
+    assert d._idle_timer is None
+
+
+def test_timer_does_not_arm_when_busy() -> None:
+    d = _make_daemon_in_state(state=STATE_BUSY)
+    d.set_idle_timeout_seconds(5.0)
+    assert d._idle_timer is None
+
+
+def test_timer_does_not_arm_when_no_proc() -> None:
+    d = _make_daemon_in_state(with_proc=False)
+    d.set_idle_timeout_seconds(5.0)
+    assert d._idle_timer is None
+
+
+def test_timer_arms_when_idle_and_loaded() -> None:
+    d = _make_daemon_in_state()
+    d.set_idle_timeout_seconds(60.0)
+    try:
+        assert d._idle_timer is not None
+        assert d._idle_timer.is_alive()
+    finally:
+        if d._idle_timer is not None:
+            d._idle_timer.cancel()
+
+
+# ---------- 触发 unload -------------------------------------------------------
+
+
+def test_timer_fires_request_unload(monkeypatch: pytest.MonkeyPatch) -> None:
+    """timer 到期且仍 idle+loaded → 调 request_unload。"""
+    d = _make_daemon_in_state()
+    calls: list[None] = []
+
+    def fake_unload() -> None:
+        calls.append(None)
+
+    monkeypatch.setattr(d, "request_unload", fake_unload)
+    d.set_idle_timeout_seconds(0.05)
+
+    assert _wait_until(lambda: len(calls) >= 1, timeout=1.0)
+    assert len(calls) == 1
+
+
+def test_timer_does_not_fire_if_state_changed_before_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """timer 到期瞬间状态已变（race window）→ 不发 unload。
+
+    模拟：timer arm 后用户 submit_task 进 BUSY。我们手动改 state 不调
+    reschedule，让 timer 残留然后到期；_on_idle_timeout 自检发现 BUSY 应放弃。
+    """
+    d = _make_daemon_in_state()
+    calls: list[None] = []
+    monkeypatch.setattr(d, "request_unload", lambda: calls.append(None))
+    d.set_idle_timeout_seconds(0.05)
+    # 不走 reschedule，直接改 state 模拟 race（race window 内 callback 已排队）
+    with d._lock:
+        d._state = STATE_BUSY
+    time.sleep(0.2)  # 让 timer 跑完
+    assert calls == []
+
+
+def test_set_idle_timeout_zero_cancels_existing_timer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """已经 arm 的 timer：set_idle_timeout_seconds(0) 立刻 cancel + 不再触发。"""
+    d = _make_daemon_in_state()
+    calls: list[None] = []
+    monkeypatch.setattr(d, "request_unload", lambda: calls.append(None))
+    d.set_idle_timeout_seconds(0.1)
+    assert d._idle_timer is not None
+    d.set_idle_timeout_seconds(0)
+    assert d._idle_timer is None
+    time.sleep(0.2)
+    assert calls == []
+
+
+# ---------- 状态切换钩子 ------------------------------------------------------
+
+
+def test_busy_then_idle_rearms_timer(monkeypatch: pytest.MonkeyPatch) -> None:
+    """BUSY → IDLE（task done）→ timer 重新启动。"""
+    d = _make_daemon_in_state()
+    d.set_idle_timeout_seconds(60.0)
+    first_timer = d._idle_timer
+    assert first_timer is not None
+
+    # 模拟 submit_task：进 BUSY
+    with d._lock:
+        d._state = STATE_BUSY
+        d._reschedule_idle_timer_locked()
+    assert d._idle_timer is None  # busy 时 cancel
+
+    # 模拟 task done：回 IDLE
+    with d._lock:
+        d._state = STATE_IDLE
+        d._reschedule_idle_timer_locked()
+    try:
+        assert d._idle_timer is not None
+        assert d._idle_timer is not first_timer  # 是新的 timer
+    finally:
+        if d._idle_timer is not None:
+            d._idle_timer.cancel()
+
+
+def test_unloaded_event_cancels_timer() -> None:
+    """收到 unloaded → 模型走了 → timer cancel。"""
+    d = _make_daemon_in_state()
+    d.set_idle_timeout_seconds(60.0)
+    assert d._idle_timer is not None
+    # 模拟 _handle_event 的 unloaded 分支
+    with d._lock:
+        d._state = STATE_IDLE
+        d._model_loaded = False
+        d._reschedule_idle_timer_locked()
+    assert d._idle_timer is None
+
+
+def test_unloading_state_cancels_timer() -> None:
+    """request_unload 进 UNLOADING → timer cancel。"""
+    d = _make_daemon_in_state()
+    d.set_idle_timeout_seconds(60.0)
+    assert d._idle_timer is not None
+    with d._lock:
+        d._state = STATE_UNLOADING
+        d._reschedule_idle_timer_locked()
+    assert d._idle_timer is None
+
+
+def test_stopped_cancels_timer() -> None:
+    """proc 退出 → STOPPED → timer cancel。"""
+    d = _make_daemon_in_state()
+    d.set_idle_timeout_seconds(60.0)
+    assert d._idle_timer is not None
+    with d._lock:
+        d._proc = None
+        d._state = STATE_STOPPED
+        d._model_loaded = False
+        d._reschedule_idle_timer_locked()
+    assert d._idle_timer is None
+
+
+# ---------- secrets 同步 ------------------------------------------------------
+
+
+def test_sync_idle_timeout_from_secrets_reads_minutes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """sync 从 secrets.generate.idle_timeout_minutes 读，换算成秒。"""
+    from studio.infrastructure import secrets as _secrets
+
+    fake = _secrets.Secrets()
+    fake.generate.idle_timeout_minutes = 7
+    monkeypatch.setattr(_secrets, "load", lambda: fake)
+
+    d = _make_daemon_in_state()
+    d.sync_idle_timeout_from_secrets()
+    assert d._idle_timeout_seconds == 7 * 60.0
+    if d._idle_timer is not None:
+        d._idle_timer.cancel()
+
+
+def test_sync_idle_timeout_zero_minutes_disables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """secrets 里 idle_timeout_minutes=0 → timer 关闭。"""
+    from studio.infrastructure import secrets as _secrets
+
+    fake = _secrets.Secrets()
+    fake.generate.idle_timeout_minutes = 0
+    monkeypatch.setattr(_secrets, "load", lambda: fake)
+
+    d = _make_daemon_in_state()
+    d.sync_idle_timeout_from_secrets()
+    assert d._idle_timeout_seconds == 0
+    assert d._idle_timer is None
+
+
+def test_sync_idle_timeout_handles_secrets_load_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """secrets.load() 抛错时 sync 不改当前值（不抛出）。"""
+    from studio.infrastructure import secrets as _secrets
+
+    d = _make_daemon_in_state()
+    d.set_idle_timeout_seconds(120.0)
+    assert d._idle_timeout_seconds == 120.0
+
+    def boom() -> Any:
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(_secrets, "load", boom)
+    d.sync_idle_timeout_from_secrets()  # 不抛
+    assert d._idle_timeout_seconds == 120.0  # 未变
+    if d._idle_timer is not None:
+        d._idle_timer.cancel()


### PR DESCRIPTION
## 背景

测试出图（Generate 页）daemon 加载模型后会常驻 VRAM。现状下只有三条卸载路径：用户手动点"清理显存"按钮、训练 / 打标任务派发时 daemon 让位 GPU、daemon 进程被杀。用户切到别的页面后忘记清理，下次开训练就爆显存。

## 改动概要

后端 `InferenceDaemon` 加 idle timer：进入 `IDLE + 模型 loaded` 状态时启动倒计时，超时调 `request_unload()`；进 `BUSY` / 收到 `unloaded` / 进程退出 时自动 cancel。

- `studio/infrastructure/secrets.py` — `GenerateConfig.idle_timeout_minutes: int = 10`（0 = 关）
- `studio/services/inference/daemon.py` — `_idle_timer` + `set_idle_timeout_seconds()` + `sync_idle_timeout_from_secrets()` + `_reschedule_idle_timer_locked()`；在 7 个状态切换点都挂钩。`_on_idle_timeout` 回调内重检状态防 race（即便没拦住，`request_unload` 内的 BUSY 检查也会兜底拒绝）。
- `studio/supervisor/core.py` — `_submit_to_daemon` 中 daemon spawn 后调一次 `sync_idle_timeout_from_secrets()`
- `studio/api/routers/secrets.py` — PUT secrets 后调一次 sync，让运行中改值即时生效
- `studio/web/src/pages/tools/Settings.tsx` — Settings → 测试 tab 加 `IdleTimeoutSection`；EMPTY + section index 同步
- `studio/web/src/api/client.ts` — `GenerateSecretsConfig.idle_timeout_minutes`
- zh/en i18n 各加 5 个 keys（title / label / desc / help / minutesSuffix / offHint）

新增字段不是改 schema 字段含义，是加新字段；新功能默认开（10 分钟），用户可设 0 关闭。

## 测试方式

- 新增 `tests/test_inference_daemon_idle_timeout.py`（15 个 case）：arming 条件（timeout=0 / 未 loaded / BUSY / 无 proc / IDLE+loaded）、真实 Timer 触发 unload、state-change race window、状态切换重置、`UNLOADING`/`unloaded`/`STOPPED` cancel、`sync_idle_timeout_from_secrets` 含读取失败兜底
- 原有 `tests/test_inference_daemon.py` (9) + `tests/test_daemon_gpu_yield.py` (8) + `tests/test_secrets.py` (33) 全过
- 前端 `Settings.test.tsx` (3) 全过；`tsc --noEmit` + `eslint src` 干净

## UI

![screenshot pending]

(截图需在 dev server 跑起来时补 — Settings → 测试 → 显存自动清理 section 一个 numeric input + ⓘ 长说明 tooltip)

## 不在范围内

- 不动 `release_notes.yaml` / `CHANGELOG.md`（dev PR 约定）
- 不动 `runtime/anima_daemon.py`（idle timer 挂在 supervisor 端 `InferenceDaemon` 层，不改 daemon 子进程协议）
- 不改"取消任务"行为（按设计：cancel 只停当前出图，模型保留方便调参）