### PR TITLE
fix(static): 主动注册 .js / .css MIME 类型防 Windows 注册表污染白屏

### DIFF
--- a/studio/api/static.py
+++ b/studio/api/static.py
@@ -1,10 +1,20 @@
 """SPA 静态文件 mount（PR-5 从 server.py 抽出）。"""
 from __future__ import annotations
 
+import mimetypes
 from pathlib import Path
 
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+
+# Windows 注册表常把 .js 标成 text/plain（IIS / 杀软 / 旧装机污染），
+# 导致 ES module strict MIME check 拒载 → 启动白屏。issue #228
+# import time 主动覆盖，确保跨平台一致。
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("application/javascript", ".mjs")
+mimetypes.add_type("text/css", ".css")
+mimetypes.add_type("application/json", ".json")
+mimetypes.add_type("image/svg+xml", ".svg")
 
 
 class SPAStaticFiles(StaticFiles):

--- a/tests/test_static_mime.py
+++ b/tests/test_static_mime.py
@@ -1,0 +1,22 @@
+"""issue #228 regression: studio.api.static must force .js / .css / .svg etc.
+to canonical MIME types so Windows registry pollution (e.g. .js → text/plain
+set by IIS / 杀软 / 旧装机) can't break ES module loading and white-screen the SPA.
+"""
+from __future__ import annotations
+
+import importlib
+import mimetypes
+
+
+def test_static_module_overrides_polluted_js_mime() -> None:
+    mimetypes.add_type("text/plain", ".js")
+    assert mimetypes.guess_type("foo.js")[0] == "text/plain"
+
+    import studio.api.static as static_mod
+    importlib.reload(static_mod)
+
+    assert mimetypes.guess_type("foo.js")[0] == "application/javascript"
+    assert mimetypes.guess_type("foo.mjs")[0] == "application/javascript"
+    assert mimetypes.guess_type("foo.css")[0] == "text/css"
+    assert mimetypes.guess_type("foo.svg")[0] == "image/svg+xml"
+    assert mimetypes.guess_type("foo.json")[0] == "application/json"


### PR DESCRIPTION
## 背景

issue #228 — Windows 启动后浏览器白屏，console 报：

> Failed to load module script: Expected a JavaScript-or-Wasm module script but the server responded with a MIME type of "text/plain".

根因是 Python stdlib `mimetypes` 模块在 Windows 上会读注册表 `HKCR\.js` 的 `Content Type`，部分机器（IIS / 杀软 / 旧装机污染）把该值改成了 `text/plain`。FastAPI / starlette `StaticFiles` 通过 `mimetypes.guess_type()` 决定响应头，于是 `.js` 被返回成 `text/plain`，浏览器 strict MIME check 拒绝加载 ES module → 白屏。

## 改动

`studio/api/static.py` import time 主动注册一组规范 MIME（`.js` / `.mjs` / `.css` / `.json` / `.svg`），覆盖系统污染值。`add_type` 在 stdlib 内部走 `types_map[True][ext] = type`，是覆盖写入。

## 测试

- `tests/test_static_mime.py` 模拟注册表污染：先 `mimetypes.add_type("text/plain", ".js")`，再 reload `studio.api.static`，断言 `.js` / `.mjs` / `.css` / `.svg` / `.json` 全部为正确 MIME。
- 本机 Windows 跑过 `pytest tests/test_static_mime.py` 通过。