### PR TITLE
fix(booru): 区分 429/503 语义 + API/CDN 独立 sticky + 同窗口日志去重

### DIFF
--- a/studio/services/booru/pool.py
+++ b/studio/services/booru/pool.py
@@ -106,6 +106,8 @@ class BooruPoolConfig:
     api_rate_per_sec: float = 2.0
     cdn_rate_per_sec: float = 5.0
     backoff_on_429: float = 60.0
+    # 503 = 服务端瞬时不可用，纯瞬时问题，不应像 429 那样长时间 sticky + 减速
+    backoff_on_503: float = 15.0
 
 
 class BooruClient:
@@ -128,7 +130,8 @@ class BooruClient:
         self.cfg = cfg or BooruPoolConfig()
         self._session = session or requests.Session()
         patch_requests_session(self._session)
-        logger.info(f"BooruClient session proxies: {self._session.proxies}")
+        # 外部传入的 session 不一定是 requests.Session（测试里有最小 FakeSession 只实现 .get）
+        logger.info("BooruClient session proxies: %s", getattr(self._session, "proxies", {}))
         self._owns_session = session is None
         self._api_bucket = TokenBucket(self.cfg.api_rate_per_sec)
         self._cdn_bucket = TokenBucket(self.cfg.cdn_rate_per_sec)
@@ -136,9 +139,9 @@ class BooruClient:
             max_workers=max(1, self.cfg.parallel_workers),
             thread_name_prefix="booru-pool",
         )
-        # 429 sticky 退避状态
+        # sticky 退避状态 —— API / CDN 独立，避免 CDN 503 风暴锁住 API host
         self._lock = threading.Lock()
-        self._backoff_until: float = 0.0
+        self._backoff_until: dict[str, float] = {"api": 0.0, "cdn": 0.0}
         self._rate_halved = False
 
     # -------------------- lifecycle --------------------
@@ -160,63 +163,85 @@ class BooruClient:
     def __exit__(self, *_exc: Any) -> None:
         self.close()
 
-    # -------------------- 429 sticky 状态 --------------------
+    # -------------------- sticky 退避状态 --------------------
 
-    def _wait_if_backoff(self) -> None:
-        """若上次撞 429，整 client 等到 backoff_until 之后才发新请求。"""
+    def _wait_if_backoff(self, kind: str) -> None:
+        """若该 host class 处在 backoff window 内，阻塞到 window 结束。
+
+        不 log —— 进入 backoff 时 `_trigger_backoff` 已经 log 过一次；
+        每个 worker 各自在这里 log 会刷屏（N worker → N 行相同 backoff 提示）。
+        """
         with self._lock:
-            until = self._backoff_until
+            until = self._backoff_until[kind]
         wait = until - time.monotonic()
         if wait > 0:
-            logger.warning("[booru_pool] 429 backoff，等 %.1fs", wait)
             time.sleep(wait)
 
-    def _trigger_backoff(self, status_code: int) -> None:
-        """收到 429/503 → 全 client backoff 60s + 永久减半速率。"""
+    def _trigger_backoff(self, status_code: int, kind: str) -> None:
+        """收到 429/503 → 该 host class 进 sticky backoff。
+
+        - 429（服务端明确「太快了」）：长退避 + 永久减半速率（一次）
+        - 503（服务端瞬时不可用）：短退避，不动速率 —— 服务端宕机不是我们的问题
+        - 一个 backoff window 内连续触发只 log 一次（避免 burst 503 时刷 N 行）
+        """
+        is_429 = status_code == 429
+        backoff = self.cfg.backoff_on_429 if is_429 else self.cfg.backoff_on_503
+        log_new_window = False
+        do_halve = False
         with self._lock:
-            self._backoff_until = time.monotonic() + self.cfg.backoff_on_429
-            if not self._rate_halved:
+            # 仅在当前不在 backoff window 内时视为「新 window」→ log 一次
+            if self._backoff_until[kind] <= time.monotonic():
+                log_new_window = True
+            self._backoff_until[kind] = time.monotonic() + backoff
+            if is_429 and not self._rate_halved:
                 self._rate_halved = True
                 self.cfg.api_rate_per_sec /= 2
                 self.cfg.cdn_rate_per_sec /= 2
-                self._api_bucket.set_rate(self.cfg.api_rate_per_sec)
-                self._cdn_bucket.set_rate(self.cfg.cdn_rate_per_sec)
-                logger.warning(
-                    "[booru_pool] 收到 %d，速率永久减半（API %.2f / CDN %.2f req/s）",
-                    status_code,
-                    self.cfg.api_rate_per_sec,
-                    self.cfg.cdn_rate_per_sec,
-                )
+                do_halve = True
 
-    def _check_response(self, resp: requests.Response) -> None:
+        if log_new_window:
+            logger.warning(
+                "[booru_pool] %s 收到 %d，sticky backoff %.0fs",
+                kind, status_code, backoff,
+            )
+        if do_halve:
+            self._api_bucket.set_rate(self.cfg.api_rate_per_sec)
+            self._cdn_bucket.set_rate(self.cfg.cdn_rate_per_sec)
+            logger.warning(
+                "[booru_pool] 429 触发速率永久减半（API %.2f / CDN %.2f req/s）",
+                self.cfg.api_rate_per_sec,
+                self.cfg.cdn_rate_per_sec,
+            )
+
+    def _check_response(self, resp: requests.Response, kind: str) -> None:
         """429/503 触发 sticky 退避；其他 4xx/5xx 不动池子（让上层抛错）。"""
         if resp.status_code in (429, 503):
-            self._trigger_backoff(resp.status_code)
+            self._trigger_backoff(resp.status_code, kind)
 
     # -------------------- 公开 API --------------------
 
     def search_posts(self, api_source: str, tags_query: str, **kw: Any) -> list[dict[str, Any]]:
         """走 API bucket。kw 透传给 booru_api.search_posts。"""
-        self._wait_if_backoff()
+        self._wait_if_backoff("api")
         self._api_bucket.acquire()
         kw.setdefault("session", self._session)
         try:
             return booru_api.search_posts(api_source, tags_query, **kw)
         except requests.HTTPError as exc:
             if exc.response is not None:
-                self._check_response(exc.response)
+                self._check_response(exc.response, "api")
             raise
 
     def download_image(self, url: str, save_path: Path, **kw: Any) -> Path:
         """走 CDN bucket。kw 透传给 booru_api.download_image。"""
-        self._wait_if_backoff()
+        self._wait_if_backoff("cdn")
         self._cdn_bucket.acquire()
         kw.setdefault("session", self._session)
         try:
             return booru_api.download_image(url, save_path, **kw)
         except requests.HTTPError as exc:
             if exc.response is not None:
-                self._check_response(exc.response)
+                self._check_response(exc.response, "cdn")
             raise
 
     def parallel_download(

--- a/tests/test_booru_pool.py
+++ b/tests/test_booru_pool.py
@@ -177,6 +177,100 @@ def test_429_triggers_backoff_and_halves_rate(monkeypatch: pytest.MonkeyPatch) -
     client.close()
 
 
+def test_503_triggers_backoff_but_does_not_halve_rate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """503 是服务端瞬时不可用（非「我们太快」）—— 进 sticky 但不减速率。"""
+    cfg = booru_pool.BooruPoolConfig(
+        parallel_workers=2,
+        api_rate_per_sec=10.0,
+        cdn_rate_per_sec=10.0,
+        backoff_on_429=0.05,
+        backoff_on_503=0.05,
+    )
+    client = booru_pool.BooruClient(cfg)
+
+    resp = MagicMock()
+    resp.status_code = 503
+    err = requests.HTTPError("503"); err.response = resp
+
+    def fake_download(*_a, **_k):
+        raise err
+
+    monkeypatch.setattr(booru_api, "download_image", fake_download)
+    with pytest.raises(requests.HTTPError):
+        client.download_image(
+            "https://img3.gelbooru.com/x.png",
+            Path("/tmp/x.png"),
+            convert_to_png=False,
+            remove_alpha_channel=False,
+        )
+    # 503 不减速
+    assert client.cfg.api_rate_per_sec == pytest.approx(10.0)
+    assert client.cfg.cdn_rate_per_sec == pytest.approx(10.0)
+    # 但 CDN sticky 状态已设
+    assert client._backoff_until["cdn"] > 0
+    # API 侧不受影响（独立 backoff）
+    assert client._backoff_until["api"] == 0.0
+    client.close()
+
+
+def test_cdn_backoff_does_not_block_api(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CDN 503 不该让后续 search（API host）也等 sticky window。"""
+    cfg = booru_pool.BooruPoolConfig(
+        parallel_workers=2,
+        api_rate_per_sec=100.0,
+        cdn_rate_per_sec=100.0,
+        backoff_on_429=10.0,  # 故意长，证明 API 不被它拖
+        backoff_on_503=10.0,
+    )
+    client = booru_pool.BooruClient(cfg)
+
+    # CDN 抛 503，触发 cdn sticky 10s
+    resp = MagicMock(); resp.status_code = 503
+    err = requests.HTTPError("503"); err.response = resp
+    monkeypatch.setattr(booru_api, "download_image", lambda *_a, **_k: (_ for _ in ()).throw(err))
+    monkeypatch.setattr(booru_api, "search_posts", lambda *_a, **_k: [{"id": 1}])
+
+    with pytest.raises(requests.HTTPError):
+        client.download_image(
+            "https://img3.gelbooru.com/x.png",
+            Path("/tmp/x.png"),
+            convert_to_png=False,
+            remove_alpha_channel=False,
+        )
+    # 后续 API search 应立即返回（不等 10s）
+    t0 = time.monotonic()
+    client.search_posts("gelbooru", "x", user_id="u", api_key="k")
+    elapsed = time.monotonic() - t0
+    assert elapsed < 0.5, f"API 被 CDN backoff 拖住了，耗时 {elapsed:.2f}s"
+    client.close()
+
+
+def test_burst_503_in_same_window_logs_once(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """同一 backoff window 内多 worker 连发 503 只应 log 1 次（避免刷屏）。
+
+    模拟原 bug：4 个 worker 在 sticky window 设置后还在飞中，全部撞 503 回来。
+    这里直接连发 _trigger_backoff 模拟并发；正常下载路径下 _wait_if_backoff
+    会让后续 worker sleep 出窗口再触发，那是真正的「新事件」应当 log。
+    """
+    cfg = booru_pool.BooruPoolConfig(backoff_on_503=10.0)  # 窗口足够大
+    client = booru_pool.BooruClient(cfg)
+    caplog.set_level("WARNING", logger="studio.services.booru.pool")
+
+    for _ in range(10):
+        client._trigger_backoff(503, "cdn")
+
+    sticky_logs = [r for r in caplog.records if "sticky backoff" in r.message]
+    assert len(sticky_logs) == 1, (
+        f"同一 window 内 503 应仅 log 1 次，实际 {len(sticky_logs)} 次："
+        f"{[r.message for r in sticky_logs]}"
+    )
+    client.close()
+
+
 def test_parallel_download_respects_workers(monkeypatch: pytest.MonkeyPatch) -> None:
     """parallel_workers=2 → 同时活动的 fn 调用数 ≤ 2。"""
     cfg = booru_pool.BooruPoolConfig(


### PR DESCRIPTION
## 背景 / 动机

用户在本地跑下载时撞 gelbooru CDN 不稳，日志里出现一串看起来像「速率被 429 限了」的提示，但其实今天 gelbooru 服务端就是发 503（8-worker 全速 burst 30 张 → **27/30 是 503**，0 个 429）。排查发现我们代码自己放大了它：

1. **日志措辞误导**：`_wait_if_backoff()` 里 log 字串写死 `"429 backoff"`，但 `_backoff_until` 是 429 **或** 503 任何一个都会设。一个 503 触发 60s sticky timer 后，4 个并发 worker 都进 wait → 4 行 `"429 backoff，等 59.5s"`，看起来像撞了 4 次 429。
2. **过度减速**：一个偶发 503 永久把 API + CDN 速率都减半（一次性、不可恢复）。今天这种全网 503 风暴 → 速率被砍残但其实根因是 gelbooru 服务端瞬时不可用，不是「我们太快」。
3. **API / CDN 共用 sticky**：CDN 503 风暴期间，连 API host 的 search 也跟着等 60s（两者根本是不同主机）。
4. **附带**：master 上 `tests/test_downloader.py` 2 个 case 在 PR #162 引入 proxy 后一直 fail —— `BooruClient.__init__` 访问 `self._session.proxies` 在测试 FakeSession 上 AttributeError。同模块顺手修。

## 改动

`studio/services/booru/pool.py`：

- 拆 API / CDN 独立 sticky：`_backoff_until: dict[str, float]` 按 host class 隔离
- 区分 429 vs 503：
  - 429（"你太快了"）→ 60s sticky + 永久减半速率（一次）
  - 503（"我挂了"）→ 15s sticky + **不动速率**
- 同窗口日志去重：`_trigger_backoff` 仅当前不在 backoff window 时才 log（避免 burst 503 时 N worker × N 行刷屏；`_wait_if_backoff` 改为 silent wait）
- 修日志措辞：`"429 backoff，等 59.5s"` → `"cdn 收到 503，sticky backoff 15s"`，带 host class + 实际触发码
- `getattr(self._session, "proxies", {})` 修 FakeSession 兼容（修了 2 个预存在的 test_downloader fail）

`tests/test_booru_pool.py` 新增 3 个 regression：

- `test_503_triggers_backoff_but_does_not_halve_rate`：503 进 sticky 但 rate 不变
- `test_cdn_backoff_does_not_block_api`：CDN 503 期间 API search 立即返回
- `test_burst_503_in_same_window_logs_once`：同窗口连 10 次 503 只 log 1 行

## 测试

- `python -m pytest tests/test_booru_pool.py tests/test_downloader.py -q` → **33/33 通过**（含修复的 2 个预存在 fail + 3 个新 regression）
- 全套 `python -m studio test`：相比 dev 基线 **多 11 个 pass（-8 fail + 3 new test）**，其余 64 个 fail 均与 booru 无关（lycoris_resume / reg_dedup / schema endpoints / flash_attn etc.，dev 自带）

## 验证逻辑（PR description only，不入 release notes）

带当前 token / UA + Referer，8-worker burst 30 张 → 27/30 直接 503，0 个 429。
不带 Referer → CDN 直接路由成 HTML 详情页（42KB 而非 700KB jpg）。
生产路径 (`downloader.py:208`) 一直带 Referer，所以这条不是 bug，只是测试时验证。