### PR TITLE
test: 修复 dev 上 10 个 stale test failures

### DIFF
--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 160,
+  "count": 165,
   "routes": [
     {
       "path": "/",
@@ -996,6 +996,14 @@
     {
       "path": "/api/queue/{task_id}/outputs",
       "methods": [
+        "DELETE"
+      ],
+      "name": "delete_task_output_files",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/queue/{task_id}/outputs",
+      "methods": [
         "GET"
       ],
       "name": "list_task_outputs",
@@ -1167,6 +1175,38 @@
         "GET"
       ],
       "name": "system_version",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/tag-dictionary/data",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_data",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/tag-dictionary/meta",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_meta",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/tag-dictionary/reset",
+      "methods": [
+        "POST"
+      ],
+      "name": "reset",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/tag-dictionary/upload",
+      "methods": [
+        "POST"
+      ],
+      "name": "upload",
       "type": "APIRoute"
     },
     {

--- a/tests/test_cltagger_tagger.py
+++ b/tests/test_cltagger_tagger.py
@@ -10,6 +10,7 @@ import pytest
 from PIL import Image
 
 from studio import secrets
+from studio.services import models as model_downloader
 from studio.services.tagging import cltagger as cltagger_tagger
 
 
@@ -17,6 +18,9 @@ from studio.services.tagging import cltagger as cltagger_tagger
 def isolated_secrets(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     sf = tmp_path / "secrets.json"
     monkeypatch.setattr(secrets, "SECRETS_FILE", sf)
+    # 隔离 models_root：默认回退到 REPO_ROOT/models，dev 机上可能真有
+    # cl_tagger_1_02，导致 is_available 误判 True。
+    monkeypatch.setattr(model_downloader, "models_root", lambda: tmp_path / "models")
     return tmp_path
 
 

--- a/tests/test_logging_bootstrap.py
+++ b/tests/test_logging_bootstrap.py
@@ -45,6 +45,11 @@ def test_webui_lifespan_calls_setup_logging(tmp_path: Path,
     with TestClient(server.app) as client:
         client.get("/api/health")
 
+    # RotatingFileHandler delay=True，不 emit 不开文件；
+    # dev 机上 taeflux/tag-dictionary 都已装时 lifespan 不会自动 emit。
+    # 主动 emit 一次强制 handler 打开 studio.log。
+    logging.getLogger("test.lifespan").info("force-emit to open file handler")
+
     # studio.log 应该被创建
     assert (tmp_path / "studio.log").exists(), (
         "lifespan 应该调 setup_logging('webui')，会装 studio.log file handler"

--- a/tests/test_studio_configs.py
+++ b/tests/test_studio_configs.py
@@ -367,7 +367,7 @@ def test_get_preset_with_warnings_reports_defaulted(
 ) -> None:
     """字段值不合法时回退默认值并列入 defaulted_fields。"""
     payload = _payload()
-    payload["optimizer_type"] = "lion"  # 不在 Literal 里
+    payload["optimizer_type"] = "made_up_optim"  # 不在 Literal 里
     yaml_bytes = yaml.safe_dump(payload, allow_unicode=True).encode("utf-8")
     (presets_dir / "badval.yaml").write_bytes(yaml_bytes)
 
@@ -375,7 +375,7 @@ def test_get_preset_with_warnings_reports_defaulted(
     assert resp.status_code == 200
     body = resp.json()
     assert "optimizer_type" in body["defaulted_fields"]
-    assert body["config"]["optimizer_type"] != "lion"
+    assert body["config"]["optimizer_type"] != "made_up_optim"
 
 
 def test_get_preset_without_warnings_returns_flat(
@@ -394,7 +394,7 @@ def test_tolerant_load_invalid_values(
 ) -> None:
     """跨分支预设：未知字段 + 非法值 → 都能加载，不会 500。"""
     payload = _payload()
-    payload["optimizer_type"] = "lion"
+    payload["optimizer_type"] = "made_up_optim"
     payload["infonoise_K"] = 0
     raw = {**payload, "nonexistent_thing": True}
     yaml_bytes = yaml.safe_dump(raw, allow_unicode=True).encode("utf-8")

--- a/tests/test_train_endpoints.py
+++ b/tests/test_train_endpoints.py
@@ -215,7 +215,9 @@ def test_fork_preset_still_forces_project_overrides(
     assert cfg["output_name"] != "wrong_name"
 
 
-def test_put_config_invalid_data_400(client: TestClient, env) -> None:
+def test_put_config_tolerates_invalid_values(client: TestClient, env) -> None:
+    """PR #146 之后 write_version_config 走 _tolerant_validate：非法字段
+    静默回退默认值（不再 400）。和 preset 导入路径行为一致。"""
     pid, vid = _make(client)
     _seed_preset(env, "tpl")
     client.post(
@@ -223,9 +225,10 @@ def test_put_config_invalid_data_400(client: TestClient, env) -> None:
         json={"name": "tpl"},
     )
     cfg = client.get(f"/api/projects/{pid}/versions/{vid}/config").json()["config"]
-    cfg["lora_rank"] = 0  # ge=4 → 下限越界（lora_rank 故意没设上限，LoKr 全维度走大数）
+    cfg["lora_rank"] = 0  # ge=4 越界 → 回退默认 32
     r = client.put(f"/api/projects/{pid}/versions/{vid}/config", json=cfg)
-    assert r.status_code == 400
+    assert r.status_code == 200
+    assert r.json()["config"]["lora_rank"] == 32
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_version_config.py
+++ b/tests/test_version_config.py
@@ -88,13 +88,13 @@ def test_write_tolerates_stale_preset_fields(env) -> None:
     p, v = _make_pv(env)
     cfg_in = _minimal_config(
         lora_rank=64,
-        optimizer_type="lion",
+        optimizer_type="made_up_optim",
         future_field_from_other_branch=True,
     )
     version_config.write_version_config(p, v, cfg_in)
     cfg_out = version_config.read_version_config(p, v)
     assert cfg_out["lora_rank"] == 64
-    assert cfg_out["optimizer_type"] != "lion"
+    assert cfg_out["optimizer_type"] != "made_up_optim"
     assert "future_field_from_other_branch" not in cfg_out
 
 
@@ -102,7 +102,7 @@ def test_read_tolerates_stale_version_config(env) -> None:
     p, v = _make_pv(env)
     raw = _minimal_config(
         lora_rank=96,
-        optimizer_type="lion",
+        optimizer_type="made_up_optim",
         future_field_from_other_branch=True,
     )
     path = version_config.version_config_path(p, v)
@@ -111,7 +111,7 @@ def test_read_tolerates_stale_version_config(env) -> None:
 
     cfg_out = version_config.read_version_config(p, v)
     assert cfg_out["lora_rank"] == 96
-    assert cfg_out["optimizer_type"] != "lion"
+    assert cfg_out["optimizer_type"] != "made_up_optim"
     assert "future_field_from_other_branch" not in cfg_out
 
 
@@ -172,7 +172,7 @@ def test_fork_preset_for_version_reports_warnings(env) -> None:
     p, v = _make_pv(env)
     raw = _minimal_config(
         lora_rank=128,
-        optimizer_type="lion",
+        optimizer_type="made_up_optim",
         future_field_from_other_branch=True,
     )
     (env["presets"] / "stale.yaml").write_text(
@@ -186,14 +186,14 @@ def test_fork_preset_for_version_reports_warnings(env) -> None:
     assert cfg["lora_rank"] == 128
     assert dropped == ["future_field_from_other_branch"]
     assert "optimizer_type" in defaulted
-    assert presets_io.read_preset("stale")["optimizer_type"] != "lion"
+    assert presets_io.read_preset("stale")["optimizer_type"] != "made_up_optim"
 
 
 def test_fork_preset_endpoint_returns_warnings(env) -> None:
     p, v = _make_pv(env)
     raw = _minimal_config(
         lora_rank=128,
-        optimizer_type="lion",
+        optimizer_type="made_up_optim",
         future_field_from_other_branch=True,
     )
     (env["presets"] / "stale.yaml").write_text(

--- a/tests/test_xy_matrix_schema.py
+++ b/tests/test_xy_matrix_schema.py
@@ -225,21 +225,6 @@ def test_generate_xy_y_axis_validated_too() -> None:
         )
 
 
-def test_generate_legacy_attention_with_xy_compatible() -> None:
-    """老 cfg（xformers/flash_attn 双 bool）+ xy_matrix 共存可以正常 migrate。"""
-    g = GenerateConfig.model_validate({
-        "transformer_path": "t",
-        "vae_path": "v",
-        "text_encoder_path": "te",
-        "xformers": True,  # 老字段
-        "xy_matrix": {
-            "x": {"axis": "steps", "values": [20, 25]},
-        },
-    })
-    assert g.attention_backend == "xformers"  # migrate 生效
-    assert g.xy_matrix is not None
-
-
 def test_generate_xy_serialize_round_trip() -> None:
     """model_dump → model_validate 等幂（确保 server 端透传不丢字段）。"""
     g = _gen(


### PR DESCRIPTION
## 背景

切 dev 跑全量 pytest 发现 10 个 failure / 2019 pass。逐簇调研后确认**全部是 PR 合并时漏更新测试**，没有真代码 bug。本 PR 只动 `tests/`。

## 改动概要

6 簇 stale tests，按引入 PR 分类：

| Cluster | 数量 | 根因 PR | 修法 |
|---|---|---|---|
| **A** | 5 | #214 把 `lion` 加进合法 optimizer | 桩值改 `made_up_optim` |
| **B** | 1 | #146 故意移除 `GenerateConfig._migrate_attention` | 删 obsolete 测试 |
| **C** | 1 | #217 / #225 加 5 个新 route | 删 snapshot 重生成 |
| **D** | 1 | 测试缺 `models_root()` 隔离 | fixture 加 monkeypatch |
| **E** | 1 | #146 PUT /config 改走 `_tolerant_validate` | 断言改成容错契约 |
| **F** | 1 | RotatingFileHandler `delay=True` + 模型已装 → 无 log emit | 测试主动 emit 强制开文件 |

详细：

- **A** `test_version_config::test_{write_tolerates_stale_preset_fields,read_tolerates_stale_version_config,fork_preset_for_version_reports_warnings,fork_preset_endpoint_returns_warnings}` + `test_studio_configs::test_get_preset_with_warnings_reports_defaulted`。PR #214 (#2674cf2) 把 `lion` 加进 `optimizer_type: Literal[...]`，测试用它做"非法桩值"导致 `_tolerant_validate` 不再 default → `defaulted_fields=[]`。
- **B** `test_xy_matrix_schema::test_generate_legacy_attention_with_xy_compatible`。PR #146 显式移除 `GenerateConfig._migrate_attention`，commit message："without reintroducing the global attention migration"。legacy `xformers/flash_attn` 迁移现由 `studio/services/presets/io.py::_tolerant_validate` 在 TrainingConfig 层兜底。
- **C** `test_route_snapshot::test_route_snapshot`。PR #217 加 `DELETE /api/queue/{task_id}/outputs`，PR #225 加 4 个 `/api/tag-dictionary/*`。删 `tests/_snapshots/studio_routes.json` 重跑生成，165 routes。
- **D** `test_cltagger_tagger::test_is_available_does_not_download_when_model_missing`。fixture `isolated_secrets` 只 isolate `secrets.SECRETS_FILE`，`models_root()` 回退 `REPO_ROOT/models` —— dev 机真有 `cl_tagger_1_02` 导致 is_available 返 True。给 fixture 加 `monkeypatch.setattr(model_downloader, 'models_root', lambda: tmp_path/'models')`，CI clean 环境本来能过。
- **E** `test_train_endpoints::test_put_config_invalid_data_400`。PR #146 让 `write_version_config` 走 `_tolerant_validate`（intentional：跟 preset 导入对齐），`lora_rank=0` 不再 400 而是静默 default 32。改名 `test_put_config_tolerates_invalid_values` + 断言新契约（200 + lora_rank=32）。
- **F** `test_logging_bootstrap::test_webui_lifespan_calls_setup_logging`。`make_studio_log_handler` 用 `delay=True`，文件首次 emit 才开；dev 机 `taeflux_available()` / 词典都 True 时 lifespan `_bg_download_*` 不 emit log → 文件不存在。测试里主动 `logging.getLogger('test.lifespan').info(...)` 强制开。

## 测试方式

- `python -m pytest tests -q` → **2029 passed / 0 failed**（110s）
- 每簇修完单独跑过对应 file 验证
- D / F 两类是 dev 机有真模型时才暴露的 local-only failure，加 isolation 让测试不依赖宿主机状态

## 与 dev master 关系

本 PR base = dev（按 CONTRIBUTING 标准 contributor 流程）。Test-only，无代码 / schema / 行为改动，无需 release notes。

🤖 Generated with [Claude Code](https://claude.com/claude-code)