### PR TITLE
feat(tagger): 加 on_existing 策略（跳过 / 覆盖 / 追加）

### DIFF
--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -89,6 +89,8 @@ def start_tag(pid: int, vid: int, body: TagJobRequest) -> dict[str, Any]:
         raise HTTPException(400, f"unknown tagger: {body.tagger}")
     if body.output_format not in {"txt", "json"}:
         raise HTTPException(400, "output_format must be txt|json")
+    if body.on_existing not in {"overwrite", "skip", "append"}:
+        raise HTTPException(400, "on_existing must be overwrite|skip|append")
     _, v, _ = _version_train_dir_or_404(pid, vid)
 
     # 触发词：先 strip，落到 version 表（持久化，TagEdit / Train 都能读），再
@@ -101,6 +103,9 @@ def start_tag(pid: int, vid: int, body: TagJobRequest) -> dict[str, Any]:
         "version_id": vid,
         "output_format": body.output_format,
     }
+    # 默认值 "overwrite" 不写入 params（worker 端默认就是 overwrite），减小 payload。
+    if body.on_existing != "overwrite":
+        params["on_existing"] = body.on_existing
     if trigger_word:
         params["trigger_word"] = trigger_word
     # 通用：按 tagger 名取 `<name>_overrides` 字段并落到 params 同名键。

--- a/studio/api/schemas/training.py
+++ b/studio/api/schemas/training.py
@@ -60,6 +60,9 @@ class LLMTaggerOverrides(BaseModel):
 class TagJobRequest(BaseModel):
     tagger: str = "wd14"
     output_format: str = "txt"                # "txt" | "json"
+    # 已有 caption 文件时的策略："overwrite"（默认，覆盖）| "skip"（保留原文件）
+    # | "append"（tag 级 merge + dedupe，写回原格式）。
+    on_existing: str = "overwrite"
     wd14_overrides: Optional[Wd14Overrides] = None
     cltagger_overrides: Optional[CLTaggerOverrides] = None
     llm_overrides: Optional[LLMTaggerOverrides] = None

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1945,6 +1945,11 @@ export const api = {
       tagger: TaggerName
       output_format?: 'txt' | 'json'
       /**
+       * 已有 caption 文件时的策略：overwrite（默认覆盖）/ skip（保留原文件）
+       * / append（tag 级 merge + dedupe 后写回原格式）。
+       */
+      on_existing?: 'overwrite' | 'skip' | 'append'
+      /**
        * wd14 本次任务的临时覆盖；仅在 worker 进程生效，不写回 settings。
        * 字段为 undefined / null 时沿用全局 settings。
        */

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1904,7 +1904,12 @@
     "cancelToast": "Cancelled",
     "triggerWord": "trigger word",
     "triggerWordPlaceholder": "e.g. ohwx / mychar",
-    "triggerWordHint": "Prepended as the first tag of every caption during tagging; empty = disabled. Changing this and starting tagging will persist it to the current version."
+    "triggerWordHint": "Prepended as the first tag of every caption during tagging; empty = disabled. Changing this and starting tagging will persist it to the current version.",
+    "onExisting": "existing",
+    "onExistingHint": "What to do when an image already has a caption file (.txt or .json).",
+    "onExistingOverwrite": "Overwrite",
+    "onExistingSkip": "Skip",
+    "onExistingAppend": "Append"
   },
   "presets": {
     "loadSchemaFailed": "Failed to load schema: {{error}}",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1904,7 +1904,12 @@
     "cancelToast": "已取消",
     "triggerWord": "触发词",
     "triggerWordPlaceholder": "如 ohwx / mychar",
-    "triggerWordHint": "打标时作为第一个 tag 写入每张 caption；空 = 不启用。改后启动打标会同步落库到当前 version。"
+    "triggerWordHint": "打标时作为第一个 tag 写入每张 caption；空 = 不启用。改后启动打标会同步落库到当前 version。",
+    "onExisting": "已有 caption",
+    "onExistingHint": "图片已有 caption 文件（.txt 或 .json）时怎么处理。",
+    "onExistingOverwrite": "覆盖",
+    "onExistingSkip": "跳过",
+    "onExistingAppend": "追加到末尾"
   },
   "presets": {
     "loadSchemaFailed": "schema 加载失败: {{error}}",

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -131,6 +131,7 @@ export default function TaggingPage() {
   const [tagger, setTagger] = useState<TaggerName>('wd14')
   const [taggerStatus, setTaggerStatus] = useState<TaggerStatus | null>(null)
   const [outputFormat, setOutputFormat] = useState<'txt' | 'json'>('txt')
+  const [onExisting, setOnExisting] = useState<'overwrite' | 'skip' | 'append'>('overwrite')
   // 触发词：初值从 activeVersion 取（持久化在 version 表）；启动打标时一并提交，
   // 后端会同步落库 + 传给 worker prepend 到每张 caption。
   const [triggerWord, setTriggerWord] = useState<string>('')
@@ -285,7 +286,8 @@ export default function TaggingPage() {
       const overrides = wd14_overrides ?? cltagger_overrides ?? llm_overrides
       const trigger = triggerWord.trim()
       const j = await api.startTag(project.id, activeVersion.id, {
-        tagger, output_format: outputFormat, wd14_overrides, cltagger_overrides, llm_overrides,
+        tagger, output_format: outputFormat, on_existing: onExisting,
+        wd14_overrides, cltagger_overrides, llm_overrides,
         // 传 trigger 永远，让 server 决定是否落库（与现有值比较），空串显式清空
         trigger_word: trigger,
       })
@@ -381,6 +383,23 @@ export default function TaggingPage() {
             >
               <option value="txt">.txt</option>
               <option value="json">.json</option>
+            </select>
+
+            <span className="text-dim">|</span>
+            <span className="text-fg-tertiary" title={t('tag.onExistingHint')}>
+              {t('tag.onExisting')}
+            </span>
+            <select
+              value={onExisting}
+              onChange={(e) => setOnExisting(e.target.value as 'overwrite' | 'skip' | 'append')}
+              disabled={isLive}
+              className="input text-sm"
+              style={{ padding: '3px 8px' }}
+              title={t('tag.onExistingHint')}
+            >
+              <option value="overwrite">{t('tag.onExistingOverwrite')}</option>
+              <option value="skip">{t('tag.onExistingSkip')}</option>
+              <option value="append">{t('tag.onExistingAppend')}</option>
             </select>
 
             <span className="text-dim">|</span>

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -5,6 +5,7 @@
       "tagger": "wd14" | "cltagger" | "joycaption",
       "version_id": int,
       "output_format": "txt"|"json",  # 默认 "txt"，已存在的 .json 仍按 .json 写
+      "on_existing": "overwrite"|"skip"|"append",  # 默认 "overwrite"
       "<tagger>_overrides": {...}     # 可选；本次任务对全局 settings 的覆盖
     }
 
@@ -76,6 +77,9 @@ def run(job_id: int) -> int:
         fmt = str(params.get("output_format", "txt"))
         # 触发词：worker 端 prepend 到 caption 第一位。空串 / 缺省 = 不启用。
         trigger_word = str(params.get("trigger_word") or "").strip()
+        on_existing = str(params.get("on_existing") or "overwrite")
+        if on_existing not in ("skip", "overwrite", "append"):
+            on_existing = "overwrite"
         # 约定：每个支持本次覆盖的 tagger 都把 overrides 存在 `<name>_overrides` 键下
         overrides = params.get(f"{tagger_name}_overrides") or None
 
@@ -95,7 +99,7 @@ def run(job_id: int) -> int:
 
         progress(
             f"[start] tagger={tagger_name} version={v['label']} "
-            f"images={len(images)} format={fmt}"
+            f"images={len(images)} format={fmt} on_existing={on_existing}"
         )
         if trigger_word:
             progress(f"[trigger] '{trigger_word}' 将作为第一个 tag prepend 到每张图")
@@ -110,6 +114,8 @@ def run(job_id: int) -> int:
 
         ok = 0
         errs = 0
+        skipped = 0
+        appended = 0
         for r in tagger.tag(
             images,
             on_progress=lambda d, t: progress(f"[progress] {d}/{t}"),
@@ -118,16 +124,25 @@ def run(job_id: int) -> int:
                 progress(f"[err] {r['image'].name}: {r['error']}")
                 errs += 1
                 continue
-            _write_caption(
+            action = _write_caption(
                 r["image"],
                 r.get("tags") or [],
                 fmt,
                 caption_text=r.get("caption"),
                 caption_json=r.get("caption_json"),
                 trigger_word=trigger_word,
+                on_existing=on_existing,
             )
+            if action == "skipped":
+                skipped += 1
+                progress(f"[skip] {r['image'].name}")
+            elif action == "appended":
+                appended += 1
             ok += 1
-        progress(f"[done] tagged {ok}/{len(images)} (errors={errs})")
+        suffix = ""
+        if skipped or appended:
+            suffix = f" (skipped={skipped}, appended={appended})"
+        progress(f"[done] tagged {ok}/{len(images)} (errors={errs}){suffix}")
         return 0 if ok > 0 or errs == 0 else 1
     except Exception as exc:  # noqa: BLE001
         # PR-1 C7: logger.exception 进 stderr（supervisor 收 → jobs/<id>.log），
@@ -166,15 +181,37 @@ def _write_caption(
     caption_text: str | None = None,
     caption_json: dict[str, Any] | None = None,
     trigger_word: str = "",
-) -> None:
+    on_existing: str = "overwrite",
+) -> str:
     """fmt 仅决定「不存在 caption 时」用什么格式；已存在的 .json 仍走 .json。
 
-    trigger_word 非空时：
+    on_existing：已有 caption 文件（.txt 或 .json）时的策略
+      - "overwrite"（默认）：覆盖（原行为）
+      - "skip"：直接 return，不改任何文件
+      - "append"：tag 级 merge + dedupe，写回原格式；现有保留在前
+
+    返回 "wrote" | "skipped" | "appended"，供调用方计数。
+
+    trigger_word 非空时（仅 overwrite 路径需特殊 prepend；append 走 merge 顺序自然处理）：
       - 标签列表：作为第 0 项 prepend（去重）
       - 字符串 caption：prepend 到最前
       - JSON：写入 ``meta.trigger`` 字段；caption_utils.build_caption_from_json
         会把它作为输出的第一个 token，不参与 shuffle —— 与 .txt 路径行为一致。
     """
+    existing_path = tagedit.caption_path(image)
+    if existing_path is not None:
+        if on_existing == "skip":
+            return "skipped"
+        if on_existing == "append":
+            _append_caption(
+                image,
+                existing_path,
+                tags,
+                caption_text=caption_text,
+                caption_json=caption_json,
+                trigger_word=trigger_word,
+            )
+            return "appended"
     if caption_json is not None:
         if fmt == "json":
             doc = standard_to_documented_full(caption_json)
@@ -189,12 +226,12 @@ def _write_caption(
                 encoding="utf-8",
             )
             image.with_suffix(".txt").unlink(missing_ok=True)
-            return
+            return "wrote"
         text = caption_text if caption_text is not None else caption_json_to_text(caption_json)
         text = _prepend_trigger_to_text(text, trigger_word)
         image.with_suffix(".txt").write_text(text, encoding="utf-8")
         image.with_suffix(".json").unlink(missing_ok=True)
-        return
+        return "wrote"
     if fmt == "json" and not image.with_suffix(".txt").exists():
         # 强制写 json（即使没有现成 json 文件）
         data: dict[str, Any] = {"tags": _prepend_trigger_to_tags(tags, trigger_word)}
@@ -204,7 +241,7 @@ def _write_caption(
             json.dumps(data, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
-        return
+        return "wrote"
     # 否则交给 tagedit 决定（已有 .json 就写 .json，否则 .txt）。
     # 已有 .json 时 tagedit 保留其他字段（包括 meta.trigger 如有），只覆盖 tags 数组；
     # 这里我们把 trigger prepend 进 tags list，并保证 .json 走 tagedit 的同时也补 meta.trigger。
@@ -226,6 +263,71 @@ def _write_caption(
             json.dumps(existing, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
+    return "wrote"
+
+
+def _new_caption_to_tags(
+    tags: list[str],
+    *,
+    caption_text: str | None,
+    caption_json: dict[str, Any] | None,
+) -> list[str]:
+    """把 tagger 本次产出统一渲染为 tag list，供 append 模式 merge。
+
+    LLM 产 `caption_text`（自然语言整句）也按逗号切；append 是用户显式选择
+    "把新结果加到末尾"，重复的标签靠后续 merge 去重，自然语言句子会作为
+    一整段 token 留在末尾——这是 append 模式可接受的代价。
+    """
+    if caption_json is not None:
+        text = caption_text if caption_text is not None else caption_json_to_text(caption_json)
+        return [t.strip() for t in text.split(",") if t.strip()]
+    if caption_text is not None:
+        return [t.strip() for t in caption_text.split(",") if t.strip()]
+    return [t.strip() for t in tags if (t or "").strip()]
+
+
+def _append_caption(
+    image: Path,
+    existing_path: Path,
+    tags: list[str],
+    *,
+    caption_text: str | None,
+    caption_json: dict[str, Any] | None,
+    trigger_word: str,
+) -> None:
+    """append 模式：把新生成的 tags 合并到 existing caption 末尾（保持顺序、去重），
+    写回原格式（.txt 或 .json）。trigger_word 仍 prepend 到新增段，merge dedupe
+    自然保证已有的 trigger 不会被重复加。"""
+    new_tags = _new_caption_to_tags(tags, caption_text=caption_text, caption_json=caption_json)
+    new_tags = _prepend_trigger_to_tags(new_tags, trigger_word)
+    cur_tags = tagedit.read_tags(image)
+    merged: list[str] = []
+    seen: set[str] = set()
+    for t in (*cur_tags, *new_tags):
+        if t in seen:
+            continue
+        seen.add(t)
+        merged.append(t)
+    if existing_path.suffix == ".json":
+        try:
+            data = json.loads(existing_path.read_text(encoding="utf-8"))
+        except Exception:
+            data = {}
+        if not isinstance(data, dict):
+            data = {}
+        data["tags"] = merged
+        if trigger_word:
+            meta = data.get("meta")
+            if not isinstance(meta, dict):
+                meta = {}
+            meta["trigger"] = trigger_word
+            data["meta"] = meta
+        existing_path.write_text(
+            json.dumps(data, ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        return
+    existing_path.write_text(", ".join(merged), encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/tests/test_tag_endpoints.py
+++ b/tests/test_tag_endpoints.py
@@ -314,6 +314,53 @@ def test_start_tag_drops_empty_wd14_overrides(client: TestClient) -> None:
     assert "wd14_overrides" not in params
 
 
+def test_start_tag_on_existing_skip(client: TestClient) -> None:
+    """on_existing=skip 时端点把它落进 params。"""
+    import json as _json
+    pid, vid = _make(client)
+    r = client.post(
+        f"/api/projects/{pid}/versions/{vid}/tag",
+        json={"tagger": "wd14", "output_format": "txt", "on_existing": "skip"},
+    )
+    assert r.status_code == 200, r.text
+    params = _json.loads(r.json()["params"])
+    assert params["on_existing"] == "skip"
+
+
+def test_start_tag_on_existing_append(client: TestClient) -> None:
+    import json as _json
+    pid, vid = _make(client)
+    r = client.post(
+        f"/api/projects/{pid}/versions/{vid}/tag",
+        json={"tagger": "wd14", "output_format": "txt", "on_existing": "append"},
+    )
+    assert r.status_code == 200, r.text
+    params = _json.loads(r.json()["params"])
+    assert params["on_existing"] == "append"
+
+
+def test_start_tag_on_existing_overwrite_not_persisted(client: TestClient) -> None:
+    """默认 overwrite 不写入 params（worker 端默认即 overwrite，减小 payload）。"""
+    import json as _json
+    pid, vid = _make(client)
+    r = client.post(
+        f"/api/projects/{pid}/versions/{vid}/tag",
+        json={"tagger": "wd14", "output_format": "txt", "on_existing": "overwrite"},
+    )
+    assert r.status_code == 200, r.text
+    params = _json.loads(r.json()["params"])
+    assert "on_existing" not in params
+
+
+def test_start_tag_on_existing_bad_value_400(client: TestClient) -> None:
+    pid, vid = _make(client)
+    r = client.post(
+        f"/api/projects/{pid}/versions/{vid}/tag",
+        json={"tagger": "wd14", "output_format": "txt", "on_existing": "bogus"},
+    )
+    assert r.status_code == 400
+
+
 def test_start_tag_ignores_overrides_for_joycaption(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_tag_worker.py
+++ b/tests/test_tag_worker.py
@@ -369,6 +369,101 @@ def test_trigger_word_dataset_loader_sees_meta(env, tmp_path: Path) -> None:
     assert caption.startswith("ohwx,")
 
 
+# ---------------------------------------------------------------------------
+# on_existing: skip / overwrite / append（已有 caption 时的策略）
+# ---------------------------------------------------------------------------
+
+
+def _set_on_existing(env, mode: str) -> None:
+    with db.connection_for(env["db"]) as conn:
+        conn.execute(
+            "UPDATE project_jobs SET params = json_set(params, '$.on_existing', ?) "
+            "WHERE id = ?",
+            (mode, env["job_id"]),
+        )
+        conn.commit()
+
+
+def test_on_existing_skip_preserves_existing_txt(env) -> None:
+    """skip：已有 .txt 完全保留，新 tagger 输出被丢弃。"""
+    (env["train"] / "a.txt").write_text("manual_a, kept", encoding="utf-8")
+    _set_on_existing(env, "skip")
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "manual_a, kept"
+    # b 没有 existing，正常写
+    assert (env["train"] / "b.txt").read_text(encoding="utf-8") == "tag_b, common"
+
+
+def test_on_existing_skip_preserves_existing_json(env) -> None:
+    """skip：已有 .json 也不动；不应写出 .txt。"""
+    (env["train"] / "a.json").write_text(
+        json.dumps({"tags": ["manual_a", "kept"], "extra": "x"}),
+        encoding="utf-8",
+    )
+    _set_on_existing(env, "skip")
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    data = json.loads((env["train"] / "a.json").read_text(encoding="utf-8"))
+    assert data["tags"] == ["manual_a", "kept"]
+    assert data["extra"] == "x"
+    assert not (env["train"] / "a.txt").exists()
+
+
+def test_on_existing_append_merges_and_dedupes_txt(env) -> None:
+    """append：现有 tag 在前，tagger 新 tag 追加在后；重复去重。"""
+    (env["train"] / "a.txt").write_text("existing, common", encoding="utf-8")
+    _set_on_existing(env, "append")
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    # existing, common 在前；tag_a 追加；common 重复被去重
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "existing, common, tag_a"
+    # b 没有 existing，正常写
+    assert (env["train"] / "b.txt").read_text(encoding="utf-8") == "tag_b, common"
+
+
+def test_on_existing_append_merges_json_preserves_other_fields(env) -> None:
+    """append + 已有 .json：merge tags 数组，保留其他顶层字段。"""
+    (env["train"] / "a.json").write_text(
+        json.dumps({"tags": ["existing"], "extra": "x"}),
+        encoding="utf-8",
+    )
+    _set_on_existing(env, "append")
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    data = json.loads((env["train"] / "a.json").read_text(encoding="utf-8"))
+    assert data["tags"] == ["existing", "tag_a", "common"]
+    assert data["extra"] == "x"
+
+
+def test_on_existing_append_with_trigger_word(env) -> None:
+    """append + trigger：trigger 已在 existing 里 → 不重复加在末尾。"""
+    (env["train"] / "a.txt").write_text("ohwx, manual_a", encoding="utf-8")
+    _set_on_existing(env, "append")
+    _set_trigger(env, "ohwx")
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    # existing 已有 ohwx，append 段也会 prepend ohwx，但 merge dedupe 保留位置
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "ohwx, manual_a, tag_a, common"
+
+
+def test_on_existing_overwrite_is_default(env) -> None:
+    """不设 on_existing → 仍是覆盖（保留 PR 前行为）。"""
+    (env["train"] / "a.txt").write_text("old_a", encoding="utf-8")
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "tag_a, common"
+
+
+def test_on_existing_invalid_falls_back_to_overwrite(env) -> None:
+    """非法 on_existing → 当 overwrite 处理（防 worker crash）。"""
+    (env["train"] / "a.txt").write_text("old_a", encoding="utf-8")
+    _set_on_existing(env, "bogus")
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "tag_a, common"
+
+
 def test_worker_imports_onnxruntime_setup_at_module_level() -> None:
     """worker 是独立 subprocess —— 必须在任何 `import onnxruntime` 之前触发
     onnxruntime_setup 的顶层 preload。回归测试：防止有人删掉那行 import 后


### PR DESCRIPTION
## 背景

打标对已有 caption 文件（`.txt` / `.json`）的处理只有一种行为——silent overwrite。用户希望：

- 在已经手工 / LLM 打过标的数据集上跑 WD14/CLTagger 补一次，不想覆盖
- 或者把新一轮 tagger 输出**追加**到现有 caption 后面合并

## 改动概要

Tagging 页顶栏 `format` 旁边新增「已有 caption」下拉，3 个选项：

| 模式 | 行为 |
|---|---|
| **覆盖**（默认） | 保留原行为，向后兼容 |
| **跳过** | 已有 caption 文件直接保留，日志 `[skip] <name>` |
| **追加到末尾** | tag 级 merge + dedupe，写回原格式；现有 tag 在前 |

设计点：
- per-run 选项（和 `output_format` / `trigger_word` 一样），**不进**全局 secrets / Settings 页
- router 端默认 `overwrite` 不写入 `params`（减小 payload）
- 三个 tagger（WD14 / CLTagger / LLM）走同一路径：`tag_worker._write_caption` 头部 dispatch
- append 模式下 trigger_word 已经被 prepend 进新 tag list，merge dedupe 自然保证已有的 trigger 不会被重复加
- LLM tagger 在 append + .txt 模式下产 `caption_text`（自然语言整句），按逗号切后作为一段 token 留在末尾——append 是用户显式选择，重复 / 句子作为 token 是可接受的代价

## 改动文件

**后端**
- `studio/workers/tag_worker.py` — `_write_caption` 加 `on_existing` 参数；新增 `_append_caption` / `_new_caption_to_tags`；`run()` 统计 skipped/appended
- `studio/api/schemas/training.py` — `TagJobRequest.on_existing: str = \"overwrite\"`
- `studio/api/routers/projects/training.py` — 端点校验 400；默认值不进 params

**前端**
- `studio/web/src/api/client.ts` — `startTag` body 加字段
- `studio/web/src/pages/project/steps/Tagging.tsx` — 顶栏 select
- `studio/web/src/i18n/locales/{en,zh}.json` — 4 个新 key

**测试**
- `tests/test_tag_worker.py` — 7 个新 case：skip 保留 .txt / .json、append merge+dedupe（含 .json 保留其他字段）、append + trigger 不重复、overwrite 默认、非法值兜底
- `tests/test_tag_endpoints.py` — 4 个新 case：params 流转 + 400 校验 + 默认值不入库

## 测试方式

- `python -m pytest tests/test_tag_worker.py tests/test_tag_endpoints.py` — 50 / 50 ✅
- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- 手测：跑过单元测试覆盖三种模式 + trigger word 组合；UI dev server 因功能本身在 worker 进程跑，单测覆盖即可