### PR TITLE
feat(onboarding): 首次启动引导 modal — 基础能力 checklist + 一键安装

### DIFF
--- a/docs/todo/onboarding-first-run.md
+++ b/docs/todo/onboarding-first-run.md
@@ -1,0 +1,201 @@
+# 首次启动引导 Modal（First-Run Onboarding）
+
+**创建于** 2026-06-06
+**状态** 🟡 设计已对齐，开始实现
+
+---
+
+## 背景
+
+Settings 里有很多东西必须先下载/配置才能用（底模、VAE、Qwen3、T5、WD14、ONNX Runtime、训练加速等）。新人第一次打开 app 不知道这些东西的存在，只能在训练 / 打标时不断撞墙，再回到 Settings 里翻配置。
+
+我们需要一个**首次启动引导 modal**，在选完语言后立即弹出，用 checklist 形式列出所有"基础能力"，每条可独立勾选安装，状态实时反馈，装完统一重启。
+
+---
+
+## 设计 Spec
+
+### 触发与生命周期
+
+| 时机 | 行为 |
+|---|---|
+| 首次启动 | `FirstRunLangModal` 选完语言关闭后立即弹 Onboarding modal |
+| Skip / 关掉 | 写 `localStorage.studio.onboarding.done = "true"`，下次不自动弹 |
+| 重新查看 | Settings 顶部加 **"重新运行首次引导"** 按钮（清 localStorage + 打开 modal） |
+| 已装好的项 | 进 modal 时自动显绿勾，不需要重装 |
+
+### 形态：Checklist（不是 Stepper）
+
+- 一屏 modal 不分页（5 条目预估 ~600px 高，1080p / 14" MacBook 都能放下）
+- 顶部全局下载源 + 中部 3 主条目 + 底部"高级"折叠区 2 条目 + sticky bar
+- 复选框模式：默认勾推荐项 → 底部"一键安装选中(N)"按钮一次性触发
+
+### Modal 布局
+
+```
+┌─ Onboarding ────────────────────────────────────────────┐
+│  欢迎使用 AnimaLoraStudio                                │
+│  下面是建议安装的基础能力，可以勾选后一键安装。            │
+│                                                          │
+│  下载源:  ◉ ModelScope   ○ HuggingFace                  │
+│           (已为你按语言推荐，可改)                        │
+│  ─────────────────────────────────────────────           │
+│  ☑ 底模套件             ⚪ 未安装                        │
+│    Anima + VAE + Qwen3 + T5,训练所需基础模型              │
+│                                                          │
+│  ☑ 打标功能             ⚪ 未安装                        │
+│    WD14 + ONNX Runtime,自动给训练集打标签                │
+│                                                          │
+│  ▾ 高级选项                                              │
+│    ☐ 训练加速                                            │
+│       ◉ Flash Attention  ○ Xformers  ○ 不装             │
+│    ☐ 图像增强 (Upscaler 4x-AnimeSharp)                  │
+│  ─────────────────────────────────────────────           │
+│  跳过引导                          [一键安装选中(2)]  →   │
+└──────────────────────────────────────────────────────────┘
+```
+
+### 状态机
+
+每条目五态：
+
+| 状态 | 徽章 | 说明 |
+|---|---|---|
+| `idle` | ⚪ 未安装 | 默认，未触发安装 |
+| `queued` | ⏳ 排队中 | 一键装中，等待轮到 |
+| `installing` | 🔄 安装中 | 正在下载/安装，展开可看 log tail |
+| `done` | ✓ 已安装 | catalog 显示全部组件 exists |
+| `failed` | 🔴 失败 | 显 Retry 按钮，log 手动展开 |
+
+**多组件聚合规则**（底模套件、打标功能）：
+- 底层组件全 `exists` → `done`
+- 任意一个 `running` → `installing`（显进度 `X/N`）
+- 任意一个 `failed` → `failed`（其他不受影响继续装）
+- 其余 → `idle`
+
+**安装中态布局示例：**
+
+```
+┌─ 正在安装: 底模套件 (2/4)  ·  总进度 1/2 ────────────────┐
+│  ☑ 底模套件             🔄 安装中  [▾ 查看日志]          │
+│  ☑ 打标功能             ⏳ 排队中                         │
+└──────────────────────────────────────────────────────────┘
+```
+
+**完成态：**
+
+```
+│  ✓ 全部安装完成,需要重启服务才能生效                       │
+│  [稍后手动重启]              [现在重启服务]               │
+```
+
+如果没有需要重启的项（只装了底模套件），直接显示"完成 [关闭]"。
+
+### 下载源
+
+- 顶部全局选一次，按 i18n 当前语言推断默认：
+  - `zh` → ModelScope
+  - 其余 → HuggingFace
+- 此默认值**也下沉到 Settings**：用户跳过 onboarding 直接进 Settings 时，如果 `secrets.download_source` 为空，按 i18n 显示默认值，不显示空白下拉
+
+### 失败处理
+
+- 状态变红 + 单独 Retry 按钮
+- log tail 折叠在"展开详情"里，用户主动展开
+- **不中断其他项的安装**（队列继续）
+
+### 重启
+
+- **全部装完后统一一次性提示**
+- 复用 `POST /api/system/restart` + `pollHealthThenReload()`
+- 中途不打断别的下载
+
+### 进度反馈
+
+- **不做 % 进度条**（HF/ModelScope/PyPI 没有可靠统一 %）
+- 顶部 sticky："正在安装: 底模套件 (2/4 文件) · 总进度 1/2"
+- 条目"展开"显 log tail（来自 `catalog.downloads[key].log_tail`）
+
+### 训练加速（折叠区单选）
+
+```
+☐ 训练加速 (可选)
+   ◉ Flash Attention  推荐,速度最快
+   ○ Xformers         备选,flash-attn 装不上时用
+   ○ 不装             CPU/旧显卡也能跑,只是慢
+```
+
+只展开一次、装一个、装完打勾就完事。
+
+---
+
+## 条目清单
+
+| 条目 | 聚合内容 | 默认 | 区域 |
+|---|---|---|---|
+| 下载源 | HF / ModelScope 二选一 | 按 i18n 推断 | 顶部 |
+| 底模套件 | Anima 主模型 + VAE + Qwen3 + T5 | ☑ 勾选 | 主区 |
+| 打标功能 | WD14 + ONNX Runtime | ☑ 勾选 | 主区 |
+| 训练加速 | Flash-Attn / Xformers / 不装（单选） | ☐ 不勾 | 折叠 |
+| 图像增强 | Upscaler 4x-AnimeSharp | ☐ 不勾 | 折叠 |
+
+---
+
+## 不在 scope（继续走 Settings 配）
+
+- 数据集凭证（Gelbooru / Danbooru token）
+- LLM Tagger 预设
+- CLTagger（WD14 一个够新人用，CLTagger 是进阶选项）
+- PyTorch 重装（CUDA 版本切换；setup 时已装）
+- HF / ModelScope token（不强制，无 token 也能下载公开模型；进阶可去 Settings）
+
+---
+
+## 代码改动清单
+
+### 前端
+
+| 文件 | 改动 |
+|---|---|
+| `web/src/components/FirstRunOnboardingModal.tsx` | 新建主组件 |
+| `web/src/components/FirstRunLangModal.tsx` | 同层，关掉 lang modal 后触发 onboarding（或在 App 层挂） |
+| `web/src/App.tsx`（或同层） | 挂载 onboarding modal + localStorage 控制 |
+| `web/src/pages/tools/Settings.tsx` | (1) 顶部加"重新运行首次引导"按钮 (2) `download_source` 读取加 i18n 兜底 |
+| `web/src/i18n/locales/zh.json` + `en.json` | onboarding 全部文案 |
+| `web/src/storage.ts`（或同等） | `localStorage` helper：`studio.onboarding.done` |
+
+### 后端
+
+**不需要改后端接口。** 全部复用：
+- `POST /api/models/download` — 触发下载
+- `GET /api/models/catalog` — 查状态（含 `downloads.log_tail`）
+- SSE `model_download_changed` — 实时状态推送
+- `POST /api/system/restart` — 重启
+- `secrets.download_source` — 已存在
+
+---
+
+## 实施计划
+
+1. 写 design 文档（本文件）
+2. 实现 `FirstRunOnboardingModal.tsx`（主组件 + 状态机）
+3. App 层挂载（lang modal close → 弹 onboarding）
+4. Settings 加"重新运行首次引导"按钮
+5. Settings `download_source` 加 i18n 兜底
+6. i18n 文案（zh + en）
+7. 本地手测（首次启动模拟：清 localStorage 重开）
+8. commit + push + PR → dev（squash 合入）
+
+---
+
+## 验证清单（手测）
+
+- [ ] 清 localStorage 后启动：lang modal → 选完语言 → onboarding 自动弹
+- [ ] 中文环境默认源 = ModelScope；英文默认 = HuggingFace
+- [ ] 修改下载源，关闭重开 Settings：源持久化正确
+- [ ] 跳过 onboarding 后，Settings 顶部按钮可重新触发
+- [ ] 跳过 onboarding 直接进 Settings：下载源默认按 i18n 显示，不是空白
+- [ ] 一键装：底模套件 + 打标功能并行/串行 OK，状态实时
+- [ ] 装失败：变红 + Retry，其他项继续
+- [ ] 全部装完：统一重启提示；点重启 → 服务回来后 modal 关闭
+- [ ] 中途关 modal：后台继续装，重开 modal 显示进度

--- a/studio/web/src/components/FirstRunLangModal.tsx
+++ b/studio/web/src/components/FirstRunLangModal.tsx
@@ -3,6 +3,7 @@
 // 替代 PR #76 那个塞在 studio.bat/sh 里的 CLI prompt（触达率低 + ASCII 受限 +
 // 无法预览要选的语言长什么样）。
 import { useEffect, useRef, useState } from 'react'
+import { ONBOARDING_EVENTS } from './FirstRunOnboardingModal'
 import i18n, { getStoredLang, setStoredLang } from '../i18n'
 
 type Lang = 'en' | 'zh'
@@ -37,6 +38,8 @@ export function FirstRunLangModal() {
     setStoredLang(lang)
     void i18n.changeLanguage(lang)
     setOpen(false)
+    // 通知 OnboardingModal: lang 已设好,可以接力弹引导。
+    window.dispatchEvent(new Event(ONBOARDING_EVENTS.langSet))
   }
 
   return (

--- a/studio/web/src/components/FirstRunOnboardingModal.tsx
+++ b/studio/web/src/components/FirstRunOnboardingModal.tsx
@@ -44,7 +44,7 @@ export function defaultDownloadSource(lang: string | null | undefined): 'hugging
 // ---- item states ---------------------------------------------------------
 
 type ItemKey = 'base' | 'tagger' | 'accel' | 'upscaler'
-type ItemStatus = 'idle' | 'queued' | 'installing' | 'done' | 'failed'
+type ItemStatus = 'checking' | 'idle' | 'queued' | 'installing' | 'done' | 'failed'
 
 interface ItemDerived {
   status: ItemStatus
@@ -54,7 +54,7 @@ interface ItemDerived {
 
 // 从 catalog 派生底模套件状态（4 个子文件全 exists 算 done）。
 function deriveBaseStatus(c: ModelsCatalog | null, dl: Record<ItemKey, ItemStatus>): ItemDerived {
-  if (!c) return { status: dl.base }
+  if (!c) return { status: 'checking' }
   const animaLatest = c.anima_main.variants.find((v) => v.is_latest)
   const checks: boolean[] = [
     !!animaLatest?.exists,
@@ -77,9 +77,10 @@ function deriveBaseStatus(c: ModelsCatalog | null, dl: Record<ItemKey, ItemStatu
 function deriveTaggerStatus(
   c: ModelsCatalog | null,
   hasOnnx: boolean,
+  runtimeChecked: boolean,
   dl: Record<ItemKey, ItemStatus>,
 ): ItemDerived {
-  if (!c) return { status: dl.tagger }
+  if (!c || !runtimeChecked) return { status: 'checking' }
   const current = c.wd14.variants.find((v) => v.is_current) ?? c.wd14.variants[0]
   const wd14Ok = !!current?.exists
   const checks = [wd14Ok, hasOnnx]
@@ -98,8 +99,10 @@ function deriveTaggerStatus(
 function deriveAccelStatus(
   hasFlash: boolean,
   hasXformers: boolean,
+  runtimeChecked: boolean,
   dl: Record<ItemKey, ItemStatus>,
 ): ItemDerived {
+  if (!runtimeChecked) return { status: 'checking' }
   if (hasFlash || hasXformers) return { status: 'done' }
   if (dl.accel === 'failed') return { status: 'failed' }
   if (dl.accel === 'installing' || dl.accel === 'queued') return { status: dl.accel }
@@ -111,7 +114,8 @@ function deriveUpscalerStatus(
   c: ModelsCatalog | null,
   dl: Record<ItemKey, ItemStatus>,
 ): ItemDerived {
-  if (!c?.upscalers) return { status: dl.upscaler }
+  if (!c) return { status: 'checking' }
+  if (!c.upscalers) return { status: dl.upscaler }
   const current =
     c.upscalers.variants.find((v) => v.is_current)
     ?? c.upscalers.variants.find((v) => v.label === c.upscalers!.default)
@@ -142,6 +146,9 @@ export function FirstRunOnboardingModal() {
     flashAttn: boolean
     xformers: boolean
   }>({ onnx: false, flashAttn: false, xformers: false })
+  // runtime status 是否拉过(区分"还没拉"和"拉完都没装");catalog 有自己的 null
+  // 表示未拉,runtime 是个对象所以需要单独 flag。
+  const [runtimeChecked, setRuntimeChecked] = useState<boolean>(false)
   const [restartRequired, setRestartRequired] = useState<boolean>(false)
   const [restarting, setRestarting] = useState<boolean>(false)
   const [currentItem, setCurrentItem] = useState<ItemKey | null>(null)
@@ -178,6 +185,7 @@ export function FirstRunOnboardingModal() {
         flashAttn: !!fa?.installed,
         xformers: !!xf?.installed,
       })
+      setRuntimeChecked(true)
     })
     return () => { cancelled = true }
   }, [open])
@@ -185,10 +193,10 @@ export function FirstRunOnboardingModal() {
   // 派生每个条目状态。
   const itemStatus = useMemo<Record<ItemKey, ItemDerived>>(() => ({
     base: deriveBaseStatus(catalog, installState),
-    tagger: deriveTaggerStatus(catalog, runtimeStatus.onnx, installState),
-    accel: deriveAccelStatus(runtimeStatus.flashAttn, runtimeStatus.xformers, installState),
+    tagger: deriveTaggerStatus(catalog, runtimeStatus.onnx, runtimeChecked, installState),
+    accel: deriveAccelStatus(runtimeStatus.flashAttn, runtimeStatus.xformers, runtimeChecked, installState),
     upscaler: deriveUpscalerStatus(catalog, installState),
-  }), [catalog, installState, runtimeStatus])
+  }), [catalog, installState, runtimeStatus, runtimeChecked])
 
   // 全部装完判定：选中的条目全 done。
   const allSelectedDone = useMemo(() => {
@@ -203,6 +211,12 @@ export function FirstRunOnboardingModal() {
     return (['base', 'tagger', 'accel', 'upscaler'] as ItemKey[])
       .some((k) => installState[k] === 'installing' || installState[k] === 'queued')
   }, [installState])
+
+  // catalog 或 runtime status 还在拉,任一条目处于 checking 态。
+  const isChecking = useMemo(() => {
+    return (['base', 'tagger', 'accel', 'upscaler'] as ItemKey[])
+      .some((k) => itemStatus[k].status === 'checking')
+  }, [itemStatus])
 
   const toggleSelected = useCallback((key: ItemKey) => {
     if (installingNow) return
@@ -479,6 +493,15 @@ export function FirstRunOnboardingModal() {
                 {restarting ? t('onboarding.restarting') : t('onboarding.restart')}
               </button>
             </div>
+          ) : isChecking ? (
+            <button
+              type="button"
+              disabled
+              className="px-4 py-2 text-sm font-medium bg-accent text-white rounded opacity-50 cursor-not-allowed"
+              data-testid="onboarding-checking"
+            >
+              {t('onboarding.checkingState')}
+            </button>
           ) : allSelectedDone ? (
             <button
               type="button"
@@ -553,6 +576,8 @@ function StatusBadge({ status, progress }: { status: ItemStatus; progress?: { do
       return <span className={`${baseClass} bg-surface text-fg-tertiary`}>⏱ {t('onboarding.status.queued')}</span>
     case 'failed':
       return <span className={`${baseClass} bg-err-soft text-err`}>✕ {t('onboarding.status.failed')}</span>
+    case 'checking':
+      return <span className={`${baseClass} bg-surface text-fg-tertiary`}>⋯ {t('onboarding.status.checking')}</span>
     default: {
       const suffix = progress && progress.done > 0 ? ` (${progress.done}/${progress.total})` : ''
       return <span className={`${baseClass} bg-surface text-fg-tertiary`}>○ {t('onboarding.status.idle')}{suffix}</span>

--- a/studio/web/src/components/FirstRunOnboardingModal.tsx
+++ b/studio/web/src/components/FirstRunOnboardingModal.tsx
@@ -155,6 +155,10 @@ export function FirstRunOnboardingModal() {
   const [savingSource, setSavingSource] = useState<boolean>(false)
   // first-run 自动按 i18n 写一次 secrets.download_source(只跑一次,避免覆盖用户手动改)。
   const autoSourceWrittenRef = useRef<boolean>(false)
+  // catalog 最新值 ref —— installItem polling 闭包里看不到 catalog state 更新,
+  // 必须经 ref 拿。catalog 本身通过 SettingsData 的 SSE 自动刷新。
+  const catalogRef = useRef(catalog)
+  useEffect(() => { catalogRef.current = catalog }, [catalog])
 
   // 触发：lang 已设 + onboarding 未 done → 自动弹；显式 open 事件 → 强制弹。
   useEffect(() => {
@@ -264,40 +268,92 @@ export function FirstRunOnboardingModal() {
     autoSourceWrittenRef.current = true
   }, [open, secrets, i18n.language, saveDownloadSource])
 
-  // 安装单个条目。返回是否成功（用于判断 restart_required）。
+  // 等 catalog 反映"装齐"或"失败",最长 timeoutMs。SettingsData 通过 SSE
+  // model_download_changed 自动 reloadCatalog,所以这里只要轮询 ref 就行。
+  // 任意一个 relevant download 进 failed → 立刻返回失败;全 done → 成功。
+  const waitForCatalog = useCallback(async (
+    isAllDone: (c: ModelsCatalog) => boolean,
+    keyFilter: (k: string) => boolean,
+    timeoutMs = 30 * 60_000,
+  ): Promise<{ ok: boolean; errors: string[] }> => {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      const c = catalogRef.current
+      if (c) {
+        if (isAllDone(c)) return { ok: true, errors: [] }
+        const failed = Object.entries(c.downloads)
+          .filter(([k]) => keyFilter(k))
+          .map(([, v]) => v)
+          .filter((d) => d.status === 'failed')
+        if (failed.length > 0) {
+          const tail = failed.flatMap((d) => d.log_tail.slice(-10))
+          return { ok: false, errors: tail.length > 0 ? tail : [failed.map((d) => d.message).join('\n')] }
+        }
+      }
+      await new Promise((r) => setTimeout(r, 1500))
+    }
+    return { ok: false, errors: ['Timed out waiting for download to finish'] }
+  }, [])
+
+  // 安装单个条目。触发后端开始下载/装包,然后 polling catalog 等到真完成,
+  // 才把状态切到 done/failed —— startModelDownload 只是 fire-and-forget,
+  // 立刻 set done 会让派生状态短暂闪一下又回 idle。
   const installItem = useCallback(async (key: ItemKey): Promise<{ ok: boolean; needsRestart: boolean }> => {
     setInstallState((s) => ({ ...s, [key]: 'installing' }))
     setCurrentItem(key)
-    let ok = true
     let needsRestart = false
     const errors: string[] = []
     try {
       if (key === 'base' && catalog) {
         const latest = catalog.anima_main.variants.find((v) => v.is_latest)
+        const triggers: Promise<unknown>[] = []
         if (latest && !latest.exists) {
-          await api.startModelDownload({ model_id: 'anima_main', variant: latest.variant })
+          triggers.push(api.startModelDownload({ model_id: 'anima_main', variant: latest.variant }))
         }
         if (!catalog.anima_vae.exists) {
-          await api.startModelDownload({ model_id: 'anima_vae' })
+          triggers.push(api.startModelDownload({ model_id: 'anima_vae' }))
         }
         if (!catalog.qwen3.files.every((f) => f.exists)) {
-          await api.startModelDownload({ model_id: 'qwen3' })
+          triggers.push(api.startModelDownload({ model_id: 'qwen3' }))
         }
         if (!catalog.t5_tokenizer.files.every((f) => f.exists)) {
-          await api.startModelDownload({ model_id: 't5_tokenizer' })
+          triggers.push(api.startModelDownload({ model_id: 't5_tokenizer' }))
+        }
+        if (triggers.length > 0) {
+          await Promise.all(triggers)
+          const res = await waitForCatalog(
+            (c) => {
+              const a = c.anima_main.variants.find((v) => v.is_latest)
+              return !!a?.exists
+                && !!c.anima_vae.exists
+                && c.qwen3.files.length > 0 && c.qwen3.files.every((f) => f.exists)
+                && c.t5_tokenizer.files.length > 0 && c.t5_tokenizer.files.every((f) => f.exists)
+            },
+            (k) => k.startsWith('anima_main') || k.startsWith('anima_vae')
+                || k.startsWith('qwen3') || k.startsWith('t5_tokenizer'),
+          )
+          if (!res.ok) errors.push(...res.errors)
         }
       } else if (key === 'tagger' && catalog) {
         const current = catalog.wd14.variants.find((v) => v.is_current) ?? catalog.wd14.variants[0]
-        if (current && !current.exists) {
+        const needWd14 = current && !current.exists
+        if (needWd14) {
           await api.startModelDownload({ model_id: 'wd14', variant: current.model_id })
+          const res = await waitForCatalog(
+            (c) => {
+              const cur = c.wd14.variants.find((v) => v.is_current) ?? c.wd14.variants[0]
+              return !!cur?.exists
+            },
+            (k) => k.startsWith('wd14'),
+          )
+          if (!res.ok) errors.push(...res.errors)
         }
-        if (!runtimeStatus.onnx) {
+        if (errors.length === 0 && !runtimeStatus.onnx) {
           const r = await api.installWD14Runtime('auto')
           if (r.installed) {
             setRuntimeStatus((s) => ({ ...s, onnx: true }))
             needsRestart = needsRestart || !!r.restart_required
           } else {
-            ok = false
             errors.push(r.stdout_tail.split('\n').slice(-10).join('\n'))
           }
         }
@@ -308,7 +364,6 @@ export function FirstRunOnboardingModal() {
             setRuntimeStatus((s) => ({ ...s, flashAttn: true }))
             needsRestart = needsRestart || !!r.restart_required
           } else {
-            ok = false
             errors.push(r.stdout_tail.split('\n').slice(-10).join('\n'))
           }
         }
@@ -318,12 +373,22 @@ export function FirstRunOnboardingModal() {
           ?? catalog.upscalers.variants.find((v) => v.label === catalog.upscalers!.default)
         if (target && !target.exists) {
           await api.startModelDownload({ model_id: 'upscalers', variant: target.label })
+          const res = await waitForCatalog(
+            (c) => {
+              if (!c.upscalers) return true
+              const t = c.upscalers.variants.find((v) => v.is_current)
+                ?? c.upscalers.variants.find((v) => v.label === c.upscalers!.default)
+              return !!t?.exists
+            },
+            (k) => k.startsWith('upscalers'),
+          )
+          if (!res.ok) errors.push(...res.errors)
         }
       }
     } catch (e) {
-      ok = false
       errors.push(String(e))
     }
+    const ok = errors.length === 0
     if (!ok) {
       setFailureLogs((s) => ({ ...s, [key]: errors }))
       setInstallState((s) => ({ ...s, [key]: 'failed' }))
@@ -332,7 +397,7 @@ export function FirstRunOnboardingModal() {
     }
     await reloadCatalog()
     return { ok, needsRestart }
-  }, [catalog, runtimeStatus, reloadCatalog])
+  }, [catalog, runtimeStatus, reloadCatalog, waitForCatalog])
 
   // 一键装：串行跑选中条目（后端有些接口本身是同步阻塞 pip，无法并行）。
   const installAll = useCallback(async () => {

--- a/studio/web/src/components/FirstRunOnboardingModal.tsx
+++ b/studio/web/src/components/FirstRunOnboardingModal.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, type ModelsCatalog } from '../api/client'
 import { useSettingsData } from '../lib/SettingsData'
+import { useToast } from './Toast'
 
 const ONBOARDING_DONE_KEY = 'studio.onboarding.done'
 const LANG_KEY = 'studio.lang'
@@ -130,6 +131,7 @@ function deriveUpscalerStatus(
 export function FirstRunOnboardingModal() {
   const { t, i18n } = useTranslation()
   const { secrets, setSecrets, catalog, reloadCatalog } = useSettingsData()
+  const { toast } = useToast()
 
   const [open, setOpen] = useState<boolean>(false)
   // 选中要装的条目；初次 mount 时按"推荐勾选"填充。
@@ -221,6 +223,27 @@ export function FirstRunOnboardingModal() {
     return (['base', 'tagger', 'accel', 'upscaler'] as ItemKey[])
       .some((k) => itemStatus[k].status === 'checking')
   }, [itemStatus])
+
+  // 派生每个条目对应 catalog.downloads 里 running 任务的 log_tail,实时显示
+  // 下载速度 / tqdm 进度;accel(pip install) 不进 catalog.downloads,空。
+  const liveLogs = useMemo<Record<ItemKey, string[]>>(() => {
+    const empty = { base: [], tagger: [], accel: [], upscaler: [] }
+    if (!catalog) return empty
+    const collect = (filter: (k: string) => boolean): string[] => {
+      const tails = Object.entries(catalog.downloads)
+        .filter(([k]) => filter(k))
+        .filter(([, v]) => v.status === 'running' || v.status === 'pending')
+        .map(([, v]) => v.log_tail)
+      return tails.flat()
+    }
+    return {
+      base: collect((k) => k.startsWith('anima_main') || k.startsWith('anima_vae')
+                       || k.startsWith('qwen3') || k.startsWith('t5_tokenizer')),
+      tagger: collect((k) => k.startsWith('wd14')),
+      accel: [],
+      upscaler: collect((k) => k.startsWith('upscalers')),
+    }
+  }, [catalog])
 
   const toggleSelected = useCallback((key: ItemKey) => {
     if (installingNow) return
@@ -442,9 +465,11 @@ export function FirstRunOnboardingModal() {
   }, [])
 
   const handleSkip = useCallback(() => {
-    if (installingNow) return
+    // 装中也允许关 modal —— 后端 daemon thread 不受影响,继续下载。
+    // 给个 toast 提示让用户知道不是"按了就停",真要停得重启 Studio。
+    if (installingNow) toast(t('onboarding.skipWhileInstalling'), 'info')
     handleClose()
-  }, [installingNow, handleClose])
+  }, [installingNow, handleClose, toast, t])
 
   if (!open) return null
 
@@ -476,7 +501,8 @@ export function FirstRunOnboardingModal() {
           <DownloadSourceRow
             value={downloadSource}
             onChange={saveDownloadSource}
-            disabled={installingNow || savingSource}
+            disabled={savingSource}
+            installHint={installingNow ? t('onboarding.downloadSourceInstallHint') : null}
           />
 
           <div className="border-t border-dim" />
@@ -489,6 +515,7 @@ export function FirstRunOnboardingModal() {
             onToggle={() => toggleSelected('base')}
             status={itemStatus.base}
             failureLog={failureLogs.base}
+            liveLog={liveLogs.base}
             onRetry={() => retryItem('base')}
             disabled={installingNow}
           />
@@ -501,6 +528,7 @@ export function FirstRunOnboardingModal() {
             onToggle={() => toggleSelected('tagger')}
             status={itemStatus.tagger}
             failureLog={failureLogs.tagger}
+            liveLog={liveLogs.tagger}
             onRetry={() => retryItem('tagger')}
             disabled={installingNow}
           />
@@ -513,6 +541,7 @@ export function FirstRunOnboardingModal() {
             onToggle={() => toggleSelected('accel')}
             status={itemStatus.accel}
             failureLog={failureLogs.accel}
+            liveLog={liveLogs.accel}
             onRetry={() => retryItem('accel')}
             disabled={installingNow}
           />
@@ -525,6 +554,7 @@ export function FirstRunOnboardingModal() {
             onToggle={() => toggleSelected('upscaler')}
             status={itemStatus.upscaler}
             failureLog={failureLogs.upscaler}
+            liveLog={liveLogs.upscaler}
             onRetry={() => retryItem('upscaler')}
             disabled={installingNow}
           />
@@ -534,7 +564,7 @@ export function FirstRunOnboardingModal() {
           <button
             type="button"
             onClick={handleSkip}
-            disabled={installingNow}
+            disabled={false}
             className="px-3 py-1.5 text-sm text-fg-tertiary hover:text-fg-primary disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-none cursor-pointer"
             data-testid="onboarding-skip"
           >
@@ -599,6 +629,7 @@ function DownloadSourceRow(props: {
   value: 'huggingface' | 'modelscope'
   onChange: (v: 'huggingface' | 'modelscope') => void
   disabled: boolean
+  installHint: string | null
 }) {
   const { t } = useTranslation()
   return (
@@ -622,7 +653,9 @@ function DownloadSourceRow(props: {
           </button>
         ))}
       </div>
-      <div className="text-xs text-fg-tertiary">{t('onboarding.downloadSourceHint')}</div>
+      <div className="text-xs text-fg-tertiary">
+        {props.installHint ?? t('onboarding.downloadSourceHint')}
+      </div>
     </div>
   )
 }
@@ -658,12 +691,22 @@ function ChecklistItem(props: {
   onToggle: () => void
   status: ItemDerived
   failureLog: string[]
+  liveLog: string[]
   onRetry: () => void
   disabled: boolean
 }) {
   const { t } = useTranslation()
   const [logOpen, setLogOpen] = useState(false)
   const isDone = props.status.status === 'done'
+  const isInstalling = props.status.status === 'installing'
+  const isFailed = props.status.status === 'failed'
+  // installing 时默认展开 log,让用户能看到下载速度(tqdm 输出);failed 默认折叠
+  // (避免错误信息一下糊到屏幕)。这里用 useEffect 跟着状态切默认值。
+  useEffect(() => {
+    if (isInstalling) setLogOpen(true)
+    if (isDone) setLogOpen(false)
+  }, [isInstalling, isDone])
+  const shownLog = isFailed ? props.failureLog : props.liveLog
   return (
     <div className="flex flex-col gap-2">
       <div className="flex items-start gap-3">
@@ -680,9 +723,18 @@ function ChecklistItem(props: {
           <div className="flex items-center gap-2 flex-wrap">
             <div className="text-sm font-medium text-fg-primary">{props.label}</div>
             <StatusBadge status={props.status.status} progress={props.status.progress} />
+            {(isInstalling || isFailed) && shownLog.length > 0 && (
+              <button
+                type="button"
+                onClick={() => setLogOpen((v) => !v)}
+                className="ml-auto px-2 py-0.5 text-xs text-fg-tertiary hover:text-fg-primary bg-transparent border-none cursor-pointer"
+              >
+                {logOpen ? t('onboarding.hideLog') : t('onboarding.showLog')}
+              </button>
+            )}
           </div>
           <div className="text-xs text-fg-tertiary mt-0.5">{props.description}</div>
-          {props.status.status === 'failed' && (
+          {isFailed && (
             <div className="mt-2 flex items-center gap-2">
               <button
                 type="button"
@@ -692,18 +744,11 @@ function ChecklistItem(props: {
               >
                 {t('onboarding.retry')}
               </button>
-              <button
-                type="button"
-                onClick={() => setLogOpen((v) => !v)}
-                className="px-2 py-1 text-xs text-fg-tertiary hover:text-fg-primary bg-transparent border-none cursor-pointer"
-              >
-                {logOpen ? t('onboarding.hideLog') : t('onboarding.showLog')}
-              </button>
             </div>
           )}
-          {logOpen && props.failureLog.length > 0 && (
-            <pre className="mt-2 p-2 text-xs bg-surface border border-dim rounded overflow-x-auto whitespace-pre-wrap max-h-32">
-              {props.failureLog.join('\n')}
+          {logOpen && shownLog.length > 0 && (
+            <pre className="mt-2 p-2 text-xs bg-surface border border-dim rounded overflow-x-auto whitespace-pre-wrap max-h-40 font-mono leading-snug">
+              {shownLog.join('\n')}
             </pre>
           )}
         </div>

--- a/studio/web/src/components/FirstRunOnboardingModal.tsx
+++ b/studio/web/src/components/FirstRunOnboardingModal.tsx
@@ -134,7 +134,6 @@ export function FirstRunOnboardingModal() {
   // 选中要装的条目；初次 mount 时按"推荐勾选"填充。
   const [selected, setSelected] = useState<Set<ItemKey>>(new Set(['base', 'tagger']))
   const [accelChoice, setAccelChoice] = useState<AccelChoice>('flash_attn')
-  const [advancedOpen, setAdvancedOpen] = useState<boolean>(false)
   // 安装本地状态机（catalog 还没反映到结果时用）。
   const [installState, setInstallState] = useState<Record<ItemKey, ItemStatus>>({
     base: 'idle', tagger: 'idle', accel: 'idle', upscaler: 'idle',
@@ -440,40 +439,28 @@ export function FirstRunOnboardingModal() {
             disabled={installingNow}
           />
 
-          <details
-            open={advancedOpen}
-            onToggle={(e) => setAdvancedOpen((e.target as HTMLDetailsElement).open)}
-            className="border-t border-dim pt-4"
-          >
-            <summary className="cursor-pointer text-sm font-medium text-fg-secondary hover:text-fg-primary select-none">
-              {t('onboarding.advanced')}
-            </summary>
+          <AccelItem
+            checked={selected.has('accel')}
+            onToggle={() => toggleSelected('accel')}
+            choice={accelChoice}
+            onChoiceChange={setAccelChoice}
+            status={itemStatus.accel}
+            failureLog={failureLogs.accel}
+            onRetry={() => retryItem('accel')}
+            disabled={installingNow}
+          />
 
-            <div className="mt-3 flex flex-col gap-4">
-              <AccelItem
-                checked={selected.has('accel')}
-                onToggle={() => toggleSelected('accel')}
-                choice={accelChoice}
-                onChoiceChange={setAccelChoice}
-                status={itemStatus.accel}
-                failureLog={failureLogs.accel}
-                onRetry={() => retryItem('accel')}
-                disabled={installingNow}
-              />
-
-              <ChecklistItem
-                itemKey="upscaler"
-                label={t('onboarding.items.upscaler.label')}
-                description={t('onboarding.items.upscaler.description')}
-                checked={selected.has('upscaler')}
-                onToggle={() => toggleSelected('upscaler')}
-                status={itemStatus.upscaler}
-                failureLog={failureLogs.upscaler}
-                onRetry={() => retryItem('upscaler')}
-                disabled={installingNow}
-              />
-            </div>
-          </details>
+          <ChecklistItem
+            itemKey="upscaler"
+            label={t('onboarding.items.upscaler.label')}
+            description={t('onboarding.items.upscaler.description')}
+            checked={selected.has('upscaler')}
+            onToggle={() => toggleSelected('upscaler')}
+            status={itemStatus.upscaler}
+            failureLog={failureLogs.upscaler}
+            onRetry={() => retryItem('upscaler')}
+            disabled={installingNow}
+          />
         </div>
 
         <div className="border-t border-dim p-4 flex items-center justify-between bg-surface">
@@ -606,7 +593,7 @@ function ChecklistItem(props: {
           type="checkbox"
           checked={props.checked || isDone}
           onChange={props.onToggle}
-          disabled={props.disabled || isDone}
+          disabled={props.disabled}
           className="mt-1 cursor-pointer disabled:cursor-not-allowed"
           data-testid={`onboarding-check-${props.itemKey}`}
         />

--- a/studio/web/src/components/FirstRunOnboardingModal.tsx
+++ b/studio/web/src/components/FirstRunOnboardingModal.tsx
@@ -45,7 +45,6 @@ export function defaultDownloadSource(lang: string | null | undefined): 'hugging
 
 type ItemKey = 'base' | 'tagger' | 'accel' | 'upscaler'
 type ItemStatus = 'idle' | 'queued' | 'installing' | 'done' | 'failed'
-type AccelChoice = 'flash_attn' | 'xformers' | 'none'
 
 interface ItemDerived {
   status: ItemStatus
@@ -94,16 +93,14 @@ function deriveTaggerStatus(
   return { status: 'idle', progress: { done, total } }
 }
 
-// 训练加速 = 用户选的那个已装；'none' 选项永远 done（用户主动不装）。
+// 训练加速：检测 flash_attn 或 xformers 任一已装(尊重用户已有环境),
+// 安装时统一装 flash_attn(推荐方案,新人不用选)。
 function deriveAccelStatus(
-  choice: AccelChoice,
   hasFlash: boolean,
   hasXformers: boolean,
   dl: Record<ItemKey, ItemStatus>,
 ): ItemDerived {
-  if (choice === 'none') return { status: 'done' }
-  if (choice === 'flash_attn' && hasFlash) return { status: 'done' }
-  if (choice === 'xformers' && hasXformers) return { status: 'done' }
+  if (hasFlash || hasXformers) return { status: 'done' }
   if (dl.accel === 'failed') return { status: 'failed' }
   if (dl.accel === 'installing' || dl.accel === 'queued') return { status: dl.accel }
   return { status: 'idle' }
@@ -133,7 +130,6 @@ export function FirstRunOnboardingModal() {
   const [open, setOpen] = useState<boolean>(false)
   // 选中要装的条目；初次 mount 时按"推荐勾选"填充。
   const [selected, setSelected] = useState<Set<ItemKey>>(new Set(['base', 'tagger']))
-  const [accelChoice, setAccelChoice] = useState<AccelChoice>('flash_attn')
   // 安装本地状态机（catalog 还没反映到结果时用）。
   const [installState, setInstallState] = useState<Record<ItemKey, ItemStatus>>({
     base: 'idle', tagger: 'idle', accel: 'idle', upscaler: 'idle',
@@ -190,9 +186,9 @@ export function FirstRunOnboardingModal() {
   const itemStatus = useMemo<Record<ItemKey, ItemDerived>>(() => ({
     base: deriveBaseStatus(catalog, installState),
     tagger: deriveTaggerStatus(catalog, runtimeStatus.onnx, installState),
-    accel: deriveAccelStatus(accelChoice, runtimeStatus.flashAttn, runtimeStatus.xformers, installState),
+    accel: deriveAccelStatus(runtimeStatus.flashAttn, runtimeStatus.xformers, installState),
     upscaler: deriveUpscalerStatus(catalog, installState),
-  }), [catalog, installState, runtimeStatus, accelChoice])
+  }), [catalog, installState, runtimeStatus])
 
   // 全部装完判定：选中的条目全 done。
   const allSelectedDone = useMemo(() => {
@@ -292,19 +288,10 @@ export function FirstRunOnboardingModal() {
           }
         }
       } else if (key === 'accel') {
-        if (accelChoice === 'flash_attn' && !runtimeStatus.flashAttn) {
+        if (!runtimeStatus.flashAttn && !runtimeStatus.xformers) {
           const r = await api.installFlashAttn(null)
           if (r.installed) {
             setRuntimeStatus((s) => ({ ...s, flashAttn: true }))
-            needsRestart = needsRestart || !!r.restart_required
-          } else {
-            ok = false
-            errors.push(r.stdout_tail.split('\n').slice(-10).join('\n'))
-          }
-        } else if (accelChoice === 'xformers' && !runtimeStatus.xformers) {
-          const r = await api.installXformers()
-          if (r.installed) {
-            setRuntimeStatus((s) => ({ ...s, xformers: true }))
             needsRestart = needsRestart || !!r.restart_required
           } else {
             ok = false
@@ -331,7 +318,7 @@ export function FirstRunOnboardingModal() {
     }
     await reloadCatalog()
     return { ok, needsRestart }
-  }, [catalog, accelChoice, runtimeStatus, reloadCatalog])
+  }, [catalog, runtimeStatus, reloadCatalog])
 
   // 一键装：串行跑选中条目（后端有些接口本身是同步阻塞 pip，无法并行）。
   const installAll = useCallback(async () => {
@@ -439,11 +426,12 @@ export function FirstRunOnboardingModal() {
             disabled={installingNow}
           />
 
-          <AccelItem
+          <ChecklistItem
+            itemKey="accel"
+            label={t('onboarding.items.accel.label')}
+            description={t('onboarding.items.accel.description')}
             checked={selected.has('accel')}
             onToggle={() => toggleSelected('accel')}
-            choice={accelChoice}
-            onChoiceChange={setAccelChoice}
             status={itemStatus.accel}
             failureLog={failureLogs.accel}
             onRetry={() => retryItem('accel')}
@@ -556,15 +544,15 @@ function StatusBadge({ status, progress }: { status: ItemStatus; progress?: { do
   const baseClass = 'inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded'
   switch (status) {
     case 'done':
-      return <span className={`${baseClass} bg-success-soft text-success`}>✓ {t('onboarding.status.done')}</span>
+      return <span className={`${baseClass} bg-accent-soft text-accent`}>✓ {t('onboarding.status.done')}</span>
     case 'installing': {
       const suffix = progress ? ` (${progress.done}/${progress.total})` : ''
-      return <span className={`${baseClass} bg-accent-soft text-accent`}>⏳ {t('onboarding.status.installing')}{suffix}</span>
+      return <span className={`${baseClass} bg-info-soft text-info`}>⏳ {t('onboarding.status.installing')}{suffix}</span>
     }
     case 'queued':
       return <span className={`${baseClass} bg-surface text-fg-tertiary`}>⏱ {t('onboarding.status.queued')}</span>
     case 'failed':
-      return <span className={`${baseClass} bg-danger-soft text-danger`}>✕ {t('onboarding.status.failed')}</span>
+      return <span className={`${baseClass} bg-err-soft text-err`}>✕ {t('onboarding.status.failed')}</span>
     default: {
       const suffix = progress && progress.done > 0 ? ` (${progress.done}/${progress.total})` : ''
       return <span className={`${baseClass} bg-surface text-fg-tertiary`}>○ {t('onboarding.status.idle')}{suffix}</span>
@@ -595,6 +583,7 @@ function ChecklistItem(props: {
           onChange={props.onToggle}
           disabled={props.disabled}
           className="mt-1 cursor-pointer disabled:cursor-not-allowed"
+          style={{ accentColor: 'var(--accent)' }}
           data-testid={`onboarding-check-${props.itemKey}`}
         />
         <div className="flex-1 min-w-0">
@@ -633,78 +622,3 @@ function ChecklistItem(props: {
   )
 }
 
-function AccelItem(props: {
-  checked: boolean
-  onToggle: () => void
-  choice: AccelChoice
-  onChoiceChange: (c: AccelChoice) => void
-  status: ItemDerived
-  failureLog: string[]
-  onRetry: () => void
-  disabled: boolean
-}) {
-  const { t } = useTranslation()
-  const [logOpen, setLogOpen] = useState(false)
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="flex items-start gap-3">
-        <input
-          type="checkbox"
-          checked={props.checked}
-          onChange={props.onToggle}
-          disabled={props.disabled}
-          className="mt-1 cursor-pointer"
-          data-testid="onboarding-check-accel"
-        />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 flex-wrap">
-            <div className="text-sm font-medium text-fg-primary">{t('onboarding.items.accel.label')}</div>
-            <StatusBadge status={props.status.status} />
-          </div>
-          <div className="text-xs text-fg-tertiary mt-0.5">{t('onboarding.items.accel.description')}</div>
-          {props.checked && (
-            <div className="mt-2 flex flex-col gap-1 pl-1">
-              {(['flash_attn', 'xformers', 'none'] as const).map((c) => (
-                <label key={c} className="flex items-center gap-2 text-xs cursor-pointer">
-                  <input
-                    type="radio"
-                    name="onboarding-accel-choice"
-                    checked={props.choice === c}
-                    onChange={() => props.onChoiceChange(c)}
-                    disabled={props.disabled}
-                    className="cursor-pointer"
-                  />
-                  <span className="font-medium text-fg-secondary">{t(`onboarding.items.accel.choice.${c}.label`)}</span>
-                  <span className="text-fg-tertiary">{t(`onboarding.items.accel.choice.${c}.hint`)}</span>
-                </label>
-              ))}
-            </div>
-          )}
-          {props.status.status === 'failed' && (
-            <div className="mt-2 flex items-center gap-2">
-              <button
-                type="button"
-                onClick={props.onRetry}
-                className="px-2 py-1 text-xs bg-surface border border-dim rounded hover:border-accent cursor-pointer"
-              >
-                {t('onboarding.retry')}
-              </button>
-              <button
-                type="button"
-                onClick={() => setLogOpen((v) => !v)}
-                className="px-2 py-1 text-xs text-fg-tertiary hover:text-fg-primary bg-transparent border-none cursor-pointer"
-              >
-                {logOpen ? t('onboarding.hideLog') : t('onboarding.showLog')}
-              </button>
-            </div>
-          )}
-          {logOpen && props.failureLog.length > 0 && (
-            <pre className="mt-2 p-2 text-xs bg-surface border border-dim rounded overflow-x-auto whitespace-pre-wrap max-h-32">
-              {props.failureLog.join('\n')}
-            </pre>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}

--- a/studio/web/src/components/FirstRunOnboardingModal.tsx
+++ b/studio/web/src/components/FirstRunOnboardingModal.tsx
@@ -1,0 +1,723 @@
+// FirstRunOnboardingModal —— 首次启动引导 modal。
+// 设计文档：docs/todo/onboarding-first-run.md
+//
+// 流程：FirstRunLangModal 选完语言 → dispatch 'studio:lang-set' →
+// 本组件检测到 lang 已设 + onboarding 未 done → 弹出。
+// Settings 里"重新运行首次引导"按钮 → dispatch 'studio:open-onboarding' → 强制弹出。
+//
+// 数据全部复用 SettingsData (catalog + secrets + SSE 推送) + 现有 download API，
+// 后端不需要任何改动。
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { api, type ModelsCatalog } from '../api/client'
+import { useSettingsData } from '../lib/SettingsData'
+
+const ONBOARDING_DONE_KEY = 'studio.onboarding.done'
+const LANG_KEY = 'studio.lang'
+
+// CustomEvent name 集中在这里，跟 LangModal / Settings 共享。
+export const ONBOARDING_EVENTS = {
+  langSet: 'studio:lang-set',
+  open: 'studio:open-onboarding',
+} as const
+
+export function isOnboardingDone(): boolean {
+  try { return localStorage.getItem(ONBOARDING_DONE_KEY) === 'true' } catch { return false }
+}
+function setOnboardingDone() {
+  try { localStorage.setItem(ONBOARDING_DONE_KEY, 'true') } catch { /* ignore */ }
+}
+export function clearOnboardingDone() {
+  try { localStorage.removeItem(ONBOARDING_DONE_KEY) } catch { /* ignore */ }
+}
+function langIsSet(): boolean {
+  try { return localStorage.getItem(LANG_KEY) !== null } catch { return false }
+}
+
+// 按 i18n 推断默认下载源：中文 → ModelScope；其余 → HuggingFace。
+// 用户在国内的概率高且大多不知道 ModelScope 是啥；海外用户走 HF 直连。
+export function defaultDownloadSource(lang: string | null | undefined): 'huggingface' | 'modelscope' {
+  if ((lang ?? '').toLowerCase().startsWith('zh')) return 'modelscope'
+  return 'huggingface'
+}
+
+// ---- item states ---------------------------------------------------------
+
+type ItemKey = 'base' | 'tagger' | 'accel' | 'upscaler'
+type ItemStatus = 'idle' | 'queued' | 'installing' | 'done' | 'failed'
+type AccelChoice = 'flash_attn' | 'xformers' | 'none'
+
+interface ItemDerived {
+  status: ItemStatus
+  // 多组件聚合时显当前 X/N
+  progress?: { done: number; total: number }
+}
+
+// 从 catalog 派生底模套件状态（4 个子文件全 exists 算 done）。
+function deriveBaseStatus(c: ModelsCatalog | null, dl: Record<ItemKey, ItemStatus>): ItemDerived {
+  if (!c) return { status: dl.base }
+  const animaLatest = c.anima_main.variants.find((v) => v.is_latest)
+  const checks: boolean[] = [
+    !!animaLatest?.exists,
+    !!c.anima_vae.exists,
+    c.qwen3.files.length > 0 && c.qwen3.files.every((f) => f.exists),
+    c.t5_tokenizer.files.length > 0 && c.t5_tokenizer.files.every((f) => f.exists),
+  ]
+  const done = checks.filter(Boolean).length
+  const total = checks.length
+  if (done === total) return { status: 'done', progress: { done, total } }
+  // catalog 不在 done 状态时，叠加本地 install state（installing/failed/queued）
+  if (dl.base === 'failed') return { status: 'failed', progress: { done, total } }
+  if (dl.base === 'installing' || dl.base === 'queued') {
+    return { status: dl.base, progress: { done, total } }
+  }
+  return { status: 'idle', progress: { done, total } }
+}
+
+// 打标功能 = WD14 当前 variant 装好 + ONNX runtime 已装。
+function deriveTaggerStatus(
+  c: ModelsCatalog | null,
+  hasOnnx: boolean,
+  dl: Record<ItemKey, ItemStatus>,
+): ItemDerived {
+  if (!c) return { status: dl.tagger }
+  const current = c.wd14.variants.find((v) => v.is_current) ?? c.wd14.variants[0]
+  const wd14Ok = !!current?.exists
+  const checks = [wd14Ok, hasOnnx]
+  const done = checks.filter(Boolean).length
+  const total = checks.length
+  if (done === total) return { status: 'done', progress: { done, total } }
+  if (dl.tagger === 'failed') return { status: 'failed', progress: { done, total } }
+  if (dl.tagger === 'installing' || dl.tagger === 'queued') {
+    return { status: dl.tagger, progress: { done, total } }
+  }
+  return { status: 'idle', progress: { done, total } }
+}
+
+// 训练加速 = 用户选的那个已装；'none' 选项永远 done（用户主动不装）。
+function deriveAccelStatus(
+  choice: AccelChoice,
+  hasFlash: boolean,
+  hasXformers: boolean,
+  dl: Record<ItemKey, ItemStatus>,
+): ItemDerived {
+  if (choice === 'none') return { status: 'done' }
+  if (choice === 'flash_attn' && hasFlash) return { status: 'done' }
+  if (choice === 'xformers' && hasXformers) return { status: 'done' }
+  if (dl.accel === 'failed') return { status: 'failed' }
+  if (dl.accel === 'installing' || dl.accel === 'queued') return { status: dl.accel }
+  return { status: 'idle' }
+}
+
+// Upscaler = 当前 selected variant exists。
+function deriveUpscalerStatus(
+  c: ModelsCatalog | null,
+  dl: Record<ItemKey, ItemStatus>,
+): ItemDerived {
+  if (!c?.upscalers) return { status: dl.upscaler }
+  const current =
+    c.upscalers.variants.find((v) => v.is_current)
+    ?? c.upscalers.variants.find((v) => v.label === c.upscalers!.default)
+  if (current?.exists) return { status: 'done' }
+  if (dl.upscaler === 'failed') return { status: 'failed' }
+  if (dl.upscaler === 'installing' || dl.upscaler === 'queued') return { status: dl.upscaler }
+  return { status: 'idle' }
+}
+
+// ---- main component ------------------------------------------------------
+
+export function FirstRunOnboardingModal() {
+  const { t, i18n } = useTranslation()
+  const { secrets, setSecrets, catalog, reloadCatalog } = useSettingsData()
+
+  const [open, setOpen] = useState<boolean>(false)
+  // 选中要装的条目；初次 mount 时按"推荐勾选"填充。
+  const [selected, setSelected] = useState<Set<ItemKey>>(new Set(['base', 'tagger']))
+  const [accelChoice, setAccelChoice] = useState<AccelChoice>('flash_attn')
+  const [advancedOpen, setAdvancedOpen] = useState<boolean>(false)
+  // 安装本地状态机（catalog 还没反映到结果时用）。
+  const [installState, setInstallState] = useState<Record<ItemKey, ItemStatus>>({
+    base: 'idle', tagger: 'idle', accel: 'idle', upscaler: 'idle',
+  })
+  const [failureLogs, setFailureLogs] = useState<Record<ItemKey, string[]>>({
+    base: [], tagger: [], accel: [], upscaler: [],
+  })
+  const [runtimeStatus, setRuntimeStatus] = useState<{
+    onnx: boolean
+    flashAttn: boolean
+    xformers: boolean
+  }>({ onnx: false, flashAttn: false, xformers: false })
+  const [restartRequired, setRestartRequired] = useState<boolean>(false)
+  const [restarting, setRestarting] = useState<boolean>(false)
+  const [currentItem, setCurrentItem] = useState<ItemKey | null>(null)
+  const [savingSource, setSavingSource] = useState<boolean>(false)
+  // first-run 自动按 i18n 写一次 secrets.download_source(只跑一次,避免覆盖用户手动改)。
+  const autoSourceWrittenRef = useRef<boolean>(false)
+
+  // 触发：lang 已设 + onboarding 未 done → 自动弹；显式 open 事件 → 强制弹。
+  useEffect(() => {
+    const evaluate = () => { if (langIsSet() && !isOnboardingDone()) setOpen(true) }
+    const forceOpen = () => setOpen(true)
+    // mount 时尝试一次（lang 可能在本组件 mount 前就设好了）
+    evaluate()
+    window.addEventListener(ONBOARDING_EVENTS.langSet, evaluate)
+    window.addEventListener(ONBOARDING_EVENTS.open, forceOpen)
+    return () => {
+      window.removeEventListener(ONBOARDING_EVENTS.langSet, evaluate)
+      window.removeEventListener(ONBOARDING_EVENTS.open, forceOpen)
+    }
+  }, [])
+
+  // 拉运行时（ONNX / Flash-Attn / Xformers）状态。open 时拉一次，重启回来也会重新 mount。
+  useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    Promise.all([
+      api.getWD14Runtime().catch(() => null),
+      api.getFlashAttnStatus().catch(() => null),
+      api.getXformersStatus().catch(() => null),
+    ]).then(([wd, fa, xf]) => {
+      if (cancelled) return
+      setRuntimeStatus({
+        onnx: !!wd?.installed,
+        flashAttn: !!fa?.installed,
+        xformers: !!xf?.installed,
+      })
+    })
+    return () => { cancelled = true }
+  }, [open])
+
+  // 派生每个条目状态。
+  const itemStatus = useMemo<Record<ItemKey, ItemDerived>>(() => ({
+    base: deriveBaseStatus(catalog, installState),
+    tagger: deriveTaggerStatus(catalog, runtimeStatus.onnx, installState),
+    accel: deriveAccelStatus(accelChoice, runtimeStatus.flashAttn, runtimeStatus.xformers, installState),
+    upscaler: deriveUpscalerStatus(catalog, installState),
+  }), [catalog, installState, runtimeStatus, accelChoice])
+
+  // 全部装完判定：选中的条目全 done。
+  const allSelectedDone = useMemo(() => {
+    for (const k of selected) {
+      if (itemStatus[k].status !== 'done') return false
+    }
+    return selected.size > 0
+  }, [selected, itemStatus])
+
+  // 是否正在跑一键装。
+  const installingNow = useMemo(() => {
+    return (['base', 'tagger', 'accel', 'upscaler'] as ItemKey[])
+      .some((k) => installState[k] === 'installing' || installState[k] === 'queued')
+  }, [installState])
+
+  const toggleSelected = useCallback((key: ItemKey) => {
+    if (installingNow) return
+    setSelected((s) => {
+      const n = new Set(s)
+      if (n.has(key)) n.delete(key); else n.add(key)
+      return n
+    })
+  }, [installingNow])
+
+  // 保存下载源到 secrets。
+  const saveDownloadSource = useCallback(async (next: 'huggingface' | 'modelscope') => {
+    if (!secrets) return
+    setSavingSource(true)
+    try {
+      const updated = await api.updateSecrets({ download_source: next })
+      setSecrets(updated)
+    } catch {
+      // 静默失败：保留 UI 选择，用户可重试
+    } finally {
+      setSavingSource(false)
+    }
+  }, [secrets, setSecrets])
+
+  // 当前下载源（secrets 为空时按 i18n 兜底显示）。
+  const downloadSource: 'huggingface' | 'modelscope' = useMemo(() => {
+    const fromSecrets = (secrets?.download_source ?? '').toLowerCase()
+    if (fromSecrets === 'huggingface' || fromSecrets === 'modelscope') return fromSecrets
+    return defaultDownloadSource(i18n.language)
+  }, [secrets, i18n.language])
+
+  // First-run 时按 i18n 推断把默认源写入 secrets,让中文用户跳过 onboarding 后
+  // 进 Settings 也能看到 ModelScope(而不是后端 hardcoded default 'huggingface')。
+  // 只在 onboarding 未 done(首次启动)时跑,跑过一次后 ref 锁住,用户主动改不会被覆盖。
+  useEffect(() => {
+    if (!open || !secrets || autoSourceWrittenRef.current) return
+    if (isOnboardingDone()) {
+      autoSourceWrittenRef.current = true
+      return
+    }
+    const inferred = defaultDownloadSource(i18n.language)
+    if (secrets.download_source !== inferred) {
+      void saveDownloadSource(inferred)
+    }
+    autoSourceWrittenRef.current = true
+  }, [open, secrets, i18n.language, saveDownloadSource])
+
+  // 安装单个条目。返回是否成功（用于判断 restart_required）。
+  const installItem = useCallback(async (key: ItemKey): Promise<{ ok: boolean; needsRestart: boolean }> => {
+    setInstallState((s) => ({ ...s, [key]: 'installing' }))
+    setCurrentItem(key)
+    let ok = true
+    let needsRestart = false
+    const errors: string[] = []
+    try {
+      if (key === 'base' && catalog) {
+        const latest = catalog.anima_main.variants.find((v) => v.is_latest)
+        if (latest && !latest.exists) {
+          await api.startModelDownload({ model_id: 'anima_main', variant: latest.variant })
+        }
+        if (!catalog.anima_vae.exists) {
+          await api.startModelDownload({ model_id: 'anima_vae' })
+        }
+        if (!catalog.qwen3.files.every((f) => f.exists)) {
+          await api.startModelDownload({ model_id: 'qwen3' })
+        }
+        if (!catalog.t5_tokenizer.files.every((f) => f.exists)) {
+          await api.startModelDownload({ model_id: 't5_tokenizer' })
+        }
+      } else if (key === 'tagger' && catalog) {
+        const current = catalog.wd14.variants.find((v) => v.is_current) ?? catalog.wd14.variants[0]
+        if (current && !current.exists) {
+          await api.startModelDownload({ model_id: 'wd14', variant: current.model_id })
+        }
+        if (!runtimeStatus.onnx) {
+          const r = await api.installWD14Runtime('auto')
+          if (r.installed) {
+            setRuntimeStatus((s) => ({ ...s, onnx: true }))
+            needsRestart = needsRestart || !!r.restart_required
+          } else {
+            ok = false
+            errors.push(r.stdout_tail.split('\n').slice(-10).join('\n'))
+          }
+        }
+      } else if (key === 'accel') {
+        if (accelChoice === 'flash_attn' && !runtimeStatus.flashAttn) {
+          const r = await api.installFlashAttn(null)
+          if (r.installed) {
+            setRuntimeStatus((s) => ({ ...s, flashAttn: true }))
+            needsRestart = needsRestart || !!r.restart_required
+          } else {
+            ok = false
+            errors.push(r.stdout_tail.split('\n').slice(-10).join('\n'))
+          }
+        } else if (accelChoice === 'xformers' && !runtimeStatus.xformers) {
+          const r = await api.installXformers()
+          if (r.installed) {
+            setRuntimeStatus((s) => ({ ...s, xformers: true }))
+            needsRestart = needsRestart || !!r.restart_required
+          } else {
+            ok = false
+            errors.push(r.stdout_tail.split('\n').slice(-10).join('\n'))
+          }
+        }
+      } else if (key === 'upscaler' && catalog?.upscalers) {
+        const target =
+          catalog.upscalers.variants.find((v) => v.is_current)
+          ?? catalog.upscalers.variants.find((v) => v.label === catalog.upscalers!.default)
+        if (target && !target.exists) {
+          await api.startModelDownload({ model_id: 'upscalers', variant: target.label })
+        }
+      }
+    } catch (e) {
+      ok = false
+      errors.push(String(e))
+    }
+    if (!ok) {
+      setFailureLogs((s) => ({ ...s, [key]: errors }))
+      setInstallState((s) => ({ ...s, [key]: 'failed' }))
+    } else {
+      setInstallState((s) => ({ ...s, [key]: 'done' }))
+    }
+    await reloadCatalog()
+    return { ok, needsRestart }
+  }, [catalog, accelChoice, runtimeStatus, reloadCatalog])
+
+  // 一键装：串行跑选中条目（后端有些接口本身是同步阻塞 pip，无法并行）。
+  const installAll = useCallback(async () => {
+    // 先把选中且非 done 的条目标为 queued
+    const queue: ItemKey[] = (['base', 'tagger', 'accel', 'upscaler'] as ItemKey[])
+      .filter((k) => selected.has(k) && itemStatus[k].status !== 'done')
+    setInstallState((s) => {
+      const n = { ...s }
+      for (const k of queue) n[k] = 'queued'
+      return n
+    })
+    let anyRestart = false
+    for (const k of queue) {
+      const { needsRestart } = await installItem(k)
+      anyRestart = anyRestart || needsRestart
+    }
+    setCurrentItem(null)
+    if (anyRestart) setRestartRequired(true)
+  }, [selected, itemStatus, installItem])
+
+  const retryItem = useCallback((key: ItemKey) => {
+    setInstallState((s) => ({ ...s, [key]: 'queued' }))
+    setFailureLogs((s) => ({ ...s, [key]: [] }))
+    void installItem(key)
+  }, [installItem])
+
+  const handleRestart = useCallback(async () => {
+    setRestarting(true)
+    try {
+      await api.restartServer()
+      // restart_required 后会有专用轮询；这里简化为 5s 后 reload，跟 Settings 里
+      // 的 pollHealthThenReload 行为对齐（详细轮询逻辑暂用 location.reload 兜底）。
+      setTimeout(() => { window.location.reload() }, 5000)
+    } catch {
+      setRestarting(false)
+    }
+  }, [])
+
+  const handleClose = useCallback(() => {
+    setOnboardingDone()
+    setOpen(false)
+  }, [])
+
+  const handleSkip = useCallback(() => {
+    if (installingNow) return
+    handleClose()
+  }, [installingNow, handleClose])
+
+  if (!open) return null
+
+  const selectedCount = (['base', 'tagger', 'accel', 'upscaler'] as ItemKey[])
+    .filter((k) => selected.has(k) && itemStatus[k].status !== 'done').length
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="first-run-onboarding-title"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-md p-4"
+      data-testid="first-run-onboarding-modal"
+    >
+      <div className="w-full max-w-[640px] max-h-[90vh] flex flex-col bg-elevated border border-dim rounded-lg shadow-xl overflow-hidden">
+        <div className="p-6 pb-4 border-b border-dim">
+          <h1
+            id="first-run-onboarding-title"
+            className="m-0 text-2xl font-semibold text-fg-primary"
+          >
+            {t('onboarding.title')}
+          </h1>
+          <p className="mt-2 mb-0 text-sm text-fg-secondary">
+            {t('onboarding.subtitle')}
+          </p>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-6 py-4 flex flex-col gap-4">
+          <DownloadSourceRow
+            value={downloadSource}
+            onChange={saveDownloadSource}
+            disabled={installingNow || savingSource}
+          />
+
+          <div className="border-t border-dim" />
+
+          <ChecklistItem
+            itemKey="base"
+            label={t('onboarding.items.base.label')}
+            description={t('onboarding.items.base.description')}
+            checked={selected.has('base')}
+            onToggle={() => toggleSelected('base')}
+            status={itemStatus.base}
+            failureLog={failureLogs.base}
+            onRetry={() => retryItem('base')}
+            disabled={installingNow}
+          />
+
+          <ChecklistItem
+            itemKey="tagger"
+            label={t('onboarding.items.tagger.label')}
+            description={t('onboarding.items.tagger.description')}
+            checked={selected.has('tagger')}
+            onToggle={() => toggleSelected('tagger')}
+            status={itemStatus.tagger}
+            failureLog={failureLogs.tagger}
+            onRetry={() => retryItem('tagger')}
+            disabled={installingNow}
+          />
+
+          <details
+            open={advancedOpen}
+            onToggle={(e) => setAdvancedOpen((e.target as HTMLDetailsElement).open)}
+            className="border-t border-dim pt-4"
+          >
+            <summary className="cursor-pointer text-sm font-medium text-fg-secondary hover:text-fg-primary select-none">
+              {t('onboarding.advanced')}
+            </summary>
+
+            <div className="mt-3 flex flex-col gap-4">
+              <AccelItem
+                checked={selected.has('accel')}
+                onToggle={() => toggleSelected('accel')}
+                choice={accelChoice}
+                onChoiceChange={setAccelChoice}
+                status={itemStatus.accel}
+                failureLog={failureLogs.accel}
+                onRetry={() => retryItem('accel')}
+                disabled={installingNow}
+              />
+
+              <ChecklistItem
+                itemKey="upscaler"
+                label={t('onboarding.items.upscaler.label')}
+                description={t('onboarding.items.upscaler.description')}
+                checked={selected.has('upscaler')}
+                onToggle={() => toggleSelected('upscaler')}
+                status={itemStatus.upscaler}
+                failureLog={failureLogs.upscaler}
+                onRetry={() => retryItem('upscaler')}
+                disabled={installingNow}
+              />
+            </div>
+          </details>
+        </div>
+
+        <div className="border-t border-dim p-4 flex items-center justify-between bg-surface">
+          <button
+            type="button"
+            onClick={handleSkip}
+            disabled={installingNow}
+            className="px-3 py-1.5 text-sm text-fg-tertiary hover:text-fg-primary disabled:opacity-50 disabled:cursor-not-allowed bg-transparent border-none cursor-pointer"
+            data-testid="onboarding-skip"
+          >
+            {t('onboarding.skip')}
+          </button>
+
+          {installingNow ? (
+            <div className="text-sm text-fg-secondary">
+              {currentItem ? t(`onboarding.installing.${currentItem}`) : t('onboarding.installing.generic')}
+            </div>
+          ) : restartRequired ? (
+            <div className="flex items-center gap-3">
+              <span className="text-sm text-fg-secondary">{t('onboarding.restartHint')}</span>
+              <button
+                type="button"
+                onClick={handleRestart}
+                disabled={restarting}
+                className="px-4 py-2 text-sm font-medium bg-accent text-white rounded hover:opacity-90 disabled:opacity-50 cursor-pointer"
+                data-testid="onboarding-restart"
+              >
+                {restarting ? t('onboarding.restarting') : t('onboarding.restart')}
+              </button>
+            </div>
+          ) : allSelectedDone ? (
+            <button
+              type="button"
+              onClick={handleClose}
+              className="px-4 py-2 text-sm font-medium bg-accent text-white rounded hover:opacity-90 cursor-pointer"
+              data-testid="onboarding-finish"
+            >
+              {t('onboarding.finish')}
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={installAll}
+              disabled={selectedCount === 0}
+              className="px-4 py-2 text-sm font-medium bg-accent text-white rounded hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+              data-testid="onboarding-install-all"
+            >
+              {t('onboarding.installSelected', { count: selectedCount })}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---- subcomponents --------------------------------------------------------
+
+function DownloadSourceRow(props: {
+  value: 'huggingface' | 'modelscope'
+  onChange: (v: 'huggingface' | 'modelscope') => void
+  disabled: boolean
+}) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="text-sm font-medium text-fg-primary">{t('onboarding.downloadSource')}</div>
+      <div className="flex gap-2">
+        {(['modelscope', 'huggingface'] as const).map((src) => (
+          <button
+            key={src}
+            type="button"
+            onClick={() => props.onChange(src)}
+            disabled={props.disabled}
+            className={`flex-1 px-3 py-2 text-sm border rounded transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer ${
+              props.value === src
+                ? 'border-accent bg-accent-soft text-fg-primary'
+                : 'border-dim bg-surface text-fg-secondary hover:border-accent/50'
+            }`}
+            data-testid={`onboarding-source-${src}`}
+          >
+            {src === 'modelscope' ? 'ModelScope' : 'HuggingFace'}
+          </button>
+        ))}
+      </div>
+      <div className="text-xs text-fg-tertiary">{t('onboarding.downloadSourceHint')}</div>
+    </div>
+  )
+}
+
+function StatusBadge({ status, progress }: { status: ItemStatus; progress?: { done: number; total: number } }) {
+  const { t } = useTranslation()
+  const baseClass = 'inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded'
+  switch (status) {
+    case 'done':
+      return <span className={`${baseClass} bg-success-soft text-success`}>✓ {t('onboarding.status.done')}</span>
+    case 'installing': {
+      const suffix = progress ? ` (${progress.done}/${progress.total})` : ''
+      return <span className={`${baseClass} bg-accent-soft text-accent`}>⏳ {t('onboarding.status.installing')}{suffix}</span>
+    }
+    case 'queued':
+      return <span className={`${baseClass} bg-surface text-fg-tertiary`}>⏱ {t('onboarding.status.queued')}</span>
+    case 'failed':
+      return <span className={`${baseClass} bg-danger-soft text-danger`}>✕ {t('onboarding.status.failed')}</span>
+    default: {
+      const suffix = progress && progress.done > 0 ? ` (${progress.done}/${progress.total})` : ''
+      return <span className={`${baseClass} bg-surface text-fg-tertiary`}>○ {t('onboarding.status.idle')}{suffix}</span>
+    }
+  }
+}
+
+function ChecklistItem(props: {
+  itemKey: ItemKey
+  label: string
+  description: string
+  checked: boolean
+  onToggle: () => void
+  status: ItemDerived
+  failureLog: string[]
+  onRetry: () => void
+  disabled: boolean
+}) {
+  const { t } = useTranslation()
+  const [logOpen, setLogOpen] = useState(false)
+  const isDone = props.status.status === 'done'
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          checked={props.checked || isDone}
+          onChange={props.onToggle}
+          disabled={props.disabled || isDone}
+          className="mt-1 cursor-pointer disabled:cursor-not-allowed"
+          data-testid={`onboarding-check-${props.itemKey}`}
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <div className="text-sm font-medium text-fg-primary">{props.label}</div>
+            <StatusBadge status={props.status.status} progress={props.status.progress} />
+          </div>
+          <div className="text-xs text-fg-tertiary mt-0.5">{props.description}</div>
+          {props.status.status === 'failed' && (
+            <div className="mt-2 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={props.onRetry}
+                className="px-2 py-1 text-xs bg-surface border border-dim rounded hover:border-accent cursor-pointer"
+                data-testid={`onboarding-retry-${props.itemKey}`}
+              >
+                {t('onboarding.retry')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setLogOpen((v) => !v)}
+                className="px-2 py-1 text-xs text-fg-tertiary hover:text-fg-primary bg-transparent border-none cursor-pointer"
+              >
+                {logOpen ? t('onboarding.hideLog') : t('onboarding.showLog')}
+              </button>
+            </div>
+          )}
+          {logOpen && props.failureLog.length > 0 && (
+            <pre className="mt-2 p-2 text-xs bg-surface border border-dim rounded overflow-x-auto whitespace-pre-wrap max-h-32">
+              {props.failureLog.join('\n')}
+            </pre>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function AccelItem(props: {
+  checked: boolean
+  onToggle: () => void
+  choice: AccelChoice
+  onChoiceChange: (c: AccelChoice) => void
+  status: ItemDerived
+  failureLog: string[]
+  onRetry: () => void
+  disabled: boolean
+}) {
+  const { t } = useTranslation()
+  const [logOpen, setLogOpen] = useState(false)
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-start gap-3">
+        <input
+          type="checkbox"
+          checked={props.checked}
+          onChange={props.onToggle}
+          disabled={props.disabled}
+          className="mt-1 cursor-pointer"
+          data-testid="onboarding-check-accel"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <div className="text-sm font-medium text-fg-primary">{t('onboarding.items.accel.label')}</div>
+            <StatusBadge status={props.status.status} />
+          </div>
+          <div className="text-xs text-fg-tertiary mt-0.5">{t('onboarding.items.accel.description')}</div>
+          {props.checked && (
+            <div className="mt-2 flex flex-col gap-1 pl-1">
+              {(['flash_attn', 'xformers', 'none'] as const).map((c) => (
+                <label key={c} className="flex items-center gap-2 text-xs cursor-pointer">
+                  <input
+                    type="radio"
+                    name="onboarding-accel-choice"
+                    checked={props.choice === c}
+                    onChange={() => props.onChoiceChange(c)}
+                    disabled={props.disabled}
+                    className="cursor-pointer"
+                  />
+                  <span className="font-medium text-fg-secondary">{t(`onboarding.items.accel.choice.${c}.label`)}</span>
+                  <span className="text-fg-tertiary">{t(`onboarding.items.accel.choice.${c}.hint`)}</span>
+                </label>
+              ))}
+            </div>
+          )}
+          {props.status.status === 'failed' && (
+            <div className="mt-2 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={props.onRetry}
+                className="px-2 py-1 text-xs bg-surface border border-dim rounded hover:border-accent cursor-pointer"
+              >
+                {t('onboarding.retry')}
+              </button>
+              <button
+                type="button"
+                onClick={() => setLogOpen((v) => !v)}
+                className="px-2 py-1 text-xs text-fg-tertiary hover:text-fg-primary bg-transparent border-none cursor-pointer"
+              >
+                {logOpen ? t('onboarding.hideLog') : t('onboarding.showLog')}
+              </button>
+            </div>
+          )}
+          {logOpen && props.failureLog.length > 0 && (
+            <pre className="mt-2 p-2 text-xs bg-surface border border-dim rounded overflow-x-auto whitespace-pre-wrap max-h-32">
+              {props.failureLog.join('\n')}
+            </pre>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1026,6 +1026,10 @@
     "currentDevLocked": "Currently on dev · cannot disable",
     "updateLogTitle": "Last update log",
     "close": "Close",
+    "onboardingSection": "First-run guide",
+    "onboardingReopenTitle": "Re-run first-run guide",
+    "onboardingReopenHelp": "Re-open the first-run install panel. Useful for checking what's not installed yet, or for filling in what you skipped.",
+    "onboardingReopen": "Re-run guide",
     "serviceRestartTitle": "Restart Studio",
     "serviceRestartHelp1": "Shut down and restart the backend process.",
     "serviceRestartHelp2": "Common use cases: force refresh after editing <code>secrets.json</code>, or apply a newly installed onnxruntime / PyTorch EP.",
@@ -2185,5 +2189,67 @@
     "processing": "Server processing…",
     "failed": "Failed",
     "etaPrefix": "ETA"
+  },
+  "onboarding": {
+    "title": "Welcome to AnimaLoraStudio",
+    "subtitle": "Here are the basics you'll want set up. Tick what you need and install them in one go. Already-installed items are auto-checked.",
+    "downloadSource": "Download source",
+    "downloadSourceHint": "Pre-selected based on your language; feel free to change. This source is used for all model downloads.",
+    "advanced": "Advanced",
+    "skip": "Skip",
+    "installSelected": "Install selected ({{count}})",
+    "finish": "Done",
+    "retry": "Retry",
+    "showLog": "Show log",
+    "hideLog": "Hide log",
+    "restart": "Restart now",
+    "restarting": "Restarting…",
+    "restartHint": "All installs done — a service restart is required to take effect",
+    "installing": {
+      "generic": "Installing…",
+      "base": "Installing: Base model bundle",
+      "tagger": "Installing: Auto-tagging",
+      "accel": "Installing: Training acceleration",
+      "upscaler": "Installing: Image upscaler"
+    },
+    "status": {
+      "idle": "Not installed",
+      "queued": "Queued",
+      "installing": "Installing",
+      "done": "Installed",
+      "failed": "Failed"
+    },
+    "items": {
+      "base": {
+        "label": "Base model bundle",
+        "description": "Anima main + VAE + Qwen3 + T5 — the core models needed for training (about 30 GB total)"
+      },
+      "tagger": {
+        "label": "Auto-tagging",
+        "description": "WD14 model + ONNX Runtime — auto-generates tags for your training set"
+      },
+      "accel": {
+        "label": "Training acceleration (optional)",
+        "description": "Faster attention implementations for noticeable speedups; skip on CPU / older GPUs",
+        "choice": {
+          "flash_attn": {
+            "label": "Flash Attention",
+            "hint": "Recommended, fastest"
+          },
+          "xformers": {
+            "label": "Xformers",
+            "hint": "Fallback when flash-attn won't install"
+          },
+          "none": {
+            "label": "Skip",
+            "hint": "CPU / older GPUs work too, just slower"
+          }
+        }
+      },
+      "upscaler": {
+        "label": "Image upscaler (optional)",
+        "description": "4x-AnimeSharp — upscales training images during preprocessing"
+      }
+    }
   }
 }

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -2195,6 +2195,8 @@
     "subtitle": "Here are the basics you'll want set up. Tick what you need and install them in one go. Already-installed items are auto-checked.",
     "downloadSource": "Download source",
     "downloadSourceHint": "Pre-selected based on your language; feel free to change. This source is used for all model downloads.",
+    "downloadSourceInstallHint": "Switching applies to downloads not yet started — current in-flight downloads keep running. To switch right now, close this guide and restart Studio.",
+    "skipWhileInstalling": "Guide closed — downloads keep running in the background. To stop them, restart Studio.",
     "skip": "Skip",
     "installSelected": "Install selected ({{count}})",
     "checkingState": "Checking installed state…",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -2197,6 +2197,7 @@
     "downloadSourceHint": "Pre-selected based on your language; feel free to change. This source is used for all model downloads.",
     "skip": "Skip",
     "installSelected": "Install selected ({{count}})",
+    "checkingState": "Checking installed state…",
     "finish": "Done",
     "retry": "Retry",
     "showLog": "Show log",
@@ -2212,6 +2213,7 @@
       "upscaler": "Installing: Image upscaler"
     },
     "status": {
+      "checking": "Checking…",
       "idle": "Not installed",
       "queued": "Queued",
       "installing": "Installing",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -2195,7 +2195,6 @@
     "subtitle": "Here are the basics you'll want set up. Tick what you need and install them in one go. Already-installed items are auto-checked.",
     "downloadSource": "Download source",
     "downloadSourceHint": "Pre-selected based on your language; feel free to change. This source is used for all model downloads.",
-    "advanced": "Advanced",
     "skip": "Skip",
     "installSelected": "Install selected ({{count}})",
     "finish": "Done",
@@ -2230,21 +2229,7 @@
       },
       "accel": {
         "label": "Training acceleration (optional)",
-        "description": "Faster attention implementations for noticeable speedups; skip on CPU / older GPUs",
-        "choice": {
-          "flash_attn": {
-            "label": "Flash Attention",
-            "hint": "Recommended, fastest"
-          },
-          "xformers": {
-            "label": "Xformers",
-            "hint": "Fallback when flash-attn won't install"
-          },
-          "none": {
-            "label": "Skip",
-            "hint": "CPU / older GPUs work too, just slower"
-          }
-        }
+        "description": "Flash Attention — noticeable training speedup; skip on CPU / older GPUs where it won't build"
       },
       "upscaler": {
         "label": "Image upscaler (optional)",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -2195,7 +2195,6 @@
     "subtitle": "下面是建议安装的基础能力,勾选后一键安装。已装好的会自动打勾。",
     "downloadSource": "下载源",
     "downloadSourceHint": "已为你按语言推荐,可以改。下载源同时影响后续所有模型下载。",
-    "advanced": "高级选项",
     "skip": "跳过引导",
     "installSelected": "一键安装选中 ({{count}})",
     "finish": "完成",
@@ -2230,21 +2229,7 @@
       },
       "accel": {
         "label": "训练加速 (可选)",
-        "description": "更快的注意力实现,显著提速;CPU / 旧显卡可不装",
-        "choice": {
-          "flash_attn": {
-            "label": "Flash Attention",
-            "hint": "推荐,速度最快"
-          },
-          "xformers": {
-            "label": "Xformers",
-            "hint": "备选,flash-attn 装不上时用"
-          },
-          "none": {
-            "label": "不装",
-            "hint": "CPU / 旧显卡也能跑,只是慢"
-          }
-        }
+        "description": "Flash Attention,显著提速训练;CPU / 旧显卡装不上时可跳过"
       },
       "upscaler": {
         "label": "图像增强 (可选)",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -2197,6 +2197,7 @@
     "downloadSourceHint": "已为你按语言推荐,可以改。下载源同时影响后续所有模型下载。",
     "skip": "跳过引导",
     "installSelected": "一键安装选中 ({{count}})",
+    "checkingState": "检查安装状态…",
     "finish": "完成",
     "retry": "重试",
     "showLog": "查看日志",
@@ -2212,6 +2213,7 @@
       "upscaler": "正在安装: 图像增强"
     },
     "status": {
+      "checking": "检查中…",
       "idle": "未安装",
       "queued": "排队中",
       "installing": "安装中",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -2195,6 +2195,8 @@
     "subtitle": "下面是建议安装的基础能力,勾选后一键安装。已装好的会自动打勾。",
     "downloadSource": "下载源",
     "downloadSourceHint": "已为你按语言推荐,可以改。下载源同时影响后续所有模型下载。",
+    "downloadSourceInstallHint": "切换后对未启动的下载生效;当前进行中的任务不会被中断。如要立即换源,可关闭引导并重启 Studio。",
+    "skipWhileInstalling": "已关闭引导,后台仍在继续下载。要彻底停止请重启 Studio。",
     "skip": "跳过引导",
     "installSelected": "一键安装选中 ({{count}})",
     "checkingState": "检查安装状态…",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1026,6 +1026,10 @@
     "currentDevLocked": "当前在 dev · 不可关闭",
     "updateLogTitle": "上次更新日志",
     "close": "关闭",
+    "onboardingSection": "首次引导",
+    "onboardingReopenTitle": "重新运行首次引导",
+    "onboardingReopenHelp": "重新弹出首次启动时的「基础能力安装」面板,可用于检查哪些还没装、或装漏了想补。",
+    "onboardingReopen": "重新运行引导",
     "serviceRestartTitle": "重启 Studio",
     "serviceRestartHelp1": "关闭并重新启动后端进程。",
     "serviceRestartHelp2": "常用场景：修改 <code>secrets.json</code> 后强制刷新、装完新 onnxruntime / PyTorch 让 EP 生效。",
@@ -2185,5 +2189,67 @@
     "processing": "服务器处理中…",
     "failed": "失败",
     "etaPrefix": "剩余"
+  },
+  "onboarding": {
+    "title": "欢迎使用 AnimaLoraStudio",
+    "subtitle": "下面是建议安装的基础能力,勾选后一键安装。已装好的会自动打勾。",
+    "downloadSource": "下载源",
+    "downloadSourceHint": "已为你按语言推荐,可以改。下载源同时影响后续所有模型下载。",
+    "advanced": "高级选项",
+    "skip": "跳过引导",
+    "installSelected": "一键安装选中 ({{count}})",
+    "finish": "完成",
+    "retry": "重试",
+    "showLog": "查看日志",
+    "hideLog": "收起日志",
+    "restart": "现在重启服务",
+    "restarting": "重启中…",
+    "restartHint": "全部装完,需要重启服务才能生效",
+    "installing": {
+      "generic": "安装中…",
+      "base": "正在安装: 底模套件",
+      "tagger": "正在安装: 打标功能",
+      "accel": "正在安装: 训练加速",
+      "upscaler": "正在安装: 图像增强"
+    },
+    "status": {
+      "idle": "未安装",
+      "queued": "排队中",
+      "installing": "安装中",
+      "done": "已安装",
+      "failed": "失败"
+    },
+    "items": {
+      "base": {
+        "label": "底模套件",
+        "description": "Anima 主模型 + VAE + Qwen3 + T5,训练所需基础模型(总计约 30GB)"
+      },
+      "tagger": {
+        "label": "打标功能",
+        "description": "WD14 模型 + ONNX Runtime,自动给训练集打标签"
+      },
+      "accel": {
+        "label": "训练加速 (可选)",
+        "description": "更快的注意力实现,显著提速;CPU / 旧显卡可不装",
+        "choice": {
+          "flash_attn": {
+            "label": "Flash Attention",
+            "hint": "推荐,速度最快"
+          },
+          "xformers": {
+            "label": "Xformers",
+            "hint": "备选,flash-attn 装不上时用"
+          },
+          "none": {
+            "label": "不装",
+            "hint": "CPU / 旧显卡也能跑,只是慢"
+          }
+        }
+      },
+      "upscaler": {
+        "label": "图像增强 (可选)",
+        "description": "4x-AnimeSharp,预处理时把训练图放大"
+      }
+    }
   }
 }

--- a/studio/web/src/main.tsx
+++ b/studio/web/src/main.tsx
@@ -4,6 +4,7 @@ import App from './App'
 import { DialogProvider } from './components/Dialog'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import { FirstRunLangModal } from './components/FirstRunLangModal'
+import { FirstRunOnboardingModal } from './components/FirstRunOnboardingModal'
 import { ToastProvider } from './components/Toast'
 import { installGlobalErrorHandlers } from './lib/errors/setup'
 import { SettingsDataProvider } from './lib/SettingsData'
@@ -25,6 +26,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <SettingsDataProvider>
             <SettingsDrawerProvider>
               <FirstRunLangModal />
+              <FirstRunOnboardingModal />
               <App />
             </SettingsDrawerProvider>
           </SettingsDataProvider>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -26,6 +26,10 @@ import {
   type WD14Runtime,
 } from '../../api/client'
 import { useDialog } from '../../components/Dialog'
+import {
+  clearOnboardingDone,
+  ONBOARDING_EVENTS,
+} from '../../components/FirstRunOnboardingModal'
 import { InfoButton } from '../../components/InfoButton'
 import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
 import { TagListInput } from '../../components/TagsInput'
@@ -122,6 +126,7 @@ const TAB_SECTIONS: Record<Tab, { id: string; labelKey: string }[]> = {
     { id: 'display', labelKey: 'settings.display' },
   ],
   system: [
+    { id: 'onboarding', labelKey: 'settings.onboardingSection' },
     { id: 'version', labelKey: 'settings.version' },
     { id: 'service', labelKey: 'settings.service' },
   ],
@@ -3164,9 +3169,38 @@ function DisplaySection() {
 function SystemSection() {
   return (
     <>
+      <OnboardingSection />
       <VersionSection />
       <ServiceSection />
     </>
+  )
+}
+
+// ── 重新运行首次引导 Section ─────────────────────────────────────────────
+//
+// 清掉 localStorage 的 onboarding done 标记 + dispatch event,触发
+// FirstRunOnboardingModal 显示。不重启服务、不动 secrets。
+function OnboardingSection() {
+  const { t } = useTranslation()
+  const handleReopen = () => {
+    clearOnboardingDone()
+    window.dispatchEvent(new Event(ONBOARDING_EVENTS.open))
+  }
+  return (
+    <SettingsSection id="onboarding" title={t('settings.onboardingSection')}>
+      <SettingsField
+        label={t('settings.onboardingReopenTitle')}
+        helpTooltip={<p>{t('settings.onboardingReopenHelp')}</p>}
+      >
+        <button
+          type="button"
+          onClick={handleReopen}
+          className="btn btn-secondary btn-sm self-start"
+        >
+          {t('settings.onboardingReopen')}
+        </button>
+      </SettingsField>
+    </SettingsSection>
   )
 }
 


### PR DESCRIPTION
## 背景 / 动机

Settings 里有很多东西必须先下载/配置才能用（底模、VAE、Qwen3、T5、WD14、ONNX Runtime、训练加速等）。新人第一次开 app 不知道这些东西的存在,只能在训练/打标时不断撞墙,再回 Settings 翻配置。

加一个首次启动引导 modal,在 lang modal 选完语言后立即弹出,把"必装才能用"的基础能力汇总成 checklist,勾选一键装。

设计 spec 落到 `docs/todo/onboarding-first-run.md`,六轮对齐 + 实际测试期间的迭代都记录在 commit 序列里。

## 改动概要

**新增前端组件**
- `studio/web/src/components/FirstRunOnboardingModal.tsx` — 主 modal:下载源 + 4 条目 checklist(底模套件 / 打标功能 / 训练加速 / 图像增强) + 状态机(checking/idle/queued/installing/done/failed) + sticky bar
- 触发机制:`FirstRunLangModal` 选完语言 dispatch `studio:lang-set` event → 本 modal 检测 lang 已设 + onboarding 未 done → 自动弹
- Settings 系统 tab 加"重新运行首次引导"按钮,清 localStorage + dispatch `studio:open-onboarding`

**多组件状态汇总**
- 底模套件 = Anima 主模型 + VAE + Qwen3 + T5,任一缺就显"未安装 (X/4)",全装齐显 done
- 打标功能 = WD14 + ONNX Runtime,聚合到一个状态
- 训练加速 = flash-attn(默认装的就是这个);xformers 已装也算 done(尊重用户已有环境)

**异步下载状态机**
- `startModelDownload` 是 fire-and-forget,触发后端 daemon thread 几 ms 就 return;本 PR 加 `waitForCatalog` polling helper(1.5s 间隔轮 catalogRef),触发后等到 catalog 显示装齐或 `downloads[].status` 出现 failed 才切 done/failed,避免状态闪一下回 idle
- catalog 由 `SettingsData` 通过 SSE `model_download_changed` 自动 reload,polling 只读 ref

**装中态 UX**
- 默认展开 catalog.downloads[].log_tail 实时显示 tqdm 进度(速度/ETA/当前文件)
- 下载源切换装中也可点,加 hint "对未启动的下载生效"
- "跳过引导"装中也可点,关掉后台继续下,toast 提示真要停得重启 Studio

**i18n + 主题色对齐**
- 中文 → 默认 ModelScope;英文 → 默认 HuggingFace,first-run 时自动写入 secrets
- StatusBadge done 用 theme 橙色(`bg-accent-soft text-accent`),checkbox `accentColor: var(--accent)`
- 项目状态色 token 是 `ok/err/warn/info`(不是 `success/danger`),代码用对的

**后端零改动**
- 全部复用 `POST /api/models/download` + `GET /api/models/catalog` + `model_download_changed` SSE + `POST /api/wd14/install` + `POST /api/flash-attention/install` + `POST /api/system/restart`

## Scope 之外(单独 follow-up)

- **真"取消下载"**:后端 daemon thread 拿 HF/MS SDK 拉文件,SDK 内部 IO 中断不了,要做得改 `downloader.py` + 替换 SDK 调用为带 cancel callback 的实现。当前用户能做的:换源(失败 retry 时生效) / 关 modal(后台继续) / 重启 Studio(唯一彻底停)
- **PyTorch 切 CUDA 版本**:reinstallTorch 是 deferred(必须 launcher 重启 + 几分钟 pip),不适合塞一键装队列。Setup 时已装 torch(Windows 默认 CPU wheel),进阶用户走 Settings 训练 tab 切换
- **数据集凭证 / LLM Tagger 预设 / CLTagger**:进阶选项,继续走 Settings 配

## 测试方式

**自动**
- `npx tsc --noEmit` 通过
- `npm run lint` 通过
- `npx vitest run` 35 files / 328 tests 全过(含 FirstRunLangModal 已有 6 个测试因 dispatch event 改动也覆盖了)

**手测(用户在本机环境验证过)**
- 清 localStorage 走完整 first-run:lang modal 选完语言 → onboarding 立刻弹
- Settings 系统 tab 触发重新打开 OK
- 已装齐状态:全部橙色 ✓ 已安装,显示"完成"按钮
- checking 态:Slow 3G throttle 可见 0.5-2s 灰色 "⋯ 检查中…" + disabled 按钮
- 装中态:rename `anima-base-v1.0.safetensors` 为 .bak → 弹 modal 显示 "未安装 (3/4)" → 点一键装 → 状态稳定保持 "🔄 安装中" + 实时 log tail 滚动显示下载速度
- 中英文 i18n 切换 OK
- 中文默认 ModelScope / 英文默认 HuggingFace

## 文件清单

```
docs/todo/onboarding-first-run.md                              新建,设计 spec
studio/web/src/components/FirstRunOnboardingModal.tsx          新建,主组件 ~700 行
studio/web/src/components/FirstRunLangModal.tsx                选完语言 dispatch event
studio/web/src/main.tsx                                        挂载新 modal
studio/web/src/pages/tools/Settings.tsx                        +OnboardingSection
studio/web/src/i18n/locales/{zh,en}.json                       onboarding 全部文案
```