### PR TITLE
feat(generate): 测试页落盘开关 + 删除历史栏每图 × 按钮

### DIFF
--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -18,9 +18,12 @@ task 结束 supervisor 仍调 cleanup_generate_tempdir 清掉空目录。server 
 from __future__ import annotations
 
 import json
+import re
+from datetime import date
+from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.responses import Response
 
 from ..deps import _resolve_anima_model_paths
@@ -29,8 +32,27 @@ from ..schemas.generate import GenerateRequest
 from ... import db, secrets
 from ...domain import GenerateConfig
 from ...infrastructure.event_bus import bus
+from ...infrastructure.paths import STUDIO_DATA
 
 router = APIRouter()
+
+TEST_IMAGES_DIR = STUDIO_DATA / "test"
+_IMAGE_NAME_RE = re.compile(r"^image_(\d+)\.png$")
+
+
+def _next_image_index(dir_: Path) -> int:
+    """扫描 dir 下 image_<N>.png，返回最大 N+1。找不到则 0。"""
+    if not dir_.is_dir():
+        return 0
+    max_n = -1
+    for p in dir_.iterdir():
+        m = _IMAGE_NAME_RE.match(p.name)
+        if m:
+            try:
+                max_n = max(max_n, int(m.group(1)))
+            except ValueError:
+                pass
+    return max_n + 1
 
 
 @router.post("/api/generate")
@@ -219,3 +241,36 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
         media_type="image/png",
         headers={"Cache-Control": "no-store"},
     )
+
+
+@router.post("/api/generate/save")
+async def save_test_image(
+    mode: str = Form(...),
+    image: UploadFile = File(...),
+) -> dict[str, Any]:
+    """落盘测试出图到 studio_data/test/<YYYY-MM-DD>/<mode>/image_N.png。
+
+    - mode ∈ {"single", "xy"}，其它值（含 "compare"）400
+    - Settings 开关 generate.save_test_images=False → 403
+    - N = 当前 <date>/<mode>/ 下已有 image_*.png 最大编号+1（找不到则 0）
+    - 并发兜底：x-flag 写入，FileExistsError 则重扫一次
+    """
+    if mode not in ("single", "xy"):
+        raise HTTPException(400, f"unsupported mode: {mode}")
+    if not secrets.load().generate.save_test_images:
+        raise HTTPException(403, "save_test_images is disabled")
+    raw = await image.read()
+    if not raw:
+        raise HTTPException(400, "empty image body")
+    target_dir = TEST_IMAGES_DIR / date.today().isoformat() / mode
+    target_dir.mkdir(parents=True, exist_ok=True)
+    for _ in range(20):
+        idx = _next_image_index(target_dir)
+        target = target_dir / f"image_{idx}.png"
+        try:
+            with open(target, "xb") as f:
+                f.write(raw)
+            return {"path": str(target), "index": idx}
+        except FileExistsError:
+            continue
+    raise HTTPException(500, "could not allocate filename")

--- a/studio/infrastructure/secrets.py
+++ b/studio/infrastructure/secrets.py
@@ -436,10 +436,14 @@ class GenerateConfig(BaseModel):
     - `idle_timeout_minutes`：daemon 闲置 N 分钟自动卸载模型释放 VRAM。
       0 = 关闭，模型常驻直到用户手动清。计时只在 daemon idle + 模型已 load
       时跑；进 busy / 已 unload 时取消。
+    - `save_test_images`：开关测试出图自动落盘。默认关；开后每次出完图前端
+      会调 /api/generate/save 把成图存到 studio_data/test/<date>/{single,xy}/
+      image_N.png（N 按当前文件夹已有最大编号+1）。compare 模式不落盘。
     """
     preview_every_n_steps: int = 3
     attention_backend: str = "auto"
     idle_timeout_minutes: int = 10
+    save_test_images: bool = False
 
 
 class SystemConfig(BaseModel):

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -379,6 +379,9 @@ export interface GenerateSecretsConfig {
   /** 测试出图 daemon 闲置 N 分钟自动卸载模型释放 VRAM。0 = 关闭，模型常驻
    * 直到手动点"清理显存"。计时只在 idle + 模型 loaded 时跑。 */
   idle_timeout_minutes: number
+  /** 开后每次出图自动落盘到 studio_data/test/<date>/{single,xy}/image_N.png。
+   * 默认关；compare 模式始终不落盘。 */
+  save_test_images: boolean
 }
 
 /** 系统级偏好（ADR 0002 / 0005）。update_channel 是用户视图偏好（"stable" /

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1005,6 +1005,11 @@
       "minutesSuffix": "min",
       "offHint": "Off: model stays resident until manually freed"
     },
+    "saveTestImages": {
+      "title": "Save test images to disk",
+      "label": "Save test images",
+      "desc": "When enabled, every generation is written to studio_data/test/<date>/{single,xy}/image_N.png. xy mode saves the composed grid; compare mode is never saved. Default: off."
+    },
     "theme": "Theme",
     "themeLight": "☀ Light",
     "themeDark": "☾ Dark",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1005,6 +1005,11 @@
       "minutesSuffix": "分",
       "offHint": "已关闭：模型常驻直到手动清理"
     },
+    "saveTestImages": {
+      "title": "测试出图自动落盘",
+      "label": "保存测试图片",
+      "desc": "打开后每次出图自动保存到 studio_data/test/<日期>/{single,xy}/image_N.png。xy 模式存合成的网格图；compare 模式不保存。默认关闭。"
+    },
     "theme": "主题",
     "themeLight": "☀ 日间",
     "themeDark": "☾ 暗色",

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -20,6 +20,7 @@ import NumField from './generate/NumField'
 import PreviewCompare from './generate/PreviewCompare'
 import PreviewHistoryRail from './generate/PreviewHistoryRail'
 import PromptFromDatasetPicker, { type DatasetPick } from './generate/PromptFromDatasetPicker'
+import { saveSingleSamples, saveXYMatrix } from './generate/saveTestImages'
 import { makeThumbnail, useGenerateHistory, type HistoryEntry } from './generate/useGenerateHistory'
 import PreviewXYGrid from './generate/PreviewXYGrid'
 import PromptList from './generate/PromptList'
@@ -365,6 +366,26 @@ export default function GeneratePage() {
         xy: xyMeta,
       }))
       .catch(() => { /* thumbnail 失败 — 不入库（避免无封面 entry） */ })
+    // 自动落盘（Settings.generate.save_test_images=on 时）。compare 不落盘；
+    // 关闭时跳过避免 XY 模式白白合成网格图。
+    if (mode === 'single' || mode === 'xy') {
+      void api.getSecrets().then((sec) => {
+        if (!sec.generate?.save_test_images) return
+        if (mode === 'single') {
+          return saveSingleSamples(taskId, filenames)
+        }
+        if (xyMeta) {
+          return saveXYMatrix({
+            samples: xyMeta.samples.map((s) => ({ path: s.path, xy: { xi: s.xy.xi, yi: s.xy.yi } })),
+            taskId,
+            xAxis: xyMeta.xAxis as Parameters<typeof saveXYMatrix>[0]['xAxis'],
+            yAxis: xyMeta.yAxis as Parameters<typeof saveXYMatrix>[0]['yAxis'],
+            xValues: xyMeta.xValues,
+            yValues: xyMeta.yValues,
+          })
+        }
+      }).catch(() => { /* silent */ })
+    }
   }, [currentTask, samples, mode, selectedIndices, history, xDraft, yDraft])
 
   const handleHistorySelect = (entry: HistoryEntry) => {
@@ -812,7 +833,6 @@ export default function GeneratePage() {
             entries={history.entries}
             mode={mode}
             onSelect={handleHistorySelect}
-            onRemove={(id) => { void history.remove(id) }}
             onClear={() => { void history.clearByMode(mode) }}
             onPruneStale={history.pruneStale}
           />

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -121,6 +121,7 @@ const TAB_SECTIONS: Record<Tab, { id: string; labelKey: string }[]> = {
   testing: [
     { id: 'idle-timeout', labelKey: 'settings.idleTimeout.title' },
     { id: 'preview', labelKey: 'settings.intermediatePreview' },
+    { id: 'save-test-images', labelKey: 'settings.saveTestImages.title' },
   ],
   appearance: [
     { id: 'display', labelKey: 'settings.display' },
@@ -257,7 +258,7 @@ const EMPTY: Secrets = {
   },
   models: { root: null, selected_anima: '1.0', selected_upscaler: '4x-AnimeSharp', auto_sync_paths: true },
   queue: { allow_gpu_during_train: false },
-  generate: { preview_every_n_steps: 3, attention_backend: 'auto', idle_timeout_minutes: 10 },
+  generate: { preview_every_n_steps: 3, attention_backend: 'auto', idle_timeout_minutes: 10, save_test_images: false },
   system: { update_channel: 'stable', show_dev_channel: false },
   proxy: {
     enabled: false,
@@ -1197,6 +1198,7 @@ export default function SettingsPage() {
             （flash_attn / xformers / none）。安装管理在『训练』tab。 */}
         <IdleTimeoutSection draft={draft} update={update} />
         <TaeFluxSection draft={draft} update={update} />
+        <SaveTestImagesSection draft={draft} update={update} />
       </>)}
 
       {tab === 'appearance' && (
@@ -3059,6 +3061,31 @@ function TaeFluxSection({
           onChange={(e) => update('generate', 'preview_every_n_steps', Number(e.target.value) || 0)}
           className="input"
           style={{ width: 80 }}
+        />
+      </SettingsField>
+    </SettingsSection>
+  )
+}
+
+
+function SaveTestImagesSection({
+  draft, update,
+}: {
+  draft: Secrets
+  update: <S extends Section, K extends keyof Secrets[S]>(
+    section: S, key: K, value: Secrets[S][K],
+  ) => void
+}) {
+  const { t } = useTranslation()
+  return (
+    <SettingsSection id="save-test-images" title={t('settings.saveTestImages.title')}>
+      <SettingsField
+        label={t('settings.saveTestImages.label')}
+        desc={t('settings.saveTestImages.desc')}
+      >
+        <Bool
+          value={draft.generate.save_test_images}
+          onChange={(v) => update('generate', 'save_test_images', v)}
         />
       </SettingsField>
     </SettingsSection>

--- a/studio/web/src/pages/tools/generate/PreviewHistoryRail.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewHistoryRail.tsx
@@ -15,14 +15,13 @@ interface Props {
   entries: HistoryEntry[]
   mode: HistoryMode
   onSelect: (entry: HistoryEntry) => void
-  onRemove?: (id: string) => void
   onClear?: () => void
   /** 清理失效（server cache 已没的 entry） */
   onPruneStale?: () => Promise<number>
 }
 
 export default function PreviewHistoryRail({
-  entries, mode, onSelect, onRemove, onClear, onPruneStale,
+  entries, mode, onSelect, onClear, onPruneStale,
 }: Props) {
   const { t } = useTranslation()
   const list = entries.filter((e) => e.mode === mode)
@@ -76,7 +75,6 @@ export default function PreviewHistoryRail({
             key={entry.id}
             entry={entry}
             onSelect={() => onSelect(entry)}
-            onRemove={onRemove ? () => onRemove(entry.id) : undefined}
           />
         ))
       )}
@@ -87,11 +85,9 @@ export default function PreviewHistoryRail({
 interface ItemProps {
   entry: HistoryEntry
   onSelect: () => void
-  onRemove?: () => void
 }
 
-function HistoryItem({ entry, onSelect, onRemove }: ItemProps) {
-  const { t } = useTranslation()
+function HistoryItem({ entry, onSelect }: ItemProps) {
   return (
     <div
       className="relative rounded-sm border border-subtle hover:border-strong cursor-pointer overflow-hidden"
@@ -112,19 +108,6 @@ function HistoryItem({ entry, onSelect, onRemove }: ItemProps) {
         >
           {entry.badge}
         </span>
-      )}
-      {onRemove && (
-        <button
-          className="absolute top-0 right-0 bg-canvas/80 text-fg-tertiary hover:text-err text-xs leading-none"
-          style={{ padding: '1px 4px', lineHeight: 1 }}
-          onClick={(e) => {
-            e.stopPropagation()
-            onRemove()
-          }}
-          title={t('common.delete')}
-        >
-          ×
-        </button>
       )}
     </div>
   )

--- a/studio/web/src/pages/tools/generate/exportXY.ts
+++ b/studio/web/src/pages/tools/generate/exportXY.ts
@@ -19,7 +19,7 @@ interface ExportSample {
   xy: { xi: number; yi: number }
 }
 
-interface ExportInput {
+export interface ExportInput {
   samples: ExportSample[]
   taskId: number
   xAxis: XYAxisType
@@ -37,7 +37,8 @@ function loadImage(url: string): Promise<HTMLImageElement> {
   })
 }
 
-export async function exportXYMatrix(input: ExportInput): Promise<void> {
+/** 把 XY 矩阵合成成一张 PNG Blob —— exportXYMatrix 下载 + saveTestImages 自动落盘共用。 */
+export async function composeXYMatrix(input: ExportInput): Promise<Blob> {
   const { samples, taskId, xAxis, yAxis, xValues, yValues } = input
   const xLen = xValues.length
   const yLen = Math.max(yValues.length, 1)
@@ -120,19 +121,22 @@ export async function exportXYMatrix(input: ExportInput): Promise<void> {
     }
   }
 
-  // toBlob → 下载
-  return new Promise<void>((resolve, reject) => {
+  return new Promise<Blob>((resolve, reject) => {
     canvas.toBlob((b) => {
       if (!b) { reject(new Error(i18n.t('generate.canvasToBlobNull'))); return }
-      const url = URL.createObjectURL(b)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = `xy_matrix_${taskId}_${Date.now()}.png`
-      document.body.appendChild(a)
-      a.click()
-      document.body.removeChild(a)
-      URL.revokeObjectURL(url)
-      resolve()
+      resolve(b)
     }, 'image/png')
   })
+}
+
+export async function exportXYMatrix(input: ExportInput): Promise<void> {
+  const blob = await composeXYMatrix(input)
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = `xy_matrix_${input.taskId}_${Date.now()}.png`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
 }

--- a/studio/web/src/pages/tools/generate/saveTestImages.ts
+++ b/studio/web/src/pages/tools/generate/saveTestImages.ts
@@ -1,0 +1,40 @@
+/** 测试出图自动落盘（Settings → testing → save_test_images 开启时）。
+ *
+ * 路径：studio_data/test/<YYYY-MM-DD>/{single,xy}/image_N.png
+ * - single：每张 sample 单独上传一份（image_N 逐张递增）
+ * - xy：用 composeXYMatrix 把整张网格合成单图后上传一次
+ * - compare：调用方负责跳过；本模块不处理
+ *
+ * 失败 / 后端 403（开关被关）都静默吞掉 —— 不打扰用户主流程。
+ */
+import { api } from '../../../api/client'
+import { composeXYMatrix, type ExportInput } from './exportXY'
+
+async function postSave(mode: 'single' | 'xy', blob: Blob): Promise<void> {
+  const fd = new FormData()
+  fd.append('mode', mode)
+  fd.append('image', blob, `${mode}.png`)
+  await fetch('/api/generate/save', { method: 'POST', body: fd })
+}
+
+export async function saveSingleSamples(taskId: number, filenames: string[]): Promise<void> {
+  for (const fn of filenames) {
+    try {
+      const res = await fetch(api.generateSampleUrl(taskId, fn))
+      if (!res.ok) continue
+      const blob = await res.blob()
+      await postSave('single', blob)
+    } catch {
+      // 单张失败不阻塞剩下的
+    }
+  }
+}
+
+export async function saveXYMatrix(input: ExportInput): Promise<void> {
+  try {
+    const blob = await composeXYMatrix(input)
+    await postSave('xy', blob)
+  } catch {
+    // 合成 / 上传失败静默
+  }
+}

--- a/studio/web/src/pages/tools/generate/useGenerateHistory.ts
+++ b/studio/web/src/pages/tools/generate/useGenerateHistory.ts
@@ -170,7 +170,6 @@ export async function makeThumbnail(
 export interface UseGenerateHistoryResult {
   entries: HistoryEntry[]
   add: (entry: Omit<HistoryEntry, 'id' | 'createdAt'>) => Promise<void>
-  remove: (id: string) => Promise<void>
   clearByMode: (mode: HistoryMode) => Promise<void>
   /** 检查每条 entry 的第一张图是否还在 server cache 里；
    * 404 / fail 的 entry 删除（"原图已释放，留着只剩 thumbnail 没意义"）。
@@ -201,11 +200,6 @@ export function useGenerateHistory(): UseGenerateHistoryResult {
     setEntries((prev) => [full, ...prev])
   }
 
-  const remove = async (id: string) => {
-    await deleteEntry(id)
-    setEntries((prev) => prev.filter((e) => e.id !== id))
-  }
-
   const clearByMode = async (mode: HistoryMode) => {
     await clearMode(mode)
     setEntries((prev) => prev.filter((e) => e.mode !== mode))
@@ -231,5 +225,5 @@ export function useGenerateHistory(): UseGenerateHistoryResult {
     return stale.length
   }
 
-  return { entries, add, remove, clearByMode, pruneStale }
+  return { entries, add, clearByMode, pruneStale }
 }


### PR DESCRIPTION
## 背景 / 动机

测试页两个独立的 UX 调整，bundle 在同 1 个 PR：

1. **测试图自动落盘**：测试页生成的图目前只在内存 cache（commit 10 起改的）。
   常用 LoRA 调参时用户想保留出图作训练参考集，每次手动 right-click → 下载
   太麻烦，加一个全局开关让它自动落盘。
2. **删除历史栏每图 × 按钮**：右侧历史栏每张缩略图左上角的 × 误触率太高
   ——本意是回看历史结果，误点 × 一不小心就丢。栏顶有"清空"按钮和"清失效"
   按钮，单条删除场景几乎没人用。整个 UI 元素拿掉。

## 改动概要

### 后端
- `studio/infrastructure/secrets.py:442` —— `GenerateConfig` 加 `save_test_images: bool = False`
- `studio/api/routers/generate.py` —— 新 endpoint `POST /api/generate/save`
  - 接 `mode` (form, `single`/`xy`) + `image` (file upload)
  - 落到 `studio_data/test/<YYYY-MM-DD>/<mode>/image_N.png`
  - N = 当前文件夹 `image_<N>.png` 最大编号 + 1（找不到 → 0）
  - 并发兜底：x-flag open，FileExistsError 重扫一次
  - 开关关时 403；`compare` / 其它 mode 400

### 前端
- `studio/web/src/api/client.ts:381` —— `GenerateSecretsConfig` 加 `save_test_images: boolean`
- `studio/web/src/pages/tools/Settings.tsx` —— 测试 tab 新增 `SaveTestImagesSection`
  （Bool toggle，描述说明路径和 compare 例外）
- `studio/web/src/pages/tools/generate/exportXY.ts` —— 拆出 `composeXYMatrix(): Promise<Blob>`，
  `exportXYMatrix` 下载逻辑改成调用它；落盘和下载共用合成路径
- `studio/web/src/pages/tools/generate/saveTestImages.ts` (新) —— `saveSingleSamples` 逐张上传 /
  `saveXYMatrix` 合成网格后上传；失败一律 swallow
- `studio/web/src/pages/tools/Generate.tsx` —— "任务 done" useEffect 里 history.add 之后追加
  落盘调用；先 `api.getSecrets()` 看开关（off 时短路，避免 XY 白白合成）
- `studio/web/src/pages/tools/generate/PreviewHistoryRail.tsx` —— 删除每图 × 按钮 + 配套
  `onRemove` props 链路
- `studio/web/src/pages/tools/generate/useGenerateHistory.ts` —— `remove(id)` 同步删掉
  （× 是它唯一调用方）

### i18n
- `settings.saveTestImages.{title,label,desc}` zh + en

## 测试方式

- 后端 scoped 测试：`pytest -k "secrets or generate or routers"` → 123/123 ✅
- 前端单元测：`npx vitest run` → 328/328 ✅
- 前端 typecheck：`npx tsc --noEmit` 干净
- 前端 lint：`npm run lint` 干净
- `_next_image_index` 手测：空目录返 0；目录有 `image_0/3/10.png` + 杂项时返 11；
  不存在目录返 0
- `python -m studio test` 后端 56 个 pre-existing 失败（`types.UnionType` 需要 Py 3.10+，
  和本 PR 无关——在 clean dev 上同样失败）

## 注意

- `studio_data/test/` 本身没在 `.gitignore` 显式列，但 `studio_data/*` 已被忽略
  （上层 `studio_data` 整目录排除），新建子目录天然不入库 ✅