### PR TITLE
fix(lycoris): 分层 rank LoKr 推理对齐（metadata + per-layer alpha）

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -90,10 +90,14 @@ def _emit_for(req_id: str, kind: str, **extra: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _lora_topology(meta: LoRAMeta) -> tuple[int, float, str, int, bool, bool]:
+def _lora_topology(meta: LoRAMeta) -> tuple:
     # weight_decompose / rs_lora 改了网络结构（前者加 dora_scale 张量、后者改
     # effective alpha 公式），不同设置不能走热换权重路径，必须重新 inject。
-    return (meta.rank, meta.alpha, meta.algo, meta.factor, meta.weight_decompose, meta.rs_lora)
+    # lora_reg_dims 直接改单层 rank → 不同 pattern 配置同 base rank 也不能复用。
+    reg = meta.lora_reg_dims
+    reg_key: Any = tuple(sorted(reg.items())) if reg else None
+    return (meta.rank, meta.alpha, meta.algo, meta.factor,
+            meta.weight_decompose, meta.rs_lora, reg_key)
 
 
 def _load_lora_state_dict(path: str, device: str, dtype: Any) -> dict[str, Any]:

--- a/studio/services/inference/core.py
+++ b/studio/services/inference/core.py
@@ -25,9 +25,9 @@ import json
 import logging
 import shutil
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Sequence
+from typing import Any, Optional, Sequence
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +58,10 @@ class LoRAMeta:
     weight_decompose / rs_lora 必须忠实回放训练侧设置 —— 否则推理网络结构
     与文件不匹配：DoRA 漏 dora_scale 张量（unexpected keys），RS-LoRA 把
     effective alpha 从 α/√rank 错算成 α/rank，强度被砍 √rank 倍。
+
+    lora_reg_dims（正则 → rank）同理：训练时按 pattern 把部分层的 rank 覆盖
+    成自定义值；推理重建网络若用全局 rank 实例化，被覆盖层的 lokr_w2_a/b
+    形状跟 checkpoint 立刻 mismatch。
     """
     rank: int
     alpha: float
@@ -65,6 +69,7 @@ class LoRAMeta:
     factor: int
     weight_decompose: bool = False
     rs_lora: bool = False
+    lora_reg_dims: Optional[dict[str, int]] = None
 
 
 def read_lora_meta(path: str) -> LoRAMeta:
@@ -119,6 +124,20 @@ def read_lora_meta(path: str) -> LoRAMeta:
     weight_decompose = bool(ss_args.get("weight_decompose", False))
     rs_lora = bool(ss_args.get("rs_lora", False))
 
+    # lora_reg_dims：训练时按正则覆盖部分层 rank；推理必须按同样 pattern 重建，
+    # 否则被覆盖层 shape 与 checkpoint 不匹配。校验是 dict[str, int]，其他形态丢弃。
+    lora_reg_dims: Optional[dict[str, int]] = None
+    raw_reg = ss_args.get("lora_reg_dims")
+    if isinstance(raw_reg, dict) and raw_reg:
+        parsed: dict[str, int] = {}
+        for k, v in raw_reg.items():
+            try:
+                parsed[str(k)] = int(v)
+            except (ValueError, TypeError):
+                logger.warning(f"lora_reg_dims 条目跳过（rank 非整数）: {k!r}={v!r}")
+        if parsed:
+            lora_reg_dims = parsed
+
     return LoRAMeta(
         rank=rank,
         alpha=alpha,
@@ -126,6 +145,7 @@ def read_lora_meta(path: str) -> LoRAMeta:
         factor=factor,
         weight_decompose=weight_decompose,
         rs_lora=rs_lora,
+        lora_reg_dims=lora_reg_dims,
     )
 
 
@@ -164,6 +184,7 @@ def apply_loras(
             factor=meta.factor,
             weight_decompose=meta.weight_decompose,
             rs_lora=meta.rs_lora,
+            lora_reg_dims=meta.lora_reg_dims,
         )
         adapter.inject(model)
 

--- a/tests/test_lycoris_save_alpha.py
+++ b/tests/test_lycoris_save_alpha.py
@@ -1,0 +1,98 @@
+"""save() 时 per-layer .alpha 重写覆盖测试。
+
+回归保护：lycoris LokrModule init 写入 .alpha=scale×lora_dim；_apply_reg_dims_
+改 lora_dim 后没动 self.scale / self.alpha buffer → 分层 rank 层的 .alpha 与
+per-layer rank 失配 → ComfyUI 按 alpha/rank 算 scale 偏离训练几十倍 → 噪点。
+save() 调 _rewrite_per_layer_alpha_ 在落盘前按当前真实 (scale, lora_dim) 重算。
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from utils.lycoris_adapter import _rewrite_per_layer_alpha_
+
+
+class _FakeLora:
+    def __init__(self, name: str, scale: float, dim: int) -> None:
+        self.lora_name = name
+        self.scale = scale
+        self.lora_dim = dim
+
+
+class _FakeNet:
+    def __init__(self, loras: list) -> None:
+        self.loras = loras
+
+
+def test_rewrite_alpha_uses_scale_times_dim() -> None:
+    """每层 .alpha = scale × lora_dim，让下游 alpha/rank 还原训练 scale。"""
+    net = _FakeNet([
+        _FakeLora("layer_a", scale=5.6569, dim=1),    # 分层 rank=1：5.6569
+        _FakeLora("layer_b", scale=5.6569, dim=8),    # 分层 rank=8：45.255
+        _FakeLora("layer_c", scale=5.6569, dim=32),   # base rank：181.0
+        _FakeLora("layer_d", scale=5.6569, dim=64),   # 分层 rank=64：362.0
+    ])
+    sd = {
+        "layer_a.alpha": torch.tensor(181.0, dtype=torch.float32),  # lycoris 写入的旧值
+        "layer_b.alpha": torch.tensor(181.0, dtype=torch.float32),
+        "layer_c.alpha": torch.tensor(181.0, dtype=torch.float32),
+        "layer_d.alpha": torch.tensor(181.0, dtype=torch.float32),
+        "layer_a.lokr_w2_a": torch.zeros(2, 1),  # 非 alpha 张量不动
+    }
+    _rewrite_per_layer_alpha_(net, sd)
+    assert sd["layer_a.alpha"].item() == pytest.approx(5.6569, abs=1e-4)
+    assert sd["layer_b.alpha"].item() == pytest.approx(45.2552, abs=1e-4)
+    assert sd["layer_c.alpha"].item() == pytest.approx(181.0208, abs=1e-3)
+    assert sd["layer_d.alpha"].item() == pytest.approx(362.0416, abs=1e-3)
+    assert sd["layer_a.lokr_w2_a"].shape == (2, 1)
+
+
+def test_rewrite_alpha_noop_when_dim_equals_base() -> None:
+    """未触发分层 rank 时 scale × dim 必等于 lycoris 原写入值 → no-op."""
+    # lycoris init: alpha_buf = user_alpha × (dim / r_factor)；scale = user_alpha / r_factor
+    # → alpha_buf == scale × dim 恒等
+    net = _FakeNet([_FakeLora("x", scale=1.0, dim=32)])
+    sd = {"x.alpha": torch.tensor(32.0)}
+    _rewrite_per_layer_alpha_(net, sd)
+    assert sd["x.alpha"].item() == pytest.approx(32.0)
+
+
+def test_rewrite_alpha_handles_none_network() -> None:
+    """network 未 inject 时 noop，不爆。"""
+    sd = {"x.alpha": torch.tensor(99.0)}
+    _rewrite_per_layer_alpha_(None, sd)
+    assert sd["x.alpha"].item() == 99.0
+
+
+def test_rewrite_alpha_skips_layer_without_alpha_key() -> None:
+    """sd 没该层 .alpha 张量时跳过。"""
+    net = _FakeNet([_FakeLora("missing", scale=1.0, dim=4)])
+    sd = {"other.alpha": torch.tensor(7.0)}
+    _rewrite_per_layer_alpha_(net, sd)
+    assert sd["other.alpha"].item() == 7.0
+    assert "missing.alpha" not in sd
+
+
+def test_rewrite_alpha_preserves_dtype() -> None:
+    """新 alpha 张量保留原 dtype（bf16/fp16 训练管线常见）。"""
+    net = _FakeNet([_FakeLora("x", scale=5.6569, dim=1)])
+    sd = {"x.alpha": torch.tensor(181.0, dtype=torch.bfloat16)}
+    _rewrite_per_layer_alpha_(net, sd)
+    assert sd["x.alpha"].dtype == torch.bfloat16
+
+
+def test_rewrite_alpha_skips_lora_missing_attrs() -> None:
+    """LoRA 对象缺 scale/lora_dim/lora_name 时跳过，不破坏 sd。"""
+    class _NoName:
+        scale = 1.0
+        lora_dim = 4
+
+    class _NoScale:
+        lora_name = "x"
+        lora_dim = 4
+
+    net = _FakeNet([_NoName(), _NoScale()])
+    sd = {"x.alpha": torch.tensor(7.0)}
+    _rewrite_per_layer_alpha_(net, sd)
+    assert sd["x.alpha"].item() == 7.0

--- a/utils/lycoris_adapter.py
+++ b/utils/lycoris_adapter.py
@@ -257,20 +257,32 @@ class AnimaLycorisAdapter:
     def save(self, path: str | Path) -> None:
         """保存为 safetensors（带 ss_* metadata，ComfyUI/sd-scripts 兼容）"""
         sd = self.state_dict()
+        # 每层 .alpha 按当前 (scale, lora_dim) 重算，让下游标准公式 alpha/rank 还原
+        # 训练 scale。lycoris init 写入的 .alpha 已经是 scale*lora_dim；但
+        # _apply_reg_dims_ 改 lora_dim 后没动 self.scale / self.alpha buffer，
+        # 分层 rank 的层 .alpha 与 per-layer rank 失配 → ComfyUI 按 alpha/rank
+        # 算出的 scale 偏离训练实际值几十倍，导致出图噪点。
+        # 这里按 lora 当前真实 (scale, lora_dim) 重写：未分层层 no-op；分层层修正。
+        _rewrite_per_layer_alpha_(self.network, sd)
+        # lora_reg_dims 必须写入：训练时按 pattern 改了部分层的 rank，推理重建
+        # 网络要用同一份字典才能让 lokr_w2_a/b 形状对齐 checkpoint。
+        ss_args: dict[str, Any] = {
+            "algo": self.algo,
+            "factor": self.factor,
+            "preset": "anima_full",
+            "dropout": self.dropout,
+            "rank_dropout": self.rank_dropout,
+            "module_dropout": self.module_dropout,
+            "weight_decompose": self.weight_decompose,
+            "rs_lora": self.rs_lora,
+        }
+        if self.lora_reg_dims:
+            ss_args["lora_reg_dims"] = self.lora_reg_dims
         meta = {
             "ss_network_dim": str(self.rank),
             "ss_network_alpha": str(self.alpha),
             "ss_network_module": "lycoris.kohya",
-            "ss_network_args": json.dumps({
-                "algo": self.algo,
-                "factor": self.factor,
-                "preset": "anima_full",
-                "dropout": self.dropout,
-                "rank_dropout": self.rank_dropout,
-                "module_dropout": self.module_dropout,
-                "weight_decompose": self.weight_decompose,
-                "rs_lora": self.rs_lora,
-            }),
+            "ss_network_args": json.dumps(ss_args),
         }
         save_file(sd, str(path), metadata=meta)
         logger.info(f"LoRA 保存到: {path}")
@@ -315,6 +327,32 @@ class AnimaLycorisAdapter:
         部 caller（如 phase log 决策）调。
         """
         return self.use_lokr and "lokr_w1" in param_name
+
+
+def _rewrite_per_layer_alpha_(network: Optional[nn.Module], sd: dict[str, torch.Tensor]) -> None:
+    """对 sd 里每层 .alpha tensor 重算为 lora.scale × lora.lora_dim。
+
+    保持下游标准 LoRA 公式 alpha/rank 还原训练 scale。对未触发 lora_reg_dims
+    的层是 no-op（lycoris init 写入的 .alpha 本来就 = scale × lora_dim）；对
+    分层 rank 的层是修正。
+    """
+    if network is None:
+        return
+    loras = getattr(network, "loras", None) or []
+    for lora in loras:
+        name = getattr(lora, "lora_name", None)
+        if not name:
+            continue
+        alpha_key = f"{name}.alpha"
+        if alpha_key not in sd:
+            continue
+        try:
+            scale = float(getattr(lora, "scale"))
+            dim = int(getattr(lora, "lora_dim"))
+        except (AttributeError, TypeError, ValueError):
+            continue
+        old = sd[alpha_key]
+        sd[alpha_key] = torch.tensor(scale * dim, dtype=old.dtype, device=old.device)
 
 
 def _apply_reg_dims_(network: nn.Module, lora_reg_dims: dict[str, int]) -> None:


### PR DESCRIPTION
## 背景

用户用 `lora_reg_dims` 训出来的 LoKr（不同 block 不同 rank，例如 v3.5 配置 block_0=1, block_15=32, block_20=64）出现两个症状：

1. **Studio 测试页 / CLI resume 直接报 size mismatch**
   ```
   size mismatch for lora_unet_blocks_0_self_attn_q_proj.lokr_w2_a:
     copying [512, 1] vs current model [512, 32]
   ```
2. **ComfyUI 加载能跑但出图全是噪点**（rank=1 的层在下游被放大 32 倍）

## 根因

### 症状 1：metadata 漏字段

`AnimaLycorisAdapter.save()` 写 `ss_network_args` 时漏了 `lora_reg_dims` —— 任何路径从 metadata 重建 `LycorisNetwork` 都用全局 `ss_network_dim=32` 实例化所有层，与 checkpoint 里被 `_apply_reg_dims_` 改成 rank=1/8/48/64 的层 shape 立刻 mismatch。

### 症状 2：`.alpha` 张量与 per-layer rank 失配

`utils/lycoris_adapter.py:_apply_reg_dims_` 改 `lora_mod.lora_dim` 后**没动 `self.scale` 也没动 `self.alpha` buffer**。

lycoris-lora 在 init 时按 `(base_alpha, base_rank, rs_lora)` 算：
- `self.scale = base_alpha / r_factor`（训练 forward 用）
- `self.alpha buffer = base_alpha × (base_rank / r_factor)` ≈ 5.66 × 32 = 181（v3.5）

训练时所有层共享这个 init scale。但 ComfyUI 读 `.alpha=181 / per_layer_rank` 算每层 scale：

| 层 | per-layer rank | ComfyUI 算 scale | 训练实际 scale | 偏差 |
|---|---|---|---|---|
| block_0 | 1 | 181/1 = **181** | 5.66 | **32× 过曝** |
| block_15 | 32 | 181/32 = 5.66 | 5.66 | ✓ |
| block_20 | 64 | 181/64 = 2.83 | 5.66 | 0.5× 偏弱 |

低 rank 层 ΔW 被放大几十倍 → 噪点。

## 改动

| 文件 | 改动 |
|---|---|
| `utils/lycoris_adapter.py` | `save()` 写入 `lora_reg_dims`；新增 `_rewrite_per_layer_alpha_()`，落盘前按当前真实 `(scale, lora_dim)` 重算每层 `.alpha = scale × lora_dim`，让下游 `alpha/rank` 公式还原训练 scale。未分层层数学上 no-op |
| `studio/services/inference/core.py` | `LoRAMeta` 加 `lora_reg_dims` 字段；`read_lora_meta` 解析；`apply_loras` 透传给 `AnimaLycorisAdapter` |
| `runtime/anima_daemon.py` | `_lora_topology` cache key 把 `lora_reg_dims` 算进去 — 不同 pattern 配置不能复用热换权重路径，必须重 inject |
| `tests/test_lycoris_save_alpha.py` | 6 个新单测覆盖 `_rewrite_per_layer_alpha_` |

## 测试

- 新增 6 单测：`pytest tests/test_lycoris_save_alpha.py` → 6/6 pass
- 现有 `tests/test_inference_core.py` 16 个测试不退化：16/16 pass（含原 `read_lora_meta` + `apply_loras` round-trip）
- 真实 v3.5 文件人工验证：补完两份 metadata 后，每层 `.alpha / per_layer_rank ≈ 5.66`（训练 base scale）；Studio 测试页能出图，ComfyUI 能出图

## Out of scope

已训出的 LoRA 仍有缺字段的 metadata + 失配的 `.alpha`，但这是用户私有数据，不在本 PR 修复范围。本次只保证未来训出的 checkpoint 自动对齐。