### PR TITLE
feat(generate): 测试页参数恢复 — 历史点击回填 + 落盘 PNG metadata/sidecar

### DIFF
--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -17,14 +17,16 @@ task 结束 supervisor 仍调 cleanup_generate_tempdir 清掉空目录。server 
 """
 from __future__ import annotations
 
+import io
 import json
 import re
+import time
 from datetime import date
 from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, File, Form, HTTPException, UploadFile
-from fastapi.responses import Response
+from fastapi.responses import FileResponse, Response
 
 from ..deps import _resolve_anima_model_paths
 from ..errors import _validate_component_or_400
@@ -243,10 +245,34 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
     )
 
 
+SIDECAR_SCHEMA_VERSION = 1
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_DISK_MODES = ("single", "xy")
+
+
+def _inject_png_params(raw: bytes, params: dict[str, Any]) -> bytes:
+    """把 params 作为 tEXt `anima_params` 注入 PNG。失败返回原 bytes。
+
+    单一 tEXt 块即可——用户拷走单文件，参数随图走。a1111 兼容文本块按需后加。
+    """
+    try:
+        from PIL import Image, PngImagePlugin
+        img = Image.open(io.BytesIO(raw))
+        info = PngImagePlugin.PngInfo()
+        info.add_text("anima_params", json.dumps(params, ensure_ascii=False))
+        out = io.BytesIO()
+        img.save(out, format="PNG", pnginfo=info)
+        return out.getvalue()
+    except Exception:
+        return raw
+
+
 @router.post("/api/generate/save")
 async def save_test_image(
     mode: str = Form(...),
     image: UploadFile = File(...),
+    params: str = Form(""),
 ) -> dict[str, Any]:
     """落盘测试出图到 studio_data/test/<YYYY-MM-DD>/<mode>/image_N.png。
 
@@ -254,6 +280,8 @@ async def save_test_image(
     - Settings 开关 generate.save_test_images=False → 403
     - N = 当前 <date>/<mode>/ 下已有 image_*.png 最大编号+1（找不到则 0）
     - 并发兜底：x-flag 写入，FileExistsError 则重扫一次
+    - params 非空 → 注入 PNG `anima_params` tEXt + 同目录写 image_N.json sidecar
+      （sidecar 是 disk-history 扫描入口；PNG metadata 给"拷走 PNG 还能恢复"用）
     """
     if mode not in ("single", "xy"):
         raise HTTPException(400, f"unsupported mode: {mode}")
@@ -262,6 +290,18 @@ async def save_test_image(
     raw = await image.read()
     if not raw:
         raise HTTPException(400, "empty image body")
+
+    params_obj: dict[str, Any] | None = None
+    if params:
+        try:
+            decoded = json.loads(params)
+        except json.JSONDecodeError as e:
+            raise HTTPException(400, f"params: invalid JSON ({e})")
+        if not isinstance(decoded, dict):
+            raise HTTPException(400, "params: must be a JSON object")
+        params_obj = decoded
+        raw = _inject_png_params(raw, params_obj)
+
     target_dir = TEST_IMAGES_DIR / date.today().isoformat() / mode
     target_dir.mkdir(parents=True, exist_ok=True)
     for _ in range(20):
@@ -270,7 +310,108 @@ async def save_test_image(
         try:
             with open(target, "xb") as f:
                 f.write(raw)
-            return {"path": str(target), "index": idx}
         except FileExistsError:
             continue
+        sidecar_path: str | None = None
+        if params_obj is not None:
+            sidecar = target_dir / f"image_{idx}.json"
+            sidecar.write_text(
+                json.dumps({
+                    "schema_version": SIDECAR_SCHEMA_VERSION,
+                    "mode": mode,
+                    "created_at": time.time(),
+                    "filename": f"image_{idx}.png",
+                    "params": params_obj,
+                }, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            sidecar_path = str(sidecar)
+        return {"path": str(target), "index": idx, "sidecar": sidecar_path}
     raise HTTPException(500, "could not allocate filename")
+
+
+# ---------------------------------------------------------------------------
+# 磁盘历史浏览：扫 sidecar JSON 列 entries，按图片 URL 单独服务
+# ---------------------------------------------------------------------------
+
+
+def _disk_history_id(date_str: str, mode: str, stem: str) -> str:
+    """前端 dedup / merge 用的稳定 id。同图不论几次扫描都映射同一 id。"""
+    return f"disk:{date_str}:{mode}:{stem}"
+
+
+def _scan_sidecars(limit: int) -> list[dict[str, Any]]:
+    """扫 TEST_IMAGES_DIR 下所有 <date>/{single,xy}/image_*.json。
+
+    没有 sidecar 的图不入列表（参数缺失，回填无意义；用户仍可去文件夹手动看）。
+    """
+    if not TEST_IMAGES_DIR.is_dir():
+        return []
+    out: list[dict[str, Any]] = []
+    for date_dir in TEST_IMAGES_DIR.iterdir():
+        if not date_dir.is_dir() or not _DATE_RE.match(date_dir.name):
+            continue
+        for mode in _DISK_MODES:
+            mode_dir = date_dir / mode
+            if not mode_dir.is_dir():
+                continue
+            for sc in mode_dir.glob("image_*.json"):
+                stem = sc.stem  # image_5
+                img = mode_dir / f"{stem}.png"
+                if not img.is_file():
+                    continue  # sidecar 留着但图没了 → 跳过
+                try:
+                    data = json.loads(sc.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    continue
+                params = data.get("params")
+                if not isinstance(params, dict):
+                    continue
+                created_at = data.get("created_at")
+                if not isinstance(created_at, (int, float)):
+                    # 容错：旧 sidecar 缺时间 → fallback 文件 mtime
+                    try:
+                        created_at = img.stat().st_mtime
+                    except OSError:
+                        continue
+                out.append({
+                    "id": _disk_history_id(date_dir.name, mode, stem),
+                    "date": date_dir.name,
+                    "mode": mode,
+                    "filename": f"{stem}.png",
+                    "path": str(img),
+                    "url": f"/api/generate/disk/image/{date_dir.name}/{mode}/{stem}.png",
+                    "created_at": float(created_at),
+                    "schema_version": data.get("schema_version", 1),
+                    "params": params,
+                })
+    out.sort(key=lambda e: e["created_at"], reverse=True)
+    return out[:limit]
+
+
+@router.get("/api/generate/disk/history")
+def list_disk_history(limit: int = 500) -> dict[str, Any]:
+    """列出所有落盘测试图（按 sidecar JSON 扫），按 created_at desc 排。
+
+    前端历史栏拉一次 merge 到 IndexedDB 视图；entry.id 稳定，前端按 id dedup。
+    没有 sidecar 的图（老数据 / 客户端没传 params）不入列表。
+    """
+    limit = max(1, min(int(limit), 2000))
+    return {"entries": _scan_sidecars(limit)}
+
+
+@router.get("/api/generate/disk/image/{date_str}/{mode}/{filename}")
+def get_disk_image(date_str: str, mode: str, filename: str) -> Any:
+    """读落盘测试图（前端历史栏点击磁盘 entry 时大图来源）。"""
+    if not _DATE_RE.match(date_str):
+        raise HTTPException(400, "invalid date")
+    if mode not in _DISK_MODES:
+        raise HTTPException(400, "invalid mode")
+    _validate_component_or_400(filename)
+    if not filename.lower().endswith(".png"):
+        raise HTTPException(400, "only .png supported")
+    path = TEST_IMAGES_DIR / date_str / mode / filename
+    if not path.is_file():
+        raise HTTPException(404)
+    # 落盘图内容稳定（不会被同名覆盖——image_N 编号递增），可缓存
+    return FileResponse(path, media_type="image/png")

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1161,6 +1161,27 @@ export interface GenerateRequest {
   xy_matrix?: XYMatrixSpec | null
 }
 
+/** 落盘测试图历史 entry（GET /api/generate/disk-history）。
+ *  params 是 GenerateParamsSnapshot（前端用 paramsSnapshot.ts 的类型解读），
+ *  这里用 unknown 让 api/client.ts 不依赖 pages 层类型。 */
+export interface DiskGenerateHistoryEntry {
+  /** 稳定 ID："disk:<date>:<mode>:image_<N>"；前端按此 dedup */
+  id: string
+  /** YYYY-MM-DD */
+  date: string
+  mode: 'single' | 'xy'
+  filename: string
+  /** 服务端绝对路径，用于和 IDB entry.diskPath 做 dedup */
+  path: string
+  /** /api/generate/disk-image/<date>/<mode>/<filename> */
+  url: string
+  /** Unix timestamp（sidecar 写入或 fallback 文件 mtime） */
+  created_at: number
+  schema_version: number
+  /** sidecar 里的 params object（前端按 GenerateParamsSnapshot 解读） */
+  params: Record<string, unknown>
+}
+
 /** version output/ 下扫到的 training_state_step*.pt（断点续训用）。 */
 export interface StateCkpt {
   /** global_step 数 */
@@ -2115,6 +2136,11 @@ export const api = {
   /** PR-9 — 启动测试出图 task。Phase 2 起：图走 server 内存 cache，关页面即丢。 */
   enqueueGenerate: (body: GenerateRequest) =>
     req<Task>('/api/generate', { method: 'POST', body: JSON.stringify(body) }),
+  /** 落盘历史：扫 studio_data/test/&lt;date&gt;/{single,xy}/image_N.json sidecar，
+   *  按 created_at desc 返回；用于历史栏跨会话回看已落盘的测试图。
+   *  注意路径用 disk/ 子前缀避开 `/api/generate/{task_id}` 的单段 catch-all。 */
+  listDiskGenerateHistory: (limit = 500) =>
+    req<{ entries: DiskGenerateHistoryEntry[] }>(`/api/generate/disk/history?limit=${limit}`),
   /** 查询测试 task 状态。 */
   getGenerateTask: (id: number) => req<Task>(`/api/generate/${id}`),
   /** 测试出图单张 URL（task 跑中或刚完成时拉；客户端断连 30s + LRU 后 404）。 */

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -20,8 +20,9 @@ import NumField from './generate/NumField'
 import PreviewCompare from './generate/PreviewCompare'
 import PreviewHistoryRail from './generate/PreviewHistoryRail'
 import PromptFromDatasetPicker, { type DatasetPick } from './generate/PromptFromDatasetPicker'
+import { PARAMS_SNAPSHOT_VERSION, type GenerateParamsSnapshot } from './generate/paramsSnapshot'
 import { saveSingleSamples, saveXYMatrix } from './generate/saveTestImages'
-import { makeThumbnail, useGenerateHistory, type HistoryEntry } from './generate/useGenerateHistory'
+import { historyImageUrl, makeThumbnail, useGenerateHistory, type HistoryEntry } from './generate/useGenerateHistory'
 import PreviewXYGrid from './generate/PreviewXYGrid'
 import PromptList from './generate/PromptList'
 import NegPromptInput from './generate/NegPromptInput'
@@ -356,7 +357,22 @@ export default function GeneratePage() {
         xValues, yValues, samples: xySamples,
       }
     }
-    void makeThumbnail(api.generateSampleUrl(taskId, filename), 256)
+    // 参数快照（IDB entry.params + 落盘 sidecar 共用）。回填时按 mode 路由
+    // 灌 singleLoras / xyLoras + xDraft/yDraft；compare 视图记录为 'compare'
+    // 但回填时映射到 xy。
+    const params: GenerateParamsSnapshot = {
+      schema_version: PARAMS_SNAPSHOT_VERSION,
+      mode,
+      prompts,
+      negative_prompt: negPrompt,
+      width, height, steps,
+      cfg_scale: cfgScale,
+      count, seed,
+      lora_configs: loras,
+      xy_draft: mode === 'xy' ? { x: xDraft, y: yDraft } : null,
+      dataset_pick: datasetPick,
+    }
+    const entryPromise = makeThumbnail(api.generateSampleUrl(taskId, filename), 256)
       .then((dataUrl) => history.add({
         mode,
         taskId,
@@ -364,32 +380,71 @@ export default function GeneratePage() {
         filenames,
         badge: badge || undefined,
         xy: xyMeta,
+        params,
       }))
-      .catch(() => { /* thumbnail 失败 — 不入库（避免无封面 entry） */ })
+      .catch(() => null /* thumbnail 失败 — 不入库（avoid 无封面 entry），落盘仍跑 */)
     // 自动落盘（Settings.generate.save_test_images=on 时）。compare 不落盘；
-    // 关闭时跳过避免 XY 模式白白合成网格图。
+    // 关闭时跳过避免 XY 模式白白合成网格图。落盘成功 → patch entry.diskPath
+    // 用于和 disk-history 接口的 entries 做 dedup（IDB 优先，磁盘兜底）。
     if (mode === 'single' || mode === 'xy') {
-      void api.getSecrets().then((sec) => {
-        if (!sec.generate?.save_test_images) return
+      void (async () => {
+        const sec = await api.getSecrets().catch(() => null)
+        if (!sec?.generate?.save_test_images) return
+        let diskPath: string | null = null
         if (mode === 'single') {
-          return saveSingleSamples(taskId, filenames)
-        }
-        if (xyMeta) {
-          return saveXYMatrix({
+          const paths = await saveSingleSamples(taskId, filenames, params)
+          // 用第一张图的 path 作为 entry.diskPath（去重 key）；后续若用户跨
+          // session 看 disk-history，能正确合并到对应 IDB entry。
+          diskPath = paths.find(Boolean) ?? null
+        } else if (xyMeta) {
+          diskPath = await saveXYMatrix({
             samples: xyMeta.samples.map((s) => ({ path: s.path, xy: { xi: s.xy.xi, yi: s.xy.yi } })),
             taskId,
             xAxis: xyMeta.xAxis as Parameters<typeof saveXYMatrix>[0]['xAxis'],
             yAxis: xyMeta.yAxis as Parameters<typeof saveXYMatrix>[0]['yAxis'],
             xValues: xyMeta.xValues,
             yValues: xyMeta.yValues,
-          })
+          }, params)
         }
-      }).catch(() => { /* silent */ })
+        if (!diskPath) return
+        const entryId = await entryPromise
+        if (entryId) await history.patch(entryId, { diskPath })
+      })()
     }
-  }, [currentTask, samples, mode, selectedIndices, history, xDraft, yDraft])
+  }, [currentTask, samples, mode, selectedIndices, history, xDraft, yDraft,
+      prompts, negPrompt, width, height, steps, cfgScale, count, seed, loras, datasetPick])
 
   const handleHistorySelect = (entry: HistoryEntry) => {
     setHistoryOverride(entry)
+    const params = entry.params
+    if (!params) return  // 老 entry / 早于本次改动 → 仅切图，不回填
+    // compare 视图回填到 xy 模式（compare 是 xy 子视图，没 selectedIndices 不直接进）
+    const newMode: ViewMode = params.mode === 'single' ? 'single' : 'xy'
+    setPrefs((prev) => {
+      const base: GeneratePrefs = {
+        ...prev,
+        mode: newMode,
+        prompts: params.prompts.length > 0 ? params.prompts : prev.prompts,
+        negPrompt: params.negative_prompt,
+        width: params.width,
+        height: params.height,
+        aspect: aspectFromDimensions(params.width, params.height),
+        steps: params.steps,
+        cfgScale: params.cfg_scale,
+        count: params.count,
+        seed: params.seed,
+        datasetPick: params.dataset_pick ?? null,
+      }
+      if (params.mode === 'single') {
+        return { ...base, singleLoras: params.lora_configs }
+      }
+      return {
+        ...base,
+        xyLoras: params.lora_configs,
+        xDraft: params.xy_draft?.x ?? prev.xDraft,
+        yDraft: params.xy_draft?.y ?? null,
+      }
+    })
   }
 
   const handleGenerate = async () => {
@@ -724,8 +779,8 @@ export default function GeneratePage() {
                           gap: 2,
                         }}
                       >
-                        {historyOverride.filenames.map((fn) => {
-                          const url = api.generateSampleUrl(historyOverride.taskId, fn)
+                        {historyOverride.filenames.map((fn, idx) => {
+                          const url = historyImageUrl(historyOverride, idx)
                           return (
                             <a
                               key={fn} href={url} target="_blank" rel="noreferrer"
@@ -750,13 +805,13 @@ export default function GeneratePage() {
                     /* 单图回看（single / compare 历史 / 单张 xy） */
                     <a
                       className="flex-1 min-h-0 flex items-center justify-center w-full"
-                      href={api.generateSampleUrl(historyOverride.taskId, historyOverride.filenames[0] ?? '')}
+                      href={historyImageUrl(historyOverride, 0)}
                       target="_blank"
                       rel="noreferrer"
                     >
                       <img
                         key={historyOverride.id}
-                        src={api.generateSampleUrl(historyOverride.taskId, historyOverride.filenames[0] ?? '')}
+                        src={historyImageUrl(historyOverride, 0)}
                         onError={(e) => {
                           (e.currentTarget as HTMLImageElement).src = historyOverride.thumbnailDataUrl
                           ;(e.currentTarget as HTMLImageElement).title = t('generate.originalReleasedThumbOnly')

--- a/studio/web/src/pages/tools/generate/paramsSnapshot.ts
+++ b/studio/web/src/pages/tools/generate/paramsSnapshot.ts
@@ -1,0 +1,37 @@
+/** 测试出图参数快照：落盘 sidecar + IndexedDB HistoryEntry.params 共用。
+ *
+ * 用途：
+ * - 落盘 image_N.json sidecar 时存 → 历史栏点击磁盘 entry 时取出回填 prefs
+ * - IndexedDB HistoryEntry.params 同 shape → 未落盘的 entry 也能回填
+ *
+ * 设计为 prefs 视图（含 xy_draft.raw / dataset_pick），不是 daemon 接口视图：
+ * 回填时直接灌回 prefs 各字段，UI 完整重建（dataset picker / xy 文本框等）。
+ */
+import type { LoraEntry } from '../../../api/client'
+import type { DatasetPick } from './PromptFromDatasetPicker'
+import type { XYAxisDraft } from './xy'
+
+export const PARAMS_SNAPSHOT_VERSION = 1
+
+export interface GenerateParamsSnapshot {
+  schema_version: number
+  /** 当时的 mode；回填时按 mode 决定灌 singleLoras 还是 xyLoras + xDraft/yDraft */
+  mode: 'single' | 'xy' | 'compare'
+  /** prefs.prompts 原文（未与 datasetPick.tags 合并） */
+  prompts: string[]
+  negative_prompt: string
+  width: number
+  height: number
+  steps: number
+  cfg_scale: number
+  /** xy 模式下 daemon 端强制 1，仅 single 有意义 */
+  count: number
+  seed: number
+  /** 当时 mode 对应的 LoRA 列表（single→singleLoras，xy→xyLoras） */
+  lora_configs: LoraEntry[]
+  /** 仅 xy 模式：prefs 视图（含 raw 字符串），回填时直接灌回 xDraft/yDraft；
+   *  重 submit 时前端从这里重 buildXYMatrix（不冗余存 daemon xy_matrix） */
+  xy_draft?: { x: XYAxisDraft; y: XYAxisDraft | null } | null
+  /** 训练集 caption picker 选择（保留 picker UI 上下文） */
+  dataset_pick?: DatasetPick | null
+}

--- a/studio/web/src/pages/tools/generate/saveTestImages.ts
+++ b/studio/web/src/pages/tools/generate/saveTestImages.ts
@@ -5,36 +5,67 @@
  * - xy：用 composeXYMatrix 把整张网格合成单图后上传一次
  * - compare：调用方负责跳过；本模块不处理
  *
+ * 上传时附 params JSON（GenerateParamsSnapshot）：后端写进 PNG `anima_params`
+ * tEXt + 同目录 image_N.json sidecar，供历史栏回看 / 用户拷走 PNG 复用参数。
+ *
  * 失败 / 后端 403（开关被关）都静默吞掉 —— 不打扰用户主流程。
  */
 import { api } from '../../../api/client'
 import { composeXYMatrix, type ExportInput } from './exportXY'
+import type { GenerateParamsSnapshot } from './paramsSnapshot'
 
-async function postSave(mode: 'single' | 'xy', blob: Blob): Promise<void> {
+interface SaveResult {
+  /** 落盘路径（用于回写 IndexedDB entry.diskPath，做 disk-history 去重） */
+  path: string
+  index: number
+}
+
+async function postSave(
+  mode: 'single' | 'xy',
+  blob: Blob,
+  params: GenerateParamsSnapshot,
+): Promise<SaveResult | null> {
   const fd = new FormData()
   fd.append('mode', mode)
   fd.append('image', blob, `${mode}.png`)
-  await fetch('/api/generate/save', { method: 'POST', body: fd })
+  fd.append('params', JSON.stringify(params))
+  const r = await fetch('/api/generate/save', { method: 'POST', body: fd })
+  if (!r.ok) return null
+  return (await r.json()) as SaveResult
 }
 
-export async function saveSingleSamples(taskId: number, filenames: string[]): Promise<void> {
+/** 落盘 single 模式所有 sample。返回每张图的 server path（与 filenames 同序，
+ *  失败的位置为 null）。调用者用第 0 张的 path 作为 entry.diskPath（去重 key）。 */
+export async function saveSingleSamples(
+  taskId: number,
+  filenames: string[],
+  params: GenerateParamsSnapshot,
+): Promise<Array<string | null>> {
+  const paths: Array<string | null> = []
   for (const fn of filenames) {
     try {
       const res = await fetch(api.generateSampleUrl(taskId, fn))
-      if (!res.ok) continue
+      if (!res.ok) { paths.push(null); continue }
       const blob = await res.blob()
-      await postSave('single', blob)
+      const r = await postSave('single', blob, params)
+      paths.push(r?.path ?? null)
     } catch {
-      // 单张失败不阻塞剩下的
+      paths.push(null)
     }
   }
+  return paths
 }
 
-export async function saveXYMatrix(input: ExportInput): Promise<void> {
+/** 落盘 xy 合成大图。返回落盘 path（失败为 null）。 */
+export async function saveXYMatrix(
+  input: ExportInput,
+  params: GenerateParamsSnapshot,
+): Promise<string | null> {
   try {
     const blob = await composeXYMatrix(input)
-    await postSave('xy', blob)
+    const r = await postSave('xy', blob, params)
+    return r?.path ?? null
   } catch {
-    // 合成 / 上传失败静默
+    return null
   }
 }

--- a/studio/web/src/pages/tools/generate/useGenerateHistory.ts
+++ b/studio/web/src/pages/tools/generate/useGenerateHistory.ts
@@ -12,8 +12,9 @@
  * tab 关后留下也无伤大雅 —— 用户重开 tab 还能看到历史，符合"看图/对比"
  * 主流程。整体内存 / 磁盘可控（每条 thumb ~20KB，1000 条也才 20MB）。
  */
-import { useEffect, useRef, useState } from 'react'
-import { api } from '../../../api/client'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { api, type DiskGenerateHistoryEntry } from '../../../api/client'
+import type { GenerateParamsSnapshot } from './paramsSnapshot'
 
 const DB_NAME = 'anima-generate-history'
 const DB_VERSION = 1
@@ -47,6 +48,24 @@ export interface HistoryEntry {
   badge?: string
   /** XY 模式才填：回看时重建 PreviewXYGrid 用 */
   xy?: HistoryXYMeta
+  /** 测试参数快照（用于历史点击回填 prefs）。老 entry 缺此字段 → 回填 noop。 */
+  params?: GenerateParamsSnapshot
+  /** 落盘成功后回写：第一张图（single）/ 合成图（xy）的 server path；用于和
+   *  GET /api/generate/disk-history 拉到的 disk entries 做 dedup。 */
+  diskPath?: string
+  /** 缺省时按 generateSampleUrl(taskId, filename) 构造（cache 来源 entry）。
+   *  磁盘来源 entry 必填（指向 /api/generate/disk-image/...），因为它的 taskId
+   *  是 sentinel，generateSampleUrl 路径不可用。 */
+  imageUrls?: string[]
+}
+
+/** entry 对应位置 idx 的图片 URL。disk entry 走 imageUrls，cache entry 走
+ *  generateSampleUrl(taskId, filename)。所有历史回看渲染处都该用这个 helper。 */
+export function historyImageUrl(entry: HistoryEntry, idx = 0): string {
+  const explicit = entry.imageUrls?.[idx]
+  if (explicit) return explicit
+  const fn = entry.filenames[idx] ?? ''
+  return api.generateSampleUrl(entry.taskId, fn)
 }
 
 function openDb(): Promise<IDBDatabase> {
@@ -99,6 +118,27 @@ async function putEntry(entry: HistoryEntry): Promise<void> {
   }
 }
 
+async function updateEntry(id: string, patch: Partial<HistoryEntry>): Promise<HistoryEntry | null> {
+  try {
+    const db = await openDb()
+    return await new Promise<HistoryEntry | null>((resolve, reject) => {
+      const tx = db.transaction(STORE, 'readwrite')
+      const store = tx.objectStore(STORE)
+      const getReq = store.get(id)
+      getReq.onsuccess = () => {
+        const cur = getReq.result as HistoryEntry | undefined
+        if (!cur) { resolve(null); return }
+        const next = { ...cur, ...patch, id: cur.id }
+        store.put(next)
+        tx.oncomplete = () => resolve(next)
+      }
+      tx.onerror = () => reject(tx.error)
+    })
+  } catch {
+    return null
+  }
+}
+
 async function deleteEntry(id: string): Promise<void> {
   try {
     const db = await openDb()
@@ -110,6 +150,35 @@ async function deleteEntry(id: string): Promise<void> {
     })
   } catch {
     /* ignore */
+  }
+}
+
+/** disk-history server entry → HistoryEntry shape。
+ *  - taskId = -1 sentinel（cache 接口不可用，所有图片走 imageUrls）
+ *  - thumbnailDataUrl 直接放 disk-image URL（不预生成缩略图，浏览器自缩；
+ *    落盘历史规模有限，避免 disk → fetch → canvas → dataURL 的额外开销）
+ *  - id 保持服务端给的 "disk:<date>:<mode>:image_<N>"（前端按此 dedup）
+ */
+function diskEntryToHistory(d: DiskGenerateHistoryEntry): HistoryEntry {
+  return {
+    id: d.id,
+    mode: d.mode,
+    taskId: -1,
+    createdAt: d.created_at * 1000,  // server 给的是秒；HistoryEntry.createdAt 是 ms
+    thumbnailDataUrl: d.url,
+    filenames: [d.filename],
+    imageUrls: [d.url],
+    diskPath: d.path,
+    params: d.params as unknown as GenerateParamsSnapshot,
+  }
+}
+
+async function loadDisk(): Promise<HistoryEntry[]> {
+  try {
+    const resp = await api.listDiskGenerateHistory()
+    return resp.entries.map(diskEntryToHistory)
+  } catch {
+    return []
   }
 }
 
@@ -169,24 +238,43 @@ export async function makeThumbnail(
 
 export interface UseGenerateHistoryResult {
   entries: HistoryEntry[]
-  add: (entry: Omit<HistoryEntry, 'id' | 'createdAt'>) => Promise<void>
+  /** 返回新 entry 的 id，方便 add 后续 patch（如落盘成功回写 diskPath） */
+  add: (entry: Omit<HistoryEntry, 'id' | 'createdAt'>) => Promise<string>
+  /** 局部更新 entry —— 主要给 saveTestImages 回写 diskPath 用 */
+  patch: (id: string, patch: Partial<HistoryEntry>) => Promise<void>
   clearByMode: (mode: HistoryMode) => Promise<void>
   /** 检查每条 entry 的第一张图是否还在 server cache 里；
-   * 404 / fail 的 entry 删除（"原图已释放，留着只剩 thumbnail 没意义"）。
+   * 404 / fail 的 entry：若已落盘（有 diskPath）保留（磁盘还能看），否则删除。
    * 返回删除的 entry 数量。 */
   pruneStale: () => Promise<number>
 }
 
-/** 全局 history 状态 hook。所有调用者共享一份内存视图（loadAll 一次）。 */
+/** 合并 IDB + disk entries：diskPath 重复时 IDB 优先（带本地 thumbnail）。 */
+function mergeEntries(idb: HistoryEntry[], disk: HistoryEntry[]): HistoryEntry[] {
+  const usedDiskPaths = new Set(
+    idb.map((e) => e.diskPath).filter((p): p is string => Boolean(p))
+  )
+  const remainingDisk = disk.filter((d) => !d.diskPath || !usedDiskPaths.has(d.diskPath))
+  return [...idb, ...remainingDisk].sort((a, b) => b.createdAt - a.createdAt)
+}
+
+/** 全局 history 状态 hook。IDB 持久化 + 磁盘 sidecar 兜底（跨会话回看）。 */
 export function useGenerateHistory(): UseGenerateHistoryResult {
-  const [entries, setEntries] = useState<HistoryEntry[]>([])
+  const [idbEntries, setIdbEntries] = useState<HistoryEntry[]>([])
+  const [diskEntries, setDiskEntries] = useState<HistoryEntry[]>([])
   const loadedRef = useRef(false)
 
   useEffect(() => {
     if (loadedRef.current) return
     loadedRef.current = true
-    void loadAll().then(setEntries)
+    void loadAll().then(setIdbEntries)
+    void loadDisk().then(setDiskEntries)
   }, [])
+
+  const entries = useMemo(
+    () => mergeEntries(idbEntries, diskEntries),
+    [idbEntries, diskEntries],
+  )
 
   const add = async (entry: Omit<HistoryEntry, 'id' | 'createdAt'>) => {
     const full: HistoryEntry = {
@@ -197,20 +285,31 @@ export function useGenerateHistory(): UseGenerateHistoryResult {
       createdAt: Date.now(),
     }
     await putEntry(full)
-    setEntries((prev) => [full, ...prev])
+    setIdbEntries((prev) => [full, ...prev])
+    return full.id
+  }
+
+  const patch = async (id: string, p: Partial<HistoryEntry>) => {
+    const next = await updateEntry(id, p)
+    if (next) setIdbEntries((prev) => prev.map((e) => (e.id === id ? next : e)))
   }
 
   const clearByMode = async (mode: HistoryMode) => {
+    // 只清 IDB；磁盘文件用户得手动去文件夹删（避免误删历史档案）。
+    // 下次 loadDisk 时磁盘 entries 仍会出现 — 这是有意保留。
     await clearMode(mode)
-    setEntries((prev) => prev.filter((e) => e.mode !== mode))
+    setIdbEntries((prev) => prev.filter((e) => e.mode !== mode))
   }
 
   const pruneStale = async (): Promise<number> => {
-    // 并发 HEAD 请求每条 entry 的第一张图；4xx/5xx 则视为失效，IndexedDB 删
+    // 只对 IDB entries 操作（disk entries 是只读视图，背后是磁盘文件）。
+    // 已落盘（diskPath）的 IDB entry：图在磁盘上随时回看，不删（仅 HEAD 失败说明
+    // 内存 cache 释放了，并不代表"图没了"）。
     const stale: string[] = []
-    await Promise.all(entries.map(async (e) => {
+    await Promise.all(idbEntries.map(async (e) => {
       const fn = e.filenames[0]
       if (!fn) return  // 没 filename 不动
+      if (e.diskPath) return  // 已落盘 → 永远不剪
       const url = api.generateSampleUrl(e.taskId, fn)
       try {
         const r = await fetch(url, { method: 'HEAD' })
@@ -221,9 +320,9 @@ export function useGenerateHistory(): UseGenerateHistoryResult {
     }))
     if (stale.length === 0) return 0
     await Promise.all(stale.map((id) => deleteEntry(id)))
-    setEntries((prev) => prev.filter((e) => !stale.includes(e.id)))
+    setIdbEntries((prev) => prev.filter((e) => !stale.includes(e.id)))
     return stale.length
   }
 
-  return { entries, add, clearByMode, pruneStale }
+  return { entries, add, patch, clearByMode, pruneStale }
 }

--- a/tests/test_generate_save_metadata.py
+++ b/tests/test_generate_save_metadata.py
@@ -1,0 +1,228 @@
+"""POST /api/generate/save 写 PNG metadata + sidecar、GET /api/generate/disk/history
+扫描、GET /api/generate/disk/image/* 静态返回的覆盖测试。"""
+from __future__ import annotations
+
+import json
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from PIL import Image
+
+
+def _png_bytes(color: tuple[int, int, int] = (0, 0, 0), size: tuple[int, int] = (8, 8)) -> bytes:
+    buf = BytesIO()
+    Image.new("RGB", size, color).save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _params(**overrides) -> dict:
+    base = {
+        "schema_version": 1,
+        "mode": "single",
+        "prompts": ["a"],
+        "negative_prompt": "",
+        "width": 8,
+        "height": 8,
+        "steps": 5,
+        "cfg_scale": 4.0,
+        "count": 1,
+        "seed": 7,
+        "lora_configs": [],
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture
+def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient, Path]:
+    from studio.api.routers import generate as _gen
+
+    test_dir = tmp_path / "test"
+    monkeypatch.setattr(_gen, "TEST_IMAGES_DIR", test_dir)
+
+    class _FakeGenCfg:
+        save_test_images = True
+
+    class _FakeSecrets:
+        generate = _FakeGenCfg()
+
+    monkeypatch.setattr(_gen.secrets, "load", lambda: _FakeSecrets())
+
+    app = FastAPI()
+    app.include_router(_gen.router)
+    return TestClient(app), test_dir
+
+
+def test_save_writes_png_metadata_and_sidecar(client) -> None:
+    tc, _ = client
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params(seed=42))},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 200, r.text
+    data = r.json()
+    saved = Path(data["path"])
+    assert saved.exists()
+    sidecar = saved.with_suffix(".json")
+    assert sidecar.exists()
+    sidecar_obj = json.loads(sidecar.read_text(encoding="utf-8"))
+    assert sidecar_obj["mode"] == "single"
+    assert sidecar_obj["schema_version"] == 1
+    assert sidecar_obj["filename"] == saved.name
+    assert sidecar_obj["params"]["seed"] == 42
+
+    # PNG tEXt 注入：再读图应该带 anima_params
+    img = Image.open(saved)
+    img.load()
+    assert "anima_params" in img.text
+    parsed = json.loads(img.text["anima_params"])
+    assert parsed["seed"] == 42
+
+
+def test_save_without_params_skips_sidecar_and_metadata(client) -> None:
+    tc, _ = client
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single"},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["sidecar"] is None
+    saved = Path(data["path"])
+    assert not saved.with_suffix(".json").exists()
+    img = Image.open(saved)
+    img.load()
+    assert "anima_params" not in img.text
+
+
+def test_save_rejects_invalid_params_json(client) -> None:
+    tc, _ = client
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": "not-json{"},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 400
+
+
+def test_save_rejects_non_object_params(client) -> None:
+    tc, _ = client
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": "[1, 2, 3]"},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 400
+
+
+def test_disk_history_lists_entries_with_sidecar(client) -> None:
+    tc, _ = client
+    for seed in (1, 2, 3):
+        tc.post(
+            "/api/generate/save",
+            data={"mode": "single", "params": json.dumps(_params(seed=seed))},
+            files={"image": (f"{seed}.png", _png_bytes(), "image/png")},
+        )
+
+    r = tc.get("/api/generate/disk/history")
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    assert len(entries) == 3
+    # 按 created_at desc
+    for a, b in zip(entries, entries[1:]):
+        assert a["created_at"] >= b["created_at"]
+    seeds = sorted(e["params"]["seed"] for e in entries)
+    assert seeds == [1, 2, 3]
+    # url 指向 disk-image 接口
+    assert all(e["url"].startswith("/api/generate/disk/image/") for e in entries)
+    # id 稳定且唯一
+    assert len({e["id"] for e in entries}) == 3
+
+
+def test_disk_history_skips_entry_without_sidecar(client) -> None:
+    """没有 sidecar 的图（老数据 / 客户端没传 params）不入列表。"""
+    tc, test_dir = client
+    single_dir = test_dir / "2026-01-01" / "single"
+    single_dir.mkdir(parents=True)
+    (single_dir / "image_0.png").write_bytes(_png_bytes())
+
+    r = tc.get("/api/generate/disk/history")
+    assert r.status_code == 200
+    assert r.json()["entries"] == []
+
+
+def test_disk_history_skips_sidecar_without_image(client) -> None:
+    """sidecar 留着但图被删 → 不入列表（避免历史栏点 404）。"""
+    tc, test_dir = client
+    single_dir = test_dir / "2026-01-01" / "single"
+    single_dir.mkdir(parents=True)
+    (single_dir / "image_0.json").write_text(
+        json.dumps({"schema_version": 1, "mode": "single", "created_at": 0,
+                    "filename": "image_0.png", "params": _params()}),
+        encoding="utf-8",
+    )
+
+    r = tc.get("/api/generate/disk/history")
+    assert r.status_code == 200
+    assert r.json()["entries"] == []
+
+
+def test_disk_image_serves_saved_file(client) -> None:
+    tc, _ = client
+    save_resp = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params(seed=99))},
+        files={"image": ("a.png", _png_bytes((255, 0, 0)), "image/png")},
+    )
+    assert save_resp.status_code == 200
+
+    listing = tc.get("/api/generate/disk/history").json()["entries"]
+    assert len(listing) == 1
+    url = listing[0]["url"]
+
+    r = tc.get(url)
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "image/png"
+    assert len(r.content) > 0
+
+
+def test_disk_image_validates_inputs(client) -> None:
+    tc, _ = client
+    # 非法 date
+    assert tc.get("/api/generate/disk/image/not-a-date/single/image_0.png").status_code == 400
+    # 非法 mode
+    assert tc.get("/api/generate/disk/image/2026-01-01/bad/image_0.png").status_code == 400
+    # 非 png 扩展
+    assert tc.get("/api/generate/disk/image/2026-01-01/single/image_0.jpg").status_code == 400
+    # 文件不存在
+    assert tc.get("/api/generate/disk/image/2026-01-01/single/image_0.png").status_code == 404
+
+
+def test_save_disabled_returns_403(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Settings.save_test_images=False → 403。"""
+    from studio.api.routers import generate as _gen
+
+    monkeypatch.setattr(_gen, "TEST_IMAGES_DIR", tmp_path / "test")
+
+    class _FakeGenCfg:
+        save_test_images = False
+
+    class _FakeSecrets:
+        generate = _FakeGenCfg()
+
+    monkeypatch.setattr(_gen.secrets, "load", lambda: _FakeSecrets())
+    app = FastAPI()
+    app.include_router(_gen.router)
+    tc = TestClient(app)
+
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params())},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 403


### PR DESCRIPTION
## 背景 / 动机

测试页（Generate）历史栏现在点击只切大图，参数区不动。每次"基于这张图改一下重跑"都得用户对着图肉眼回忆参数手填，体验糟。

进一步：用户开了 Settings → save_test_images 把图落盘后，PNG 文件本身没带任何参数 metadata，拷走再回到 Studio / 别的工具都识别不出。

需求：
1. 点历史图 → 参数区直接恢复到那张图的参数
2. 已落盘的图永久可回看 + 回填，跨浏览器 / 清缓存 / 换设备都行
3. PNG 文件自描述（用户拷走也能用）

## 改动概要

**后端 (`studio/api/routers/generate.py`)**
- POST `/api/generate/save` 加 `params` Form 字段 → 用 PIL 注入 PNG `anima_params` tEXt 块 + 同目录写 `image_N.json` sidecar
- 新增 GET `/api/generate/disk/history` 扫所有 `<date>/{single,xy}/image_*.json` 返回 entries（按 created_at desc）
- 新增 GET `/api/generate/disk/image/{date}/{mode}/{filename}` 静态文件
- 路径用 `disk/` 子前缀避开 `/api/generate/{task_id}` 单段 catch-all 截获

**前端**
- 新文件 `paramsSnapshot.ts` — `GenerateParamsSnapshot` 类型（prefs 视图，含 xy_draft.raw / datasetPick），sidecar + IDB 共用
- `useGenerateHistory.ts`
  - `HistoryEntry` 加 `params?` / `diskPath?` / `imageUrls?` 三个 optional 字段（向后兼容老 entry）
  - 拆 state 为 `idbEntries + diskEntries`，merge 时按 diskPath dedup（IDB 优先，带本地缩略图）
  - 加 `patch(id, partial)` 和 `historyImageUrl(entry, idx)` 导出
  - `pruneStale` 只动 IDB，已落盘 entry 不剪
- `Generate.tsx`
  - 入库 useEffect 拼 params snapshot 写入 entry；落盘成功后 `history.patch(id, {diskPath})` 做去重
  - `handleHistorySelect` 加回填：xy 模式同时灌 xyLoras + xDraft/yDraft，single 灌 singleLoras + count；老 entry 无 params 时仅切图不回填
  - 三处大图 URL 改 `historyImageUrl()` helper（disk entry 走 disk/image URL）
- `saveTestImages.ts` 接 params + 返回 server path 给 IDB 回写

## 行为对照

| 场景 | 行为 |
|---|---|
| 未落盘 entry 点击 | 回填参数 + 大图（释放后大图 404 走原有 tooltip 提示） |
| 已落盘 entry 同会话点击 | IDB 优先，回填参数 + 大图（走 cache URL） |
| 已落盘 entry 跨会话 / 清缓存后点击 | 磁盘扫描兜底，回填参数（从 sidecar 读）+ 大图（走 disk/image URL） |
| 老 entry（本 PR 前入库）点击 | 仅切大图，不回填（前向兼容） |
| 没有 sidecar 的老落盘图 | disk-history 跳过不列（缺参数列出来无意义） |

## 测试

- 新增 `tests/test_generate_save_metadata.py` — 10 个用例覆盖：
  - PNG metadata + sidecar 写入正确
  - 缺 params 时跳过 sidecar / metadata 注入
  - 无效 JSON / 非对象 params 返 400
  - disk-history 列表 + 排序 + 去重
  - 跳过缺 sidecar / 缺图 的孤儿
  - disk-image 服务 + 路径校验
  - save 关闭返 403
- 前端：`npx tsc --noEmit` + `npm run lint` 全过；现有 vitest 5 个 generate 测试文件 66/66 过
- 后端：现有 generate 相关 3 个测试文件 25/25 + 新加 10 个 = 35/35 过

## 截图

UI 上无视觉变化（已落盘 vs 未落盘 entry 不加边框区分，按用户要求"实现细节用户不需要看见"）。行为变化在点击后参数区的同步上。

🤖 Generated with [Claude Code](https://claude.com/claude-code)