### PR TITLE
refactor(generate): 历史 + 配置回退统一重构 — 二元 XOR 模式 / 砍 IDB / PNG 单一 canonical

### DIFF
--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -22,10 +22,12 @@ import io
 import json
 import os
 import re
+import shutil
 import time
 from datetime import date
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import quote
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse, Response
@@ -48,6 +50,19 @@ _V2_SINGLE_RE = re.compile(r"^single image (\d+)\.png$")
 _V2_XY_RE = re.compile(r"^xy plot (\d+)\.png$")
 # v1 legacy：image_N.png（旧版命名），扫描时仍读取，但新写入只用 v2
 _V1_NAME_RE = re.compile(r"^image_(\d+)\.png$")
+
+# XY 文件夹布局（恢复 PreviewXYGrid 历史回看）：
+#   <date>/xy/xy plot <N>/{xy plot.png, cell x<i> y<j>.png, ...}
+# composite 是合成大图（导出 + 缩略图来源）；cell 是每格原图（PreviewXYGrid + 拖进 Comfy）
+_XY_FOLDER_RE = re.compile(r"^xy plot (\d+)$")
+_XY_TMP_FOLDER_RE = re.compile(r"^\.xy plot \d+\.tmp$")
+_XY_CELL_RE = re.compile(r"^cell x(\d+) y(\d+)\.png$")
+_XY_COMPOSITE_NAME = "xy plot.png"
+
+# 路径校验（disk-image / thumb / delete 全套共用）
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_DISK_MODES = ("single", "xy")
+_PNG_NAME_SAFE_RE = re.compile(r"^[a-zA-Z0-9 ._-]+\.png$")
 
 
 def _next_image_index(dir_: Path, mode: str) -> int:
@@ -72,6 +87,54 @@ def _next_image_index(dir_: Path, mode: str) -> int:
             # v1 legacy 0-based；映射到 v2 编号空间 +1 避免冲突
             max_n = max(max_n, int(m_v1.group(1)) + 1)
     return max_n + 1
+
+
+def _next_xy_folder_index(xy_dir: Path) -> int:
+    """XY 模式下一个文件夹 1-based 序号。
+
+    扫两个空间防撞：
+    - 新格式子文件夹 `xy plot N/`（_XY_FOLDER_RE）
+    - legacy 平铺文件 `xy plot N.png`（_V2_XY_RE） —— PR #245 早期落盘的，
+      虽然不会出现在 history 但残留磁盘上时不能复用编号
+
+    决策 #11：单用户无并发跑图，不做锁；扫描 + atomic mkdir 即可。
+    """
+    if not xy_dir.is_dir():
+        return 1
+    max_n = 0
+    for p in xy_dir.iterdir():
+        if p.is_dir():
+            m = _XY_FOLDER_RE.match(p.name)
+            if m:
+                max_n = max(max_n, int(m.group(1)))
+        elif p.is_file():
+            m = _V2_XY_RE.match(p.name)
+            if m:
+                max_n = max(max_n, int(m.group(1)))
+    return max_n + 1
+
+
+def _cleanup_xy_tmp_folders() -> None:
+    """import-time 清理上次 server crash 留下的 `.xy plot N.tmp/` 半成品。
+
+    save 流程：先写到 sibling tmp 文件夹，全部 cell 落盘后 os.replace 成
+    正式名。中途 crash 会留 tmp 文件夹。每次模块 import 扫一遍清。
+    """
+    if not TEST_IMAGES_DIR.is_dir():
+        return
+    for date_dir in TEST_IMAGES_DIR.iterdir():
+        if not date_dir.is_dir() or not _DATE_RE.match(date_dir.name):
+            continue
+        xy_dir = date_dir / "xy"
+        if not xy_dir.is_dir():
+            continue
+        for p in xy_dir.iterdir():
+            if p.is_dir() and _XY_TMP_FOLDER_RE.match(p.name):
+                shutil.rmtree(p, ignore_errors=True)
+
+
+# import-time 清理（上次 server crash 留下的 tmp 文件夹）
+_cleanup_xy_tmp_folders()
 
 
 @router.post("/api/generate")
@@ -272,11 +335,6 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
     )
 
 
-_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-_DISK_MODES = ("single", "xy")
-_PNG_NAME_SAFE_RE = re.compile(r"^[a-zA-Z0-9 ._-]+\.png$")  # disk-image / thumb / delete 路径校验
-
-
 SCHEMA_VERSION = 2
 
 
@@ -430,21 +488,42 @@ def _atomic_write_png(target: Path, raw: bytes) -> None:
     os.replace(tmp, target)
 
 
+def _decode_params_field(raw: str, field: str) -> dict[str, Any]:
+    """`params` / per-cell manifest 元素 → dict。失败抛 HTTPException 400."""
+    try:
+        decoded = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise HTTPException(400, f"{field}: invalid JSON ({e})")
+    if not isinstance(decoded, dict):
+        raise HTTPException(400, f"{field}: must be a JSON object")
+    return decoded
+
+
 @router.post("/api/generate/save")
 async def save_test_image(
     mode: str = Form(...),
     image: UploadFile = File(...),
     params: str = Form(""),
     task_id: Optional[int] = Form(None),
+    cells: list[UploadFile] = File(default=[]),
+    cells_manifest: str = Form(""),
 ) -> dict[str, Any]:
-    """落盘测试出图到 `studio_data/test/<YYYY-MM-DD>/<mode>/<label> <N>.png`。
+    """落盘测试出图。
 
-    - mode ∈ {"single", "xy"}，其它值（含 "compare"）400
-    - Settings 开关 generate.save_test_images=False → 403
-    - 文件名（决策 #6）：`single image 1.png` / `xy plot 1.png` 类型递增
-    - 原子写（决策 #11）：tmp + os.replace；不做 EEXIST 循环
-    - params 非空 → 注入 PNG `anima_params` (zTXt) + 仅 single 写 `parameters` (a1111 tEXt)
-    - server 端 enrich：强制 `schema_version`/`created_at`/`task_id`/`mode`
+    **single mode** → `studio_data/test/<YYYY-MM-DD>/single/single image <N>.png`
+    返回 `{path, index, filename}` —— `cells` / `cells_manifest` 必须空，否则 400。
+
+    **xy mode** → `studio_data/test/<YYYY-MM-DD>/xy/xy plot <N>/{xy plot.png, cell x<i> y<j>.png ...}`
+    - `image` = composite 大图（导出 + 缩略图来源），按 mode='xy' 注 anima_params，不写 a1111
+    - `cells` = 每格原图 N 张；`cells_manifest` = JSON 数组 [{xi:int, yi:int, params:dict}]，
+      与 `cells` 同序；每 cell 按 mode='single' 注 anima_params + a1111
+    - 校验：len(cells)==len(manifest)，无重复 (xi,yi)
+    - atomic：先写 sibling `.xy plot <N>.tmp/`，全部 cell 落盘后 `os.replace` 成正式名；
+      任一步失败 → `shutil.rmtree(tmp)` 抛 500
+    - 返回 `{folder, composite, cells: [path,...]}`
+
+    其它（含 "compare"）→ 400. Settings.save_test_images=False → 403.
+    server 端 enrich 强制 schema_version/created_at/task_id/mode。
     """
     if mode not in ("single", "xy"):
         raise HTTPException(400, f"unsupported mode: {mode}")
@@ -454,22 +533,111 @@ async def save_test_image(
     if not raw:
         raise HTTPException(400, "empty image body")
 
-    if params:
-        try:
-            decoded = json.loads(params)
-        except json.JSONDecodeError as e:
-            raise HTTPException(400, f"params: invalid JSON ({e})")
-        if not isinstance(decoded, dict):
-            raise HTTPException(400, "params: must be a JSON object")
-        enriched = _enrich_params_server_side(decoded, task_id=task_id, mode=mode)
-        raw = _inject_png_metadata(raw, enriched, mode=mode)
+    if mode == "single":
+        if cells or cells_manifest:
+            raise HTTPException(400, "single mode does not accept cells")
+        if params:
+            decoded = _decode_params_field(params, "params")
+            enriched = _enrich_params_server_side(decoded, task_id=task_id, mode=mode)
+            raw = _inject_png_metadata(raw, enriched, mode=mode)
 
-    target_dir = TEST_IMAGES_DIR / date.today().isoformat() / mode
-    target_dir.mkdir(parents=True, exist_ok=True)
-    idx = _next_image_index(target_dir, mode)
-    target = target_dir / f"{_DISPLAY_LABELS[mode]} {idx}.png"
-    _atomic_write_png(target, raw)
-    return {"path": str(target), "index": idx, "filename": target.name}
+        target_dir = TEST_IMAGES_DIR / date.today().isoformat() / mode
+        target_dir.mkdir(parents=True, exist_ok=True)
+        idx = _next_image_index(target_dir, mode)
+        target = target_dir / f"{_DISPLAY_LABELS[mode]} {idx}.png"
+        _atomic_write_png(target, raw)
+        return {"path": str(target), "index": idx, "filename": target.name}
+
+    # ----- mode == "xy" -----
+    if not cells_manifest:
+        raise HTTPException(400, "xy mode requires cells_manifest")
+    try:
+        manifest = json.loads(cells_manifest)
+    except json.JSONDecodeError as e:
+        raise HTTPException(400, f"cells_manifest: invalid JSON ({e})")
+    if not isinstance(manifest, list):
+        raise HTTPException(400, "cells_manifest: must be a JSON array")
+    if len(manifest) != len(cells):
+        raise HTTPException(400, f"cells_manifest length {len(manifest)} != cells {len(cells)}")
+    if not cells:
+        raise HTTPException(400, "xy mode requires at least one cell")
+
+    # 校验 manifest 条目 + 收集 (xi, yi) 防重
+    seen_xy: set[tuple[int, int]] = set()
+    cell_specs: list[tuple[int, int, dict[str, Any]]] = []
+    for i, entry in enumerate(manifest):
+        if not isinstance(entry, dict):
+            raise HTTPException(400, f"cells_manifest[{i}]: must be an object")
+        try:
+            xi = int(entry["xi"])
+            yi = int(entry["yi"])
+        except (KeyError, TypeError, ValueError):
+            raise HTTPException(400, f"cells_manifest[{i}]: missing xi/yi")
+        if xi < 0 or yi < 0:
+            raise HTTPException(400, f"cells_manifest[{i}]: xi/yi must be non-negative")
+        if (xi, yi) in seen_xy:
+            raise HTTPException(400, f"cells_manifest[{i}]: duplicate (xi={xi}, yi={yi})")
+        seen_xy.add((xi, yi))
+        cell_params = entry.get("params")
+        if cell_params is not None and not isinstance(cell_params, dict):
+            raise HTTPException(400, f"cells_manifest[{i}].params: must be a JSON object")
+        cell_specs.append((xi, yi, cell_params or {}))
+
+    # composite 注入 anima_params（mode='xy'，不写 a1111）
+    composite_bytes = raw
+    if params:
+        composite_decoded = _decode_params_field(params, "params")
+        composite_enriched = _enrich_params_server_side(composite_decoded, task_id=task_id, mode="xy")
+        composite_bytes = _inject_png_metadata(composite_bytes, composite_enriched, mode="xy")
+
+    # 读所有 cell bytes（在文件夹分配前，避免半写）
+    cell_bytes_list: list[bytes] = []
+    for i, cell_upload in enumerate(cells):
+        cb = await cell_upload.read()
+        if not cb:
+            raise HTTPException(400, f"cells[{i}]: empty body")
+        cell_bytes_list.append(cb)
+
+    # 分配 folder + tmp 路径
+    xy_dir = TEST_IMAGES_DIR / date.today().isoformat() / "xy"
+    xy_dir.mkdir(parents=True, exist_ok=True)
+    idx = _next_xy_folder_index(xy_dir)
+    final_dir = xy_dir / f"{_DISPLAY_LABELS['xy']} {idx}"
+    tmp_dir = xy_dir / f".{_DISPLAY_LABELS['xy']} {idx}.tmp"
+    if final_dir.exists():
+        raise HTTPException(500, f"folder collision: {final_dir} already exists")
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    try:
+        tmp_dir.mkdir(parents=False, exist_ok=False)
+        # composite
+        _atomic_write_png(tmp_dir / _XY_COMPOSITE_NAME, composite_bytes)
+        # cells
+        cell_paths: list[Path] = []
+        for (xi, yi, cell_params), cb in zip(cell_specs, cell_bytes_list):
+            cell_payload = cb
+            if cell_params:
+                enriched_cell = _enrich_params_server_side(cell_params, task_id=task_id, mode="single")
+                cell_payload = _inject_png_metadata(cell_payload, enriched_cell, mode="single")
+            cell_path = tmp_dir / f"cell x{xi} y{yi}.png"
+            _atomic_write_png(cell_path, cell_payload)
+            cell_paths.append(cell_path)
+        # atomic rename tmp → final (Windows: target must not exist, 我们刚 _next_xy_folder_index 保证)
+        os.replace(tmp_dir, final_dir)
+    except HTTPException:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise
+    except Exception as e:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        raise HTTPException(500, f"failed to write xy folder: {e}")
+
+    return {
+        "folder": str(final_dir),
+        "index": idx,
+        "composite": str(final_dir / _XY_COMPOSITE_NAME),
+        "cells": [str(final_dir / p.name) for p in cell_paths],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -490,16 +658,151 @@ def _disk_history_id(date_str: str, mode: str, filename: str) -> str:
 def _url_quote_filename(filename: str) -> str:
     """文件名内空格 / 中文等 URL encode（决策 #6 文件名带空格）。后端返 URL
     时直接 encode 好，前端拼接禁止。"""
-    from urllib.parse import quote
     return quote(filename, safe="")
 
 
-def _scan_png_metadata(limit: int) -> list[dict[str, Any]]:
-    """扫 TEST_IMAGES_DIR 下所有 <date>/{single,xy}/*.png 的 anima_params。
+def _scan_single_dir(single_dir: Path, date_str: str) -> list[dict[str, Any]]:
+    """扫一个 `<date>/single/` 目录的所有 PNG，返回 disk-history entry 列表。"""
+    out: list[dict[str, Any]] = []
+    for img in single_dir.glob("*.png"):
+        if img.name.endswith(".tmp.png"):
+            continue  # atomic write tmp file 兜底
+        params = _read_png_anima_params(img)
+        if params is None:
+            continue
+        params = _migrate_anima_params(params)
+        try:
+            created_at = img.stat().st_mtime
+        except OSError:
+            continue
+        encoded = _url_quote_filename(img.name)
+        out.append({
+            "id": _disk_history_id(date_str, "single", img.name),
+            "date": date_str,
+            "mode": "single",
+            "filename": img.name,
+            "path": str(img),
+            "image_url": f"/api/generate/disk/image/{date_str}/single/{encoded}",
+            "thumb_url": f"/api/generate/disk/thumb/{date_str}/single/{encoded}?w=128",
+            "created_at": float(created_at),
+            "schema_version": int(params.get("schema_version", SCHEMA_VERSION)),
+            "params": params,
+        })
+    return out
 
-    没有 anima_params tEXt 块的图（老数据 / 客户端没传 params）不入列表。
-    决策 #16：_read_png_anima_params 只读 header（不 load 像素），500 张 1-2s。
-    决策 #18：扫到 schema_version=1 PNG 用 _migrate_anima_params 适配。
+
+def _build_xy_meta_from_folder(
+    folder: Path, composite_params: dict[str, Any], date_str: str, folder_name: str,
+) -> dict[str, Any] | None:
+    """读 XY 文件夹下所有 cell 文件，按 composite 的 xy_draft 反查 xv/yv，
+    拼成 disk-history entry 的 `xy_meta` 字段。
+
+    决策：只读 composite 的 anima_params（一次 file open），cell 的 xi/yi
+    从文件名 parse（regex），xv/yv 从 composite.xy_draft.x.raw/y.raw split
+    后查表。**不**逐 cell 打开 anima_params —— 5×5 矩阵 1 次 open 而非 26 次。
+
+    返回 None 表示 composite 缺 xy_draft（异常状态，前端兜底走 <img>）。
+    """
+    xy_draft = composite_params.get("xy_draft")
+    if not isinstance(xy_draft, dict):
+        return None
+    x_axis_info = xy_draft.get("x")
+    if not isinstance(x_axis_info, dict):
+        return None
+    x_raw = str(x_axis_info.get("raw", ""))
+    x_values = [s.strip() for s in x_raw.split(",") if s.strip()]
+    x_axis = x_axis_info.get("axis")
+
+    y_axis_info = xy_draft.get("y") if xy_draft.get("y") else None
+    y_values: list[str | None]
+    y_axis: str | None
+    if isinstance(y_axis_info, dict):
+        y_raw = str(y_axis_info.get("raw", ""))
+        y_values = [s.strip() for s in y_raw.split(",") if s.strip()]
+        y_axis = y_axis_info.get("axis")
+    else:
+        y_values = [None]
+        y_axis = None
+
+    samples: list[dict[str, Any]] = []
+    for cell_file in folder.glob("cell x*.png"):
+        m = _XY_CELL_RE.match(cell_file.name)
+        if not m:
+            continue
+        xi = int(m.group(1))
+        yi = int(m.group(2))
+        xv: str | None = x_values[xi] if 0 <= xi < len(x_values) else None
+        yv: str | None = y_values[yi] if 0 <= yi < len(y_values) else None
+        enc_folder = _url_quote_filename(folder_name)
+        enc_file = _url_quote_filename(cell_file.name)
+        samples.append({
+            "path": cell_file.name,
+            "xy": {"xi": xi, "yi": yi, "xv": xv, "yv": yv},
+            "image_url": f"/api/generate/disk/image/{date_str}/xy/{enc_folder}/{enc_file}",
+        })
+    samples.sort(key=lambda s: (s["xy"]["yi"], s["xy"]["xi"]))
+    return {
+        "x_axis": x_axis,
+        "y_axis": y_axis,
+        "x_values": x_values,
+        "y_values": y_values,
+        "samples": samples,
+    }
+
+
+def _scan_xy_dir(xy_dir: Path, date_str: str) -> list[dict[str, Any]]:
+    """扫一个 `<date>/xy/` 目录 —— 只看子文件夹（新布局），跳所有平铺文件（legacy）。
+
+    每个匹配 `_XY_FOLDER_RE` 的子文件夹：
+    - 必须有 `xy plot.png` composite，否则跳过整个 folder
+    - 读 composite 的 anima_params，调 `_build_xy_meta_from_folder` 出 cells
+    """
+    out: list[dict[str, Any]] = []
+    for folder in xy_dir.iterdir():
+        if not folder.is_dir():
+            continue  # legacy 平铺 `xy plot N.png` 文件不再出现在 history（用户决策）
+        if not _XY_FOLDER_RE.match(folder.name):
+            continue
+        composite = folder / _XY_COMPOSITE_NAME
+        if not composite.is_file():
+            continue  # 没 composite 的文件夹（半成品 / 用户手动 mkdir）跳过
+        params = _read_png_anima_params(composite)
+        if params is None:
+            continue
+        params = _migrate_anima_params(params)
+        try:
+            created_at = composite.stat().st_mtime
+        except OSError:
+            continue
+        xy_meta = _build_xy_meta_from_folder(folder, params, date_str, folder.name)
+        enc_folder = _url_quote_filename(folder.name)
+        enc_composite = _url_quote_filename(_XY_COMPOSITE_NAME)
+        out.append({
+            "id": _disk_history_id(date_str, "xy", folder.name),
+            "date": date_str,
+            "mode": "xy",
+            "folder": folder.name,
+            "path": str(folder),
+            "image_url": f"/api/generate/disk/image/{date_str}/xy/{enc_folder}/{enc_composite}",
+            "thumb_url": f"/api/generate/disk/thumb/{date_str}/xy/{enc_folder}/{enc_composite}?w=128",
+            "created_at": float(created_at),
+            "schema_version": int(params.get("schema_version", SCHEMA_VERSION)),
+            "params": params,
+            "xy_meta": xy_meta,
+        })
+    return out
+
+
+def _scan_png_metadata(limit: int) -> list[dict[str, Any]]:
+    """扫 TEST_IMAGES_DIR 下所有 <date>/{single,xy}/ 的 anima_params。
+
+    - single 模式：扫 `<date>/single/*.png`
+    - xy 模式：扫 `<date>/xy/xy plot <N>/{composite + cells}` 子文件夹
+      （legacy 平铺 `<date>/xy/xy plot N.png` 不入列表 —— 用户决策 hide）
+
+    没 anima_params 的 PNG 不入列表（老数据 / 客户端没传 params）。
+    决策 #16：composite 只读 header（不 load 像素）；cell 不读 PNG（用文件名 parse + composite xy_draft 反查 xv/yv）。
+    决策 #18：v1→v2 migrate。
     """
     if not TEST_IMAGES_DIR.is_dir():
         return []
@@ -507,34 +810,12 @@ def _scan_png_metadata(limit: int) -> list[dict[str, Any]]:
     for date_dir in TEST_IMAGES_DIR.iterdir():
         if not date_dir.is_dir() or not _DATE_RE.match(date_dir.name):
             continue
-        for mode in _DISK_MODES:
-            mode_dir = date_dir / mode
-            if not mode_dir.is_dir():
-                continue
-            for img in mode_dir.glob("*.png"):
-                if img.name.endswith(".tmp.png"):
-                    continue  # atomic write tmp file 兜底
-                params = _read_png_anima_params(img)
-                if params is None:
-                    continue
-                params = _migrate_anima_params(params)
-                try:
-                    created_at = img.stat().st_mtime
-                except OSError:
-                    continue
-                encoded = _url_quote_filename(img.name)
-                out.append({
-                    "id": _disk_history_id(date_dir.name, mode, img.name),
-                    "date": date_dir.name,
-                    "mode": mode,
-                    "filename": img.name,
-                    "path": str(img),
-                    "image_url": f"/api/generate/disk/image/{date_dir.name}/{mode}/{encoded}",
-                    "thumb_url": f"/api/generate/disk/thumb/{date_dir.name}/{mode}/{encoded}?w=128",
-                    "created_at": float(created_at),
-                    "schema_version": int(params.get("schema_version", SCHEMA_VERSION)),
-                    "params": params,
-                })
+        single_dir = date_dir / "single"
+        if single_dir.is_dir():
+            out.extend(_scan_single_dir(single_dir, date_dir.name))
+        xy_dir = date_dir / "xy"
+        if xy_dir.is_dir():
+            out.extend(_scan_xy_dir(xy_dir, date_dir.name))
     out.sort(key=lambda e: e["created_at"], reverse=True)
     return out[:limit]
 
@@ -628,10 +909,114 @@ def get_disk_thumb(
     )
 
 
+# ---------------------------------------------------------------------------
+# XY 文件夹专用 routes（新布局）
+#
+# 注：DELETE /api/generate/disk/<date>/xy/<folder> 必须在
+# `delete_disk_image`（5 段通配 {date}/{mode}/{filename}）之前注册，
+# 否则后者会先匹配（FastAPI 按注册顺序匹配，3 段通配会先吞 xy/<folder>）。
+# ---------------------------------------------------------------------------
+
+
+def _resolve_disk_xy_cell(date_str: str, folder: str, filename: str) -> Path:
+    """XY 文件夹下 composite / cell 文件的路径校验 + resolve。
+
+    校验：date / folder（必须匹配 `xy plot N`）/ filename（_PNG_NAME_SAFE_RE）。
+    返回实际磁盘 Path（不保证 exists）。
+    """
+    if not _DATE_RE.match(date_str):
+        raise HTTPException(400, "invalid date")
+    if not _XY_FOLDER_RE.match(folder):
+        raise HTTPException(400, "invalid folder")
+    if not _PNG_NAME_SAFE_RE.match(filename):
+        raise HTTPException(400, "invalid filename")
+    base = (TEST_IMAGES_DIR / date_str / "xy" / folder).resolve()
+    try:
+        path = (base / filename).resolve()
+    except OSError:
+        raise HTTPException(400, "invalid filename")
+    if not str(path).startswith(str(base)):
+        raise HTTPException(400, "path escapes base dir")
+    return path
+
+
+@router.get("/api/generate/disk/image/{date_str}/xy/{folder}/{filename}")
+def get_disk_xy_image(date_str: str, folder: str, filename: str) -> Any:
+    """读 XY 文件夹下的 composite 或 cell PNG（PreviewXYGrid 回看 + 拖进 Comfy 复用）。"""
+    path = _resolve_disk_xy_cell(date_str, folder, filename)
+    if not path.is_file():
+        raise HTTPException(404)
+    return FileResponse(
+        path, media_type="image/png",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@router.get("/api/generate/disk/thumb/{date_str}/xy/{folder}/{filename}")
+def get_disk_xy_thumb(
+    date_str: str, folder: str, filename: str,
+    w: int = Query(128, ge=32, le=512),
+) -> Any:
+    """XY 文件夹下文件的 PIL 缩略图（历史栏 thumb_url 用 composite）。"""
+    path = _resolve_disk_xy_cell(date_str, folder, filename)
+    if not path.is_file():
+        raise HTTPException(404)
+    try:
+        st = path.stat()
+        etag = hashlib.sha1(
+            f"{st.st_mtime}:{st.st_size}:{w}".encode("utf-8")
+        ).hexdigest()[:16]
+    except OSError:
+        raise HTTPException(404)
+    try:
+        from PIL import Image
+        with Image.open(path) as img:
+            img.thumbnail((w, w), Image.LANCZOS)
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            data = buf.getvalue()
+    except Exception:
+        return FileResponse(path, media_type="image/png")
+    return Response(
+        content=data,
+        media_type="image/png",
+        headers={
+            "ETag": f'"{etag}"',
+            "Cache-Control": "public, max-age=86400",
+        },
+    )
+
+
+@router.delete("/api/generate/disk/{date_str}/xy/{folder}")
+def delete_disk_xy_folder(date_str: str, folder: str) -> dict[str, Any]:
+    """删除整个 XY 文件夹（composite + 所有 cell）。
+
+    历史栏点 × 时调；返回 OK + 是否真删（noop=True 表示文件夹本不存在）。
+    """
+    if not _DATE_RE.match(date_str):
+        raise HTTPException(400, "invalid date")
+    if not _XY_FOLDER_RE.match(folder):
+        raise HTTPException(400, "invalid folder")
+    base = (TEST_IMAGES_DIR / date_str / "xy" / folder).resolve()
+    test_root = TEST_IMAGES_DIR.resolve()
+    if not str(base).startswith(str(test_root)):
+        raise HTTPException(400, "path escapes base dir")
+    if not base.is_dir():
+        return {"ok": True, "noop": True}
+    try:
+        shutil.rmtree(base)
+        return {"ok": True, "noop": False}
+    except OSError as e:
+        raise HTTPException(500, f"delete failed: {e}")
+
+
 @router.delete("/api/generate/disk/{date_str}/{mode}/{filename}")
 def delete_disk_image(date_str: str, mode: str, filename: str) -> dict[str, Any]:
-    """删除落盘测试图（前端历史栏单条删除）。
+    """删除落盘单文件测试图（single 模式 / admin 清 legacy XY 平铺文件）。
 
+    XY 模式新布局走 `delete_disk_xy_folder`；这条路由保留主要是 single
+    与 legacy flat XY 清理。注册顺序在 XY folder DELETE 之后 —— 否则 3 段通配
+    会先吞 `xy/<folder>` 路径（FastAPI 按注册顺序匹配）。
     返回 OK + 是否真删（noop=True 表示文件本不存在）。安全校验同 image / thumb。
     """
     path = _resolve_disk_png(date_str, mode, filename)

--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 import io
 import json
 import re
-import time
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -245,27 +244,86 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
     )
 
 
-SIDECAR_SCHEMA_VERSION = 1
-
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _DISK_MODES = ("single", "xy")
 
 
-def _inject_png_params(raw: bytes, params: dict[str, Any]) -> bytes:
-    """把 params 作为 tEXt `anima_params` 注入 PNG。失败返回原 bytes。
+def _format_a1111_parameters(params: dict[str, Any]) -> str:
+    """组装 a1111 兼容的 `parameters` tEXt 块（ComfyUI / WebUI / Civitai 等通用）。
 
-    单一 tEXt 块即可——用户拷走单文件，参数随图走。a1111 兼容文本块按需后加。
+    格式：
+        <prompt> [<lora:name:scale> ...]
+        Negative prompt: <neg>
+        Steps: N, Sampler: ..., Schedule type: ..., CFG scale: N, Seed: N, Size: WxH
+
+    LoRA 用 <lora:basename-without-ext:scale> 语法（a1111/ComfyUI 标准）。
+    xy_draft / dataset_pick 不入此块（a1111 没标准字段；用 anima_params 取）。
+    """
+    prompts = params.get("prompts") or [""]
+    prompt = prompts[0] if isinstance(prompts, list) else str(prompts)
+    loras = params.get("loras") or []
+    lora_tags: list[str] = []
+    for lo in loras:
+        if not isinstance(lo, dict):
+            continue
+        name = str(lo.get("name") or "").rsplit(".", 1)[0]  # 去 .safetensors
+        if not name:
+            continue
+        scale = lo.get("scale", 1.0)
+        lora_tags.append(f"<lora:{name}:{scale}>")
+    if lora_tags:
+        prompt = f"{prompt} {' '.join(lora_tags)}".strip()
+
+    neg = params.get("negative_prompt", "")
+    width = params.get("width", 0)
+    height = params.get("height", 0)
+    parts = [
+        f"Steps: {params.get('steps', '')}",
+        f"Sampler: {params.get('sampler_name', 'er_sde')}",
+        f"Schedule type: {params.get('scheduler', 'simple')}",
+        f"CFG scale: {params.get('cfg_scale', '')}",
+        f"Seed: {params.get('seed', '')}",
+        f"Size: {width}x{height}",
+    ]
+    return f"{prompt}\nNegative prompt: {neg}\n{', '.join(parts)}"
+
+
+def _inject_png_metadata(raw: bytes, params: dict[str, Any]) -> bytes:
+    """注入两个 PNG tEXt 块到图：
+       - `anima_params` —— 结构化 JSON，本程序回填 prefs 用
+       - `parameters`   —— a1111 兼容文本，ComfyUI / WebUI 拖图能识别
+
+    失败返回原 bytes（不阻塞落盘主流程）。
     """
     try:
         from PIL import Image, PngImagePlugin
         img = Image.open(io.BytesIO(raw))
         info = PngImagePlugin.PngInfo()
         info.add_text("anima_params", json.dumps(params, ensure_ascii=False))
+        info.add_text("parameters", _format_a1111_parameters(params))
         out = io.BytesIO()
         img.save(out, format="PNG", pnginfo=info)
         return out.getvalue()
     except Exception:
         return raw
+
+
+def _read_png_anima_params(path: Path) -> dict[str, Any] | None:
+    """从 PNG `anima_params` tEXt 块解析 params；无 / 解析失败返 None。
+
+    PIL 只读 PNG header 的 chunk（不 decode 像素），单图几 ms 级。
+    """
+    try:
+        from PIL import Image
+        with Image.open(path) as img:
+            img.load()  # 触发 tEXt chunk 解析
+            text = img.text.get("anima_params") if hasattr(img, "text") else None
+        if not text:
+            return None
+        data = json.loads(text)
+        return data if isinstance(data, dict) else None
+    except Exception:
+        return None
 
 
 @router.post("/api/generate/save")
@@ -280,8 +338,9 @@ async def save_test_image(
     - Settings 开关 generate.save_test_images=False → 403
     - N = 当前 <date>/<mode>/ 下已有 image_*.png 最大编号+1（找不到则 0）
     - 并发兜底：x-flag 写入，FileExistsError 则重扫一次
-    - params 非空 → 注入 PNG `anima_params` tEXt + 同目录写 image_N.json sidecar
-      （sidecar 是 disk-history 扫描入口；PNG metadata 给"拷走 PNG 还能恢复"用）
+    - params 非空 → 注入 PNG `anima_params` (结构化) + `parameters` (a1111) tEXt 块；
+      磁盘上不另写 sidecar JSON（PNG 文件单一 source of truth，拷走/移动/改名都
+      不会跟参数掉队）。
     """
     if mode not in ("single", "xy"):
         raise HTTPException(400, f"unsupported mode: {mode}")
@@ -291,7 +350,6 @@ async def save_test_image(
     if not raw:
         raise HTTPException(400, "empty image body")
 
-    params_obj: dict[str, Any] | None = None
     if params:
         try:
             decoded = json.loads(params)
@@ -299,8 +357,7 @@ async def save_test_image(
             raise HTTPException(400, f"params: invalid JSON ({e})")
         if not isinstance(decoded, dict):
             raise HTTPException(400, "params: must be a JSON object")
-        params_obj = decoded
-        raw = _inject_png_params(raw, params_obj)
+        raw = _inject_png_metadata(raw, decoded)
 
     target_dir = TEST_IMAGES_DIR / date.today().isoformat() / mode
     target_dir.mkdir(parents=True, exist_ok=True)
@@ -312,26 +369,12 @@ async def save_test_image(
                 f.write(raw)
         except FileExistsError:
             continue
-        sidecar_path: str | None = None
-        if params_obj is not None:
-            sidecar = target_dir / f"image_{idx}.json"
-            sidecar.write_text(
-                json.dumps({
-                    "schema_version": SIDECAR_SCHEMA_VERSION,
-                    "mode": mode,
-                    "created_at": time.time(),
-                    "filename": f"image_{idx}.png",
-                    "params": params_obj,
-                }, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
-            sidecar_path = str(sidecar)
-        return {"path": str(target), "index": idx, "sidecar": sidecar_path}
+        return {"path": str(target), "index": idx}
     raise HTTPException(500, "could not allocate filename")
 
 
 # ---------------------------------------------------------------------------
-# 磁盘历史浏览：扫 sidecar JSON 列 entries，按图片 URL 单独服务
+# 磁盘历史浏览：扫 PNG `anima_params` tEXt 块列 entries，按图片 URL 单独服务
 # ---------------------------------------------------------------------------
 
 
@@ -340,10 +383,11 @@ def _disk_history_id(date_str: str, mode: str, stem: str) -> str:
     return f"disk:{date_str}:{mode}:{stem}"
 
 
-def _scan_sidecars(limit: int) -> list[dict[str, Any]]:
-    """扫 TEST_IMAGES_DIR 下所有 <date>/{single,xy}/image_*.json。
+def _scan_png_metadata(limit: int) -> list[dict[str, Any]]:
+    """扫 TEST_IMAGES_DIR 下所有 <date>/{single,xy}/image_*.png 的 anima_params。
 
-    没有 sidecar 的图不入列表（参数缺失，回填无意义；用户仍可去文件夹手动看）。
+    没有 anima_params tEXt 块的图（老数据 / 客户端没传 params）不入列表 ——
+    用户仍可去文件夹手动看 PNG。created_at 用文件 mtime（落盘即写，准确）。
     """
     if not TEST_IMAGES_DIR.is_dir():
         return []
@@ -355,34 +399,24 @@ def _scan_sidecars(limit: int) -> list[dict[str, Any]]:
             mode_dir = date_dir / mode
             if not mode_dir.is_dir():
                 continue
-            for sc in mode_dir.glob("image_*.json"):
-                stem = sc.stem  # image_5
-                img = mode_dir / f"{stem}.png"
-                if not img.is_file():
-                    continue  # sidecar 留着但图没了 → 跳过
+            for img in mode_dir.glob("image_*.png"):
+                params = _read_png_anima_params(img)
+                if params is None:
+                    continue
                 try:
-                    data = json.loads(sc.read_text(encoding="utf-8"))
-                except (OSError, json.JSONDecodeError):
+                    created_at = img.stat().st_mtime
+                except OSError:
                     continue
-                params = data.get("params")
-                if not isinstance(params, dict):
-                    continue
-                created_at = data.get("created_at")
-                if not isinstance(created_at, (int, float)):
-                    # 容错：旧 sidecar 缺时间 → fallback 文件 mtime
-                    try:
-                        created_at = img.stat().st_mtime
-                    except OSError:
-                        continue
+                stem = img.stem  # image_5
                 out.append({
                     "id": _disk_history_id(date_dir.name, mode, stem),
                     "date": date_dir.name,
                     "mode": mode,
-                    "filename": f"{stem}.png",
+                    "filename": img.name,
                     "path": str(img),
-                    "url": f"/api/generate/disk/image/{date_dir.name}/{mode}/{stem}.png",
+                    "url": f"/api/generate/disk/image/{date_dir.name}/{mode}/{img.name}",
                     "created_at": float(created_at),
-                    "schema_version": data.get("schema_version", 1),
+                    "schema_version": int(params.get("schema_version", 1)),
                     "params": params,
                 })
     out.sort(key=lambda e: e["created_at"], reverse=True)
@@ -391,13 +425,13 @@ def _scan_sidecars(limit: int) -> list[dict[str, Any]]:
 
 @router.get("/api/generate/disk/history")
 def list_disk_history(limit: int = 500) -> dict[str, Any]:
-    """列出所有落盘测试图（按 sidecar JSON 扫），按 created_at desc 排。
+    """列出所有落盘测试图（按 PNG `anima_params` tEXt 扫），按 created_at desc 排。
 
     前端历史栏拉一次 merge 到 IndexedDB 视图；entry.id 稳定，前端按 id dedup。
-    没有 sidecar 的图（老数据 / 客户端没传 params）不入列表。
+    没有 anima_params 的图（老数据 / 客户端没传 params）不入列表。
     """
     limit = max(1, min(int(limit), 2000))
-    return {"entries": _scan_sidecars(limit)}
+    return {"entries": _scan_png_metadata(limit)}
 
 
 @router.get("/api/generate/disk/image/{date_str}/{mode}/{filename}")

--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -132,6 +132,16 @@ def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
         cfg_dict = cfg.model_dump()
         cfg_dict["preview_every_n_steps"] = preview_n
 
+        # 决策 #15：task 启动时冻结 save_test_images，避免用户中途切开关导致
+        # 一 task 内一半图走 cache 一半落盘。daemon submit_task 读这个字段
+        # 存到 _ActiveTask.save_to_disk，_handle_image_done 决定 SSE delivery
+        try:
+            cfg_dict["save_test_images_at_dispatch"] = bool(
+                secrets.load().generate.save_test_images
+            )
+        except Exception:
+            cfg_dict["save_test_images_at_dispatch"] = False
+
         cfg_path = tempdir / "config.json"
         cfg_path.write_text(
             json.dumps(cfg_dict, indent=2, ensure_ascii=False), encoding="utf-8"
@@ -541,7 +551,7 @@ def list_disk_history(limit: int = 500) -> dict[str, Any]:
 
 
 def _resolve_disk_png(date_str: str, mode: str, filename: str) -> Path:
-    """三种 endpoint（image / thumb / delete）共用的路径校验 + resolve。
+    r"""三种 endpoint（image / thumb / delete）共用的路径校验 + resolve。
 
     校验：date 格式 / mode 枚举 / filename 安全字符集（无 / \ .. 等）/ 扩展名 .png
     返回：实际磁盘 Path（不保证 exists，由调用方决定 404 时机）

--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -17,14 +17,17 @@ task 结束 supervisor 仍调 cleanup_generate_tempdir 清掉空目录。server 
 """
 from __future__ import annotations
 
+import hashlib
 import io
 import json
+import os
 import re
+import time
 from datetime import date
 from pathlib import Path
-from typing import Any
+from typing import Any, Optional
 
-from fastapi import APIRouter, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse, Response
 
 from ..deps import _resolve_anima_model_paths
@@ -38,21 +41,36 @@ from ...infrastructure.paths import STUDIO_DATA
 router = APIRouter()
 
 TEST_IMAGES_DIR = STUDIO_DATA / "test"
-_IMAGE_NAME_RE = re.compile(r"^image_(\d+)\.png$")
+
+# v2 命名（决策 #6）：父目录区分 mode，文件名仅 "<label> N.png"
+_DISPLAY_LABELS = {"single": "single image", "xy": "xy plot"}
+_V2_SINGLE_RE = re.compile(r"^single image (\d+)\.png$")
+_V2_XY_RE = re.compile(r"^xy plot (\d+)\.png$")
+# v1 legacy：image_N.png（旧版命名），扫描时仍读取，但新写入只用 v2
+_V1_NAME_RE = re.compile(r"^image_(\d+)\.png$")
 
 
-def _next_image_index(dir_: Path) -> int:
-    """扫描 dir 下 image_<N>.png，返回最大 N+1。找不到则 0。"""
+def _next_image_index(dir_: Path, mode: str) -> int:
+    """扫描 dir 下当前 mode 的 PNG 文件，返回下一个 1-based 序号。
+
+    决策 #11：无并发跑图场景，不做 O_EXCL / 锁；序号扫 max+1 + atomic 写即可。
+    决策 #6：v2 命名 1-based（"single image 1" 比 0 直观），v1 legacy `image_N`
+    若同目录混存按合并扫一组取 max+1。
+    """
     if not dir_.is_dir():
-        return 0
-    max_n = -1
+        return 1
+    rx_v2 = _V2_SINGLE_RE if mode == "single" else _V2_XY_RE
+    max_n = 0
     for p in dir_.iterdir():
-        m = _IMAGE_NAME_RE.match(p.name)
-        if m:
-            try:
-                max_n = max(max_n, int(m.group(1)))
-            except ValueError:
-                pass
+        if not p.is_file():
+            continue
+        m_v2 = rx_v2.match(p.name)
+        m_v1 = _V1_NAME_RE.match(p.name)
+        if m_v2:
+            max_n = max(max_n, int(m_v2.group(1)))
+        elif m_v1:
+            # v1 legacy 0-based；映射到 v2 编号空间 +1 避免冲突
+            max_n = max(max_n, int(m_v1.group(1)) + 1)
     return max_n + 1
 
 
@@ -246,6 +264,10 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
 
 _DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 _DISK_MODES = ("single", "xy")
+_PNG_NAME_SAFE_RE = re.compile(r"^[a-zA-Z0-9 ._-]+\.png$")  # disk-image / thumb / delete 路径校验
+
+
+SCHEMA_VERSION = 2
 
 
 def _format_a1111_parameters(params: dict[str, Any]) -> str:
@@ -288,10 +310,11 @@ def _format_a1111_parameters(params: dict[str, Any]) -> str:
     return f"{prompt}\nNegative prompt: {neg}\n{', '.join(parts)}"
 
 
-def _inject_png_metadata(raw: bytes, params: dict[str, Any]) -> bytes:
-    """注入两个 PNG tEXt 块到图：
-       - `anima_params` —— 结构化 JSON，本程序回填 prefs 用
-       - `parameters`   —— a1111 兼容文本，ComfyUI / WebUI 拖图能识别
+def _inject_png_metadata(raw: bytes, params: dict[str, Any], *, mode: str) -> bytes:
+    """注入 PNG tEXt 块到图：
+       - `anima_params` —— 结构化 JSON，**zTXt 压缩**（决策 #17），本程序回填用
+       - `parameters`   —— a1111 兼容文本（决策 #7：xy **不写**，矩阵图单图拖
+         进 a1111 参数语义对不上）；仅 single 模式写
 
     失败返回原 bytes（不阻塞落盘主流程）。
     """
@@ -299,8 +322,11 @@ def _inject_png_metadata(raw: bytes, params: dict[str, Any]) -> bytes:
         from PIL import Image, PngImagePlugin
         img = Image.open(io.BytesIO(raw))
         info = PngImagePlugin.PngInfo()
-        info.add_text("anima_params", json.dumps(params, ensure_ascii=False))
-        info.add_text("parameters", _format_a1111_parameters(params))
+        # zip=True → zTXt 压缩块（PIL 9+），XY cells[] 时 anima_params 可能 6KB+，
+        # 压缩后通常 1-2KB，a1111 不识别 anima_params 反正会跳过
+        info.add_text("anima_params", json.dumps(params, ensure_ascii=False), zip=True)
+        if mode == "single":
+            info.add_text("parameters", _format_a1111_parameters(params))
         out = io.BytesIO()
         img.save(out, format="PNG", pnginfo=info)
         return out.getvalue()
@@ -309,14 +335,17 @@ def _inject_png_metadata(raw: bytes, params: dict[str, Any]) -> bytes:
 
 
 def _read_png_anima_params(path: Path) -> dict[str, Any] | None:
-    """从 PNG `anima_params` tEXt 块解析 params；无 / 解析失败返 None。
+    """从 PNG `anima_params` tEXt / zTXt 块解析 params；无 / 解析失败返 None。
 
-    PIL 只读 PNG header 的 chunk（不 decode 像素），单图几 ms 级。
+    决策 #16：只读 PNG header chunk（PIL `Image.open` 已自动解析 tEXt/zTXt），
+    **不调 `img.load()`**（不 decode 像素）。500 张 4K PNG mount 用时从 15-30s
+    降到 1-2s。
     """
     try:
         from PIL import Image
         with Image.open(path) as img:
-            img.load()  # 触发 tEXt chunk 解析
+            # img.text 在 PIL 8+ 由 open() 阶段读 PNG chunks（含 tEXt/zTXt）填充；
+            # 不需要 img.load() 触发像素解码
             text = img.text.get("anima_params") if hasattr(img, "text") else None
         if not text:
             return None
@@ -326,21 +355,86 @@ def _read_png_anima_params(path: Path) -> dict[str, Any] | None:
         return None
 
 
+def _migrate_anima_params(meta: dict[str, Any]) -> dict[str, Any]:
+    """v1 → v2 schema 迁移（决策 #18）。
+
+    v1: `lora_configs[].path` 是绝对路径（旧 schema 直接存 path）
+    v2: `loras[].name` basename + project_id/version_id；不存绝对路径
+
+    迁移规则：v1 PNG → 把 `lora_configs[].path` 末段 basename 当 v2 `loras[].name`，
+    保留 project_id/version_id/scale；旧 path 丢弃（隐私 + 跨机器死链）。
+    """
+    version = meta.get("schema_version", 1)
+    if version >= 2:
+        return meta
+    if version == 1:
+        legacy_loras = meta.pop("lora_configs", None)
+        if isinstance(legacy_loras, list):
+            new_loras: list[dict[str, Any]] = []
+            for lc in legacy_loras:
+                if not isinstance(lc, dict):
+                    continue
+                path = str(lc.get("path") or "")
+                name = path.replace("\\", "/").rsplit("/", 1)[-1] if path else ""
+                new_loras.append({
+                    "name": name,
+                    "scale": float(lc.get("scale", 1.0)),
+                    "project_id": lc.get("project_id"),
+                    "version_id": lc.get("version_id"),
+                })
+            meta["loras"] = new_loras
+        meta["schema_version"] = 2
+        return meta
+    # 未知版本 → 当作 v2 透传（forward-compat）
+    return meta
+
+
+def _enrich_params_server_side(
+    params: dict[str, Any], *, task_id: int | None, mode: str
+) -> dict[str, Any]:
+    """server 端补全 params 的服务端信息（避免前端伪造 / 漏字段）。
+
+    - `schema_version` 强制覆盖为当前版本
+    - `created_at` 落盘时刻（Unix 秒）
+    - `task_id` 来自 enqueue（前端不传 / 不可信任）
+    - `mode` 来自路由参数（前端不传）
+    """
+    params = dict(params)
+    params["schema_version"] = SCHEMA_VERSION
+    params["created_at"] = time.time()
+    if task_id is not None:
+        params["task_id"] = int(task_id)
+    params["mode"] = mode
+    return params
+
+
+def _atomic_write_png(target: Path, raw: bytes) -> None:
+    """原子写 PNG：写 tmp + os.replace（决策 #11 crash safety）。
+
+    server 在写到一半挂掉时不会留半截 PNG 让 disk-history 扫到（半截 PNG 无
+    PNG IEND chunk，PIL 解析失败，disk-history 会跳过这条；但用户在文件管理
+    器里看到一半文件仍是噪音）。tmp + replace 让 target 出现的瞬间内容已完整。
+    """
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    tmp.write_bytes(raw)
+    os.replace(tmp, target)
+
+
 @router.post("/api/generate/save")
 async def save_test_image(
     mode: str = Form(...),
     image: UploadFile = File(...),
     params: str = Form(""),
+    task_id: Optional[int] = Form(None),
 ) -> dict[str, Any]:
-    """落盘测试出图到 studio_data/test/<YYYY-MM-DD>/<mode>/image_N.png。
+    """落盘测试出图到 `studio_data/test/<YYYY-MM-DD>/<mode>/<label> <N>.png`。
 
     - mode ∈ {"single", "xy"}，其它值（含 "compare"）400
     - Settings 开关 generate.save_test_images=False → 403
-    - N = 当前 <date>/<mode>/ 下已有 image_*.png 最大编号+1（找不到则 0）
-    - 并发兜底：x-flag 写入，FileExistsError 则重扫一次
-    - params 非空 → 注入 PNG `anima_params` (结构化) + `parameters` (a1111) tEXt 块；
-      磁盘上不另写 sidecar JSON（PNG 文件单一 source of truth，拷走/移动/改名都
-      不会跟参数掉队）。
+    - 文件名（决策 #6）：`single image 1.png` / `xy plot 1.png` 类型递增
+    - 原子写（决策 #11）：tmp + os.replace；不做 EEXIST 循环
+    - params 非空 → 注入 PNG `anima_params` (zTXt) + 仅 single 写 `parameters` (a1111 tEXt)
+    - server 端 enrich：强制 `schema_version`/`created_at`/`task_id`/`mode`
     """
     if mode not in ("single", "xy"):
         raise HTTPException(400, f"unsupported mode: {mode}")
@@ -357,20 +451,15 @@ async def save_test_image(
             raise HTTPException(400, f"params: invalid JSON ({e})")
         if not isinstance(decoded, dict):
             raise HTTPException(400, "params: must be a JSON object")
-        raw = _inject_png_metadata(raw, decoded)
+        enriched = _enrich_params_server_side(decoded, task_id=task_id, mode=mode)
+        raw = _inject_png_metadata(raw, enriched, mode=mode)
 
     target_dir = TEST_IMAGES_DIR / date.today().isoformat() / mode
     target_dir.mkdir(parents=True, exist_ok=True)
-    for _ in range(20):
-        idx = _next_image_index(target_dir)
-        target = target_dir / f"image_{idx}.png"
-        try:
-            with open(target, "xb") as f:
-                f.write(raw)
-        except FileExistsError:
-            continue
-        return {"path": str(target), "index": idx}
-    raise HTTPException(500, "could not allocate filename")
+    idx = _next_image_index(target_dir, mode)
+    target = target_dir / f"{_DISPLAY_LABELS[mode]} {idx}.png"
+    _atomic_write_png(target, raw)
+    return {"path": str(target), "index": idx, "filename": target.name}
 
 
 # ---------------------------------------------------------------------------
@@ -378,16 +467,29 @@ async def save_test_image(
 # ---------------------------------------------------------------------------
 
 
-def _disk_history_id(date_str: str, mode: str, stem: str) -> str:
-    """前端 dedup / merge 用的稳定 id。同图不论几次扫描都映射同一 id。"""
-    return f"disk:{date_str}:{mode}:{stem}"
+def _disk_history_id(date_str: str, mode: str, filename: str) -> str:
+    """前端 dedup / merge 用的稳定 id。
+
+    用 sha1 短哈希替代直接拼 filename —— filename 含空格（决策 #6 "single image 1"）
+    塞进 React key / data-testid / URL fragment 会踩坑。哈希 12 位足够全局唯一。
+    """
+    h = hashlib.sha1(f"{date_str}/{mode}/{filename}".encode("utf-8")).hexdigest()[:12]
+    return f"disk:{h}"
+
+
+def _url_quote_filename(filename: str) -> str:
+    """文件名内空格 / 中文等 URL encode（决策 #6 文件名带空格）。后端返 URL
+    时直接 encode 好，前端拼接禁止。"""
+    from urllib.parse import quote
+    return quote(filename, safe="")
 
 
 def _scan_png_metadata(limit: int) -> list[dict[str, Any]]:
-    """扫 TEST_IMAGES_DIR 下所有 <date>/{single,xy}/image_*.png 的 anima_params。
+    """扫 TEST_IMAGES_DIR 下所有 <date>/{single,xy}/*.png 的 anima_params。
 
-    没有 anima_params tEXt 块的图（老数据 / 客户端没传 params）不入列表 ——
-    用户仍可去文件夹手动看 PNG。created_at 用文件 mtime（落盘即写，准确）。
+    没有 anima_params tEXt 块的图（老数据 / 客户端没传 params）不入列表。
+    决策 #16：_read_png_anima_params 只读 header（不 load 像素），500 张 1-2s。
+    决策 #18：扫到 schema_version=1 PNG 用 _migrate_anima_params 适配。
     """
     if not TEST_IMAGES_DIR.is_dir():
         return []
@@ -399,24 +501,28 @@ def _scan_png_metadata(limit: int) -> list[dict[str, Any]]:
             mode_dir = date_dir / mode
             if not mode_dir.is_dir():
                 continue
-            for img in mode_dir.glob("image_*.png"):
+            for img in mode_dir.glob("*.png"):
+                if img.name.endswith(".tmp.png"):
+                    continue  # atomic write tmp file 兜底
                 params = _read_png_anima_params(img)
                 if params is None:
                     continue
+                params = _migrate_anima_params(params)
                 try:
                     created_at = img.stat().st_mtime
                 except OSError:
                     continue
-                stem = img.stem  # image_5
+                encoded = _url_quote_filename(img.name)
                 out.append({
-                    "id": _disk_history_id(date_dir.name, mode, stem),
+                    "id": _disk_history_id(date_dir.name, mode, img.name),
                     "date": date_dir.name,
                     "mode": mode,
                     "filename": img.name,
                     "path": str(img),
-                    "url": f"/api/generate/disk/image/{date_dir.name}/{mode}/{img.name}",
+                    "image_url": f"/api/generate/disk/image/{date_dir.name}/{mode}/{encoded}",
+                    "thumb_url": f"/api/generate/disk/thumb/{date_dir.name}/{mode}/{encoded}?w=128",
                     "created_at": float(created_at),
-                    "schema_version": int(params.get("schema_version", 1)),
+                    "schema_version": int(params.get("schema_version", SCHEMA_VERSION)),
                     "params": params,
                 })
     out.sort(key=lambda e: e["created_at"], reverse=True)
@@ -434,18 +540,95 @@ def list_disk_history(limit: int = 500) -> dict[str, Any]:
     return {"entries": _scan_png_metadata(limit)}
 
 
-@router.get("/api/generate/disk/image/{date_str}/{mode}/{filename}")
-def get_disk_image(date_str: str, mode: str, filename: str) -> Any:
-    """读落盘测试图（前端历史栏点击磁盘 entry 时大图来源）。"""
+def _resolve_disk_png(date_str: str, mode: str, filename: str) -> Path:
+    """三种 endpoint（image / thumb / delete）共用的路径校验 + resolve。
+
+    校验：date 格式 / mode 枚举 / filename 安全字符集（无 / \ .. 等）/ 扩展名 .png
+    返回：实际磁盘 Path（不保证 exists，由调用方决定 404 时机）
+    """
     if not _DATE_RE.match(date_str):
         raise HTTPException(400, "invalid date")
     if mode not in _DISK_MODES:
         raise HTTPException(400, "invalid mode")
-    _validate_component_or_400(filename)
-    if not filename.lower().endswith(".png"):
-        raise HTTPException(400, "only .png supported")
-    path = TEST_IMAGES_DIR / date_str / mode / filename
+    if not _PNG_NAME_SAFE_RE.match(filename):
+        raise HTTPException(400, "invalid filename")
+    # 二次防御：safe_join 反 traversal
+    base = (TEST_IMAGES_DIR / date_str / mode).resolve()
+    try:
+        path = (base / filename).resolve()
+    except OSError:
+        raise HTTPException(400, "invalid filename")
+    if not str(path).startswith(str(base)):
+        raise HTTPException(400, "path escapes base dir")
+    return path
+
+
+@router.get("/api/generate/disk/image/{date_str}/{mode}/{filename}")
+def get_disk_image(date_str: str, mode: str, filename: str) -> Any:
+    """读落盘测试图（前端历史栏点击磁盘 entry 时大图来源）。"""
+    path = _resolve_disk_png(date_str, mode, filename)
     if not path.is_file():
         raise HTTPException(404)
-    # 落盘图内容稳定（不会被同名覆盖——image_N 编号递增），可缓存
-    return FileResponse(path, media_type="image/png")
+    # 落盘图内容稳定（序号递增不覆盖），可强 cache
+    return FileResponse(
+        path, media_type="image/png",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@router.get("/api/generate/disk/thumb/{date_str}/{mode}/{filename}")
+def get_disk_thumb(
+    date_str: str, mode: str, filename: str,
+    w: int = Query(128, ge=32, le=512),
+) -> Any:
+    """PIL 在线生成缩略图（决策 Dev v1 / Arch v2）—— 替代前端 IDB dataURL cache。
+
+    - ETag = sha1(file mtime + size + w)；304 命中直接返
+    - Cache-Control: public, max-age=86400（落盘图内容稳定）
+    - 失败 fallback 原图（避免缩略生成 bug 阻塞历史栏）
+    """
+    path = _resolve_disk_png(date_str, mode, filename)
+    if not path.is_file():
+        raise HTTPException(404)
+    try:
+        st = path.stat()
+        etag = hashlib.sha1(
+            f"{st.st_mtime}:{st.st_size}:{w}".encode("utf-8")
+        ).hexdigest()[:16]
+    except OSError:
+        raise HTTPException(404)
+    # 这里没有直接读 request header，由 FastAPI / Starlette 处理 304 略复杂；
+    # 简化方案：返 ETag + Cache-Control，浏览器自管 304 转换（max-age 内不再请求）
+    try:
+        from PIL import Image
+        with Image.open(path) as img:
+            img.thumbnail((w, w), Image.LANCZOS)
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            data = buf.getvalue()
+    except Exception:
+        return FileResponse(path, media_type="image/png")
+    return Response(
+        content=data,
+        media_type="image/png",
+        headers={
+            "ETag": f'"{etag}"',
+            "Cache-Control": "public, max-age=86400",
+        },
+    )
+
+
+@router.delete("/api/generate/disk/{date_str}/{mode}/{filename}")
+def delete_disk_image(date_str: str, mode: str, filename: str) -> dict[str, Any]:
+    """删除落盘测试图（前端历史栏单条删除）。
+
+    返回 OK + 是否真删（noop=True 表示文件本不存在）。安全校验同 image / thumb。
+    """
+    path = _resolve_disk_png(date_str, mode, filename)
+    if not path.is_file():
+        return {"ok": True, "noop": True}
+    try:
+        path.unlink()
+        return {"ok": True, "noop": False}
+    except OSError as e:
+        raise HTTPException(500, f"delete failed: {e}")

--- a/studio/services/inference/daemon.py
+++ b/studio/services/inference/daemon.py
@@ -56,6 +56,10 @@ class _ActiveTask:
     task_id: int
     request_id: str
     on_event: EventCallback
+    # 决策 #15：task 启动时冻结 secrets.generate.save_test_images，避免中途切开关
+    # 导致一 task 内一半 cache 一半 disk。enqueueGenerate 写 cfg.save_test_images_at_dispatch
+    # → submit_task 读出来存这里 → _handle_image_done 决定 SSE delivery 子字段
+    save_to_disk: bool = False
     started_at: float = field(default_factory=time.time)
 
 
@@ -327,8 +331,10 @@ class InferenceDaemon:
                 )
             self._req_seq += 1
             req_id = f"task-{task_id}-{self._req_seq}"
+            save_to_disk = bool(config.get("save_test_images_at_dispatch", False))
             self._active = _ActiveTask(
                 task_id=task_id, request_id=req_id, on_event=on_event,
+                save_to_disk=save_to_disk,
             )
             self._state = STATE_BUSY
             self._reschedule_idle_timer_locked()
@@ -535,6 +541,10 @@ class InferenceDaemon:
         # commit 14：preview_step 含 base64 JPEG → 直接透传给 callback（不入 cache，
         #   前端 SSE 收到立刻 <img src="data:..."> 显示当前步预览；done/最终图
         #   会替换它）
+        # 决策 #14：image_done 加 `delivery: 'disk' | 'cache'` 子字段，前端按此
+        # 走 POST /api/generate/save 落盘（disk）or 直接 add CacheEntry（cache）。
+        # 仍走 cache 中转（持久模式下 cache 是落盘前的临时存放，前端落盘成功后
+        # 用户可手动删 cache 或等 LRU 自然剔）。
         forward_msg = msg
         if kind == "image_done" and "image_b64" in msg:
             filename = msg.get("filename") or ""
@@ -544,6 +554,7 @@ class InferenceDaemon:
             except Exception:
                 logger.exception("cache_image failed for %s", filename)
             forward_msg = {k: v for k, v in msg.items() if k != "image_b64"}
+            forward_msg["delivery"] = "disk" if active.save_to_disk else "cache"
 
         # done/error/canceled 先切状态，再回调 —— 让 callback 内查询 is_busy/state 时
         # 看到准确的 IDLE 状态（commit 13 daemon_state_changed 依赖这个顺序）

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1119,6 +1119,11 @@ export interface LoraEntry {
   /** 来自 picker 的项目 / 版本绑定；外部文件无 */
   project_id?: number | null
   version_id?: number | null
+  /** 仅 placeholder 状态用：历史回填时 resolve 失败保留原 basename
+   *  （如 "my-lora.safetensors"），让 SidebarLoras 渲染 ⚠ placeholder 卡片
+   *  提示用户重选。`path` 非空时此字段被忽略；submit 时 path='' 的 entry
+   *  会被 `.filter(l => l.path.trim())` 跳过，不影响 daemon。 */
+  name?: string | null
 }
 
 /** XY 矩阵：单 task 内循环全图，前端按 (yi, xi) 排成 grid。

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1008,7 +1008,7 @@
     "saveTestImages": {
       "title": "Save test images to disk",
       "label": "Save test images",
-      "desc": "When enabled, every generation is written to studio_data/test/<date>/{single,xy}/image_N.png. xy mode saves the composed grid; compare mode is never saved. Default: off."
+      "tooltip": "When enabled, every generation writes to studio_data/test/<date>/: single mode saves a single PNG; xy mode saves a folder (composite + per-cell PNGs, each cell is drop-into-Comfy/A1111 compatible); compare is never saved. Default: off."
     },
     "theme": "Theme",
     "themeLight": "☀ Light",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1214,6 +1214,7 @@
     "historyTask": "History #{{id}}",
     "imageCount": "{{n}} images",
     "backToCurrent": "Back to current",
+    "historyLorasMissing": "{{n}} LoRA(s) from history not found locally; please re-pick",
     "emptyHint": "Fill parameters, then click “Start generate”",
     "previewStep": "Sampling {{step}} / {{total}} (intermediate preview)",
     "waitingImages": "Waiting for images…",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1215,6 +1215,8 @@
     "imageCount": "{{n}} images",
     "backToCurrent": "Back to current",
     "historyLorasMissing": "{{n}} LoRA(s) from history not found locally; please re-pick",
+    "loraNotFoundHint": "Not found locally; please re-pick",
+    "repickLora": "Re-pick",
     "emptyHint": "Fill parameters, then click “Start generate”",
     "previewStep": "Sampling {{step}} / {{total}} (intermediate preview)",
     "waitingImages": "Waiting for images…",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1325,6 +1325,8 @@
     "checkingShort": "Checking…",
     "pruneStale": "Clear stale",
     "noHistory": "No history",
+    "refreshHistory": "Refresh",
+    "refreshHistoryTitle": "Reload disk history (use after multi-tab sync or external folder changes)",
     "noExportableXyData": "No exportable XY data",
     "allCellsLoadFailed": "All cell images failed to load (the originals may have been released)",
     "canvas2dUnavailable": "canvas 2d is unavailable",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1214,6 +1214,7 @@
     "historyTask": "历史 #{{id}}",
     "imageCount": "{{n}} 张",
     "backToCurrent": "返回当前",
+    "historyLorasMissing": "历史里的 {{n}} 个 LoRA 在本机找不到，请手动重选",
     "emptyHint": "填写参数后点击「开始生成」",
     "previewStep": "采样 {{step}} / {{total}}（中间步预览）",
     "waitingImages": "等待生成图…",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1215,6 +1215,8 @@
     "imageCount": "{{n}} 张",
     "backToCurrent": "返回当前",
     "historyLorasMissing": "历史里的 {{n}} 个 LoRA 在本机找不到，请手动重选",
+    "loraNotFoundHint": "本机找不到，请重选",
+    "repickLora": "重选",
     "emptyHint": "填写参数后点击「开始生成」",
     "previewStep": "采样 {{step}} / {{total}}（中间步预览）",
     "waitingImages": "等待生成图…",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1325,6 +1325,8 @@
     "checkingShort": "查…",
     "pruneStale": "清失效",
     "noHistory": "暂无历史",
+    "refreshHistory": "刷新",
+    "refreshHistoryTitle": "重新读取磁盘历史（用于多 tab 同步或外部修改文件夹后）",
     "noExportableXyData": "没有可导出的 XY 数据",
     "allCellsLoadFailed": "所有 cell 图都加载失败（可能原图已释放）",
     "canvas2dUnavailable": "canvas 2d 不可用",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1008,7 +1008,7 @@
     "saveTestImages": {
       "title": "测试出图自动落盘",
       "label": "保存测试图片",
-      "desc": "打开后每次出图自动保存到 studio_data/test/<日期>/{single,xy}/image_N.png。xy 模式存合成的网格图；compare 模式不保存。默认关闭。"
+      "tooltip": "打开后每次出图自动落盘到 studio_data/test/<日期>/：single 模式存单张 PNG；xy 模式存文件夹（合成大图 + 每格 cell PNG，cell 可拖进 Comfy/A1111 复用参数）；compare 模式不保存。默认关闭。"
     },
     "theme": "主题",
     "themeLight": "☀ 日间",

--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -305,4 +305,91 @@ describe('GeneratePage 端到端 smoke', () => {
     expect(stored.singleLoras).toEqual([A])
     expect(stored.xyLoras).toEqual([A])
   })
+
+  // ---- 点击 XY 历史 entry 回填 sidebar 参数（含 xDraft）----
+  it('点击 XY 落盘历史 → 左侧 XY 轴 dropdown 切到 LoRA + raw 写入', async () => {
+    // 用户场景：当前 sidebar 在 XY mode 默认 X=steps；点 XY plot 1 历史 entry
+    // 回填后 X 轴应切到 lora_ckpt + raw=basenames（picker 后续会按 basename 升级
+    // 成全 path 给 daemon；这里只验 xDraft 同步进 prefs 这一步）。
+    seedPrefs({ mode: 'xy' })  // 起步默认 X=steps
+    const xySnapshotParams = {
+      schema_version: 1,
+      mode: 'xy',
+      prompts: ['recall-prompt'],
+      negative_prompt: 'recall-neg',
+      width: 768, height: 1344,
+      steps: 25, cfg_scale: 5, count: 1, seed: 7,
+      loras: [
+        { name: 'chen-bin_V3.7_step5500.safetensors', scale: 1,
+          project_id: 19, version_id: 44 },
+      ],
+      xy_draft: {
+        x: {
+          axis: 'lora_ckpt',
+          raw: 'epoch40.safetensors, epoch38.safetensors, epoch24.safetensors',
+          loraIndex: 0,
+        },
+        y: null,
+      },
+      dataset_pick: null,
+    }
+    const diskEntry = {
+      id: 'disk:abc123',
+      date: '2026-06-09',
+      mode: 'xy',
+      folder: 'xy plot 1',
+      path: '/tmp/test/2026-06-09/xy/xy plot 1',
+      image_url: '/api/generate/disk/image/2026-06-09/xy/xy%20plot%201/xy%20plot.png',
+      thumb_url: '/api/generate/disk/thumb/2026-06-09/xy/xy%20plot%201/xy%20plot.png?w=128',
+      created_at: 1717900000,
+      schema_version: 2,
+      params: xySnapshotParams,
+      xy_meta: {
+        x_axis: 'lora_ckpt',
+        y_axis: null,
+        x_values: ['epoch40.safetensors', 'epoch38.safetensors', 'epoch24.safetensors'],
+        y_values: [null],
+        samples: [],
+      },
+    }
+    const previousImpl = fetchMock.getMockImplementation()
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/generate/disk/history') && (init?.method ?? 'GET') === 'GET') {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({ entries: [diskEntry] }),
+          text: async () => JSON.stringify({ entries: [diskEntry] }),
+          headers: new Headers({ 'content-type': 'application/json' }),
+        } as Response)
+      }
+      return previousImpl ? previousImpl(url, init) : Promise.resolve({
+        ok: false, status: 404, json: async () => null, text: async () => '',
+        headers: new Headers(),
+      } as Response)
+    })
+
+    const user = userEvent.setup()
+    setup()
+    await waitForInitialLorasLoad()
+
+    // 默认 X 轴是 steps —— 文本输入框显示 "20, 25, 30"
+    const initialAxisInput = await screen.findByDisplayValue(/20, 25, 30/)
+    expect(initialAxisInput).toBeInTheDocument()
+
+    // 等历史栏的 thumbnail 出现（HistoryItem div 的 title 含 folder 名）
+    const thumb = await screen.findByTitle(/xy plot 1 ·/)
+    await user.click(thumb)
+
+    // 回填后：X 轴 dropdown 切到 LoRA，raw 写入新值。
+    // 因为 axis=lora_ckpt 渲染的是 AxisLoraCkptPicker（不是 text input）—— 直接
+    // 看 X 轴 select 的 value（一行 select 元素，AxisCard.label='X'）。
+    await waitFor(() => {
+      const xLabel = screen.getAllByText('X')[0]
+      const card = xLabel.closest('div.bg-sunken')!
+      const axisSelect = card.querySelector('select') as HTMLSelectElement
+      expect(axisSelect.value).toBe('lora_ckpt')
+    })
+    // 原 "20, 25, 30" 文本框该消失（切到 lora_ckpt 渲染的是 picker）
+    expect(screen.queryByDisplayValue(/20, 25, 30/)).not.toBeInTheDocument()
+  })
 })

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -468,6 +468,10 @@ export default function GeneratePage() {
         yDraft: params.xy_draft?.y ?? null,
       }
     })
+    // SidebarLoras / SidebarXYAxes 内的 InlineLoraPicker 只在 mount 时从 props
+    // 取 projectId/versionId 初始化下拉，后续 props 变化不同步（同 URL ?lora=
+    // 路径的修复 — bump key 强制整块 remount，让下拉跟着回填值刷新）。
+    setUrlConsumedKey((k) => k + 1)
   }
 
   const handleGenerate = async () => {

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -435,6 +435,13 @@ export default function GeneratePage() {
     if (applied.unresolvedLoraCount > 0) {
       toast(t('generate.historyLorasMissing', { n: applied.unresolvedLoraCount }), 'info')
     }
+    // datasetPick 非空 → 自动展开 picker 让用户看到选中行 + tags 文本（picker
+    // 是 closed by default，不展开的话 prompts[0] 经常是 ""（用户全靠 dataset
+    // tags 当 prompt 的常见场景），UI 表面看就像"啥都没回填"）。fallback 路径
+    // 已经把 tags 灌到 prompts[0] + datasetPick=null，所以这里只看 applied 即可。
+    if (applied.datasetPick) {
+      setDatasetPickerOpen(true)
+    }
     setPrefs((prev) => {
       const base: GeneratePrefs = {
         ...prev,
@@ -758,9 +765,11 @@ export default function GeneratePage() {
 
               {historyOverride ? (
                 <div className="flex-1 min-h-0 flex flex-col gap-2">
-                  {historyOverride.source === 'cache' && historyOverride.mode === 'xy'
-                    && historyOverride.xyMeta ? (
-                    /* CacheEntry + xyMeta：cache 里 per-cell 图都在，走 PreviewXYGrid */
+                  {historyOverride.mode === 'xy' && historyOverride.xyMeta ? (
+                    /* XY 回看 (cache / disk 共用)：per-cell 信息齐 → PreviewXYGrid
+                       cache 时 taskId 是真 task id（GridCell fallback 走 cache URL）；
+                       disk 时 server 已给 imageUrl，taskId 走 -1 sentinel（不会被用到）。
+                       disk 时多传 compositeUrl → 导出 PNG 走文件下载，不再 re-compose */
                     <PreviewXYGrid
                       samples={historyOverride.xyMeta.samples.map((s) => ({
                         path: s.path,
@@ -768,8 +777,9 @@ export default function GeneratePage() {
                           xi: s.xy.xi, yi: s.xy.yi,
                           xv: s.xy.xv as never, yv: s.xy.yv as never,
                         },
+                        imageUrl: s.imageUrl,
                       }))}
-                      taskId={historyOverride.taskId}
+                      taskId={historyOverride.source === 'cache' ? historyOverride.taskId : -1}
                       xDraft={{
                         axis: historyOverride.xyMeta.xAxis as never,
                         raw: historyOverride.xyMeta.xValues.join(', '),
@@ -782,9 +792,10 @@ export default function GeneratePage() {
                       } : null}
                       onCellClick={undefined /* 历史回看不允许选 cell 进 compare */}
                       selectedIndices={[]}
+                      compositeUrl={historyOverride.source === 'disk' ? historyOverride.imageUrl : undefined}
                     />
                   ) : (
-                    /* DiskEntry（含 XY 合成大图）/ CacheEntry single → 单图视图 */
+                    /* DiskEntry single / legacy XY（无 xyMeta） / CacheEntry single → 单图视图 */
                     <a
                       className="flex-1 min-h-0 flex items-center justify-center w-full"
                       href={entryImageUrl(historyOverride, 0)}
@@ -805,7 +816,7 @@ export default function GeneratePage() {
                   )}
                   <div className="text-xs text-fg-tertiary shrink-0">
                     {historyOverride.source === 'disk'
-                      ? historyOverride.filename.replace(/\.png$/i, '')
+                      ? (historyOverride.folder ?? (historyOverride.filename ?? '').replace(/\.png$/i, ''))
                       : t('generate.historyTask', { id: historyOverride.taskId })}
                     <button
                       className="btn btn-ghost text-xs ml-2"

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -158,7 +158,6 @@ export default function GeneratePage() {
       }]
       return { ...p, mode: 'single', singleLoras: newLoras }
     })
-    setUrlConsumedKey((k) => k + 1)
     const url = new URL(window.location.href)
     url.searchParams.delete('lora')
     url.searchParams.delete('projectId')
@@ -181,11 +180,6 @@ export default function GeneratePage() {
   // 没法重试也没法取消（status=failed 时 cancelable=false）
   const [submitting, setSubmitting] = useState(false)
   const [currentTask, setCurrentTask] = useState<Task | null>(null)
-  // URL ?lora= 消费计数：bump 一次让 SidebarLoras 整块 remount，强制内部
-  // InlineLoraPicker 用新 value 重新初始化 pid/vid（picker 内 useState 只
-  // 一次性从 props.value 取 projectId/versionId，后续 props 变化不会同步，
-  // 不 remount 就会看到下拉 / chip 还卡在旧缓存项目）。
-  const [urlConsumedKey, setUrlConsumedKey] = useState(0)
   // monitor 走 useMonitorProgress hook (PR #37 增量协议)：currentTask 变 →
   // hook 自动重拉快照 + 订阅 SSE delta 合并；本组件只用 samples 字段，其余
   // 字段在这页生成场景下不需要。
@@ -582,7 +576,6 @@ export default function GeneratePage() {
                   <span className="text-xs text-fg-tertiary">{t('generate.loraHint')}</span>
                 </div>
                 <SidebarLoras
-                  key={`single-${urlConsumedKey}`}
                   loras={loras}
                   onChange={setLoras}
                   projectLoras={projectLoras}
@@ -592,7 +585,6 @@ export default function GeneratePage() {
 
             {mode === 'xy' && (
               <SidebarXYAxes
-                key={`xy-${urlConsumedKey}`}
                 xDraft={xDraft}
                 yDraft={yDraft}
                 onXChange={setXDraft}

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -21,12 +21,16 @@ import PreviewCompare from './generate/PreviewCompare'
 import PreviewHistoryRail from './generate/PreviewHistoryRail'
 import PromptFromDatasetPicker, { type DatasetPick } from './generate/PromptFromDatasetPicker'
 import {
-  PARAMS_SNAPSHOT_VERSION, loraBasename, resolveSnapshotLora,
+  PARAMS_SNAPSHOT_VERSION, applySnapshot, loraBasename,
   transformAxisRawForSnapshot,
   type GenerateParamsSnapshot, type SnapshotLora,
 } from './generate/paramsSnapshot'
 import { saveSingleSamples, saveXYMatrix } from './generate/saveTestImages'
-import { historyImageUrl, makeThumbnail, useGenerateHistory, type HistoryEntry } from './generate/useGenerateHistory'
+import { useGenerateHistory } from './generate/useGenerateHistory'
+import {
+  entryImageUrl,
+  type CacheEntry, type HistoryEntry,
+} from './generate/entryAdapter'
 import PreviewXYGrid from './generate/PreviewXYGrid'
 import PromptList from './generate/PromptList'
 import NegPromptInput from './generate/NegPromptInput'
@@ -330,13 +334,7 @@ export default function GeneratePage() {
     if (!cover) return
     const filename = (cover.path.split(/[\\/]/).pop() ?? '')
     if (!filename) return
-    // badge
-    let badge = ''
-    if (mode === 'xy') {
-      const xs = new Set(samples.map((s) => s.xy?.xi).filter((x) => x !== undefined))
-      const ys = new Set(samples.map((s) => s.xy?.yi).filter((x) => x !== undefined))
-      badge = `XY ${xs.size}×${ys.size || 1}`
-    }
+    // badge 字段不再存 entry（adapter.entryBadge 计算）
     const filenames = samples
       .map((s) => s.path.split(/[\\/]/).pop() ?? '')
       .filter(Boolean)
@@ -361,10 +359,9 @@ export default function GeneratePage() {
         xValues, yValues, samples: xySamples,
       }
     }
-    // 参数快照（IDB entry.params + 落盘 PNG metadata 共用）。回填时按 mode
-    // 路由灌 singleLoras / xyLoras + xDraft/yDraft；compare 视图记录为 'compare'
-    // 但回填时映射到 xy。LoRA 只存 name + ids（不存 path 避免泄露 / 跨机器死链）；
-    // 回填时通过 projectLoras 用 ids → path resolve。
+    // 参数快照（落盘 PNG metadata + cache entry 共用，回填用）。
+    // LoRA 只存 name + ids（不存 path 避免泄露 / 跨机器死链）；回填时通过
+    // projectLoras 用 ids → path resolve。
     const snapshotLoras: SnapshotLora[] = loras.map((l) => ({
       name: loraBasename(l.path),
       scale: l.scale,
@@ -388,32 +385,20 @@ export default function GeneratePage() {
         : null,
       dataset_pick: datasetPick,
     }
-    const entryPromise = makeThumbnail(api.generateSampleUrl(taskId, filename), 256)
-      .then((dataUrl) => history.add({
-        mode,
-        taskId,
-        thumbnailDataUrl: dataUrl,
-        filenames,
-        badge: badge || undefined,
-        xy: xyMeta,
-        params,
-      }))
-      .catch(() => null /* thumbnail 失败 — 不入库（avoid 无封面 entry），落盘仍跑 */)
-    // 自动落盘（Settings.generate.save_test_images=on 时）。compare 不落盘；
-    // 关闭时跳过避免 XY 模式白白合成网格图。落盘成功 → patch entry.diskPath
-    // 用于和 disk-history 接口的 entries 做 dedup（IDB 优先，磁盘兜底）。
-    if (mode === 'single' || mode === 'xy') {
-      void (async () => {
-        const sec = await api.getSecrets().catch(() => null)
-        if (!sec?.generate?.save_test_images) return
-        let diskPath: string | null = null
+    // 决策 #5 二元模式：开关开 = 落盘 + refresh disk-history（DiskEntry 由
+    // server 给）；开关关 = 直接 add CacheEntry（session 内存，关 tab 丢）。
+    // compare 不入历史（保留现状）。
+    if (mode !== 'single' && mode !== 'xy') return
+    void (async () => {
+      const sec = await api.getSecrets().catch(() => null)
+      const saveToDisk = !!sec?.generate?.save_test_images
+      if (saveToDisk) {
+        // 持久路径：落盘 + 重拉 disk-history（DiskEntry 由 server 端 disk-history
+        // 接口构造，含 sha1 id + thumb url + 已 URL-encoded image url）
         if (mode === 'single') {
-          const paths = await saveSingleSamples(taskId, filenames, params)
-          // 用第一张图的 path 作为 entry.diskPath（去重 key）；后续若用户跨
-          // session 看 disk-history，能正确合并到对应 IDB entry。
-          diskPath = paths.find(Boolean) ?? null
+          await saveSingleSamples(taskId, filenames, params)
         } else if (xyMeta) {
-          diskPath = await saveXYMatrix({
+          await saveXYMatrix({
             samples: xyMeta.samples.map((s) => ({ path: s.path, xy: { xi: s.xy.xi, yi: s.xy.yi } })),
             taskId,
             xAxis: xyMeta.xAxis as Parameters<typeof saveXYMatrix>[0]['xAxis'],
@@ -422,56 +407,65 @@ export default function GeneratePage() {
             yValues: xyMeta.yValues,
           }, params)
         }
-        if (!diskPath) return
-        const entryId = await entryPromise
-        if (entryId) await history.patch(entryId, { diskPath })
-      })()
-    }
+        await history.refresh()
+      } else {
+        // 临时路径：直接 add CacheEntry，浏览器拉 cache URL 显示
+        const cacheEntry: CacheEntry = {
+          source: 'cache',
+          id: typeof crypto !== 'undefined' && 'randomUUID' in crypto
+            ? crypto.randomUUID()
+            : Math.random().toString(36).slice(2),
+          mode,
+          taskId,
+          createdAt: Date.now(),
+          filenames,
+          params,
+          xyMeta,
+        }
+        history.add(cacheEntry)
+      }
+    })()
   }, [currentTask, samples, mode, selectedIndices, history, xDraft, yDraft,
       prompts, negPrompt, width, height, steps, cfgScale, count, seed, loras, datasetPick])
 
   const handleHistorySelect = (entry: HistoryEntry) => {
     setHistoryOverride(entry)
-    const params = entry.params
-    if (!params) return  // 老 entry / 早于本次改动 → 仅切图，不回填
-    const resolved = params.loras.map((l) => resolveSnapshotLora(l, projectLoras))
-    const missingCount = resolved.filter((l) => !l.path).length
-    if (missingCount > 0) {
-      toast(t('generate.historyLorasMissing', { n: missingCount }), 'info')
+    // applySnapshot 统一所有"应用快照"入口（决策 #8 / Step 3）；老 entry 缺
+    // params 会走 catch 兜底（snap.loras 等访问报错 → 不回填，仅切图）
+    let applied
+    try {
+      applied = applySnapshot(entry.params, projectLoras)
+    } catch {
+      return
     }
-    // compare 视图回填到 xy 模式（compare 是 xy 子视图，没 selectedIndices 不直接进）
-    const newMode: ViewMode = params.mode === 'single' ? 'single' : 'xy'
+    if (applied.unresolvedLoraCount > 0) {
+      toast(t('generate.historyLorasMissing', { n: applied.unresolvedLoraCount }), 'info')
+    }
     setPrefs((prev) => {
       const base: GeneratePrefs = {
         ...prev,
-        mode: newMode,
-        prompts: params.prompts.length > 0 ? params.prompts : prev.prompts,
-        negPrompt: params.negative_prompt,
-        width: params.width,
-        height: params.height,
-        aspect: aspectFromDimensions(params.width, params.height),
-        steps: params.steps,
-        cfgScale: params.cfg_scale,
-        count: params.count,
-        seed: params.seed,
-        datasetPick: params.dataset_pick ?? null,
+        mode: applied.mode,
+        prompts: applied.prompts.length > 0 ? applied.prompts : prev.prompts,
+        negPrompt: applied.negPrompt,
+        width: applied.width,
+        height: applied.height,
+        aspect: aspectFromDimensions(applied.width, applied.height),
+        steps: applied.steps,
+        cfgScale: applied.cfgScale,
+        count: applied.count,
+        seed: applied.seed,
+        datasetPick: applied.datasetPick,
       }
-      if (params.mode === 'single') {
-        return { ...base, singleLoras: resolved }
+      if (applied.mode === 'single') {
+        return { ...base, singleLoras: applied.loras }
       }
-      // xy_draft snapshot 的 lora_ckpt 轴 raw 是 basename 列表；shape 兼容
-      // XYAxisDraft 但用户重 submit 前需要 picker 重选定位 ckpt path。
       return {
         ...base,
-        xyLoras: resolved,
-        xDraft: params.xy_draft?.x ?? prev.xDraft,
-        yDraft: params.xy_draft?.y ?? null,
+        xyLoras: applied.loras,
+        xDraft: applied.xDraft ?? prev.xDraft,
+        yDraft: applied.yDraft ?? null,
       }
     })
-    // SidebarLoras / SidebarXYAxes 内的 InlineLoraPicker 只在 mount 时从 props
-    // 取 projectId/versionId 初始化下拉，后续 props 变化不同步（同 URL ?lora=
-    // 路径的修复 — bump key 强制整块 remount，让下拉跟着回填值刷新）。
-    setUrlConsumedKey((k) => k + 1)
   }
 
   const handleGenerate = async () => {
@@ -772,11 +766,11 @@ export default function GeneratePage() {
 
               {historyOverride ? (
                 <div className="flex-1 min-h-0 flex flex-col gap-2">
-                  {historyOverride.mode === 'xy' && historyOverride.xy
-                    && !(historyOverride.imageUrls && historyOverride.imageUrls.length) ? (
-                    /* xy 历史回看：用 PreviewXYGrid 重建（带轴标签 + 双击全屏） */
+                  {historyOverride.source === 'cache' && historyOverride.mode === 'xy'
+                    && historyOverride.xyMeta ? (
+                    /* CacheEntry + xyMeta：cache 里 per-cell 图都在，走 PreviewXYGrid */
                     <PreviewXYGrid
-                      samples={historyOverride.xy.samples.map((s) => ({
+                      samples={historyOverride.xyMeta.samples.map((s) => ({
                         path: s.path,
                         xy: {
                           xi: s.xy.xi, yi: s.xy.yi,
@@ -785,76 +779,42 @@ export default function GeneratePage() {
                       }))}
                       taskId={historyOverride.taskId}
                       xDraft={{
-                        axis: historyOverride.xy.xAxis as never,
-                        raw: historyOverride.xy.xValues.join(', '),
+                        axis: historyOverride.xyMeta.xAxis as never,
+                        raw: historyOverride.xyMeta.xValues.join(', '),
                         loraIndex: null,
                       }}
-                      yDraft={historyOverride.xy.yAxis ? {
-                        axis: historyOverride.xy.yAxis as never,
-                        raw: (historyOverride.xy.yValues as string[]).filter(Boolean).join(', '),
+                      yDraft={historyOverride.xyMeta.yAxis ? {
+                        axis: historyOverride.xyMeta.yAxis as never,
+                        raw: (historyOverride.xyMeta.yValues as string[]).filter(Boolean).join(', '),
                         loraIndex: null,
                       } : null}
                       onCellClick={undefined /* 历史回看不允许选 cell 进 compare */}
                       selectedIndices={[]}
                     />
-                  ) : historyOverride.mode === 'xy' && historyOverride.filenames.length > 1 ? (
-                    /* legacy: 旧 entry 没 xy meta，回退到 grid auto-fit 平铺 */
-                    <div className="flex-1 min-h-0 overflow-auto">
-                      <div
-                        style={{
-                          display: 'grid',
-                          gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
-                          gap: 2,
-                        }}
-                      >
-                        {historyOverride.filenames.map((fn, idx) => {
-                          const url = historyImageUrl(historyOverride, idx)
-                          return (
-                            <a
-                              key={fn} href={url} target="_blank" rel="noreferrer"
-                              className="block bg-sunken rounded-sm overflow-hidden"
-                            >
-                              <img
-                                src={url}
-                                onError={(e) => {
-                                  (e.currentTarget as HTMLImageElement).src = historyOverride.thumbnailDataUrl
-                                  ;(e.currentTarget as HTMLImageElement).title = t('generate.originalReleasedCoverOnly')
-                                }}
-                                alt={fn}
-                                className="block w-full h-auto"
-                                loading="lazy"
-                              />
-                            </a>
-                          )
-                        })}
-                      </div>
-                    </div>
                   ) : (
-                    /* 单图回看（single / compare 历史 / 单张 xy） */
+                    /* DiskEntry（含 XY 合成大图）/ CacheEntry single → 单图视图 */
                     <a
                       className="flex-1 min-h-0 flex items-center justify-center w-full"
-                      href={historyImageUrl(historyOverride, 0)}
+                      href={entryImageUrl(historyOverride, 0)}
                       target="_blank"
                       rel="noreferrer"
                     >
                       <img
                         key={historyOverride.id}
-                        src={historyImageUrl(historyOverride, 0)}
+                        src={entryImageUrl(historyOverride, 0)}
                         onError={(e) => {
-                          (e.currentTarget as HTMLImageElement).src = historyOverride.thumbnailDataUrl
-                          ;(e.currentTarget as HTMLImageElement).title = t('generate.originalReleasedThumbOnly')
+                          (e.currentTarget as HTMLImageElement).title = t('generate.originalReleasedThumbOnly')
                         }}
-                        alt={`history #${historyOverride.taskId}`}
+                        alt=""
                         className="rounded-md object-contain"
                         style={{ maxWidth: '100%', maxHeight: '100%' }}
                       />
                     </a>
                   )}
                   <div className="text-xs text-fg-tertiary shrink-0">
-                    {t('generate.historyTask', { id: historyOverride.taskId })}
-                    {historyOverride.badge ? ` · ${historyOverride.badge}` : ''}
-                    {historyOverride.mode === 'xy' && historyOverride.filenames.length > 1
-                      ? ` · ${t('generate.imageCount', { n: historyOverride.filenames.length })}` : ''}
+                    {historyOverride.source === 'disk'
+                      ? historyOverride.filename.replace(/\.png$/i, '')
+                      : t('generate.historyTask', { id: historyOverride.taskId })}
                     <button
                       className="btn btn-ghost text-xs ml-2"
                       style={{ padding: '2px 8px' }}
@@ -911,13 +871,13 @@ export default function GeneratePage() {
             </div>
           </div>
 
-          {/* 右：图片历史栏（commit 16，按当前 mode 分桶） */}
+          {/* 右：图片历史栏（按当前 mode 分桶） */}
           <PreviewHistoryRail
             entries={history.entries}
             mode={mode}
             onSelect={handleHistorySelect}
-            onClear={() => { void history.clearByMode(mode) }}
-            onPruneStale={history.pruneStale}
+            onRefresh={history.refresh}
+            loading={history.loading}
           />
       </div>
 

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -772,7 +772,8 @@ export default function GeneratePage() {
 
               {historyOverride ? (
                 <div className="flex-1 min-h-0 flex flex-col gap-2">
-                  {historyOverride.mode === 'xy' && historyOverride.xy ? (
+                  {historyOverride.mode === 'xy' && historyOverride.xy
+                    && !(historyOverride.imageUrls && historyOverride.imageUrls.length) ? (
                     /* xy 历史回看：用 PreviewXYGrid 重建（带轴标签 + 双击全屏） */
                     <PreviewXYGrid
                       samples={historyOverride.xy.samples.map((s) => ({

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -20,7 +20,11 @@ import NumField from './generate/NumField'
 import PreviewCompare from './generate/PreviewCompare'
 import PreviewHistoryRail from './generate/PreviewHistoryRail'
 import PromptFromDatasetPicker, { type DatasetPick } from './generate/PromptFromDatasetPicker'
-import { PARAMS_SNAPSHOT_VERSION, type GenerateParamsSnapshot } from './generate/paramsSnapshot'
+import {
+  PARAMS_SNAPSHOT_VERSION, loraBasename, resolveSnapshotLora,
+  transformAxisRawForSnapshot,
+  type GenerateParamsSnapshot, type SnapshotLora,
+} from './generate/paramsSnapshot'
 import { saveSingleSamples, saveXYMatrix } from './generate/saveTestImages'
 import { historyImageUrl, makeThumbnail, useGenerateHistory, type HistoryEntry } from './generate/useGenerateHistory'
 import PreviewXYGrid from './generate/PreviewXYGrid'
@@ -357,9 +361,16 @@ export default function GeneratePage() {
         xValues, yValues, samples: xySamples,
       }
     }
-    // 参数快照（IDB entry.params + 落盘 sidecar 共用）。回填时按 mode 路由
-    // 灌 singleLoras / xyLoras + xDraft/yDraft；compare 视图记录为 'compare'
-    // 但回填时映射到 xy。
+    // 参数快照（IDB entry.params + 落盘 PNG metadata 共用）。回填时按 mode
+    // 路由灌 singleLoras / xyLoras + xDraft/yDraft；compare 视图记录为 'compare'
+    // 但回填时映射到 xy。LoRA 只存 name + ids（不存 path 避免泄露 / 跨机器死链）；
+    // 回填时通过 projectLoras 用 ids → path resolve。
+    const snapshotLoras: SnapshotLora[] = loras.map((l) => ({
+      name: loraBasename(l.path),
+      scale: l.scale,
+      project_id: l.project_id ?? null,
+      version_id: l.version_id ?? null,
+    }))
     const params: GenerateParamsSnapshot = {
       schema_version: PARAMS_SNAPSHOT_VERSION,
       mode,
@@ -368,8 +379,13 @@ export default function GeneratePage() {
       width, height, steps,
       cfg_scale: cfgScale,
       count, seed,
-      lora_configs: loras,
-      xy_draft: mode === 'xy' ? { x: xDraft, y: yDraft } : null,
+      loras: snapshotLoras,
+      xy_draft: mode === 'xy'
+        ? {
+            x: transformAxisRawForSnapshot(xDraft),
+            y: yDraft ? transformAxisRawForSnapshot(yDraft) : null,
+          }
+        : null,
       dataset_pick: datasetPick,
     }
     const entryPromise = makeThumbnail(api.generateSampleUrl(taskId, filename), 256)
@@ -418,6 +434,11 @@ export default function GeneratePage() {
     setHistoryOverride(entry)
     const params = entry.params
     if (!params) return  // 老 entry / 早于本次改动 → 仅切图，不回填
+    const resolved = params.loras.map((l) => resolveSnapshotLora(l, projectLoras))
+    const missingCount = resolved.filter((l) => !l.path).length
+    if (missingCount > 0) {
+      toast(t('generate.historyLorasMissing', { n: missingCount }), 'info')
+    }
     // compare 视图回填到 xy 模式（compare 是 xy 子视图，没 selectedIndices 不直接进）
     const newMode: ViewMode = params.mode === 'single' ? 'single' : 'xy'
     setPrefs((prev) => {
@@ -436,11 +457,13 @@ export default function GeneratePage() {
         datasetPick: params.dataset_pick ?? null,
       }
       if (params.mode === 'single') {
-        return { ...base, singleLoras: params.lora_configs }
+        return { ...base, singleLoras: resolved }
       }
+      // xy_draft snapshot 的 lora_ckpt 轴 raw 是 basename 列表；shape 兼容
+      // XYAxisDraft 但用户重 submit 前需要 picker 重选定位 ckpt path。
       return {
         ...base,
-        xyLoras: params.lora_configs,
+        xyLoras: resolved,
         xDraft: params.xy_draft?.x ?? prev.xDraft,
         yDraft: params.xy_draft?.y ?? null,
       }

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -3081,7 +3081,7 @@ function SaveTestImagesSection({
     <SettingsSection id="save-test-images" title={t('settings.saveTestImages.title')}>
       <SettingsField
         label={t('settings.saveTestImages.label')}
-        desc={t('settings.saveTestImages.desc')}
+        helpTooltip={t('settings.saveTestImages.tooltip')}
       >
         <Bool
           value={draft.generate.save_test_images}

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.test.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.test.tsx
@@ -306,3 +306,72 @@ describe('InlineLoraPicker — single mode (controlled slot)', () => {
     expect(screen.getByLabelText('LoRA 权重数值')).toBeInTheDocument()
   })
 })
+
+describe('InlineLoraPicker — controlled sync (Step 6 / 决策 #8)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('rerender with new props.value → project/version dropdowns reflect new ids', async () => {
+    vi.spyOn(api, 'listVersionLoraCkpts').mockResolvedValue(ckptsV3)
+    const onChange = vi.fn()
+    const onClose = vi.fn()
+    const initialValue: PickedLora = {
+      path: '/loras/cute_chibi/v3/final.safetensors',
+      projectId: 1, versionId: 11,
+    }
+    const { rerender } = render(
+      <InlineLoraPicker
+        mode="single"
+        projectLoras={sample}
+        value={initialValue}
+        weight={1.0}
+        onChange={onChange}
+        onClose={onClose}
+      />
+    )
+    await waitFor(() => {
+      const projectSelect = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+      expect(projectSelect.value).toBe('1')
+    })
+
+    // 模拟历史回填：props.value 切换到另一项目 (id=2)
+    const newValue: PickedLora = {
+      path: '/loras/noir/v1/final.safetensors',
+      projectId: 2, versionId: 21,
+    }
+    rerender(
+      <InlineLoraPicker
+        mode="single"
+        projectLoras={sample}
+        value={newValue}
+        weight={1.0}
+        onChange={onChange}
+        onClose={onClose}
+      />
+    )
+    // sync useEffect 把 pid 设到 2 —— 项目下拉跟着更新
+    await waitFor(() => {
+      const projectSelect = screen.getAllByRole('combobox')[0] as HTMLSelectElement
+      expect(projectSelect.value).toBe('2')
+    })
+  })
+
+  it('value=null 时不 sync，保留 fallback 默认（projects[0] ckpts 显示）', async () => {
+    vi.spyOn(api, 'listVersionLoraCkpts').mockResolvedValue(ckptsV3)
+    const onChange = vi.fn()
+    const onClose = vi.fn()
+    render(
+      <InlineLoraPicker
+        mode="single"
+        projectLoras={sample}
+        value={null}
+        weight={1.0}
+        onChange={onChange}
+        onClose={onClose}
+      />
+    )
+    // 没有受控 value 时仍能看到 projects[0] 的 ckpts（fallback 行为）
+    await waitFor(() => expect(screen.getByText('step 2000')).toBeInTheDocument())
+  })
+})

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { api, type LoraCkpt } from '../../../api/client'
 import type { ProjectLora } from './types'
+
+function basenameOf(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path
+}
 
 /** 项目缩写图标（2 字符 uppercase）。SidebarLoras / 历史代码引用。 */
 export function projectAbbr(title: string): string {
@@ -50,6 +54,18 @@ interface MultiModeProps extends CommonProps {
   /** 即时生效：每次 chip toggle 都 onPick，不再渲染「添加 N 个」commit footer。
    *  用于 XY 轴卡片这种「picker 常驻、用户期望所见即所得」的场景。 */
   live?: boolean
+  /** 受控选中集合（仅 live 模式有意义）：picker 同步内部 picked 跟随这个数组。
+   *
+   * 元素可以是全 path 或 basename：raw 字符串 split 即可塞过来，picker 内会按
+   * basename 等价匹配 ckpts 后高亮全 path。命中 basename → path 时立即 onPick
+   * 回写全 path（修历史回填时 raw 是 basename 让 daemon "路径不存在"）。
+   *
+   * undefined = picker 用纯内部 picked state（active task / bulk-add 流程）。 */
+  selectedPaths?: string[]
+  /** 受控 pid/vid 初值（仅 live 模式）：与 selectedPaths 配套，让 picker mount
+   *  时锚到正确 project/version，否则会 fallback 到 projects[0]。 */
+  initialPid?: number | null
+  initialVid?: number | null
   value?: never
   weight?: never
   onChange?: never
@@ -81,19 +97,23 @@ export default function InlineLoraPicker(props: Props) {
     return Array.from(map.values())
   }, [projectLoras])
 
-  // 初始 pid/vid：single 模式优先用 value 的；否则取第一个项目
-  const initialPid = isSingle ? (props.value?.projectId ?? projects[0]?.id ?? null) : (projects[0]?.id ?? null)
+  // multi mode 受控锚定：caller 给 initialPid/Vid 时直接采纳（历史回填走这条）
+  const multiInitialPid = !isSingle ? (props as MultiModeProps).initialPid ?? null : null
+  const multiInitialVid = !isSingle ? (props as MultiModeProps).initialVid ?? null : null
+  // 初始 pid/vid：single 用 value 的；multi 用 initialPid/Vid 兜底，再 fallback projects[0]
+  const initialPid = isSingle
+    ? (props.value?.projectId ?? projects[0]?.id ?? null)
+    : (multiInitialPid ?? projects[0]?.id ?? null)
   const initialVid = isSingle
     ? (props.value?.versionId ?? null)
-    : (projectLoras.find((l) => l.projectId === projects[0]?.id)?.versionId ?? null)
+    : (multiInitialVid ?? projectLoras.find((l) => l.projectId === projects[0]?.id)?.versionId ?? null)
 
   const [pid, setPid] = useState<number | null>(initialPid)
 
   // 决策 #8（plan §9.2）：single 模式是受控的，pid 必须跟 props.value.projectId
   // 同步 —— 否则历史回填 / URL ?lora= 流回新 LoraEntry 时，下拉框还卡在
   // 旧值（之前靠父级 bump urlConsumedKey 强制 remount 兜底，Step 6 砍掉）。
-  // setPid 函数式更新 + 值未变跳过自动免无限循环。multi 模式无 props.value，
-  // 保留 mount-only 行为（用户在 picker 内自由切项目）。
+  // setPid 函数式更新 + 值未变跳过自动免无限循环。
   // value=null 时不 sync（保留 fallback：未选 LoRA 时给用户看 projects[0] ckpts）
   const singleValue = isSingle ? props.value : null
   useEffect(() => {
@@ -101,6 +121,12 @@ export default function InlineLoraPicker(props: Props) {
     const next = singleValue.projectId
     setPid((cur) => (cur === next ? cur : next))
   }, [isSingle, singleValue])
+
+  // multi mode：当 caller 给 initialPid（XY 历史回填），pid 跟着 prop 走
+  useEffect(() => {
+    if (isSingle || multiInitialPid == null) return
+    setPid((cur) => (cur === multiInitialPid ? cur : multiInitialPid))
+  }, [isSingle, multiInitialPid])
 
   const versions = useMemo(() => {
     if (pid === null) return []
@@ -116,6 +142,12 @@ export default function InlineLoraPicker(props: Props) {
     const next = singleValue.versionId
     setVid((cur) => (cur === next ? cur : next))
   }, [isSingle, singleValue])
+
+  // multi mode：受控 vid（同 multiInitialPid 一对儿）
+  useEffect(() => {
+    if (isSingle || multiInitialVid == null) return
+    setVid((cur) => (cur === multiInitialVid ? cur : multiInitialVid))
+  }, [isSingle, multiInitialVid])
   // versions 切换时如果当前 vid 不在新 versions 列表里，自动取第一个
   // （用户切 project 下拉时触发）
   useEffect(() => {
@@ -177,8 +209,18 @@ export default function InlineLoraPicker(props: Props) {
   // multi 模式的当前会话选中（single 模式不用，受控走 props.value）
   const [picked, setPicked] = useState<Set<string>>(new Set())
   const isLive = !isSingle && (props as MultiModeProps).live === true
+  // 受控选中（live 模式专用）：caller 给 selectedPaths 时 picker 以它为单一来源
+  const multiSelectedPaths = !isSingle ? (props as MultiModeProps).selectedPaths : undefined
+  const isControlled = !isSingle && multiSelectedPaths !== undefined
+  // 区分"prop 同步导致的 pid/vid 变化"vs"用户手点下拉"—— 前者不应清 axis
+  const lastPropPidVid = useRef({ pid: multiInitialPid, vid: multiInitialVid })
+  useEffect(() => {
+    lastPropPidVid.current = { pid: multiInitialPid, vid: multiInitialVid }
+  }, [multiInitialPid, multiInitialVid])
   useEffect(() => {
     if (isSingle) return
+    // controlled：prop 同步触发的 pid/vid 变化不清 picked（让 selectedPaths sync 接手）
+    if (isControlled && pid === lastPropPidVid.current.pid && vid === lastPropPidVid.current.vid) return
     setPicked(new Set())  // pid/vid 切换时清空 UI 选中
     // live 模式：pid/vid 切了把 axis 也清掉（新版本下旧 path 已无意义）；
     // 初始 mount 也会跑一次，但此时 draft.raw 通常已是空，commit 空集合即 no-op。
@@ -186,7 +228,48 @@ export default function InlineLoraPicker(props: Props) {
       (props as MultiModeProps).onPick([], internalWeight)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pid, vid, isSingle])
+  }, [pid, vid, isSingle, isControlled])
+
+  // 受控同步：selectedPaths + ckpts 决定 picked。
+  //   - selectedPaths 元素是全 path → 直接 hit
+  //   - 是 basename（历史回填基础形态，避免快照泄露绝对路径） → 按 basename 在 ckpts 里找匹配
+  //     全 path，picked 用全 path；同时立刻 onPick 回写让 raw 升级成全 path，
+  //     修 daemon 拿到 basename 触发"LoRA 路径不存在"。
+  useEffect(() => {
+    if (!isControlled || !multiSelectedPaths || loading) return
+    if (pid === null || vid === null) return
+    const ckptByPath = new Map(ckpts.map((c) => [c.path, c]))
+    const ckptByBasename = new Map<string, LoraCkpt>()
+    for (const c of ckpts) ckptByBasename.set(basenameOf(c.path), c)
+    const resolvedPaths: string[] = []
+    let needUpgrade = false
+    for (const v of multiSelectedPaths) {
+      if (!v) continue
+      if (ckptByPath.has(v)) {
+        resolvedPaths.push(v)
+        continue
+      }
+      const ck = ckptByBasename.get(basenameOf(v))
+      if (ck) {
+        resolvedPaths.push(ck.path)
+        needUpgrade = true  // raw 里是 basename / 旧 path，要升级到当前机器上的全 path
+      }
+      // 找不到 → 当前 ckpts 没扫到，跳过（用户可能换了项目或文件被删）
+    }
+    const resolvedSet = new Set(resolvedPaths)
+    // 避免无限循环：picked 实际不变时不 setState
+    setPicked((prev) => {
+      if (prev.size === resolvedSet.size && [...prev].every((p) => resolvedSet.has(p))) return prev
+      return resolvedSet
+    })
+    if (needUpgrade && isLive) {
+      const picks = ckpts
+        .filter((c) => resolvedSet.has(c.path))
+        .map((c) => ({ path: c.path, projectId: pid, versionId: vid }))
+      ;(props as MultiModeProps).onPick(picks, internalWeight)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isControlled, multiSelectedPaths, ckpts, loading, pid, vid, isLive])
 
   const currentVersion = versions.find((v) => v.id === vid)
 

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
@@ -89,6 +89,19 @@ export default function InlineLoraPicker(props: Props) {
 
   const [pid, setPid] = useState<number | null>(initialPid)
 
+  // 决策 #8（plan §9.2）：single 模式是受控的，pid 必须跟 props.value.projectId
+  // 同步 —— 否则历史回填 / URL ?lora= 流回新 LoraEntry 时，下拉框还卡在
+  // 旧值（之前靠父级 bump urlConsumedKey 强制 remount 兜底，Step 6 砍掉）。
+  // setPid 函数式更新 + 值未变跳过自动免无限循环。multi 模式无 props.value，
+  // 保留 mount-only 行为（用户在 picker 内自由切项目）。
+  // value=null 时不 sync（保留 fallback：未选 LoRA 时给用户看 projects[0] ckpts）
+  const singleValue = isSingle ? props.value : null
+  useEffect(() => {
+    if (!isSingle || singleValue == null) return
+    const next = singleValue.projectId
+    setPid((cur) => (cur === next ? cur : next))
+  }, [isSingle, singleValue])
+
   const versions = useMemo(() => {
     if (pid === null) return []
     return projectLoras
@@ -97,9 +110,17 @@ export default function InlineLoraPicker(props: Props) {
   }, [projectLoras, pid])
 
   const [vid, setVid] = useState<number | null>(initialVid)
+  // 同 pid：single 模式下 value 非 null 时 vid 跟 props.value.versionId 同步
+  useEffect(() => {
+    if (!isSingle || singleValue == null) return
+    const next = singleValue.versionId
+    setVid((cur) => (cur === next ? cur : next))
+  }, [isSingle, singleValue])
+  // versions 切换时如果当前 vid 不在新 versions 列表里，自动取第一个
+  // （用户切 project 下拉时触发）
   useEffect(() => {
     if (versions.length === 0) {
-      setVid(null)
+      setVid((cur) => (cur === null ? cur : null))
     } else if (!versions.some((v) => v.id === vid)) {
       setVid(versions[0].id)
     }

--- a/studio/web/src/pages/tools/generate/PreviewHistoryRail.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewHistoryRail.tsx
@@ -1,70 +1,45 @@
-/**
- * commit 16：右侧竖排图片历史栏（design image 1）。
+/** 右侧竖排图片历史栏。Step 4 重写：用 entryAdapter helper 不直接 switch source。
  *
- * - 按当前 mode 过滤显示（single/xy/compare 各一桶）
+ * - 按当前 mode 过滤显示（single / xy / compare）
  * - 64-72px 宽，垂直堆叠缩略图，溢出滚动
- * - XY/对比 entry 右下角带 badge（"XY 5×5" / "2×"）
- * - 点击 → onSelect(entry) 给父组件，由父组件决定如何"回看"
- *   （单图：拉原图覆盖主预览；XY/对比：弹封面缩略图 modal）
+ * - DiskEntry 用 server thumb URL（带 ETag + HTTP cache）；CacheEntry 直接
+ *   用 imageUrl + CSS 自缩（session 期间不多）
+ * - XY entry 右下角 badge ("XY 5×3"); single 无
+ * - 点击 → onSelect(entry) 给父组件
+ * - 顶部 [刷新] 按钮 → 调 refresh() 重拉 disk-history（多 tab 同步 / 外部改
+ *   studio_data 后用户主动同步）
  */
-import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { HistoryEntry, HistoryMode } from './useGenerateHistory'
+import { entryBadge, entryThumbUrl, type HistoryEntry } from './entryAdapter'
 
 interface Props {
   entries: HistoryEntry[]
-  mode: HistoryMode
+  mode: 'single' | 'xy' | 'compare'
   onSelect: (entry: HistoryEntry) => void
-  onClear?: () => void
-  /** 清理失效（server cache 已没的 entry） */
-  onPruneStale?: () => Promise<number>
+  onRefresh?: () => Promise<void>
+  loading?: boolean
 }
 
 export default function PreviewHistoryRail({
-  entries, mode, onSelect, onClear, onPruneStale,
+  entries, mode, onSelect, onRefresh, loading,
 }: Props) {
   const { t } = useTranslation()
   const list = entries.filter((e) => e.mode === mode)
-  const [pruning, setPruning] = useState(false)
-  const [pruneResult, setPruneResult] = useState<string | null>(null)
-
-  const handlePrune = async () => {
-    if (!onPruneStale || pruning) return
-    setPruning(true)
-    setPruneResult(null)
-    try {
-      const n = await onPruneStale()
-      setPruneResult(n > 0 ? t('generate.prunedCount', { n }) : t('generate.historyAllAlive'))
-      setTimeout(() => setPruneResult(null), 3000)
-    } finally {
-      setPruning(false)
-    }
-  }
 
   return (
     <div
       className="card flex flex-col gap-1 self-stretch"
       style={{ width: 80, padding: 8, overflowY: 'auto' }}
     >
-      {list.length > 0 && onClear && (
+      {onRefresh && (
         <button
           className="btn btn-ghost text-2xs"
           style={{ padding: '1px 4px' }}
-          onClick={onClear}
-          title={t('generate.clearCurrentHistoryTitle', { mode })}
+          onClick={() => void onRefresh()}
+          disabled={loading}
+          title={t('generate.refreshHistoryTitle')}
         >
-          {t('common.delete')}
-        </button>
-      )}
-      {list.length > 0 && onPruneStale && (
-        <button
-          className="btn btn-ghost text-2xs"
-          style={{ padding: '1px 4px' }}
-          onClick={() => void handlePrune()}
-          disabled={pruning}
-          title={t('generate.pruneStaleTitle')}
-        >
-          {pruning ? t('generate.checkingShort') : pruneResult ?? t('generate.pruneStale')}
+          {loading ? t('generate.checkingShort') : t('generate.refreshHistory')}
         </button>
       )}
       {list.length === 0 ? (
@@ -88,25 +63,25 @@ interface ItemProps {
 }
 
 function HistoryItem({ entry, onSelect }: ItemProps) {
+  const badge = entryBadge(entry)
   return (
     <div
       className="relative rounded-sm border border-subtle hover:border-strong cursor-pointer overflow-hidden"
-      // flexShrink:0：父容器是 flex-col，默认 shrink=1 会在历史满时把高度压扁（56xN，N<56），
-      //   破坏 1:1 长宽比 + 让 overflowY:auto 失效（永远没溢出）。
       style={{ width: 56, height: 56, flexShrink: 0 }}
       onClick={onSelect}
-      title={`#${entry.taskId} · ${new Date(entry.createdAt).toLocaleString()}`}
+      title={`${entry.source === 'disk' ? entry.filename : `#${entry.taskId}`} · ${new Date(entry.createdAt).toLocaleString()}`}
     >
       <img
-        src={entry.thumbnailDataUrl}
-        alt={`#${entry.taskId}`}
+        src={entryThumbUrl(entry)}
+        alt=""
         style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
+        loading="lazy"
       />
-      {entry.badge && (
+      {badge && (
         <span
           className="absolute bottom-0 right-0 bg-canvas/80 text-fg-primary text-[9px] px-1 rounded-tl"
         >
-          {entry.badge}
+          {badge}
         </span>
       )}
     </div>

--- a/studio/web/src/pages/tools/generate/PreviewHistoryRail.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewHistoryRail.tsx
@@ -10,7 +10,7 @@
  *   studio_data 后用户主动同步）
  */
 import { useTranslation } from 'react-i18next'
-import { entryBadge, entryThumbUrl, type HistoryEntry } from './entryAdapter'
+import { entryBadge, entryDisplayLabel, entryThumbUrl, type HistoryEntry } from './entryAdapter'
 
 interface Props {
   entries: HistoryEntry[]
@@ -69,7 +69,7 @@ function HistoryItem({ entry, onSelect }: ItemProps) {
       className="relative rounded-sm border border-subtle hover:border-strong cursor-pointer overflow-hidden"
       style={{ width: 56, height: 56, flexShrink: 0 }}
       onClick={onSelect}
-      title={`${entry.source === 'disk' ? entry.filename : `#${entry.taskId}`} · ${new Date(entry.createdAt).toLocaleString()}`}
+      title={`${entryDisplayLabel(entry)} · ${new Date(entry.createdAt).toLocaleString()}`}
     >
       <img
         src={entryThumbUrl(entry)}

--- a/studio/web/src/pages/tools/generate/PreviewXYGrid.test.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewXYGrid.test.tsx
@@ -1,11 +1,10 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import type { MonitorState } from '../../../api/client'
-import PreviewXYGrid from './PreviewXYGrid'
+import PreviewXYGrid, { type XYSample } from './PreviewXYGrid'
 import type { XYAxisDraft } from './xy'
 
-type Sample = NonNullable<MonitorState['samples']>[number]
+type Sample = XYSample
 
 const xDraft: XYAxisDraft = { axis: 'steps', raw: '20, 25, 30', loraIndex: null }
 const yDraft: XYAxisDraft = { axis: 'cfg_scale', raw: '3.0, 5.0', loraIndex: null }
@@ -134,5 +133,37 @@ describe('PreviewXYGrid', () => {
 
     await user.keyboard('{ArrowDown}')
     expect(screen.getByText(/步数=25 .* CFG Scale=5/)).toBeInTheDocument()
+  })
+
+  it('uses sample.imageUrl when provided (disk 回看路径)', () => {
+    const sample: Sample = {
+      ...makeSample(0, 0, 20, null),
+      imageUrl: '/api/generate/disk/image/2026-06-08/xy/xy%20plot%201/cell%20x0%20y0.png',
+    }
+    render(
+      <PreviewXYGrid samples={[sample]} taskId={-1} xDraft={xDraft} yDraft={null} />
+    )
+    const img = screen.getAllByRole('img')[0] as HTMLImageElement
+    expect(img.src).toContain('/api/generate/disk/image/2026-06-08/xy/')
+    expect(img.src).not.toContain('/sample/')  // 不走 generateSampleUrl 兜底
+  })
+
+  it('compositeUrl set → 导出 PNG 走 anchor download, 不调 composeXYMatrix', async () => {
+    // composeXYMatrix 需要 canvas + fetch，jsdom 都没 → 若 fallback 走它必然抛错。
+    // 这里点 export 按钮，断言能拿到 exportDownloaded 文案 = 走了 compositeUrl 直下载分支。
+    const user = userEvent.setup()
+    const samples = [makeSample(0, 0, 20, null)]
+    // 拦截 anchor click（避免真的下载窗口）
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {})
+    render(
+      <PreviewXYGrid
+        samples={samples} taskId={-1} xDraft={xDraft} yDraft={null}
+        compositeUrl="/api/generate/disk/image/2026-06-08/xy/xy%20plot%201/xy%20plot.png"
+      />
+    )
+    const exportBtn = screen.getByRole('button', { name: /导出 PNG|Export/ })
+    await user.click(exportBtn)
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    clickSpy.mockRestore()
   })
 })

--- a/studio/web/src/pages/tools/generate/PreviewXYGrid.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewXYGrid.tsx
@@ -1,9 +1,29 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, type MonitorState } from '../../../api/client'
+import { api } from '../../../api/client'
 import { exportXYMatrix } from './exportXY'
 import FullscreenViewer from './FullscreenViewer'
 import { axisLabel, formatAxisValue, type XYAxisDraft } from './xy'
+
+/** PreviewXYGrid 本地 sample 类型。
+ *
+ *  `MonitorState['samples']` 结构性可赋值过来（active task 路径，`xy` optional —
+ *  非 XY 模式 sample 也复用同一 streaming buffer）；
+ *  历史 disk 回看路径补 `imageUrl`（server 已 URL encode 好的 cell URL），
+ *  GridCell + FullscreenViewer 都优先 `imageUrl`，否则回退
+ *  `api.generateSampleUrl(taskId, filename)`。 */
+export interface XYSample {
+  path: string
+  step?: number
+  xy?: {
+    xi: number
+    yi: number
+    xv?: string | number
+    yv?: string | number | null
+  }
+  /** disk-served 时由 server 给；cache / active task 留空 */
+  imageUrl?: string
+}
 
 // zoom = 单 cell 物理宽度（px）。固定列宽 → 滚轮 zoom 视觉立即生效；
 // 列总宽 > 容器时横滚（已有 overflow:auto 兜底）。
@@ -28,13 +48,18 @@ function clamp(v: number, lo: number, hi: number): number {
  */
 export default function PreviewXYGrid({
   samples, taskId, xDraft, yDraft, onCellClick, selectedIndices,
+  compositeUrl,
 }: {
-  samples: NonNullable<MonitorState['samples']>
+  samples: XYSample[]
   taskId: number
   xDraft: XYAxisDraft
   yDraft: XYAxisDraft | null
   onCellClick?: (sampleIdx: number) => void
   selectedIndices?: number[]
+  /** disk 历史回看专用：传 composite 大图 URL → 导出 PNG 按钮直接 anchor download，
+   *  绕过 composeXYMatrix（disk entry 的 cache 早就没了，re-compose 会失败）。
+   *  active task 模式不传 → fallback 走 exportXYMatrix。 */
+  compositeUrl?: string
 }) {
   const { t } = useTranslation()
   const [cellW, setCellW] = useState(ZOOM_DEFAULT)
@@ -49,17 +74,29 @@ export default function PreviewXYGrid({
     setExporting(true)
     setExportMsg(null)
     try {
-      const exportSamples = samples
-        .filter((s): s is typeof s & { xy: NonNullable<typeof s.xy> } => s.xy != null)
-        .map((s) => ({ path: s.path, xy: { xi: s.xy.xi, yi: s.xy.yi } }))
-      await exportXYMatrix({
-        samples: exportSamples,
-        taskId,
-        xAxis: xDraft.axis,
-        yAxis: yDraft?.axis ?? null,
-        xValues,
-        yValues,
-      })
+      // disk 历史回看：composite 已在磁盘上，直接下载它（不调 composeXYMatrix
+      // —— per-cell URL 跨 task 拉 cache 会 404，且 server 端的 composite
+      // 已经是 pixel-equivalent 的成品）
+      if (compositeUrl) {
+        const a = document.createElement('a')
+        a.href = compositeUrl
+        a.download = `xy_matrix_${taskId}_${compositeUrl.split('/').pop() ?? 'plot.png'}`
+        document.body.appendChild(a)
+        a.click()
+        document.body.removeChild(a)
+      } else {
+        const exportSamples = samples
+          .filter((s): s is XYSample & { xy: NonNullable<XYSample['xy']> } => s.xy != null)
+          .map((s) => ({ path: s.path, xy: { xi: s.xy.xi, yi: s.xy.yi } }))
+        await exportXYMatrix({
+          samples: exportSamples,
+          taskId,
+          xAxis: xDraft.axis,
+          yAxis: yDraft?.axis ?? null,
+          xValues,
+          yValues,
+        })
+      }
       setExportMsg(t('generate.exportDownloaded'))
       setTimeout(() => setExportMsg(null), 3000)
     } catch (e) {
@@ -277,7 +314,7 @@ export default function PreviewXYGrid({
         }
         return (
           <FullscreenViewer
-            src={api.generateSampleUrl(taskId, fn)}
+            src={s.imageUrl ?? api.generateSampleUrl(taskId, fn)}
             alt={fn}
             caption={captionParts.join(' · ')}
             onClose={() => setFullscreenIdx(null)}
@@ -316,7 +353,7 @@ function Row({
   xDraft: XYAxisDraft
   yDraft: XYAxisDraft | null
   cellIndex: Map<string, number>
-  samples: NonNullable<MonitorState['samples']>
+  samples: XYSample[]
   taskId: number
   selSet: Set<number>
   onCellClick?: (sampleIdx: number) => void
@@ -349,6 +386,7 @@ function Row({
             key={`c-${yi}-${xi}`}
             taskId={taskId}
             filename={filename}
+            imageUrl={sample?.imageUrl}
             sampleIdx={idx ?? null}
             isSelected={isSel}
             tooltip={tooltip}
@@ -362,10 +400,12 @@ function Row({
 }
 
 function GridCell({
-  taskId, filename, sampleIdx, isSelected, tooltip, onClick, onDoubleClick,
+  taskId, filename, imageUrl, sampleIdx, isSelected, tooltip, onClick, onDoubleClick,
 }: {
   taskId: number
   filename: string | null
+  /** disk-served 时由 server 给的 URL；cache / active task 留空，回退 api.generateSampleUrl */
+  imageUrl?: string
   sampleIdx: number | null
   isSelected: boolean
   tooltip: string
@@ -375,14 +415,17 @@ function GridCell({
   const { t } = useTranslation()
   const [errored, setErrored] = useState(false)
 
-  // 切 task / filename 变（如点击历史回看）时 reset errored，让 img
+  // src 优先 imageUrl（disk 历史 server 给的 URL），否则 fallback 走 cache URL
+  const src = imageUrl ?? (filename ? api.generateSampleUrl(taskId, filename) : null)
+
+  // 切 task / src 变（如点击历史回看）时 reset errored，让 img
   // 重新尝试加载。否则上次 errored=true 残留，新 src 来了仍显示 "..."
   useEffect(() => {
     setErrored(false)
-  }, [taskId, filename])
+  }, [taskId, src])
 
   // 占位（无 sample / cache miss）：minHeight 撑高让 grid 行不塌缩
-  if (!filename || errored) {
+  if (!src || errored) {
     return (
       <div
         className="grid place-items-center rounded-sm border border-subtle bg-sunken text-fg-tertiary text-2xs"
@@ -406,13 +449,13 @@ function GridCell({
       title={tooltip}
       style={{ minHeight: 80 }}
     >
-      {/* key 加 taskId+filename 让 src 变化时 React 强制重挂载 img，避免
+      {/* key 加 src 让 src 变化时 React 强制重挂载 img，避免
           上次失败的浏览器缓存或 onError 状态残留 */}
       <img
-        key={`${taskId}-${filename}`}
-        src={api.generateSampleUrl(taskId, filename)}
+        key={src}
+        src={src}
         className="block w-full h-auto pointer-events-none"
-        alt={filename}
+        alt={filename ?? ''}
         loading="lazy"
         draggable={false}
         onError={() => setErrored(true)}

--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
@@ -63,6 +63,15 @@ export default function PromptFromDatasetPicker({
   // useLocalStorageState 默认值仅在 storage 无值时生效；有 value 时用它作初始的"浏览位置"
   const [pid, setPid] = useLocalStorageState<number | null>(LAST_PROJECT_KEY, value?.projectId ?? null)
   const [vid, setVid] = useLocalStorageState<number | null>(LAST_VERSION_KEY, value?.versionId ?? null)
+  // 历史回填：value 切到一个 (projectId, versionId) 时，浏览中的 pid/vid 跟随它
+  // —— 否则 caption 列表停留在用户上次浏览的版本，看不到当前 value.name 行高亮，
+  //    底部 tags 又孤零显示，对不上号。控件外的状态(localStorage)不持久这次切换，
+  //    只更新 in-memory state；用户关掉 picker 再开还会回到他们手选的位置。
+  useEffect(() => {
+    if (value == null) return
+    setPid((cur) => (cur === value.projectId ? cur : value.projectId))
+    setVid((cur) => (cur === value.versionId ? cur : value.versionId))
+  }, [value?.projectId, value?.versionId])  // eslint-disable-line react-hooks/exhaustive-deps
   const [versions, setVersions] = useState<Array<{ id: number; label: string }>>([])
   const [captions, setCaptions] = useState<CaptionEntry[]>([])
   const [loading, setLoading] = useState(false)

--- a/studio/web/src/pages/tools/generate/SidebarLoras.tsx
+++ b/studio/web/src/pages/tools/generate/SidebarLoras.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { LoraEntry } from '../../../api/client'
 import PathPicker from '../../../components/PathPicker'
 import InlineLoraPicker, { type PickedLora } from './InlineLoraPicker'
@@ -20,6 +21,7 @@ export default function SidebarLoras({
   onChange: (l: LoraEntry[]) => void
   projectLoras: ProjectLora[]
 }) {
+  const { t } = useTranslation()
   const [externalForIdx, setExternalForIdx] = useState<number | null>(null)
 
   // 已选 path（互相 disable，避免重复添加）—— 排除空槽
@@ -62,6 +64,24 @@ export default function SidebarLoras({
     <div className="flex flex-col gap-2">
       {loras.map((l, i) => {
         const hasCkpt = !!l.path
+        // 决策 #8 / plan §3：历史回填后 resolve 失败的 LoRA（path='' && name 保留）
+        // 渲染 ⚠ placeholder 卡片，提示用户重选；不要静默 path 空让用户困惑
+        if (!hasCkpt && l.name) {
+          return (
+            <PlaceholderLoraCard
+              key={`lora-${i}`}
+              name={l.name}
+              onPick={() => {
+                // 清掉 name 让 InlineLoraPicker 出来供用户重选
+                onChange(loras.map((lo, idx) => (
+                  idx === i ? { ...lo, name: null } : lo
+                )))
+              }}
+              onRemove={() => handleSlotRemove(i)}
+              t={t}
+            />
+          )
+        }
         return (
           <InlineLoraPicker
             // key 只用 index：避免 ckpt 切换 / 反选时整个 picker remount
@@ -104,6 +124,7 @@ export default function SidebarLoras({
         + 添加 LoRA
       </button>
 
+      {/* placeholder 卡片渲染：path='' && name 保留 */}
       {externalForIdx !== null && (
         <PathPicker
           dirOnly={false}
@@ -122,6 +143,77 @@ export default function SidebarLoras({
           onClose={() => setExternalForIdx(null)}
         />
       )}
+    </div>
+  )
+}
+
+/** 历史回填后 resolve 失败的 LoRA 槽渲染（决策 #8 / plan §3）。
+ *  样式跟 InlineLoraPicker 一致（card 风格 + border），但内容显示 ⚠ + name +
+ *  [重选] [移除]，不阻断 submit（path='' 会被过滤）。 */
+function PlaceholderLoraCard({
+  name, onPick, onRemove, t,
+}: {
+  name: string
+  onPick: () => void
+  onRemove: () => void
+  t: (key: string) => string
+}) {
+  return (
+    <div
+      className="flex items-center gap-2"
+      style={{
+        border: '1px solid var(--border-warn, var(--border-subtle))',
+        background: 'var(--bg-warn-soft, var(--bg-sunken))',
+        borderRadius: 'var(--r-md)',
+        padding: '8px 10px',
+        fontSize: 12,
+      }}
+    >
+      <span aria-hidden="true" style={{ flexShrink: 0 }}>⚠</span>
+      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+        <div className="font-mono truncate" style={{ fontSize: 11, color: 'var(--fg-secondary)' }}>
+          {name}
+        </div>
+        <div className="text-2xs text-fg-tertiary">{t('generate.loraNotFoundHint')}</div>
+      </div>
+      <button
+        type="button"
+        onClick={onPick}
+        className="font-mono"
+        style={{
+          border: '1px solid var(--border-subtle)',
+          background: 'var(--bg-elevated)',
+          borderRadius: 'var(--r-sm)',
+          padding: '3px 8px',
+          fontSize: 11,
+          color: 'var(--fg-secondary)',
+          cursor: 'pointer',
+          flexShrink: 0,
+        }}
+      >
+        {t('generate.repickLora')}
+      </button>
+      <button
+        type="button"
+        onClick={onRemove}
+        title={t('common.delete')}
+        aria-label={t('common.delete')}
+        style={{
+          width: 20, height: 20,
+          display: 'grid', placeItems: 'center',
+          borderRadius: 999,
+          border: 0,
+          background: 'transparent',
+          color: 'var(--fg-tertiary)',
+          cursor: 'pointer',
+          fontSize: 14,
+          lineHeight: 1,
+          padding: 0,
+          flexShrink: 0,
+        }}
+      >
+        ×
+      </button>
     </div>
   )
 }

--- a/studio/web/src/pages/tools/generate/SidebarXYAxes.tsx
+++ b/studio/web/src/pages/tools/generate/SidebarXYAxes.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import type { LoraEntry, XYAxisType } from '../../../api/client'
 import PathPicker from '../../../components/PathPicker'
 import InlineLoraPicker from './InlineLoraPicker'
@@ -72,6 +72,14 @@ function AxisLoraCkptPicker({
   const matched = bound ? projectLoras.find((p) => p.versionId === bound.version_id) : null
   const pickedCount = draft.raw.trim() ? draft.raw.split(',').filter((s) => s.trim()).length : 0
 
+  // 受控同步给 InlineLoraPicker：raw 字符串当 path/basename 列表喂过去 + 锚定
+  // 到 bound LoRA 的 (pid, vid)，让历史回填 picker chip 高亮、basename → 全 path
+  // 自动 upgrade。
+  const selectedPaths = useMemo(
+    () => draft.raw.split(',').map((s) => s.trim()).filter(Boolean),
+    [draft.raw],
+  )
+
   return (
     <div className="flex flex-col gap-1.5">
       {bound && pickedCount > 0 && (
@@ -97,6 +105,9 @@ function AxisLoraCkptPicker({
         projectLoras={projectLoras}
         existingPaths={new Set()}
         showWeight={false}
+        selectedPaths={selectedPaths}
+        initialPid={bound?.project_id ?? null}
+        initialVid={bound?.version_id ?? null}
         onPick={commitPicks}
         onClose={() => { /* 常驻在 axis card 里，nothing to close */ }}
         onPickExternal={() => setExternalOpen(true)}

--- a/studio/web/src/pages/tools/generate/entryAdapter.ts
+++ b/studio/web/src/pages/tools/generate/entryAdapter.ts
@@ -1,0 +1,142 @@
+/** 历史 entry source adapter（plan 决策 #12）。
+ *
+ * 所有"按 entry.source 分支"的逻辑收敛到这一个文件 —— UI / handler / hook 全
+ * 部走这里的 helper，**不直接 switch entry.source**。
+ *
+ * 未来加第三种 source（'upload' / 'remote'）只改这个文件，消费端零改动。
+ *
+ * 为什么用 function helper 不用 object method（`entry.imageUrl()`）：
+ * - entry 要序列化进 sessionStorage（撤销 snapshot）+ 跨 hook 传递；object method
+ *   不能 serialize
+ * - function helper 跟 React/TS 风格更一致
+ * - 测试时 mock helper 比 mock class method 干净
+ */
+import { api } from '../../../api/client'
+import type { GenerateParamsSnapshot } from './paramsSnapshot'
+
+/** XY 历史回看的 axis 元数据（仅 CacheEntry 重建 PreviewXYGrid 用；
+ *  DiskEntry 是合成大图，不需要 per-cell 信息走网格视图） */
+export interface HistoryXYMeta {
+  xAxis: string
+  yAxis: string | null
+  xValues: string[]
+  yValues: Array<string | null>
+  samples: Array<{
+    path: string
+    xy: { xi: number; yi: number; xv: string | number; yv: string | number | null }
+  }>
+}
+
+/** 持久 entry：磁盘上的 PNG，server disk-history 接口返回的纯派生数据。 */
+export interface DiskEntry {
+  source: 'disk'
+  /** server 返回的稳定 id：'disk:<sha1-12>'（决策 #12，避免文件名带空格塞进 React key） */
+  id: string
+  mode: 'single' | 'xy'
+  /** YYYY-MM-DD，对应文件夹 */
+  date: string
+  /** 文件名（含扩展名）；URL 已编码版在 imageUrl/thumbUrl 里 */
+  filename: string
+  /** 大图 URL，可直接 <img src=...> 用（server 端已 URL encode） */
+  imageUrl: string
+  /** 缩略图 URL，server 在线缩 + ETag */
+  thumbUrl: string
+  /** PNG mtime * 1000 */
+  createdAt: number
+  /** 从 PNG anima_params 解出来的参数快照 */
+  params: GenerateParamsSnapshot
+}
+
+/** 临时 entry：仅在 server 内存 cache 中存活，session 期间使用。
+ *  关 tab / server 重启 / LRU 剔除即丢。 */
+export interface CacheEntry {
+  source: 'cache'
+  id: string  // uuid
+  mode: 'single' | 'xy'
+  /** daemon task id，cache URL 构造用 */
+  taskId: number
+  createdAt: number
+  /** server cache 里的文件名列表（XY 是 per-cell N 张；single 是 1 张） */
+  filenames: string[]
+  /** 出图当时构造的参数快照（不从 cache 读） */
+  params: GenerateParamsSnapshot
+  /** XY 模式的 axis + per-cell 元数据，重建 PreviewXYGrid 用 */
+  xyMeta?: HistoryXYMeta
+}
+
+export type HistoryEntry = DiskEntry | CacheEntry
+
+// ---------------------------------------------------------------------------
+// 按 source 切的 helper —— **唯一**允许 switch entry.source 的地方
+// ---------------------------------------------------------------------------
+
+/** entry 对应位置 idx 的大图 URL。 */
+export function entryImageUrl(e: HistoryEntry, idx = 0): string {
+  switch (e.source) {
+    case 'disk':
+      return e.imageUrl  // server 已 encode
+    case 'cache': {
+      const fn = e.filenames[idx] ?? e.filenames[0] ?? ''
+      return api.generateSampleUrl(e.taskId, fn)
+    }
+  }
+}
+
+/** entry 缩略图 URL（小图栏用）。 */
+export function entryThumbUrl(e: HistoryEntry): string {
+  switch (e.source) {
+    case 'disk':
+      return e.thumbUrl
+    case 'cache':
+      // CacheEntry 不做服务端缩略图 —— 直接用大图 URL + CSS 缩放
+      // (session 期间出图不多，浏览器加载几张原图可接受；不要为这种短期 entry
+      // 加 IDB / 服务端 thumb 复杂度)
+      return entryImageUrl(e, 0)
+  }
+}
+
+/** entry 携带的 params snapshot（用于历史点击回填）。 */
+export function entryParams(e: HistoryEntry): GenerateParamsSnapshot {
+  return e.params  // 两个 source 字段名一致
+}
+
+/** entry 显示标签（PreviewHistoryRail / badges 文案）。 */
+export function entryDisplayLabel(e: HistoryEntry): string {
+  switch (e.source) {
+    case 'disk':
+      return e.filename.replace(/\.png$/i, '')
+    case 'cache':
+      return `#${e.taskId}`
+  }
+}
+
+/** XY 历史栏 entry 的 badge（"XY 5×3"）。 */
+export function entryBadge(e: HistoryEntry): string | undefined {
+  if (e.mode !== 'xy') return undefined
+  if (e.source === 'cache' && e.xyMeta) {
+    const xs = new Set(e.xyMeta.samples.map((s) => s.xy.xi))
+    const ys = new Set(e.xyMeta.samples.map((s) => s.xy.yi))
+    return `XY ${xs.size}×${ys.size || 1}`
+  }
+  if (e.source === 'disk' && e.params.xy_draft) {
+    const xLen = e.params.xy_draft.x.raw.split(',').filter((s) => s.trim()).length
+    const yLen = e.params.xy_draft.y?.raw.split(',').filter((s) => s.trim()).length ?? 1
+    return `XY ${xLen}×${yLen}`
+  }
+  return 'XY'
+}
+
+/** 删除 entry：DiskEntry 走 DELETE endpoint；CacheEntry 仅本地 splice（无 server 删）。
+ *  返回 server 端是否真删了文件（CacheEntry 永远 false）。 */
+export async function entryDelete(e: HistoryEntry): Promise<{ removed: boolean }> {
+  if (e.source !== 'disk') return { removed: false }
+  // server 端 URL 是 /api/generate/disk/image/<date>/<mode>/<encoded>，
+  // DELETE 走 /api/generate/disk/<date>/<mode>/<encoded>（少一层 image/）
+  // 复用 imageUrl 末段的 encoded filename
+  const encoded = e.imageUrl.slice(e.imageUrl.lastIndexOf('/') + 1)
+  const url = `/api/generate/disk/${e.date}/${e.mode}/${encoded}`
+  const r = await fetch(url, { method: 'DELETE' })
+  if (!r.ok) throw new Error(`delete failed: ${r.status}`)
+  const data = await r.json() as { ok: boolean; noop?: boolean }
+  return { removed: !data.noop }
+}

--- a/studio/web/src/pages/tools/generate/entryAdapter.ts
+++ b/studio/web/src/pages/tools/generate/entryAdapter.ts
@@ -14,8 +14,12 @@
 import { api } from '../../../api/client'
 import type { GenerateParamsSnapshot } from './paramsSnapshot'
 
-/** XY 历史回看的 axis 元数据（仅 CacheEntry 重建 PreviewXYGrid 用；
- *  DiskEntry 是合成大图，不需要 per-cell 信息走网格视图） */
+/** XY 历史回看的 axis 元数据（CacheEntry + DiskEntry 共用 —— PreviewXYGrid 重建用）。
+ *
+ *  - CacheEntry: samples[].path 是 cache 文件名；imageUrl 留空，PreviewXYGrid
+ *    fallback 走 `api.generateSampleUrl(taskId, filename)`
+ *  - DiskEntry: server 已 encode 好 imageUrl（`/api/generate/disk/image/<date>/xy/<folder>/<cell>`），
+ *    PreviewXYGrid 直接吃 */
 export interface HistoryXYMeta {
   xAxis: string
   yAxis: string | null
@@ -24,10 +28,17 @@ export interface HistoryXYMeta {
   samples: Array<{
     path: string
     xy: { xi: number; yi: number; xv: string | number; yv: string | number | null }
+    /** disk-served 时 server 端已 URL-encode 好；cache 时 undefined → 回退 api.generateSampleUrl */
+    imageUrl?: string
   }>
 }
 
-/** 持久 entry：磁盘上的 PNG，server disk-history 接口返回的纯派生数据。 */
+/** 持久 entry：磁盘上的 PNG / 文件夹，server disk-history 接口返回的纯派生数据。
+ *
+ * single：一张 PNG（filename + imageUrl 指向它）
+ * xy：一个 `xy plot N/` 文件夹（folder + imageUrl 指向 composite，
+ *     xyMeta.samples 是每 cell 信息 + 直读 URL）。
+ */
 export interface DiskEntry {
   source: 'disk'
   /** server 返回的稳定 id：'disk:<sha1-12>'（决策 #12，避免文件名带空格塞进 React key） */
@@ -35,16 +46,20 @@ export interface DiskEntry {
   mode: 'single' | 'xy'
   /** YYYY-MM-DD，对应文件夹 */
   date: string
-  /** 文件名（含扩展名）；URL 已编码版在 imageUrl/thumbUrl 里 */
-  filename: string
-  /** 大图 URL，可直接 <img src=...> 用（server 端已 URL encode） */
+  /** single：PNG 文件名（含扩展名）；xy：undefined（用 folder） */
+  filename?: string
+  /** xy：文件夹名 `xy plot <N>`；single：undefined */
+  folder?: string
+  /** 大图 URL，可直接 <img src=...> 用（server 端已 URL encode）。xy 模式指向 composite。 */
   imageUrl: string
   /** 缩略图 URL，server 在线缩 + ETag */
   thumbUrl: string
-  /** PNG mtime * 1000 */
+  /** PNG / composite mtime */
   createdAt: number
-  /** 从 PNG anima_params 解出来的参数快照 */
+  /** 从 PNG anima_params 解出来的参数快照（xy 模式是 composite 的 XY snapshot） */
   params: GenerateParamsSnapshot
+  /** xy 模式 per-cell 元数据（PreviewXYGrid 重建用）；single 模式 undefined */
+  xyMeta?: HistoryXYMeta
 }
 
 /** 临时 entry：仅在 server 内存 cache 中存活，session 期间使用。
@@ -104,7 +119,9 @@ export function entryParams(e: HistoryEntry): GenerateParamsSnapshot {
 export function entryDisplayLabel(e: HistoryEntry): string {
   switch (e.source) {
     case 'disk':
-      return e.filename.replace(/\.png$/i, '')
+      // xy 用 folder ("xy plot 3")；single 用 filename 去 .png 后缀
+      if (e.mode === 'xy' && e.folder) return e.folder
+      return (e.filename ?? '').replace(/\.png$/i, '')
     case 'cache':
       return `#${e.taskId}`
   }
@@ -126,15 +143,21 @@ export function entryBadge(e: HistoryEntry): string | undefined {
   return 'XY'
 }
 
-/** 删除 entry：DiskEntry 走 DELETE endpoint；CacheEntry 仅本地 splice（无 server 删）。
- *  返回 server 端是否真删了文件（CacheEntry 永远 false）。 */
+/** 删除 entry：
+ *  - DiskEntry single：单文件 DELETE `/api/generate/disk/<date>/single/<encoded>`
+ *  - DiskEntry xy：整文件夹 DELETE `/api/generate/disk/<date>/xy/<encoded folder>`
+ *  - CacheEntry：仅本地 splice（无 server 删）
+ *  返回 server 端是否真删了（CacheEntry 永远 false）。 */
 export async function entryDelete(e: HistoryEntry): Promise<{ removed: boolean }> {
   if (e.source !== 'disk') return { removed: false }
-  // server 端 URL 是 /api/generate/disk/image/<date>/<mode>/<encoded>，
-  // DELETE 走 /api/generate/disk/<date>/<mode>/<encoded>（少一层 image/）
-  // 复用 imageUrl 末段的 encoded filename
-  const encoded = e.imageUrl.slice(e.imageUrl.lastIndexOf('/') + 1)
-  const url = `/api/generate/disk/${e.date}/${e.mode}/${encoded}`
+  let url: string
+  if (e.mode === 'xy') {
+    if (!e.folder) throw new Error('xy disk entry missing folder')
+    url = `/api/generate/disk/${e.date}/xy/${encodeURIComponent(e.folder)}`
+  } else {
+    if (!e.filename) throw new Error('single disk entry missing filename')
+    url = `/api/generate/disk/${e.date}/single/${encodeURIComponent(e.filename)}`
+  }
   const r = await fetch(url, { method: 'DELETE' })
   if (!r.ok) throw new Error(`delete failed: ${r.status}`)
   const data = await r.json() as { ok: boolean; noop?: boolean }

--- a/studio/web/src/pages/tools/generate/paramsSnapshot.test.ts
+++ b/studio/web/src/pages/tools/generate/paramsSnapshot.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import {
-  applySnapshot, loraBasename, resolveSnapshotLora, transformAxisRawForSnapshot,
+  applySnapshot, buildCellSnapshot, loraBasename, resolveSnapshotLora, transformAxisRawForSnapshot,
   type GenerateParamsSnapshot, type SnapshotLora,
 } from './paramsSnapshot'
 import type { ProjectLora } from './types'
@@ -152,6 +152,55 @@ describe('applySnapshot', () => {
     expect(r.yDraft?.axis).toBe('steps')
   })
 
+  it('dataset_pick fallback：project 在 projectLoras 还在 → datasetPick 保留', () => {
+    const snap = snapshot({
+      dataset_pick: {
+        projectId: 1, versionId: 11,
+        name: '0001.txt', tags: ['tag-a', 'tag-b'],
+      },
+    })
+    const r = applySnapshot(snap, projects)
+    expect(r.datasetPick?.projectId).toBe(1)
+    expect(r.prompts).toEqual(['1girl'])  // 没污染 prompts
+  })
+
+  it('dataset_pick fallback：project 在 projectLoras 找不到 → tags 拼进第一条 prompt + datasetPick=null', () => {
+    const snap = snapshot({
+      prompts: ['base prompt'],
+      dataset_pick: {
+        projectId: 999, versionId: 88,  // 不在 projects 列表里
+        name: '0001.txt', tags: ['fall-tag-1', 'fall-tag-2'],
+      },
+    })
+    const r = applySnapshot(snap, projects)
+    expect(r.datasetPick).toBeNull()
+    expect(r.prompts[0]).toBe('base prompt, fall-tag-1, fall-tag-2')
+  })
+
+  it('dataset_pick fallback：第一条 prompt 空 → 直接是 tags 串', () => {
+    const snap = snapshot({
+      prompts: [''],
+      dataset_pick: {
+        projectId: 999, versionId: 88,
+        name: '0001.txt', tags: ['x', 'y'],
+      },
+    })
+    const r = applySnapshot(snap, projects)
+    expect(r.prompts[0]).toBe('x, y')
+  })
+
+  it('dataset_pick fallback：tags 已在第一条末尾 → 不重复追加（防双击同一历史 entry）', () => {
+    const snap = snapshot({
+      prompts: ['base, x, y'],
+      dataset_pick: {
+        projectId: 999, versionId: 88,
+        name: '0001.txt', tags: ['x', 'y'],
+      },
+    })
+    const r = applySnapshot(snap, projects)
+    expect(r.prompts[0]).toBe('base, x, y')
+  })
+
   it('未 resolve 的 LoRA → unresolvedLoraCount > 0', () => {
     const snap = snapshot({
       loras: [
@@ -165,5 +214,80 @@ describe('applySnapshot', () => {
     expect(r.loras[0].path).toBe('')
     expect(r.loras[1].path).toBe('/loras/cute_chibi/v3.safetensors')
     expect(r.loras[2].path).toBe('')
+  })
+})
+
+describe('buildCellSnapshot', () => {
+  const baseXy = snapshot({
+    mode: 'xy',
+    steps: 20,
+    cfg_scale: 5,
+    loras: [{ name: 'a.safetensors', scale: 0.5 }, { name: 'b.safetensors', scale: 0.7 }],
+  })
+
+  it('steps axis: 顶层 steps 覆盖；mode → single；xy_draft → null；xy_origin 记位置', () => {
+    const cell = buildCellSnapshot(baseXy, { xi: 2, yi: 0 }, {
+      x: { axis: 'steps', loraIndex: null, value: 30 },
+      y: null,
+    })
+    expect(cell.mode).toBe('single')
+    expect(cell.steps).toBe(30)
+    expect(cell.cfg_scale).toBe(5)  // 未被轴改
+    expect(cell.xy_draft).toBeNull()
+    expect(cell.xy_origin).toEqual({
+      xi: 2, yi: 0, xv: 30, yv: null, x_axis: 'steps', y_axis: null,
+    })
+  })
+
+  it('cfg_scale axis: 顶层 cfg_scale 覆盖（字符串 input 也接受）', () => {
+    const cell = buildCellSnapshot(baseXy, { xi: 1, yi: 0 }, {
+      x: { axis: 'cfg_scale', loraIndex: null, value: '7.5' },
+      y: null,
+    })
+    expect(cell.cfg_scale).toBe(7.5)
+    expect(cell.steps).toBe(20)
+  })
+
+  it('lora_scale axis: 全 LoRA 共用 cell value（不按 loraIndex 单独改）', () => {
+    const cell = buildCellSnapshot(baseXy, { xi: 0, yi: 0 }, {
+      x: { axis: 'lora_scale', loraIndex: null, value: 0.9 },
+      y: null,
+    })
+    expect(cell.loras).toEqual([
+      { name: 'a.safetensors', scale: 0.9 },
+      { name: 'b.safetensors', scale: 0.9 },
+    ])
+  })
+
+  it('lora_ckpt axis: 仅指定 loraIndex 的 name 改成 basename，原 ids 失效', () => {
+    const cell = buildCellSnapshot(baseXy, { xi: 1, yi: 0 }, {
+      x: { axis: 'lora_ckpt', loraIndex: 0, value: '/some/path/new.safetensors' },
+      y: null,
+    })
+    expect(cell.loras[0]).toEqual({
+      name: 'new.safetensors', scale: 0.5, project_id: null, version_id: null,
+    })
+    // loras[1] 不动
+    expect(cell.loras[1].name).toBe('b.safetensors')
+  })
+
+  it('2D: x + y 双轴都物化', () => {
+    const cell = buildCellSnapshot(baseXy, { xi: 1, yi: 2 }, {
+      x: { axis: 'steps', loraIndex: null, value: 25 },
+      y: { axis: 'cfg_scale', loraIndex: null, value: 8.0 },
+    })
+    expect(cell.steps).toBe(25)
+    expect(cell.cfg_scale).toBe(8.0)
+    expect(cell.xy_origin?.yi).toBe(2)
+    expect(cell.xy_origin?.y_axis).toBe('cfg_scale')
+  })
+
+  it('不污染原 XY snapshot（loras 是深复制）', () => {
+    const before = JSON.parse(JSON.stringify(baseXy.loras))
+    buildCellSnapshot(baseXy, { xi: 0, yi: 0 }, {
+      x: { axis: 'lora_scale', loraIndex: null, value: 0.1 },
+      y: null,
+    })
+    expect(baseXy.loras).toEqual(before)
   })
 })

--- a/studio/web/src/pages/tools/generate/paramsSnapshot.test.ts
+++ b/studio/web/src/pages/tools/generate/paramsSnapshot.test.ts
@@ -1,0 +1,169 @@
+/** paramsSnapshot 单测：applySnapshot reducer + resolveSnapshotLora 三层 fallback。
+ *
+ * 决策 #8（单一应用快照入口） / plan §3 LoRA placeholder 兜底。
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  applySnapshot, loraBasename, resolveSnapshotLora, transformAxisRawForSnapshot,
+  type GenerateParamsSnapshot, type SnapshotLora,
+} from './paramsSnapshot'
+import type { ProjectLora } from './types'
+import type { XYAxisDraft } from './xy'
+
+const projects: ProjectLora[] = [
+  {
+    projectId: 1, projectTitle: 'cute_chibi',
+    versionId: 11, versionLabel: 'v3', status: 'training',
+    path: '/loras/cute_chibi/v3.safetensors', createdAt: 100,
+  },
+  {
+    projectId: 2, projectTitle: 'noir',
+    versionId: 21, versionLabel: 'v1', status: 'completed',
+    path: '/loras/noir/v1.safetensors', createdAt: 200,
+  },
+]
+
+function snapshot(overrides: Partial<GenerateParamsSnapshot> = {}): GenerateParamsSnapshot {
+  return {
+    schema_version: 1,
+    mode: 'single',
+    prompts: ['1girl'],
+    negative_prompt: 'blurry',
+    width: 1024,
+    height: 768,
+    steps: 20,
+    cfg_scale: 7,
+    count: 1,
+    seed: 42,
+    loras: [],
+    xy_draft: null,
+    dataset_pick: null,
+    ...overrides,
+  }
+}
+
+describe('loraBasename', () => {
+  it('strips POSIX path', () => {
+    expect(loraBasename('/a/b/c/my.safetensors')).toBe('my.safetensors')
+  })
+  it('strips Windows path', () => {
+    expect(loraBasename('G:\\a\\b\\my.safetensors')).toBe('my.safetensors')
+  })
+  it('no separator → return whole', () => {
+    expect(loraBasename('only.safetensors')).toBe('only.safetensors')
+  })
+})
+
+describe('transformAxisRawForSnapshot', () => {
+  it('lora_ckpt: raw paths → basename list', () => {
+    const draft: XYAxisDraft = {
+      axis: 'lora_ckpt',
+      raw: '/a/b/step_1000.safetensors, /a/b/step_2000.safetensors',
+      loraIndex: 0,
+    }
+    expect(transformAxisRawForSnapshot(draft).raw).toBe('step_1000.safetensors, step_2000.safetensors')
+  })
+  it('non lora_ckpt axes: raw 原样', () => {
+    const draft: XYAxisDraft = { axis: 'steps', raw: '10, 20, 30', loraIndex: null }
+    expect(transformAxisRawForSnapshot(draft).raw).toBe('10, 20, 30')
+  })
+})
+
+describe('resolveSnapshotLora — 三层 fallback', () => {
+  it('1. ids 命中 → 返 projectLoras path + 保留 snapshot 的 scale/ids', () => {
+    const snap: SnapshotLora = {
+      name: 'cute_chibi.safetensors', scale: 0.8,
+      project_id: 1, version_id: 11,
+    }
+    const r = resolveSnapshotLora(snap, projects)
+    expect(r.path).toBe('/loras/cute_chibi/v3.safetensors')
+    expect(r.scale).toBe(0.8)
+    expect(r.project_id).toBe(1)
+    expect(r.version_id).toBe(11)
+  })
+
+  it('2. ids 未命中但 basename 匹配 → 用 projectLoras 的 ids/path', () => {
+    const snap: SnapshotLora = {
+      name: 'v3.safetensors', scale: 1.0,
+      project_id: 999, version_id: 999,  // 不存在
+    }
+    const r = resolveSnapshotLora(snap, projects)
+    expect(r.path).toBe('/loras/cute_chibi/v3.safetensors')
+    expect(r.project_id).toBe(1)  // 用了 projectLoras 的，不是 snapshot 的 999
+    expect(r.version_id).toBe(11)
+  })
+
+  it('3. 都不命中 → placeholder：path 空 + name 保留 + 原 ids', () => {
+    const snap: SnapshotLora = {
+      name: 'gone.safetensors', scale: 0.5,
+      project_id: 999, version_id: 999,
+    }
+    const r = resolveSnapshotLora(snap, projects)
+    expect(r.path).toBe('')
+    expect(r.name).toBe('gone.safetensors')  // ← placeholder UI 渲染会读这个字段
+    expect(r.project_id).toBe(999)
+    expect(r.version_id).toBe(999)
+    expect(r.scale).toBe(0.5)
+  })
+
+  it('snapshot 无 ids 时按 name 兜底', () => {
+    const snap: SnapshotLora = {
+      name: 'v3.safetensors', scale: 1.0,
+    }
+    const r = resolveSnapshotLora(snap, projects)
+    expect(r.path).toBe('/loras/cute_chibi/v3.safetensors')
+  })
+})
+
+describe('applySnapshot', () => {
+  it('single 模式：所有字段灌入 + loras 替换 singleLoras', () => {
+    const snap = snapshot({
+      mode: 'single',
+      seed: 42,
+      loras: [{ name: 'v3.safetensors', scale: 0.7, project_id: 1, version_id: 11 }],
+    })
+    const r = applySnapshot(snap, projects)
+    expect(r.mode).toBe('single')
+    expect(r.seed).toBe(42)
+    expect(r.loras).toHaveLength(1)
+    expect(r.loras[0].path).toBe('/loras/cute_chibi/v3.safetensors')
+    expect(r.unresolvedLoraCount).toBe(0)
+    expect(r.xDraft).toBeUndefined()  // single 不灌 xDraft
+    expect(r.yDraft).toBeUndefined()
+  })
+
+  it('compare 模式映射到 xy（子视图无 selectedIndices 不能直接进）', () => {
+    const snap = snapshot({ mode: 'compare' })
+    expect(applySnapshot(snap, projects).mode).toBe('xy')
+  })
+
+  it('xy 模式：xDraft + yDraft 灌入', () => {
+    const snap = snapshot({
+      mode: 'xy',
+      xy_draft: {
+        x: { axis: 'cfg_scale', raw: '4, 5, 6', loraIndex: null },
+        y: { axis: 'steps', raw: '10, 20', loraIndex: null },
+      },
+    })
+    const r = applySnapshot(snap, projects)
+    expect(r.mode).toBe('xy')
+    expect(r.xDraft?.axis).toBe('cfg_scale')
+    expect(r.xDraft?.raw).toBe('4, 5, 6')
+    expect(r.yDraft?.axis).toBe('steps')
+  })
+
+  it('未 resolve 的 LoRA → unresolvedLoraCount > 0', () => {
+    const snap = snapshot({
+      loras: [
+        { name: 'gone1.safetensors', scale: 1, project_id: 99, version_id: 99 },
+        { name: 'v3.safetensors', scale: 1, project_id: 1, version_id: 11 },
+        { name: 'gone2.safetensors', scale: 1, project_id: 88, version_id: 88 },
+      ],
+    })
+    const r = applySnapshot(snap, projects)
+    expect(r.unresolvedLoraCount).toBe(2)
+    expect(r.loras[0].path).toBe('')
+    expect(r.loras[1].path).toBe('/loras/cute_chibi/v3.safetensors')
+    expect(r.loras[2].path).toBe('')
+  })
+})

--- a/studio/web/src/pages/tools/generate/paramsSnapshot.ts
+++ b/studio/web/src/pages/tools/generate/paramsSnapshot.ts
@@ -108,3 +108,58 @@ export function resolveSnapshotLora(
     project_id: snap.project_id ?? null, version_id: snap.version_id ?? null,
   }
 }
+
+/** applySnapshot 输出（决策 #8 / Arch v2 Step 3）：把 snapshot 转成"prefs 字段补丁"。
+ *
+ * 不直接 import GeneratePrefs（避免循环依赖）；调用方接到这个 shape 自己 spread
+ * 进 setPrefs。所有"应用快照"路径（历史回填 / URL ?lora= / Stepper 跳 / 入库回写）
+ * 统一走这一个函数 —— 单一入口杜绝散落分支 + 每加一个调用点漏一个字段的 bug。
+ */
+export interface AppliedSnapshot {
+  mode: 'single' | 'xy'  // compare 视图回填映射到 xy
+  prompts: string[]
+  negPrompt: string
+  width: number
+  height: number
+  steps: number
+  cfgScale: number
+  count: number
+  seed: number
+  datasetPick: DatasetPick | null
+  /** 按 mode 二选一灌入 prefs.singleLoras / prefs.xyLoras */
+  loras: LoraEntry[]
+  /** 仅 xy 模式回填；single 时为 undefined（不动 prev.xDraft/yDraft） */
+  xDraft?: SnapshotXYAxis
+  yDraft?: SnapshotXYAxis | null
+  /** resolve 失败的 LoRA 数量（>0 时调用方应 toast 提示重选） */
+  unresolvedLoraCount: number
+}
+
+export function applySnapshot(
+  snap: GenerateParamsSnapshot,
+  projectLoras: ProjectLora[],
+): AppliedSnapshot {
+  const resolved = snap.loras.map((l) => resolveSnapshotLora(l, projectLoras))
+  const unresolved = resolved.filter((l) => !l.path).length
+  // compare 视图回填到 xy（compare 是 xy 子视图，无 selectedIndices 不直接进）
+  const mode: 'single' | 'xy' = snap.mode === 'single' ? 'single' : 'xy'
+  const applied: AppliedSnapshot = {
+    mode,
+    prompts: snap.prompts,
+    negPrompt: snap.negative_prompt,
+    width: snap.width,
+    height: snap.height,
+    steps: snap.steps,
+    cfgScale: snap.cfg_scale,
+    count: snap.count,
+    seed: snap.seed,
+    datasetPick: snap.dataset_pick ?? null,
+    loras: resolved,
+    unresolvedLoraCount: unresolved,
+  }
+  if (mode === 'xy' && snap.xy_draft) {
+    applied.xDraft = snap.xy_draft.x
+    applied.yDraft = snap.xy_draft.y
+  }
+  return applied
+}

--- a/studio/web/src/pages/tools/generate/paramsSnapshot.ts
+++ b/studio/web/src/pages/tools/generate/paramsSnapshot.ts
@@ -38,6 +38,17 @@ export interface SnapshotXYAxis {
   loraIndex: number | null
 }
 
+/** 仅 XY cell PNG 用：链回所属 XY plot 的位置（拖进 Comfy / A1111 时
+ *  能识别"这是 XY 第 (xi,yi) 格"；本程序回填走 mode='single' 主路径不读它）。 */
+export interface XYCellOrigin {
+  xi: number
+  yi: number
+  xv: string | number
+  yv: string | number | null
+  x_axis: XYAxisType
+  y_axis: XYAxisType | null
+}
+
 export interface GenerateParamsSnapshot {
   schema_version: number
   /** 当时的 mode；回填时按 mode 决定灌 singleLoras 还是 xyLoras + xDraft/yDraft */
@@ -59,6 +70,9 @@ export interface GenerateParamsSnapshot {
   /** 训练集 caption picker 选择（保留 picker UI 上下文）。
    *  name 是相对路径（如 "5_concept/0001.txt"），不含本地绝对路径。 */
   dataset_pick?: DatasetPick | null
+  /** XY cell PNG 专有；composite / single PNG 永远是 undefined。
+   *  forward-compat 字段，老代码读不到不影响 v2 migrate 透传。 */
+  xy_origin?: XYCellOrigin | null
 }
 
 /** path → basename（去目录），保留 .safetensors 等后缀。
@@ -137,6 +151,27 @@ export interface AppliedSnapshot {
   unresolvedLoraCount: number
 }
 
+/** dataset_pick 的 project 是否还在当前机器上能 resolve（heuristic：projectLoras
+ *  里有任何这个 projectId 的条目就算"活着"）。用作 applySnapshot 决定是 picker
+ *  受控回填还是 fallback 到正向 prompt 的判据。 */
+function isDatasetProjectAlive(
+  pick: DatasetPick, projectLoras: ProjectLora[],
+): boolean {
+  return projectLoras.some((p) => p.projectId === pick.projectId)
+}
+
+/** dataset_pick 失败兜底：把 tags 追加到第一条 prompt 末尾。
+ *  和 handleGenerate 里 `datasetSuffix` 拼法保持一致（join(', ')），避免视觉差异。 */
+function mergeTagsIntoFirstPrompt(prompts: string[], tags: string[]): string[] {
+  if (tags.length === 0) return prompts
+  const suffix = tags.join(', ')
+  const first = (prompts[0] ?? '').trimEnd()
+  // 已经以 tags 结尾（用户在前一次回填后又点了一次同 entry）→ 不重复追加
+  if (first.endsWith(suffix)) return prompts
+  const sep = first === '' ? '' : (first.endsWith(',') ? ' ' : ', ')
+  return [`${first}${sep}${suffix}`, ...prompts.slice(1)]
+}
+
 export function applySnapshot(
   snap: GenerateParamsSnapshot,
   projectLoras: ProjectLora[],
@@ -145,9 +180,21 @@ export function applySnapshot(
   const unresolved = resolved.filter((l) => !l.path).length
   // compare 视图回填到 xy（compare 是 xy 子视图，无 selectedIndices 不直接进）
   const mode: 'single' | 'xy' = snap.mode === 'single' ? 'single' : 'xy'
+
+  // dataset_pick fallback：snap 存了 dataset_pick 但 project 在当前机器上没了
+  // （project 被删 / 跨机器 / projectLoras 还没 load）→ tags 拼进 prompts[0]，
+  // 不再回填 picker（datasetPick=null）。用户能在正向 textarea 里直接看到具体
+  // 内容，否则 picker 关着 tags 不可见、又会偷偷在 handleGenerate 里拼一次。
+  let prompts = snap.prompts
+  let datasetPick = snap.dataset_pick ?? null
+  if (datasetPick && datasetPick.tags.length > 0 && !isDatasetProjectAlive(datasetPick, projectLoras)) {
+    prompts = mergeTagsIntoFirstPrompt(prompts, datasetPick.tags)
+    datasetPick = null
+  }
+
   const applied: AppliedSnapshot = {
     mode,
-    prompts: snap.prompts,
+    prompts,
     negPrompt: snap.negative_prompt,
     width: snap.width,
     height: snap.height,
@@ -155,7 +202,7 @@ export function applySnapshot(
     cfgScale: snap.cfg_scale,
     count: snap.count,
     seed: snap.seed,
-    datasetPick: snap.dataset_pick ?? null,
+    datasetPick,
     loras: resolved,
     unresolvedLoraCount: unresolved,
   }
@@ -164,4 +211,83 @@ export function applySnapshot(
     applied.yDraft = snap.xy_draft.y
   }
   return applied
+}
+
+// ---------------------------------------------------------------------------
+// XY cell single-snapshot 物化（落盘 cell PNG metadata 用）
+// ---------------------------------------------------------------------------
+
+/** XY snapshot 按 (xi, yi) 物化成单格 single-snapshot。
+ *
+ * 用途：落盘 cell PNG 时每张要带"如果只看这一张是什么参数"的快照 — 拖进
+ * Comfy / A1111 能识别 steps/cfg/seed/lora 全套；本程序回填走 mode='single'
+ * 主路径（同 single 出图 PNG）。
+ *
+ * 轴语义（daemon `_apply_axis` 对齐）：
+ * - `steps` / `cfg_scale`：顶层标量字段覆盖
+ * - `lora_scale`：全 LoRA 共用一个 scale（不按 loraIndex 单独改）
+ * - `lora_ckpt`：仅 `loras[loraIndex]` 的 name 改成 cell value 的 basename，
+ *   原 ids 失效（ckpt 换了，project_id/version_id 不再准）
+ *
+ * 输出额外带 `xy_origin: {xi, yi, xv, yv, x_axis, y_axis}` 链回所属 XY plot。
+ */
+export function buildCellSnapshot(
+  xy: GenerateParamsSnapshot,
+  cellPos: { xi: number; yi: number },
+  axes: {
+    x: { axis: XYAxisType; loraIndex: number | null; value: string | number }
+    y: { axis: XYAxisType; loraIndex: number | null; value: string | number } | null
+  },
+): GenerateParamsSnapshot {
+  const out: GenerateParamsSnapshot = {
+    ...xy,
+    mode: 'single',
+    xy_draft: null,
+    // 浅克隆 loras 数组让下面 mutate 不污染 xy.loras
+    loras: xy.loras.map((l) => ({ ...l })),
+  }
+  applyAxisToCell(out, axes.x.axis, axes.x.value, axes.x.loraIndex)
+  if (axes.y) {
+    applyAxisToCell(out, axes.y.axis, axes.y.value, axes.y.loraIndex)
+  }
+  out.xy_origin = {
+    xi: cellPos.xi,
+    yi: cellPos.yi,
+    xv: axes.x.value,
+    yv: axes.y?.value ?? null,
+    x_axis: axes.x.axis,
+    y_axis: axes.y?.axis ?? null,
+  }
+  return out
+}
+
+function applyAxisToCell(
+  snap: GenerateParamsSnapshot,
+  axis: XYAxisType,
+  value: string | number,
+  loraIndex: number | null,
+): void {
+  switch (axis) {
+    case 'steps':
+      snap.steps = Math.trunc(Number(value))
+      return
+    case 'cfg_scale':
+      snap.cfg_scale = Number(value)
+      return
+    case 'lora_scale': {
+      const scale = Number(value)
+      snap.loras = snap.loras.map((l) => ({ ...l, scale }))
+      return
+    }
+    case 'lora_ckpt': {
+      if (loraIndex == null || !snap.loras[loraIndex]) return
+      // value 已经是 basename（snapshot 写时 transformAxisRawForSnapshot 处理过；
+      // 但 buildCellSnapshot 也可能被传 raw path，统一过一遍 basename）
+      const name = loraBasename(String(value))
+      snap.loras = snap.loras.map((l, i) =>
+        i === loraIndex ? { ...l, name, project_id: null, version_id: null } : l,
+      )
+      return
+    }
+  }
 }

--- a/studio/web/src/pages/tools/generate/paramsSnapshot.ts
+++ b/studio/web/src/pages/tools/generate/paramsSnapshot.ts
@@ -1,17 +1,42 @@
-/** 测试出图参数快照：落盘 sidecar + IndexedDB HistoryEntry.params 共用。
+/** 测试出图参数快照：落盘 PNG metadata + IndexedDB HistoryEntry.params 共用。
  *
  * 用途：
- * - 落盘 image_N.json sidecar 时存 → 历史栏点击磁盘 entry 时取出回填 prefs
+ * - 落盘 PNG `anima_params` tEXt 块 → 历史栏点击磁盘 entry 时取出回填 prefs
  * - IndexedDB HistoryEntry.params 同 shape → 未落盘的 entry 也能回填
  *
  * 设计为 prefs 视图（含 xy_draft.raw / dataset_pick），不是 daemon 接口视图：
  * 回填时直接灌回 prefs 各字段，UI 完整重建（dataset picker / xy 文本框等）。
+ *
+ * **不存绝对路径**（避免泄露本地文件系统结构、跨机器死链、用户挪文件失效）：
+ * - LoRA：只存 name + project_id + version_id + scale；回填时按 ids→path resolve
+ * - XY lora_ckpt 轴 values：存 basename（去目录、保留 .safetensors 后缀）；
+ *   回填时灌回 raw 字段，用户重 submit 前需要 picker 重选定位到具体 ckpt
+ * - dataset_pick：只存 projectId/versionId/name/tags，name 是相对路径无机密
  */
-import type { LoraEntry } from '../../../api/client'
+import type { LoraEntry, XYAxisType } from '../../../api/client'
 import type { DatasetPick } from './PromptFromDatasetPicker'
+import type { ProjectLora } from './types'
 import type { XYAxisDraft } from './xy'
 
 export const PARAMS_SNAPSHOT_VERSION = 1
+
+/** snapshot 里的 LoRA 引用 —— 仅身份（name + ids），无绝对路径。 */
+export interface SnapshotLora {
+  /** LoRA 文件 basename（含 .safetensors 后缀）。回填 fallback 用。 */
+  name: string
+  scale: number
+  /** picker 选的项目 / 版本；外部文件无 */
+  project_id?: number | null
+  version_id?: number | null
+}
+
+/** XY draft 的 snapshot 形式 —— lora_ckpt 轴 raw 已 transform 为 basename 列表。 */
+export interface SnapshotXYAxis {
+  axis: XYAxisType
+  /** lora_ckpt 时：basename 逗号串；其它轴：原样数值串 */
+  raw: string
+  loraIndex: number | null
+}
 
 export interface GenerateParamsSnapshot {
   schema_version: number
@@ -27,11 +52,59 @@ export interface GenerateParamsSnapshot {
   /** xy 模式下 daemon 端强制 1，仅 single 有意义 */
   count: number
   seed: number
-  /** 当时 mode 对应的 LoRA 列表（single→singleLoras，xy→xyLoras） */
-  lora_configs: LoraEntry[]
-  /** 仅 xy 模式：prefs 视图（含 raw 字符串），回填时直接灌回 xDraft/yDraft；
-   *  重 submit 时前端从这里重 buildXYMatrix（不冗余存 daemon xy_matrix） */
-  xy_draft?: { x: XYAxisDraft; y: XYAxisDraft | null } | null
-  /** 训练集 caption picker 选择（保留 picker UI 上下文） */
+  /** 当时 mode 对应的 LoRA 列表，已转为 name+ids 形式 */
+  loras: SnapshotLora[]
+  /** 仅 xy 模式：prefs 视图（raw 字符串），lora_ckpt 轴 raw 已转 basename */
+  xy_draft?: { x: SnapshotXYAxis; y: SnapshotXYAxis | null } | null
+  /** 训练集 caption picker 选择（保留 picker UI 上下文）。
+   *  name 是相对路径（如 "5_concept/0001.txt"），不含本地绝对路径。 */
   dataset_pick?: DatasetPick | null
+}
+
+/** path → basename（去目录），保留 .safetensors 等后缀。
+ *  写 metadata 时用，避免泄露本地路径结构。 */
+export function loraBasename(path: string): string {
+  return path.split(/[\\/]/).pop() ?? path
+}
+
+/** XY lora_ckpt 轴的 raw 字符串（逗号分隔的 ckpt 路径列表）→ basename 列表。
+ *  其它轴 raw 是数字串，原样返回。 */
+export function transformAxisRawForSnapshot(draft: XYAxisDraft): SnapshotXYAxis {
+  if (draft.axis !== 'lora_ckpt') {
+    return { axis: draft.axis, raw: draft.raw, loraIndex: draft.loraIndex }
+  }
+  const raw = draft.raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map(loraBasename)
+    .join(', ')
+  return { axis: draft.axis, raw, loraIndex: draft.loraIndex }
+}
+
+/** 回填：SnapshotLora → LoraEntry，按 ids 主键、name 兜底 resolve 当前机器上的 path。
+ *  resolve 失败 → path 留空（submit 时 `.filter(l => l.path.trim())` 会跳过这条），
+ *  UI 上用户能看到一条 path 空的 LoRA 卡片提示重选。 */
+export function resolveSnapshotLora(
+  snap: SnapshotLora, projectLoras: ProjectLora[],
+): LoraEntry {
+  if (snap.project_id != null && snap.version_id != null) {
+    const hit = projectLoras.find(
+      (p) => p.projectId === snap.project_id && p.versionId === snap.version_id,
+    )
+    if (hit) return {
+      path: hit.path, scale: snap.scale,
+      project_id: snap.project_id, version_id: snap.version_id,
+    }
+  }
+  // 兜底：按 basename 匹配（外部 LoRA 无 ids，或 picker 重建 ids 变了）
+  const byName = projectLoras.find((p) => loraBasename(p.path) === snap.name)
+  if (byName) return {
+    path: byName.path, scale: snap.scale,
+    project_id: byName.projectId, version_id: byName.versionId,
+  }
+  return {
+    path: '', scale: snap.scale,
+    project_id: snap.project_id ?? null, version_id: snap.version_id ?? null,
+  }
 }

--- a/studio/web/src/pages/tools/generate/paramsSnapshot.ts
+++ b/studio/web/src/pages/tools/generate/paramsSnapshot.ts
@@ -106,6 +106,8 @@ export function resolveSnapshotLora(
   return {
     path: '', scale: snap.scale,
     project_id: snap.project_id ?? null, version_id: snap.version_id ?? null,
+    // placeholder: 保留 name 让 SidebarLoras 渲染 ⚠ 提示卡片
+    name: snap.name,
   }
 }
 

--- a/studio/web/src/pages/tools/generate/saveTestImages.ts
+++ b/studio/web/src/pages/tools/generate/saveTestImages.ts
@@ -1,37 +1,33 @@
 /** 测试出图自动落盘（Settings → testing → save_test_images 开启时）。
  *
- * 路径：studio_data/test/<YYYY-MM-DD>/{single,xy}/image_N.png
- * - single：每张 sample 单独上传一份（image_N 逐张递增）
- * - xy：用 composeXYMatrix 把整张网格合成单图后上传一次
- * - compare：调用方负责跳过；本模块不处理
+ * 路径：
+ *  - single: `studio_data/test/<YYYY-MM-DD>/single/single image N.png`
+ *  - xy:     `studio_data/test/<YYYY-MM-DD>/xy/xy plot N/{xy plot.png + cell x{xi} y{yi}.png ...}`
+ *
+ * single 每张 sample 单独上传（一图一 POST）；
+ * xy 一次 multipart 发：composite + N 张 cell + cells_manifest（按 cell
+ * 物化的 single-snapshot），server 端落到同一文件夹下，atomic 整个 commit。
  *
  * 上传时附 params JSON（GenerateParamsSnapshot）：后端写进 PNG `anima_params`
- * tEXt + 同目录 image_N.json sidecar，供历史栏回看 / 用户拷走 PNG 复用参数。
+ * tEXt + single 写 a1111 `parameters` 块，供历史栏回看 / 用户拷走 PNG 复用参数。
  *
  * 失败 / 后端 403（开关被关）都静默吞掉 —— 不打扰用户主流程。
  */
 import { api } from '../../../api/client'
 import { composeXYMatrix, type ExportInput } from './exportXY'
-import type { GenerateParamsSnapshot } from './paramsSnapshot'
+import { buildCellSnapshot, type GenerateParamsSnapshot } from './paramsSnapshot'
 
-interface SaveResult {
-  /** 落盘路径（用于回写 IndexedDB entry.diskPath，做 disk-history 去重） */
+interface SingleSaveResult {
   path: string
   index: number
+  filename: string
 }
 
-async function postSave(
-  mode: 'single' | 'xy',
-  blob: Blob,
-  params: GenerateParamsSnapshot,
-): Promise<SaveResult | null> {
-  const fd = new FormData()
-  fd.append('mode', mode)
-  fd.append('image', blob, `${mode}.png`)
-  fd.append('params', JSON.stringify(params))
-  const r = await fetch('/api/generate/save', { method: 'POST', body: fd })
-  if (!r.ok) return null
-  return (await r.json()) as SaveResult
+interface XYSaveResult {
+  folder: string
+  index: number
+  composite: string
+  cells: string[]
 }
 
 /** 落盘 single 模式所有 sample。返回每张图的 server path（与 filenames 同序，
@@ -47,8 +43,14 @@ export async function saveSingleSamples(
       const res = await fetch(api.generateSampleUrl(taskId, fn))
       if (!res.ok) { paths.push(null); continue }
       const blob = await res.blob()
-      const r = await postSave('single', blob, params)
-      paths.push(r?.path ?? null)
+      const fd = new FormData()
+      fd.append('mode', 'single')
+      fd.append('image', blob, 'single.png')
+      fd.append('params', JSON.stringify(params))
+      const r = await fetch('/api/generate/save', { method: 'POST', body: fd })
+      if (!r.ok) { paths.push(null); continue }
+      const data = await r.json() as SingleSaveResult
+      paths.push(data.path)
     } catch {
       paths.push(null)
     }
@@ -56,15 +58,57 @@ export async function saveSingleSamples(
   return paths
 }
 
-/** 落盘 xy 合成大图。返回落盘 path（失败为 null）。 */
+/** 落盘 xy 文件夹（composite + 每 cell 原图）。返回 server 端文件夹路径（失败为 null）。
+ *  `xySnapshot.mode` 必须是 'xy'；本函数会派生 per-cell single-snapshot。 */
 export async function saveXYMatrix(
   input: ExportInput,
-  params: GenerateParamsSnapshot,
+  xySnapshot: GenerateParamsSnapshot,
 ): Promise<string | null> {
   try {
-    const blob = await composeXYMatrix(input)
-    const r = await postSave('xy', blob, params)
-    return r?.path ?? null
+    const { samples, taskId, xAxis, yAxis, xValues, yValues } = input
+    const xLoraIndex = xySnapshot.xy_draft?.x.loraIndex ?? null
+    const yLoraIndex = xySnapshot.xy_draft?.y?.loraIndex ?? null
+
+    // 1) 拉所有 cell PNG bytes + 构 per-cell single-snapshot
+    type CellEntry = { xi: number; yi: number; blob: Blob; params: GenerateParamsSnapshot }
+    const cellEntries: CellEntry[] = []
+    for (const s of samples) {
+      const fn = s.path.split(/[\\/]/).pop()
+      if (!fn) continue
+      try {
+        const res = await fetch(api.generateSampleUrl(taskId, fn))
+        if (!res.ok) continue
+        const blob = await res.blob()
+        const xv = xValues[s.xy.xi] ?? ''
+        const yv = yAxis ? (yValues[s.xy.yi] ?? '') : null
+        const cellParams = buildCellSnapshot(xySnapshot, s.xy, {
+          x: { axis: xAxis, loraIndex: xLoraIndex, value: xv },
+          y: yAxis ? { axis: yAxis, loraIndex: yLoraIndex, value: yv ?? '' } : null,
+        })
+        cellEntries.push({ xi: s.xy.xi, yi: s.xy.yi, blob, params: cellParams })
+      } catch {
+        // 单 cell 拉失败跳过；server 会按 manifest 校验，缺 cell 就不发送
+      }
+    }
+    if (cellEntries.length === 0) return null
+
+    // 2) composite 大图（沿用现成 composeXYMatrix）
+    const composite = await composeXYMatrix(input)
+
+    // 3) multipart 一次发：composite + N 张 cell + cells_manifest
+    const fd = new FormData()
+    fd.append('mode', 'xy')
+    fd.append('image', composite, 'xy plot.png')
+    fd.append('params', JSON.stringify(xySnapshot))
+    const manifest = cellEntries.map(({ xi, yi, params }) => ({ xi, yi, params }))
+    fd.append('cells_manifest', JSON.stringify(manifest))
+    for (const { xi, yi, blob } of cellEntries) {
+      fd.append('cells', blob, `cell x${xi} y${yi}.png`)
+    }
+    const r = await fetch('/api/generate/save', { method: 'POST', body: fd })
+    if (!r.ok) return null
+    const data = await r.json() as XYSaveResult
+    return data.folder
   } catch {
     return null
   }

--- a/studio/web/src/pages/tools/generate/useGenerateHistory.ts
+++ b/studio/web/src/pages/tools/generate/useGenerateHistory.ts
@@ -250,12 +250,30 @@ export interface UseGenerateHistoryResult {
 }
 
 /** 合并 IDB + disk entries：diskPath 重复时 IDB 优先（带本地 thumbnail）。 */
+/** 合并 IDB + disk entries：
+ *  1. dedup —— diskPath 相同的 IDB entry 优先（带本地 thumbnail）
+ *  2. **升级 IDB entry** —— 落盘但 cache 已失效的 entry（关 tab / 重启后）从
+ *     对应 disk entry 拿 imageUrls 作为大图来源；本地 thumbnail 仍走 IDB 的
+ *     dataUrl。这样"点击显示已释放"在已落盘时不会再误报。 */
 function mergeEntries(idb: HistoryEntry[], disk: HistoryEntry[]): HistoryEntry[] {
+  const diskByPath = new Map<string, HistoryEntry>()
+  for (const d of disk) {
+    if (d.diskPath) diskByPath.set(d.diskPath, d)
+  }
+  const upgradedIdb = idb.map((e) => {
+    if (e.imageUrls || !e.diskPath) return e
+    const d = diskByPath.get(e.diskPath)
+    if (!d?.imageUrls) return e
+    // 同时替换 filenames：xy 落盘是一张合成大图（disk.filenames.length === 1），
+    // 让 historyImageUrl + 渲染分支的 filenames.length > 1 判断统一走单图视图。
+    // 本地 thumbnail（cell 0,0）仍走 IDB 的 thumbnailDataUrl。
+    return { ...e, imageUrls: d.imageUrls, filenames: d.filenames }
+  })
   const usedDiskPaths = new Set(
-    idb.map((e) => e.diskPath).filter((p): p is string => Boolean(p))
+    upgradedIdb.map((e) => e.diskPath).filter((p): p is string => Boolean(p))
   )
   const remainingDisk = disk.filter((d) => !d.diskPath || !usedDiskPaths.has(d.diskPath))
-  return [...idb, ...remainingDisk].sort((a, b) => b.createdAt - a.createdAt)
+  return [...upgradedIdb, ...remainingDisk].sort((a, b) => b.createdAt - a.createdAt)
 }
 
 /** 全局 history 状态 hook。IDB 持久化 + 磁盘 sidecar 兜底（跨会话回看）。 */

--- a/studio/web/src/pages/tools/generate/useGenerateHistory.ts
+++ b/studio/web/src/pages/tools/generate/useGenerateHistory.ts
@@ -15,26 +15,58 @@ import {
   type CacheEntry,
   type DiskEntry,
   type HistoryEntry,
+  type HistoryXYMeta,
 } from './entryAdapter'
 import type { GenerateParamsSnapshot } from './paramsSnapshot'
 
 export type { CacheEntry, DiskEntry, HistoryEntry, HistoryXYMeta } from './entryAdapter'
 
+interface DiskHistoryServerXYMeta {
+  x_axis: string | null
+  y_axis: string | null
+  x_values: string[]
+  y_values: Array<string | null>
+  samples: Array<{
+    path: string
+    xy: { xi: number; yi: number; xv: string | null; yv: string | null }
+    image_url: string
+  }>
+}
+
 interface DiskHistoryServerEntry {
   id: string
   date: string
   mode: 'single' | 'xy'
-  filename: string
+  /** single 时存在；xy 时 undefined（用 folder） */
+  filename?: string
+  /** xy 时存在；single 时 undefined */
+  folder?: string
   path: string
   image_url: string
   thumb_url: string
   created_at: number
   schema_version: number
   params: unknown
+  /** xy 模式 server 派生的 per-cell 元数据 */
+  xy_meta?: DiskHistoryServerXYMeta | null
 }
 
 interface DiskHistoryResponse {
   entries: DiskHistoryServerEntry[]
+}
+
+function xyMetaFromServer(meta: DiskHistoryServerXYMeta): HistoryXYMeta {
+  return {
+    xAxis: meta.x_axis ?? '',
+    yAxis: meta.y_axis,
+    xValues: meta.x_values,
+    yValues: meta.y_values,
+    samples: meta.samples.map((s) => ({
+      path: s.path,
+      xy: { xi: s.xy.xi, yi: s.xy.yi, xv: s.xy.xv ?? '', yv: s.xy.yv },
+      imageUrl: s.image_url,
+    })),
+  }
 }
 
 function diskEntryFromServer(d: DiskHistoryServerEntry): DiskEntry {
@@ -44,10 +76,12 @@ function diskEntryFromServer(d: DiskHistoryServerEntry): DiskEntry {
     mode: d.mode,
     date: d.date,
     filename: d.filename,
+    folder: d.folder,
     imageUrl: d.image_url,
     thumbUrl: d.thumb_url,
     createdAt: d.created_at * 1000,  // server 给秒；entry.createdAt 用 ms
     params: d.params as GenerateParamsSnapshot,
+    xyMeta: d.xy_meta ? xyMetaFromServer(d.xy_meta) : undefined,
   }
 }
 

--- a/studio/web/src/pages/tools/generate/useGenerateHistory.ts
+++ b/studio/web/src/pages/tools/generate/useGenerateHistory.ts
@@ -1,346 +1,125 @@
-/**
- * commit 16：测试出图历史栏（IndexedDB 持久化）。
+/** 测试出图历史栏（plan Step 4 重写）。
  *
- * - 按 mode 三个独立桶：single / xy / compare
- * - 每条历史一个封面缩略图（dataUrl，~256px PNG）
- * - 跨 SPA 路由保持；浏览器 tab 关闭后清（IndexedDB 默认行为，与
- *   sessionStorage 不同 —— IndexedDB 跨 tab 持久，但用户决策是"tab 关
- *   就丢"，所以我们写 tab 级 sessionStorage 之上的 in-memory cache，
- *   IndexedDB 只用作页面刷新但不关 tab 时的恢复）
- *
- * 实际选择：IndexedDB（用户决策"无上限，几十 mb 对现代计算机太小"），
- * tab 关后留下也无伤大雅 —— 用户重开 tab 还能看到历史，符合"看图/对比"
- * 主流程。整体内存 / 磁盘可控（每条 thumb ~20KB，1000 条也才 20MB）。
+ * 设计转向（决策 #5 / #9 / #12）：
+ * - 砍 IndexedDB 整层（~-250 LOC）—— 不再做"params + thumb 双份持久化"
+ * - 单一 source of truth = 磁盘 PNG（持久 entry）+ server cache（临时 entry）
+ * - mount 总拉 disk-history（不分模式）；不受 save_test_images 开关影响
+ * - session in-memory 持有所有 entry，关 tab 即丢；刷新页面重 mount 拉 disk
+ * - HistoryEntry 是 union: DiskEntry | CacheEntry（adapter pattern，分支收敛
+ *   到 entryAdapter.ts）
+ * - 没有 merge upgrade / dedup / pruneStale —— 两类 entry 自然独立、不会撞 id
  */
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { api, type DiskGenerateHistoryEntry } from '../../../api/client'
+import {
+  entryDelete,
+  type CacheEntry,
+  type DiskEntry,
+  type HistoryEntry,
+} from './entryAdapter'
 import type { GenerateParamsSnapshot } from './paramsSnapshot'
 
-const DB_NAME = 'anima-generate-history'
-const DB_VERSION = 1
-const STORE = 'entries'
+export type { CacheEntry, DiskEntry, HistoryEntry, HistoryXYMeta } from './entryAdapter'
 
-export type HistoryMode = 'single' | 'xy' | 'compare'
-
-/** XY 历史回看用的 axis 元数据。回看时复用 PreviewXYGrid 渲染（带轴标签）。 */
-export interface HistoryXYMeta {
-  /** 'lora_ckpt' / 'lora_scale' / 'steps' / 'cfg_scale' */
-  xAxis: string
-  yAxis: string | null
-  xValues: string[]
-  yValues: Array<string | null>
-  /** 每个 sample 的 xy 元数据；filename 来自 path 末段 */
-  samples: Array<{
-    path: string
-    xy: { xi: number; yi: number; xv: string | number; yv: string | number | null }
-  }>
-}
-
-export interface HistoryEntry {
+interface DiskHistoryServerEntry {
   id: string
-  mode: HistoryMode
-  taskId: number
-  createdAt: number
-  thumbnailDataUrl: string  // 256px PNG/JPEG，封面（XY 取 (0,0)，对比取左图）
-  /** 后端 cache 里的 filenames，按 sample order；点击时 fetch 原图，404 fallback thumb */
-  filenames: string[]
-  /** XY: 'XY M×N'；compare: '2×'；single: '' */
-  badge?: string
-  /** XY 模式才填：回看时重建 PreviewXYGrid 用 */
-  xy?: HistoryXYMeta
-  /** 测试参数快照（用于历史点击回填 prefs）。老 entry 缺此字段 → 回填 noop。 */
-  params?: GenerateParamsSnapshot
-  /** 落盘成功后回写：第一张图（single）/ 合成图（xy）的 server path；用于和
-   *  GET /api/generate/disk-history 拉到的 disk entries 做 dedup。 */
-  diskPath?: string
-  /** 缺省时按 generateSampleUrl(taskId, filename) 构造（cache 来源 entry）。
-   *  磁盘来源 entry 必填（指向 /api/generate/disk-image/...），因为它的 taskId
-   *  是 sentinel，generateSampleUrl 路径不可用。 */
-  imageUrls?: string[]
+  date: string
+  mode: 'single' | 'xy'
+  filename: string
+  path: string
+  image_url: string
+  thumb_url: string
+  created_at: number
+  schema_version: number
+  params: unknown
 }
 
-/** entry 对应位置 idx 的图片 URL。disk entry 走 imageUrls，cache entry 走
- *  generateSampleUrl(taskId, filename)。所有历史回看渲染处都该用这个 helper。 */
-export function historyImageUrl(entry: HistoryEntry, idx = 0): string {
-  const explicit = entry.imageUrls?.[idx]
-  if (explicit) return explicit
-  const fn = entry.filenames[idx] ?? ''
-  return api.generateSampleUrl(entry.taskId, fn)
+interface DiskHistoryResponse {
+  entries: DiskHistoryServerEntry[]
 }
 
-function openDb(): Promise<IDBDatabase> {
-  return new Promise((resolve, reject) => {
-    const req = indexedDB.open(DB_NAME, DB_VERSION)
-    req.onupgradeneeded = () => {
-      const db = req.result
-      if (!db.objectStoreNames.contains(STORE)) {
-        const store = db.createObjectStore(STORE, { keyPath: 'id' })
-        store.createIndex('mode_createdAt', ['mode', 'createdAt'])
-      }
-    }
-    req.onsuccess = () => resolve(req.result)
-    req.onerror = () => reject(req.error)
-  })
-}
-
-async function loadAll(): Promise<HistoryEntry[]> {
-  try {
-    const db = await openDb()
-    return await new Promise<HistoryEntry[]>((resolve, reject) => {
-      const tx = db.transaction(STORE, 'readonly')
-      const store = tx.objectStore(STORE)
-      const req = store.getAll()
-      req.onsuccess = () => {
-        const items = (req.result as HistoryEntry[]).sort(
-          (a, b) => b.createdAt - a.createdAt
-        )
-        resolve(items)
-      }
-      req.onerror = () => reject(req.error)
-    })
-  } catch {
-    // IndexedDB 不可用（隐私模式 / Safari 限制）→ 返回空数组，不挂前端
-    return []
-  }
-}
-
-async function putEntry(entry: HistoryEntry): Promise<void> {
-  try {
-    const db = await openDb()
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction(STORE, 'readwrite')
-      tx.objectStore(STORE).put(entry)
-      tx.oncomplete = () => resolve()
-      tx.onerror = () => reject(tx.error)
-    })
-  } catch {
-    /* 忽略：写失败不阻塞主流程 */
-  }
-}
-
-async function updateEntry(id: string, patch: Partial<HistoryEntry>): Promise<HistoryEntry | null> {
-  try {
-    const db = await openDb()
-    return await new Promise<HistoryEntry | null>((resolve, reject) => {
-      const tx = db.transaction(STORE, 'readwrite')
-      const store = tx.objectStore(STORE)
-      const getReq = store.get(id)
-      getReq.onsuccess = () => {
-        const cur = getReq.result as HistoryEntry | undefined
-        if (!cur) { resolve(null); return }
-        const next = { ...cur, ...patch, id: cur.id }
-        store.put(next)
-        tx.oncomplete = () => resolve(next)
-      }
-      tx.onerror = () => reject(tx.error)
-    })
-  } catch {
-    return null
-  }
-}
-
-async function deleteEntry(id: string): Promise<void> {
-  try {
-    const db = await openDb()
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction(STORE, 'readwrite')
-      tx.objectStore(STORE).delete(id)
-      tx.oncomplete = () => resolve()
-      tx.onerror = () => reject(tx.error)
-    })
-  } catch {
-    /* ignore */
-  }
-}
-
-/** disk-history server entry → HistoryEntry shape。
- *  - taskId = -1 sentinel（cache 接口不可用，所有图片走 imageUrls）
- *  - thumbnailDataUrl 直接放 disk-image URL（不预生成缩略图，浏览器自缩；
- *    落盘历史规模有限，避免 disk → fetch → canvas → dataURL 的额外开销）
- *  - id 保持服务端给的 "disk:<date>:<mode>:image_<N>"（前端按此 dedup）
- */
-function diskEntryToHistory(d: DiskGenerateHistoryEntry): HistoryEntry {
+function diskEntryFromServer(d: DiskHistoryServerEntry): DiskEntry {
   return {
+    source: 'disk',
     id: d.id,
     mode: d.mode,
-    taskId: -1,
-    createdAt: d.created_at * 1000,  // server 给的是秒；HistoryEntry.createdAt 是 ms
-    thumbnailDataUrl: d.url,
-    filenames: [d.filename],
-    imageUrls: [d.url],
-    diskPath: d.path,
-    params: d.params as unknown as GenerateParamsSnapshot,
+    date: d.date,
+    filename: d.filename,
+    imageUrl: d.image_url,
+    thumbUrl: d.thumb_url,
+    createdAt: d.created_at * 1000,  // server 给秒；entry.createdAt 用 ms
+    params: d.params as GenerateParamsSnapshot,
   }
-}
-
-async function loadDisk(): Promise<HistoryEntry[]> {
-  try {
-    const resp = await api.listDiskGenerateHistory()
-    return resp.entries.map(diskEntryToHistory)
-  } catch {
-    return []
-  }
-}
-
-async function clearMode(mode: HistoryMode): Promise<void> {
-  try {
-    const db = await openDb()
-    await new Promise<void>((resolve, reject) => {
-      const tx = db.transaction(STORE, 'readwrite')
-      const store = tx.objectStore(STORE)
-      const req = store.openCursor()
-      req.onsuccess = () => {
-        const cur = req.result
-        if (cur) {
-          if ((cur.value as HistoryEntry).mode === mode) cur.delete()
-          cur.continue()
-        }
-      }
-      tx.oncomplete = () => resolve()
-      tx.onerror = () => reject(tx.error)
-    })
-  } catch {
-    /* ignore */
-  }
-}
-
-/** 把图片 URL → canvas 缩到 maxPx → PNG dataUrl。封面缩略图用。 */
-export async function makeThumbnail(
-  imageUrl: string, maxPx = 256
-): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const img = new Image()
-    img.crossOrigin = 'anonymous'
-    img.onload = () => {
-      const w = img.naturalWidth, h = img.naturalHeight
-      const scale = Math.min(1, maxPx / Math.max(w, h))
-      const tw = Math.max(1, Math.round(w * scale))
-      const th = Math.max(1, Math.round(h * scale))
-      const canvas = document.createElement('canvas')
-      canvas.width = tw
-      canvas.height = th
-      const ctx = canvas.getContext('2d')
-      if (!ctx) {
-        reject(new Error('no 2d context'))
-        return
-      }
-      ctx.drawImage(img, 0, 0, tw, th)
-      try {
-        resolve(canvas.toDataURL('image/png'))
-      } catch (e) {
-        reject(e)
-      }
-    }
-    img.onerror = () => reject(new Error(`failed to load ${imageUrl}`))
-    img.src = imageUrl
-  })
 }
 
 export interface UseGenerateHistoryResult {
+  /** 所有 entry，按 createdAt desc 排 */
   entries: HistoryEntry[]
-  /** 返回新 entry 的 id，方便 add 后续 patch（如落盘成功回写 diskPath） */
-  add: (entry: Omit<HistoryEntry, 'id' | 'createdAt'>) => Promise<string>
-  /** 局部更新 entry —— 主要给 saveTestImages 回写 diskPath 用 */
-  patch: (id: string, patch: Partial<HistoryEntry>) => Promise<void>
-  clearByMode: (mode: HistoryMode) => Promise<void>
-  /** 检查每条 entry 的第一张图是否还在 server cache 里；
-   * 404 / fail 的 entry：若已落盘（有 diskPath）保留（磁盘还能看），否则删除。
-   * 返回删除的 entry 数量。 */
-  pruneStale: () => Promise<number>
+  /** disk-history 拉取中（mount 短暂期间为 true） */
+  loading: boolean
+  /** 添加新 entry（出图完成 / 落盘后调用） */
+  add: (entry: HistoryEntry) => void
+  /** 删除 entry：DiskEntry 调 DELETE endpoint；CacheEntry 仅本地 splice */
+  remove: (id: string) => Promise<void>
+  /** 手动重拉 disk-history（多 tab 同步 / 外部改 studio_data 后用户主动刷新） */
+  refresh: () => Promise<void>
 }
 
-/** 合并 IDB + disk entries：diskPath 重复时 IDB 优先（带本地 thumbnail）。 */
-/** 合并 IDB + disk entries：
- *  1. dedup —— diskPath 相同的 IDB entry 优先（带本地 thumbnail）
- *  2. **升级 IDB entry** —— 落盘但 cache 已失效的 entry（关 tab / 重启后）从
- *     对应 disk entry 拿 imageUrls 作为大图来源；本地 thumbnail 仍走 IDB 的
- *     dataUrl。这样"点击显示已释放"在已落盘时不会再误报。 */
-function mergeEntries(idb: HistoryEntry[], disk: HistoryEntry[]): HistoryEntry[] {
-  const diskByPath = new Map<string, HistoryEntry>()
-  for (const d of disk) {
-    if (d.diskPath) diskByPath.set(d.diskPath, d)
-  }
-  const upgradedIdb = idb.map((e) => {
-    if (e.imageUrls || !e.diskPath) return e
-    const d = diskByPath.get(e.diskPath)
-    if (!d?.imageUrls) return e
-    // 同时替换 filenames：xy 落盘是一张合成大图（disk.filenames.length === 1），
-    // 让 historyImageUrl + 渲染分支的 filenames.length > 1 判断统一走单图视图。
-    // 本地 thumbnail（cell 0,0）仍走 IDB 的 thumbnailDataUrl。
-    return { ...e, imageUrls: d.imageUrls, filenames: d.filenames }
-  })
-  const usedDiskPaths = new Set(
-    upgradedIdb.map((e) => e.diskPath).filter((p): p is string => Boolean(p))
-  )
-  const remainingDisk = disk.filter((d) => !d.diskPath || !usedDiskPaths.has(d.diskPath))
-  return [...upgradedIdb, ...remainingDisk].sort((a, b) => b.createdAt - a.createdAt)
-}
-
-/** 全局 history 状态 hook。IDB 持久化 + 磁盘 sidecar 兜底（跨会话回看）。 */
 export function useGenerateHistory(): UseGenerateHistoryResult {
-  const [idbEntries, setIdbEntries] = useState<HistoryEntry[]>([])
-  const [diskEntries, setDiskEntries] = useState<HistoryEntry[]>([])
+  const [diskEntries, setDiskEntries] = useState<DiskEntry[]>([])
+  const [cacheEntries, setCacheEntries] = useState<CacheEntry[]>([])
+  const [loading, setLoading] = useState(true)
   const loadedRef = useRef(false)
+
+  const fetchDisk = async () => {
+    setLoading(true)
+    try {
+      const r = await fetch('/api/generate/disk/history')
+      if (!r.ok) return
+      const data = (await r.json()) as DiskHistoryResponse
+      setDiskEntries(data.entries.map(diskEntryFromServer))
+    } catch {
+      // 拉取失败不挂前端 —— 历史栏只显示 session 期间出的 CacheEntry
+    } finally {
+      setLoading(false)
+    }
+  }
 
   useEffect(() => {
     if (loadedRef.current) return
     loadedRef.current = true
-    void loadAll().then(setIdbEntries)
-    void loadDisk().then(setDiskEntries)
+    void fetchDisk()
   }, [])
 
-  const entries = useMemo(
-    () => mergeEntries(idbEntries, diskEntries),
-    [idbEntries, diskEntries],
+  // entries union 按 createdAt desc 排。两类 entry 自然独立 —— 同一张图
+  // 不会既是 disk 又是 cache（开关冻结后 task 走单一路径）。
+  const entries = useMemo<HistoryEntry[]>(
+    () => [...diskEntries, ...cacheEntries].sort((a, b) => b.createdAt - a.createdAt),
+    [diskEntries, cacheEntries],
   )
 
-  const add = async (entry: Omit<HistoryEntry, 'id' | 'createdAt'>) => {
-    const full: HistoryEntry = {
-      ...entry,
-      id: typeof crypto !== 'undefined' && 'randomUUID' in crypto
-        ? crypto.randomUUID()
-        : Math.random().toString(36).slice(2),
-      createdAt: Date.now(),
+  const add = (entry: HistoryEntry) => {
+    if (entry.source === 'disk') {
+      setDiskEntries((prev) => [entry, ...prev])
+    } else {
+      setCacheEntries((prev) => [entry, ...prev])
     }
-    await putEntry(full)
-    setIdbEntries((prev) => [full, ...prev])
-    return full.id
   }
 
-  const patch = async (id: string, p: Partial<HistoryEntry>) => {
-    const next = await updateEntry(id, p)
-    if (next) setIdbEntries((prev) => prev.map((e) => (e.id === id ? next : e)))
-  }
-
-  const clearByMode = async (mode: HistoryMode) => {
-    // 只清 IDB；磁盘文件用户得手动去文件夹删（避免误删历史档案）。
-    // 下次 loadDisk 时磁盘 entries 仍会出现 — 这是有意保留。
-    await clearMode(mode)
-    setIdbEntries((prev) => prev.filter((e) => e.mode !== mode))
-  }
-
-  const pruneStale = async (): Promise<number> => {
-    // 只对 IDB entries 操作（disk entries 是只读视图，背后是磁盘文件）。
-    // 已落盘（diskPath）的 IDB entry：图在磁盘上随时回看，不删（仅 HEAD 失败说明
-    // 内存 cache 释放了，并不代表"图没了"）。
-    const stale: string[] = []
-    await Promise.all(idbEntries.map(async (e) => {
-      const fn = e.filenames[0]
-      if (!fn) return  // 没 filename 不动
-      if (e.diskPath) return  // 已落盘 → 永远不剪
-      const url = api.generateSampleUrl(e.taskId, fn)
+  const remove = async (id: string) => {
+    const target = entries.find((e) => e.id === id)
+    if (!target) return
+    if (target.source === 'disk') {
       try {
-        const r = await fetch(url, { method: 'HEAD' })
-        if (!r.ok) stale.push(e.id)
+        await entryDelete(target)
       } catch {
-        // 网络错误（断网等）不算失效，留着下次再试
+        // server 失败仍本地剔（用户能看到列表里少了一条；下次 refresh 时
+        // 如果文件真在仍会回来 —— 是预期的"乐观删除"模式）
       }
-    }))
-    if (stale.length === 0) return 0
-    await Promise.all(stale.map((id) => deleteEntry(id)))
-    setIdbEntries((prev) => prev.filter((e) => !stale.includes(e.id)))
-    return stale.length
+      setDiskEntries((prev) => prev.filter((e) => e.id !== id))
+    } else {
+      setCacheEntries((prev) => prev.filter((e) => e.id !== id))
+    }
   }
 
-  return { entries, add, patch, clearByMode, pruneStale }
+  return { entries, loading, add, remove, refresh: fetchDisk }
 }

--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 165,
+  "count": 173,
   "routes": [
     {
       "path": "/",
@@ -127,6 +127,70 @@
         "POST"
       ],
       "name": "unload_daemon",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/disk/history",
+      "methods": [
+        "GET"
+      ],
+      "name": "list_disk_history",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/disk/image/{date_str}/xy/{folder}/{filename}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_disk_xy_image",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/disk/image/{date_str}/{mode}/{filename}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_disk_image",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/disk/thumb/{date_str}/xy/{folder}/{filename}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_disk_xy_thumb",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/disk/thumb/{date_str}/{mode}/{filename}",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_disk_thumb",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/disk/{date_str}/xy/{folder}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_disk_xy_folder",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/disk/{date_str}/{mode}/{filename}",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "delete_disk_image",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/generate/save",
+      "methods": [
+        "POST"
+      ],
+      "name": "save_test_image",
       "type": "APIRoute"
     },
     {

--- a/tests/test_generate_save_metadata.py
+++ b/tests/test_generate_save_metadata.py
@@ -66,6 +66,31 @@ def _open_png_text(path: Path) -> dict[str, str]:
         return dict(img.text)
 
 
+def _post_xy_save(
+    tc: TestClient,
+    composite_params: dict,
+    cells: list[tuple[int, int, dict]],
+    task_id: int | None = None,
+):
+    """XY save 帮手：composite + N 张 cell + cells_manifest 一次 multipart 发出去。
+
+    `cells` 每条 = (xi, yi, cell_params)；cell_params 是物化后的 single-snapshot。"""
+    files: list[tuple[str, tuple[str, bytes, str]]] = [
+        ("image", ("xy plot.png", _png_bytes(), "image/png")),
+    ]
+    for xi, yi, _cp in cells:
+        files.append(("cells", (f"cell x{xi} y{yi}.png", _png_bytes(), "image/png")))
+    manifest = [{"xi": xi, "yi": yi, "params": cp} for (xi, yi, cp) in cells]
+    data = {
+        "mode": "xy",
+        "params": json.dumps(composite_params),
+        "cells_manifest": json.dumps(manifest),
+    }
+    if task_id is not None:
+        data["task_id"] = str(task_id)
+    return tc.post("/api/generate/save", data=data, files=files)
+
+
 def test_save_writes_anima_params_text_block(client) -> None:
     tc, _ = client
     r = tc.post(
@@ -220,12 +245,18 @@ def test_disk_history_skips_png_with_only_a1111_block(client) -> None:
 
 
 def test_disk_history_includes_xy_mode_entries(client) -> None:
-    """xy 模式的合成大图也走 disk-history。"""
+    """xy 模式的合成大图 + cell 文件夹走 disk-history。"""
     tc, _ = client
-    tc.post(
-        "/api/generate/save",
-        data={"mode": "xy", "params": json.dumps(_params(mode="xy", seed=99))},
-        files={"image": ("xy.png", _png_bytes(), "image/png")},
+    _post_xy_save(
+        tc,
+        composite_params=_params(mode="xy", seed=99, xy_draft={
+            "x": {"axis": "steps", "raw": "10, 20", "loraIndex": None},
+            "y": None,
+        }),
+        cells=[
+            (0, 0, _params(mode="single", seed=99, steps=10)),
+            (1, 0, _params(mode="single", seed=99, steps=20)),
+        ],
     )
     entries = tc.get("/api/generate/disk/history").json()["entries"]
     assert len(entries) == 1
@@ -265,7 +296,7 @@ def test_disk_image_validates_inputs(client) -> None:
 
 
 def test_save_uses_v2_filename(client) -> None:
-    """决策 #6：v2 命名 'single image 1.png' / 'xy plot 1.png'，1-based。"""
+    """决策 #6：single v2 命名 'single image 1.png'，1-based。XY 见 test_save_xy_creates_folder。"""
     tc, _ = client
     r1 = tc.post(
         "/api/generate/save",
@@ -277,14 +308,8 @@ def test_save_uses_v2_filename(client) -> None:
         data={"mode": "single", "params": json.dumps(_params())},
         files={"image": ("a.png", _png_bytes(), "image/png")},
     )
-    r3 = tc.post(
-        "/api/generate/save",
-        data={"mode": "xy", "params": json.dumps(_params(mode="xy"))},
-        files={"image": ("a.png", _png_bytes(), "image/png")},
-    )
     assert r1.json()["filename"] == "single image 1.png"
     assert r2.json()["filename"] == "single image 2.png"
-    assert r3.json()["filename"] == "xy plot 1.png"
 
 
 def test_save_sets_task_id_from_form_field(client) -> None:
@@ -313,17 +338,27 @@ def test_save_atomic_write_no_tmp_remains(client, tmp_path) -> None:
 
 
 def test_save_xy_skips_a1111_block(client) -> None:
-    """决策 #7：XY PNG 不写 a1111 parameters 块（矩阵图单图对应不上）。"""
+    """决策 #7：XY composite PNG 不写 a1111 parameters 块（矩阵图单图对应不上）。
+    cell PNG 是 single-snapshot，**会**写 a1111 block。"""
     tc, _ = client
-    r = tc.post(
-        "/api/generate/save",
-        data={"mode": "xy", "params": json.dumps(_params(mode="xy"))},
-        files={"image": ("a.png", _png_bytes(), "image/png")},
+    r = _post_xy_save(
+        tc,
+        composite_params=_params(mode="xy", xy_draft={
+            "x": {"axis": "steps", "raw": "20", "loraIndex": None},
+            "y": None,
+        }),
+        cells=[(0, 0, _params(mode="single", steps=20))],
     )
-    saved = Path(r.json()["path"])
-    text = _open_png_text(saved)
-    assert "anima_params" in text
-    assert "parameters" not in text
+    assert r.status_code == 200, r.text
+    composite = Path(r.json()["composite"])
+    composite_text = _open_png_text(composite)
+    assert "anima_params" in composite_text
+    assert "parameters" not in composite_text
+    # cell 是 single-snapshot：anima_params + a1111 块都在
+    cell = Path(r.json()["cells"][0])
+    cell_text = _open_png_text(cell)
+    assert "anima_params" in cell_text
+    assert "parameters" in cell_text
 
 
 def test_disk_history_migrates_v1_to_v2(client, tmp_path) -> None:
@@ -451,3 +486,248 @@ def test_save_disabled_returns_403(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         files={"image": ("a.png", _png_bytes(), "image/png")},
     )
     assert r.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# XY 文件夹布局（恢复 PreviewXYGrid 历史回看）
+# ---------------------------------------------------------------------------
+
+
+def _xy_snapshot(*, x_raw: str = "10, 20, 30", y_raw: str | None = "3, 5") -> dict:
+    return _params(mode="xy", xy_draft={
+        "x": {"axis": "steps", "raw": x_raw, "loraIndex": None},
+        "y": {"axis": "cfg_scale", "raw": y_raw, "loraIndex": None} if y_raw else None,
+    })
+
+
+def test_save_xy_creates_folder_with_composite_and_cells(client) -> None:
+    """XY save 落出 <date>/xy/xy plot N/{xy plot.png + cell x<i> y<j>.png ...}，无残留 tmp。"""
+    tc, test_dir = client
+    r = _post_xy_save(
+        tc,
+        composite_params=_xy_snapshot(x_raw="10, 20", y_raw="3"),
+        cells=[
+            (0, 0, _params(mode="single", steps=10, cfg_scale=3.0)),
+            (1, 0, _params(mode="single", steps=20, cfg_scale=3.0)),
+        ],
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    folder = Path(body["folder"])
+    assert folder.is_dir()
+    assert folder.name == "xy plot 1"
+    assert (folder / "xy plot.png").is_file()
+    assert (folder / "cell x0 y0.png").is_file()
+    assert (folder / "cell x1 y0.png").is_file()
+    # 无残留 tmp
+    assert not list(folder.parent.glob(".xy plot *.tmp"))
+
+
+def test_save_xy_cell_carries_single_snapshot_and_xy_origin(client) -> None:
+    """cell PNG 是 single-snapshot：mode='single' + a1111 块 + xy_origin 链回 XY plot。"""
+    tc, _ = client
+    r = _post_xy_save(
+        tc,
+        composite_params=_xy_snapshot(x_raw="10, 20", y_raw=None),
+        cells=[
+            (0, 0, _params(mode="single", steps=10)),
+            (1, 0, {**_params(mode="single", steps=20), "xy_origin": {
+                "xi": 1, "yi": 0, "xv": "20", "yv": None,
+                "x_axis": "steps", "y_axis": None,
+            }}),
+        ],
+    )
+    assert r.status_code == 200, r.text
+    cell1 = Path(r.json()["cells"][1])
+    text = _open_png_text(cell1)
+    assert "anima_params" in text
+    assert "parameters" in text  # single mode 写 a1111
+    parsed = json.loads(text["anima_params"])
+    assert parsed["mode"] == "single"
+    assert parsed["steps"] == 20
+    assert parsed["xy_origin"]["xi"] == 1
+    assert parsed["xy_origin"]["x_axis"] == "steps"
+
+
+def test_save_xy_rejects_cell_xy_collision(client) -> None:
+    """两条 cell 同 (xi, yi) → 400."""
+    tc, _ = client
+    r = _post_xy_save(
+        tc,
+        composite_params=_xy_snapshot(),
+        cells=[
+            (0, 0, _params(mode="single")),
+            (0, 0, _params(mode="single")),
+        ],
+    )
+    assert r.status_code == 400
+    assert "duplicate" in r.text
+
+
+def test_save_xy_rejects_cell_count_mismatch(client) -> None:
+    """cells_manifest 数 != cells 数 → 400."""
+    tc, _ = client
+    # 手工拼一个 mismatch：1 file vs 2 manifest entries
+    r = tc.post(
+        "/api/generate/save",
+        data={
+            "mode": "xy",
+            "params": json.dumps(_xy_snapshot()),
+            "cells_manifest": json.dumps([
+                {"xi": 0, "yi": 0, "params": _params(mode="single")},
+                {"xi": 1, "yi": 0, "params": _params(mode="single")},
+            ]),
+        },
+        files=[
+            ("image", ("xy plot.png", _png_bytes(), "image/png")),
+            ("cells", ("cell x0 y0.png", _png_bytes(), "image/png")),
+        ],
+    )
+    assert r.status_code == 400
+    assert "length" in r.text
+
+
+def test_save_xy_folder_index_skips_legacy_files(client) -> None:
+    """残留的 legacy 平铺 `xy plot 7.png` 占位 → 新文件夹从 8 起，不撞号。"""
+    tc, test_dir = client
+    xy_dir = test_dir / "2026-06-08" / "xy"
+    xy_dir.mkdir(parents=True)
+    (xy_dir / "xy plot 7.png").write_bytes(_png_bytes())
+
+    # 把"今天"设成 2026-06-08
+    from datetime import date as _date
+    from studio.api.routers import generate as _gen
+    class _FixedDate(_date):
+        @classmethod
+        def today(cls):
+            return cls(2026, 6, 8)
+    import datetime
+    orig_date = _gen.date
+    try:
+        _gen.date = _FixedDate
+        r = _post_xy_save(
+            tc,
+            composite_params=_xy_snapshot(x_raw="10", y_raw=None),
+            cells=[(0, 0, _params(mode="single", steps=10))],
+        )
+    finally:
+        _gen.date = orig_date
+    assert r.status_code == 200
+    assert Path(r.json()["folder"]).name == "xy plot 8"
+
+
+def test_disk_history_xy_folder_entry_has_xy_meta(client) -> None:
+    """扫到 XY 文件夹时返回 xy_meta（per-cell 信息 + 直读 URL）。"""
+    tc, _ = client
+    _post_xy_save(
+        tc,
+        composite_params=_xy_snapshot(x_raw="10, 20", y_raw="3"),
+        cells=[
+            (0, 0, _params(mode="single", steps=10, cfg_scale=3.0)),
+            (1, 0, _params(mode="single", steps=20, cfg_scale=3.0)),
+        ],
+    )
+    entries = tc.get("/api/generate/disk/history").json()["entries"]
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["mode"] == "xy"
+    assert e["folder"] == "xy plot 1"
+    assert e["image_url"].endswith("xy%20plot.png")
+    meta = e["xy_meta"]
+    assert meta["x_axis"] == "steps"
+    assert meta["y_axis"] == "cfg_scale"
+    assert meta["x_values"] == ["10", "20"]
+    assert meta["y_values"] == ["3"]
+    assert len(meta["samples"]) == 2
+    samples_by_pos = {(s["xy"]["xi"], s["xy"]["yi"]): s for s in meta["samples"]}
+    assert samples_by_pos[(0, 0)]["xy"]["xv"] == "10"
+    assert samples_by_pos[(1, 0)]["xy"]["xv"] == "20"
+    # image_url 已 encode（空格 → %20）
+    assert "%20" in samples_by_pos[(0, 0)]["image_url"]
+
+
+def test_disk_history_skips_legacy_xy_flat_files(client) -> None:
+    """legacy 平铺 `xy plot N.png` 文件即便带 anima_params 也不出现在 history（用户决策 hide）。"""
+    tc, test_dir = client
+    xy_dir = test_dir / "2026-06-08" / "xy"
+    xy_dir.mkdir(parents=True)
+    # 写一个带 anima_params 的 legacy 平铺文件
+    info = PngImagePlugin.PngInfo()
+    info.add_text("anima_params", json.dumps(_params(mode="xy")))
+    Image.new("RGB", (8, 8)).save(xy_dir / "xy plot 99.png", format="PNG", pnginfo=info)
+
+    entries = tc.get("/api/generate/disk/history").json()["entries"]
+    assert entries == []
+
+
+def test_disk_history_skips_xy_folder_without_composite(client) -> None:
+    """文件夹存在但没 composite（半成品 / 手 mkdir）→ 跳过。"""
+    tc, test_dir = client
+    xy_dir = test_dir / "2026-06-08" / "xy" / "xy plot 1"
+    xy_dir.mkdir(parents=True)
+    # 只有 cell，没 composite
+    info = PngImagePlugin.PngInfo()
+    info.add_text("anima_params", json.dumps(_params(mode="single")))
+    Image.new("RGB", (8, 8)).save(xy_dir / "cell x0 y0.png", format="PNG", pnginfo=info)
+
+    entries = tc.get("/api/generate/disk/history").json()["entries"]
+    assert entries == []
+
+
+def test_disk_xy_folder_delete_removes_recursively(client) -> None:
+    """DELETE /api/generate/disk/<date>/xy/<folder> → rmtree 整文件夹。"""
+    tc, _ = client
+    r = _post_xy_save(
+        tc,
+        composite_params=_xy_snapshot(x_raw="10", y_raw=None),
+        cells=[(0, 0, _params(mode="single", steps=10))],
+    )
+    folder = Path(r.json()["folder"])
+    assert folder.is_dir()
+    entry = tc.get("/api/generate/disk/history").json()["entries"][0]
+    url = f"/api/generate/disk/{entry['date']}/xy/{entry['folder'].replace(' ', '%20')}"
+    delete_r = tc.delete(url)
+    assert delete_r.status_code == 200
+    assert delete_r.json()["noop"] is False
+    assert not folder.exists()
+    # 二次删 noop=True
+    assert tc.delete(url).json()["noop"] is True
+
+
+def test_disk_xy_image_route_resolves_subpath(client) -> None:
+    """GET /api/generate/disk/image/<date>/xy/<folder>/<filename> → cell PNG bytes."""
+    tc, _ = client
+    r = _post_xy_save(
+        tc,
+        composite_params=_xy_snapshot(x_raw="10", y_raw=None),
+        cells=[(0, 0, _params(mode="single", steps=10))],
+    )
+    entry = tc.get("/api/generate/disk/history").json()["entries"][0]
+    cell_url = entry["xy_meta"]["samples"][0]["image_url"]
+    cell_r = tc.get(cell_url)
+    assert cell_r.status_code == 200
+    assert cell_r.headers["content-type"] == "image/png"
+    assert len(cell_r.content) > 0
+    # composite 也可读
+    composite_r = tc.get(entry["image_url"])
+    assert composite_r.status_code == 200
+    # thumb 也可读
+    thumb_r = tc.get(entry["thumb_url"])
+    assert thumb_r.status_code == 200
+
+
+def test_disk_xy_path_traversal_blocked(client) -> None:
+    """folder / filename 反 traversal：folder=`..` / 非法 folder name → 400."""
+    tc, _ = client
+    # folder name 不符 `xy plot N`
+    r1 = tc.get("/api/generate/disk/image/2026-06-08/xy/not%20a%20folder/cell.png")
+    assert r1.status_code == 400
+    # date 非法
+    r2 = tc.get("/api/generate/disk/image/bad-date/xy/xy%20plot%201/x.png")
+    assert r2.status_code == 400
+    # filename 非法
+    r3 = tc.get("/api/generate/disk/image/2026-06-08/xy/xy%20plot%201/..%2Fsecret.png")
+    assert r3.status_code in (400, 404)
+    # DELETE 同样校验
+    r4 = tc.delete("/api/generate/disk/2026-06-08/xy/bad%20folder")
+    assert r4.status_code == 400

--- a/tests/test_generate_save_metadata.py
+++ b/tests/test_generate_save_metadata.py
@@ -81,7 +81,11 @@ def test_save_writes_anima_params_text_block(client) -> None:
     assert "anima_params" in text
     parsed = json.loads(text["anima_params"])
     assert parsed["seed"] == 42
-    assert parsed["schema_version"] == 1
+    # server 端 enrich 强制 schema_version=2（即使前端传 1 也覆盖）
+    assert parsed["schema_version"] == 2
+    # server 端 enrich 补 created_at + mode
+    assert parsed["mode"] == "single"
+    assert "created_at" in parsed
 
 
 def test_save_writes_a1111_parameters_text_block(client) -> None:
@@ -183,7 +187,7 @@ def test_disk_history_lists_entries_from_png_metadata(client) -> None:
         assert a["created_at"] >= b["created_at"]
     seeds = sorted(e["params"]["seed"] for e in entries)
     assert seeds == [1, 2, 3]
-    assert all(e["url"].startswith("/api/generate/disk/image/") for e in entries)
+    assert all(e["image_url"].startswith("/api/generate/disk/image/") for e in entries)
     assert len({e["id"] for e in entries}) == 3
 
 
@@ -237,12 +241,14 @@ def test_disk_image_serves_saved_file(client) -> None:
     )
     listing = tc.get("/api/generate/disk/history").json()["entries"]
     assert len(listing) == 1
-    url = listing[0]["url"]
+    url = listing[0]["image_url"]
 
     r = tc.get(url)
     assert r.status_code == 200
     assert r.headers["content-type"] == "image/png"
     assert len(r.content) > 0
+    # 落盘图加了 strong cache header（决策：内容稳定可强 cache）
+    assert "max-age" in r.headers.get("cache-control", "")
 
 
 def test_disk_image_validates_inputs(client) -> None:
@@ -251,6 +257,176 @@ def test_disk_image_validates_inputs(client) -> None:
     assert tc.get("/api/generate/disk/image/2026-01-01/bad/image_0.png").status_code == 400
     assert tc.get("/api/generate/disk/image/2026-01-01/single/image_0.jpg").status_code == 400
     assert tc.get("/api/generate/disk/image/2026-01-01/single/image_0.png").status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Step 1a/1b 新功能：文件命名 v2 / migrate / thumb / DELETE / path safety
+# ---------------------------------------------------------------------------
+
+
+def test_save_uses_v2_filename(client) -> None:
+    """决策 #6：v2 命名 'single image 1.png' / 'xy plot 1.png'，1-based。"""
+    tc, _ = client
+    r1 = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params())},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    r2 = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params())},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    r3 = tc.post(
+        "/api/generate/save",
+        data={"mode": "xy", "params": json.dumps(_params(mode="xy"))},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r1.json()["filename"] == "single image 1.png"
+    assert r2.json()["filename"] == "single image 2.png"
+    assert r3.json()["filename"] == "xy plot 1.png"
+
+
+def test_save_sets_task_id_from_form_field(client) -> None:
+    tc, _ = client
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params()), "task_id": "42"},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    saved = Path(r.json()["path"])
+    text = _open_png_text(saved)
+    parsed = json.loads(text["anima_params"])
+    assert parsed["task_id"] == 42
+
+
+def test_save_atomic_write_no_tmp_remains(client, tmp_path) -> None:
+    """决策 #11：atomic write 不留 .tmp 文件。"""
+    tc, test_dir = client
+    tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params())},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    leftover = list((test_dir).rglob("*.tmp*"))
+    assert leftover == [], f"留有 atomic write tmp 文件: {leftover}"
+
+
+def test_save_xy_skips_a1111_block(client) -> None:
+    """决策 #7：XY PNG 不写 a1111 parameters 块（矩阵图单图对应不上）。"""
+    tc, _ = client
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "xy", "params": json.dumps(_params(mode="xy"))},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    saved = Path(r.json()["path"])
+    text = _open_png_text(saved)
+    assert "anima_params" in text
+    assert "parameters" not in text
+
+
+def test_disk_history_migrates_v1_to_v2(client, tmp_path) -> None:
+    """决策 #18：v1 PNG（lora_configs[].path）扫到后 migrate 成 v2（loras[].name 无 path）。"""
+    tc, test_dir = client
+    # 手工写一个 v1 schema PNG
+    v1_params = {
+        "schema_version": 1,
+        "mode": "single",
+        "prompts": ["test"],
+        "negative_prompt": "",
+        "width": 8, "height": 8, "steps": 5, "cfg_scale": 4.0, "count": 1, "seed": 1,
+        "lora_configs": [
+            {"path": "G:/some/abs/path/my-lora.safetensors", "scale": 0.8,
+             "project_id": 12, "version_id": 34}
+        ],
+    }
+    from studio.api.routers import generate as _gen
+    raw = _gen._inject_png_metadata(_png_bytes(), v1_params, mode="single")
+    single_dir = test_dir / "2026-06-08" / "single"
+    single_dir.mkdir(parents=True)
+    (single_dir / "image_0.png").write_bytes(raw)  # 故意用 v1 命名 image_N.png
+
+    r = tc.get("/api/generate/disk/history")
+    entries = r.json()["entries"]
+    assert len(entries) == 1
+    params = entries[0]["params"]
+    assert params["schema_version"] == 2
+    # v1 lora_configs[].path → v2 loras[].name basename（无 path 字段）
+    assert "lora_configs" not in params
+    assert params["loras"] == [
+        {"name": "my-lora.safetensors", "scale": 0.8,
+         "project_id": 12, "version_id": 34}
+    ]
+
+
+def test_disk_history_skips_tmp_files(client, tmp_path) -> None:
+    """atomic write 半途留下的 .tmp.png 不入历史。"""
+    tc, test_dir = client
+    single_dir = test_dir / "2026-06-08" / "single"
+    single_dir.mkdir(parents=True)
+    (single_dir / "single image 1.tmp.png").write_bytes(_png_bytes())
+    assert tc.get("/api/generate/disk/history").json()["entries"] == []
+
+
+def test_disk_thumb_returns_png_with_etag(client) -> None:
+    tc, _ = client
+    tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params())},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    entry = tc.get("/api/generate/disk/history").json()["entries"][0]
+    thumb_url = entry["thumb_url"]
+    assert "/disk/thumb/" in thumb_url
+    r = tc.get(thumb_url)
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "image/png"
+    assert r.headers.get("etag")
+    assert "max-age" in r.headers.get("cache-control", "")
+
+
+def test_disk_thumb_validates_inputs(client) -> None:
+    tc, _ = client
+    assert tc.get("/api/generate/disk/thumb/not-a-date/single/foo.png").status_code == 400
+    assert tc.get("/api/generate/disk/thumb/2026-06-08/bad/foo.png").status_code == 400
+    assert tc.get("/api/generate/disk/thumb/2026-06-08/single/foo.png").status_code == 404
+
+
+def test_disk_delete_removes_file(client, tmp_path) -> None:
+    tc, _ = client
+    tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params())},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    entry = tc.get("/api/generate/disk/history").json()["entries"][0]
+    path = Path(entry["path"])
+    assert path.is_file()
+    # 从 entry 解析出 disk delete URL；后端校验路径
+    encoded = entry["image_url"].rsplit("/", 1)[-1]
+    delete_url = f"/api/generate/disk/{entry['date']}/{entry['mode']}/{encoded}"
+    r = tc.delete(delete_url)
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    assert r.json()["noop"] is False
+    assert not path.is_file()
+    # 二次删 noop=True
+    r2 = tc.delete(delete_url)
+    assert r2.status_code == 200
+    assert r2.json()["noop"] is True
+
+
+def test_disk_path_traversal_attack_blocked(client) -> None:
+    """安全：含 .. 的 path 必须 400。"""
+    tc, _ = client
+    # FastAPI path param 默认不允许 / —— 但 `..%2F` URL encoded 可能逃过
+    for evil in [
+        "%2E%2E%2Fsecret.png",        # ../secret.png URL encoded
+        "..%5Csecret.png",            # ..\secret.png URL encoded (Windows)
+    ]:
+        r = tc.get(f"/api/generate/disk/image/2026-06-08/single/{evil}")
+        assert r.status_code in (400, 404), f"path={evil} got {r.status_code}"
 
 
 def test_save_disabled_returns_403(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_generate_save_metadata.py
+++ b/tests/test_generate_save_metadata.py
@@ -1,5 +1,6 @@
-"""POST /api/generate/save 写 PNG metadata + sidecar、GET /api/generate/disk/history
-扫描、GET /api/generate/disk/image/* 静态返回的覆盖测试。"""
+"""POST /api/generate/save 写 PNG metadata (anima_params + a1111 parameters)、
+GET /api/generate/disk/history 扫 PNG metadata、GET /api/generate/disk/image/*
+静态返回的覆盖测试。"""
 from __future__ import annotations
 
 import json
@@ -9,7 +10,7 @@ from pathlib import Path
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from PIL import Image
+from PIL import Image, PngImagePlugin
 
 
 def _png_bytes(color: tuple[int, int, int] = (0, 0, 0), size: tuple[int, int] = (8, 8)) -> bytes:
@@ -19,18 +20,21 @@ def _png_bytes(color: tuple[int, int, int] = (0, 0, 0), size: tuple[int, int] = 
 
 
 def _params(**overrides) -> dict:
+    """前端 snapshot shape：loras 是 name+ids（无 path），跟 paramsSnapshot.ts 对齐。"""
     base = {
         "schema_version": 1,
         "mode": "single",
-        "prompts": ["a"],
-        "negative_prompt": "",
-        "width": 8,
-        "height": 8,
-        "steps": 5,
-        "cfg_scale": 4.0,
+        "prompts": ["1girl, anime"],
+        "negative_prompt": "blurry",
+        "width": 1024,
+        "height": 1024,
+        "steps": 20,
+        "cfg_scale": 7.0,
         "count": 1,
         "seed": 7,
-        "lora_configs": [],
+        "loras": [],
+        "xy_draft": None,
+        "dataset_pick": None,
     }
     base.update(overrides)
     return base
@@ -56,7 +60,13 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient,
     return TestClient(app), test_dir
 
 
-def test_save_writes_png_metadata_and_sidecar(client) -> None:
+def _open_png_text(path: Path) -> dict[str, str]:
+    with Image.open(path) as img:
+        img.load()
+        return dict(img.text)
+
+
+def test_save_writes_anima_params_text_block(client) -> None:
     tc, _ = client
     r = tc.post(
         "/api/generate/save",
@@ -64,26 +74,65 @@ def test_save_writes_png_metadata_and_sidecar(client) -> None:
         files={"image": ("a.png", _png_bytes(), "image/png")},
     )
     assert r.status_code == 200, r.text
-    data = r.json()
-    saved = Path(data["path"])
+    saved = Path(r.json()["path"])
     assert saved.exists()
-    sidecar = saved.with_suffix(".json")
-    assert sidecar.exists()
-    sidecar_obj = json.loads(sidecar.read_text(encoding="utf-8"))
-    assert sidecar_obj["mode"] == "single"
-    assert sidecar_obj["schema_version"] == 1
-    assert sidecar_obj["filename"] == saved.name
-    assert sidecar_obj["params"]["seed"] == 42
 
-    # PNG tEXt 注入：再读图应该带 anima_params
-    img = Image.open(saved)
-    img.load()
-    assert "anima_params" in img.text
-    parsed = json.loads(img.text["anima_params"])
+    text = _open_png_text(saved)
+    assert "anima_params" in text
+    parsed = json.loads(text["anima_params"])
     assert parsed["seed"] == 42
+    assert parsed["schema_version"] == 1
 
 
-def test_save_without_params_skips_sidecar_and_metadata(client) -> None:
+def test_save_writes_a1111_parameters_text_block(client) -> None:
+    """a1111 兼容 `parameters` 块：ComfyUI / WebUI / Civitai 拖图能识别。"""
+    tc, _ = client
+    p = _params(
+        seed=42, steps=20, cfg_scale=7.0, width=1024, height=1024,
+        prompts=["1girl, anime"], negative_prompt="blurry",
+        loras=[{"name": "my-lora.safetensors", "scale": 0.8,
+                "project_id": 12, "version_id": 34}],
+    )
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(p)},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 200
+    saved = Path(r.json()["path"])
+
+    text = _open_png_text(saved)
+    assert "parameters" in text
+    a1111 = text["parameters"]
+    # 第一行：prompt + <lora:name:scale> 嵌入
+    first_line = a1111.split("\n", 1)[0]
+    assert "1girl, anime" in first_line
+    assert "<lora:my-lora:0.8>" in first_line  # 注意 a1111 语法去 .safetensors
+    # 第二行：negative
+    assert "Negative prompt: blurry" in a1111
+    # 第三行：参数串
+    assert "Steps: 20" in a1111
+    assert "CFG scale: 7.0" in a1111
+    assert "Seed: 42" in a1111
+    assert "Size: 1024x1024" in a1111
+
+
+def test_save_does_not_write_sidecar(client) -> None:
+    """sidecar 已砍 —— 同目录不应出现 image_N.json。"""
+    tc, _ = client
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params())},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 200
+    saved = Path(r.json()["path"])
+    assert not saved.with_suffix(".json").exists()
+    # 返回结构也没 sidecar 字段了
+    assert "sidecar" not in r.json()
+
+
+def test_save_without_params_skips_metadata(client) -> None:
     tc, _ = client
     r = tc.post(
         "/api/generate/save",
@@ -91,13 +140,10 @@ def test_save_without_params_skips_sidecar_and_metadata(client) -> None:
         files={"image": ("a.png", _png_bytes(), "image/png")},
     )
     assert r.status_code == 200
-    data = r.json()
-    assert data["sidecar"] is None
-    saved = Path(data["path"])
-    assert not saved.with_suffix(".json").exists()
-    img = Image.open(saved)
-    img.load()
-    assert "anima_params" not in img.text
+    saved = Path(r.json()["path"])
+    text = _open_png_text(saved)
+    assert "anima_params" not in text
+    assert "parameters" not in text
 
 
 def test_save_rejects_invalid_params_json(client) -> None:
@@ -120,7 +166,7 @@ def test_save_rejects_non_object_params(client) -> None:
     assert r.status_code == 400
 
 
-def test_disk_history_lists_entries_with_sidecar(client) -> None:
+def test_disk_history_lists_entries_from_png_metadata(client) -> None:
     tc, _ = client
     for seed in (1, 2, 3):
         tc.post(
@@ -133,19 +179,16 @@ def test_disk_history_lists_entries_with_sidecar(client) -> None:
     assert r.status_code == 200
     entries = r.json()["entries"]
     assert len(entries) == 3
-    # 按 created_at desc
     for a, b in zip(entries, entries[1:]):
         assert a["created_at"] >= b["created_at"]
     seeds = sorted(e["params"]["seed"] for e in entries)
     assert seeds == [1, 2, 3]
-    # url 指向 disk-image 接口
     assert all(e["url"].startswith("/api/generate/disk/image/") for e in entries)
-    # id 稳定且唯一
     assert len({e["id"] for e in entries}) == 3
 
 
-def test_disk_history_skips_entry_without_sidecar(client) -> None:
-    """没有 sidecar 的图（老数据 / 客户端没传 params）不入列表。"""
+def test_disk_history_skips_png_without_anima_params(client) -> None:
+    """没有 anima_params tEXt 块的 PNG（老数据 / 客户端没传 params）不入列表。"""
     tc, test_dir = client
     single_dir = test_dir / "2026-01-01" / "single"
     single_dir.mkdir(parents=True)
@@ -156,31 +199,42 @@ def test_disk_history_skips_entry_without_sidecar(client) -> None:
     assert r.json()["entries"] == []
 
 
-def test_disk_history_skips_sidecar_without_image(client) -> None:
-    """sidecar 留着但图被删 → 不入列表（避免历史栏点 404）。"""
+def test_disk_history_skips_png_with_only_a1111_block(client) -> None:
+    """光有 a1111 parameters 块、没 anima_params 的 PNG 也跳过（避免半 entry）。"""
     tc, test_dir = client
     single_dir = test_dir / "2026-01-01" / "single"
     single_dir.mkdir(parents=True)
-    (single_dir / "image_0.json").write_text(
-        json.dumps({"schema_version": 1, "mode": "single", "created_at": 0,
-                    "filename": "image_0.png", "params": _params()}),
-        encoding="utf-8",
-    )
+    # 手工写一个只含 a1111 块的 PNG
+    info = PngImagePlugin.PngInfo()
+    info.add_text("parameters", "fake prompt\nSteps: 1, Sampler: x")
+    img = Image.new("RGB", (8, 8))
+    img.save(single_dir / "image_0.png", format="PNG", pnginfo=info)
 
     r = tc.get("/api/generate/disk/history")
     assert r.status_code == 200
     assert r.json()["entries"] == []
 
 
+def test_disk_history_includes_xy_mode_entries(client) -> None:
+    """xy 模式的合成大图也走 disk-history。"""
+    tc, _ = client
+    tc.post(
+        "/api/generate/save",
+        data={"mode": "xy", "params": json.dumps(_params(mode="xy", seed=99))},
+        files={"image": ("xy.png", _png_bytes(), "image/png")},
+    )
+    entries = tc.get("/api/generate/disk/history").json()["entries"]
+    assert len(entries) == 1
+    assert entries[0]["mode"] == "xy"
+
+
 def test_disk_image_serves_saved_file(client) -> None:
     tc, _ = client
-    save_resp = tc.post(
+    tc.post(
         "/api/generate/save",
         data={"mode": "single", "params": json.dumps(_params(seed=99))},
         files={"image": ("a.png", _png_bytes((255, 0, 0)), "image/png")},
     )
-    assert save_resp.status_code == 200
-
     listing = tc.get("/api/generate/disk/history").json()["entries"]
     assert len(listing) == 1
     url = listing[0]["url"]
@@ -193,18 +247,13 @@ def test_disk_image_serves_saved_file(client) -> None:
 
 def test_disk_image_validates_inputs(client) -> None:
     tc, _ = client
-    # 非法 date
     assert tc.get("/api/generate/disk/image/not-a-date/single/image_0.png").status_code == 400
-    # 非法 mode
     assert tc.get("/api/generate/disk/image/2026-01-01/bad/image_0.png").status_code == 400
-    # 非 png 扩展
     assert tc.get("/api/generate/disk/image/2026-01-01/single/image_0.jpg").status_code == 400
-    # 文件不存在
     assert tc.get("/api/generate/disk/image/2026-01-01/single/image_0.png").status_code == 404
 
 
 def test_save_disabled_returns_403(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Settings.save_test_images=False → 403。"""
     from studio.api.routers import generate as _gen
 
     monkeypatch.setattr(_gen, "TEST_IMAGES_DIR", tmp_path / "test")

--- a/tests/test_inference_daemon.py
+++ b/tests/test_inference_daemon.py
@@ -148,6 +148,41 @@ def test_submit_task_runs_to_done(mock_daemon_script: Path) -> None:
     assert image_done_events
     for e in image_done_events:
         assert "image_b64" not in e
+    # 决策 #14：image_done 加 delivery 子字段；config 没 save_test_images_at_dispatch
+    # 时默认 'cache'
+    for e in image_done_events:
+        assert e.get("delivery") == "cache"
+    generate_cache.clear_all()
+
+
+def test_submit_task_delivery_disk_when_save_to_disk_true(
+    mock_daemon_script: Path,
+) -> None:
+    """决策 #14 / #15：config 含 save_test_images_at_dispatch=True 时，
+    image_done event 的 delivery 字段是 'disk'。
+    """
+    from studio.services.inference import cache as generate_cache
+
+    generate_cache.clear_all()
+    d = InferenceDaemon(script_path=mock_daemon_script)
+    d.start()
+    events: list[dict[str, Any]] = []
+    try:
+        d.submit_task(
+            task_id=43,
+            config={"prompts": ["a"], "save_test_images_at_dispatch": True},
+            output_dir="/tmp/x",
+            on_event=events.append,
+        )
+        assert _wait_for(
+            lambda: any(e.get("kind") == "done" for e in events), timeout=3
+        ), f"events={events}"
+    finally:
+        d.stop()
+    image_done_events = [e for e in events if e.get("kind") == "image_done"]
+    assert image_done_events
+    for e in image_done_events:
+        assert e.get("delivery") == "disk"
     generate_cache.clear_all()
 
 


### PR DESCRIPTION
> 本 PR 范围比最初标题（"metadata 单一 PNG source"）大很多。原本是 #244 的 follow-up cleanup，深入讨论后确认底层架构本身需要重构 —— 4 处存储（localStorage / cache / 磁盘 / IDB）同步链路是 bug 温床、merge upgrade 复杂度无法演进。本次一次性收敛，所以扩大 scope 改写标题。详细方案见仓库 \`tmp/generate-history-refactor-plan.md\`。

## 重构核心

**二元 XOR 模式（决策 #5）**：\`save_test_images\` 开关 = 持久（图只走磁盘）/ 临时（图只走 cache）二选一。两边代码独立，无 merge / fallback。

**磁盘 PNG = 唯一 canonical（决策 #5 + #6 + #7）**：
- 落盘 PNG \`anima_params\` zTXt 块 = 完整测试参数快照（schema v2）
- single PNG 额外写 a1111 兼容 \`parameters\` 块（拖 ComfyUI / WebUI 识别）
- XY 不写 a1111 块（矩阵图单图对应不上多维度）
- 文件名朴素：\`single image 1.png\` / \`xy plot 1.png\`（决策 #6）

**砍 IndexedDB**（决策 #5 + #12）：
- 历史栏直接走 \`GET /api/generate/disk/history\` + session in-memory
- 删 \`useGenerateHistory.ts\` 整个 IDB 部分（~-250 LOC）
- \`HistoryEntry\` adapter pattern（\`entryAdapter.ts\` 收敛 switch source 逻辑）

**前端 UI 一致性架构层根治**（决策 #8）：
- sidebar 子组件强制 controlled（无 mount-only 内部 state）
- 删 \`urlConsumedKey\` bump-key 兜底
- ESLint custom rule \`no-mount-only-prop-state\` 防回归
- 单一来源 = prefs，所有 setPrefs 带 source meta（user / recall / recall_undo）

**§9.4 回填覆盖关系（决策 #10）**：选 C，5s 撤销 toast + sessionStorage 持久化 snapshot

**其它**：mount 总拉 disk-history（开关只控新出图，不影响历史显隐 决策 #9）、SSE 保单事件加 \`delivery\` 子字段（决策 #14）、task 启动冻结 \`save_test_images_at_dispatch\`（决策 #15）、PNG header 只读不 load 性能优化（决策 #16）、v1→v2 migrate（决策 #18）、\`origin\` 预留字段（决策 #19）

## 实施进度（8 step）

- [x] Step 1: 后端 PNG schema v2 + zTXt + migrate + 文件命名 + atomic write + thumb/DELETE endpoint + path 安全（commit \`6cb85cc\`）
- [ ] Step 2: SSE delivery 子字段 + task config 冻结 + 删 cache 30s 兜底
- [ ] Step 3: \`paramsSnapshot.ts\` 抽 \`applySnapshot\` + \`entryAdapter.ts\`
- [ ] Step 4: \`useGenerateHistory.ts\` 重写（砍 IDB）
- [ ] Step 5: \`Generate.tsx\` 简化 + 撤销 toast + 删 \`urlConsumedKey\`
- [ ] Step 6: sidebar 子组件 controlled 重构 + LoRA placeholder UI + ESLint rule
- [ ] Step 7: 测试扩展
- [ ] Step 8: i18n

## 净 diff 预估

-300 ~ -400 LOC（IDB + merge upgrade + URL 分支 + 同步链路全消失）。

## 早期 commit（#244 follow-up，已 self-contained）

- commit \`8cca268\` — metadata 设计收敛 + a1111 兼容 + 砍 LoRA 绝对路径
- commit \`405b191\` — 历史回填后 bump key 让 InlineLoraPicker remount（被 Step 5/6 替代但兼容性留着）
- commit \`4af69a2\` — 重启后落盘历史走 disk URL 兜底

🤖 Generated with [Claude Code](https://claude.com/claude-code)