### PR TITLE
fix(tagger): 移除 chip 模式输入框 Backspace 误删标签行为

### DIFF
--- a/studio/web/src/components/TagEditor.tsx
+++ b/studio/web/src/components/TagEditor.tsx
@@ -193,8 +193,6 @@ export default function TagEditor({
                   if (draftSuggest.handleKeyDown(e)) return
                   if (e.key === 'Enter' || e.key === ',' || e.key === '，') {
                     e.preventDefault(); addTag(draft)
-                  } else if (e.key === 'Backspace' && !draft && tags.length) {
-                    removeTag(tags[tags.length - 1])
                   }
                 }}
                 onFocus={() => draftSuggest.notifyFocus()}


### PR DESCRIPTION
## 背景

在标签编辑 chip 模式下，当右下角输入框为空时按退格键会删除上方末位标签。这不符合用户预期——空输入框的退格应当无操作。

## 改动

移除 TagEditor chip 模式输入框  中的 Backspace 处理逻辑（-2 行）。标签删除仅通过每个 chip 上的 × 按钮完成。

## 测试

- `npm run lint` 通过
- `npx tsc --noEmit` 通过
- `vitest run` 329 全部通过