### PR TITLE
feat(tagger): 优化标签自动补全排序为热度优先 + 支持紧凑匹配

### DIFF
--- a/studio/api/routers/tag_dictionary.py
+++ b/studio/api/routers/tag_dictionary.py
@@ -32,8 +32,10 @@ def get_data() -> JSONResponse:
     entries, meta = loaded
     # `Cache-Control: public, max-age=300` 让浏览器 5 分钟内不重发；上传/reset 后
     # 后端没有 ETag，前端通过 meta.downloaded_at 比对决定是否强刷。
+    # `keys` 单独下发：JS 对象会把整数型 key（"69"、年份 tag 等）重排到最前，
+    # 前端靠这个数组拿到文件原始行序（默认源 = post_count 降序的热度序）。
     return JSONResponse(
-        content={"entries": entries, "meta": meta},
+        content={"entries": entries, "keys": list(entries.keys()), "meta": meta},
         headers={"Cache-Control": "public, max-age=300"},
     )
 

--- a/studio/infrastructure/tag_dictionary.py
+++ b/studio/infrastructure/tag_dictionary.py
@@ -50,6 +50,8 @@ def parse_csv(text: str) -> dict[str, list[str]]:
       （如 `breasts,胸部 乳房 oppai`），全部保留让反向索引覆盖度高
     - 空行 / '#' 起头注释跳过
     - 超 MAX_ENTRIES 截断 + 日志告警；返回字典（最后一次出现的 tag 覆盖前面）
+    - 条目顺序 = 文件行序，原样透传给前端做 autocomplete 排序。默认源按
+      post_count 降序（热度序）；用户上传的文件无此保证，补全顺序即其行序
     """
     entries: dict[str, list[str]] = {}
     truncated = False

--- a/studio/web/src/components/tagSuggest/useTagSuggest.ts
+++ b/studio/web/src/components/tagSuggest/useTagSuggest.ts
@@ -72,9 +72,13 @@ export function useTagSuggest({
     return findSuggestions(tokenInfo.token, {
       entries: dict.entries,
       tagKeys: dict.tagKeys,
+      compactedKeys: dict.compactedKeys,
       reverse: dict.reverse,
     })
-  }, [disabled, open, tokenInfo.token, dict.status, dict.entries, dict.tagKeys, dict.reverse])
+  }, [
+    disabled, open, tokenInfo.token,
+    dict.status, dict.entries, dict.tagKeys, dict.compactedKeys, dict.reverse,
+  ])
 
   // suggestions 列表变化时重置 active
   const sugKey = suggestions.map((s) => s.tag).join('|')

--- a/studio/web/src/tagDict/store.ts
+++ b/studio/web/src/tagDict/store.ts
@@ -15,7 +15,7 @@ import type { ReverseEntry, TagDictMeta, TagDictPayload, TagDictStatus } from '.
 interface State {
   status: TagDictStatus
   entries: Map<string, string[]>
-  /** key 升序后的 tag 列表（autocomplete prefix/substring 扫描用）。 */
+  /** tag 列表（保持 CSV 原始顺序，即 post_count DESC 的热度排序；autocomplete 扫描用）。 */
   tagKeys: string[]
   reverse: ReverseEntry[]
   meta: TagDictMeta | null
@@ -79,7 +79,7 @@ async function fetchDict(): Promise<void> {
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
     const payload = (await resp.json()) as TagDictPayload
     const entries = new Map(Object.entries(payload.entries || {}))
-    const tagKeys = Array.from(entries.keys()).sort((a, b) => a.length - b.length)
+    const tagKeys = Array.from(entries.keys())
     const reverse = buildReverse(entries)
     setState({
       status: 'ready',

--- a/studio/web/src/tagDict/store.ts
+++ b/studio/web/src/tagDict/store.ts
@@ -15,8 +15,12 @@ import type { ReverseEntry, TagDictMeta, TagDictPayload, TagDictStatus } from '.
 interface State {
   status: TagDictStatus
   entries: Map<string, string[]>
-  /** tag 列表（保持 CSV 原始顺序，即 post_count DESC 的热度排序；autocomplete 扫描用）。 */
+  /** tag 列表（保持词典文件行序；默认源即 post_count DESC 的热度排序，
+   * 用户上传的词典无此保证。autocomplete 扫描用）。 */
   tagKeys: string[]
+  /** tagKeys 的紧凑形式（去空格/_），同下标对齐。加载时一次算好，
+   * 避免 suggest 每次按键对全字典逐个 regex replace。 */
+  compactedKeys: string[]
   reverse: ReverseEntry[]
   meta: TagDictMeta | null
   error: string | null
@@ -26,6 +30,7 @@ let state: State = {
   status: 'idle',
   entries: new Map(),
   tagKeys: [],
+  compactedKeys: [],
   reverse: [],
   meta: null,
   error: null,
@@ -56,7 +61,7 @@ function buildReverse(entries: Map<string, string[]>): ReverseEntry[] {
       else zhToTags.set(zh, [tag])
     })
   })
-  // 按 zh 长度升序，让 prefix match 短的优先；suggest.ts 内部还会再排序。
+  // 按 zh 长度升序，让 prefix match 短的优先；suggest.ts 按此扫描序直接输出。
   return Array.from(zhToTags.entries())
     .map(([zh, tags]) => ({ zh, tags }))
     .sort((a, b) => a.zh.length - b.zh.length)
@@ -71,6 +76,7 @@ async function fetchDict(): Promise<void> {
         status: 'empty',
         entries: new Map(),
         tagKeys: [],
+        compactedKeys: [],
         reverse: [],
         meta: null,
       })
@@ -79,12 +85,18 @@ async function fetchDict(): Promise<void> {
     if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
     const payload = (await resp.json()) as TagDictPayload
     const entries = new Map(Object.entries(payload.entries || {}))
-    const tagKeys = Array.from(entries.keys())
+    // 行序以后端 keys 数组为准：JS 对象会把整数型 key（"69"、年份 tag 等）
+    // 重排到最前，entries 自身的 key 序不可靠。旧后端没有 keys 时退回对象序。
+    const tagKeys = payload.keys && payload.keys.length === entries.size
+      ? payload.keys
+      : Array.from(entries.keys())
+    const compactedKeys = tagKeys.map((t) => t.replace(/[\s_]/g, ''))
     const reverse = buildReverse(entries)
     setState({
       status: 'ready',
       entries,
       tagKeys,
+      compactedKeys,
       reverse,
       meta: payload.meta || null,
       error: null,

--- a/studio/web/src/tagDict/suggest.test.ts
+++ b/studio/web/src/tagDict/suggest.test.ts
@@ -81,8 +81,10 @@ function buildStore(entries: Record<string, string[]>): SuggestStore {
   const reverse: ReverseEntry[] = Array.from(reverseMap.entries())
     .map(([zh, tags]) => ({ zh, tags }))
     .sort((a, b) => a.zh.length - b.zh.length)
-  const tagKeys = Array.from(map.keys()).sort((a, b) => a.length - b.length)
-  return { entries: map, tagKeys, reverse }
+  // 与生产 store.fetchDict 一致：tagKeys 保持词典行序（热度序），不重排
+  const tagKeys = Array.from(map.keys())
+  const compactedKeys = tagKeys.map((t) => t.replace(/[\s_]/g, ''))
+  return { entries: map, tagKeys, compactedKeys, reverse }
 }
 
 describe('findSuggestions — English path', () => {
@@ -102,10 +104,19 @@ describe('findSuggestions — English path', () => {
     expect(findSuggestions('foo', buildStore({}))).toEqual([])
   })
 
-  it('finds prefix matches in natural order', () => {
+  it('finds prefix matches in dictionary order', () => {
     const r = findSuggestions('lon', store)
     expect(r.map((s) => s.tag)).toEqual(['long hair', 'longest day'])
     expect(r[0].matchType).toBe('prefix')
+  })
+
+  it('orders prefix matches by dictionary (popularity) order, not length', () => {
+    // 'red eyes' 在词典里靠前（更热门）但比 'red' 长；热度序应当赢
+    const s = buildStore({
+      'red eyes': ['红眼'],
+      'red': ['红'],
+    })
+    expect(findSuggestions('re', s).map((x) => x.tag)).toEqual(['red eyes', 'red'])
   })
 
   it('case-insensitive', () => {
@@ -137,6 +148,18 @@ describe('findSuggestions — English path', () => {
     const r = findSuggestions('redey', store)
     expect(r.map((s) => s.tag)).toContain('red eyes')
     expect(r[0].matchType).toBe('prefix')
+  })
+
+  it('matches when token uses booru underscore form: "red_ey" → "red eyes"', () => {
+    const s = buildStore({ 'red eyes': ['红眼'], 'solo': ['单人'] })
+    const r = findSuggestions('red_ey', s)
+    expect(r.map((x) => x.tag)).toContain('red eyes')
+    expect(r[0].matchType).toBe('prefix')
+  })
+
+  it('returns [] for token made of separators only', () => {
+    // compactToken 为空时必须直接放弃，否则 ''.startsWith 让全字典都命中
+    expect(findSuggestions('_', store)).toEqual([])
   })
 
   it('honors limit', () => {

--- a/studio/web/src/tagDict/suggest.test.ts
+++ b/studio/web/src/tagDict/suggest.test.ts
@@ -102,7 +102,7 @@ describe('findSuggestions — English path', () => {
     expect(findSuggestions('foo', buildStore({}))).toEqual([])
   })
 
-  it('finds prefix matches sorted by length', () => {
+  it('finds prefix matches in natural order', () => {
     const r = findSuggestions('lon', store)
     expect(r.map((s) => s.tag)).toEqual(['long hair', 'longest day'])
     expect(r[0].matchType).toBe('prefix')
@@ -125,6 +125,18 @@ describe('findSuggestions — English path', () => {
     // 1girl should show up via substring path
     const r = findSuggestions('girl', store, 5)
     expect(r.find((s) => s.tag === '1girl')?.matchType).toBe('substring')
+  })
+
+  it('matches compacted form (skip spaces/_): "redey" → "red eyes"', () => {
+    const store = buildStore({
+      '1girl': ['1女孩'],
+      'red eyes': ['红眼'],
+      'red hair': ['红发'],
+      'solo': ['单人'],
+    })
+    const r = findSuggestions('redey', store)
+    expect(r.map((s) => s.tag)).toContain('red eyes')
+    expect(r[0].matchType).toBe('prefix')
   })
 
   it('honors limit', () => {

--- a/studio/web/src/tagDict/suggest.ts
+++ b/studio/web/src/tagDict/suggest.ts
@@ -41,6 +41,8 @@ export function extractCurrentToken(value: string, cursor: number): ExtractedTok
 export interface SuggestStore {
   entries: Map<string, string[]>
   tagKeys: string[]
+  /** tagKeys 的紧凑形式（去空格/_），同下标对齐；store 加载时预计算。 */
+  compactedKeys: string[]
   reverse: ReverseEntry[]
 }
 
@@ -52,10 +54,8 @@ export function hasCjk(s: string): boolean {
 interface InternalCandidate {
   tag: string
   zh: string[]
-  /** prefix=0；substring=1；用于稳定排序。 */
+  /** prefix=0；substring=1。两轮扫描天然 prefix 组在前，无需再排序。 */
   matchOrder: 0 | 1
-  /** 排序键：英文走 tag 长度；中文走匹配到的 zh 长度。 */
-  weight: number
 }
 
 function toSuggestion(c: InternalCandidate): TagSuggestion {
@@ -74,7 +74,8 @@ function pushUnique(out: InternalCandidate[], seen: Set<string>, c: InternalCand
 
 /** 给定查询 token 找候选；空 token / 未加载 → []。
  *
- * 排序：先 matchOrder（prefix 优先），再 weight（短优先）。 */
+ * 顺序：prefix 组在前，组内保持扫描顺序（英文 = 词典行序即热度；
+ * 中文 = zh 长度升序，见 store.buildReverse）。 */
 export function findSuggestions(
   rawToken: string,
   store: SuggestStore,
@@ -94,8 +95,7 @@ export function findSuggestions(
       if (re.zh === token || re.zh.startsWith(token)) {
         for (const tag of re.tags) {
           pushUnique(candidates, seen, {
-            tag, zh: store.entries.get(tag) ?? [],
-            matchOrder: 0, weight: re.zh.length,
+            tag, zh: store.entries.get(tag) ?? [], matchOrder: 0,
           })
           if (candidates.length >= limit * 4) break
         }
@@ -107,8 +107,7 @@ export function findSuggestions(
         if (!re.zh.startsWith(token) && re.zh.includes(token)) {
           for (const tag of re.tags) {
             pushUnique(candidates, seen, {
-              tag, zh: store.entries.get(tag) ?? [],
-              matchOrder: 1, weight: re.zh.length,
+              tag, zh: store.entries.get(tag) ?? [], matchOrder: 1,
             })
             if (candidates.length >= limit * 4) break
           }
@@ -117,36 +116,38 @@ export function findSuggestions(
       }
     }
   } else {
-    // 英文正向：扫 tagKeys，prefix 先，substring 后；同时匹配 tag 的紧凑形式
-    // （去除空格和 _），让 "redey" 也能命中 "red eyes"。
-    for (const tag of store.tagKeys) {
-      const compacted = tag.replace(/[\s_]/g, '')
-      if (tag === token || tag.startsWith(token) || compacted.startsWith(token)) {
-        pushUnique(candidates, seen, {
-          tag, zh: store.entries.get(tag) ?? [],
-          matchOrder: 0, weight: tag.length,
-        })
-        if (candidates.length >= limit * 4) break
-      }
-    }
-    if (candidates.length < limit * 2) {
-      for (const tag of store.tagKeys) {
-        const compacted = tag.replace(/[\s_]/g, '')
-        if (
-          !tag.startsWith(token) &&
-          !compacted.startsWith(token) &&
-          (tag.includes(token) || compacted.includes(token))
-        ) {
+    // 英文正向：扫 tagKeys（词典行序即热度序），prefix 先，substring 后。
+    // 双方都用紧凑形式（去空格/_）比较：tag 侧用预计算的 compactedKeys，
+    // token 侧现算一次 —— "redey" / "red_ey" / "red ey" 都能命中 "red eyes"。
+    // 原串 startsWith/includes 为真时紧凑形式必然也为真，无需重复判断。
+    const compactToken = token.replace(/[\s_]/g, '')
+    if (compactToken) {
+      for (let i = 0; i < store.tagKeys.length; i++) {
+        if (store.compactedKeys[i].startsWith(compactToken)) {
           pushUnique(candidates, seen, {
-            tag, zh: store.entries.get(tag) ?? [],
-            matchOrder: 1, weight: tag.length,
+            tag: store.tagKeys[i],
+            zh: store.entries.get(store.tagKeys[i]) ?? [],
+            matchOrder: 0,
           })
           if (candidates.length >= limit * 4) break
+        }
+      }
+      if (candidates.length < limit * 2) {
+        for (let i = 0; i < store.tagKeys.length; i++) {
+          const compacted = store.compactedKeys[i]
+          if (!compacted.startsWith(compactToken) && compacted.includes(compactToken)) {
+            pushUnique(candidates, seen, {
+              tag: store.tagKeys[i],
+              zh: store.entries.get(store.tagKeys[i]) ?? [],
+              matchOrder: 1,
+            })
+            if (candidates.length >= limit * 4) break
+          }
         }
       }
     }
   }
 
-  candidates.sort((a, b) => a.matchOrder - b.matchOrder)
+  // 两轮扫描天然 prefix 在前 + 组内保持扫描顺序，直接截断即可。
   return candidates.slice(0, limit).map(toSuggestion)
 }

--- a/studio/web/src/tagDict/suggest.ts
+++ b/studio/web/src/tagDict/suggest.ts
@@ -5,7 +5,7 @@
  *    及其在原串里的 range（commit 时用来切片替换）。逗号边界兼容 ASCII `,`
  *    和中文 `，`；换行也作为分隔（textarea 多行场景）。
  * 2. findSuggestions：根据 token 找 prefix + substring 候选；含 CJK 自动走
- *    反向索引；按 prefix 优先 + 长度升序。
+ *    反向索引；按 prefix 优先，同组内保持词典原始顺序（CSV 按 post_count DESC）。
  */
 import type { ReverseEntry, TagSuggestion } from './types'
 
@@ -117,9 +117,11 @@ export function findSuggestions(
       }
     }
   } else {
-    // 英文正向：扫 tagKeys（已按长度升序），prefix 先，substring 后
+    // 英文正向：扫 tagKeys，prefix 先，substring 后；同时匹配 tag 的紧凑形式
+    // （去除空格和 _），让 "redey" 也能命中 "red eyes"。
     for (const tag of store.tagKeys) {
-      if (tag === token || tag.startsWith(token)) {
+      const compacted = tag.replace(/[\s_]/g, '')
+      if (tag === token || tag.startsWith(token) || compacted.startsWith(token)) {
         pushUnique(candidates, seen, {
           tag, zh: store.entries.get(tag) ?? [],
           matchOrder: 0, weight: tag.length,
@@ -129,7 +131,12 @@ export function findSuggestions(
     }
     if (candidates.length < limit * 2) {
       for (const tag of store.tagKeys) {
-        if (!tag.startsWith(token) && tag.includes(token)) {
+        const compacted = tag.replace(/[\s_]/g, '')
+        if (
+          !tag.startsWith(token) &&
+          !compacted.startsWith(token) &&
+          (tag.includes(token) || compacted.includes(token))
+        ) {
           pushUnique(candidates, seen, {
             tag, zh: store.entries.get(tag) ?? [],
             matchOrder: 1, weight: tag.length,
@@ -140,6 +147,6 @@ export function findSuggestions(
     }
   }
 
-  candidates.sort((a, b) => a.matchOrder - b.matchOrder || a.weight - b.weight)
+  candidates.sort((a, b) => a.matchOrder - b.matchOrder)
   return candidates.slice(0, limit).map(toSuggestion)
 }

--- a/studio/web/src/tagDict/types.ts
+++ b/studio/web/src/tagDict/types.ts
@@ -14,6 +14,9 @@ export interface TagDictMeta {
 
 export interface TagDictPayload {
   entries: Record<string, string[]>
+  /** tag 的文件原始行序（默认源 = post_count 降序）。JS 对象会把整数型 key
+   * （"69"、年份等）重排到最前，entries 自身的 key 序不可靠。旧后端可能缺省。 */
+  keys?: string[]
   meta: TagDictMeta
 }
 

--- a/tests/test_tag_dictionary.py
+++ b/tests/test_tag_dictionary.py
@@ -217,6 +217,19 @@ def test_upload_endpoint_persists(client: TestClient, tag_dict_dir: Path) -> Non
     assert data["entries"]["mytag"] == ["我的标签"]
 
 
+def test_get_data_endpoint_keys_preserve_file_order(
+    client: TestClient, tag_dict_dir: Path
+) -> None:
+    # 纯数字 tag（"69"）会被 JS 对象重排到最前；keys 数组是前端唯一可靠的
+    # 行序来源，必须严格等于文件行序
+    csv = "1girl,1女孩\n69,六九\nsolo,单人\n"
+    files = {"file": ("o.csv", csv.encode("utf-8"), "text/csv")}
+    assert client.post("/api/tag-dictionary/upload", files=files).status_code == 200
+    r = client.get("/api/tag-dictionary/data")
+    assert r.status_code == 200
+    assert r.json()["keys"] == ["1girl", "69", "solo"]
+
+
 def test_upload_endpoint_400_on_bad_file(client: TestClient) -> None:
     files = {"file": ("empty.csv", b"# comments only\n", "text/csv")}
     r = client.post("/api/tag-dictionary/upload", files=files)


### PR DESCRIPTION
## 背景

当前标签自动补全按 tag 名长度排序（短优先），导致输入 "red" 时偏门的短 tag 排在常见 tag 如 "red eyes" 前面。此外，输入 "redey" 无法匹配 "red eyes"（缺少空格）。

## 改动

### 排序优化
- `store.ts`: tagKeys 保持 CSV 原始顺序（即为 `ORDER BY post_count DESC` 的热度排序），不再按 tag 名长度重排
- `suggest.ts`: 最终排序移除 weight（tag 长度）排序键，只保留 matchOrder（前缀优先）

### 紧凑匹配
- `suggest.ts`: 前缀/子串匹配时同时检查紧凑形式（去除空格和 `_`），让 "redey" 命中 "red eyes"

### 测试
- `suggest.test.ts`: 新增紧凑匹配测试用例，更新排序测试描述

## 测试

- `npm run lint` 通过
- `npx tsc --noEmit` 通过
- `vitest run` 329 全部通过（含新增 1 测试）