### PR TITLE
fix: UI polish – log replay, tagging pre-filter, crop cleanup & duplicate panel

### DIFF
--- a/studio/api/routers/logs.py
+++ b/studio/api/routers/logs.py
@@ -15,16 +15,26 @@ from ...paths import LOGS_DIR, task_log_path
 router = APIRouter()
 
 
-@router.get("/api/logs/{task_id}")
-def get_log(task_id: int) -> dict[str, Any]:
-    # 新 task 走 tasks/<id>/run.log；老 task 在 studio_data/logs/<id>.log，
-    # 不写迁移脚本（DB 里也没记 log 路径，看哪个存在），按存在性 fallback。
+def read_task_log(task_id: int) -> str:
+    """task 全量日志文本（剥掉 __EVENT__: 协议行）；不存在返回 ""。
+
+    新 task 走 tasks/<id>/run.log；老 task 在 studio_data/logs/<id>.log，
+    不写迁移脚本（DB 里也没记 log 路径，看哪个存在），按存在性 fallback。
+    其他 router（training.py 的 reg 先验回放端点）也复用这个 helper。
+    """
     p = task_log_path(task_id)
     if not p.exists():
         p = LOGS_DIR / f"{task_id}.log"
     if not p.exists():
-        return {"task_id": task_id, "content": "", "size": 0}
+        return ""
     raw = p.read_text(encoding="utf-8", errors="replace")
-    lines = [ln for ln in raw.splitlines(keepends=True) if not ln.startswith("__EVENT__:")]
-    text = "".join(lines)
+    return "".join(
+        ln for ln in raw.splitlines(keepends=True)
+        if not ln.startswith("__EVENT__:")
+    )
+
+
+@router.get("/api/logs/{task_id}")
+def get_log(task_id: int) -> dict[str, Any]:
+    text = read_task_log(task_id)
     return {"task_id": task_id, "content": text, "size": len(text.encode("utf-8"))}

--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -16,8 +16,9 @@
     GET /reg/preview-tags   GET /reg   POST /reg/build
     GET /reg/caption   DELETE /reg
 
-  reg_ai (2)
-    POST /reg/generate-prior   GET /reg/generate-prior/{task_id}
+  reg_ai (3)
+    POST /reg/generate-prior   GET /reg/generate-prior/latest
+    GET /reg/generate-prior/{task_id}
 
   version_config (4)
     GET /config  PUT /config  POST /config/from_preset  POST /config/save_as_preset
@@ -66,7 +67,7 @@ from ....services.projects import jobs as project_jobs, projects, versions
 from ....services.dataset import scan as datasets
 from ....domain import RegAiConfig
 from ....infrastructure.event_bus import bus
-from ....paths import STUDIO_DATA, safe_join
+from ....paths import LOGS_DIR, STUDIO_DATA, safe_join, task_log_path
 from ....services import model_downloader, version_config
 from ....services import presets as preset_flow
 from ....services.tagging import caption_snapshot
@@ -76,6 +77,19 @@ from ....services.tagging.base import VALID_TAGGER_NAMES
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+
+def _read_task_log(task_id: int) -> str:
+    p = task_log_path(task_id)
+    if not p.exists():
+        p = LOGS_DIR / f"{task_id}.log"
+    if not p.exists():
+        return ""
+    raw = p.read_text(encoding="utf-8", errors="replace")
+    return "".join(
+        ln for ln in raw.splitlines(keepends=True)
+        if not ln.startswith("__EVENT__:")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -434,6 +448,26 @@ def reg_generate_prior(pid: int, vid: int, body: RegAiRequest) -> dict[str, Any]
 
     bus.publish({"type": "task_state_changed", "task_id": task_id, "status": "pending"})
     return task or {"id": task_id}
+
+
+@router.get("/api/projects/{pid}/versions/{vid}/reg/generate-prior/latest")
+def get_latest_reg_prior_task(pid: int, vid: int) -> dict[str, Any]:
+    """页面 hydrate 用：返回当前 version 最近一次 AI 先验 task + 全量日志。"""
+    with db.connection_for() as conn:
+        row = conn.execute(
+            """
+            SELECT * FROM tasks
+            WHERE project_id = ? AND version_id = ? AND task_type = 'reg_ai'
+            ORDER BY created_at DESC
+            LIMIT 1
+            """,
+            (pid, vid),
+        ).fetchone()
+    task = dict(row) if row else None
+    return {
+        "task": task,
+        "log": _read_task_log(int(task["id"])) if task else "",
+    }
 
 
 @router.get("/api/projects/{pid}/versions/{vid}/reg/generate-prior/{task_id}")

--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -41,6 +41,7 @@ from fastapi.responses import FileResponse
 
 from ...deps import _resolve_anima_model_paths
 from ...errors import _preset_err_code as _err_code, _safe_join_or_400
+from ..logs import read_task_log
 from ...responses import _thumb_response
 from ...schemas.training import (
     BatchOp,
@@ -67,7 +68,7 @@ from ....services.projects import jobs as project_jobs, projects, versions
 from ....services.dataset import scan as datasets
 from ....domain import RegAiConfig
 from ....infrastructure.event_bus import bus
-from ....paths import LOGS_DIR, STUDIO_DATA, safe_join, task_log_path
+from ....paths import STUDIO_DATA, safe_join
 from ....services import model_downloader, version_config
 from ....services import presets as preset_flow
 from ....services.tagging import caption_snapshot
@@ -77,19 +78,6 @@ from ....services.tagging.base import VALID_TAGGER_NAMES
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
-
-
-def _read_task_log(task_id: int) -> str:
-    p = task_log_path(task_id)
-    if not p.exists():
-        p = LOGS_DIR / f"{task_id}.log"
-    if not p.exists():
-        return ""
-    raw = p.read_text(encoding="utf-8", errors="replace")
-    return "".join(
-        ln for ln in raw.splitlines(keepends=True)
-        if not ln.startswith("__EVENT__:")
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -466,7 +454,7 @@ def get_latest_reg_prior_task(pid: int, vid: int) -> dict[str, Any]:
     task = dict(row) if row else None
     return {
         "task": task,
-        "log": _read_task_log(int(task["id"])) if task else "",
+        "log": read_task_log(int(task["id"])) if task else "",
     }
 
 

--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -446,7 +446,7 @@ def get_latest_reg_prior_task(pid: int, vid: int) -> dict[str, Any]:
             """
             SELECT * FROM tasks
             WHERE project_id = ? AND version_id = ? AND task_type = 'reg_ai'
-            ORDER BY created_at DESC
+            ORDER BY created_at DESC, id DESC
             LIMIT 1
             """,
             (pid, vid),

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -26,11 +26,13 @@ zip 结构（schema_version 2，bundle.zip）：
     └── presets/         # 可选：预设
         └── {name}.yaml
 
-导入语义：永远新建 project + v1（不合并到现有），slug 冲突自动加 -imported-{ts}。
+导入语义：永远新建 project + source.version_label（缺失/非法时 v1，不合并到现有），
+slug 冲突自动加 -imported-{ts}。
 """
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 import time
 import zipfile
@@ -49,6 +51,7 @@ TRAIN_PREFIX = "train/"
 REG_PREFIX = "reg/"
 PRESETS_PREFIX = "presets/"
 CAPTION_EXTS = {".txt"}
+VERSION_LABEL_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 VERSION_CONFIG_ARC = "presets/config.yaml"
@@ -455,6 +458,8 @@ def export_bundle(
             "title": p["title"],
             "version_label": v["label"],
             "slug": p["slug"],
+            "preset_name": v.get("config_name"),
+            "config_name": v.get("config_name"),
         },
         "includes": {
             "train": opts.train,
@@ -521,12 +526,25 @@ def _safe_arc_bundle(name: str) -> Optional[tuple[str, str]]:
     return None
 
 
+def _bundle_source_version_label(source: dict[str, Any]) -> str:
+    raw = str(source.get("version_label") or "v1").strip()
+    return raw if VERSION_LABEL_RE.fullmatch(raw) else "v1"
+
+
+def _bundle_source_preset_name(source: dict[str, Any]) -> Optional[str]:
+    raw = source.get("preset_name") or source.get("config_name")
+    if raw is None:
+        return None
+    name = str(raw).strip()
+    return name or None
+
+
 def import_bundle(
     conn: sqlite3.Connection,
     zip_path: Path,
     presets_base: Path,
 ) -> dict[str, Any]:
-    """从 bundle.zip（schema_version 1 或 2）导入，新建 project + v1。
+    """从 bundle.zip（schema_version 1 或 2）导入，新建 project + source version。
 
     v1（旧 train.zip）：等同于 import_train。
     v2：按 manifest.includes 分别处理 train / reg / presets。
@@ -547,6 +565,8 @@ def import_bundle(
             source = manifest.get("source") or {}
             title = (source.get("title") or "imported").strip() or "imported"
             base_slug = projects.slugify(source.get("slug") or title)
+            version_label = _bundle_source_version_label(source)
+            preset_name = _bundle_source_preset_name(source)
 
             if schema_ver == 1:
                 # v1：仅 train/ entries，用原有安全检查
@@ -566,7 +586,9 @@ def import_bundle(
                 slug = _resolve_slug_conflict(conn, base_slug)
                 p = projects.create_project(conn, title=title, slug=slug,
                                              note=f"imported from {title!r}")
-                v = versions.create_version(conn, project_id=p["id"], label="v1")
+                v = versions.create_version(conn, project_id=p["id"], label=version_label)
+                if preset_name:
+                    v = versions.update_version(conn, v["id"], config_name=preset_name)
                 vdir = versions.version_dir(p["id"], p["slug"], v["label"])
                 train_dir = vdir / "train"
                 seen_folders: set[str] = set()
@@ -622,7 +644,9 @@ def import_bundle(
             slug = _resolve_slug_conflict(conn, base_slug)
             p = projects.create_project(conn, title=title, slug=slug,
                                          note=f"imported from {title!r}")
-            v = versions.create_version(conn, project_id=p["id"], label="v1")
+            v = versions.create_version(conn, project_id=p["id"], label=version_label)
+            if preset_name:
+                v = versions.update_version(conn, v["id"], config_name=preset_name)
             vdir = versions.version_dir(p["id"], p["slug"], v["label"])
 
             # --- 写入 train ---

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -32,7 +32,6 @@ slug 冲突自动加 -imported-{ts}。
 from __future__ import annotations
 
 import json
-import re
 import sqlite3
 import time
 import zipfile
@@ -51,7 +50,6 @@ TRAIN_PREFIX = "train/"
 REG_PREFIX = "reg/"
 PRESETS_PREFIX = "presets/"
 CAPTION_EXTS = {".txt"}
-VERSION_LABEL_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
 
 
 VERSION_CONFIG_ARC = "presets/config.yaml"
@@ -527,8 +525,10 @@ def _safe_arc_bundle(name: str) -> Optional[tuple[str, str]]:
 
 
 def _bundle_source_version_label(source: dict[str, Any]) -> str:
+    """manifest 是不可信输入 — 校验走 versions 同一套规则（含拒绝 "." / ".."），
+    不合法回退 v1 而不是报错，保证老 / 手改 bundle 仍可导入。"""
     raw = str(source.get("version_label") or "v1").strip()
-    return raw if VERSION_LABEL_RE.fullmatch(raw) else "v1"
+    return raw if versions.is_valid_label(raw) else "v1"
 
 
 def _bundle_source_preset_name(source: dict[str, Any]) -> Optional[str]:

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -457,7 +457,6 @@ def export_bundle(
             "version_label": v["label"],
             "slug": p["slug"],
             "preset_name": v.get("config_name"),
-            "config_name": v.get("config_name"),
         },
         "includes": {
             "train": opts.train,
@@ -539,6 +538,26 @@ def _bundle_source_preset_name(source: dict[str, Any]) -> Optional[str]:
     return name or None
 
 
+def _restore_preset_name(
+    conn: sqlite3.Connection,
+    version_id: int,
+    preset_name: Optional[str],
+    presets_base: Path,
+) -> Optional[dict[str, Any]]:
+    """preset 真实存在（本机原有，或刚从 bundle 解出）才回填 config_name，
+    避免 version 指向不存在的预设；preset_path 自带名字校验，非法名
+    （路径分隔符等）按不存在处理。返回更新后的 version；没动返回 None。"""
+    if not preset_name:
+        return None
+    from ..presets import io as _presets_io
+    try:
+        if not _presets_io.preset_path(preset_name, presets_base).exists():
+            return None
+    except _presets_io.PresetError:
+        return None
+    return versions.update_version(conn, version_id, config_name=preset_name)
+
+
 def import_bundle(
     conn: sqlite3.Connection,
     zip_path: Path,
@@ -587,8 +606,7 @@ def import_bundle(
                 p = projects.create_project(conn, title=title, slug=slug,
                                              note=f"imported from {title!r}")
                 v = versions.create_version(conn, project_id=p["id"], label=version_label)
-                if preset_name:
-                    v = versions.update_version(conn, v["id"], config_name=preset_name)
+                v = _restore_preset_name(conn, v["id"], preset_name, presets_base) or v
                 vdir = versions.version_dir(p["id"], p["slug"], v["label"])
                 train_dir = vdir / "train"
                 seen_folders: set[str] = set()
@@ -645,8 +663,6 @@ def import_bundle(
             p = projects.create_project(conn, title=title, slug=slug,
                                          note=f"imported from {title!r}")
             v = versions.create_version(conn, project_id=p["id"], label=version_label)
-            if preset_name:
-                v = versions.update_version(conn, v["id"], config_name=preset_name)
             vdir = versions.version_dir(p["id"], p["slug"], v["label"])
 
             # --- 写入 train ---
@@ -741,6 +757,10 @@ def import_bundle(
                                 n += 1
                         _presets_io.write_preset(target_name, config, presets_base)
                         preset_count += 1
+
+            # preset 解包完成后再回填 config_name：本机真的有这个预设
+            # （原本就有，或刚从 bundle 解出）才记，避免悬空引用。
+            v = _restore_preset_name(conn, v["id"], preset_name, presets_base) or v
 
             img_cnt, tag_cnt = _count_train(vdir / "train", seen_train) if train_entries else (0, 0)
 

--- a/studio/services/projects/versions.py
+++ b/studio/services/projects/versions.py
@@ -147,8 +147,15 @@ def reconcile_version_status(
     update_version(conn, version_id, status=derived)
     return get_version(conn, version_id), True
 
-# label 必须是路径安全的：字母 / 数字 / 下划线 / 连字符 / 点
-_VALID_LABEL = re.compile(r"^[A-Za-z0-9_.-]+$")
+# label 必须是路径安全的：字母 / 数字 / 下划线 / 连字符 / 点。
+# 纯点 label（"." / ".."）会让 version_dir 解析到 versions/ 之外
+# （".." == project 根，delete_version 时 rmtree 整个项目），必须拒绝。
+_VALID_LABEL = re.compile(r"^(?!\.+$)[A-Za-z0-9_.-]+$")
+
+
+def is_valid_label(label: str) -> bool:
+    """version label 校验，给外部输入源（如 bundle manifest）复用。"""
+    return bool(_VALID_LABEL.fullmatch(label))
 
 
 from studio.domain.errors import DomainError

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -2119,6 +2119,11 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(body),
     }),
+  /** 回放最近一次先验生成 task + 日志，用于切页面/刷新后的日志恢复。 */
+  getLatestRegPriorTask: (pid: number, vid: number) =>
+    req<{ task: Task | null; log: string }>(
+      `/api/projects/${pid}/versions/${vid}/reg/generate-prior/latest`,
+    ),
   /** 查询先验生成 task 状态。 */
   getRegPriorTask: (pid: number, vid: number, taskId: number) =>
     req<Task>(`/api/projects/${pid}/versions/${vid}/reg/generate-prior/${taskId}`),

--- a/studio/web/src/index.css
+++ b/studio/web/src/index.css
@@ -7,6 +7,11 @@
 @tailwind components;
 @tailwind utilities;
 
+input[type='checkbox'],
+input[type='radio'] {
+  accent-color: var(--accent);
+}
+
 /* 给所有 overflow-auto / overflow-y-auto 默认预留滚动槽，杜绝抖动 */
 .overflow-auto,
 .overflow-y-auto {

--- a/studio/web/src/lib/useLatestJobReplay.ts
+++ b/studio/web/src/lib/useLatestJobReplay.ts
@@ -1,0 +1,76 @@
+import { useCallback, useRef, useState } from 'react'
+
+/** Job / Task 的最小公共形状 — 回放 guard 只看这三个字段。 */
+interface ReplayableItem {
+  id: number
+  status: string
+  version_id?: number | null
+}
+
+export const splitLog = (log: string): string[] => (log ? log.split('\n') : [])
+
+/**
+ * 「最近一次任务 + 日志回放」状态容器（Tagging / Regularization 共用）。
+ *
+ * 进页面 / SSE 重连（onOpen）时调 refresh() 从服务端 hydrate 最近一次
+ * 任务和全量日志；SSE 增量日志照常走 setItem / setLogs append。
+ *
+ * refresh 三层防回退 guard：
+ * 1. 本地正在跟踪 running/pending 任务时，不被另一个 id 的结果顶掉
+ * 2. 同 id 时服务端日志比本地短（文件落盘滞后）不覆盖
+ * 3. 服务端无任务时只清掉「属于其它 version」的残留状态
+ *
+ * onHydrated 在 refresh 实际改写状态时回调（清空时传 null），给调用方
+ * 同步衍生状态（如 aiBusy）。fetchLatest / onHydrated 走 ref，不要求
+ * 调用方 memoize。
+ */
+export function useLatestJobReplay<T extends ReplayableItem>(
+  vid: number | null,
+  fetchLatest: (vid: number) => Promise<{ item: T | null; log: string }>,
+  onHydrated?: (item: T | null) => void,
+) {
+  const [item, setItem] = useState<T | null>(null)
+  const [logs, setLogs] = useState<string[]>([])
+  const itemRef = useRef<T | null>(null)
+  const logsRef = useRef<string[]>([])
+  const itemIdRef = useRef<number | null>(null)
+  itemRef.current = item
+  logsRef.current = logs
+  itemIdRef.current = item?.id ?? null
+  const fetchRef = useRef(fetchLatest)
+  fetchRef.current = fetchLatest
+  const onHydratedRef = useRef(onHydrated)
+  onHydratedRef.current = onHydrated
+
+  const refresh = useCallback(async () => {
+    if (!vid) return
+    try {
+      const r = await fetchRef.current(vid)
+      if (!r.item) {
+        if (itemRef.current?.version_id !== vid) {
+          setItem(null)
+          setLogs([])
+          onHydratedRef.current?.(null)
+        }
+        return
+      }
+      const current = itemRef.current
+      if (
+        current?.version_id === vid &&
+        current.id !== r.item.id &&
+        (current.status === 'pending' || current.status === 'running')
+      ) return
+      const hydratedLogs = splitLog(r.log)
+      if (
+        current?.version_id === vid &&
+        current.id === r.item.id &&
+        logsRef.current.length > hydratedLogs.length
+      ) return
+      setItem(r.item)
+      setLogs(hydratedLogs)
+      onHydratedRef.current?.(r.item)
+    } catch { /* hydrate 失败不阻塞页面 */ }
+  }, [vid])
+
+  return { item, logs, setItem, setLogs, itemIdRef, refresh }
+}

--- a/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
@@ -43,6 +43,7 @@ export default function PreprocessDuplicatesPage() {
   const [logs, setLogs] = useState<DuplicateLog[]>([])
   const [scanLogVisible, setScanLogVisible] = useState(false)
   const [previewIdx, setPreviewIdx] = useState<number | null>(null)
+  const [reviewMode, setReviewMode] = useState<'groups' | 'quality'>('groups')
   const lastLogAtRef = useRef(0)
 
   useEffect(() => {
@@ -80,12 +81,20 @@ export default function PreprocessDuplicatesPage() {
   const hasQualityCandidates = !!result && (
     result.blur_candidates.length > 0 || result.crop_relations.length > 0
   )
+  const activeReviewMode = reviewMode === 'quality' && hasQualityCandidates ? 'quality' : 'groups'
+
+  useEffect(() => {
+    if (!hasQualityCandidates && reviewMode === 'quality') {
+      setReviewMode('groups')
+    }
+  }, [hasQualityCandidates, reviewMode])
 
   const scan = async () => {
     if (busy) return
     setBusy(true)
     setResult(null)
     setSelected(new Set())
+    setReviewMode('groups')
     setScanLogVisible(true)
     setLogs([{ ts: Date.now(), status: 'running', text: t('duplicates.logStarted') }])
     try {
@@ -175,39 +184,76 @@ export default function PreprocessDuplicatesPage() {
               onApply={apply}
             />
             {scanLogVisible && <DuplicateLogStrip logs={logs} busy={busy} />}
-            <div className={
-              hasQualityCandidates
-                ? 'grid gap-2 flex-1 min-h-0 xl:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]'
-                : 'flex flex-col flex-1 min-h-0'
-            }>
-              <DuplicateReviewPanel
-                projectId={project.id}
-                versionId={vid}
-                result={result}
-                selected={selected}
-                busy={busy}
-                onSelect={setSelected}
-                onPreview={openPreview}
-              />
-              <QualityReviewPanel
-                projectId={project.id}
-                versionId={vid}
-                result={result}
-                selected={selected}
-                busy={busy}
-                onSelectNames={(names) => {
-                  const next = new Set(selected)
-                  names.forEach((name) => next.add(name))
-                  setSelected(next)
-                }}
-                onToggle={(name) => {
-                  const next = new Set(selected)
-                  if (next.has(name)) next.delete(name)
-                  else next.add(name)
-                  setSelected(next)
-                }}
-                onPreview={openPreview}
-              />
+            <div className="flex flex-col flex-1 min-h-0 gap-2">
+              <div className="shrink-0 rounded-md border border-subtle bg-surface px-2 py-1.5 flex items-center gap-1.5">
+                <button
+                  type="button"
+                  onClick={() => setReviewMode('groups')}
+                  className={`btn btn-sm !py-1 text-xs ${
+                    activeReviewMode === 'groups'
+                      ? 'border-warn bg-warn-soft text-warn'
+                      : 'btn-secondary'
+                  }`}
+                >
+                  {t('duplicates.reviewTitle')} ({result?.group_count ?? 0})
+                </button>
+                <button
+                  type="button"
+                  disabled={!hasQualityCandidates}
+                  onClick={() => setReviewMode('quality')}
+                  className={`btn btn-sm !py-1 text-xs ${
+                    activeReviewMode === 'quality'
+                      ? 'border-accent bg-accent-soft text-accent'
+                      : 'btn-secondary'
+                  }`}
+                >
+                  {t('duplicates.qualityTitle')} ({(result?.blur_candidate_count ?? 0) + (result?.crop_relation_count ?? 0)})
+                </button>
+                <span className="text-xs text-fg-tertiary truncate">
+                  {activeReviewMode === 'quality'
+                    ? t('duplicates.qualitySummary', {
+                        blur: result?.blur_candidate_count ?? 0,
+                        crops: result?.crop_relation_count ?? 0,
+                      })
+                    : t('duplicates.panelSummary', {
+                        total: result?.total_images ?? project.download_image_count ?? 0,
+                        groups: result?.group_count ?? 0,
+                        selected: selected.size,
+                      })}
+                </span>
+              </div>
+
+              {activeReviewMode === 'groups' ? (
+                <DuplicateReviewPanel
+                  projectId={project.id}
+                  versionId={vid}
+                  result={result}
+                  selected={selected}
+                  busy={busy}
+                  onSelect={setSelected}
+                  onPreview={openPreview}
+                />
+              ) : (
+                <QualityReviewPanel
+                  projectId={project.id}
+                  versionId={vid}
+                  result={result}
+                  selected={selected}
+                  busy={busy}
+                  onSelectNames={(names) => {
+                    const next = new Set(selected)
+                    names.forEach((name) => next.add(name))
+                    setSelected(next)
+                  }}
+                  onToggle={(name) => {
+                    const next = new Set(selected)
+                    if (next.has(name)) next.delete(name)
+                    else next.add(name)
+                    setSelected(next)
+                  }}
+                  onPreview={openPreview}
+                />
+              )}
             </div>
           </div>
           <DuplicateStatsSidebar
@@ -498,6 +544,7 @@ function QualityReviewPanel({
   const { t } = useTranslation()
   const blurCandidates = result?.blur_candidates ?? []
   const cropRelations = result?.crop_relations ?? []
+  const [activeTab, setActiveTab] = useState<'blur' | 'crop'>('blur')
   const blurNames = useMemo(
     () => Array.from(new Set((result?.blur_candidates ?? []).map((item) => item.name))),
     [result],
@@ -524,7 +571,21 @@ function QualityReviewPanel({
       ? t('duplicates.cropLargerSameArea')
       : t('duplicates.cropLarger', { name })
   )
+  useEffect(() => {
+    if (blurCandidates.length === 0 && cropRelations.length > 0) {
+      setActiveTab('crop')
+    } else if (blurCandidates.length > 0 && cropRelations.length === 0) {
+      setActiveTab('blur')
+    }
+  }, [blurCandidates.length, cropRelations.length])
   if (!result || (blurCandidates.length === 0 && cropRelations.length === 0)) return null
+  const activeQualityTab =
+    blurCandidates.length === 0 && cropRelations.length > 0
+      ? 'crop'
+      : cropRelations.length === 0 && blurCandidates.length > 0
+        ? 'blur'
+        : activeTab
+  const showBlur = activeQualityTab === 'blur'
   return (
     <section className="flex flex-col min-h-0 rounded-md border border-subtle bg-surface overflow-hidden">
       <div className="h-0.5 bg-accent" />
@@ -536,43 +597,74 @@ function QualityReviewPanel({
         <span className="text-xs text-fg-tertiary min-w-full">
           {t('duplicates.qualityHint')}
         </span>
+        <div className="grid grid-cols-2 gap-1.5 min-w-full">
+          <button
+            type="button"
+            disabled={blurCandidates.length === 0}
+            onClick={() => setActiveTab('blur')}
+            className={`btn btn-sm !py-1 text-xs justify-center ${
+              showBlur
+                ? 'border-accent bg-accent-soft text-accent'
+                : 'btn-secondary'
+            }`}
+          >
+            {t('duplicates.blurTitle')} ({blurCandidates.length})
+          </button>
+          <button
+            type="button"
+            disabled={cropRelations.length === 0}
+            onClick={() => setActiveTab('crop')}
+            className={`btn btn-sm !py-1 text-xs justify-center ${
+              !showBlur
+                ? 'border-accent bg-accent-soft text-accent'
+                : 'btn-secondary'
+            }`}
+          >
+            {t('duplicates.cropTitle')} ({cropRelations.length})
+          </button>
+        </div>
         <div className="flex flex-wrap items-center gap-1.5 min-w-full">
-          <button
-            type="button"
-            disabled={busy || blurNames.length === 0}
-            onClick={() => onSelectNames(blurNames)}
-            className="btn btn-secondary btn-sm !py-0.5 text-[11px]"
-          >
-            {t('duplicates.selectBlur')}
-          </button>
-          <button
-            type="button"
-            disabled={busy || cropCandidateNames.length === 0}
-            onClick={() => onSelectNames(cropCandidateNames)}
-            className="btn btn-secondary btn-sm !py-0.5 text-[11px]"
-          >
-            {t('duplicates.selectCropCandidates')}
-          </button>
-          <button
-            type="button"
-            disabled={busy || cropSourceNames.length === 0}
-            onClick={() => onSelectNames(cropSourceNames)}
-            className="btn btn-secondary btn-sm !py-0.5 text-[11px]"
-          >
-            {t('duplicates.selectCropSources')}
-          </button>
-          <button
-            type="button"
-            disabled={busy || cropBothNames.length === 0}
-            onClick={() => onSelectNames(cropBothNames)}
-            className="btn btn-secondary btn-sm !py-0.5 text-[11px]"
-          >
-            {t('duplicates.selectCropBoth')}
-          </button>
+          {showBlur ? (
+            <button
+              type="button"
+              disabled={busy || blurNames.length === 0}
+              onClick={() => onSelectNames(blurNames)}
+              className="btn btn-secondary btn-sm !py-0.5 text-[11px]"
+            >
+              {t('duplicates.selectBlur')}
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                disabled={busy || cropCandidateNames.length === 0}
+                onClick={() => onSelectNames(cropCandidateNames)}
+                className="btn btn-secondary btn-sm !py-0.5 text-[11px]"
+              >
+                {t('duplicates.selectCropCandidates')}
+              </button>
+              <button
+                type="button"
+                disabled={busy || cropSourceNames.length === 0}
+                onClick={() => onSelectNames(cropSourceNames)}
+                className="btn btn-secondary btn-sm !py-0.5 text-[11px]"
+              >
+                {t('duplicates.selectCropSources')}
+              </button>
+              <button
+                type="button"
+                disabled={busy || cropBothNames.length === 0}
+                onClick={() => onSelectNames(cropBothNames)}
+                className="btn btn-secondary btn-sm !py-0.5 text-[11px]"
+              >
+                {t('duplicates.selectCropBoth')}
+              </button>
+            </>
+          )}
         </div>
       </header>
       <div className="grid grid-cols-1 gap-2 p-2 min-h-0 overflow-y-auto">
-        {blurCandidates.length > 0 && (
+        {showBlur && (
           <QualitySection
             title={t('duplicates.blurTitle')}
             empty={t('duplicates.blurEmpty')}
@@ -594,7 +686,7 @@ function QualityReviewPanel({
             onPreview={onPreview}
           />
         )}
-        {cropRelations.length > 0 && (
+        {!showBlur && (
           <QualitySection
             title={t('duplicates.cropTitle')}
             empty={t('duplicates.cropEmpty')}

--- a/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
@@ -77,6 +77,9 @@ export default function PreprocessDuplicatesPage() {
       : [],
     [result],
   )
+  const hasQualityCandidates = !!result && (
+    result.blur_candidates.length > 0 || result.crop_relations.length > 0
+  )
 
   const scan = async () => {
     if (busy) return
@@ -172,34 +175,40 @@ export default function PreprocessDuplicatesPage() {
               onApply={apply}
             />
             {scanLogVisible && <DuplicateLogStrip logs={logs} busy={busy} />}
-            <DuplicateReviewPanel
-              projectId={project.id}
-              versionId={vid}
-              result={result}
-              selected={selected}
-              busy={busy}
-              onSelect={setSelected}
-              onPreview={openPreview}
-            />
-            <QualityReviewPanel
-              projectId={project.id}
-              versionId={vid}
-              result={result}
-              selected={selected}
-              busy={busy}
-              onSelectNames={(names) => {
-                const next = new Set(selected)
-                names.forEach((name) => next.add(name))
-                setSelected(next)
-              }}
-              onToggle={(name) => {
-                const next = new Set(selected)
-                if (next.has(name)) next.delete(name)
-                else next.add(name)
-                setSelected(next)
-              }}
-              onPreview={openPreview}
-            />
+            <div className={
+              hasQualityCandidates
+                ? 'grid gap-2 flex-1 min-h-0 xl:grid-cols-[minmax(0,1fr)_minmax(320px,420px)]'
+                : 'flex flex-col flex-1 min-h-0'
+            }>
+              <DuplicateReviewPanel
+                projectId={project.id}
+                versionId={vid}
+                result={result}
+                selected={selected}
+                busy={busy}
+                onSelect={setSelected}
+                onPreview={openPreview}
+              />
+              <QualityReviewPanel
+                projectId={project.id}
+                versionId={vid}
+                result={result}
+                selected={selected}
+                busy={busy}
+                onSelectNames={(names) => {
+                  const next = new Set(selected)
+                  names.forEach((name) => next.add(name))
+                  setSelected(next)
+                }}
+                onToggle={(name) => {
+                  const next = new Set(selected)
+                  if (next.has(name)) next.delete(name)
+                  else next.add(name)
+                  setSelected(next)
+                }}
+                onPreview={openPreview}
+              />
+            </div>
           </div>
           <DuplicateStatsSidebar
             result={result}
@@ -517,7 +526,7 @@ function QualityReviewPanel({
   )
   if (!result || (blurCandidates.length === 0 && cropRelations.length === 0)) return null
   return (
-    <section className="flex flex-col rounded-md border border-subtle bg-surface overflow-hidden shrink-0">
+    <section className="flex flex-col min-h-0 rounded-md border border-subtle bg-surface overflow-hidden">
       <div className="h-0.5 bg-accent" />
       <header className="flex flex-wrap items-center gap-2 px-2.5 py-1.5 border-b border-subtle text-sm">
         <h3 className="font-semibold">{t('duplicates.qualityTitle')}</h3>
@@ -562,56 +571,60 @@ function QualityReviewPanel({
           </button>
         </div>
       </header>
-      <div className="grid gap-2 p-2 lg:grid-cols-2">
-        <QualitySection
-          title={t('duplicates.blurTitle')}
-          empty={t('duplicates.blurEmpty')}
-          items={blurCandidates.map((item) => ({
-            key: item.name,
-            images: [{ name: item.name }],
-            meta: `${item.width}x${item.height} · ${item.filesize_kb}KB`,
-            score: t('duplicates.blurMetric', {
-              score: Math.round(item.blur_score),
-              local: Math.round(item.largest_blur_region_ratio * 100),
-            }),
-            note: item.reason,
-          }))}
-          projectId={projectId}
-          versionId={versionId}
-          selected={selected}
-          busy={busy}
-          onToggle={onToggle}
-          onPreview={onPreview}
-        />
-        <QualitySection
-          title={t('duplicates.cropTitle')}
-          empty={t('duplicates.cropEmpty')}
-          items={cropRelations.map((item, index) => ({
-            key: `${item.source}:${item.crop_candidate}:${index}`,
-            images: [
-              { name: item.source, label: t('duplicates.cropSource') },
-              { name: item.crop_candidate, label: t('duplicates.cropCandidate') },
-            ],
-            meta: `${item.source_width}x${item.source_height} → ${item.crop_width}x${item.crop_height}`,
-            score: t('duplicates.cropMetric', {
-              score: Math.round(item.score * 100),
-              area: Math.round(item.window_ratio * 100),
-            }),
-            note: [
-              cropRelationKindLabel(item.relation_kind),
-              cropLargerLabel(item.larger_image),
-              t('duplicates.cropAreaRatio', { ratio: item.area_ratio.toFixed(2) }),
-              `${item.source_window.x},${item.source_window.y},${item.source_window.width},${item.source_window.height}`,
-              item.note,
-            ].join(' · '),
-          }))}
-          projectId={projectId}
-          versionId={versionId}
-          selected={selected}
-          busy={busy}
-          onToggle={onToggle}
-          onPreview={onPreview}
-        />
+      <div className="grid grid-cols-1 gap-2 p-2 min-h-0 overflow-y-auto">
+        {blurCandidates.length > 0 && (
+          <QualitySection
+            title={t('duplicates.blurTitle')}
+            empty={t('duplicates.blurEmpty')}
+            items={blurCandidates.map((item) => ({
+              key: item.name,
+              images: [{ name: item.name }],
+              meta: `${item.width}x${item.height} · ${item.filesize_kb}KB`,
+              score: t('duplicates.blurMetric', {
+                score: Math.round(item.blur_score),
+                local: Math.round(item.largest_blur_region_ratio * 100),
+              }),
+              note: item.reason,
+            }))}
+            projectId={projectId}
+            versionId={versionId}
+            selected={selected}
+            busy={busy}
+            onToggle={onToggle}
+            onPreview={onPreview}
+          />
+        )}
+        {cropRelations.length > 0 && (
+          <QualitySection
+            title={t('duplicates.cropTitle')}
+            empty={t('duplicates.cropEmpty')}
+            items={cropRelations.map((item, index) => ({
+              key: `${item.source}:${item.crop_candidate}:${index}`,
+              images: [
+                { name: item.source, label: t('duplicates.cropSource') },
+                { name: item.crop_candidate, label: t('duplicates.cropCandidate') },
+              ],
+              meta: `${item.source_width}x${item.source_height} → ${item.crop_width}x${item.crop_height}`,
+              score: t('duplicates.cropMetric', {
+                score: Math.round(item.score * 100),
+                area: Math.round(item.window_ratio * 100),
+              }),
+              note: [
+                cropRelationKindLabel(item.relation_kind),
+                cropLargerLabel(item.larger_image),
+                t('duplicates.cropAreaRatio', { ratio: item.area_ratio.toFixed(2) }),
+                `${item.source_window.x},${item.source_window.y},${item.source_window.width},${item.source_window.height}`,
+                item.note,
+              ].join(' · '),
+            }))}
+            projectId={projectId}
+            versionId={versionId}
+            selected={selected}
+            busy={busy}
+            onToggle={onToggle}
+            onPreview={onPreview}
+          />
+        )}
       </div>
     </section>
   )

--- a/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
@@ -81,13 +81,9 @@ export default function PreprocessDuplicatesPage() {
   const hasQualityCandidates = !!result && (
     result.blur_candidates.length > 0 || result.crop_relations.length > 0
   )
+  // 渲染期推导兜底：质量候选清空后自动落回 groups，不需要 effect 改 state
+  //（scan() 重置 reviewMode，质量计数只会在重扫时变化）。
   const activeReviewMode = reviewMode === 'quality' && hasQualityCandidates ? 'quality' : 'groups'
-
-  useEffect(() => {
-    if (!hasQualityCandidates && reviewMode === 'quality') {
-      setReviewMode('groups')
-    }
-  }, [hasQualityCandidates, reviewMode])
 
   const scan = async () => {
     if (busy) return
@@ -571,14 +567,9 @@ function QualityReviewPanel({
       ? t('duplicates.cropLargerSameArea')
       : t('duplicates.cropLarger', { name })
   )
-  useEffect(() => {
-    if (blurCandidates.length === 0 && cropRelations.length > 0) {
-      setActiveTab('crop')
-    } else if (blurCandidates.length > 0 && cropRelations.length === 0) {
-      setActiveTab('blur')
-    }
-  }, [blurCandidates.length, cropRelations.length])
   if (!result || (blurCandidates.length === 0 && cropRelations.length === 0)) return null
+  // 渲染期推导：某一侧为空时强制落到另一侧（tab 按钮对空侧也是 disabled），
+  // 不用 effect 写回 state。
   const activeQualityTab =
     blurCandidates.length === 0 && cropRelations.length > 0
       ? 'crop'

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -50,6 +50,8 @@ const ADVANCED_DEFAULTS: AdvancedParams = {
   postprocess_max_crop_ratio: 0.1,
 }
 
+const splitLog = (log: string): string[] => (log ? log.split('\n') : [])
+
 export default function RegularizationPage() {
   const { t } = useTranslation()
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
@@ -77,7 +79,11 @@ export default function RegularizationPage() {
 
   const [job, setJob] = useState<Job | null>(null)
   const [logs, setLogs] = useState<string[]>([])
+  const jobRef = useRef<Job | null>(null)
+  const logsRef = useRef<string[]>([])
   const jobIdRef = useRef<number | null>(null)
+  jobRef.current = job
+  logsRef.current = logs
   jobIdRef.current = job?.id ?? null
 
   // B2（PR-2）：「设置 & 日志」+「先验生成」合并成单 tab「生成」；顶部 source picker
@@ -101,7 +107,11 @@ export default function RegularizationPage() {
   const [aiTask, setAiTask] = useState<Task | null>(null)
   const [aiLogs, setAiLogs] = useState<string[]>([])
   const [aiBusy, setAiBusy] = useState(false)
+  const aiTaskRef = useRef<Task | null>(null)
+  const aiLogsRef = useRef<string[]>([])
   const aiTaskIdRef = useRef<number | null>(null)
+  aiTaskRef.current = aiTask
+  aiLogsRef.current = aiLogs
   aiTaskIdRef.current = aiTask?.id ?? null
 
   // 预览 modal
@@ -165,18 +175,74 @@ export default function RegularizationPage() {
     } catch { /* quota / privacy mode：丢就丢，不打扰用户 */ }
   }, [excludedStorageKey, excluded])
 
-  // 刷新 / 进入页面时回放最近一次 reg_build job：锁回 jid + 回放历史日志
-  useEffect(() => {
+  const refreshLatestRegBuild = useCallback(async () => {
     if (!vid) return
-    void api
-      .getLatestVersionJob(project.id, vid, 'reg_build')
-      .then((r) => {
-        if (!r.job) return
-        setJob(r.job)
-        setLogs(r.log ? r.log.split('\n') : [])
-      })
-      .catch(() => {})
+    try {
+      const r = await api.getLatestVersionJob(project.id, vid, 'reg_build')
+      if (!r.job) {
+        if (jobRef.current?.version_id !== vid) {
+          setJob(null)
+          setLogs([])
+        }
+        return
+      }
+      const current = jobRef.current
+      if (
+        current?.version_id === vid &&
+        current.id !== r.job.id &&
+        (current.status === 'pending' || current.status === 'running')
+      ) return
+      const hydratedLogs = splitLog(r.log)
+      if (
+        current?.version_id === vid &&
+        current.id === r.job.id &&
+        logsRef.current.length > hydratedLogs.length
+      ) return
+      setJob(r.job)
+      setLogs(hydratedLogs)
+    } catch { /* hydrate failure should not block the page */ }
   }, [project.id, vid])
+
+  const refreshLatestRegPrior = useCallback(async () => {
+    if (!vid) return
+    try {
+      const r = await api.getLatestRegPriorTask(project.id, vid)
+      if (!r.task) {
+        if (aiTaskRef.current?.version_id !== vid) {
+          setAiTask(null)
+          setAiLogs([])
+          setAiBusy(false)
+        }
+        return
+      }
+      const current = aiTaskRef.current
+      if (
+        current?.version_id === vid &&
+        current.id !== r.task.id &&
+        (current.status === 'pending' || current.status === 'running')
+      ) return
+      const hydratedLogs = splitLog(r.log)
+      if (
+        current?.version_id === vid &&
+        current.id === r.task.id &&
+        aiLogsRef.current.length > hydratedLogs.length
+      ) return
+      setAiTask(r.task)
+      setAiLogs(hydratedLogs)
+      setAiBusy(r.task.status === 'running' || r.task.status === 'pending')
+    } catch { /* hydrate failure should not block the page */ }
+  }, [project.id, vid])
+
+  // 刷新 / 进入页面时回放最近一次生成任务：锁回 id + 回放历史日志。
+  useEffect(() => {
+    void refreshLatestRegBuild()
+    void refreshLatestRegPrior()
+  }, [refreshLatestRegBuild, refreshLatestRegPrior])
+
+  const refreshLiveLogs = useCallback(() => {
+    void refreshLatestRegBuild()
+    void refreshLatestRegPrior()
+  }, [refreshLatestRegBuild, refreshLatestRegPrior])
 
   useEventStream((evt) => {
     const jid = jobIdRef.current
@@ -202,7 +268,7 @@ export default function RegularizationPage() {
         }
       }).catch(() => {})
     }
-  })
+  }, { onOpen: refreshLiveLogs })
 
   const trainImageCount = activeVersion?.stats?.train_image_count ?? 0
   // 任意一种生成跑着都视为 live —— 防止 booru / AI 并发同时写 reg/。

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -23,6 +23,7 @@ import { useTagSuggest } from '../../../components/tagSuggest/useTagSuggest'
 import { useDialog } from '../../../components/Dialog'
 import { useToast } from '../../../components/Toast'
 import { useEventStream } from '../../../lib/useEventStream'
+import { useLatestJobReplay } from '../../../lib/useLatestJobReplay'
 
 interface Ctx {
   project: ProjectDetail
@@ -50,8 +51,6 @@ const ADVANCED_DEFAULTS: AdvancedParams = {
   postprocess_max_crop_ratio: 0.1,
 }
 
-const splitLog = (log: string): string[] => (log ? log.split('\n') : [])
-
 export default function RegularizationPage() {
   const { t } = useTranslation()
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
@@ -77,14 +76,19 @@ export default function RegularizationPage() {
   const [apiSource, setApiSource] = useState<'gelbooru' | 'danbooru'>('gelbooru')
   const [advanced, setAdvanced] = useState<AdvancedParams>(ADVANCED_DEFAULTS)
 
-  const [job, setJob] = useState<Job | null>(null)
-  const [logs, setLogs] = useState<string[]>([])
-  const jobRef = useRef<Job | null>(null)
-  const logsRef = useRef<string[]>([])
-  const jobIdRef = useRef<number | null>(null)
-  jobRef.current = job
-  logsRef.current = logs
-  jobIdRef.current = job?.id ?? null
+  const vid = activeVersion?.id ?? null
+
+  // booru reg_build job：最近一次任务 + 日志回放（进页面 / SSE 重连时 hydrate）
+  const {
+    item: job,
+    logs,
+    setItem: setJob,
+    setLogs,
+    itemIdRef: jobIdRef,
+    refresh: refreshLatestRegBuild,
+  } = useLatestJobReplay<Job>(vid, (v) =>
+    api.getLatestVersionJob(project.id, v, 'reg_build').then((r) => ({ item: r.job, log: r.log })),
+  )
 
   // B2（PR-2）：「设置 & 日志」+「先验生成」合并成单 tab「生成」；顶部 source picker
   // 决定渲染 Booru 配置面板还是 AI 配置面板。「开始生成」按钮按 source 调对应 endpoint。
@@ -104,21 +108,24 @@ export default function RegularizationPage() {
   const [aiCfg, setAiCfg] = useState(4.0)
   const [aiSeed, setAiSeed] = useState(0)
   const [aiIncremental, setAiIncremental] = useState(false)
-  const [aiTask, setAiTask] = useState<Task | null>(null)
-  const [aiLogs, setAiLogs] = useState<string[]>([])
   const [aiBusy, setAiBusy] = useState(false)
-  const aiTaskRef = useRef<Task | null>(null)
-  const aiLogsRef = useRef<string[]>([])
-  const aiTaskIdRef = useRef<number | null>(null)
-  aiTaskRef.current = aiTask
-  aiLogsRef.current = aiLogs
-  aiTaskIdRef.current = aiTask?.id ?? null
+  // AI 先验 task：同上；hydrate 时顺带把 aiBusy 同步到 task 真实状态
+  const {
+    item: aiTask,
+    logs: aiLogs,
+    setItem: setAiTask,
+    setLogs: setAiLogs,
+    itemIdRef: aiTaskIdRef,
+    refresh: refreshLatestRegPrior,
+  } = useLatestJobReplay<Task>(
+    vid,
+    (v) => api.getLatestRegPriorTask(project.id, v).then((r) => ({ item: r.task, log: r.log })),
+    (task) => setAiBusy(task ? task.status === 'running' || task.status === 'pending' : false),
+  )
 
   // 预览 modal
   const [previewIdx, setPreviewIdx] = useState<number | null>(null)
   const [previewCaption, setPreviewCaption] = useState<string>('')
-
-  const vid = activeVersion?.id ?? null
 
   const refreshReg = useCallback(async () => {
     if (!vid) return
@@ -174,64 +181,6 @@ export default function RegularizationPage() {
       localStorage.setItem(excludedStorageKey, JSON.stringify(Array.from(excluded)))
     } catch { /* quota / privacy mode：丢就丢，不打扰用户 */ }
   }, [excludedStorageKey, excluded])
-
-  const refreshLatestRegBuild = useCallback(async () => {
-    if (!vid) return
-    try {
-      const r = await api.getLatestVersionJob(project.id, vid, 'reg_build')
-      if (!r.job) {
-        if (jobRef.current?.version_id !== vid) {
-          setJob(null)
-          setLogs([])
-        }
-        return
-      }
-      const current = jobRef.current
-      if (
-        current?.version_id === vid &&
-        current.id !== r.job.id &&
-        (current.status === 'pending' || current.status === 'running')
-      ) return
-      const hydratedLogs = splitLog(r.log)
-      if (
-        current?.version_id === vid &&
-        current.id === r.job.id &&
-        logsRef.current.length > hydratedLogs.length
-      ) return
-      setJob(r.job)
-      setLogs(hydratedLogs)
-    } catch { /* hydrate failure should not block the page */ }
-  }, [project.id, vid])
-
-  const refreshLatestRegPrior = useCallback(async () => {
-    if (!vid) return
-    try {
-      const r = await api.getLatestRegPriorTask(project.id, vid)
-      if (!r.task) {
-        if (aiTaskRef.current?.version_id !== vid) {
-          setAiTask(null)
-          setAiLogs([])
-          setAiBusy(false)
-        }
-        return
-      }
-      const current = aiTaskRef.current
-      if (
-        current?.version_id === vid &&
-        current.id !== r.task.id &&
-        (current.status === 'pending' || current.status === 'running')
-      ) return
-      const hydratedLogs = splitLog(r.log)
-      if (
-        current?.version_id === vid &&
-        current.id === r.task.id &&
-        aiLogsRef.current.length > hydratedLogs.length
-      ) return
-      setAiTask(r.task)
-      setAiLogs(hydratedLogs)
-      setAiBusy(r.task.status === 'running' || r.task.status === 'pending')
-    } catch { /* hydrate failure should not block the page */ }
-  }, [project.id, vid])
 
   // 刷新 / 进入页面时回放最近一次生成任务：锁回 id + 回放历史日志。
   useEffect(() => {

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useOutletContext } from 'react-router-dom'
 import {
@@ -122,6 +122,8 @@ function fromLLMPreset(p: LLMPreset): LLMTaggerForm {
   }
 }
 
+const splitLog = (log: string): string[] => (log ? log.split('\n') : [])
+
 export default function TaggingPage() {
   const { t } = useTranslation()
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
@@ -146,7 +148,11 @@ export default function TaggingPage() {
 
   const [job, setJob] = useState<Job | null>(null)
   const [logs, setLogs] = useState<string[]>([])
+  const jobRef = useRef<Job | null>(null)
+  const logsRef = useRef<string[]>([])
   const jobIdRef = useRef<number | null>(null)
+  jobRef.current = job
+  logsRef.current = logs
   jobIdRef.current = job?.id ?? null
 
   useEffect(() => {
@@ -176,17 +182,38 @@ export default function TaggingPage() {
   }, [tagger])
 
   const vid = activeVersion?.id ?? null
-  useEffect(() => {
+
+  const refreshLatestTagJob = useCallback(async () => {
     if (!vid) return
-    void api
-      .getLatestVersionJob(project.id, vid, 'tag')
-      .then((r) => {
-        if (!r.job) return
-        setJob(r.job)
-        setLogs(r.log ? r.log.split('\n') : [])
-      })
-      .catch(() => {})
+    try {
+      const r = await api.getLatestVersionJob(project.id, vid, 'tag')
+      if (!r.job) {
+        if (jobRef.current?.version_id !== vid) {
+          setJob(null)
+          setLogs([])
+        }
+        return
+      }
+      const current = jobRef.current
+      if (
+        current?.version_id === vid &&
+        current.id !== r.job.id &&
+        (current.status === 'pending' || current.status === 'running')
+      ) return
+      const hydratedLogs = splitLog(r.log)
+      if (
+        current?.version_id === vid &&
+        current.id === r.job.id &&
+        logsRef.current.length > hydratedLogs.length
+      ) return
+      setJob(r.job)
+      setLogs(hydratedLogs)
+    } catch { /* hydrate failure should not block tagging controls */ }
   }, [project.id, vid])
+
+  useEffect(() => {
+    void refreshLatestTagJob()
+  }, [refreshLatestTagJob])
 
   // version 切换时同步 triggerWord 初值（持久化字段，避免回到 "" 让用户以为没保存）
   useEffect(() => {
@@ -203,7 +230,7 @@ export default function TaggingPage() {
         void reload()
       }
     }
-  })
+  }, { onOpen: () => void refreshLatestTagJob() })
 
   if (!activeVersion) {
     return <p className="text-fg-tertiary p-6">{t('tag.noVersion')}</p>

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useOutletContext } from 'react-router-dom'
 import {
@@ -21,6 +21,7 @@ import StepShell from '../../../components/StepShell'
 import { useToast } from '../../../components/Toast'
 import { useSettingsDrawer } from '../../../lib/SettingsDrawer'
 import { useEventStream } from '../../../lib/useEventStream'
+import { useLatestJobReplay } from '../../../lib/useLatestJobReplay'
 
 interface Ctx {
   project: ProjectDetail
@@ -122,8 +123,6 @@ function fromLLMPreset(p: LLMPreset): LLMTaggerForm {
   }
 }
 
-const splitLog = (log: string): string[] => (log ? log.split('\n') : [])
-
 export default function TaggingPage() {
   const { t } = useTranslation()
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
@@ -146,14 +145,18 @@ export default function TaggingPage() {
   const [llmForm, setLlmForm] = useState<LLMTaggerForm | null>(null)
   const [advOpen, setAdvOpen] = useState(false)
 
-  const [job, setJob] = useState<Job | null>(null)
-  const [logs, setLogs] = useState<string[]>([])
-  const jobRef = useRef<Job | null>(null)
-  const logsRef = useRef<string[]>([])
-  const jobIdRef = useRef<number | null>(null)
-  jobRef.current = job
-  logsRef.current = logs
-  jobIdRef.current = job?.id ?? null
+  const vid = activeVersion?.id ?? null
+
+  const {
+    item: job,
+    logs,
+    setItem: setJob,
+    setLogs,
+    itemIdRef: jobIdRef,
+    refresh: refreshLatestTagJob,
+  } = useLatestJobReplay<Job>(vid, (v) =>
+    api.getLatestVersionJob(project.id, v, 'tag').then((r) => ({ item: r.job, log: r.log })),
+  )
 
   useEffect(() => {
     void api
@@ -181,36 +184,7 @@ export default function TaggingPage() {
       )
   }, [tagger])
 
-  const vid = activeVersion?.id ?? null
-
-  const refreshLatestTagJob = useCallback(async () => {
-    if (!vid) return
-    try {
-      const r = await api.getLatestVersionJob(project.id, vid, 'tag')
-      if (!r.job) {
-        if (jobRef.current?.version_id !== vid) {
-          setJob(null)
-          setLogs([])
-        }
-        return
-      }
-      const current = jobRef.current
-      if (
-        current?.version_id === vid &&
-        current.id !== r.job.id &&
-        (current.status === 'pending' || current.status === 'running')
-      ) return
-      const hydratedLogs = splitLog(r.log)
-      if (
-        current?.version_id === vid &&
-        current.id === r.job.id &&
-        logsRef.current.length > hydratedLogs.length
-      ) return
-      setJob(r.job)
-      setLogs(hydratedLogs)
-    } catch { /* hydrate failure should not block tagging controls */ }
-  }, [project.id, vid])
-
+  // 刷新 / 进入页面时回放最近一次打标 job：锁回 id + 回放历史日志。
   useEffect(() => {
     void refreshLatestTagJob()
   }, [refreshLatestTagJob])

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -350,9 +350,9 @@ export default function TaggingPage() {
 
       <div className="grid gap-3 flex-1 min-h-0" style={{ gridTemplateColumns: '1.5fr 1fr' }}>
 
-        {/* 左栏 */}
-        <div className="flex flex-col gap-3 min-h-0 min-w-0 overflow-y-auto">
-
+        {/* 左栏：参数区可滚动，日志区固定在底部，避免高级选项展开后把日志挤出视口。 */}
+        <div className="flex flex-col gap-3 min-h-0 min-w-0">
+          <div className="flex flex-col gap-3 flex-1 min-h-0 min-w-0 overflow-y-auto pr-1">
           <section className="rounded-md border border-subtle bg-surface px-3 py-2 flex flex-wrap items-center gap-2 shrink-0 text-sm">
             <span className="text-fg-tertiary">tagger</span>
             <select
@@ -482,19 +482,23 @@ export default function TaggingPage() {
             />
           )}
 
+          </div>
+
           {job && (
-            <JobProgress
-              job={job}
-              logs={logs}
-              onCancel={async () => {
-                try {
-                  await api.cancelJob(job.id)
-                  toast(t('tag.cancelToast'), 'success')
-                } catch (e) {
-                  toast(String(e), 'error')
-                }
-              }}
-            />
+            <div className="shrink-0">
+              <JobProgress
+                job={job}
+                logs={logs}
+                onCancel={async () => {
+                  try {
+                    await api.cancelJob(job.id)
+                    toast(t('tag.cancelToast'), 'success')
+                  } catch (e) {
+                    toast(String(e), 'error')
+                  }
+                }}
+              />
+            </div>
           )}
         </div>
 

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -400,6 +400,9 @@ def _run_crop_train(
 
             # 输出可能换成 .png 或 fan-out 成多张；源不再属于 outputs 时必须删，
             # 否则从 bundle/版本复制来的 train-only 数据会同时保留原图 + 裁剪图。
+            # 已知边界（沿袭旧行为）：`{stem}.png` 进 stale 集是为了清掉历史
+            # N=1 crop 的产物；若 train 里恰好有同 stem 的两张独立图
+            # （X.jpg + X.png），对 X.jpg fan-out 会把无关的 X.png 一并删掉。
             stale_rels = {src_rel, f"{folder}/{src_stem}.png"} - set(out_rels)
             output_stems = {Path(rel).stem for rel in out_rels}
             for stale_rel in sorted(stale_rels):

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -49,6 +49,16 @@ def _install_signal_handlers() -> None:
         signal.signal(signal.SIGBREAK, _on_signal)  # type: ignore[attr-defined]
 
 
+def _unlink_image_and_sidecars(path: Path, *, keep_sidecars: bool = False) -> None:
+    """Remove an image and caption sidecars that are no longer part of train/."""
+    if path.is_file():
+        path.unlink(missing_ok=True)
+    if keep_sidecars:
+        return
+    for ext in (".txt", ".json"):
+        path.with_suffix(ext).unlink(missing_ok=True)
+
+
 def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
     _install_signal_handlers()
 
@@ -277,9 +287,9 @@ def _run_crop_train(
     """ADR 0010 train-scope crop。
 
     `params['crops']` = `{rel_path: [rects]}`，rel_path 形如 `1_data/X.png`。
-    crop 产物输出到同 folder 内：N=1 覆盖源文件名（`folder/stem.png`），
-    N>1 fan-out 成 `folder/stem_c0.png` / `folder/stem_c1.png` / ...；
-    train_replace_with_crops 原子替换 manifest。
+    crop 产物输出到同 folder 内：N=1 产出 `folder/stem.png`，N>1 fan-out
+    成 `folder/stem_c0.png` / `folder/stem_c1.png` / ...；成功后清理不再
+    属于 outputs 的旧源图，再用 train_replace_with_crops 原子替换 manifest。
     """
     project_dir = projects.project_dir(project["id"], project["slug"])
     train_dir = preprocess.version_train_dir(project, version["label"])
@@ -388,13 +398,22 @@ def _run_crop_train(
                     "mtime": mt,
                 })
 
-            # N>1：原 src 物理文件（如果不在 outputs 列表里）应当删
-            if n > 1:
-                stale_rel = f"{folder}/{src_stem}.png"
+            # 输出可能换成 .png 或 fan-out 成多张；源不再属于 outputs 时必须删，
+            # 否则从 bundle/版本复制来的 train-only 数据会同时保留原图 + 裁剪图。
+            stale_rels = {src_rel, f"{folder}/{src_stem}.png"} - set(out_rels)
+            output_stems = {Path(rel).stem for rel in out_rels}
+            for stale_rel in sorted(stale_rels):
                 stale_path = train_dir / stale_rel
-                if stale_path.is_file() and stale_rel not in out_rels:
+                has_sidecar = (
+                    stale_path.with_suffix(".txt").exists()
+                    or stale_path.with_suffix(".json").exists()
+                )
+                if stale_path.exists() or has_sidecar:
                     try:
-                        stale_path.unlink()
+                        _unlink_image_and_sidecars(
+                            stale_path,
+                            keep_sidecars=Path(stale_rel).stem in output_stems,
+                        )
                     except OSError as exc:
                         log(f"   ⚠ 删旧 {stale_rel} 失败: {exc}")
 

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -56,6 +56,18 @@ def _collect_images(train_dir: Path) -> list[Path]:
     return out
 
 
+def _filter_existing_captions(images: list[Path]) -> tuple[list[Path], list[Path]]:
+    """Split images into (needs_tagging, skipped_existing_caption)."""
+    needs_tagging: list[Path] = []
+    skipped: list[Path] = []
+    for img in images:
+        if tagedit.caption_path(img) is not None:
+            skipped.append(img)
+        else:
+            needs_tagging.append(img)
+    return needs_tagging, skipped
+
+
 def run(job_id: int) -> int:
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, job_id)
@@ -96,13 +108,24 @@ def run(job_id: int) -> int:
         if not images:
             progress("[done] 没有图可打标（train/ 是空的）")
             return 0
+        total_images = len(images)
 
         progress(
             f"[start] tagger={tagger_name} version={v['label']} "
-            f"images={len(images)} format={fmt} on_existing={on_existing}"
+            f"images={total_images} format={fmt} on_existing={on_existing}"
         )
         if trigger_word:
             progress(f"[trigger] '{trigger_word}' 将作为第一个 tag prepend 到每张图")
+        skipped = 0
+        if on_existing == "skip":
+            images, skipped_images = _filter_existing_captions(images)
+            skipped = len(skipped_images)
+            for img in skipped_images:
+                progress(f"[skip] {img.name}")
+        if not images:
+            suffix = f" (skipped={skipped})" if skipped else ""
+            progress(f"[done] tagged {skipped}/{total_images} (errors=0){suffix}")
+            return 0
 
         tagger = get_tagger(tagger_name, overrides=overrides)
         tagger.prepare()
@@ -114,7 +137,6 @@ def run(job_id: int) -> int:
 
         ok = 0
         errs = 0
-        skipped = 0
         appended = 0
         for r in tagger.tag(
             images,
@@ -142,7 +164,7 @@ def run(job_id: int) -> int:
         suffix = ""
         if skipped or appended:
             suffix = f" (skipped={skipped}, appended={appended})"
-        progress(f"[done] tagged {ok}/{len(images)} (errors={errs}){suffix}")
+        progress(f"[done] tagged {ok + skipped}/{total_images} (errors={errs}){suffix}")
         return 0 if ok > 0 or errs == 0 else 1
     except Exception as exc:  # noqa: BLE001
         # PR-1 C7: logger.exception 进 stderr（supervisor 收 → jobs/<id>.log），

--- a/tests/test_preprocess_worker_train.py
+++ b/tests/test_preprocess_worker_train.py
@@ -96,6 +96,25 @@ def test_crop_train_single_rect_overwrites_source(env) -> None:
     assert entry["origin"] == "X.png"
 
 
+def test_crop_train_single_rect_replaces_jpg_without_doubling(env) -> None:
+    """train-only 导入/复制后没有 manifest：JPG 裁剪成 PNG 时必须删旧 JPG。"""
+    sub = env["sub"]
+    _make_image(sub / "X.jpg", size=(200, 100))
+    (sub / "X.txt").write_text("existing caption", encoding="utf-8")
+
+    rc = worker._run_crop_train(
+        env["project"], env["version"],
+        {"crops": {"1_data/X.jpg": [{"x": 0.2, "y": 0.0, "w": 0.5, "h": 1.0}]}},
+        _silence, _silence,
+    )
+    assert rc == 0
+    assert not (sub / "X.jpg").exists()
+    assert (sub / "X.png").is_file()
+    # Same stem, so the sidecar still belongs to X.png.
+    assert (sub / "X.txt").read_text(encoding="utf-8") == "existing caption"
+    assert sorted(p.name for p in sub.iterdir() if p.suffix.lower() in {".jpg", ".png"}) == ["X.png"]
+
+
 # ---------------------------------------------------------------------------
 # _run_crop_train: N>1 fan-out
 # ---------------------------------------------------------------------------
@@ -128,6 +147,27 @@ def test_crop_train_fan_out_writes_multiple(env) -> None:
     # 多 crop 共享 origin
     assert m["images"]["1_data/Y_c0.png"]["origin"] == "Y.png"
     assert m["images"]["1_data/Y_c1.png"]["origin"] == "Y.png"
+
+
+def test_crop_train_fan_out_removes_source_sidecars(env) -> None:
+    """fan-out 后原图不再存在，旧 caption sidecar 也要清掉。"""
+    sub = env["sub"]
+    _make_image(sub / "Z.jpg", size=(200, 100))
+    (sub / "Z.txt").write_text("old caption", encoding="utf-8")
+
+    rc = worker._run_crop_train(
+        env["project"], env["version"],
+        {"crops": {"1_data/Z.jpg": [
+            {"x": 0.0, "y": 0.0, "w": 0.4, "h": 1.0},
+            {"x": 0.5, "y": 0.0, "w": 0.4, "h": 1.0},
+        ]}},
+        _silence, _silence,
+    )
+    assert rc == 0
+    assert not (sub / "Z.jpg").exists()
+    assert not (sub / "Z.txt").exists()
+    assert (sub / "Z_c0.png").is_file()
+    assert (sub / "Z_c1.png").is_file()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tag_worker.py
+++ b/tests/test_tag_worker.py
@@ -410,6 +410,46 @@ def test_on_existing_skip_preserves_existing_json(env) -> None:
     assert not (env["train"] / "a.txt").exists()
 
 
+def test_on_existing_skip_filters_before_tagger(env, monkeypatch: pytest.MonkeyPatch) -> None:
+    """skip：已有 caption 的图片不应进入 tagger，避免 LLM/ONNX 白跑。"""
+    seen: list[str] = []
+
+    class _SpyTagger(_FakeTagger):
+        def tag(self, paths, on_progress=lambda d, t: None):
+            seen.extend(p.name for p in paths)
+            yield from super().tag(paths, on_progress=on_progress)
+
+    (env["train"] / "a.txt").write_text("manual_a, kept", encoding="utf-8")
+    _set_on_existing(env, "skip")
+    monkeypatch.setattr(
+        "studio.workers.tag_worker.get_tagger",
+        lambda name, overrides=None: _SpyTagger(),
+    )
+
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    assert seen == ["b.png"]
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "manual_a, kept"
+    assert (env["train"] / "b.txt").read_text(encoding="utf-8") == "tag_b, common"
+
+
+def test_on_existing_skip_all_does_not_prepare_tagger(env, monkeypatch: pytest.MonkeyPatch) -> None:
+    """skip：全量已有 caption 时不实例化 tagger，尤其避免 LLM 请求。"""
+    (env["train"] / "a.txt").write_text("manual_a", encoding="utf-8")
+    (env["train"] / "b.txt").write_text("manual_b", encoding="utf-8")
+    _set_on_existing(env, "skip")
+
+    def _factory(name: str, overrides=None):
+        raise AssertionError("tagger should not be created when all images are skipped")
+
+    monkeypatch.setattr("studio.workers.tag_worker.get_tagger", _factory)
+
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "manual_a"
+    assert (env["train"] / "b.txt").read_text(encoding="utf-8") == "manual_b"
+
+
 def test_on_existing_append_merges_and_dedupes_txt(env) -> None:
     """append：现有 tag 在前，tagger 新 tag 追加在后；重复去重。"""
     (env["train"] / "a.txt").write_text("existing, common", encoding="utf-8")

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -306,6 +306,31 @@ def test_import_bundle_restores_version_and_preset_names(isolated, tmp_path: Pat
     assert (train_dir / "1_data" / "a.png").exists()
 
 
+def test_import_bundle_rejects_dot_version_label(isolated, tmp_path: Path) -> None:
+    """manifest 不可信：纯点 label（".." == project 根）必须回退 v1，
+    否则 delete_version 时 rmtree 会带走整个项目目录。"""
+    bundle = tmp_path / "dots.bundle.zip"
+    with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr(
+            "manifest.json",
+            json.dumps({
+                "schema_version": 2,
+                "source": {"title": "Evil", "slug": "evil", "version_label": ".."},
+                "includes": {"train": True},
+            }),
+        )
+        zf.writestr("train/1_data/a.png", b"fake")
+
+    with db.connection_for(isolated["db"]) as conn:
+        result = train_io.import_bundle(conn, bundle, presets_base=tmp_path / "presets")
+
+    assert result["version"]["label"] == "v1"
+    vdir = versions.version_dir(
+        result["project"]["id"], result["project"]["slug"], "v1"
+    )
+    assert (vdir / "train" / "1_data" / "a.png").exists()
+
+
 def _build_bundle_with_config(
     tmp_path: Path,
     *,

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -249,6 +249,63 @@ def test_import_bad_zip(isolated, tmp_path: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_export_bundle_records_version_and_preset_names(isolated, tmp_path: Path) -> None:
+    p, v, train = _make_project_with_train(isolated, label="anime-v2")
+    (train / "1_data").mkdir(parents=True, exist_ok=True)
+    (train / "1_data" / "a.png").write_bytes(_png())
+
+    dest = tmp_path / "out.bundle.zip"
+    with db.connection_for(isolated["db"]) as conn:
+        versions.update_version(conn, v["id"], config_name="style_preset")
+        result = train_io.export_bundle(
+            conn,
+            v["id"],
+            dest,
+            train_io.BundleOptions(train=True, train_captions=True),
+        )
+
+    source = result["manifest"]["source"]
+    assert source["version_label"] == "anime-v2"
+    assert source["preset_name"] == "style_preset"
+    assert source["config_name"] == "style_preset"
+
+    with zipfile.ZipFile(dest) as zf:
+        manifest = json.loads(zf.read("manifest.json"))
+    assert manifest["source"]["version_label"] == "anime-v2"
+    assert manifest["source"]["preset_name"] == "style_preset"
+
+
+def test_import_bundle_restores_version_and_preset_names(isolated, tmp_path: Path) -> None:
+    bundle = tmp_path / "named.bundle.zip"
+    with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr(
+            "manifest.json",
+            json.dumps({
+                "schema_version": 2,
+                "source": {
+                    "title": "Named Bundle",
+                    "slug": "named-bundle",
+                    "version_label": "anime-v2",
+                    "preset_name": "style_preset",
+                },
+                "includes": {"train": True},
+            }),
+        )
+        zf.writestr("train/1_data/a.png", b"fake")
+
+    with db.connection_for(isolated["db"]) as conn:
+        result = train_io.import_bundle(conn, bundle, presets_base=tmp_path / "presets")
+
+    assert result["version"]["label"] == "anime-v2"
+    assert result["version"]["config_name"] == "style_preset"
+    train_dir = versions.version_dir(
+        result["project"]["id"],
+        result["project"]["slug"],
+        "anime-v2",
+    ) / "train"
+    assert (train_dir / "1_data" / "a.png").exists()
+
+
 def _build_bundle_with_config(
     tmp_path: Path,
     *,

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -267,7 +267,6 @@ def test_export_bundle_records_version_and_preset_names(isolated, tmp_path: Path
     source = result["manifest"]["source"]
     assert source["version_label"] == "anime-v2"
     assert source["preset_name"] == "style_preset"
-    assert source["config_name"] == "style_preset"
 
     with zipfile.ZipFile(dest) as zf:
         manifest = json.loads(zf.read("manifest.json"))
@@ -275,7 +274,7 @@ def test_export_bundle_records_version_and_preset_names(isolated, tmp_path: Path
     assert manifest["source"]["preset_name"] == "style_preset"
 
 
-def test_import_bundle_restores_version_and_preset_names(isolated, tmp_path: Path) -> None:
+def _named_bundle(tmp_path: Path, *, with_preset: bool) -> Path:
     bundle = tmp_path / "named.bundle.zip"
     with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_STORED) as zf:
         zf.writestr(
@@ -288,10 +287,24 @@ def test_import_bundle_restores_version_and_preset_names(isolated, tmp_path: Pat
                     "version_label": "anime-v2",
                     "preset_name": "style_preset",
                 },
-                "includes": {"train": True},
+                "includes": {"train": True, "presets": with_preset},
             }),
         )
         zf.writestr("train/1_data/a.png", b"fake")
+        if with_preset:
+            import yaml
+            from studio.schema import TrainingConfig
+
+            zf.writestr(
+                "presets/style_preset.yaml",
+                yaml.safe_dump(TrainingConfig().model_dump(mode="python"),
+                               allow_unicode=True, sort_keys=False),
+            )
+    return bundle
+
+
+def test_import_bundle_restores_version_and_preset_names(isolated, tmp_path: Path) -> None:
+    bundle = _named_bundle(tmp_path, with_preset=True)
 
     with db.connection_for(isolated["db"]) as conn:
         result = train_io.import_bundle(conn, bundle, presets_base=tmp_path / "presets")
@@ -304,6 +317,17 @@ def test_import_bundle_restores_version_and_preset_names(isolated, tmp_path: Pat
         "anime-v2",
     ) / "train"
     assert (train_dir / "1_data" / "a.png").exists()
+
+
+def test_import_bundle_skips_preset_name_when_preset_missing(isolated, tmp_path: Path) -> None:
+    """bundle 没带预设、本机也没有 → config_name 不回填，避免悬空引用。"""
+    bundle = _named_bundle(tmp_path, with_preset=False)
+
+    with db.connection_for(isolated["db"]) as conn:
+        result = train_io.import_bundle(conn, bundle, presets_base=tmp_path / "presets")
+
+    assert result["version"]["label"] == "anime-v2"
+    assert result["version"]["config_name"] is None
 
 
 def test_import_bundle_rejects_dot_version_label(isolated, tmp_path: Path) -> None:

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -47,7 +47,9 @@ def test_create_version_builds_tree_and_activates(isolated) -> None:
 def test_create_version_rejects_invalid_label(isolated) -> None:
     p = _new_project(isolated)
     with db.connection_for(isolated["db"]) as conn:
-        for bad in ("has space", "../escape", "name/sub", "中文"):
+        # "." / ".." 单独列出：字符集本身放行点号，但纯点 label 会让
+        # version_dir 解析到 versions/ 之外（".." == project 根）。
+        for bad in ("has space", "../escape", "name/sub", "中文", ".", "..", "..."):
             with pytest.raises(versions.VersionError, match="label"):
                 versions.create_version(conn, project_id=p["id"], label=bad)
 


### PR DESCRIPTION
  ## Summary

  - **日志回放**：切页面/刷新后恢复生成页和打标页的实时日志（新增 `GET /reg/generate-prior/latest` 端点 + EventStream
  `onOpen` 回放）
  - **打标前置过滤**：`on_existing=skip` 时在实例化 tagger 之前过滤已有 caption 的图片，避免 LLM/ONNX 空转
  - **裁剪残留清理**：train-scope crop 完成后删除不再属于 outputs 的旧源图及其 sidecar（修复
  bundle/版本复制后原图+裁剪图同时残留）
  - **去重面板布局**：质量审核面板改为切换显示模式（groups / quality），防止窄屏下面板互相挤压
  - **打标高级选项布局**：防止展开高级选项时挤掉日志面板
  - **Bundle 导入导出**：保留 version_label 和 preset_name，导入时还原而非硬编码 v1
  - **勾选控件强调色**：全局 `accent-color: var(--accent)` 统一 checkbox/radio 颜色

  ## Changed files

  | 区域 | 文件 | 改动 |
  |------|------|------|
  | Backend | `training.py` | 新增 latest reg_prior task 端点 + 日志读取 |
  | Backend | `train_io.py` | 导出写入 version_label/preset_name，导入还原 |
  | Backend | `preprocess_worker.py` | crop 后清理旧源图 + sidecar |
  | Backend | `tag_worker.py` | skip 前置过滤，全跳过时不实例化 tagger |
  | Frontend | `Regularization.tsx` | 日志回放 + EventStream onOpen |
  | Frontend | `Tagging.tsx` | 同上 + 高级选项布局修复 |
  | Frontend | `PreprocessDuplicates.tsx` | 切换显示模式 + 响应式布局 |
  | Frontend | `client.ts` | 新 API 方法 |
  | Frontend | `index.css` | accent-color 全局统一 |
  | Tests | 3 files | +137 lines 覆盖裁剪残留、skip 过滤、bundle 版本名 |

  ## Test plan

  - [x] `test_tag_worker.py` — 24 passed
  - [x] `test_train_io.py` — 17 passed
  - [x] `test_preprocess_worker_train.py` — 10 passed
  - [x] 手动验证：刷新/切页面后日志恢复
  - [x] 手动验证：去重页面 groups/quality 切换
