### PR TITLE
fix(preprocess): 质量候选审核面板布局 — 卡片响应式多列 + 高度占满

### DIFF
--- a/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
@@ -578,7 +578,7 @@ function QualityReviewPanel({
         : activeTab
   const showBlur = activeQualityTab === 'blur'
   return (
-    <section className="flex flex-col min-h-0 rounded-md border border-subtle bg-surface overflow-hidden">
+    <section className="flex flex-col flex-1 min-h-0 rounded-md border border-subtle bg-surface overflow-hidden">
       <div className="h-0.5 bg-accent" />
       <header className="flex flex-wrap items-center gap-2 px-2.5 py-1.5 border-b border-subtle text-sm">
         <h3 className="font-semibold">{t('duplicates.qualityTitle')}</h3>
@@ -654,7 +654,7 @@ function QualityReviewPanel({
           )}
         </div>
       </header>
-      <div className="grid grid-cols-1 gap-2 p-2 min-h-0 overflow-y-auto">
+      <div className="flex-1 min-h-0 overflow-y-auto p-2">
         {showBlur && (
           <QualitySection
             title={t('duplicates.blurTitle')}
@@ -740,7 +740,16 @@ function QualitySection({
       {items.length === 0 ? (
         <div className="px-2 py-3 text-xs text-fg-tertiary">{empty}</div>
       ) : (
-        <div className="max-h-[360px] overflow-y-auto p-2 flex flex-col gap-2">
+        // 卡片铺响应式多列：缩略图只有 256px，卡片不能拉满面板宽（会放大到糊）。
+        // 滚动交给面板内容区的 overflow-y-auto，这里不再嵌套 max-h 滚动窗口。
+        <div
+          className="p-2 grid gap-2"
+          style={{
+            gridTemplateColumns: `repeat(auto-fill, minmax(${
+              items.some((item) => item.images.length > 1) ? 340 : 200
+            }px, 1fr))`,
+          }}
+        >
           {items.map((item) => (
             <article key={item.key} className="rounded-sm border border-subtle bg-surface p-1.5">
               <div className="grid gap-1.5" style={{ gridTemplateColumns: `repeat(${item.images.length}, minmax(0, 1fr))` }}>


### PR DESCRIPTION
## Summary

修复 PR #249 合并后质量候选审核面板的两个布局问题（手动测试发现）：

- **卡片拉满宽、缩略图放大到糊**：单 section 切换显示后卡片列表还是单列 flex，每张卡 ≈ 面板全宽（~1600px），`aspect-square` 让 256px 缩略图被 `object-cover` 放大六倍。改成 `repeat(auto-fill, minmax(200px, 1fr))` 响应式多列（裁剪关系卡含两张图，用 340px），与分组审核工作区 `DuplicateReviewPanel` 的 auto-fill 网格约定一致。
- **面板可视高度被压到 360px**：`QualitySection` 内残留旧双栏布局的 `max-h-[360px]` 嵌套滚动窗口；删掉，滚动职责统一交给面板内容区的 `overflow-y-auto`，section 加 `flex-1` 填满左列剩余高度。

Relates to #250 — 本 PR 只修布局可用性；质量审核与去重的功能解耦（挪到放大页 / 工作区合并）按 #250 另行处理。

## Test plan

- [x] `tsc -b` / eslint 干净
- [x] 手动验证：模糊候选多列排布、缩略图不再放大；面板占满可用高度，滚动正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)