### PR TITLE
test: 修复 model_downloader 机器态依赖 + 补更 route snapshot

### DIFF
--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 173,
+  "count": 174,
   "routes": [
     {
       "path": "/",
@@ -895,6 +895,14 @@
         "POST"
       ],
       "name": "reg_generate_prior",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/reg/generate-prior/latest",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_latest_reg_prior_task",
       "type": "APIRoute"
     },
     {

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -361,6 +361,10 @@ def test_download_upscaler_delegates_to_download_flat(
         return True
 
     monkeypatch.setattr("studio.services.models.sources.download_flat", fake_download_flat)
+    # 钉死下载源：_get_download_source 读真实 secrets.json，开发机若配了
+    # modelscope 会走 download_flat_ms 分支（甚至真实下载），patch 落空。
+    # env 优先级最高，保证任何机器上都走 HF 分支。
+    monkeypatch.setenv("MODELSCOPE_SOURCE", "huggingface")
 
     ok = model_downloader.download_upscaler("4x-AnimeSharp", tmp_path, on_log=lambda _l: None)
     assert ok


### PR DESCRIPTION
## 背景 / 动机

dev 全量自检长期挂着 2 个失败，每次都要人工排除，这次查清根因一并修掉：

1. **`test_download_upscaler_delegates_to_download_flat`**：不是代码 bug，是测试依赖机器状态——`download_upscaler` 经 `_get_download_source()` 读真实 `studio_data/secrets.json`，开发机配了 `download_source: modelscope` 时走 `download_flat_ms` 分支（target 不存在时甚至会发起真实下载），测试 patch 的 HF `download_flat` 落空，`calls == []` 断言失败。只在配了 ModelScope 源的机器上失败，所以一直被当成"环境问题"。
2. **`test_route_snapshot`**：PR #249 新增 `GET /api/projects/{pid}/versions/{vid}/reg/generate-prior/latest`（log replay 功能）时漏更 snapshot，173 → 174。

## 改动概要

- `tests/test_model_downloader.py` — 用 `monkeypatch.setenv("MODELSCOPE_SOURCE", "huggingface")`（`_get_download_source` 的第一优先级）钉死 HF 分支，任何机器上行为一致；附注释说明陷阱
- `tests/_snapshots/studio_routes.json` — 删除重生成，diff 仅 #249 的一条新 route + count

## 测试方式

- `tests/test_model_downloader.py` 全文件 27 passed
- `tests/test_route_snapshot.py` 重生成后连跑两次均过（确认确定性）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
