### PR TITLE
ci: 全量测试门禁 workflow — PR/push 跑 pytest + vitest/lint/tsc

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,70 @@
+# 全量测试门禁 — PR 与 dev/master push 自动跑后端 pytest + 前端 vitest/lint/tsc。
+#
+# 定位（见 CONTRIBUTING「测试时机」）：本地开发只跑相关测试，全量由本 workflow
+# 在机器时间兜底；release 前的全量人工自检照旧。
+#
+# 注意：runner 无 GPU。torch 装 CPU 版（官方 cpu index，避免拉 CUDA 大包）；
+# 依赖 CUDA 的测试应当用 torch.cuda.is_available() 守卫或 skip，在 CI 上走 CPU 路径。
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [dev, master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install CPU torch
+        run: pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          # requirements.txt 里注释掉的可选项，测试需要：
+          # pytest/httpx（TestClient）、onnxruntime（wd14/cltagger 路径）
+          pip install pytest httpx onnxruntime
+
+      - name: pytest
+        run: python -m pytest tests/ -q
+
+  frontend:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        working-directory: studio/web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: studio/web/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: vitest
+        run: npx vitest run
+
+      - name: lint
+        run: npm run lint
+
+      - name: typecheck
+        run: npx tsc --noEmit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 # 全量测试门禁 — PR 与 dev/master push 自动跑后端 pytest + 前端 vitest/lint/tsc。
 #
-# 定位（见 CONTRIBUTING「测试时机」）：本地开发只跑相关测试，全量由本 workflow
+# 定位（见 CONTRIBUTING「提交前自检」）：本地开发只跑相关测试，全量由本 workflow
 # 在机器时间兜底；release 前的全量人工自检照旧。
 #
 # 注意：runner 无 GPU。torch 装 CPU 版（官方 cpu index，避免拉 CUDA 大包）；
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -49,9 +49,9 @@ jobs:
       run:
         working-directory: studio/web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,12 +86,33 @@ chore(release): v0.5.0 — 版本控制系统 + bump 0.4 → 0.5.0
 
 ### 3. 提交前自检
 
+本地**不要求跑全量**（Windows 上全量 pytest 十几分钟；CI 会在 PR 上自动跑全量兜底），只跑两类：
+
 ```bash
-python -m studio test          # 后端 pytest + 前端 vitest 全过
+# (1) 相关测试：改了哪个模块就跑对应 tests/test_<module>*.py
+python -m pytest tests/test_xxx.py -q
+
+# (2) 横切安全网（秒级，改后端必带——专抓"改 A 坏 B"）：
+python -m pytest tests/test_route_snapshot.py tests/test_studio_configs.py -q
+
+# 改了前端：
 cd studio/web
-npm run lint                   # 前端 lint
-npx tsc --noEmit               # 前端 typecheck
+npx vitest run                 # 前端全量也只要 ~20s
+npm run lint && npx tsc --noEmit
 ```
+
+想本地全量也可以：`python -m studio test`。
+
+**测试卫生三条**（违反的测试在别人机器 / CI 上会假红，等于拆掉安全网）：
+
+1. **不依赖机器状态**：secrets.json / 环境变量 / 已安装的可选包 / 网络都要
+   monkeypatch 掉。反例教训：`_get_download_source()` 读真实 secrets，配了
+   ModelScope 的机器上测试常年红。
+2. **不依赖平台分支**：代码里有 `sys.platform` / GPU 检测分支的，测试要么
+   mock 掉分支入口，要么显式参数化两个平台路径。CI 是 Linux 无 GPU，本地是
+   Windows 有 GPU——两边都得绿。
+3. **flake 即修，不许习惯**：超时类断言要留并发余量（CI runner 2 核且邻居
+   吵）。一旦大家习惯"红的是 flake，重跑就行"，门禁就废了。
 
 ### 4. 开 PR
 
@@ -107,7 +128,10 @@ npx tsc --noEmit               # 前端 typecheck
 
 - Maintainer review，可能让你改
 - 改完不需要重开 PR，在原 branch 继续 push 就行
-- CI 必须全过（如果有）
+- **CI 必须全绿才能合并**（`.github/workflows/test.yml`：全量 pytest +
+  vitest + lint + tsc，PR 推上来自动跑，几分钟出结果）。CI 红了先看是不是
+  自己改挂的；确认是 flake / 既有问题就修它或单独开 issue，**不要默默重跑
+  到绿为止**
 
 ### 6. 合并
 

--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 174,
+  "count": 173,
   "routes": [
     {
       "path": "/",
@@ -1396,12 +1396,6 @@
       ],
       "name": "get_sample",
       "type": "APIRoute"
-    },
-    {
-      "path": "/studio",
-      "methods": [],
-      "name": "studio",
-      "type": "Mount"
     }
   ]
 }

--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 173,
+  "count": 174,
   "routes": [
     {
       "path": "/",
@@ -895,6 +895,14 @@
         "POST"
       ],
       "name": "reg_generate_prior",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/versions/{vid}/reg/generate-prior/latest",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_latest_reg_prior_task",
       "type": "APIRoute"
     },
     {

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -361,6 +361,10 @@ def test_download_upscaler_delegates_to_download_flat(
         return True
 
     monkeypatch.setattr("studio.services.models.sources.download_flat", fake_download_flat)
+    # 钉死下载源：_get_download_source 读真实 secrets.json，开发机若配了
+    # modelscope 会走 download_flat_ms 分支（甚至真实下载），patch 落空。
+    # env 优先级最高，保证任何机器上都走 HF 分支。
+    monkeypatch.setenv("MODELSCOPE_SOURCE", "huggingface")
 
     ok = model_downloader.download_upscaler("4x-AnimeSharp", tmp_path, on_log=lambda _l: None)
     assert ok

--- a/tests/test_onnxruntime_setup.py
+++ b/tests/test_onnxruntime_setup.py
@@ -123,6 +123,13 @@ def test_install_runtime_runs_uninstall_then_install(
         ors, "_query_dist_info",
         lambda: ("onnxruntime-gpu", "1.20.0"),
     )
+    # GPU 路径会续接 _install_cuda_runtime_wheels，其内部 _pip 调用数随平台
+    # 变化（Windows skip / Linux 真装）。本测试只验证 uninstall→install 序列，
+    # mock 掉保持平台无关（同 DirectML 测试的处理）。
+    monkeypatch.setattr(
+        ors, "_install_cuda_runtime_wheels",
+        lambda: {"installed": [], "skipped": [], "platform_skip": True, "stdout": ""},
+    )
     res = ors.install_runtime("gpu")
     assert len(calls) == 2
     assert calls[0][0] == "uninstall"

--- a/tests/test_route_snapshot.py
+++ b/tests/test_route_snapshot.py
@@ -34,6 +34,9 @@ def _route_entry(route: Any) -> dict[str, Any]:
 
 def _collect_routes() -> list[dict[str, Any]]:
     entries = [_route_entry(r) for r in app.routes]
+    # /studio 静态 Mount 是条件挂载（server.py 仅在前端 dist/ 存在时挂）——
+    # CI 不构建前端，本地构建过；纳入 snapshot 会让结果依赖环境，排除。
+    entries = [e for e in entries if not (e["type"] == "Mount" and e["path"] == "/studio")]
     entries.sort(key=lambda e: (e["path"], ",".join(e["methods"]), e["name"]))
     return entries
 


### PR DESCRIPTION
## 背景 / 动机

全量自检 13.5 分钟全靠人在本地跑，导致"PR 只跑相关测试"与"差 PR 牵连其他部分"成了两难。本 PR 把全量套件挪到 GitHub Actions（公开仓库免费）：本地开发只跑相关测试 + 横切安全网，每个 PR 由 CI 自动跑全量兜底，release 流程不变。

实测 CI 速度：backend（装依赖 + 全量 pytest 2193 用例）约 3 分钟（pytest 本体 ~60s，Linux 比本地 Windows 快一个数量级）；frontend（vitest + lint + tsc）<1 分钟。

## 改动概要

- `.github/workflows/test.yml` — 两个并行 job：
  - **backend**：CPU torch（官方 cpu index）+ requirements + pytest/httpx/onnxruntime → 全量 pytest
  - **frontend**：npm ci → vitest + eslint + tsc --noEmit
  - 触发：所有 PR + push 到 dev/master；同分支新 push 自动取消旧 run；checkout v5 / setup-python v6 / setup-node v5（Node 24 就绪）
- `CONTRIBUTING.md` — 「提交前自检」重写：本地相关测试 + 横切安全网（route snapshot / schema），全量交 CI；新增测试卫生三条（不依赖机器态 / 不依赖平台分支 / flake 即修）；Review 节明确 CI 全绿是合并门禁
- 平台无关性修复（CI 首跑暴露）：
  - `tests/test_route_snapshot.py` — snapshot 排除 `/studio` 静态 Mount（仅前端 dist 存在时挂载，CI 不构建前端）+ 重生成
  - `tests/test_onnxruntime_setup.py` — GPU 路径测试 mock `_install_cuda_runtime_wheels`（Linux 上有额外 pip 调用），对齐 DirectML 测试既有写法
- 含 cherry-pick 自 #260 的两个修复；**本 PR 是 #260 的严格超集，#260 可直接关闭**

## 测试方式

- 本 PR 自身的 CI run：第二轮起 backend + frontend 全绿（2193 passed / 4 skipped + vitest 366 passed + lint + tsc）
- 本地：`test_route_snapshot` / `test_onnxruntime_setup` / `test_model_downloader` 在 Windows 上同样全绿（平台无关性双向验证）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
