### PR TITLE
feat(ui): 测试页采样器/调度器下拉框 + 提示词输入自动撑高

### DIFF
--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -345,6 +345,14 @@
       "wandbPolicy": {
         "all": "Keep all",
         "last": "Keep latest only"
+      },
+      "sampler": {
+        "erSde": "ER SDE",
+        "dpmpp3mSde": "DPM++ 3M SDE"
+      },
+      "scheduler": {
+        "simple": "Simple",
+        "sgmUniform": "SGM Uniform"
       }
     },
     "disableHints": {
@@ -1222,6 +1230,8 @@
     "width": "Width",
     "height": "Height",
     "steps": "Steps",
+    "sampler": "Sampler",
+    "scheduler": "Scheduler",
     "perPrompt": "Per prompt",
     "seed": "Seed (0 = random)",
     "seedHint": "Specific number → reproducible; 0 → random each time",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -345,6 +345,14 @@
       "wandbPolicy": {
         "all": "保留全部",
         "last": "仅保留最新"
+      },
+      "sampler": {
+        "erSde": "ER SDE",
+        "dpmpp3mSde": "DPM++ 3M SDE"
+      },
+      "scheduler": {
+        "simple": "Simple",
+        "sgmUniform": "SGM Uniform"
       }
     },
     "disableHints": {
@@ -1222,6 +1230,8 @@
     "width": "宽",
     "height": "高",
     "steps": "步数",
+    "sampler": "采样器",
+    "scheduler": "调度器",
     "perPrompt": "每 prompt",
     "seed": "种子（0 = 随机）",
     "seedHint": "填具体数字 → 固定可复现；0 → 每次随机",

--- a/studio/web/src/lib/schema.ts
+++ b/studio/web/src/lib/schema.ts
@@ -147,6 +147,14 @@ export const SCHEMA_ENUM_LABEL_KEYS: Record<string, Record<string, string>> = {
     offset: 'schema.enums.noiseEnhancementType.offset',
     pyramid: 'schema.enums.noiseEnhancementType.pyramid',
   },
+  sample_sampler_name: {
+    er_sde: 'schema.enums.sampler.erSde',
+    dpmpp_3m_sde: 'schema.enums.sampler.dpmpp3mSde',
+  },
+  sample_scheduler: {
+    simple: 'schema.enums.scheduler.simple',
+    sgm_uniform: 'schema.enums.scheduler.sgmUniform',
+  },
   wandb_mode: {
     '': 'field.useGlobal',
     online: 'schema.enums.wandbMode.online',

--- a/studio/web/src/lib/useAutoGrowTextarea.ts
+++ b/studio/web/src/lib/useAutoGrowTextarea.ts
@@ -1,0 +1,23 @@
+import { useLayoutEffect, type RefObject } from 'react'
+
+/** textarea 随内容自动撑高，无上限；最小高度 = rows 属性决定的初始高度。
+ *
+ * 先把 height 重置为 auto 让浏览器回落到 rows 高度，再设为 scrollHeight —
+ * 内容少时 scrollHeight 被 clientHeight 托底，正好回到 rows 最小高度。
+ * 配合 className 加 resize-none overflow-hidden（手动拖拽会被下次输入覆盖，
+ * 干脆禁掉；hidden 防止撑高瞬间滚动条闪烁）。
+ */
+export function useAutoGrowTextarea(
+  ref: RefObject<HTMLTextAreaElement>,
+  value: string,
+): void {
+  useLayoutEffect(() => {
+    const el = ref.current
+    if (!el) return
+    el.style.height = 'auto'
+    // scrollHeight 不含 border；box-sizing: border-box 下补回去，否则每次少
+    // 2px 出现滚动条
+    const border = el.offsetHeight - el.clientHeight
+    el.style.height = `${el.scrollHeight + border}px`
+  }, [ref, value])
+}

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../api/client'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
+import { schemaEnumLabel } from '../../lib/schema'
 import { useEventStream } from '../../lib/useEventStream'
 import { useMonitorProgress } from '../../lib/useMonitorProgress'
 import { useLocalStorageState } from '../../lib/useLocalStorageState'
@@ -39,7 +40,11 @@ import SidebarLoras from './generate/SidebarLoras'
 import SidebarXYAxes from './generate/SidebarXYAxes'
 import StatusBadge from './generate/StatusBadge'
 import ViewModeTabs, { type ViewMode } from './generate/ViewModeTabs'
-import { DEFAULT_NEG } from './generate/types'
+import {
+  DEFAULT_NEG, DEFAULT_SAMPLER, DEFAULT_SCHEDULER,
+  SAMPLER_OPTIONS, SCHEDULER_OPTIONS,
+  type SamplerName, type SchedulerName,
+} from './generate/types'
 import { useProjectLoras } from './generate/useProjectLoras'
 import { buildXYMatrix, cellCount, parseAxisValues, type XYAxisDraft } from './generate/xy'
 
@@ -54,6 +59,8 @@ const DEFAULT_GENERATE_PREFS = {
   height: 1024,
   steps: 25,
   cfgScale: 4.0,
+  samplerName: DEFAULT_SAMPLER as SamplerName,
+  scheduler: DEFAULT_SCHEDULER as SchedulerName,
   count: 1,
   seed: 0,
   // single / xy 的 LoRA 列表完全独立（用户决策 2026-05-29）：切 mode 互不影响。
@@ -121,7 +128,7 @@ export default function GeneratePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const { mode, prompts, negPrompt, aspect, width, height, steps, cfgScale, count, seed, xDraft, yDraft, datasetPick } = prefs
+  const { mode, prompts, negPrompt, aspect, width, height, steps, cfgScale, samplerName, scheduler, count, seed, xDraft, yDraft, datasetPick } = prefs
   // LoRA 列表按 mode 完全独立：single 用 singleLoras，xy（含 compare 子视图）用
   // xyLoras。读写都按当前 mode 路由，切 mode 互不影响。
   const loras = mode === 'single' ? prefs.singleLoras : prefs.xyLoras
@@ -135,6 +142,8 @@ export default function GeneratePage() {
   const setHeight = (height: number) => setPrefs((p) => ({ ...p, height }))
   const setSteps = (steps: number) => setPrefs((p) => ({ ...p, steps }))
   const setCfgScale = (cfgScale: number) => setPrefs((p) => ({ ...p, cfgScale }))
+  const setSamplerName = (samplerName: SamplerName) => setPrefs((p) => ({ ...p, samplerName }))
+  const setScheduler = (scheduler: SchedulerName) => setPrefs((p) => ({ ...p, scheduler }))
   const setCount = (count: number) => setPrefs((p) => ({ ...p, count }))
   const setSeed = (seed: number) => setPrefs((p) => ({ ...p, seed }))
 
@@ -369,6 +378,8 @@ export default function GeneratePage() {
       negative_prompt: negPrompt,
       width, height, steps,
       cfg_scale: cfgScale,
+      sampler_name: samplerName,
+      scheduler,
       count, seed,
       loras: snapshotLoras,
       xy_draft: mode === 'xy'
@@ -420,7 +431,7 @@ export default function GeneratePage() {
       }
     })()
   }, [currentTask, samples, mode, selectedIndices, history, xDraft, yDraft,
-      prompts, negPrompt, width, height, steps, cfgScale, count, seed, loras, datasetPick])
+      prompts, negPrompt, width, height, steps, cfgScale, samplerName, scheduler, count, seed, loras, datasetPick])
 
   const handleHistorySelect = (entry: HistoryEntry) => {
     setHistoryOverride(entry)
@@ -453,6 +464,8 @@ export default function GeneratePage() {
         aspect: aspectFromDimensions(applied.width, applied.height),
         steps: applied.steps,
         cfgScale: applied.cfgScale,
+        samplerName: applied.samplerName,
+        scheduler: applied.scheduler,
         count: applied.count,
         seed: applied.seed,
         datasetPick: applied.datasetPick,
@@ -519,6 +532,8 @@ export default function GeneratePage() {
         count: mode === 'xy' ? 1 : count,
         seed,
         cfg_scale: cfgScale,
+        sampler_name: samplerName,
+        scheduler,
         lora_configs: loraConfigs,
         // attention_backend 不带：server 端套 Comfy-style runtime 并读取 generate backend。
         xy_matrix,
@@ -684,6 +699,35 @@ export default function GeneratePage() {
                   {mode !== 'xy' && (
                     <NumField label={t('generate.perPrompt')} value={count} onChange={setCount} min={1} max={32} />
                   )}
+                </div>
+                <div className="flex gap-2">
+                  <div className="flex-1 min-w-0">
+                    <label className="caption block mb-1">{t('generate.sampler')}</label>
+                    <select
+                      className="input text-xs w-full"
+                      value={samplerName}
+                      onChange={(e) => setSamplerName(e.target.value as SamplerName)}
+                      aria-label={t('generate.sampler')}
+                    >
+                      {/* 文案与训练配置页共用 schema.enums.* 映射，两边保持一致 */}
+                      {SAMPLER_OPTIONS.map((s) => (
+                        <option key={s} value={s}>{schemaEnumLabel('sample_sampler_name', s, t)}</option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <label className="caption block mb-1">{t('generate.scheduler')}</label>
+                    <select
+                      className="input text-xs w-full"
+                      value={scheduler}
+                      onChange={(e) => setScheduler(e.target.value as SchedulerName)}
+                      aria-label={t('generate.scheduler')}
+                    >
+                      {SCHEDULER_OPTIONS.map((s) => (
+                        <option key={s} value={s}>{schemaEnumLabel('sample_scheduler', s, t)}</option>
+                      ))}
+                    </select>
+                  </div>
                 </div>
                 <NumField
                   label={t('generate.seed')}

--- a/studio/web/src/pages/tools/generate/NegPromptInput.tsx
+++ b/studio/web/src/pages/tools/generate/NegPromptInput.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react'
 
 import { TagSuggestList } from '../../../components/tagSuggest/TagSuggestList'
 import { useTagSuggest } from '../../../components/tagSuggest/useTagSuggest'
+import { useAutoGrowTextarea } from '../../../lib/useAutoGrowTextarea'
 
 /** 负向提示词输入：接 tag autocomplete，跟 PromptList 同 UX。 */
 export default function NegPromptInput({ value, onChange }: {
@@ -25,11 +26,12 @@ export default function NegPromptInput({ value, onChange }: {
       })
     },
   })
+  useAutoGrowTextarea(taRef, value)
   return (
     <div className="relative">
       <textarea
         ref={taRef}
-        className="input w-full font-mono text-xs resize-y"
+        className="input w-full font-mono text-xs resize-none overflow-hidden"
         rows={5}
         value={value}
         onChange={(e) => { onChange(e.target.value); suggest.notifyChange() }}

--- a/studio/web/src/pages/tools/generate/PromptList.tsx
+++ b/studio/web/src/pages/tools/generate/PromptList.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { TagSuggestList } from '../../../components/tagSuggest/TagSuggestList'
 import { useTagSuggest } from '../../../components/tagSuggest/useTagSuggest'
+import { useAutoGrowTextarea } from '../../../lib/useAutoGrowTextarea'
 
 /** 正向提示词输入。
  *
@@ -35,11 +36,12 @@ export default function PromptList({ prompts, onChange }: {
       })
     },
   })
+  useAutoGrowTextarea(taRef, value)
   return (
     <div className="relative">
       <textarea
         ref={taRef}
-        className="input w-full font-mono text-sm resize-y"
+        className="input w-full font-mono text-sm resize-none overflow-hidden"
         rows={5}
         value={value}
         onChange={(e) => { onChange([e.target.value]); suggest.notifyChange() }}

--- a/studio/web/src/pages/tools/generate/paramsSnapshot.ts
+++ b/studio/web/src/pages/tools/generate/paramsSnapshot.ts
@@ -15,7 +15,10 @@
  */
 import type { LoraEntry, XYAxisType } from '../../../api/client'
 import type { DatasetPick } from './PromptFromDatasetPicker'
-import type { ProjectLora } from './types'
+import {
+  DEFAULT_SAMPLER, DEFAULT_SCHEDULER, SAMPLER_OPTIONS, SCHEDULER_OPTIONS,
+  type ProjectLora, type SamplerName, type SchedulerName,
+} from './types'
 import type { XYAxisDraft } from './xy'
 
 export const PARAMS_SNAPSHOT_VERSION = 1
@@ -60,6 +63,9 @@ export interface GenerateParamsSnapshot {
   height: number
   steps: number
   cfg_scale: number
+  /** v1 早期快照无此二字段（当时固定 er_sde/simple）；回填时缺省到默认值 */
+  sampler_name?: string
+  scheduler?: string
   /** xy 模式下 daemon 端强制 1，仅 single 有意义 */
   count: number
   seed: number
@@ -139,6 +145,8 @@ export interface AppliedSnapshot {
   height: number
   steps: number
   cfgScale: number
+  samplerName: SamplerName
+  scheduler: SchedulerName
   count: number
   seed: number
   datasetPick: DatasetPick | null
@@ -172,6 +180,15 @@ function mergeTagsIntoFirstPrompt(prompts: string[], tags: string[]): string[] {
   return [`${first}${sep}${suffix}`, ...prompts.slice(1)]
 }
 
+/** 快照里的 sampler/scheduler 归并到合法值 —— 老快照缺字段、或外部 PNG 带了
+ *  本程序不支持的值（如 euler）时回退默认，而不是把非法值灌进 prefs。 */
+function coerceSampler(v: string | undefined): SamplerName {
+  return (SAMPLER_OPTIONS as readonly string[]).includes(v ?? '') ? (v as SamplerName) : DEFAULT_SAMPLER
+}
+function coerceScheduler(v: string | undefined): SchedulerName {
+  return (SCHEDULER_OPTIONS as readonly string[]).includes(v ?? '') ? (v as SchedulerName) : DEFAULT_SCHEDULER
+}
+
 export function applySnapshot(
   snap: GenerateParamsSnapshot,
   projectLoras: ProjectLora[],
@@ -200,6 +217,8 @@ export function applySnapshot(
     height: snap.height,
     steps: snap.steps,
     cfgScale: snap.cfg_scale,
+    samplerName: coerceSampler(snap.sampler_name),
+    scheduler: coerceScheduler(snap.scheduler),
     count: snap.count,
     seed: snap.seed,
     datasetPick,

--- a/studio/web/src/pages/tools/generate/types.ts
+++ b/studio/web/src/pages/tools/generate/types.ts
@@ -16,3 +16,13 @@ export interface ProjectLora {
 
 export const DEFAULT_NEG =
   'worst quality, low quality, score_1, score_2, score_3, blurry, jpeg artifacts, bad anatomy, bad hands, bad feet, missing fingers, extra fingers, text, watermark, logo, signature'
+
+/** 采样器 / 调度器选项 —— 与后端 GenerateParams 的 Literal 保持一致
+ *  （studio/api/schemas/generate.py）；新增值两边要同步。 */
+export const SAMPLER_OPTIONS = ['er_sde', 'dpmpp_3m_sde'] as const
+export type SamplerName = (typeof SAMPLER_OPTIONS)[number]
+export const DEFAULT_SAMPLER: SamplerName = 'er_sde'
+
+export const SCHEDULER_OPTIONS = ['simple', 'sgm_uniform'] as const
+export type SchedulerName = (typeof SCHEDULER_OPTIONS)[number]
+export const DEFAULT_SCHEDULER: SchedulerName = 'simple'


### PR DESCRIPTION
## 背景

PR #255 给采样引入了新 sampler（dpmpp_3m_sde）/ scheduler（sgm_uniform），训练配置页通过 SchemaForm 自动有了下拉框，但测试页（Generate）UI 漏了——后端 `GenerateRequest` schema 本就接受 `sampler_name` / `scheduler`，纯前端缺线。顺带修两个同页 UX 问题（maintainer 指定合一个 PR）。

## 改动概要

**1. 测试页采样器 / 调度器下拉框**
- 「采样参数」卡片新增两个下拉框，选项与后端 Literal 一致（`er_sde` / `dpmpp_3m_sde`，`simple` / `sgm_uniform`），常量定义在 `generate/types.ts`，注释标明与 `studio/api/schemas/generate.py` 同步
- 选择持久化到 localStorage prefs（老 prefs 缺字段自动落默认值），随生成请求发往后端
- 参数快照（PNG metadata + 历史回填）带上两字段：快照字段可选，老快照 / 外部 PNG 带不支持值（如 euler）时回填归并到默认值（与后端 `_coerce_sample_sampler_scheduler` 同思路）

**2. 枚举显示文案去下划线、正确大写（测试页 + 配置页）**
- `er_sde` → ER SDE、`dpmpp_3m_sde` → DPM++ 3M SDE、`simple` → Simple、`sgm_uniform` → SGM Uniform
- 走现有 `SCHEMA_ENUM_LABEL_KEYS` → `schema.enums.*` i18n 机制；测试页 option 调 `schemaEnumLabel()` 与配置页共用同一份映射，后续加新采样器只改一处
- 发往后端的值不变，只改显示文案

**3. 正负向提示词输入框自动撑高**
- 之前固定 5 行高、内容超出滚动；现在 5 行为最小高度，随内容自动撑高、无上限、不出滚动条（新增 `lib/useAutoGrowTextarea.ts` hook，两个输入框共用）
- 手动拖拽 resize 一并禁用（拖了也会被下次输入重算覆盖）

## 测试方式

- 前端全量 `npx vitest run`：36 文件 366 测试全过
- `npm run lint` + `npx tsc --noEmit` 干净
- 既有 `Generate.test.tsx` 端到端 smoke（含 localStorage prefs 持久化/恢复）、`paramsSnapshot.test.ts` 快照回填均覆盖到改动路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)