### PR TITLE
perf(ui): 切路由时取消半途缩略图加载，避免饿死数据请求

### DIFF
--- a/studio/web/src/components/ImageGrid.test.tsx
+++ b/studio/web/src/components/ImageGrid.test.tsx
@@ -148,4 +148,30 @@ describe('ImageGrid (PP3)', () => {
     )
     expect(screen.getByText('空空')).toBeInTheDocument()
   })
+
+  // 切路由 / 滚出 overscan 时 cell unmount，浏览器不会自动取消半途的 <img>
+  // 下载 —— 几十张 thumb 占满同源 6 连接会饿死新页面的 fetch。Cell 在
+  // unmount cleanup 里把 src 置空主动 abort。注意 cleanup 跑的时候 React 已
+  // 把 ref 置 null，必须在 effect body 抓元素 —— 这个测试同时锁住该时序。
+  it('aborts in-flight image load on unmount (src cleared)', () => {
+    const { unmount } = render(
+      <ImageGrid items={items} selected={new Set()} onSelect={() => {}} />
+    )
+    const imgs = screen.getAllByRole('img')
+    // jsdom 不真正加载图片，complete 恒为 false == 永远"半途"，正好覆盖取消分支
+    expect(imgs[0]).toHaveAttribute('src', '/a')
+    unmount()
+    for (const img of imgs) expect(img).toHaveAttribute('src', '')
+  })
+
+  it('keeps src of already-loaded images on unmount (no pointless abort)', () => {
+    const { unmount } = render(
+      <ImageGrid items={items.slice(0, 1)} selected={new Set()} onSelect={() => {}} />
+    )
+    const img = screen.getByRole('img') as HTMLImageElement
+    // jsdom 的 complete 是 getter，defineProperty 模拟"已加载完"
+    Object.defineProperty(img, 'complete', { value: true })
+    unmount()
+    expect(img).toHaveAttribute('src', '/a')
+  })
 })

--- a/studio/web/src/components/ImageGrid.tsx
+++ b/studio/web/src/components/ImageGrid.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, type SyntheticEvent } from 'react'
+import { memo, useEffect, useRef, useState, type SyntheticEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { VirtuosoGrid } from 'react-virtuoso'
 
@@ -173,6 +173,20 @@ const Cell = memo(function Cell({
   // cache 命中场景下的视觉跳变；cache miss 场景也从"黑 → 啪一下出图"变成
   // "黑 → 图淡入"。
   const [loaded, setLoaded] = useState(false)
+  const imgRef = useRef<HTMLImageElement>(null)
+  // unmount 时 abort 还在下载的缩略图（src='' 是 <img> 唯一的取消手段）。
+  // 浏览器不会因为节点被移除就取消请求 —— 切路由后几十张半途的 thumb 会
+  // 继续占满同源 HTTP/1.1 的 6 个连接，新页面的 /api fetch 全在队尾排队，
+  // 用户视角就是"路由被图片卡住"。半途取消的图不进 HTTP 缓存，但后端
+  // thumb_cache 已落盘 + 完整加载过的走 304，重进页面的代价很小。
+  useEffect(() => {
+    // mount 时抓住元素：unmount 时 React 已把 ref 置 null，cleanup 里直接读
+    // imgRef.current 拿不到节点。脱离 DOM 的 <img> 改 src 同样会 abort 请求。
+    const img = imgRef.current
+    return () => {
+      if (img && !img.complete) img.src = ''
+    }
+  }, [])
   const handleCellClick = (e: React.MouseEvent) => {
     if (clickMode === 'activate' && onActivate && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
       onActivate(item.name)
@@ -219,10 +233,15 @@ const Cell = memo(function Cell({
        * 全废。这里改 eager（默认）让 Virtuoso 一 mount cell 浏览器就开 fetch
        * + decode，配合大 overscan 几乎看不到滚动闪。 */}
       <img
+        ref={imgRef}
         src={item.thumbUrl}
         alt={item.name}
         decoding="async"
         draggable={false}
+        // 让尚未开始的 thumb 请求排在数据 fetch 之后，页内操作不被图片饿死。
+        // React 18 只透传小写 unknown attribute（camelCase fetchPriority 是
+        // React 19 的事），spread 绕开 TS 对未知 prop 的检查。
+        {...{ fetchpriority: 'low' }}
         onLoad={handleImgLoad}
         className={
           'w-full h-full object-cover pointer-events-none transition-opacity duration-150 ' +


### PR DESCRIPTION
## 背景 / 动机

切到有大量缩略图的页面（Curation / Download / Tagging / Reg / Preprocess）后再点别的路由，新页面要等图片全部加载完才"动"。根因不在路由本身（所有页面静态 import，无 loader）：

1. 后端 uvicorn 是 HTTP/1.1，浏览器同源最多 6 个并发连接；
2. ImageGrid 的缩略图是有意 eager 加载的（虚拟化 + overscan 预热需要），一次几十个 `/thumb` 请求把连接占满，冷缓存时后端还要现做缩略图，单个请求更慢；
3. 关键：**`<img>` 节点被移除后浏览器并不会取消下载**——旧页面 unmount 之后那批半途请求继续跑到完，新页面的 `/api` 数据请求只能排队尾，表现就是"路由被卡"。

## 改动概要

`ImageGrid.tsx` 两处：

- `Cell` 加 unmount cleanup：图还没加载完（`!img.complete`）就把 `src` 置空，浏览器立刻 abort、释放连接。元素在 effect body 抓取——React 18 unmount 时**先置空 ref 再跑 cleanup**，在 cleanup 里读 `imgRef.current` 拿到的是 null，取消会静默失效（eslint react-hooks/exhaustive-deps 抓出来的）。
- 缩略图加 `fetchpriority="low"`：尚未开始的图片请求自动排在数据 fetch 之后，页内操作也不被图片饿死。React 18 只透传小写 unknown attribute（camelCase `fetchPriority` 是 React 19 的），用 spread 绕开 TS 对未知 prop 的检查。

权衡：半途取消的图不进 HTTP 缓存，切回来要重新下；但后端 thumb_cache 已落盘（生成开销不重复付），完整加载过的走 ETag 304，重进页面代价很小。滚出 overscan 区的 cell unmount 也走同一路径，快速滚动时顺带省掉看不见的下载。

## 测试方式

- 新增 2 个单测：unmount 时半途图片 `src` 被清空（同时锁住上面的 ref 抓取时序，防止回归）；已加载完的图不做无谓清空。
- 前端全量：vitest 372 通过 / `npm run lint` / `npx tsc --noEmit` 全绿。
- UI 无视觉变化，不附截图。

🤖 Generated with [Claude Code](https://claude.com/claude-code)