### PR TITLE
feat(ui): 项目页筛选/排序/归档 — 折叠过滤面板 + 软删除归档 + badge 显示 phase

### DIFF
--- a/studio/api/routers/projects/crud.py
+++ b/studio/api/routers/projects/crud.py
@@ -1,11 +1,13 @@
 """Projects + Versions CRUD + phase 推进 + ckpts（PR-6.5 commit 1 从 server.py 抽出）。
 
-16 routes：
-    GET    /api/projects                                       list（含 active version enrich）
+18 routes：
+    GET    /api/projects                                       list（含 active version enrich；含已归档行）
     POST   /api/projects                                       create（可选 initial version）
     GET    /api/projects/{pid}                                 get（含 versions 列表）
     PATCH  /api/projects/{pid}                                 update
     DELETE /api/projects/{pid}                                 delete
+    POST   /api/projects/{pid}/archive                         归档（软隐藏，可逆）
+    POST   /api/projects/{pid}/unarchive                       取消归档
     GET    /api/projects/{pid}/versions                        list versions
     POST   /api/projects/{pid}/versions                        create version
     GET    /api/projects/{pid}/versions/{vid}                  get version
@@ -45,19 +47,26 @@ router = APIRouter()
 
 @router.get("/api/projects")
 def list_projects_endpoint() -> dict[str, Any]:
-    """ADR-0007 §11.8-E：enrich active version label + status，卡片右上角 badge 用。"""
+    """ADR-0007 §11.8-E：enrich active version label + status，卡片右上角 badge 用。
+
+    v12 起额外带 archived_at（归档行不在这里过滤 —— 项目量小，归档/活跃的
+    切分交给前端，省一次切视图的往返）+ active_version_phase（preparing 时
+    badge 显示当前 phase，如"准备中 · 打标"）。
+    """
     with db.connection_for() as conn:
         rows = projects.list_projects(conn)
         enriched: list[dict[str, Any]] = []
         for r in projects.projects_with_stats(rows):
             r["active_version_label"] = None
             r["active_version_status"] = None
+            r["active_version_phase"] = None
             avid = r.get("active_version_id")
             if avid:
                 av = versions.get_version(conn, int(avid))
                 if av:
                     r["active_version_label"] = av["label"]
                     r["active_version_status"] = versions.get_status(av)
+                    r["active_version_phase"] = versions.get_phase(av)
             enriched.append(r)
     return {"items": enriched}
 
@@ -100,6 +109,29 @@ def patch_project_endpoint(pid: int, body: ProjectUpdate) -> dict[str, Any]:
     with db.connection_for() as conn:
         try:
             p = projects.update_project(conn, pid, **fields)
+        except projects.ProjectError as exc:
+            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    _publish_project_state(p)
+    return _project_payload(p)
+
+
+@router.post("/api/projects/{pid}/archive")
+def archive_project_endpoint(pid: int) -> dict[str, Any]:
+    """归档：列表软隐藏，目录 / versions / 任务全部原样，可随时取消。"""
+    with db.connection_for() as conn:
+        try:
+            p = projects.set_archived(conn, pid, True)
+        except projects.ProjectError as exc:
+            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    _publish_project_state(p)
+    return _project_payload(p)
+
+
+@router.post("/api/projects/{pid}/unarchive")
+def unarchive_project_endpoint(pid: int) -> dict[str, Any]:
+    with db.connection_for() as conn:
+        try:
+            p = projects.set_archived(conn, pid, False)
         except projects.ProjectError as exc:
             _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     _publish_project_state(p)

--- a/studio/infrastructure/migrations/__init__.py
+++ b/studio/infrastructure/migrations/__init__.py
@@ -26,6 +26,7 @@ from ._v8_version_status_phase import migrate as _migrate_v8
 from ._v9_drop_legacy_stage import migrate as _migrate_v9
 from ._v10_request_trace import migrate as _migrate_v10
 from ._v11_preprocessing_phase import migrate as _migrate_v11
+from ._v12_project_archived import migrate as _migrate_v12
 
 Migration = Callable[[sqlite3.Connection], None]
 
@@ -41,6 +42,7 @@ MIGRATIONS: list[Migration] = [
     _migrate_v9,  # v9: 删 projects.stage + versions.stage（ADR-0007 PR-5 destructive）
     _migrate_v10, # v10: tasks.request_trace_id（ADR-0009 PR-1 C6 trace_id 跨进程贯穿）
     _migrate_v11, # v11: versions.phase 加 preprocessing 值（ADR-0010 配套，回填 curating+train 非空 → preprocessing）
+    _migrate_v12, # v12: projects.archived_at（项目归档软隐藏）
 ]
 
 

--- a/studio/infrastructure/migrations/_v12_project_archived.py
+++ b/studio/infrastructure/migrations/_v12_project_archived.py
@@ -1,0 +1,17 @@
+"""v11 → v12: projects.archived_at — 项目归档（软隐藏）。
+
+加列 `projects.archived_at REAL`（NULL = 未归档）。归档项目不在项目页默认
+列表显示；UI 上原"删除"入口先归档，归档视图里再点才真删。归档不动
+updated_at —— 恢复后排序位置保持原样。
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from ._v2_projects import _add_column_if_missing
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    _add_column_if_missing(
+        conn, "projects", "archived_at", "archived_at REAL"
+    )

--- a/studio/services/projects/projects.py
+++ b/studio/services/projects/projects.py
@@ -6,6 +6,9 @@ title 和 note 可改。
 
 删除：直接 rmtree 项目目录 + DELETE db 行（CASCADE 清 versions /
 project_jobs）。无回收站、不可恢复 —— UI 层 confirm 提示用户。
+
+归档（v12）：archived_at 非 NULL = 归档，仅做列表软隐藏（目录 / versions /
+任务全部原样）。UI 上"×"先归档，归档视图里再删才走 delete_project。
 """
 from __future__ import annotations
 
@@ -155,6 +158,22 @@ def update_project(
     params.append(time.time())
     params.append(project_id)
     conn.execute(f"UPDATE projects SET {cols} WHERE id = ?", params)
+    conn.commit()
+    p = _must_get(conn, project_id)
+    _write_project_json(p)
+    return p
+
+
+def set_archived(
+    conn: sqlite3.Connection, project_id: int, archived: bool
+) -> dict[str, Any]:
+    """归档 / 取消归档。只写 archived_at，不动 updated_at —— 恢复后项目
+    在"按活跃时间"排序里回到原来的位置，而不是顶到最前。"""
+    _must_get(conn, project_id)
+    conn.execute(
+        "UPDATE projects SET archived_at = ? WHERE id = ?",
+        (time.time() if archived else None, project_id),
+    )
     conn.commit()
     p = _must_get(conn, project_id)
     _write_project_json(p)

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -651,8 +651,12 @@ export interface ProjectSummary {
   /** ADR-0007 §11.8-E: 项目卡片右上角 status badge / 卡片显 version 名（list 端点 enrich）。 */
   active_version_label: string | null
   active_version_status: VersionStatus | null
+  /** v12: preparing 时的 phase cursor（badge 显示"准备中 · 打标"）；无 active version 为 null。 */
+  active_version_phase: VersionPhase | null
   created_at: number
   updated_at: number
+  /** v12: 非 null = 已归档（软隐藏）。list 归档/活跃都返回，切分在前端。 */
+  archived_at: number | null
   note: string | null
   download_image_count?: number
   preprocess_image_count?: number
@@ -1778,6 +1782,11 @@ export const api = {
     }),
   deleteProject: (pid: number) =>
     req<{ deleted: number }>(`/api/projects/${pid}`, { method: 'DELETE' }),
+  /** 归档（软隐藏，可逆）：目录 / versions / 任务全部原样。 */
+  archiveProject: (pid: number) =>
+    req<ProjectDetail>(`/api/projects/${pid}/archive`, { method: 'POST' }),
+  unarchiveProject: (pid: number) =>
+    req<ProjectDetail>(`/api/projects/${pid}/unarchive`, { method: 'POST' }),
 
   listVersions: (pid: number) =>
     req<{ items: Version[] }>(`/api/projects/${pid}/versions`).then(

--- a/studio/web/src/components/VersionStatusBadge.test.tsx
+++ b/studio/web/src/components/VersionStatusBadge.test.tsx
@@ -51,12 +51,16 @@ describe('VersionStatusBadge', () => {
     expect(container.querySelector('.badge')?.textContent).toBe('准备中 · 打标')
   })
 
-  it('hides suffix for optional phases (preprocessing / regularizing)', () => {
-    for (const phase of ['preprocessing', 'regularizing'] as const) {
+  it('shows suffix for optional phases too (PR #265 review)', () => {
+    const cases = [
+      ['preprocessing', '准备中 · 预处理'],
+      ['regularizing', '准备中 · 正则集'],
+    ] as const
+    for (const [phase, text] of cases) {
       const { container } = render(
         <VersionStatusBadge status="preparing" phase={phase} />
       )
-      expect(container.querySelector('.badge')?.textContent).toBe('准备中')
+      expect(container.querySelector('.badge')?.textContent).toBe(text)
     }
   })
 

--- a/studio/web/src/components/VersionStatusBadge.test.tsx
+++ b/studio/web/src/components/VersionStatusBadge.test.tsx
@@ -42,4 +42,28 @@ describe('VersionStatusBadge', () => {
     const { container } = render(<VersionStatusBadge status="canceled" />)
     expect(container.querySelector('.badge')?.className).toContain('badge-neutral')
   })
+
+  // v12 — preparing 时显示 phase 后缀（项目卡片"准备中 · 打标"）
+  it('appends phase suffix when preparing', () => {
+    const { container } = render(
+      <VersionStatusBadge status="preparing" phase="tagging" />
+    )
+    expect(container.querySelector('.badge')?.textContent).toBe('准备中 · 打标')
+  })
+
+  it('hides suffix for optional phases (preprocessing / regularizing)', () => {
+    for (const phase of ['preprocessing', 'regularizing'] as const) {
+      const { container } = render(
+        <VersionStatusBadge status="preparing" phase={phase} />
+      )
+      expect(container.querySelector('.badge')?.textContent).toBe('准备中')
+    }
+  })
+
+  it('ignores phase when status is not preparing', () => {
+    const { container } = render(
+      <VersionStatusBadge status="training" phase="tagging" />
+    )
+    expect(container.querySelector('.badge')?.textContent).toBe('训练中')
+  })
 })

--- a/studio/web/src/components/VersionStatusBadge.tsx
+++ b/studio/web/src/components/VersionStatusBadge.tsx
@@ -5,7 +5,7 @@
  *  字段一起删，VersionStatusBadge 成为唯一 version 状态展示组件。
  */
 import { useTranslation } from 'react-i18next'
-import type { VersionStatus } from '../api/client'
+import type { VersionPhase, VersionStatus } from '../api/client'
 
 const DOT_RUNNING = (
   <span className="dot dot-running" style={{ flexShrink: 0 }} />
@@ -21,14 +21,34 @@ const STATUS_MAP: Record<VersionStatus, StatusEntry> = {
   canceled:  { badge: 'badge-neutral', key: 'versionStatus.canceled' },
 }
 
-export default function VersionStatusBadge({ status }: { status: VersionStatus | null | undefined }) {
+/** preparing 时 badge 后缀的 phase 文案。可选 phase（preprocessing /
+ * regularizing）刻意缺席 —— 用户决策：optional 步骤不值得占 badge 空间，
+ * cursor 落在上面时只显"准备中"。 */
+const PHASE_SUFFIX_KEY: Partial<Record<VersionPhase, string>> = {
+  curating: 'versionPhase.curating',
+  tagging: 'versionPhase.tagging',
+  editing: 'versionPhase.editing',
+  ready: 'versionPhase.ready',
+}
+
+export default function VersionStatusBadge({
+  status,
+  phase,
+}: {
+  status: VersionStatus | null | undefined
+  /** 传了且 status=preparing 时显示"准备中 · 打标"式后缀（项目卡片用）。 */
+  phase?: VersionPhase | null
+}) {
   const { t } = useTranslation()
   if (!status) return null
   const entry = STATUS_MAP[status] ?? { badge: 'badge-neutral', key: status }
+  const suffixKey =
+    status === 'preparing' && phase ? PHASE_SUFFIX_KEY[phase] : undefined
   return (
     <span className={`badge ${entry.badge}`}>
       {entry.dot && DOT_RUNNING}
       {STATUS_MAP[status] ? t(entry.key) : status}
+      {suffixKey ? ` · ${t(suffixKey)}` : ''}
     </span>
   )
 }

--- a/studio/web/src/components/VersionStatusBadge.tsx
+++ b/studio/web/src/components/VersionStatusBadge.tsx
@@ -21,13 +21,14 @@ const STATUS_MAP: Record<VersionStatus, StatusEntry> = {
   canceled:  { badge: 'badge-neutral', key: 'versionStatus.canceled' },
 }
 
-/** preparing 时 badge 后缀的 phase 文案。可选 phase（preprocessing /
- * regularizing）刻意缺席 —— 用户决策：optional 步骤不值得占 badge 空间，
- * cursor 落在上面时只显"准备中"。 */
-const PHASE_SUFFIX_KEY: Partial<Record<VersionPhase, string>> = {
+/** preparing 时 badge 后缀的 phase 文案（PR #265 评审改：可选步骤
+ * preprocessing / regularizing 也显示 —— cursor 在哪就显示哪）。 */
+const PHASE_SUFFIX_KEY: Record<VersionPhase, string> = {
   curating: 'versionPhase.curating',
+  preprocessing: 'versionPhase.preprocessing',
   tagging: 'versionPhase.tagging',
   editing: 'versionPhase.editing',
+  regularizing: 'versionPhase.regularizing',
   ready: 'versionPhase.ready',
 }
 

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -604,7 +604,24 @@
     "versionLabel": "Initial version label",
     "versionPlaceholder": "v1 / baseline / ...",
     "notesPlaceholder": "Training goal / notes",
-    "creating": "Creating…"
+    "creating": "Creating…",
+    "filters": "Filter / sort",
+    "filtersActive": "Filters active",
+    "searchPlaceholder": "Search title / slug / notes…",
+    "statusAll": "All statuses",
+    "sortLabel": "Sort",
+    "sort_updated": "Recently active",
+    "sort_created": "Newest created",
+    "sort_title": "By name",
+    "showArchived": "Show archived ({{n}})",
+    "archivedSection": "Archived",
+    "archiveProjectTitle": "Archive project (recoverable)",
+    "archiveConfirm": "Archive project \"{{title}}\"?\nIt will be hidden from the list; data is untouched. Recover it via \"Show archived\" in the filter panel.",
+    "archiveBtn": "Archive",
+    "archived": "Archived: {{title}}",
+    "unarchiveTitle": "Restore project",
+    "unarchiveConfirm": "Restore project \"{{title}}\" to the project list?",
+    "unarchived": "Restored: {{title}}"
   },
   "queue": {
     "title": "Queue",
@@ -1519,6 +1536,12 @@
     "completed": "Completed",
     "failed": "Failed",
     "canceled": "Canceled"
+  },
+  "versionPhase": {
+    "curating": "Curating",
+    "tagging": "Tagging",
+    "editing": "Tag edit",
+    "ready": "Ready to train"
   },
   "snapshot": {
     "title": "Training config snapshot",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -613,10 +613,10 @@
     "sort_updated": "Recently active",
     "sort_created": "Newest created",
     "sort_title": "By name",
-    "showArchived": "Show archived ({{n}})",
-    "archivedSection": "Archived",
+    "archivedToggle": "Archived ({{n}})",
+    "archivedToggleHint": "Toggle: show only archived projects",
     "archiveProjectTitle": "Archive project (recoverable)",
-    "archiveConfirm": "Archive project \"{{title}}\"?\nIt will be hidden from the list; data is untouched. Recover it via \"Show archived\" in the filter panel.",
+    "archiveConfirm": "Archive project \"{{title}}\"?\nIt will be hidden from the list; data is untouched. View and restore it via the \"Archived\" toggle in the header.",
     "archiveBtn": "Archive",
     "archived": "Archived: {{title}}",
     "unarchiveTitle": "Restore project",
@@ -1539,8 +1539,10 @@
   },
   "versionPhase": {
     "curating": "Curating",
+    "preprocessing": "Preprocess",
     "tagging": "Tagging",
     "editing": "Tag edit",
+    "regularizing": "Regularization",
     "ready": "Ready to train"
   },
   "snapshot": {

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -604,7 +604,24 @@
     "versionLabel": "初始版本标签",
     "versionPlaceholder": "v1 / baseline / ...",
     "notesPlaceholder": "训练目标 / 备注",
-    "creating": "创建中…"
+    "creating": "创建中…",
+    "filters": "筛选 / 排序",
+    "filtersActive": "有筛选生效",
+    "searchPlaceholder": "搜索标题 / slug / 备注…",
+    "statusAll": "全部状态",
+    "sortLabel": "排序",
+    "sort_updated": "最近活跃",
+    "sort_created": "最新创建",
+    "sort_title": "按名称",
+    "showArchived": "显示已归档（{{n}}）",
+    "archivedSection": "已归档",
+    "archiveProjectTitle": "归档项目（可恢复）",
+    "archiveConfirm": "归档项目「{{title}}」？\n项目将从列表隐藏，数据不受影响；可在「筛选 / 排序」面板开启「显示已归档」找回。",
+    "archiveBtn": "归档",
+    "archived": "已归档: {{title}}",
+    "unarchiveTitle": "恢复项目",
+    "unarchiveConfirm": "把项目「{{title}}」恢复回项目列表？",
+    "unarchived": "已恢复: {{title}}"
   },
   "queue": {
     "title": "队列",
@@ -1519,6 +1536,12 @@
     "completed": "已完成",
     "failed": "失败",
     "canceled": "已取消"
+  },
+  "versionPhase": {
+    "curating": "筛选",
+    "tagging": "打标",
+    "editing": "标签编辑",
+    "ready": "待训练"
   },
   "snapshot": {
     "title": "训练配置记录",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -613,10 +613,10 @@
     "sort_updated": "最近活跃",
     "sort_created": "最新创建",
     "sort_title": "按名称",
-    "showArchived": "显示已归档（{{n}}）",
-    "archivedSection": "已归档",
+    "archivedToggle": "已归档（{{n}}）",
+    "archivedToggleHint": "切换：只显示已归档项目",
     "archiveProjectTitle": "归档项目（可恢复）",
-    "archiveConfirm": "归档项目「{{title}}」？\n项目将从列表隐藏，数据不受影响；可在「筛选 / 排序」面板开启「显示已归档」找回。",
+    "archiveConfirm": "归档项目「{{title}}」？\n项目将从列表隐藏，数据不受影响；可通过标题栏「已归档」开关查看并恢复。",
     "archiveBtn": "归档",
     "archived": "已归档: {{title}}",
     "unarchiveTitle": "恢复项目",
@@ -1539,8 +1539,10 @@
   },
   "versionPhase": {
     "curating": "筛选",
+    "preprocessing": "预处理",
     "tagging": "打标",
     "editing": "标签编辑",
+    "regularizing": "正则集",
     "ready": "待训练"
   },
   "snapshot": {

--- a/studio/web/src/pages/Projects.test.tsx
+++ b/studio/web/src/pages/Projects.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import type { ProjectSummary } from '../api/client'
+import { filterProjects } from './Projects'
+
+function mk(over: Partial<ProjectSummary> & { id: number }): ProjectSummary {
+  return {
+    slug: `p${over.id}`,
+    title: `Project ${over.id}`,
+    active_version_id: null,
+    active_version_label: null,
+    active_version_status: null,
+    active_version_phase: null,
+    created_at: over.id,
+    updated_at: over.id,
+    archived_at: null,
+    note: null,
+    ...over,
+  }
+}
+
+const ITEMS: ProjectSummary[] = [
+  mk({ id: 1, title: 'Kaguya', slug: 'kaguya', active_version_status: 'completed', note: 'moon princess' }),
+  mk({ id: 2, title: 'Miku', slug: 'miku', active_version_status: 'training' }),
+  mk({ id: 3, title: 'Asuka', slug: 'asuka-style', active_version_status: 'preparing' }),
+]
+
+describe('filterProjects', () => {
+  it('default: no filter, sorted by updated_at desc', () => {
+    const r = filterProjects(ITEMS, { query: '', status: 'all', sort: 'updated' })
+    expect(r.map((p) => p.id)).toEqual([3, 2, 1])
+  })
+
+  it('query matches title / slug / note, case-insensitive', () => {
+    const byTitle = filterProjects(ITEMS, { query: 'kagu', status: 'all', sort: 'updated' })
+    expect(byTitle.map((p) => p.id)).toEqual([1])
+    const bySlug = filterProjects(ITEMS, { query: 'STYLE', status: 'all', sort: 'updated' })
+    expect(bySlug.map((p) => p.id)).toEqual([3])
+    const byNote = filterProjects(ITEMS, { query: 'princess', status: 'all', sort: 'updated' })
+    expect(byNote.map((p) => p.id)).toEqual([1])
+  })
+
+  it('status filter narrows to matching active version status', () => {
+    const r = filterProjects(ITEMS, { query: '', status: 'training', sort: 'updated' })
+    expect(r.map((p) => p.id)).toEqual([2])
+  })
+
+  it('query and status compose', () => {
+    const r = filterProjects(ITEMS, { query: 'miku', status: 'completed', sort: 'updated' })
+    expect(r).toEqual([])
+  })
+
+  it('sort by title uses locale compare', () => {
+    const r = filterProjects(ITEMS, { query: '', status: 'all', sort: 'title' })
+    expect(r.map((p) => p.title)).toEqual(['Asuka', 'Kaguya', 'Miku'])
+  })
+
+  it('does not mutate the input array', () => {
+    const before = ITEMS.map((p) => p.id)
+    filterProjects(ITEMS, { query: '', status: 'all', sort: 'title' })
+    expect(ITEMS.map((p) => p.id)).toEqual(before)
+  })
+})

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
-import { api, type BundleImportResult, type ProjectSummary } from '../api/client'
+import { api, type BundleImportResult, type ProjectSummary, type VersionStatus } from '../api/client'
 import PageHeader from '../components/PageHeader'
 import PathPicker from '../components/PathPicker'
 import UploadProgressBar from '../components/UploadProgressBar'
@@ -9,7 +9,35 @@ import VersionStatusBadge from '../components/VersionStatusBadge'
 import { useDialog } from '../components/Dialog'
 import { useToast } from '../components/Toast'
 import { useEventStream } from '../lib/useEventStream'
+import { useLocalStorageState } from '../lib/useLocalStorageState'
 import { useUploadProgress } from '../lib/useUploadProgress'
+
+export type ProjectSortKey = 'updated' | 'created' | 'title'
+export type ProjectStatusFilter = VersionStatus | 'all'
+
+const STATUS_OPTIONS: ProjectStatusFilter[] = [
+  'all', 'preparing', 'training', 'completed', 'failed', 'canceled',
+]
+const SORT_OPTIONS: ProjectSortKey[] = ['updated', 'created', 'title']
+
+/** 过滤 + 排序（纯函数，单测覆盖）。query 匹配 title / slug / note。 */
+export function filterProjects(
+  items: ProjectSummary[],
+  opts: { query: string; status: ProjectStatusFilter; sort: ProjectSortKey },
+): ProjectSummary[] {
+  const q = opts.query.trim().toLowerCase()
+  const matched = items.filter((p) => {
+    if (q && !`${p.title}\n${p.slug}\n${p.note ?? ''}`.toLowerCase().includes(q)) return false
+    if (opts.status !== 'all' && p.active_version_status !== opts.status) return false
+    return true
+  })
+  const cmp: Record<ProjectSortKey, (a: ProjectSummary, b: ProjectSummary) => number> = {
+    updated: (a, b) => b.updated_at - a.updated_at,
+    created: (a, b) => b.created_at - a.created_at,
+    title: (a, b) => a.title.localeCompare(b.title),
+  }
+  return [...matched].sort(cmp[opts.sort])
+}
 
 export default function ProjectsPage() {
   const { t } = useTranslation()
@@ -21,6 +49,12 @@ export default function ProjectsPage() {
   const [importing, setImporting] = useState(false)
   const [showImportDialog, setShowImportDialog] = useState(false)
   const [showImportPicker, setShowImportPicker] = useState(false)
+  // 过滤面板：默认折叠；排序偏好持久化，搜索 / 状态 / 归档可见性每次进页重置
+  const [filtersOpen, setFiltersOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [statusFilter, setStatusFilter] = useState<ProjectStatusFilter>('all')
+  const [sortKey, setSortKey] = useLocalStorageState<ProjectSortKey>('studio:projects:sort', 'updated')
+  const [showArchived, setShowArchived] = useState(false)
   const navigate = useNavigate()
   const { toast } = useToast()
   const { confirm } = useDialog()
@@ -72,6 +106,38 @@ export default function ProjectsPage() {
     try {
       await api.deleteProject(p.id)
       toast(t('projects.deleted', { title: p.title }), 'success')
+      await refresh()
+    } catch (err) {
+      toast(String(err), 'error')
+    }
+  }
+
+  const handleArchive = async (p: ProjectSummary, e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!(await confirm(
+      t('projects.archiveConfirm', { title: p.title }),
+      { okText: t('projects.archiveBtn') },
+    ))) return
+    try {
+      await api.archiveProject(p.id)
+      toast(t('projects.archived', { title: p.title }), 'success')
+      await refresh()
+    } catch (err) {
+      toast(String(err), 'error')
+    }
+  }
+
+  const handleUnarchive = async (p: ProjectSummary, e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    if (!(await confirm(
+      t('projects.unarchiveConfirm', { title: p.title }),
+      { okText: t('common.restore') },
+    ))) return
+    try {
+      await api.unarchiveProject(p.id)
+      toast(t('projects.unarchived', { title: p.title }), 'success')
       await refresh()
     } catch (err) {
       toast(String(err), 'error')
@@ -131,6 +197,11 @@ export default function ProjectsPage() {
     navigate(`/projects/${p.id}`)
   }
 
+  const archivedItems = items.filter((p) => p.archived_at != null)
+  const filterOpts = { query, status: statusFilter, sort: sortKey }
+  const visible = filterProjects(items.filter((p) => p.archived_at == null), filterOpts)
+  const visibleArchived = showArchived ? filterProjects(archivedItems, filterOpts) : []
+
   return (
     <div className="fade-in">
       <PageHeader
@@ -156,7 +227,21 @@ export default function ProjectsPage() {
         }
       />
 
-      <div className="p-6">
+      <FilterBar
+        open={filtersOpen}
+        onToggle={() => setFiltersOpen((o) => !o)}
+        query={query}
+        onQuery={setQuery}
+        status={statusFilter}
+        onStatus={setStatusFilter}
+        sort={sortKey}
+        onSort={setSortKey}
+        showArchived={showArchived}
+        onShowArchived={setShowArchived}
+        archivedCount={archivedItems.length}
+      />
+
+      <div className="p-6 pt-4">
         {error && (
           <div className="mb-4 px-3.5 py-2.5 rounded-md bg-err-soft border border-err text-err text-sm font-mono">{error}</div>
         )}
@@ -175,17 +260,42 @@ export default function ProjectsPage() {
             <div className="text-lg mb-2">{t('projects.noProjects')}</div>
             <div className="text-sm">{t('projects.noProjectsHint')}</div>
           </div>
-        ) : (
-          <div className="grid gap-4 auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
-            {items.map((p) => (
-              <ProjectCard
-                key={p.id}
-                project={p}
-                onClick={() => openProject(p)}
-                onDelete={(e) => handleDelete(p, e)}
-              />
-            ))}
+        ) : visible.length === 0 && visibleArchived.length === 0 ? (
+          <div className="mt-20 text-center text-fg-tertiary text-sm">
+            {t('common.noResults')}
           </div>
+        ) : (
+          <>
+            <div className="grid gap-4 auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
+              {visible.map((p) => (
+                <ProjectCard
+                  key={p.id}
+                  project={p}
+                  onClick={() => openProject(p)}
+                  onArchive={(e) => handleArchive(p, e)}
+                />
+              ))}
+            </div>
+            {showArchived && visibleArchived.length > 0 && (
+              <>
+                <div className="mt-8 mb-3 text-sm font-medium text-fg-tertiary">
+                  {t('projects.archivedSection')}（{visibleArchived.length}）
+                </div>
+                <div className="grid gap-4 auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
+                  {visibleArchived.map((p) => (
+                    <ProjectCard
+                      key={p.id}
+                      project={p}
+                      archived
+                      onClick={() => openProject(p)}
+                      onUnarchive={(e) => handleUnarchive(p, e)}
+                      onDelete={(e) => handleDelete(p, e)}
+                    />
+                  ))}
+                </div>
+              </>
+            )}
+          </>
         )}
       </div>
 
@@ -219,6 +329,93 @@ export default function ProjectsPage() {
           onClose={() => setShowImportPicker(false)}
           onPick={(path) => { void handleImportPath(path) }}
         />
+      )}
+    </div>
+  )
+}
+
+/** Header 下方的过滤 / 排序条：默认折叠成一行按钮，展开后是搜索 + 状态 +
+ * 排序 + 已归档开关。有非默认过滤生效时折叠态按钮上显示小圆点提示。 */
+function FilterBar({
+  open,
+  onToggle,
+  query,
+  onQuery,
+  status,
+  onStatus,
+  sort,
+  onSort,
+  showArchived,
+  onShowArchived,
+  archivedCount,
+}: {
+  open: boolean
+  onToggle: () => void
+  query: string
+  onQuery: (v: string) => void
+  status: ProjectStatusFilter
+  onStatus: (v: ProjectStatusFilter) => void
+  sort: ProjectSortKey
+  onSort: (v: ProjectSortKey) => void
+  showArchived: boolean
+  onShowArchived: (v: boolean) => void
+  archivedCount: number
+}) {
+  const { t } = useTranslation()
+  const filtering = query.trim() !== '' || status !== 'all' || showArchived
+  return (
+    <div className="px-6 pt-4 border-b border-subtle pb-3">
+      <button
+        type="button"
+        className="btn btn-secondary btn-sm"
+        aria-expanded={open}
+        onClick={onToggle}
+      >
+        <span className="inline-block w-3 text-center">{open ? '▾' : '▸'}</span>
+        {t('projects.filters')}
+        {filtering && <span className="dot dot-running ml-1" aria-label={t('projects.filtersActive')} />}
+      </button>
+      {open && (
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <input
+            className="input"
+            style={{ width: 240 }}
+            value={query}
+            onChange={(e) => onQuery(e.target.value)}
+            placeholder={t('projects.searchPlaceholder')}
+            aria-label={t('common.search')}
+          />
+          <select
+            className="input"
+            value={status}
+            onChange={(e) => onStatus(e.target.value as ProjectStatusFilter)}
+            aria-label={t('common.status')}
+          >
+            {STATUS_OPTIONS.map((s) => (
+              <option key={s} value={s}>
+                {s === 'all' ? t('projects.statusAll') : t(`versionStatus.${s}`)}
+              </option>
+            ))}
+          </select>
+          <select
+            className="input"
+            value={sort}
+            onChange={(e) => onSort(e.target.value as ProjectSortKey)}
+            aria-label={t('projects.sortLabel')}
+          >
+            {SORT_OPTIONS.map((s) => (
+              <option key={s} value={s}>{t(`projects.sort_${s}`)}</option>
+            ))}
+          </select>
+          <label className="flex items-center gap-1.5 text-sm text-fg-secondary cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={showArchived}
+              onChange={(e) => onShowArchived(e.target.checked)}
+            />
+            {t('projects.showArchived', { n: archivedCount })}
+          </label>
+        </div>
       )}
     </div>
   )
@@ -295,12 +492,19 @@ function BundleImportDialog({
 
 function ProjectCard({
   project: p,
+  archived = false,
   onClick,
+  onArchive,
+  onUnarchive,
   onDelete,
 }: {
   project: ProjectSummary
+  /** 已归档卡片：半透明 + ↺ 恢复（在 × 左边）+ × 真删；普通卡片 × = 归档。 */
+  archived?: boolean
   onClick: () => void
-  onDelete: (e: React.MouseEvent) => void
+  onArchive?: (e: React.MouseEvent) => void
+  onUnarchive?: (e: React.MouseEvent) => void
+  onDelete?: (e: React.MouseEvent) => void
 }) {
   const { t } = useTranslation()
   const [hovered, setHovered] = useState(false)
@@ -310,8 +514,8 @@ function ProjectCard({
       onClick={onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      className={`p-[18px] text-left rounded-lg cursor-pointer flex flex-col gap-3.5 relative w-full ${hovered ? 'border-dim shadow-sm bg-surface' : 'border border-subtle bg-surface'}`}
-      style={{ transition: 'border-color 0.15s, box-shadow 0.15s' }}
+      className={`p-[18px] text-left rounded-lg cursor-pointer flex flex-col gap-3.5 relative w-full ${hovered ? 'border-dim shadow-sm bg-surface' : 'border border-subtle bg-surface'} ${archived ? 'opacity-70' : ''}`}
+      style={{ transition: 'border-color 0.15s, box-shadow 0.15s, opacity 0.15s' }}
     >
       {/* ADR-0007 §11.8-E: 右上角 = active version status；去 stage badge / 时间 / 产物 */}
       <div className="flex justify-between items-start gap-2">
@@ -323,7 +527,7 @@ function ProjectCard({
             {p.slug}
           </div>
         </div>
-        <VersionStatusBadge status={p.active_version_status} />
+        <VersionStatusBadge status={p.active_version_status} phase={p.active_version_phase} />
       </div>
 
       {p.note && (
@@ -340,13 +544,35 @@ function ProjectCard({
           <span className="text-fg-tertiary italic text-xs">{t('projects.noActiveVersion')}</span>
         )}
         <span className="flex-1" />
-        <button
-          onClick={onDelete}
-          className="bg-transparent border-none px-1.5 py-0.5 rounded-sm text-fg-tertiary text-xs cursor-pointer"
-          title={t('projects.deleteProjectTitle')}
-        >
-          ×
-        </button>
+        {archived ? (
+          <>
+            <button
+              onClick={onUnarchive}
+              className="bg-transparent border-none px-1.5 py-0.5 rounded-sm text-fg-tertiary text-xs cursor-pointer"
+              title={t('projects.unarchiveTitle')}
+              aria-label={`${t('projects.unarchiveTitle')} ${p.title}`}
+            >
+              ↺
+            </button>
+            <button
+              onClick={onDelete}
+              className="bg-transparent border-none px-1.5 py-0.5 rounded-sm text-fg-tertiary text-xs cursor-pointer"
+              title={t('projects.deleteProjectTitle')}
+              aria-label={`${t('projects.deleteProjectTitle')} ${p.title}`}
+            >
+              ×
+            </button>
+          </>
+        ) : (
+          <button
+            onClick={onArchive}
+            className="bg-transparent border-none px-1.5 py-0.5 rounded-sm text-fg-tertiary text-xs cursor-pointer"
+            title={t('projects.archiveProjectTitle')}
+            aria-label={`${t('projects.archiveProjectTitle')} ${p.title}`}
+          >
+            ×
+          </button>
+        )}
       </div>
     </button>
   )

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -199,8 +199,12 @@ export default function ProjectsPage() {
 
   const archivedItems = items.filter((p) => p.archived_at != null)
   const filterOpts = { query, status: statusFilter, sort: sortKey }
-  const visible = filterProjects(items.filter((p) => p.archived_at == null), filterOpts)
-  const visibleArchived = showArchived ? filterProjects(archivedItems, filterOpts) : []
+  // 归档开关是视图切换（radio 语义）：开 = 只看已归档，关 = 只看活跃
+  const visible = filterProjects(
+    showArchived ? archivedItems : items.filter((p) => p.archived_at == null),
+    filterOpts,
+  )
+  const filtering = query.trim() !== '' || statusFilter !== 'all'
 
   return (
     <div className="fade-in">
@@ -209,6 +213,30 @@ export default function ProjectsPage() {
         subtitle={t('projects.description')}
         actions={
           <>
+            {/* 过滤 icon：折叠态完全不占行，开关过滤行；有筛选生效且收起时带小圆点 */}
+            <button
+              className={`btn btn-sm ${filtersOpen ? 'btn-primary' : 'btn-secondary'}`}
+              onClick={() => setFiltersOpen((o) => !o)}
+              aria-expanded={filtersOpen}
+              aria-label={t('projects.filters')}
+              title={t('projects.filters')}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M3 4h18l-7 8v6l-4 2v-8L3 4z" />
+              </svg>
+              {!filtersOpen && filtering && (
+                <span className="dot dot-running" aria-label={t('projects.filtersActive')} />
+              )}
+            </button>
+            {/* 已归档视图开关（radio 语义：开 = 列表只显示已归档项目） */}
+            <button
+              className={`btn btn-sm ${showArchived ? 'btn-primary' : 'btn-secondary'}`}
+              onClick={() => setShowArchived((v) => !v)}
+              aria-pressed={showArchived}
+              title={t('projects.archivedToggleHint')}
+            >
+              {t('projects.archivedToggle', { n: archivedItems.length })}
+            </button>
             <button
               className="btn btn-secondary btn-sm"
               onClick={() => setShowImportDialog(true)}
@@ -227,19 +255,16 @@ export default function ProjectsPage() {
         }
       />
 
-      <FilterBar
-        open={filtersOpen}
-        onToggle={() => setFiltersOpen((o) => !o)}
-        query={query}
-        onQuery={setQuery}
-        status={statusFilter}
-        onStatus={setStatusFilter}
-        sort={sortKey}
-        onSort={setSortKey}
-        showArchived={showArchived}
-        onShowArchived={setShowArchived}
-        archivedCount={archivedItems.length}
-      />
+      {filtersOpen && (
+        <FilterBar
+          query={query}
+          onQuery={setQuery}
+          status={statusFilter}
+          onStatus={setStatusFilter}
+          sort={sortKey}
+          onSort={setSortKey}
+        />
+      )}
 
       <div className="p-6 pt-4">
         {error && (
@@ -260,42 +285,24 @@ export default function ProjectsPage() {
             <div className="text-lg mb-2">{t('projects.noProjects')}</div>
             <div className="text-sm">{t('projects.noProjectsHint')}</div>
           </div>
-        ) : visible.length === 0 && visibleArchived.length === 0 ? (
+        ) : visible.length === 0 ? (
           <div className="mt-20 text-center text-fg-tertiary text-sm">
             {t('common.noResults')}
           </div>
         ) : (
-          <>
-            <div className="grid gap-4 auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
-              {visible.map((p) => (
-                <ProjectCard
-                  key={p.id}
-                  project={p}
-                  onClick={() => openProject(p)}
-                  onArchive={(e) => handleArchive(p, e)}
-                />
-              ))}
-            </div>
-            {showArchived && visibleArchived.length > 0 && (
-              <>
-                <div className="mt-8 mb-3 text-sm font-medium text-fg-tertiary">
-                  {t('projects.archivedSection')}（{visibleArchived.length}）
-                </div>
-                <div className="grid gap-4 auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
-                  {visibleArchived.map((p) => (
-                    <ProjectCard
-                      key={p.id}
-                      project={p}
-                      archived
-                      onClick={() => openProject(p)}
-                      onUnarchive={(e) => handleUnarchive(p, e)}
-                      onDelete={(e) => handleDelete(p, e)}
-                    />
-                  ))}
-                </div>
-              </>
-            )}
-          </>
+          <div className="grid gap-4 auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
+            {visible.map((p) => (
+              <ProjectCard
+                key={p.id}
+                project={p}
+                archived={showArchived}
+                onClick={() => openProject(p)}
+                onArchive={(e) => handleArchive(p, e)}
+                onUnarchive={(e) => handleUnarchive(p, e)}
+                onDelete={(e) => handleDelete(p, e)}
+              />
+            ))}
+          </div>
         )}
       </div>
 
@@ -334,94 +341,60 @@ export default function ProjectsPage() {
   )
 }
 
-/** Header 下方的过滤 / 排序条：默认折叠成一行按钮，展开后是搜索 + 状态 +
- * 排序 + 已归档开关。有非默认过滤生效时折叠态按钮上显示小圆点提示。 */
+/** Header 下方的过滤 / 排序行（仅 filtersOpen 时渲染，折叠完全不占空间；
+ * 开关在 PageHeader 的过滤 icon 上）。单行：搜索 60% 居左，状态 / 排序
+ * 各 10% 推到最右。 */
 function FilterBar({
-  open,
-  onToggle,
   query,
   onQuery,
   status,
   onStatus,
   sort,
   onSort,
-  showArchived,
-  onShowArchived,
-  archivedCount,
 }: {
-  open: boolean
-  onToggle: () => void
   query: string
   onQuery: (v: string) => void
   status: ProjectStatusFilter
   onStatus: (v: ProjectStatusFilter) => void
   sort: ProjectSortKey
   onSort: (v: ProjectSortKey) => void
-  showArchived: boolean
-  onShowArchived: (v: boolean) => void
-  archivedCount: number
 }) {
   const { t } = useTranslation()
-  const filtering = query.trim() !== '' || status !== 'all' || showArchived
-  // 单行布局（用户反馈）：收起时只剩一个细行下拉符号，不占空间；
-  // 展开后搜索 / 状态 / 排序 / 已归档全部排进同一行。
   return (
-    <div className="px-6 py-1.5 border-b border-subtle flex flex-wrap items-center gap-3">
-      <button
-        type="button"
-        className="bg-transparent border-none px-1.5 py-0.5 rounded-sm text-fg-tertiary text-sm cursor-pointer hover:text-fg-primary"
-        aria-expanded={open}
-        aria-label={t('projects.filters')}
-        title={t('projects.filters')}
-        onClick={onToggle}
+    <div className="px-6 py-2 border-b border-subtle flex items-center gap-3">
+      <input
+        className="input"
+        style={{ width: '60%' }}
+        value={query}
+        onChange={(e) => onQuery(e.target.value)}
+        placeholder={t('projects.searchPlaceholder')}
+        aria-label={t('common.search')}
+      />
+      <span className="flex-1" />
+      <select
+        className="input"
+        style={{ width: '10%', minWidth: 104 }}
+        value={status}
+        onChange={(e) => onStatus(e.target.value as ProjectStatusFilter)}
+        aria-label={t('common.status')}
       >
-        {open ? '▴' : '▾'}
-        {!open && filtering && (
-          <span className="dot dot-running ml-1" aria-label={t('projects.filtersActive')} />
-        )}
-      </button>
-      {open && (
-        <>
-          <input
-            className="input"
-            style={{ width: 220 }}
-            value={query}
-            onChange={(e) => onQuery(e.target.value)}
-            placeholder={t('projects.searchPlaceholder')}
-            aria-label={t('common.search')}
-          />
-          <select
-            className="input"
-            value={status}
-            onChange={(e) => onStatus(e.target.value as ProjectStatusFilter)}
-            aria-label={t('common.status')}
-          >
-            {STATUS_OPTIONS.map((s) => (
-              <option key={s} value={s}>
-                {s === 'all' ? t('projects.statusAll') : t(`versionStatus.${s}`)}
-              </option>
-            ))}
-          </select>
-          <select
-            className="input"
-            value={sort}
-            onChange={(e) => onSort(e.target.value as ProjectSortKey)}
-            aria-label={t('projects.sortLabel')}
-          >
-            {SORT_OPTIONS.map((s) => (
-              <option key={s} value={s}>{t(`projects.sort_${s}`)}</option>
-            ))}
-          </select>
-          <label className="flex items-center gap-1.5 text-sm text-fg-secondary cursor-pointer select-none whitespace-nowrap">
-            <input
-              type="checkbox"
-              checked={showArchived}
-              onChange={(e) => onShowArchived(e.target.checked)}
-            />
-            {t('projects.showArchived', { n: archivedCount })}
-          </label>
-        </>
-      )}
+        {STATUS_OPTIONS.map((s) => (
+          <option key={s} value={s}>
+            {s === 'all' ? t('projects.statusAll') : t(`versionStatus.${s}`)}
+          </option>
+        ))}
+      </select>
+      <select
+        className="input"
+        style={{ width: '10%', minWidth: 104 }}
+        value={sort}
+        onChange={(e) => onSort(e.target.value as ProjectSortKey)}
+        aria-label={t('projects.sortLabel')}
+      >
+        {SORT_OPTIONS.map((s) => (
+          <option key={s} value={s}>{t(`projects.sort_${s}`)}</option>
+        ))}
+      </select>
     </div>
   )
 }

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -213,9 +213,11 @@ export default function ProjectsPage() {
         subtitle={t('projects.description')}
         actions={
           <>
+            {/* btn 词汇与 Queue / Generate 页 header 统一：轻操作 ghost、
+             * 激活态 secondary、全部 btn-sm；唯一 primary 留给页面 CTA。 */}
             {/* 过滤 icon：折叠态完全不占行，开关过滤行；有筛选生效且收起时带小圆点 */}
             <button
-              className={`btn btn-sm ${filtersOpen ? 'btn-primary' : 'btn-secondary'}`}
+              className={`btn btn-sm ${filtersOpen ? 'btn-secondary' : 'btn-ghost'}`}
               onClick={() => setFiltersOpen((o) => !o)}
               aria-expanded={filtersOpen}
               aria-label={t('projects.filters')}
@@ -230,7 +232,7 @@ export default function ProjectsPage() {
             </button>
             {/* 已归档视图开关（radio 语义：开 = 列表只显示已归档项目） */}
             <button
-              className={`btn btn-sm ${showArchived ? 'btn-primary' : 'btn-secondary'}`}
+              className={`btn btn-sm ${showArchived ? 'btn-secondary' : 'btn-ghost'}`}
               onClick={() => setShowArchived((v) => !v)}
               aria-pressed={showArchived}
               title={t('projects.archivedToggleHint')}
@@ -238,14 +240,14 @@ export default function ProjectsPage() {
               {t('projects.archivedToggle', { n: archivedItems.length })}
             </button>
             <button
-              className="btn btn-secondary btn-sm"
+              className="btn btn-ghost btn-sm"
               onClick={() => setShowImportDialog(true)}
               disabled={importing}
               title={importing ? t('projects.importing') : t('projects.importZipHint')}
             >
               {importing ? t('projects.importing') : t('projects.importZip')}
             </button>
-            <button className="btn btn-primary" onClick={() => setCreating(true)}>
+            <button className="btn btn-primary btn-sm" onClick={() => setCreating(true)}>
               <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
                 <path d="M12 5v14M5 12h14" />
               </svg>

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -363,23 +363,28 @@ function FilterBar({
 }) {
   const { t } = useTranslation()
   const filtering = query.trim() !== '' || status !== 'all' || showArchived
+  // 单行布局（用户反馈）：收起时只剩一个细行下拉符号，不占空间；
+  // 展开后搜索 / 状态 / 排序 / 已归档全部排进同一行。
   return (
-    <div className="px-6 pt-4 border-b border-subtle pb-3">
+    <div className="px-6 py-1.5 border-b border-subtle flex flex-wrap items-center gap-3">
       <button
         type="button"
-        className="btn btn-secondary btn-sm"
+        className="bg-transparent border-none px-1.5 py-0.5 rounded-sm text-fg-tertiary text-sm cursor-pointer hover:text-fg-primary"
         aria-expanded={open}
+        aria-label={t('projects.filters')}
+        title={t('projects.filters')}
         onClick={onToggle}
       >
-        <span className="inline-block w-3 text-center">{open ? '▾' : '▸'}</span>
-        {t('projects.filters')}
-        {filtering && <span className="dot dot-running ml-1" aria-label={t('projects.filtersActive')} />}
+        {open ? '▴' : '▾'}
+        {!open && filtering && (
+          <span className="dot dot-running ml-1" aria-label={t('projects.filtersActive')} />
+        )}
       </button>
       {open && (
-        <div className="mt-3 flex flex-wrap items-center gap-3">
+        <>
           <input
             className="input"
-            style={{ width: 240 }}
+            style={{ width: 220 }}
             value={query}
             onChange={(e) => onQuery(e.target.value)}
             placeholder={t('projects.searchPlaceholder')}
@@ -407,7 +412,7 @@ function FilterBar({
               <option key={s} value={s}>{t(`projects.sort_${s}`)}</option>
             ))}
           </select>
-          <label className="flex items-center gap-1.5 text-sm text-fg-secondary cursor-pointer select-none">
+          <label className="flex items-center gap-1.5 text-sm text-fg-secondary cursor-pointer select-none whitespace-nowrap">
             <input
               type="checkbox"
               checked={showArchived}
@@ -415,7 +420,7 @@ function FilterBar({
             />
             {t('projects.showArchived', { n: archivedCount })}
           </label>
-        </div>
+        </>
       )}
     </div>
   )

--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 176,
+  "count": 178,
   "routes": [
     {
       "path": "/",
@@ -450,6 +450,14 @@
       "type": "APIRoute"
     },
     {
+      "path": "/api/projects/{pid}/archive",
+      "methods": [
+        "POST"
+      ],
+      "name": "archive_project_endpoint",
+      "type": "APIRoute"
+    },
+    {
       "path": "/api/projects/{pid}/download",
       "methods": [
         "POST"
@@ -511,6 +519,14 @@
         "GET"
       ],
       "name": "project_thumb",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/projects/{pid}/unarchive",
+      "methods": [
+        "POST"
+      ],
+      "name": "unarchive_project_endpoint",
       "type": "APIRoute"
     },
     {

--- a/tests/test_project_endpoints.py
+++ b/tests/test_project_endpoints.py
@@ -95,6 +95,49 @@ def test_delete_removes_dir(client: TestClient) -> None:
 
 
 # ---------------------------------------------------------------------------
+# archive（v12 软隐藏）
+# ---------------------------------------------------------------------------
+
+
+def test_archive_roundtrip(client: TestClient) -> None:
+    p = client.post("/api/projects", json={"title": "Arch"}).json()
+    pid = p["id"]
+    pdir = projects.project_dir(pid, p["slug"])
+
+    resp = client.post(f"/api/projects/{pid}/archive")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["archived_at"] is not None
+    # 归档只是软隐藏：目录原样、list 仍返回该行（带 archived_at 给前端切分）
+    assert pdir.exists()
+    items = client.get("/api/projects").json()["items"]
+    assert [r["id"] for r in items if r["archived_at"]] == [pid]
+
+    resp = client.post(f"/api/projects/{pid}/unarchive")
+    assert resp.status_code == 200
+    assert resp.json()["archived_at"] is None
+
+
+def test_archive_404(client: TestClient) -> None:
+    assert client.post("/api/projects/9999/archive").status_code == 404
+
+
+def test_archive_keeps_updated_at(client: TestClient) -> None:
+    """归档/恢复不动 updated_at —— 恢复后按活跃时间排序的位置不变。"""
+    p = client.post("/api/projects", json={"title": "Keep"}).json()
+    client.post(f"/api/projects/{p['id']}/archive")
+    after = client.post(f"/api/projects/{p['id']}/unarchive").json()
+    assert after["updated_at"] == p["updated_at"]
+
+
+def test_list_enriches_active_version_phase(client: TestClient) -> None:
+    """preparing 项目的 list 行带 phase cursor（badge"准备中 · 打标"用）。"""
+    client.post("/api/projects", json={"title": "PhaseTest"})
+    row = client.get("/api/projects").json()["items"][0]
+    assert row["active_version_status"] == "preparing"
+    assert row["active_version_phase"] == "curating"
+
+
+# ---------------------------------------------------------------------------
 # versions CRUD
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 背景 / 动机

用户反馈：项目多了之后很难浏览。三个痛点对应三块改动：找不到项目（搜索/过滤/排序）、不再活跃的项目占着列表（归档）、"准备中"看不出进行到哪一步（badge 带 phase）。

## 改动概要

**1. 过滤行（header 过滤 icon 开关，折叠时完全不占空间）**

```
[过滤▼] [已归档(2)] [导入 bundle] [新建项目]    ← header actions
┌────────────────────────────────────────────────────┐
│ [搜索标题/slug/备注……60%]      [状态 10%] [排序 10%] │  ← 仅展开时渲染
└────────────────────────────────────────────────────┘
```

- header 的过滤 icon 切换过滤行显隐；折叠且有筛选生效时 icon 上带小圆点。
- 单行布局：搜索 60% 居左，状态 / 排序两个下拉各 10% 推到最右。
- 搜索匹配标题 / slug / 备注（大小写不敏感）；排序三选（最近活跃 / 最新创建 / 按名称），排序偏好走 `useLocalStorageState` 持久化，搜索和状态每次进页重置。
- 过滤排序是纯函数 `filterProjects`（导出 + 单测），项目量小，全在前端做。

**2. 归档机制（DB migration v12：`projects.archived_at REAL`）**

- 卡片 × 从硬删除改为**归档**：软隐藏，目录 / versions / 任务全部原样，随时可恢复。
- header 的「已归档（n）」是视图切换（radio 语义）：开 = 列表只显示已归档项目（卡片半透明），关 = 只显示活跃项目；搜索 / 状态 / 排序在两个视图下都生效。
- 归档卡片两个按钮：↺ 恢复（在 × 左边）、× 真删（原删除确认流程）。
- 归档 / 恢复 / 删除三个操作都有确认 modal。
- 归档不动 `updated_at`：恢复后项目回到"按活跃时间"排序的原位置，不会顶到最前（有单测锁住）。
- 后端：`POST /api/projects/{pid}/archive` / `unarchive`，list 端点归档行照常返回（带 `archived_at`，切分在前端，省切视图往返）；route snapshot 已重新生成（+2）。

**3. "准备中"badge 显示当前 phase**

- list 端点 enrich `active_version_phase`；`VersionStatusBadge` 加可选 `phase` prop，`preparing` 时显示"准备中 · 打标"式后缀。
- 全部 6 个 phase 都显示（含可选的预处理 / 正则集 —— review 中确认）。

## 测试方式

- 后端：新增 4 个 pytest（归档往返 / 404 / updated_at 不变 / phase enrich）；`tests/test_migrations.py test_db test_projects test_project_endpoints test_route_snapshot test_studio_configs` 78 passed。
- 前端：新增 `Projects.test.tsx`（filterProjects 6 例）+ `VersionStatusBadge` phase 后缀 3 例；全量 vitest 381 passed / lint / tsc 干净。
- 截图：本机无浏览器自动化工具，未附截图——上面的 ASCII 示意是布局结构；merge 前我可以补手测。

## 备注

- 老 DB 升级走 migration v12（`_add_column_if_missing`，幂等）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)