### PR TITLE
fix(studio): version 不再预建空 samples/ + studio_data 迁移目标改为父目录

### DIFF
--- a/studio/api/schemas/studio_data.py
+++ b/studio/api/schemas/studio_data.py
@@ -5,5 +5,5 @@ from pydantic import BaseModel
 
 
 class StudioDataMigrateRequest(BaseModel):
-    """迁移目标目录（绝对路径；空目录或不存在）。"""
+    """迁移目标父目录（绝对路径；数据落 `target/studio_data/`，目标不要求为空）。"""
     target: str

--- a/studio/services/projects/versions.py
+++ b/studio/services/projects/versions.py
@@ -1,7 +1,7 @@
 """Version 数据模型 + 物理目录 + fork 训练树 + activate。
 
 Version 是 Pipeline 的「实验单元」：每个 version 独立维护 train/ reg/
-output/ samples/ 与 monitor_state.json。label 由用户起（baseline /
+output/。label 由用户起（baseline /
 high-lr 这种语义名），同 project 内唯一，且不可改（路径锚点）。
 
 删除：直接 rmtree version 目录 + DELETE db 行。不可恢复。
@@ -373,7 +373,9 @@ DEFAULT_TRAIN_FOLDER = "1_data"
 
 
 def _ensure_version_tree(vdir: Path) -> None:
-    for sub in ("train", "reg", "output", "samples"):
+    # samples/ 不再建：采样图是 task 档案（studio_data/tasks/<id>/samples/），
+    # version 树里只有老 task 的历史数据，读兼容由 samples.py 多候选解析负责
+    for sub in ("train", "reg", "output"):
         (vdir / sub).mkdir(parents=True, exist_ok=True)
     (vdir / "train" / DEFAULT_TRAIN_FOLDER).mkdir(parents=True, exist_ok=True)
 

--- a/studio/services/studio_data.py
+++ b/studio/services/studio_data.py
@@ -6,8 +6,11 @@
 3. 复制完成 → 写仓库根指针文件 `studio_data_location.json` → 重启 server 生效
 
 设计要点：
-- **只复制不删除**：旧数据原样保留（用户决策）；失败时清掉复制了一半的目标
-  目录（开始前要求目标为空，rmtree 安全），指针不写，等于什么都没发生。
+- **目标是父目录**：用户选任意目录，数据落 `目标/studio_data/`（整个
+  studio_data「搬进去」），目标本身不要求为空 —— 只要求落地子目录不存在或
+  为空（不 merge 进已有数据）。
+- **只复制不删除**：旧数据原样保留（用户决策）；失败时清掉复制了一半的落地
+  目录（开始前要求其为空 / 不存在，rmtree 安全），指针不写，等于什么都没发生。
 - **sqlite 一致性**：server 进程随请求随时可能写 studio.db，直接 copy 可能
   截到写一半的页。`.db` 文件走 sqlite3 backup API（在线备份，拿到一致快照）；
   对应的 `-wal` / `-shm` 跳过（backup 产物自含）。
@@ -31,6 +34,9 @@ from ..infrastructure.paths import DEFAULT_STUDIO_DATA, STUDIO_DATA, STUDIO_DATA
 logger = logging.getLogger(__name__)
 
 PROGRESS_INTERVAL_SECONDS = 0.2
+
+# 落地子目录名固定 —— 不跟随当前位置的目录名（老式迁移的自定义位置可能叫别的）
+DATA_DIR_NAME = "studio_data"
 
 Publish = Callable[[dict[str, Any]], None]
 
@@ -124,29 +130,34 @@ def _set_status(**kw: Any) -> None:
 # 校验 + 启动
 # ---------------------------------------------------------------------------
 
-def validate_target(target: Path, *, source: Path | None = None) -> None:
-    """迁移目标目录校验，不合法抛 ValueError（caller 转 422）。
+def validate_target(target: Path, *, source: Path | None = None) -> Path:
+    """迁移目标校验，不合法抛 ValueError（caller 转 422）；返回实际落地目录。
 
-    规则：绝对路径；不等于当前位置；双方互不嵌套（copy 进自己子树会无限递归，
-    当前嵌进目标会让旧数据被新目录"包住"语义混乱）；目标不存在或为空目录。
+    target 是用户选的任意目录，数据落 `target/studio_data/`，所以 target 本身
+    不要求为空。规则：绝对路径；target 已存在时必须是目录；落地目录不等于
+    当前位置；落地目录与当前位置互不嵌套（copy 进自己子树会无限递归）；
+    落地目录不存在或为空（不 merge 进已有数据）。
     """
     src = (source if source is not None else STUDIO_DATA).resolve()
     if not target.is_absolute():
         raise ValueError("目标必须是绝对路径")
-    tgt = target.resolve()
-    if tgt == src:
+    if target.exists() and not target.is_dir():
+        raise ValueError("目标已存在且不是目录")
+    dst = target.resolve() / DATA_DIR_NAME
+    if dst == src:
         raise ValueError("目标与当前 studio_data 位置相同")
-    for a, b in ((tgt, src), (src, tgt)):
+    for a, b in ((dst, src), (src, dst)):
         try:
             a.relative_to(b)
         except ValueError:
             continue
         raise ValueError("目标目录与当前 studio_data 互相嵌套")
-    if tgt.exists():
-        if not tgt.is_dir():
-            raise ValueError("目标已存在且不是目录")
-        if any(tgt.iterdir()):
-            raise ValueError("目标目录非空 —— 请选择空目录或不存在的路径")
+    if dst.exists():
+        if not dst.is_dir():
+            raise ValueError(f"目标下已存在同名文件 {DATA_DIR_NAME}")
+        if any(dst.iterdir()):
+            raise ValueError(f"目标下已存在非空 {DATA_DIR_NAME} 目录")
+    return dst
 
 
 def start_migration(
@@ -158,17 +169,18 @@ def start_migration(
 ) -> None:
     """校验 + 起后台复制线程。已有迁移在跑时抛 RuntimeError（caller 转 409）。
 
-    source / pointer_file 参数仅测试注入用；生产走默认（当前 STUDIO_DATA +
-    仓库根指针）。
+    target 是用户选的父目录，实际复制到 `target/studio_data/`（validate_target
+    返回值）。source / pointer_file 参数仅测试注入用；生产走默认（当前
+    STUDIO_DATA + 仓库根指针）。
     """
     src = (source if source is not None else STUDIO_DATA).resolve()
     ptr = pointer_file if pointer_file is not None else STUDIO_DATA_POINTER
-    validate_target(target, source=src)
+    dst = validate_target(target, source=src)
     with _status_lock:
         if _status.state == "running":
             raise RuntimeError("已有迁移正在进行")
         _status.state = "running"
-        _status.target = str(target)
+        _status.target = str(dst)
         _status.total_files = 0
         _status.total_bytes = 0
         _status.done_files = 0
@@ -177,7 +189,7 @@ def start_migration(
         _status.error = ""
     t = threading.Thread(
         target=_run_migration,
-        args=(src, target.resolve(), publish, ptr),
+        args=(src, dst, publish, ptr),
         name="studio-data-migration",
         daemon=True,
     )
@@ -250,7 +262,8 @@ def _run_migration(src: Path, dst: Path, publish: Publish, pointer_file: Path) -
         logger.info("studio_data 迁移完成: %s → %s（%d 文件），重启后生效", src, dst, done_files)
     except Exception as exc:
         logger.exception("studio_data 迁移失败: %s → %s", src, dst)
-        # 开始前目标为空 / 不存在（validate_target 保证），整树清掉等于回到迁移前
+        # dst 是 target/studio_data 落地目录，开始前为空 / 不存在
+        # （validate_target 保证），整树清掉等于回到迁移前；用户的 target 父目录不动
         shutil.rmtree(dst, ignore_errors=True)
         _set_status(state="error", error=str(exc))
         publish({"type": "studio_data_migrate_done", "ok": False, "error": str(exc)})

--- a/studio/web/src/components/StudioDataMigrateModal.test.tsx
+++ b/studio/web/src/components/StudioDataMigrateModal.test.tsx
@@ -45,7 +45,8 @@ describe('StudioDataMigrateModal', () => {
       expect(screen.getByText(/共 42 个文件/)).toBeInTheDocument()
     })
     expect(screen.getByText(/5\.0 MB/)).toBeInTheDocument()
-    expect(screen.getByText('D:\\data')).toBeInTheDocument()
+    // 目标显示实际落地目录 target\studio_data（用户选的是父目录）
+    expect(screen.getByText('D:\\data\\studio_data')).toBeInTheDocument()
     expect(screen.getByText('projects/')).toBeInTheDocument()
     expect(screen.getByText('studio.db')).toBeInTheDocument()
   })

--- a/studio/web/src/components/StudioDataMigrateModal.tsx
+++ b/studio/web/src/components/StudioDataMigrateModal.tsx
@@ -35,6 +35,10 @@ export default function StudioDataMigrateModal({ target, onClose, onRestart }: {
   onRestart: () => void
 }) {
   const { t } = useTranslation()
+  // 用户选的是父目录，后端实际把数据复制到 target/studio_data/（display 用，
+  // API 仍传 target，由后端拼接）
+  const sep = target.includes('\\') ? '\\' : '/'
+  const destination = target.endsWith(sep) ? `${target}studio_data` : `${target}${sep}studio_data`
   const [phase, setPhase] = useState<Phase>('loading')
   const [info, setInfo] = useState<StudioDataInfo | null>(null)
   const [progress, setProgress] = useState<Progress>(EMPTY_PROGRESS)
@@ -137,7 +141,7 @@ export default function StudioDataMigrateModal({ target, onClose, onRestart }: {
                 </div>
                 <div>
                   <span className="text-fg-tertiary">{t('settings.storage.to')}</span>{' '}
-                  <code className="font-mono">{target}</code>
+                  <code className="font-mono">{destination}</code>
                 </div>
               </div>
               <div className="text-sm font-semibold">

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -833,7 +833,7 @@
       "sectionTitle": "Storage location",
       "locationLabel": "studio_data location",
       "help1": "studio_data holds projects, datasets, task archives, presets and the database. By default it lives in the app root directory.",
-      "help2": "Changing the location copies all current data to the new directory (the original is kept, not deleted). Restart Studio afterwards for it to take effect.",
+      "help2": "Changing the location creates a studio_data subdirectory inside the chosen directory and copies all current data into it (the original is kept, not deleted). Restart Studio afterwards for it to take effect.",
       "customBadge": "custom",
       "defaultBadge": "default",
       "changeLocation": "Change location…",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -833,7 +833,7 @@
       "sectionTitle": "存储位置",
       "locationLabel": "studio_data 位置",
       "help1": "studio_data 存放项目、数据集、任务档案、预设和数据库。默认在程序根目录。",
-      "help2": "更改位置会把当前数据完整复制到新目录（原数据保留不删除），完成后需重启 Studio 生效。",
+      "help2": "更改位置会在所选目录下创建 studio_data 子目录并完整复制当前数据（原数据保留不删除），完成后需重启 Studio 生效。",
       "customBadge": "自定义",
       "defaultBadge": "默认",
       "changeLocation": "更改位置…",

--- a/tests/test_studio_data_migration.py
+++ b/tests/test_studio_data_migration.py
@@ -90,27 +90,53 @@ def test_validate_rejects_relative(tmp_path: Path) -> None:
 
 
 def test_validate_rejects_same_path(tmp_path: Path) -> None:
+    # 当前位置就是 tmp_path/studio_data，再选 tmp_path 当目标 → 落地目录撞上自己
+    src = tmp_path / "studio_data"
+    src.mkdir()
     with pytest.raises(ValueError, match="相同"):
-        svc.validate_target(tmp_path, source=tmp_path)
+        svc.validate_target(tmp_path, source=src)
 
 
 def test_validate_rejects_nested_both_ways(tmp_path: Path) -> None:
+    # 落地目录（target/studio_data）嵌进当前位置
     src = tmp_path / "sd"
     src.mkdir()
     with pytest.raises(ValueError, match="嵌套"):
         svc.validate_target(src / "inner", source=src)
+    # 当前位置嵌进落地目录
+    nested_src = tmp_path / "studio_data" / "inner"
+    nested_src.mkdir(parents=True)
     with pytest.raises(ValueError, match="嵌套"):
-        svc.validate_target(tmp_path, source=src)
+        svc.validate_target(tmp_path, source=nested_src)
 
 
-def test_validate_rejects_nonempty_target(tmp_path: Path) -> None:
+def test_validate_accepts_nonempty_target(tmp_path: Path) -> None:
+    # 目标本身非空没关系 —— 数据落 target/studio_data/ 子目录
     src = tmp_path / "sd"
     src.mkdir()
     tgt = tmp_path / "tgt"
     tgt.mkdir()
     (tgt / "junk.txt").write_text("x")
+    assert svc.validate_target(tgt, source=src) == tgt / "studio_data"
+
+
+def test_validate_rejects_nonempty_destination(tmp_path: Path) -> None:
+    src = tmp_path / "sd"
+    src.mkdir()
+    tgt = tmp_path / "tgt"
+    (tgt / "studio_data").mkdir(parents=True)
+    (tgt / "studio_data" / "junk.txt").write_text("x")
     with pytest.raises(ValueError, match="非空"):
         svc.validate_target(tgt, source=src)
+
+
+def test_validate_rejects_file_target(tmp_path: Path) -> None:
+    src = tmp_path / "sd"
+    src.mkdir()
+    f = tmp_path / "afile"
+    f.write_text("x")
+    with pytest.raises(ValueError, match="不是目录"):
+        svc.validate_target(f, source=src)
 
 
 def test_validate_accepts_empty_or_absent(tmp_path: Path) -> None:
@@ -118,8 +144,8 @@ def test_validate_accepts_empty_or_absent(tmp_path: Path) -> None:
     src.mkdir()
     empty = tmp_path / "empty"
     empty.mkdir()
-    svc.validate_target(empty, source=src)
-    svc.validate_target(tmp_path / "absent", source=src)
+    assert svc.validate_target(empty, source=src) == empty / "studio_data"
+    assert svc.validate_target(tmp_path / "absent", source=src) == tmp_path / "absent" / "studio_data"
 
 
 # ---------------------------------------------------------------------------
@@ -207,3 +233,29 @@ def test_start_migration_rejects_concurrent(tmp_path: Path, monkeypatch: pytest.
         svc.start_migration(tmp_path / "t2", source=src, publish=lambda e: None,
                             pointer_file=tmp_path / "ptr.json")
     release.set()
+
+
+def test_start_migration_lands_in_studio_data_subdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """目标传父目录（可非空），复制线程拿到的落地目录是 target/studio_data/。"""
+    src = tmp_path / "sd"
+    src.mkdir()
+    (src / "f.txt").write_text("x")
+    got: dict[str, Path] = {}
+    finished = threading.Event()
+
+    def fake_run(s: Path, d: Path, pub, ptr) -> None:
+        got["dst"] = d
+        svc._set_status(state="done")
+        finished.set()
+    monkeypatch.setattr(svc, "_run_migration", fake_run)
+
+    tgt = tmp_path / "tgt"
+    tgt.mkdir()
+    (tgt / "existing.bin").write_text("y")  # 非空目标也接受
+    svc.start_migration(tgt, source=src, publish=lambda e: None,
+                        pointer_file=tmp_path / "ptr.json")
+    assert finished.wait(5)
+    assert got["dst"] == tgt / "studio_data"
+    assert svc.migration_status()["target"] == str(tgt / "studio_data")

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -35,8 +35,10 @@ def test_create_version_builds_tree_and_activates(isolated) -> None:
         v = versions.create_version(conn, project_id=p["id"], label="baseline")
     vdir = versions.version_dir(p["id"], p["slug"], "baseline")
     assert vdir.exists()
-    for sub in ("train", "reg", "output", "samples"):
+    for sub in ("train", "reg", "output"):
         assert (vdir / sub).is_dir()
+    # 采样图归 task 档案（tasks/<id>/samples/），version 树不再预建空 samples/
+    assert not (vdir / "samples").exists()
     assert (vdir / "version.json").exists()
     # 项目里第一个版本自动设为 active
     with db.connection_for(isolated["db"]) as conn:


### PR DESCRIPTION
## 背景 / 动机

两个小 bug：

1. **新项目的 version 下出现空 `samples/` 目录** —— 采样图自 task 档案化后实际落在 `studio_data/tasks/<id>/samples/`，但 `_ensure_version_tree` 建版本目录树时仍预建 `samples/`，误导用户以为采样图还在 version 下。
2. **studio_data 迁移强制目标目录为空** —— 原语义是把 studio_data 的*内容*复制进所选目录，所以目标必须为空；用户想迁到已有的盘/目录就得先手建空子目录，体验别扭。

## 改动概要

**Bug 1（`studio/services/projects/versions.py`）**
- `_ensure_version_tree` 不再建 `samples/`，version 树只建 `train/ reg/ output/`
- 老 task 历史采样图的读取不受影响（`samples.py` 多候选解析独立处理兼容路径）
- 已存在项目里之前建出的空 `samples/` 不主动清理（留着无害）

**Bug 2（`studio/services/studio_data.py` + 前端 modal）**
- 迁移语义改为：在所选目录下创建 `studio_data/` 子目录整体搬入 —— 目标本身可非空，只要求落地子目录 `target/studio_data` 不存在或为空（不 merge 进已有数据）
- `validate_target` 返回落地目录；同名/嵌套校验、失败回滚 rmtree、指针写入全部对准落地子目录，用户的父目录不动
- 边界：当前位置恰好是 `X\studio_data` 而用户选 `X` 时，落地目录撞上当前位置，以「与当前位置相同」拒绝
- 前端确认 modal 的「到」一行显示实际落地路径（如 `D:\data\studio_data`）；Settings help 文案中英同步

## 测试方式

- `tests/test_versions.py`：断言新 version 不再有 `samples/`
- `tests/test_studio_data_migration.py`：非空目标接受 / 非空落地子目录拒绝 / 目标是文件拒绝 / 落地目录传递 / 同名与嵌套校验改写后的用例，全部通过
- 前端 `StudioDataMigrateModal.test.tsx` 4 用例通过；vitest 全量 381 passed；`npm run lint` + `npx tsc --noEmit` 干净
- 横切安全网 `test_route_snapshot.py` + `test_studio_configs.py` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)