### PR TITLE
feat(tagger): tag 翻译词典默认源换成 ffdkj Danbooru 中文翻译表

### DIFF
--- a/studio/api/lifespan.py
+++ b/studio/api/lifespan.py
@@ -105,14 +105,14 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
             logger.exception("taeflux background download crashed")
     threading.Thread(target=_bg_download_taeflux, name="taeflux-bg-download", daemon=True).start()
 
-    # Tag 翻译词典（约 3MB CSV）后台下载：仅当 active.json 不存在时拉取；失败只
+    # Tag 翻译词典（约 30MB SQLite）后台下载：仅当 active.json 不存在时拉取；失败只
     # log warning，让用户进 Settings 看状态后手动点 "恢复默认词典" 重试。
     def _bg_download_tag_dict() -> None:
         from ..infrastructure import tag_dictionary as _td
         try:
             if _td.ACTIVE_JSON.exists():
                 return
-            logger.info("background-downloading tag dictionary (~3MB)…")
+            logger.info("background-downloading tag dictionary (~30MB)…")
             _td.download_default()
         except Exception as exc:
             logger.warning(

--- a/studio/api/routers/tag_dictionary.py
+++ b/studio/api/routers/tag_dictionary.py
@@ -2,7 +2,7 @@
 
 4 routes：
     GET  /api/tag-dictionary/meta     当前词典 meta（前端启动时 ping，看是否已加载）
-    GET  /api/tag-dictionary/data     完整 dict（约 600KB gzip）给前端 in-memory 用
+    GET  /api/tag-dictionary/data     完整 dict（默认源 20 万条，约 7MB / gzip 3.5MB）给前端 in-memory 用
     POST /api/tag-dictionary/upload   multipart 上传 csv/txt 替换词典
     POST /api/tag-dictionary/reset    重新拉默认源（用户首次下载失败 / 想恢复时用）
 """

--- a/studio/infrastructure/tag_dictionary.py
+++ b/studio/infrastructure/tag_dictionary.py
@@ -2,10 +2,17 @@
 
 存储布局：
     studio_data/tag_dictionary/
-        active.json   ← 解析后的词典 + meta（前端 GET /api/tag-dictionary/data 读这个）
-        source.csv    ← 原始上传 / 下载文件留底（排查用）
+        active.json    ← 解析后的词典 + meta（前端 GET /api/tag-dictionary/data 读这个）
+        source.sqlite  ← 默认源下载文件留底（排查用）
+        source.csv     ← 用户上传文件留底（排查用；与 source.sqlite 互斥，只留当前 active 的）
 
-默认数据源（Physton/sd-webui-prompt-all-in-one-assets）格式：
+默认数据源（ffdkj/ffdkj-Danbooru_Tag-Chinese-English-Translation-Table，
+每日更新，Gemini 翻译 + 人工校对）是 SQLite 单表：
+    tags(name TEXT PRIMARY KEY, category INTEGER, cn_name TEXT, post_count INTEGER)
+    全量 ~31 万条；按 post_count 降序取前 MAX_ENTRIES 条（截掉的是引用数
+    最低的长尾，对补全 / 翻译覆盖影响最小，同时控制 active.json 体积）。
+
+用户上传仍走 csv/txt 格式：
     english_tag,zh1 zh2 zh3
     （第二列空白分隔多个中文别名；无 header；'#' 起头视为注释）
 """
@@ -13,7 +20,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+import sqlite3
 import time
 from pathlib import Path
 from typing import Any, Optional
@@ -27,14 +36,16 @@ logger = logging.getLogger(__name__)
 TAG_DICT_DIR = STUDIO_DATA / "tag_dictionary"
 ACTIVE_JSON = TAG_DICT_DIR / "active.json"
 SOURCE_FILE = TAG_DICT_DIR / "source.csv"
+SOURCE_SQLITE = TAG_DICT_DIR / "source.sqlite"
 
 DEFAULT_URL = (
-    "https://raw.githubusercontent.com/Physton/"
-    "sd-webui-prompt-all-in-one-assets/main/tags/danbooru.zh_CN.csv"
+    "https://raw.githubusercontent.com/ffdkj/"
+    "ffdkj-Danbooru_Tag-Chinese-English-Translation-Table/main/tag.sqlite"
 )
-DEFAULT_SOURCE_NAME = "physton/danbooru.zh_CN.csv"
+DEFAULT_SOURCE_NAME = "ffdkj/tag.sqlite"
 
-MAX_BYTES = 10 * 1024 * 1024  # 10MB
+MAX_BYTES = 10 * 1024 * 1024  # 10MB —— 用户上传 csv/txt 上限
+MAX_DOWNLOAD_BYTES = 64 * 1024 * 1024  # 64MB —— 默认源 sqlite 上限（当前 ~30MB）
 MAX_ENTRIES = 200_000
 
 _CJK_RE = re.compile(r"[一-鿿]")
@@ -76,6 +87,40 @@ def parse_csv(text: str) -> dict[str, list[str]]:
         logger.warning(
             "tag_dictionary: 超过 %d 条上限，截断；丢弃了后续行", MAX_ENTRIES
         )
+    return entries
+
+
+def parse_sqlite(path: Path) -> dict[str, list[str]]:
+    """解析默认源 tag.sqlite → `{english_tag: [cn_name]}`。
+
+    规则：
+    - 按 post_count 降序取前 MAX_ENTRIES 条 —— dict 插入序即热度序，
+      原样透传给前端做 autocomplete 排序（同老 csv 源的行序约定）
+    - name 列：strip + 把 '_' 换成空格（用户/caption 形态约定）
+    - cn_name 是**单个**翻译，不按空白切分（有「宝可梦 (生物)」这类含
+      空格的译名）；空值 → `[]`（英文 tag 仍参与补全）
+    - 不是 sqlite / 缺表缺列 → 抛 sqlite3.Error，caller 转 RuntimeError
+    """
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        total = conn.execute("SELECT COUNT(*) FROM tags").fetchone()[0]
+        rows = conn.execute(
+            "SELECT name, cn_name FROM tags ORDER BY post_count DESC LIMIT ?",
+            (MAX_ENTRIES,),
+        ).fetchall()
+    finally:
+        conn.close()
+    if total > MAX_ENTRIES:
+        logger.info(
+            "tag_dictionary: 源共 %d 条，按 post_count 取前 %d 条", total, MAX_ENTRIES
+        )
+    entries: dict[str, list[str]] = {}
+    for name, cn_name in rows:
+        tag = str(name or "").strip().replace("_", " ")
+        if not tag:
+            continue
+        cn = str(cn_name or "").strip()
+        entries[tag] = [cn] if cn else []
     return entries
 
 
@@ -124,26 +169,35 @@ def get_meta() -> Optional[dict[str, Any]]:
 
 
 def download_default() -> dict[str, Any]:
-    """从 GitHub 拉默认词典并 commit 成 active.json，返回新 meta。
+    """从 GitHub 拉默认词典（sqlite）并 commit 成 active.json，返回新 meta。
 
-    失败抛 RuntimeError（带原因），上层 router 转 502。
+    sqlite 必须落盘才能打开，所以先写 .tmp 解析成功后 os.replace 成留底文件
+    （解析失败不留半截 source.sqlite）。失败抛 RuntimeError（带原因），上层
+    router 转 502。
     """
     TAG_DICT_DIR.mkdir(parents=True, exist_ok=True)
     try:
-        resp = requests.get(DEFAULT_URL, timeout=30)
+        resp = requests.get(DEFAULT_URL, timeout=60)
         resp.raise_for_status()
     except Exception as exc:
         raise RuntimeError(f"download failed: {exc}") from exc
     content = resp.content
-    if len(content) > MAX_BYTES:
+    if len(content) > MAX_DOWNLOAD_BYTES:
         raise RuntimeError(
-            f"downloaded file too large: {len(content)} bytes > {MAX_BYTES}"
+            f"downloaded file too large: {len(content)} bytes > {MAX_DOWNLOAD_BYTES}"
         )
-    text = content.decode("utf-8", errors="replace")
-    entries = parse_csv(text)
+    tmp = SOURCE_SQLITE.with_suffix(".sqlite.tmp")
+    tmp.write_bytes(content)
+    try:
+        entries = parse_sqlite(tmp)
+    except sqlite3.Error as exc:
+        tmp.unlink(missing_ok=True)
+        raise RuntimeError(f"invalid sqlite file: {exc}") from exc
     if not entries:
+        tmp.unlink(missing_ok=True)
         raise RuntimeError("downloaded file parsed to zero entries")
-    SOURCE_FILE.write_bytes(content)
+    os.replace(tmp, SOURCE_SQLITE)
+    SOURCE_FILE.unlink(missing_ok=True)  # 留底只保留当前 active 的源文件
     meta = _meta(DEFAULT_SOURCE_NAME, DEFAULT_URL, "default", len(entries))
     _write_active(entries, meta)
     logger.info("tag_dictionary: 默认词典已下载 (%d 条)", len(entries))
@@ -168,6 +222,7 @@ def apply_uploaded(content: bytes, filename: str) -> dict[str, Any]:
         raise ValueError("解析后 0 条；文件格式可能不对（期望 `english_tag,zh1 zh2`）")
     TAG_DICT_DIR.mkdir(parents=True, exist_ok=True)
     SOURCE_FILE.write_bytes(content)
+    SOURCE_SQLITE.unlink(missing_ok=True)  # 留底只保留当前 active 的源文件
     meta = _meta(filename or "user-upload", "", "user", len(entries))
     _write_active(entries, meta)
     logger.info("tag_dictionary: 用户上传词典已加载 (%d 条, %s)", len(entries), filename)

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -810,7 +810,7 @@
       "uploadLabel": "Custom dictionary",
       "uploadHint": "CSV / TXT format: one line per `english_tag,zh1 zh2`. Replaces (not merges) the current dictionary. Max 10MB / 200k entries.",
       "resetButton": "Restore default dictionary",
-      "resetHint": "Re-download Physton danbooru.zh_CN.csv from GitHub (~3MB)",
+      "resetHint": "Re-download the ffdkj Danbooru tag Chinese translation table from GitHub (~30MB, top 200k tags by popularity, updated daily)",
       "resetOk": "Default dictionary restored",
       "resetFail": "Reset failed",
       "uploadOk": "Loaded {{name}}",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -810,7 +810,7 @@
       "uploadLabel": "自定义词典",
       "uploadHint": "CSV / TXT 格式：每行 `english_tag,中文1 中文2`。上传后替换当前词典（不合并）。最大 10MB / 20 万条。",
       "resetButton": "恢复默认词典",
-      "resetHint": "从 GitHub 重新下载 Physton danbooru.zh_CN.csv（约 3MB）",
+      "resetHint": "从 GitHub 重新下载 ffdkj Danbooru 标签中文翻译表（约 30MB，收录热度前 20 万条，每日更新）",
       "resetOk": "已恢复默认词典",
       "resetFail": "恢复失败",
       "uploadOk": "已加载 {{name}}",

--- a/studio/web/src/tagDict/store.ts
+++ b/studio/web/src/tagDict/store.ts
@@ -1,6 +1,7 @@
 /** Tag 翻译词典 — 模块级 singleton + useSyncExternalStore hook。
  *
- * 设计：dict 约 3MB JSON，启动拉一次后放内存；浏览器 HTTP cache 处理 304。
+ * 设计：dict 约 7MB JSON（默认源 20 万条，gzip 后约 3.5MB），启动拉一次后放
+ * 内存；浏览器 HTTP cache 处理 304。
  * 不写 IndexedDB（项目无先例，复杂度不值；体量更大后再换）。
  *
  * 对外 API：

--- a/tests/test_tag_dictionary.py
+++ b/tests/test_tag_dictionary.py
@@ -1,6 +1,7 @@
 """Tag 翻译词典：解析 / 上传 / 下载 / API 端点。"""
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 from typing import Any
 
@@ -18,7 +19,23 @@ def tag_dict_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(td, "TAG_DICT_DIR", d)
     monkeypatch.setattr(td, "ACTIVE_JSON", d / "active.json")
     monkeypatch.setattr(td, "SOURCE_FILE", d / "source.csv")
+    monkeypatch.setattr(td, "SOURCE_SQLITE", d / "source.sqlite")
     return d
+
+
+def _sqlite_bytes(tmp_path: Path, rows: list[tuple[str, int, str, int]]) -> bytes:
+    """构造默认源 schema 的 sqlite 文件，返回字节（喂给 fake requests）。"""
+    p = tmp_path / "_make_tag.sqlite"
+    p.unlink(missing_ok=True)
+    conn = sqlite3.connect(p)
+    conn.execute(
+        "CREATE TABLE tags (name TEXT PRIMARY KEY, category INTEGER, "
+        "cn_name TEXT, post_count INTEGER)"
+    )
+    conn.executemany("INSERT INTO tags VALUES (?, ?, ?, ?)", rows)
+    conn.commit()
+    conn.close()
+    return p.read_bytes()
 
 
 @pytest.fixture
@@ -83,6 +100,59 @@ def test_parse_first_comma_only() -> None:
 
 
 # ---------------------------------------------------------------------------
+# parse_sqlite（默认源格式）
+# ---------------------------------------------------------------------------
+
+
+def test_parse_sqlite_orders_by_post_count_desc(tmp_path: Path) -> None:
+    _sqlite_bytes(tmp_path, [
+        ("solo", 0, "单人", 100),
+        ("1girl", 0, "1个女孩", 300),
+        ("smile", 0, "微笑", 200),
+    ])
+    entries = td.parse_sqlite(tmp_path / "_make_tag.sqlite")
+    # dict 插入序 = post_count 降序 = 前端 autocomplete 热度序
+    assert list(entries.keys()) == ["1girl", "smile", "solo"]
+    assert entries["1girl"] == ["1个女孩"]
+
+
+def test_parse_sqlite_underscore_to_space(tmp_path: Path) -> None:
+    _sqlite_bytes(tmp_path, [("long_hair", 0, "长发", 10)])
+    entries = td.parse_sqlite(tmp_path / "_make_tag.sqlite")
+    assert entries == {"long hair": ["长发"]}
+
+
+def test_parse_sqlite_keeps_cn_name_with_spaces_whole(tmp_path: Path) -> None:
+    # cn_name 是单个译名，含空格也不能按空白切成多个别名
+    _sqlite_bytes(tmp_path, [("pokemon_(creature)", 0, "宝可梦 (生物)", 10)])
+    entries = td.parse_sqlite(tmp_path / "_make_tag.sqlite")
+    assert entries["pokemon (creature)"] == ["宝可梦 (生物)"]
+
+
+def test_parse_sqlite_empty_cn_name_keeps_tag(tmp_path: Path) -> None:
+    _sqlite_bytes(tmp_path, [("rare_tag", 0, "", 10), ("none_tag", 0, None, 5)])
+    entries = td.parse_sqlite(tmp_path / "_make_tag.sqlite")
+    assert entries == {"rare tag": [], "none tag": []}
+
+
+def test_parse_sqlite_truncates_to_max_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(td, "MAX_ENTRIES", 2)
+    _sqlite_bytes(tmp_path, [(f"tag{i}", 0, f"翻译{i}", i) for i in range(10)])
+    entries = td.parse_sqlite(tmp_path / "_make_tag.sqlite")
+    # 取 post_count 最高的前 2 条
+    assert list(entries.keys()) == ["tag9", "tag8"]
+
+
+def test_parse_sqlite_garbage_raises(tmp_path: Path) -> None:
+    p = tmp_path / "garbage.sqlite"
+    p.write_bytes(b"this is not a sqlite file at all, padding padding padding")
+    with pytest.raises(sqlite3.Error):
+        td.parse_sqlite(p)
+
+
+# ---------------------------------------------------------------------------
 # apply_uploaded
 # ---------------------------------------------------------------------------
 
@@ -135,13 +205,13 @@ class _FakeResp:
 
 
 def test_download_default_writes_active(
-    tag_dict_dir: Path, monkeypatch: pytest.MonkeyPatch
+    tag_dict_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(
-        td.requests,
-        "get",
-        lambda url, timeout: _FakeResp("1girl,1女孩\nsolo,单人\n".encode("utf-8")),
-    )
+    content = _sqlite_bytes(tmp_path, [
+        ("1girl", 0, "1个女孩", 300),
+        ("solo", 0, "单人", 100),
+    ])
+    monkeypatch.setattr(td.requests, "get", lambda url, timeout: _FakeResp(content))
     meta = td.download_default()
     assert meta["kind"] == "default"
     assert meta["source_name"] == td.DEFAULT_SOURCE_NAME
@@ -149,7 +219,35 @@ def test_download_default_writes_active(
     loaded = td.load_active()
     assert loaded is not None
     entries, _ = loaded
-    assert entries["1girl"] == ["1女孩"]
+    assert entries["1girl"] == ["1个女孩"]
+    # 留底是 sqlite，且没有半截 tmp 文件
+    assert td.SOURCE_SQLITE.exists()
+    assert not td.SOURCE_SQLITE.with_suffix(".sqlite.tmp").exists()
+
+
+def test_download_default_removes_stale_csv_source(
+    tag_dict_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """先有用户上传的 csv 留底，恢复默认后留底只剩 sqlite（互斥语义）。"""
+    td.apply_uploaded("mytag,我的标签\n".encode("utf-8"), "my.csv")
+    assert td.SOURCE_FILE.exists()
+    content = _sqlite_bytes(tmp_path, [("1girl", 0, "1个女孩", 300)])
+    monkeypatch.setattr(td.requests, "get", lambda url, timeout: _FakeResp(content))
+    td.download_default()
+    assert td.SOURCE_SQLITE.exists()
+    assert not td.SOURCE_FILE.exists()
+
+
+def test_apply_uploaded_removes_stale_sqlite_source(
+    tag_dict_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    content = _sqlite_bytes(tmp_path, [("1girl", 0, "1个女孩", 300)])
+    monkeypatch.setattr(td.requests, "get", lambda url, timeout: _FakeResp(content))
+    td.download_default()
+    assert td.SOURCE_SQLITE.exists()
+    td.apply_uploaded("mytag,我的标签\n".encode("utf-8"), "my.csv")
+    assert td.SOURCE_FILE.exists()
+    assert not td.SOURCE_SQLITE.exists()
 
 
 def test_download_default_propagates_http_error(
@@ -160,12 +258,35 @@ def test_download_default_propagates_http_error(
         td.download_default()
 
 
-def test_download_default_rejects_empty_parse(
+def test_download_default_rejects_oversize(
+    tag_dict_dir: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(td, "MAX_DOWNLOAD_BYTES", 10)
+    monkeypatch.setattr(td.requests, "get", lambda url, timeout: _FakeResp(b"x" * 11))
+    with pytest.raises(RuntimeError, match="too large"):
+        td.download_default()
+
+
+def test_download_default_rejects_non_sqlite(
     tag_dict_dir: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(
-        td.requests, "get", lambda url, timeout: _FakeResp(b"# only comments\n")
+        td.requests,
+        "get",
+        lambda url, timeout: _FakeResp(b"english_tag,zh -- old csv format, not sqlite"),
     )
+    with pytest.raises(RuntimeError, match="invalid sqlite"):
+        td.download_default()
+    # 解析失败不留半截留底
+    assert not td.SOURCE_SQLITE.exists()
+    assert not td.SOURCE_SQLITE.with_suffix(".sqlite.tmp").exists()
+
+
+def test_download_default_rejects_empty_parse(
+    tag_dict_dir: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    content = _sqlite_bytes(tmp_path, [])
+    monkeypatch.setattr(td.requests, "get", lambda url, timeout: _FakeResp(content))
     with pytest.raises(RuntimeError, match="zero entries"):
         td.download_default()
 
@@ -249,13 +370,11 @@ def test_reset_endpoint_502_on_network_error(
 
 
 def test_reset_endpoint_success(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch, tag_dict_dir: Path
+    client: TestClient, monkeypatch: pytest.MonkeyPatch,
+    tag_dict_dir: Path, tmp_path: Path,
 ) -> None:
-    monkeypatch.setattr(
-        td.requests,
-        "get",
-        lambda url, timeout: _FakeResp(b"1girl,1\xe5\xa5\xb3\xe5\xad\xa9\n"),
-    )
+    content = _sqlite_bytes(tmp_path, [("1girl", 0, "1个女孩", 300)])
+    monkeypatch.setattr(td.requests, "get", lambda url, timeout: _FakeResp(content))
     r = client.post("/api/tag-dictionary/reset")
     assert r.status_code == 200
     assert r.json()["meta"]["kind"] == "default"


### PR DESCRIPTION
## 背景 / 动机

现默认源 [Physton/sd-webui-prompt-all-in-one-assets](https://github.com/Physton/sd-webui-prompt-all-in-one-assets) 的 `danbooru.zh_CN.csv` 已停更 2.5 年（最后 push 2023-11），覆盖 99,978 条。换成 [ffdkj/ffdkj-Danbooru_Tag-Chinese-English-Translation-Table](https://github.com/ffdkj/ffdkj-Danbooru_Tag-Chinese-English-Translation-Table)：每日更新、全量 311,669 条（收录 post_count ≥ 10 的全部 tag，Gemini 翻译 + 人工校对），抽查翻译质量良好、0 条空翻译。

## 改动概要

- **默认源 URL / 格式**：CSV → SQLite 单表 `tags(name, category, cn_name, post_count)`，~30MB。新增 `parse_sqlite`：按 `post_count DESC` 取前 `MAX_ENTRIES`（20 万）条，保持「dict 插入序 = 热度序」的前端 autocomplete 约定（截掉的是引用数最低的长尾）。`cn_name` 是单个译名，不按空白切分（有「宝可梦 (生物)」这类含空格的译名），与 csv 解析路径的多别名语义不同。
- **下载健壮性**：sqlite 必须落盘才能打开，走 tmp + `os.replace`，解析失败不留半截留底；新增 `MAX_DOWNLOAD_BYTES`（64MB）单独管默认源下载上限，用户上传仍是 10MB。
- **留底互斥**：`source.sqlite`（默认源）/ `source.csv`（用户上传）只保留当前 active 对应的那个。
- **不变的部分**：用户上传 csv/txt 路径、active.json 结构、`/api/tag-dictionary/*` 协议、前端数据流全部不变。
- 文案 / 注释同步：Settings resetHint（中英）、lifespan / router / store 的体积说明。

## 数据来源声明

- 运行时由用户侧从 GitHub 下载，数据**不进仓库**（与原 Physton 模式相同）。
- 上游仓库目前无 LICENSE 文件（内容为 AI 翻译的 Danbooru 标签对照数据，非代码移植）；已知会每日重新生成。
- 国内可达性与原默认源相同（同为 raw.githubusercontent.com），不构成回归；离线/被墙环境的现有逃生门是 Settings 上传自定义词典。

## 测试方式

- `tests/test_tag_dictionary.py` 33 个用例全过：新增 `parse_sqlite` 6 例（热度序 / 下划线转空格 / 含空格译名不切分 / 空译名保留 tag / top-N 截断 / 非 sqlite 报错）+ 下载路径 4 例（写 active / 留底互斥双向 / 超限 / 非 sqlite 不留半截）。
- 真实 30MB 文件端到端冒烟：20 万条解析 0.37s，热度序正确（`1girl` 居首），active.json 7.2MB / gzip 3.5MB（原 ~3MB / gzip ~600KB，前端一次性加载，量级可接受）。
- 横切安全网 `test_route_snapshot.py` + `test_studio_configs.py` 31 过；前端 vitest 全量 381 过；`lint` + `tsc` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)