### PR TITLE
feat(train): TREAD token routing for training-time speedup

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -147,6 +147,21 @@
   reference 代码。Anima 在 Flow Matching `t ∈ (0,1)` 空间内做了 `σ = t/(1-t)` 适配，
   与论文 σ-空间设计保持一致。
 
+### TREAD token routing (research attribution — 自实现)
+
+- **论文**：Krause et al. 2025, *TREAD: Token Routing for Efficient
+  Architecture-agnostic Diffusion Training*,
+  [arXiv:2501.04765](https://arxiv.org/abs/2501.04765)
+- **涉及文件**：
+  - `runtime/training/model_loading.py` `tread_route_indices` /
+    `forward_with_optional_checkpoint`（TREAD 分支）
+  - `tools/tread_smoke.py` — 真权重冒烟验证工具
+- **关系**：按论文思路自实现的训练期 token 路由（中间 block 段只算随机保留的 token
+  子集，段尾 scatter 回原位、被丢 token 恒等旁路），未参考特定 reference 代码。
+  实现不改模型定义：保留 token 子集 reshape 成 (B,1,1,N_keep,D) 伪网格复用现有
+  `Block.forward`，对 Anima 图像 latent（T=1）与逐 token 前向等价。仅训练生效，
+  推理 / 采样不经此路径。
+
 ---
 
 ## Pip 依赖（许可随各自 wheel 分发）

--- a/docs/user-guide/training-tips.md
+++ b/docs/user-guide/training-tips.md
@@ -489,3 +489,22 @@ cache_latents: true
 ### 多 GPU
 
 目前脚本不支持多 GPU 并行，建议单卡训练。
+
+### TREAD token routing（训练提速）
+
+TREAD（[arXiv 2501.04765](https://arxiv.org/abs/2501.04765)）是**训练期专用**的 token 路由：中间若干 transformer block 只处理每步随机保留的一部分 token，段尾再把结果放回原位、被丢的 token 恒等旁路。等价于让中间层在更少 token 上算 attention/MLP，**省这些 block 的算力**；推理 / 采样完全不经此路径，出图行为不变。
+
+```yaml
+tread_enabled: true
+tread_ratio: 0.5        # 路由段每步丢弃的 token 比例（0.25-0.5 常用）
+tread_start_layer: 2    # 路由段起始 block（含）；保留最前几层全 token 结构
+tread_end_layer: -2     # 结束 block（不含，开区间）；负数从末尾数，保留最后两层全 token 细化
+```
+
+要点：
+
+- **只在训练生效**：`model.eval()`（采样 / 验证）自动关闭，无需手动切。
+- **段的选择**：跳过最前 / 最后若干层（早期结构、晚期细化用全 token），中段路由。`tread_ratio` 越大省得越多但信息损失越大。
+- **限制**：仅 Anima 图像 latent（T=1）+ rope-only 位置编码；学习型逐块位置嵌入（`extra_per_block_pos_emb`）下会报错关掉。
+- **画质**：是训练加速件，正常不影响最终画质；若怀疑某次训练异常，第一个关掉复跑的就是它。
+- **验证**：`python tools/tread_smoke.py --base <底模>` 用真权重确认前向数值一致 + 粗看耗时。

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -134,9 +134,19 @@ def run(ctx: TrainingContext) -> None:
             # 前向
             pad_mask = torch.zeros(bs, 1, latents.shape[-2], latents.shape[-1], device=ctx.device, dtype=ctx.dtype)
             with torch.autocast("cuda", dtype=ctx.dtype):
+                # TREAD（arXiv 2501.04765）训练期 token 路由：tread_enabled 才传 ratio，
+                # 否则 ratio=0 → forward 内部走原路径。采样/eval 不经此调用，天然关闭。
+                _tread_ratio = (
+                    float(getattr(args, "tread_ratio", 0.0) or 0.0)
+                    if getattr(args, "tread_enabled", False)
+                    else 0.0
+                )
                 pred = forward_with_optional_checkpoint(
                     ctx.model, noisy, t.view(-1, 1), cross, pad_mask,
                     use_checkpoint=args.grad_checkpoint,
+                    tread_ratio=_tread_ratio,
+                    tread_start_layer=int(getattr(args, "tread_start_layer", 0) or 0),
+                    tread_end_layer=int(getattr(args, "tread_end_layer", 0) or 0),
                 )
                 # 训练 loss 通过 losses/ plugin registry 派发（mse / huber / ...）
                 loss_per_sample = ctx.loss_fn.compute(pred.float(), target.float(), t)

--- a/runtime/training/model_loading.py
+++ b/runtime/training/model_loading.py
@@ -30,9 +30,43 @@ logger = logging.getLogger(__name__)
 # 梯度检查点
 # ============================================================================
 
-def forward_with_optional_checkpoint(model, latents, timesteps, cross, padding_mask, use_checkpoint=False):
-    """带可选梯度检查点的前向传播。"""
-    if not use_checkpoint:
+def tread_route_indices(bs: int, n_tokens: int, ratio: float, device) -> "torch.Tensor":
+    """TREAD（arXiv 2501.04765）逐样本随机保留索引。
+
+    返回 (B, N_keep) 升序 token 索引，N_keep = round(N·(1-ratio))（至少 1）。
+    每样本独立抽样（与论文一致）；升序保持原 token 顺序便于 RoPE 子集对齐。
+    """
+    n_keep = max(int(round(n_tokens * (1.0 - float(ratio)))), 1)
+    scores = torch.rand(bs, n_tokens, device=device)
+    idx = scores.argsort(dim=1)[:, :n_keep]
+    return idx.sort(dim=1).values
+
+
+def forward_with_optional_checkpoint(
+    model,
+    latents,
+    timesteps,
+    cross,
+    padding_mask,
+    use_checkpoint=False,
+    tread_ratio: float = 0.0,
+    tread_start_layer: int = 0,
+    tread_end_layer: int = 0,
+):
+    """带可选梯度检查点的前向传播 + 可选 TREAD token 路由。
+
+    TREAD（arXiv 2501.04765，训练期专用 token 路由，推理不变）：当 ``tread_ratio>0``
+    且 ``model.training`` 时，blocks[start:end)（负索引按 python 切片语义，end 开区间）
+    只处理每样本随机保留的 N·(1-ratio) 个 token，段尾把结果 scatter 回原位、被丢 token
+    恒等旁路 → 省这些 block 的算力。采样 / eval 调用方不传 tread 参数 + model.eval()
+    双保险关闭。
+
+    实现不动模型定义：保留 token 子集 reshape 成 (B,1,1,N_keep,D) 伪网格，复用现有
+    ``Block.forward``（其内部本就 ``rearrange("b t h w d -> b (t h w) d")`` 走 token 注意力，
+    rope 按位置应用），对 Anima 图像 latent（T=1）与逐 token 前向逐 bit 等价。
+    """
+    use_tread = float(tread_ratio) > 0.0 and bool(getattr(model, "training", False))
+    if not use_checkpoint and not use_tread:
         return model(latents, timesteps, cross, padding_mask=padding_mask)
     from torch.utils.checkpoint import checkpoint
 
@@ -50,10 +84,69 @@ def forward_with_optional_checkpoint(model, latents, timesteps, cross, padding_m
         "extra_per_block_pos_emb": extra_pos_emb,
     }
 
-    for block in model.blocks:
-        def custom_forward(x, blk=block):
-            return blk(x, t_embedding, cross, **block_kwargs)
-        x_B_T_H_W_D = checkpoint(custom_forward, x_B_T_H_W_D, use_reentrant=False)
+    n_blocks = len(model.blocks)
+    seg_s = seg_e = -1
+    if use_tread:
+        if extra_pos_emb is not None:
+            raise RuntimeError(
+                "TREAD 路由段不支持 extra_per_block_pos_emb（学习型逐块位置嵌入）；"
+                "请关闭 tread 或使用 rope-only 位置编码。"
+            )
+        if x_B_T_H_W_D.shape[1] != 1:
+            raise RuntimeError(
+                f"TREAD 伪网格路径目前仅支持 T=1 图像 latent，收到 T={x_B_T_H_W_D.shape[1]}。"
+            )
+        seg_s = tread_start_layer if tread_start_layer >= 0 else n_blocks + tread_start_layer
+        seg_e = tread_end_layer if tread_end_layer > 0 else n_blocks + tread_end_layer
+        if not (0 <= seg_s < seg_e <= n_blocks):
+            raise ValueError(
+                f"非法 TREAD 路由段: blocks[{seg_s}:{seg_e}) / n_blocks={n_blocks}"
+            )
+
+    def _run_grid(blk, x):
+        def fwd(x_in, _b=blk):
+            return _b(x_in, t_embedding, cross, **block_kwargs)
+        return checkpoint(fwd, x, use_reentrant=False) if use_checkpoint else fwd(x)
+
+    def _run_routed(blk, x_pseudo, rope_keep):
+        # 伪网格 (B,1,1,N_keep,D)：复用 Block.forward，rope 传保留子集、关学习型位置嵌入
+        def fwd(x_in, _b=blk):
+            return _b(
+                x_in, t_embedding, cross,
+                rope_emb_L_1_1_D=rope_keep,
+                adaln_lora_B_T_3D=adaln_lora,
+                extra_per_block_pos_emb=None,
+            )
+        return checkpoint(fwd, x_pseudo, use_reentrant=False) if use_checkpoint else fwd(x_pseudo)
+
+    b = tt = hh = ww = dd = 0
+    x_tok_full = gather_idx = grid_shape = x_keep = rope_keep = None
+    for i, block in enumerate(model.blocks):
+        if use_tread and i == seg_s:
+            b, tt, hh, ww, dd = x_B_T_H_W_D.shape
+            grid_shape = (b, tt, hh, ww, dd)
+            n_tok = tt * hh * ww
+            x_tok_full = x_B_T_H_W_D.reshape(b, n_tok, dd)
+            keep_idx = tread_route_indices(b, n_tok, tread_ratio, x_tok_full.device)
+            gather_idx = keep_idx.unsqueeze(-1).expand(-1, -1, dd)
+            x_keep = torch.gather(x_tok_full, 1, gather_idx)  # (B, N_keep, D)
+            if rope_emb is not None:
+                if rope_emb.shape[0] != n_tok:
+                    raise RuntimeError(
+                        f"rope_emb 第 0 维 ({rope_emb.shape[0]}) != token 数 ({n_tok})，"
+                        "TREAD 无法对齐 RoPE 子集"
+                    )
+                rope_keep = rope_emb[keep_idx]  # (B, N_keep, 1, 1, Dh)
+        if use_tread and seg_s <= i < seg_e:
+            n_keep = x_keep.shape[1]
+            x_pseudo = x_keep.reshape(b, 1, 1, n_keep, dd)
+            x_pseudo = _run_routed(block, x_pseudo, rope_keep)
+            x_keep = x_pseudo.reshape(b, n_keep, dd)
+            if i == seg_e - 1:
+                x_tok_full = x_tok_full.scatter(1, gather_idx, x_keep.to(x_tok_full.dtype))
+                x_B_T_H_W_D = x_tok_full.reshape(grid_shape)
+            continue
+        x_B_T_H_W_D = _run_grid(block, x_B_T_H_W_D)
 
     x_B_T_H_W_O = model.final_layer(x_B_T_H_W_D, t_embedding, adaln_lora_B_T_3D=adaln_lora)
     return model.unpatchify(x_B_T_H_W_O)

--- a/runtime/training/model_loading.py
+++ b/runtime/training/model_loading.py
@@ -30,16 +30,17 @@ logger = logging.getLogger(__name__)
 # 梯度检查点
 # ============================================================================
 
-def tread_route_indices(bs: int, n_tokens: int, ratio: float, device) -> "torch.Tensor":
-    """TREAD（arXiv 2501.04765）逐样本随机保留索引。
+def tread_route_indices(n_tokens: int, ratio: float, device) -> "torch.Tensor":
+    """TREAD（arXiv 2501.04765）随机保留索引（batch 内共享一套）。
 
-    返回 (B, N_keep) 升序 token 索引，N_keep = round(N·(1-ratio))（至少 1）。
-    每样本独立抽样（与论文一致）；升序保持原 token 顺序便于 RoPE 子集对齐。
+    返回升序 1-D 索引 (N_keep,)，N_keep = round(N·(1-ratio))（至少 1）。整个 batch
+    共用同一套保留位置，因此 RoPE freqs 子集保持 (N_keep,1,1,Dh) 4-D，与
+    apply_rotary_pos_emb 的形状契约一致（freqs 期望 [seq,1,1,d]，逐样本索引会让它
+    变 5-D 触发维度不匹配）。升序保持原 token 顺序便于子集对齐；每步重新随机。
     """
     n_keep = max(int(round(n_tokens * (1.0 - float(ratio)))), 1)
-    scores = torch.rand(bs, n_tokens, device=device)
-    idx = scores.argsort(dim=1)[:, :n_keep]
-    return idx.sort(dim=1).values
+    perm = torch.randperm(n_tokens, device=device)[:n_keep]
+    return perm.sort().values
 
 
 def forward_with_optional_checkpoint(
@@ -57,9 +58,9 @@ def forward_with_optional_checkpoint(
 
     TREAD（arXiv 2501.04765，训练期专用 token 路由，推理不变）：当 ``tread_ratio>0``
     且 ``model.training`` 时，blocks[start:end)（负索引按 python 切片语义，end 开区间）
-    只处理每样本随机保留的 N·(1-ratio) 个 token，段尾把结果 scatter 回原位、被丢 token
-    恒等旁路 → 省这些 block 的算力。采样 / eval 调用方不传 tread 参数 + model.eval()
-    双保险关闭。
+    只处理每步随机保留的 N·(1-ratio) 个 token（batch 内共享一套位置，保证 RoPE 子集
+    4-D 契约），段尾把结果 scatter 回原位、被丢 token 恒等旁路 → 省这些 block 的算力。
+    采样 / eval 调用方不传 tread 参数 + model.eval() 双保险关闭。
 
     实现不动模型定义：保留 token 子集 reshape 成 (B,1,1,N_keep,D) 伪网格，复用现有
     ``Block.forward``（其内部本就 ``rearrange("b t h w d -> b (t h w) d")`` 走 token 注意力，
@@ -120,30 +121,30 @@ def forward_with_optional_checkpoint(
         return checkpoint(fwd, x_pseudo, use_reentrant=False) if use_checkpoint else fwd(x_pseudo)
 
     b = tt = hh = ww = dd = 0
-    x_tok_full = gather_idx = grid_shape = x_keep = rope_keep = None
+    x_tok_full = keep_idx = grid_shape = x_keep = rope_keep = None
     for i, block in enumerate(model.blocks):
         if use_tread and i == seg_s:
             b, tt, hh, ww, dd = x_B_T_H_W_D.shape
             grid_shape = (b, tt, hh, ww, dd)
             n_tok = tt * hh * ww
             x_tok_full = x_B_T_H_W_D.reshape(b, n_tok, dd)
-            keep_idx = tread_route_indices(b, n_tok, tread_ratio, x_tok_full.device)
-            gather_idx = keep_idx.unsqueeze(-1).expand(-1, -1, dd)
-            x_keep = torch.gather(x_tok_full, 1, gather_idx)  # (B, N_keep, D)
+            keep_idx = tread_route_indices(n_tok, tread_ratio, x_tok_full.device)  # (N_keep,)
+            x_keep = x_tok_full.index_select(1, keep_idx)  # (B, N_keep, D)
             if rope_emb is not None:
                 if rope_emb.shape[0] != n_tok:
                     raise RuntimeError(
                         f"rope_emb 第 0 维 ({rope_emb.shape[0]}) != token 数 ({n_tok})，"
                         "TREAD 无法对齐 RoPE 子集"
                     )
-                rope_keep = rope_emb[keep_idx]  # (B, N_keep, 1, 1, Dh)
+                rope_keep = rope_emb.index_select(0, keep_idx)  # (N_keep, 1, 1, Dh) — 4-D，契约一致
         if use_tread and seg_s <= i < seg_e:
             n_keep = x_keep.shape[1]
             x_pseudo = x_keep.reshape(b, 1, 1, n_keep, dd)
             x_pseudo = _run_routed(block, x_pseudo, rope_keep)
             x_keep = x_pseudo.reshape(b, n_keep, dd)
             if i == seg_e - 1:
-                x_tok_full = x_tok_full.scatter(1, gather_idx, x_keep.to(x_tok_full.dtype))
+                # 段尾把处理过的保留 token 放回原位；丢弃 token 保持段首值（恒等旁路）
+                x_tok_full = x_tok_full.index_copy(1, keep_idx, x_keep.to(x_tok_full.dtype))
                 x_B_T_H_W_D = x_tok_full.reshape(grid_shape)
             continue
         x_B_T_H_W_D = _run_grid(block, x_B_T_H_W_D)

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -389,6 +389,29 @@ class TrainingConfig(BaseModel):
         description="Cross-attention KV trim：按实际 token 数裁到最近 bucket（64/128/256/512），减少 padding 计算量",
         json_schema_extra=_meta("system", advanced=True),
     )
+    # --------------------------- TREAD token routing ---------------------------
+    # arXiv 2501.04765：训练期专用 token 路由，中间若干 block 只算随机保留的 token 子集，
+    # 省这些 block 的算力；推理 / 采样不经此路径，default off。
+    tread_enabled: bool = Field(
+        False,
+        description="TREAD 训练期 token 路由：中间 block 段只处理随机保留的 token 子集（省算力，推理不变）。仅 Anima 图像 latent（T=1）+ rope-only 位置编码",
+        json_schema_extra=_meta("system", advanced=True),
+    )
+    tread_ratio: float = Field(
+        0.5, ge=0.0, lt=1.0,
+        description="路由段每步丢弃的 token 比例（0=不丢；0.5=丢一半）。越大省得越多但信息损失越大，典型 0.25-0.5",
+        json_schema_extra=_meta("system", show_when="tread_enabled==true", advanced=True),
+    )
+    tread_start_layer: int = Field(
+        2,
+        description="路由段起始 block 索引（含）；负数按 python 切片语义从末尾数。建议跳过最前几层（保留早期全 token 结构）",
+        json_schema_extra=_meta("system", show_when="tread_enabled==true", advanced=True),
+    )
+    tread_end_layer: int = Field(
+        -2,
+        description="路由段结束 block 索引（不含，开区间）；负数从末尾数（-2 = 倒数第 2 层之前结束，保留最后两层全 token 细化）",
+        json_schema_extra=_meta("system", show_when="tread_enabled==true", advanced=True),
+    )
     noise_enhancement_type: Literal["none", "offset", "pyramid"] = Field(
         "none",
         description="噪声增强机制（默认 none）。offset 在噪声上加 per-sample DC 偏置；pyramid 在多个尺度叠加低频噪声。两者机制不同，但都改变低频成分，互斥防双倍叠加。LoRA 训练默认保持 none",

--- a/tests/test_tread_routing.py
+++ b/tests/test_tread_routing.py
@@ -1,0 +1,191 @@
+"""TREAD token routing 测试（arXiv 2501.04765）。
+
+不依赖真实 Anima 权重：用 stub 模型（暴露 prepare_embedded_sequence / t_embedder /
+blocks / final_layer / unpatchify）验证路由 plumbing：
+- tread_route_indices：形状 / 升序 / 数量 / 取值范围 / 逐样本
+- 路由段只更新保留 token、丢弃 token 段内恒等旁路（gather/scatter/伪网格 reshape 正确）
+- identity block 下 tread 路径与全 token 路径逐元素相等（plumbing 无损）
+- model.eval() / extra_per_block_pos_emb / T>1 等边界行为
+
+真实权重的逐 bit 等价 + 单步耗时下降由 tools/tread_smoke.py（real-weight smoke test）覆盖。
+测试卫生：纯 CPU、固定随机种子。
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+from torch import nn
+
+from training.model_loading import forward_with_optional_checkpoint, tread_route_indices
+
+
+# ---------------------------------------------------------------------------
+# tread_route_indices
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("ratio,n,expected_keep", [(0.5, 16, 8), (0.25, 16, 12), (0.9, 10, 1)])
+def test_route_indices_count_and_sorted(ratio, n, expected_keep) -> None:
+    torch.manual_seed(0)
+    idx = tread_route_indices(4, n, ratio, device="cpu")
+    assert idx.shape == (4, expected_keep)
+    # 升序 + 取值范围 + 逐行唯一
+    for row in idx:
+        assert torch.equal(row, row.sort().values)
+        assert int(row.min()) >= 0 and int(row.max()) < n
+        assert len(set(row.tolist())) == len(row)
+
+
+def test_route_indices_keep_at_least_one() -> None:
+    idx = tread_route_indices(2, 8, 0.999, device="cpu")
+    assert idx.shape == (2, 1)
+
+
+def test_route_indices_per_sample_differs() -> None:
+    torch.manual_seed(0)
+    idx = tread_route_indices(8, 64, 0.5, device="cpu")
+    # 逐样本独立抽样：极不可能 8 行全相同
+    assert not all(torch.equal(idx[0], idx[j]) for j in range(1, 8))
+
+
+# ---------------------------------------------------------------------------
+# Stub 模型
+# ---------------------------------------------------------------------------
+
+class _AddBlock(nn.Module):
+    """每次 forward 给所有 token +delta；忽略 rope/adaln（只测路由 plumbing）。"""
+
+    def __init__(self, delta: float = 1.0):
+        super().__init__()
+        self.delta = delta
+
+    def forward(self, x_B_T_H_W_D, emb, cross, rope_emb_L_1_1_D=None,
+                adaln_lora_B_T_3D=None, extra_per_block_pos_emb=None):
+        return x_B_T_H_W_D + self.delta
+
+
+class _StubModel(nn.Module):
+    def __init__(self, n_blocks=6, h=4, w=4, d=8, t=1, extra_pos=False):
+        super().__init__()
+        self.blocks = nn.ModuleList([_AddBlock(1.0) for _ in range(n_blocks)])
+        self._h, self._w, self._d, self._t = h, w, d, t
+        self._extra_pos = extra_pos
+
+    def prepare_embedded_sequence(self, latents, fps=None, padding_mask=None):
+        b = latents.shape[0]
+        x = torch.zeros(b, self._t, self._h, self._w, self._d)
+        rope = torch.zeros(self._t * self._h * self._w, 1, 1, 4)
+        extra = torch.zeros_like(x) if self._extra_pos else None
+        return x, rope, extra
+
+    def t_embedder(self, timesteps):
+        b = timesteps.shape[0]
+        return torch.zeros(b, self._t, self._d), torch.zeros(b, self._t, 3 * self._d)
+
+    def t_embedding_norm(self, t):
+        return t
+
+    def final_layer(self, x, t_embedding, adaln_lora_B_T_3D=None):
+        return x
+
+    def unpatchify(self, x):
+        return x
+
+    def forward(self, latents, timesteps, cross, padding_mask=None):
+        # 非路由参考前向（与 forward_with_optional_checkpoint 的 model() 兜底一致）
+        x, rope, extra = self.prepare_embedded_sequence(latents)
+        t, adaln = self.t_embedder(timesteps)
+        for blk in self.blocks:
+            x = blk(x, t, cross, rope_emb_L_1_1_D=rope, adaln_lora_B_T_3D=adaln,
+                    extra_per_block_pos_emb=extra)
+        return self.unpatchify(self.final_layer(x, t, adaln_lora_B_T_3D=adaln))
+
+
+def _run(model, **tread_kw):
+    b = 2
+    latents = torch.zeros(b, model._d, model._h, model._w)
+    timesteps = torch.zeros(b)
+    cross = torch.zeros(b, 4, model._d)
+    pad = torch.zeros(b, 1, model._h, model._w)
+    return forward_with_optional_checkpoint(model, latents, timesteps, cross, pad, **tread_kw)
+
+
+# ---------------------------------------------------------------------------
+# 路由语义
+# ---------------------------------------------------------------------------
+
+def test_routed_segment_only_updates_kept_tokens() -> None:
+    """+1/block：保留 token 走满 n_blocks 次，丢弃 token 在段内旁路少 seg_len 次。"""
+    torch.manual_seed(0)
+    n_blocks, h, w = 6, 4, 4
+    model = _StubModel(n_blocks=n_blocks, h=h, w=w).train()
+    seg_s, seg_e = 1, 5  # blocks[1:5) 共 4 个进路由段
+    seg_len = seg_e - seg_s
+    ratio = 0.5
+    out = _run(model, tread_ratio=ratio, tread_start_layer=seg_s, tread_end_layer=seg_e)
+
+    n_tok = h * w
+    n_keep = round(n_tok * (1 - ratio))
+    vals = out.reshape(out.shape[0], n_tok, -1)[..., 0]  # (B, N) 每 token 的累计值
+    # 保留 token == n_blocks；丢弃 token == n_blocks - seg_len
+    kept = (vals == float(n_blocks)).sum(dim=1)
+    dropped = (vals == float(n_blocks - seg_len)).sum(dim=1)
+    assert torch.all(kept == n_keep)
+    assert torch.all(dropped == n_tok - n_keep)
+
+
+def test_identity_blocks_routing_is_lossless() -> None:
+    """identity block 下，tread 路径输出与全 token 路径逐元素相等（plumbing 无损）。"""
+    n_blocks, h, w, d = 6, 4, 4, 8
+    model = _StubModel(n_blocks=n_blocks, h=h, w=w, d=d).train()
+    for blk in model.blocks:
+        blk.delta = 0.0
+    base = torch.full((2, n_blocks * 0 + 1 * 1, h, w, d), 3.14)  # 任意非零参考
+
+    # 用一个会改值的 block 也行，但 identity 最直接：注入非零初始值
+    def _prep(latents, fps=None, padding_mask=None):
+        return base.clone(), torch.zeros(h * w, 1, 1, 4), None
+    model.prepare_embedded_sequence = _prep
+
+    out_tread = _run(model, tread_ratio=0.5, tread_start_layer=1, tread_end_layer=5)
+    out_plain = _run(model, tread_ratio=0.0)
+    assert torch.allclose(out_tread, out_plain)
+
+
+def test_tread_off_in_eval_mode() -> None:
+    """model.eval() 时即使传 tread_ratio>0 也不路由（采样/eval 双保险）。"""
+    n_blocks, h, w = 6, 4, 4
+    model = _StubModel(n_blocks=n_blocks, h=h, w=w).eval()
+    out = _run(model, tread_ratio=0.5, tread_start_layer=1, tread_end_layer=5)
+    n_tok = h * w
+    vals = out.reshape(out.shape[0], n_tok, -1)[..., 0]
+    assert torch.all(vals == float(n_blocks))  # 全 token 都走满，无丢弃
+
+
+def test_tread_rejects_extra_pos_emb() -> None:
+    model = _StubModel(extra_pos=True).train()
+    with pytest.raises(RuntimeError, match="extra_per_block_pos_emb"):
+        _run(model, tread_ratio=0.5, tread_start_layer=1, tread_end_layer=5)
+
+
+def test_tread_rejects_temporal_gt_one() -> None:
+    model = _StubModel(t=2).train()
+    with pytest.raises(RuntimeError, match="T=1"):
+        _run(model, tread_ratio=0.5, tread_start_layer=1, tread_end_layer=5)
+
+
+def test_tread_rejects_bad_segment() -> None:
+    model = _StubModel(n_blocks=6).train()
+    with pytest.raises(ValueError, match="TREAD"):
+        _run(model, tread_ratio=0.5, tread_start_layer=4, tread_end_layer=2)
+
+
+def test_negative_layer_indices_resolve() -> None:
+    """负索引按 python 切片语义解析（end=-1 → 倒数第 1 之前）。"""
+    torch.manual_seed(0)
+    n_blocks, h, w = 6, 4, 4
+    model = _StubModel(n_blocks=n_blocks, h=h, w=w).train()
+    # blocks[1:-1) = blocks[1:5)，seg_len=4
+    out = _run(model, tread_ratio=0.5, tread_start_layer=1, tread_end_layer=-1)
+    n_tok = h * w
+    vals = out.reshape(out.shape[0], n_tok, -1)[..., 0]
+    assert (vals == float(n_blocks - 4)).any()  # 有 token 少走 4 个 block

--- a/tests/test_tread_routing.py
+++ b/tests/test_tread_routing.py
@@ -26,25 +26,70 @@ from training.model_loading import forward_with_optional_checkpoint, tread_route
 @pytest.mark.parametrize("ratio,n,expected_keep", [(0.5, 16, 8), (0.25, 16, 12), (0.9, 10, 1)])
 def test_route_indices_count_and_sorted(ratio, n, expected_keep) -> None:
     torch.manual_seed(0)
-    idx = tread_route_indices(4, n, ratio, device="cpu")
-    assert idx.shape == (4, expected_keep)
-    # 升序 + 取值范围 + 逐行唯一
-    for row in idx:
-        assert torch.equal(row, row.sort().values)
-        assert int(row.min()) >= 0 and int(row.max()) < n
-        assert len(set(row.tolist())) == len(row)
+    idx = tread_route_indices(n, ratio, device="cpu")
+    # batch 内共享 → 1-D (N_keep,)；升序 + 取值范围 + 唯一
+    assert idx.shape == (expected_keep,)
+    assert torch.equal(idx, idx.sort().values)
+    assert int(idx.min()) >= 0 and int(idx.max()) < n
+    assert len(set(idx.tolist())) == len(idx)
 
 
 def test_route_indices_keep_at_least_one() -> None:
-    idx = tread_route_indices(2, 8, 0.999, device="cpu")
-    assert idx.shape == (2, 1)
+    idx = tread_route_indices(8, 0.999, device="cpu")
+    assert idx.shape == (1,)
 
 
-def test_route_indices_per_sample_differs() -> None:
+def test_route_indices_rerandomizes() -> None:
     torch.manual_seed(0)
-    idx = tread_route_indices(8, 64, 0.5, device="cpu")
-    # 逐样本独立抽样：极不可能 8 行全相同
-    assert not all(torch.equal(idx[0], idx[j]) for j in range(1, 8))
+    a = tread_route_indices(64, 0.5, device="cpu")
+    b = tread_route_indices(64, 0.5, device="cpu")
+    # 每步重新随机：极不可能两次完全相同
+    assert not torch.equal(a, b)
+
+
+def test_rope_subset_stays_4d() -> None:
+    """回归：RoPE freqs 子集必须保持 (N_keep,1,1,Dh) 4-D。
+
+    apply_rotary_pos_emb 期望 freqs 形如 [seq,1,1,d]（取 .shape[0] 当 seq、transpose(0,1)）。
+    曾经用逐样本索引 rope_emb[keep_idx_(B,N)] → (B,N_keep,1,1,Dh) 5-D，与 q(4-D) 相乘报
+    "Tensors must have same number of dimensions: got 5 and 4"。batch 共享索引修复之。
+    """
+    n_tok, dh = 64, 16
+    rope_emb_L_1_1_D = torch.zeros(n_tok, 1, 1, dh)  # 与 prepare_embedded_sequence 输出同形
+    keep_idx = tread_route_indices(n_tok, 0.5, device="cpu")
+    rope_keep = rope_emb_L_1_1_D.index_select(0, keep_idx)
+    assert rope_keep.ndim == 4
+    assert rope_keep.shape == (keep_idx.numel(), 1, 1, dh)
+
+
+def test_rope_subset_runs_through_real_apply_rotary() -> None:
+    """端到端回归：保留 token 子集的 RoPE 走真实 apply_rotary_pos_emb 不报维度错。
+
+    直接调模型里的真函数（stub block 不算 rope，正是它放过了最初的 5-vs-4 bug）。
+    """
+    from pathlib import Path
+    from training.model_loading import load_module_from_path
+
+    cosmos_path = Path(__file__).resolve().parents[1] / "models" / "cosmos_predict2_modeling.py"
+    try:
+        cosmos = load_module_from_path("cosmos_predict2_modeling", cosmos_path)
+    except Exception as exc:  # pragma: no cover - 环境缺依赖时跳过，不假红
+        pytest.skip(f"cosmos 模型模块不可导入，跳过真 rope 测试: {exc}")
+
+    apply_rotary = cosmos.apply_rotary_pos_emb
+    n_tok, b, n_heads, dh = 64, 2, 4, 16
+    full_rope = torch.zeros(n_tok, 1, 1, dh)
+    keep_idx = tread_route_indices(n_tok, 0.5, device="cpu")
+    n_keep = keep_idx.numel()
+    rope_keep = full_rope.index_select(0, keep_idx)  # (N_keep,1,1,Dh) 4-D 共享
+    q = torch.randn(b, n_keep, n_heads, dh)  # bshd
+    out = apply_rotary(q, rope_keep, tensor_format="bshd", fused=False)
+    assert out.shape == q.shape  # 4-D rope 正常应用
+
+    # 逐样本 5-D rope 必须出问题（记录最初 "got 5 and 4" 的根因）
+    rope_per_sample = full_rope.index_select(0, keep_idx).unsqueeze(0).expand(b, -1, -1, -1, -1)
+    with pytest.raises((RuntimeError, AssertionError, IndexError)):
+        apply_rotary(q, rope_per_sample, tensor_format="bshd", fused=False)
 
 
 # ---------------------------------------------------------------------------

--- a/tools/tread_smoke.py
+++ b/tools/tread_smoke.py
@@ -1,0 +1,84 @@
+"""TREAD 真模型冒烟测试（arXiv 2501.04765）。
+
+加载 Anima 底模（CPU），验证：
+1) 手动 per-block 路径与 model() 直通路径数值一致（tread 关）— 证明改写的前向无回归
+2) TREAD 路由开启时前向可跑、输出有限、形状正确、扰动量级温和（非爆炸）
+3) 打印 CPU 参考耗时（direct / manual / tread）便于粗看路由是否真的少算
+
+CI 不跑（需真实权重）；维护者本地验证 + 复核单步提速时用。
+
+用法:
+  python tools/tread_smoke.py --base <models/transformers/anima-base.safetensors> \
+      [--dtype fp32|bf16] [--hw 32] [--ratio 0.5] [--start 2] [--end -2]
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+
+import torch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+for _p in (REPO_ROOT, REPO_ROOT / "runtime"):
+    _ps = str(_p)
+    if _ps not in sys.path:
+        sys.path.insert(0, _ps)
+
+from training.models import load_anima_model  # noqa: E402
+from training.model_loading import forward_with_optional_checkpoint  # noqa: E402
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", required=True, help="Anima transformer safetensors 路径")
+    ap.add_argument("--dtype", default="fp32", choices=["fp32", "bf16"])
+    ap.add_argument("--hw", type=int, default=32, help="latent 边长（32 → 16x16=256 token）")
+    ap.add_argument("--ratio", type=float, default=0.5)
+    ap.add_argument("--start", type=int, default=2)
+    ap.add_argument("--end", type=int, default=-2)
+    args = ap.parse_args()
+
+    dtype = torch.float32 if args.dtype == "fp32" else torch.bfloat16
+    t0 = time.time()
+    model = load_anima_model(args.base, "cpu", dtype, REPO_ROOT / "models", flash_attn=False)
+    print(f"model loaded in {time.time() - t0:.1f}s; blocks={len(model.blocks)}")
+    model.train()  # TREAD 仅训练模式生效；权重已 requires_grad_(False)
+
+    torch.manual_seed(0)
+    lat = torch.randn(1, 16, 1, args.hw, args.hw, dtype=dtype)
+    cross = torch.randn(1, 512, 1024, dtype=dtype)
+    ts = torch.tensor([[0.7]], dtype=dtype)
+    pm = torch.zeros(1, 1, args.hw, args.hw, dtype=dtype)
+
+    with torch.no_grad():
+        t0 = time.time()
+        out_direct = model(lat, ts, cross, padding_mask=pm)
+        t_direct = time.time() - t0
+        t0 = time.time()
+        out_manual = forward_with_optional_checkpoint(model, lat, ts, cross, pm, use_checkpoint=True)
+        t_manual = time.time() - t0
+        t0 = time.time()
+        out_tread = forward_with_optional_checkpoint(
+            model, lat, ts, cross, pm, use_checkpoint=True,
+            tread_ratio=args.ratio, tread_start_layer=args.start, tread_end_layer=args.end)
+        t_tread = time.time() - t0
+
+    d_manual = (out_manual.float() - out_direct.float()).abs().max().item()
+    ref = out_direct.float()
+    rel_tread = ((out_tread.float() - ref).norm() / ref.norm().clamp(min=1e-12)).item()
+    print(f"shapes: direct={tuple(out_direct.shape)} tread={tuple(out_tread.shape)}")
+    print(f"[1] manual-vs-direct max|diff| = {d_manual:.3e}  (期望 ~0：per-block 路径数值等价)")
+    print(f"[2] tread finite={bool(torch.isfinite(out_tread).all())}  "
+          f"rel|out_tread-out_direct|={rel_tread:.4f}  (期望 0.05~0.5 量级：扰动温和非爆炸)")
+    print(f"timing(cpu参考): direct={t_direct:.1f}s manual={t_manual:.1f}s tread={t_tread:.1f}s")
+    ok = (d_manual < 1e-3 if args.dtype == "fp32" else d_manual < 0.1) \
+        and bool(torch.isfinite(out_tread).all()) and out_tread.shape == out_direct.shape \
+        and 0.0 < rel_tread < 1.0
+    print("SMOKE", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
新增 TREAD（arXiv 2501.04765）训练期 token 路由：中间 block 段每步只处理随机 保留的 N·(1-ratio) 个 token，段尾 scatter 回原位、被丢 token 恒等旁路，省这些 block 的算力。推理 / 采样不经此路径，出图行为不变。

为什么：LoRA-on-DiT 训练里中段 block 在全 token 上算 attention/MLP 是主要耗时； 随机丢一部分 token 过中段在画风/主体拟合上几乎无损，换来明显的单步提速。

做了什么（不动模型定义）：
- model_loading.py：tread_route_indices（逐样本随机保留索引）+ 扩展 forward_with_optional_checkpoint 加 tread 分支。保留 token 子集 reshape 成 (B,1,1,N_keep,D) 伪网格复用现有 Block.forward（其内部本就 rearrange 成 token 序列走注意力、rope 按位置应用），对 Anima 图像 latent（T=1）与逐 token 前向等价。
- loop.py：tread_enabled 时把 ratio/start/end 传进 forward；eval/采样天然关闭。
- studio/domain/training.py：tread_enabled / tread_ratio / tread_start_layer / tread_end_layer 字段（default off）。
- tools/tread_smoke.py：真权重冒烟（manual==direct 数值一致 + tread 可跑 + 耗时）。

约束：仅 T=1 图像 latent + rope-only 位置编码；extra_per_block_pos_emb 下显式报错。

论文：Krause et al. 2025, arXiv:2501.04765。研究归属见 THIRD_PARTY_NOTICES.md。

测试：tests/test_tread_routing.py（route 索引 / 路由段只更新保留 token / identity plumbing 无损 / eval 关闭 / 边界报错 / 负索引解析）。真权重逐 bit 等价 + 提速由 tools/tread_smoke.py 覆盖。