### PR TITLE
fix(setup): 修复首次启动引导下载报错 + flash_attn 错误信息

### DIFF
--- a/studio/api/routers/installs.py
+++ b/studio/api/routers/installs.py
@@ -130,15 +130,40 @@ def flash_attn_status() -> dict[str, Any]:
     候选最多取前 20 个，避免 GitHub 历史 release 一大坨刷屏。
     fetch_error 非 None 表示 GitHub API 请求失败（限流 / 网络 / 国内防火墙）；
     UI 要展示这条让用户能选择手动粘 URL。
+
+    任何意外异常都包成 fetch_error 返回 200 —— 这是 Settings 页 mount 就拉的诊断
+    数据，宁可降级显示「无法拉候选」也不要 500 把整段 UI 打成「加载失败」让用户
+    误以为后端坏了。真出问题靠 server log 里的 traceback 排查。
     """
-    status = flash_attention_setup.current_status()
-    env = flash_attention_setup.detect_env()
-    candidates, fetch_error = flash_attention_setup.find_candidates(env)
-    slim = [
-        {"url": c["url"], "name": c["name"], "notes": c["notes"], "usable": c["usable"]}
-        for c in candidates[:20]
-    ]
-    return {**status, "env": env, "candidates": slim, "fetch_error": fetch_error}
+    try:
+        status = flash_attention_setup.current_status()
+        env = flash_attention_setup.detect_env()
+        candidates, fetch_error = flash_attention_setup.find_candidates(env)
+        slim = [
+            {"url": c["url"], "name": c["name"], "notes": c["notes"], "usable": c["usable"]}
+            for c in candidates[:20]
+        ]
+        return {**status, "env": env, "candidates": slim, "fetch_error": fetch_error}
+    except Exception as exc:  # noqa: BLE001
+        # logger.exception 把 traceback 落盘 + 带 trace_id（trace middleware bound）
+        import logging  # noqa: PLC0415
+        logging.getLogger(__name__).exception("flash_attn status endpoint failed")
+        return {
+            "installed": False,
+            "version": None,
+            "env": {
+                "python_tag": None,
+                "cuda_tag": None,
+                "cuda_ver": None,
+                "driver_cuda_ver": None,
+                "torch_tag": None,
+                "torch_ver": None,
+                "torch_cuda_build": None,
+                "platform": None,
+            },
+            "candidates": [],
+            "fetch_error": f"诊断失败：{type(exc).__name__}: {exc}",
+        }
 
 
 @router.post("/api/flash-attention/install")

--- a/studio/services/runtime/flash_attention.py
+++ b/studio/services/runtime/flash_attention.py
@@ -66,28 +66,56 @@ def detect_env() -> dict[str, Any]:
     cuda_ver: Optional[str] = None
     torch_tag: Optional[str] = None
     torch_ver: Optional[str] = None
+    # 'cu128' / 'cu130' / 'cpu' / None(未装) —— 区分 CPU 误装很重要：flash_attn
+    # 是 CUDA C extension，CPU 版 torch 上压根装不了，UI 要给「先重装 CUDA 版 torch」
+    # 而不是「找不到 wheel」这种误导。
+    torch_cuda_build: Optional[str] = None
+    # 历史 except 只挡 ImportError，但 Windows 上 torch DLL 加载失败抛 OSError
+    # （WinError 126），新 torch 版本里 __version__ 解析也可能出 IndexError —— 任何
+    # 异常都不该让 status endpoint 500。捕获到走 None。
     try:
         import torch  # type: ignore[import-not-found]  # noqa: PLC0415
         torch_ver = torch.__version__
-        v = torch_ver.split("+")[0].split(".")
-        torch_tag = f"torch{v[0]}.{v[1]}"
-        m = re.search(r"\+cu(\d+)", torch_ver)
+        parts = torch_ver.split("+")[0].split(".")
+        if len(parts) >= 2:
+            torch_tag = f"torch{parts[0]}.{parts[1]}"
+        m = re.search(r"\+(cu\d+|cpu)", torch_ver)
         if m:
-            num = m.group(1)
-            cuda_tag = f"cu{num}"
-            # cu128 → 12.8、cu130 → 13.0（最后一位 minor，其余 major）
-            if len(num) >= 2:
-                cuda_ver = f"{num[:-1]}.{num[-1]}"
-    except ImportError:
+            tag = m.group(1)
+            torch_cuda_build = tag
+            if tag.startswith("cu"):
+                cuda_tag = tag
+                num = tag[2:]
+                # cu128 → 12.8、cu130 → 13.0（最后一位 minor，其余 major）
+                if len(num) >= 2:
+                    cuda_ver = f"{num[:-1]}.{num[-1]}"
+        else:
+            # 没 +cu/+cpu 后缀的老 build，靠 torch.version.cuda 判
+            cuda_v = getattr(getattr(torch, "version", None), "cuda", None)
+            if cuda_v is None:
+                torch_cuda_build = "cpu"
+            else:
+                clean = str(cuda_v).replace(".", "")
+                torch_cuda_build = f"cu{clean}"
+                cuda_tag = torch_cuda_build
+                cuda_ver = str(cuda_v)
+    except Exception:  # noqa: BLE001
         pass
 
     # nvidia-smi 仍跑一下：torch 没 +cu 后缀（CPU-only build）→ fallback 给 cuda_tag；
     # driver 版本始终单独存到 `driver_cuda_ver` 供 UI 显示与排错（让用户看到「驱动支持
     # cu130，PyTorch 是 cu128」这种场景，立刻明白为什么 wheel 应该选 cu128）。
     driver_cuda_ver: Optional[str] = None
+    # 历史只挡 (subprocess.SubprocessError, OSError)；Windows 中文 locale (cp936)
+    # 下 text=True 解码 nvidia-smi 输出可能抛 UnicodeDecodeError（非上述子类），
+    # 直接 500。改用 errors='replace' 避免，并把 except 兜底放宽到 Exception。
     try:
         r = subprocess.run(
-            ["nvidia-smi"], capture_output=True, text=True, timeout=10
+            ["nvidia-smi"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            errors="replace",
         )
         if r.returncode == 0:
             m = re.search(r"CUDA Version:\s*(\d+)\.(\d+)", r.stdout)
@@ -96,7 +124,7 @@ def detect_env() -> dict[str, Any]:
                 if cuda_tag is None:
                     cuda_tag = f"cu{m.group(1)}{m.group(2)}"
                     cuda_ver = driver_cuda_ver
-    except (subprocess.SubprocessError, OSError):
+    except Exception:  # noqa: BLE001
         pass
 
     return {
@@ -106,6 +134,7 @@ def detect_env() -> dict[str, Any]:
         "driver_cuda_ver": driver_cuda_ver,
         "torch_tag": torch_tag,
         "torch_ver": torch_ver,
+        "torch_cuda_build": torch_cuda_build,
         "platform": plat,
     }
 
@@ -247,6 +276,17 @@ def install(url: Optional[str] = None) -> dict[str, Any]:
     env = detect_env()
 
     if url is None:
+        # CPU 版 torch 装不了 flash_attn —— flash_attn 是 CUDA C extension，必须配
+        # CUDA 版 torch。auto 路径先 pre-check 给清楚错误，否则 find_best_wheel 会因
+        # cuda_tag 来自 nvidia-smi（cu130）而误报「未找到 wheel」，让用户误以为是
+        # 网络/仓库问题。显式 URL 路径不挡，留给强制安装。
+        if env.get("torch_cuda_build") == "cpu":
+            raise RuntimeError(
+                "PyTorch 是 CPU 版（torch+cpu），无法安装 flash_attn。"
+                "flash_attn 是 CUDA C extension，必须先把 PyTorch 重装为 CUDA 版。\n"
+                "请到「设置 → 训练 → PyTorch」一键重装为 cu128 / cu130 等 CUDA 版本，"
+                "重启 Studio 后再回来装 flash_attn。"
+            )
         if not env.get("platform"):
             raise RuntimeError("不支持的平台（仅 linux_x86_64 / win_amd64）")
         if not env.get("torch_tag"):

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -269,6 +269,9 @@ export interface FlashAttnEnv {
   driver_cuda_ver: string | null
   torch_tag: string | null           // torch2.5
   torch_ver: string | null
+  /** 'cu128' / 'cu130' = CUDA 版 torch；'cpu' = CPU 版（装不了 flash_attn）；
+   *  null = torch 未装 / 检测失败。UI 用 'cpu' 触发「先重装 CUDA 版」提示。 */
+  torch_cuda_build: string | null
   platform: 'linux_x86_64' | 'win_amd64' | null
 }
 export interface FlashAttnCandidate {

--- a/studio/web/src/components/FirstRunOnboardingModal.tsx
+++ b/studio/web/src/components/FirstRunOnboardingModal.tsx
@@ -241,7 +241,7 @@ export function FirstRunOnboardingModal() {
                        || k.startsWith('qwen3') || k.startsWith('t5_tokenizer')),
       tagger: collect((k) => k.startsWith('wd14')),
       accel: [],
-      upscaler: collect((k) => k.startsWith('upscalers')),
+      upscaler: collect((k) => k.startsWith('upscaler')),
     }
   }, [catalog])
 
@@ -395,7 +395,7 @@ export function FirstRunOnboardingModal() {
           catalog.upscalers.variants.find((v) => v.is_current)
           ?? catalog.upscalers.variants.find((v) => v.label === catalog.upscalers!.default)
         if (target && !target.exists) {
-          await api.startModelDownload({ model_id: 'upscalers', variant: target.label })
+          await api.startModelDownload({ model_id: 'upscaler', variant: target.label })
           const res = await waitForCatalog(
             (c) => {
               if (!c.upscalers) return true
@@ -403,7 +403,7 @@ export function FirstRunOnboardingModal() {
                 ?? c.upscalers.variants.find((v) => v.label === c.upscalers!.default)
               return !!t?.exists
             },
-            (k) => k.startsWith('upscalers'),
+            (k) => k.startsWith('upscaler'),
           )
           if (!res.ok) errors.push(...res.errors)
         }

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1043,6 +1043,7 @@
     "unsupported": "Unsupported",
     "githubApiFailed": "GitHub API request failed (network may be unstable in China; refresh and retry):",
     "noWheelForPython": "No prebuilt wheel was found for {{python}} (the current Python version may not be supported yet). Select another candidate below manually, or paste a URL from GitHub Releases.",
+    "flashAttnNeedsCudaTorch": "PyTorch is currently a CPU build (torch+cpu) and flash_attn cannot be installed on it. flash_attn is a CUDA C extension — go to the PyTorch section above to reinstall a CUDA build (cu128 / cu130), restart Studio, then come back here.",
     "noWheelManual": "No usable wheel; select manually",
     "reinstallAutoMatch": "↻ Reinstall (auto match)",
     "autoMatchInstall": "⤓ Auto-match install",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1043,6 +1043,7 @@
     "unsupported": "不支持",
     "githubApiFailed": "GitHub API 请求失败（国内网络可能不稳定，请刷新重试）：",
     "noWheelForPython": "未找到 {{python}} 的预编译 wheel（当前 Python 版本可能尚无支持）。请在下方候选列表手动选择其他版本，或从 GitHub Releases 粘贴 URL。",
+    "flashAttnNeedsCudaTorch": "PyTorch 当前是 CPU 版（torch+cpu），无法安装 flash_attn。请先去上方「PyTorch」一栏一键重装为 CUDA 版（cu128 / cu130 等），重启 Studio 后再回来装 flash_attn。",
     "noWheelManual": "无可用 wheel，请手动选择",
     "reinstallAutoMatch": "↻ 重装（自动匹配）",
     "autoMatchInstall": "⤓ 自动匹配安装",

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -2757,8 +2757,11 @@ function FlashAttentionSection() {
   const fetchError = status?.fetch_error ?? null
   const usable = candidates.filter((c) => c.usable)
   const bestCandidate = usable[0] ?? null
+  // CPU 版 torch 装不了 flash_attn —— UI 必须显著提示用户先去 PyTorch 那栏重装。
+  // 否则用户只会看到「未找到 wheel」/「Internal Server Error」这种误导信息。
+  const isCpuTorch = env?.torch_cuda_build === 'cpu'
   const hasIssue = !!error || (status && !status.installed)
-  const canAutoInstall = !!env?.torch_tag && !!env?.platform && usable.length > 0
+  const canAutoInstall = !isCpuTorch && !!env?.torch_tag && !!env?.platform && usable.length > 0
 
   const statusLabel = error
     ? t('settings.loadFailedShort')
@@ -2800,8 +2803,15 @@ function FlashAttentionSection() {
             </div>
           </div>
 
+          {/* CPU 版 torch：根本装不了 flash_attn，优先显示这条 */}
+          {isCpuTorch && (
+            <div className="rounded-sm border border-warn bg-warn-soft px-2 py-1.5 text-warn text-xs">
+              {t('settings.flashAttnNeedsCudaTorch')}
+            </div>
+          )}
+
           {/* GitHub API 失败 */}
-          {fetchError && (
+          {!isCpuTorch && fetchError && (
             <div className="rounded-sm border border-err bg-err-soft px-2 py-1.5 text-err text-xs">
               {t('settings.githubApiFailed')}
               <code className="block mt-0.5 break-all">{fetchError}</code>
@@ -2809,7 +2819,7 @@ function FlashAttentionSection() {
           )}
 
           {/* 没匹配 wheel */}
-          {!canAutoInstall && !fetchError && env.platform && env.torch_tag && (
+          {!isCpuTorch && !canAutoInstall && !fetchError && env.platform && env.torch_tag && (
             <div className="rounded-sm border border-warn bg-warn-soft px-2 py-1.5 text-warn text-xs">
               {t('settings.noWheelForPython', { python: env.python_tag })}
             </div>

--- a/tests/_route_helpers.py
+++ b/tests/_route_helpers.py
@@ -1,0 +1,32 @@
+"""共享 route 内省 helper —— 兼容 FastAPI 0.137+ 把 include_router 包装成
+`_IncludedRouter` 的内部表示。
+
+行为变化（不是应用 bug，只影响 introspection 测试）：
+
+  0.136 及之前：
+    app.include_router(sub) → sub 的每个 APIRoute 直接 append 到 app.routes
+  0.137 起：
+    app.include_router(sub) → app.routes 多 1 个 `_IncludedRouter(original_router=sub)`
+    wrapper；要拿底层 APIRoute 必须走 `wrapper.original_router.routes` 递归
+
+HTTP routing dispatch 在两版上都正常（已用 TestClient 验证）。变化只影响
+直接遍历 `app.routes` 拿 APIRoute 实例的代码 —— 主要是测试。
+"""
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+
+def iter_leaf_routes(routes: list[Any]) -> Iterator[Any]:
+    """递归展开 `_IncludedRouter` wrapper，产出 APIRoute / Mount / etc 叶子。
+
+    跨 fastapi 版本兼容：
+    - 0.136：顶层即叶子（else 分支直接 yield）
+    - 0.137+：遇 wrapper 走 `original_router.routes` 再下钻
+    - 嵌套 include_router 也能正确展开
+    """
+    for r in routes:
+        if hasattr(r, "original_router") and hasattr(r.original_router, "routes"):
+            yield from iter_leaf_routes(r.original_router.routes)
+        else:
+            yield r

--- a/tests/test_client_errors_endpoint.py
+++ b/tests/test_client_errors_endpoint.py
@@ -183,7 +183,14 @@ def test_rate_limit_window_recovers(client: TestClient,
 
 
 def test_endpoint_registered_on_webui_app() -> None:
-    """app.py 必须 include_router(client_errors)，route 在 app.routes 内。"""
+    """app.py 必须 include_router(client_errors)，route 在 app.routes 内。
+
+    FastAPI 0.137+ 把 include_router 包成 `_IncludedRouter` wrapper —— 顶层
+    iter 看不到子 path，必须递归展开（详 tests/_route_helpers.py）。
+    """
     from studio.api.app import app
-    paths = {r.path for r in app.routes if hasattr(r, "path")}
+
+    from ._route_helpers import iter_leaf_routes
+
+    paths = {r.path for r in iter_leaf_routes(app.routes) if hasattr(r, "path")}
     assert "/api/client-errors" in paths

--- a/tests/test_route_invariants.py
+++ b/tests/test_route_invariants.py
@@ -16,14 +16,19 @@ from fastapi.routing import APIRoute
 
 from studio.server import app
 
+from ._route_helpers import iter_leaf_routes
+
 STUDIO_DIR = Path(__file__).parent.parent / "studio"
 SERVER_PY = STUDIO_DIR / "server.py"
 API_ROUTERS_DIR = STUDIO_DIR / "api" / "routers"
 
 
 def test_route_count_in_sane_range() -> None:
-    n = len(app.routes)
-    assert 100 <= n <= 250, f"len(app.routes) = {n}，超出合理区间 [100, 250]"
+    # FastAPI 0.137+ 把 include_router 包成 `_IncludedRouter` wrapper（详
+    # tests/_route_helpers.py），直接 len(app.routes) 在新版只数 wrapper 不数
+    # 内部 APIRoute；递归展开后才是真实路由数。
+    n = sum(1 for _ in iter_leaf_routes(app.routes))
+    assert 100 <= n <= 250, f"app.routes 展开后 = {n}，超出合理区间 [100, 250]"
 
 
 def test_decorator_count_matches_api_routes() -> None:
@@ -52,7 +57,7 @@ def test_decorator_count_matches_api_routes() -> None:
             )
 
     decorator_total = app_decorator_count + router_decorator_count
-    api_route_count = sum(1 for r in app.routes if isinstance(r, APIRoute))
+    api_route_count = sum(1 for r in iter_leaf_routes(app.routes) if isinstance(r, APIRoute))
     assert decorator_total == api_route_count, (
         f"装饰器总数 {decorator_total}（server.py {app_decorator_count} + "
         f"api/routers/ {router_decorator_count}）≠ app.routes 里 APIRoute 实例 "

--- a/tests/test_route_snapshot.py
+++ b/tests/test_route_snapshot.py
@@ -18,6 +18,8 @@ import pytest
 
 from studio.server import app
 
+from ._route_helpers import iter_leaf_routes
+
 SNAPSHOT_PATH = Path(__file__).parent / "_snapshots" / "studio_routes.json"
 SNAPSHOT_VERSION = 1
 
@@ -33,7 +35,10 @@ def _route_entry(route: Any) -> dict[str, Any]:
 
 
 def _collect_routes() -> list[dict[str, Any]]:
-    entries = [_route_entry(r) for r in app.routes]
+    # FastAPI 0.137+ 把 include_router 包成 `_IncludedRouter` wrapper（详
+    # tests/_route_helpers.py），递归展开后才与 0.136 行为一致 —— snapshot
+    # 文件不需要因为 fastapi 升级重新生成。
+    entries = [_route_entry(r) for r in iter_leaf_routes(app.routes)]
     # /studio 静态 Mount 是条件挂载（server.py 仅在前端 dist/ 存在时挂）——
     # CI 不构建前端，本地构建过；纳入 snapshot 会让结果依赖环境，排除。
     entries = [e for e in entries if not (e["type"] == "Mount" and e["path"] == "/studio")]


### PR DESCRIPTION
## 背景 / 动机

用户反馈首次启动引导（FirstRunOnboardingModal）里两条「失败」：

1. **放大模型**：`Error: unknown model_id 'upscalers'` —— 同一个模型在设置页正常下载。
2. **Flash Attention**：`Error: Internal Server Error (see trace_id in server log)` —— 看不出原因。截图里用户 PyTorch 是 CPU 版（torch 2.12.0+cpu），实际是 CPU 版 torch 装不了 flash_attn 的根本约束，但错误信息没体现。

两个都是 v0.13.1 上的实际报错路径，不能等下次 release。

## 改动概要

### Commit 1：放大模型 model_id 复数 / 单数错位（纯 bug）

后端 `studio/services/models/downloader.py` 注册的 model_id 是单数 `upscaler`，下载 key 形如 `upscaler:4x-AnimeSharp`。Onboarding modal 里 3 处字面量用了复数 `upscalers`：
- `startModelDownload({ model_id: 'upscalers', ... })` → 后端拒为 `unknown model_id 'upscalers'`
- `liveLogs` / `waitForCatalog` 的 key 前缀 filter 同样错用复数，下载状态在 modal 里收不到

三处全改单数。catalog 字段 `catalog.upscalers` 保持复数不动（catalog schema 字段名）。

### Commit 2：flash_attn 错误信息变得 actionable

CPU 版 torch 上装 flash_attn 必然失败（C extension 依赖 CUDA runtime），但原实现把这种情况包成两类含混报错：

1. `/api/flash-attention/status` 的 `detect_env()` 路径有未捕获异常通道：Windows DLL 加载失败抛 `OSError` 而非 `ImportError`；中文 locale (cp936) 下 nvidia-smi 输出可能让 `subprocess.run(text=True)` 抛 `UnicodeDecodeError`（不在原 `(SubprocessError, OSError)` 之列）。任一发生 → status 直接 500 → Settings UI 只看到 `Internal Server Error`。
2. `install()` 走 auto-match 时，`detect_env` 把 nvidia-smi 报的 cu130 当作 cuda_tag，`find_best_wheel` 在「cu130 + torch+cpu」组合查不到 wheel → 报「未找到可用 wheel」误导用户去排网络问题。

修复：

- `detect_env()` 新增 `torch_cuda_build` 字段（`cu128` / `cu130` / `cpu` / `None`），所有 except 放宽到 `Exception`，`subprocess.run` 加 `errors='replace'`
- `install()` auto 路径先检测 `torch_cuda_build == 'cpu'` → 抛清楚的 `RuntimeError` 指向「设置 → PyTorch」重装 CUDA 版（显式给 URL 的路径不挡，留给强制安装）
- `/api/flash-attention/status` 路由整体 try/except 兜底：意外异常包成 `fetch_error` 返回 200 + `logger.exception` 落盘 trace_id 供后端排查 → Settings 整段 UI 不再红屏
- 前端 `FlashAttnEnv` 加 `torch_cuda_build` 字段；Settings 的 `FlashAttentionSection` 检测 CPU torch → 优先显示新文案 `settings.flashAttnNeedsCudaTorch`（zh/en）+ disable 自动安装按钮

## 测试方式

- 本地 venv (Py3.13):
  - `pytest tests/test_flash_attention_setup.py tests/test_route_snapshot.py tests/test_studio_configs.py -q` → **61 passed**
  - `cd studio/web && npx vitest run` → **381 passed, 38 files**
  - `npx tsc --noEmit` → 零错误
- 既有测试不破坏：`detect_env` 返回 dict 多 1 个字段，旧测试不做 strict equality；`install()` 的 CPU pre-check 只在 url=None 分支生效，`test_install_pip_failure_raises` 等显式 URL 测试不受影响

## 为什么走 hotfix

- v0.13.1 已发布，用户实际碰到「首次启动引导一键装东西就报错」是直接 UX 阻塞
- 第一条是纯字符串拼错的硬 bug，dev 上有 PR #272 (TREAD) 等其它在做的功能不该跟着发；走 hotfix 直接进 master + 同步回 dev 才能不绑定其它在飞 feature

合并后请按 CONTRIBUTING 走 §「Hotfix 加急路径」第 4 / 5 步（bump PATCH + tag + sync 回 dev）。