### PR TITLE
feat(train): add LeapAlign and SRA training options

### DIFF
--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -75,6 +75,7 @@ class TrainingContext:
     scheduler: Any = None
     timestep_sampler: Any = None    # training.timestep_samplers.TimestepSamplerProtocol
     loss_fn: Optional["LossProtocol"] = None
+    sra_aligner: Any = None         # training.sra_align.SRAAligner (optional)
 
     # ─── resume_phase 填充 ───
     global_step: int = 0

--- a/runtime/training/leap.py
+++ b/runtime/training/leap.py
@@ -1,0 +1,130 @@
+"""LeapAlign 两步跳跃自蒸馏训练步（去奖励模型版）。
+
+源自 LeapAlign 论文 (arXiv 2604.15311v2) 的 two-step leap trajectory，但去掉了
+奖励模型，把"最大化奖励"换成"两步跳跃预测的 x0 逼近数据集真实 x0"的自蒸馏目标。
+
+与原版 LeapAlign_Code/fastvideo/train_leapalign_flux.py 的关键区别：
+- 原版必须先 online rollout 跑完整采样轨迹拿 x0（最吃显存）；这里数据集本就有真实
+  x0，直接加噪到任意时刻，**无需 rollout**，天然适配 LoRA。
+- 原版 loss = max(0, λ - reward(x0))，唯一信号来自奖励模型；这里 loss = MSE(x̂0, x0)，
+  信号来自真实数据。
+- 保留：two-step leap、latent connector、gradient discounting、traj-sim weighting。
+
+约定 rectified flow（与 training/loop.py 一致）：
+- t=0 为数据端，t=1 为噪声端
+- x_t = (1-t)·x0 + t·x1，velocity v = x1 - x0
+- 一步跳跃（从时刻 a 跳到时刻 b，a>b）：x̂_b = x_a - (a-b)·v_θ(x_a, a)
+"""
+
+from __future__ import annotations
+
+import torch
+
+from training.model_loading import forward_with_optional_checkpoint
+
+
+def sample_two_timesteps(
+    bs: int,
+    device,
+    min_gap: float = 0.1,
+    dtype: torch.dtype = torch.float32,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """per-sample 采样两个时刻 (k, j)，保证 k > j 且间隔 ≥ min_gap，均 ∈ (0,1)。
+
+    k 偏噪声端（大 t），j 偏数据端（小 t）。先在 (0,1) 采两点排序成 (hi, lo)，
+    间隔不足时把 hi 往噪声端推、lo 往数据端拉，再 clamp 回开区间。
+    """
+    a = torch.rand(bs, device=device, dtype=dtype)
+    b = torch.rand(bs, device=device, dtype=dtype)
+    k = torch.maximum(a, b)
+    j = torch.minimum(a, b)
+
+    # 间隔不足 min_gap 时撑开：各取一半缺口往两端推
+    deficit = (min_gap - (k - j)).clamp(min=0.0) * 0.5
+    k = k + deficit
+    j = j - deficit
+
+    eps = 1e-3
+    k = k.clamp(min=eps + min_gap, max=1.0 - eps)
+    # j 上界是 per-sample 的 (k - eps)，clamp 不接受张量上界，用 minimum + 标量下界
+    j = torch.minimum(j, k - eps).clamp(min=eps)
+    return k, j
+
+
+def leap_training_step(
+    model,
+    x0: torch.Tensor,
+    noise: torch.Tensor,
+    cross: torch.Tensor,
+    pad_mask: torch.Tensor,
+    t_k: torch.Tensor,
+    t_j: torch.Tensor,
+    *,
+    nested_grad_coe: float = 0.3,
+    traj_sim_weighting: bool = False,
+    traj_sim_min: float = 0.1,
+    use_checkpoint: bool = False,
+) -> torch.Tensor:
+    """两步跳跃自蒸馏，返回 per-sample loss (B,)（未 reduction，未乘外部样本权重）。
+
+    Args:
+        model        — Anima transformer（接受 (B,) per-sample timestep）
+        x0           — 真实 latent，shape (B,C,T,H,W)
+        noise        — 噪声 x1，与 x0 同 shape（由 make_noise 生成）
+        cross        — 文本条件 embedding
+        pad_mask     — padding mask
+        t_k, t_j     — per-sample 时刻 (B,)，t_k > t_j
+        nested_grad_coe   — 梯度折扣 α（论文 Eq 9）：缩放嵌套梯度，0=砍掉/1=不折扣
+        traj_sim_weighting — 是否启用轨迹相似度加权（论文 Eq 12）
+        traj_sim_min       — 相似度加权下限 τ（防近乎相同的对被过度放大）
+        use_checkpoint     — 模型前向是否走梯度检查点
+    """
+    # 广播到 latent 维度 (B,1,1,1,1)
+    k = t_k.view(-1, *([1] * (x0.ndim - 1)))
+    j = t_j.view(-1, *([1] * (x0.ndim - 1)))
+
+    # 真实带噪 latent（无需 rollout）
+    x_k = (1.0 - k) * x0 + k * noise
+    x_j_real = (1.0 - j) * x0 + j * noise
+
+    # ── 第一跳（带梯度）：x_k --v_k--> x̂_{j|k} ──
+    v_k = forward_with_optional_checkpoint(
+        model, x_k, t_k.view(-1, 1), cross, pad_mask, use_checkpoint=use_checkpoint,
+    )
+    x_hat_j = x_k - (k - j) * v_k
+
+    # ── latent connector（论文 Eq 6）：前向数值=真值，反向梯度流回 v_k ──
+    x_j = x_hat_j + (x_j_real - x_hat_j).detach()
+
+    # ── 梯度折扣（论文 Eq 9）：缩放第二跳对 x_j 的嵌套梯度为 α 倍 ──
+    if nested_grad_coe <= 0.0:
+        x_j_in = x_j.detach()
+    elif nested_grad_coe >= 1.0:
+        x_j_in = x_j
+    else:
+        x_j_in = nested_grad_coe * x_j + (1.0 - nested_grad_coe) * x_j.detach()
+
+    # ── 第二跳（带梯度）：x_j --v_j--> x̂_{0|j} ──
+    v_j = forward_with_optional_checkpoint(
+        model, x_j_in, t_j.view(-1, 1), cross, pad_mask, use_checkpoint=use_checkpoint,
+    )
+    x_hat_0 = x_j - j * v_j
+
+    # ── 自蒸馏 loss：两步跳跃预测的 x̂0 逼近真实 x0（取代奖励）──
+    loss_per_sample = (x_hat_0.float() - x0.float()).pow(2).mean(
+        dim=tuple(range(1, x0.ndim))
+    )
+
+    # ── 轨迹相似度加权（论文 Eq 12）：跳跃越贴近真实路径，权重越高 ──
+    if traj_sim_weighting:
+        with torch.no_grad():
+            d_j = (x_j_real.float() - x_hat_j.float()).abs().mean(
+                dim=tuple(range(1, x0.ndim))
+            ).clamp(min=traj_sim_min)
+            d_0 = (x0.float() - x_hat_0.float()).abs().mean(
+                dim=tuple(range(1, x0.ndim))
+            ).clamp(min=traj_sim_min)
+            w_sim = 1.0 / (d_j + d_0)
+        loss_per_sample = loss_per_sample * w_sim
+
+    return loss_per_sample

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -218,13 +218,7 @@ def run(ctx: TrainingContext) -> None:
                 if ctx.sra_aligner is not None and not use_leap_this_step:
                     align_loss = ctx.sra_aligner.compute(latents)
                     sra_weight = float(getattr(args, "sra_weight", 1.0) or 1.0)
-                    sra_decay_start = int(getattr(args, "sra_decay_start_epoch", 20) or 20)
-                    if epoch > sra_decay_start:
-                        decay = 0.1 ** ((epoch - sra_decay_start) / 1000 + 1)
-                    else:
-                        decay = 1.0
-                    weighted_align = sra_weight * decay * align_loss
-                    loss = loss + weighted_align
+                    loss = loss + sra_weight * align_loss
                     if ctx.global_step % args.log_every == 0:
                         ctx.wandb_monitor.log({"train/sra_align_loss": float(align_loss.item())}, step=ctx.global_step)
 

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -9,6 +9,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import time
 from typing import Any
 
@@ -44,6 +45,38 @@ def _resolve_sra_weight(args: Any) -> float:
     """Read sra_weight without treating explicit 0 as a missing value."""
     raw = getattr(args, "sra_weight", 1.0)
     return 1.0 if raw is None else float(raw)
+
+
+def _resolve_sra_effective_weight(args: Any, global_step: int, total_steps: int | None) -> float:
+    """Apply the configured SRA schedule to the base SRA weight."""
+    base = _resolve_sra_weight(args)
+    if base == 0.0:
+        return 0.0
+
+    decay_type = str(getattr(args, "sra_decay_type", "none") or "none").lower()
+    if decay_type == "none" or not total_steps or total_steps <= 0:
+        return base
+
+    start = float(getattr(args, "sra_decay_start_ratio", 0.2) or 0.0)
+    end = float(getattr(args, "sra_decay_end_ratio", 0.3) or 0.0)
+    progress = max(0.0, min(1.0, float(global_step) / float(total_steps)))
+
+    if decay_type == "jump":
+        return base if progress < start else 0.0
+
+    if progress <= start:
+        return base
+    if progress >= end:
+        return 0.0
+
+    x = (progress - start) / max(end - start, 1e-8)
+    if decay_type == "linear":
+        scale = 1.0 - x
+    elif decay_type == "cosine":
+        scale = 0.5 * (1.0 + math.cos(math.pi * x))
+    else:
+        scale = 1.0
+    return base * max(0.0, min(1.0, scale))
 
 
 def run(ctx: TrainingContext) -> None:
@@ -145,6 +178,10 @@ def run(ctx: TrainingContext) -> None:
 
             # 前向
             pad_mask = torch.zeros(bs, 1, latents.shape[-2], latents.shape[-1], device=ctx.device, dtype=ctx.dtype)
+            denoise_loss_log = None
+            sra_align_loss_log = None
+            sra_weighted_loss_log = None
+            sra_effective_weight_log = None
             with torch.autocast("cuda", dtype=ctx.dtype):
                 if use_leap_this_step:
                     # ── LeapAlign 两步跳跃自蒸馏路径 ──
@@ -171,6 +208,7 @@ def run(ctx: TrainingContext) -> None:
                         w = batch["loss_weight"].to(ctx.device).view(-1, *([1] * (loss_per_sample.dim() - 1)))
                         loss_per_sample = loss_per_sample * w
                     loss = loss_per_sample.mean()
+                    denoise_loss_log = loss.detach()
                 else:
                     # ── 标准 rectified flow 路径（零行为变化）──
                     noisy = (1 - t_exp) * latents + t_exp * noise
@@ -219,18 +257,23 @@ def run(ctx: TrainingContext) -> None:
                         ).to(device=ctx.device, dtype=torch.float32)
                         loss_per_sample = loss_per_sample * lw.view(-1, *([1] * (loss_per_sample.dim() - 1)))
                     loss = loss_per_sample.mean()
+                    denoise_loss_log = loss.detach()
 
                 # SRA v2 表征对齐 loss（标准路径；leap 路径不适用）
                 if ctx.sra_aligner is not None and not use_leap_this_step:
-                    sra_weight = _resolve_sra_weight(args)
+                    sra_weight = _resolve_sra_effective_weight(args, ctx.global_step, ctx.total_steps)
+                    sra_effective_weight_log = sra_weight
                     if sra_weight != 0.0:
                         align_loss = ctx.sra_aligner.compute(
                             latents,
                             sample_weight=batch.get("loss_weight"),
                         )
-                        loss = loss + sra_weight * align_loss
-                        if ctx.global_step % args.log_every == 0:
-                            ctx.wandb_monitor.log({"train/sra_align_loss": float(align_loss.item())}, step=ctx.global_step)
+                        weighted_align_loss = sra_weight * align_loss
+                        loss = loss + weighted_align_loss
+                        sra_align_loss_log = align_loss.detach()
+                        sra_weighted_loss_log = weighted_align_loss.detach()
+                    else:
+                        sra_weighted_loss_log = loss.new_tensor(0.0).detach()
 
                 # PR-C：adapter hook — 变体可加正则项（OFT orth penalty /
                 # Ortho-Hydra balance loss 等）。LyCORIS 返回 None，noop。
@@ -272,6 +315,18 @@ def run(ctx: TrainingContext) -> None:
 
                 # 记录 loss 历史
                 loss_val = float(loss.item() * args.grad_accum)
+                denoise_loss_val = (
+                    float(denoise_loss_log.item())
+                    if denoise_loss_log is not None else loss_val
+                )
+                sra_align_loss_val = (
+                    float(sra_align_loss_log.item())
+                    if sra_align_loss_log is not None else None
+                )
+                sra_weighted_loss_val = (
+                    float(sra_weighted_loss_log.item())
+                    if sra_weighted_loss_log is not None else None
+                )
                 epoch_loss_sum += loss_val
                 epoch_step_count += 1
                 if args.loss_curve_steps and len(ctx.loss_history) < args.loss_curve_steps:
@@ -286,12 +341,20 @@ def run(ctx: TrainingContext) -> None:
                 if ctx.monitor_server:
                     try:
                         from train_monitor import update_monitor
+                        monitor_metrics = dict(optimizer_metrics)
+                        monitor_metrics["denoise_loss"] = denoise_loss_val
+                        if sra_align_loss_val is not None:
+                            monitor_metrics["sra_align_loss"] = sra_align_loss_val
+                        if sra_weighted_loss_val is not None:
+                            monitor_metrics["sra_weighted_loss"] = sra_weighted_loss_val
+                        if sra_effective_weight_log is not None:
+                            monitor_metrics["sra_effective_weight"] = float(sra_effective_weight_log)
                         update_monitor(
                             loss=loss_val, lr=lr, epoch=epoch + 1,
                             total_epochs=int(args.epochs or 0),
                             step=ctx.global_step,
                             total_steps=ctx.total_steps, speed=ctx.speed_ema or 0,
-                            optimizer_metrics=optimizer_metrics,
+                            optimizer_metrics=monitor_metrics,
                         )
                     except Exception:
                         pass
@@ -300,9 +363,16 @@ def run(ctx: TrainingContext) -> None:
                 ctx.speed_ema = steps_per_sec if ctx.speed_ema is None else (0.9 * ctx.speed_ema + 0.1 * steps_per_sec)
                 log_payload: dict[str, Any] = {
                     "train/loss": loss_val,
+                    "train/denoise_loss": denoise_loss_val,
                     "train/lr": float(lr),
                     "train/speed_it_s": float(ctx.speed_ema or 0),
                 }
+                if sra_align_loss_val is not None:
+                    log_payload["train/sra_align_loss"] = sra_align_loss_val
+                if sra_weighted_loss_val is not None:
+                    log_payload["train/sra_weighted_loss"] = sra_weighted_loss_val
+                if sra_effective_weight_log is not None:
+                    log_payload["train/sra_effective_weight"] = float(sra_effective_weight_log)
                 if "d" in optimizer_metrics:
                     log_payload["train/optimizer_d"] = float(optimizer_metrics["d"])
                 if "base_lr" in optimizer_metrics:
@@ -331,9 +401,23 @@ def run(ctx: TrainingContext) -> None:
                             from rich.console import Group
                             ctx.live.update(Group(ctx.progress, panel))
                 elif ctx.use_plain:
-                    print(f"epoch {epoch+1}/{args.epochs} step {ctx.global_step} loss={loss_val:.6f} lr={lr:.2e} speed={ctx.speed_ema:.2f} it/s", end="\r", flush=True)
+                    sra_suffix = (
+                        f" denoise={denoise_loss_val:.6f}"
+                        f" sra={sra_align_loss_val:.6f}"
+                        f" sra_w={sra_weighted_loss_val:.6f}"
+                        if sra_align_loss_val is not None and sra_weighted_loss_val is not None
+                        else f" denoise={denoise_loss_val:.6f}"
+                    )
+                    print(f"epoch {epoch+1}/{args.epochs} step {ctx.global_step} loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} speed={ctx.speed_ema:.2f} it/s", end="\r", flush=True)
                 elif args.log_every and ctx.global_step % args.log_every == 0:
-                    print(f"epoch={epoch} step={ctx.global_step} loss={loss_val:.6f} lr={lr:.2e} speed={steps_per_sec:.2f} it/s")
+                    sra_suffix = (
+                        f" denoise={denoise_loss_val:.6f}"
+                        f" sra={sra_align_loss_val:.6f}"
+                        f" sra_w={sra_weighted_loss_val:.6f}"
+                        if sra_align_loss_val is not None and sra_weighted_loss_val is not None
+                        else f" denoise={denoise_loss_val:.6f}"
+                    )
+                    print(f"epoch={epoch} step={ctx.global_step} loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} speed={steps_per_sec:.2f} it/s")
 
                 # 按 step 采样（轮换提示词）
                 if args.sample_steps > 0 and ctx.global_step % args.sample_steps == 0:

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -214,6 +214,20 @@ def run(ctx: TrainingContext) -> None:
                         loss_per_sample = loss_per_sample * lw.view(-1, *([1] * (loss_per_sample.dim() - 1)))
                     loss = loss_per_sample.mean()
 
+                # SRA v2 表征对齐 loss（标准路径；leap 路径不适用）
+                if ctx.sra_aligner is not None and not use_leap_this_step:
+                    align_loss = ctx.sra_aligner.compute(latents)
+                    sra_weight = float(getattr(args, "sra_weight", 1.0) or 1.0)
+                    sra_decay_start = int(getattr(args, "sra_decay_start_epoch", 20) or 20)
+                    if epoch > sra_decay_start:
+                        decay = 0.1 ** ((epoch - sra_decay_start) / 1000 + 1)
+                    else:
+                        decay = 1.0
+                    weighted_align = sra_weight * decay * align_loss
+                    loss = loss + weighted_align
+                    if ctx.global_step % args.log_every == 0:
+                        ctx.wandb_monitor.log({"train/sra_align_loss": float(align_loss.item())}, step=ctx.global_step)
+
                 # PR-C：adapter hook — 变体可加正则项（OFT orth penalty /
                 # Ortho-Hydra balance loss 等）。LyCORIS 返回 None，noop。
                 reg = ctx.injector.regularization_loss(step_ctx)

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -40,6 +40,12 @@ from utils.optimizer_utils import get_optimizer_monitor_metrics, optimizer_eval_
 logger = logging.getLogger(__name__)
 
 
+def _resolve_sra_weight(args: Any) -> float:
+    """Read sra_weight without treating explicit 0 as a missing value."""
+    raw = getattr(args, "sra_weight", 1.0)
+    return 1.0 if raw is None else float(raw)
+
+
 def run(ctx: TrainingContext) -> None:
     """跑训练直到 args.epochs 或 args.max_steps 上限。"""
     args = ctx.args
@@ -216,11 +222,15 @@ def run(ctx: TrainingContext) -> None:
 
                 # SRA v2 表征对齐 loss（标准路径；leap 路径不适用）
                 if ctx.sra_aligner is not None and not use_leap_this_step:
-                    align_loss = ctx.sra_aligner.compute(latents)
-                    sra_weight = float(getattr(args, "sra_weight", 1.0) or 1.0)
-                    loss = loss + sra_weight * align_loss
-                    if ctx.global_step % args.log_every == 0:
-                        ctx.wandb_monitor.log({"train/sra_align_loss": float(align_loss.item())}, step=ctx.global_step)
+                    sra_weight = _resolve_sra_weight(args)
+                    if sra_weight != 0.0:
+                        align_loss = ctx.sra_aligner.compute(
+                            latents,
+                            sample_weight=batch.get("loss_weight"),
+                        )
+                        loss = loss + sra_weight * align_loss
+                        if ctx.global_step % args.log_every == 0:
+                            ctx.wandb_monitor.log({"train/sra_align_loss": float(align_loss.item())}, step=ctx.global_step)
 
                 # PR-C：adapter hook — 变体可加正则项（OFT orth penalty /
                 # Ortho-Hydra balance loss 等）。LyCORIS 返回 None，noop。
@@ -367,6 +377,7 @@ def run(ctx: TrainingContext) -> None:
                             state_path, ctx.injector, ctx.optimizer, epoch, ctx.global_step,
                             ctx.loss_history, monitor_state=monitor_data, scheduler=ctx.scheduler,
                             timestep_sampler=ctx.timestep_sampler,
+                            sra_aligner=ctx.sra_aligner,
                         )
                         # 同时保存 LoRA 权重
                         lora_path = ctx.output_dir / f"{args.output_name}_step{ctx.global_step}.safetensors"
@@ -431,6 +442,7 @@ def run(ctx: TrainingContext) -> None:
                         state_path, ctx.injector, ctx.optimizer, ctx.current_epoch, ctx.global_step,
                         ctx.loss_history, monitor_state=monitor_data, scheduler=ctx.scheduler,
                         timestep_sampler=ctx.timestep_sampler,
+                        sra_aligner=ctx.sra_aligner,
                     )
                     lora_path = ctx.output_dir / f"{args.output_name}_epoch{ctx.current_epoch}.safetensors"
                     if not lora_path.exists():
@@ -461,6 +473,7 @@ def run(ctx: TrainingContext) -> None:
                     ctx.current_epoch, ctx.global_step, ctx.loss_history,
                     monitor_state=monitor_data, scheduler=ctx.scheduler,
                     timestep_sampler=ctx.timestep_sampler,
+                    sra_aligner=ctx.sra_aligner,
                 )
             ctx.wandb_monitor.upload_state_auto(auto_state_path)
             # 更新 ctx 字段供 handle_interrupt emit pause_state 用

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -128,56 +128,91 @@ def run(ctx: TrainingContext) -> None:
                 pyramid_iters=int(getattr(args, "pyramid_noise_iters", 0) or 0),
                 pyramid_discount=float(getattr(args, "pyramid_noise_discount", 0.35) or 0.35),
             )
-            noisy = (1 - t_exp) * latents + t_exp * noise
-            target = noise - latents
+
+            leap_enabled = bool(getattr(args, "leap_enabled", False))
+            # 方式 A 混合训练：每个 micro-batch 按 leap_ratio 概率掷骰子决定走哪条目标。
+            # leap 管全局结构、传统管细节锐度，两股梯度叠在同一组 LoRA 权重上各取所长。
+            # ratio=1.0 纯 leap（默认，不破坏纯 leap 行为）；0.0 纯传统；0.6 大头 leap 留点细节。
+            use_leap_this_step = leap_enabled and (
+                torch.rand(1).item() < float(getattr(args, "leap_ratio", 1.0) or 1.0)
+            )
 
             # 前向
             pad_mask = torch.zeros(bs, 1, latents.shape[-2], latents.shape[-1], device=ctx.device, dtype=ctx.dtype)
             with torch.autocast("cuda", dtype=ctx.dtype):
-                pred = forward_with_optional_checkpoint(
-                    ctx.model, noisy, t.view(-1, 1), cross, pad_mask,
-                    use_checkpoint=args.grad_checkpoint,
-                )
-                # 训练 loss 通过 losses/ plugin registry 派发（mse / huber / ...）
-                loss_per_sample = ctx.loss_fn.compute(pred.float(), target.float(), t)
-                # 自适应采样器（如 InfoNoise）记录原始 per-sample MSE（不受 huber/loss_weighting 等
-                # 加工影响）；跟训练 loss 解耦保证 InfoNoise 论文一致性。
-                # baseline 采样器是 no-op，无需 if 守卫。
-                # 用 no_grad 避免构造 autograd 元数据（比 .detach() 少一份 grad_fn 开销）。
-                with torch.no_grad():
-                    _raw_mse_per_sample = F.mse_loss(pred.float(), target.float(), reduction="none")
-                    _raw_mse = _raw_mse_per_sample.mean(
-                        dim=list(range(1, _raw_mse_per_sample.dim()))
+                if use_leap_this_step:
+                    # ── LeapAlign 两步跳跃自蒸馏路径 ──
+                    # 用真实 latent 当 x0，per-sample 采两个时刻 (k,j) 做两步跳跃，
+                    # 自蒸馏 loss = MSE(两步跳跃预测的 x̂0, 真实 x0)。详见 training/leap.py。
+                    from training.leap import leap_training_step, sample_two_timesteps
+                    t_k, t_j = sample_two_timesteps(
+                        bs, ctx.device,
+                        min_gap=float(getattr(args, "leap_min_gap", 0.1) or 0.1),
+                        dtype=torch.float32,
                     )
-                # 仅 main 集样本进 InfoNoise schedule 学习：I-MMSE 假设单一数据分布，
-                # reg 集典型是通用图（booru）vs main 集是单一主题，混入 record 学到的是
-                # mixture MMSE 不是 mmse_main(t)。用 is_reg flag 而非 loss_weight 阈值
-                # 是因为 distribution identity 跟 gradient 权重是两条独立轴
-                # （reg_weight=1.0 时 loss_weight=1.0 但 reg 仍是不同分布）。
-                # 见 docs/todo/infonoise-reg-policy-reeval.md 未来重评估条件。
-                if "is_reg" in batch:
-                    _main_mask = ~batch["is_reg"].to(t.device)
-                    if _main_mask.any():
-                        ctx.timestep_sampler.record(t.detach()[_main_mask], _raw_mse[_main_mask])
+                    loss_per_sample = leap_training_step(
+                        ctx.model, latents, noise, cross, pad_mask, t_k, t_j,
+                        nested_grad_coe=float(getattr(args, "leap_nested_grad_coe", 0.3)),
+                        traj_sim_weighting=bool(getattr(args, "leap_traj_sim_weighting", False)),
+                        traj_sim_min=float(getattr(args, "leap_traj_sim_min", 0.1) or 0.1),
+                        use_checkpoint=args.grad_checkpoint,
+                    )
+                    # leap 路径有意跳过两个标准机制（互斥校验已在 TrainingConfig 强制关闭）：
+                    #   - InfoNoise record：双 timestep 与单 t 的 I-MMSE 语义不匹配
+                    #   - loss_weighting：依赖单一 t 算 SNR 权重；leap 自带 traj_sim 加权
+                    # 仍尊重 batch 的 loss_weight（正则集降权），与标准路径一致。
+                    if "loss_weight" in batch:
+                        w = batch["loss_weight"].to(ctx.device).view(-1, *([1] * (loss_per_sample.dim() - 1)))
+                        loss_per_sample = loss_per_sample * w
+                    loss = loss_per_sample.mean()
                 else:
-                    ctx.timestep_sampler.record(t.detach(), _raw_mse)
-                # 按样本加权（正则集可降低权重）
-                if "loss_weight" in batch:
-                    w = batch["loss_weight"].to(ctx.device).view(-1, *([1] * (loss_per_sample.dim() - 1)))
-                    loss_per_sample = loss_per_sample * w
-                # timestep-dependent loss 权重
-                lw_scheme = str(getattr(args, "loss_weighting", "none") or "none")
-                if lw_scheme != "none":
-                    lw = compute_loss_weight(
-                        t,
-                        scheme=lw_scheme,
-                        min_snr_gamma=float(getattr(args, "min_snr_gamma", 5.0) or 5.0),
-                        weight_cap_ratio=float(getattr(args, "weight_cap_ratio", 0.0) or 0.0),
-                        detail_inv_t_min=float(getattr(args, "detail_inv_t_min", 1.0) or 1.0),
-                        detail_inv_t_max=float(getattr(args, "detail_inv_t_max", 5.0) or 5.0),
-                    ).to(device=ctx.device, dtype=torch.float32)
-                    loss_per_sample = loss_per_sample * lw.view(-1, *([1] * (loss_per_sample.dim() - 1)))
-                loss = loss_per_sample.mean()
+                    # ── 标准 rectified flow 路径（零行为变化）──
+                    noisy = (1 - t_exp) * latents + t_exp * noise
+                    target = noise - latents
+                    pred = forward_with_optional_checkpoint(
+                        ctx.model, noisy, t.view(-1, 1), cross, pad_mask,
+                        use_checkpoint=args.grad_checkpoint,
+                    )
+                    # 训练 loss 通过 losses/ plugin registry 派发（mse / huber / ...）
+                    loss_per_sample = ctx.loss_fn.compute(pred.float(), target.float(), t)
+                    # 自适应采样器（如 InfoNoise）记录原始 per-sample MSE（不受 huber/loss_weighting 等
+                    # 加工影响）；跟训练 loss 解耦保证 InfoNoise 论文一致性。
+                    # baseline 采样器是 no-op，无需 if 守卫。
+                    # 用 no_grad 避免构造 autograd 元数据（比 .detach() 少一份 grad_fn 开销）。
+                    with torch.no_grad():
+                        _raw_mse_per_sample = F.mse_loss(pred.float(), target.float(), reduction="none")
+                        _raw_mse = _raw_mse_per_sample.mean(
+                            dim=list(range(1, _raw_mse_per_sample.dim()))
+                        )
+                    # 仅 main 集样本进 InfoNoise schedule 学习：I-MMSE 假设单一数据分布，
+                    # reg 集典型是通用图（booru）vs main 集是单一主题，混入 record 学到的是
+                    # mixture MMSE 不是 mmse_main(t)。用 is_reg flag 而非 loss_weight 阈值
+                    # 是因为 distribution identity 跟 gradient 权重是两条独立轴
+                    # （reg_weight=1.0 时 loss_weight=1.0 但 reg 仍是不同分布）。
+                    # 见 docs/todo/infonoise-reg-policy-reeval.md 未来重评估条件。
+                    if "is_reg" in batch:
+                        _main_mask = ~batch["is_reg"].to(t.device)
+                        if _main_mask.any():
+                            ctx.timestep_sampler.record(t.detach()[_main_mask], _raw_mse[_main_mask])
+                    else:
+                        ctx.timestep_sampler.record(t.detach(), _raw_mse)
+                    # 按样本加权（正则集可降低权重）
+                    if "loss_weight" in batch:
+                        w = batch["loss_weight"].to(ctx.device).view(-1, *([1] * (loss_per_sample.dim() - 1)))
+                        loss_per_sample = loss_per_sample * w
+                    # timestep-dependent loss 权重
+                    lw_scheme = str(getattr(args, "loss_weighting", "none") or "none")
+                    if lw_scheme != "none":
+                        lw = compute_loss_weight(
+                            t,
+                            scheme=lw_scheme,
+                            min_snr_gamma=float(getattr(args, "min_snr_gamma", 5.0) or 5.0),
+                            weight_cap_ratio=float(getattr(args, "weight_cap_ratio", 0.0) or 0.0),
+                            detail_inv_t_min=float(getattr(args, "detail_inv_t_min", 1.0) or 1.0),
+                            detail_inv_t_max=float(getattr(args, "detail_inv_t_max", 5.0) or 5.0),
+                        ).to(device=ctx.device, dtype=torch.float32)
+                        loss_per_sample = loss_per_sample * lw.view(-1, *([1] * (loss_per_sample.dim() - 1)))
+                    loss = loss_per_sample.mean()
 
                 # PR-C：adapter hook — 变体可加正则项（OFT orth penalty /
                 # Ortho-Hydra balance loss 等）。LyCORIS 返回 None，noop。

--- a/runtime/training/phases/finalize.py
+++ b/runtime/training/phases/finalize.py
@@ -30,6 +30,11 @@ def run(ctx: TrainingContext) -> None:
     with optimizer_eval_mode(ctx.optimizer):
         ctx.injector.save(final_path)
 
+    # 清理 SRA v2 hook（MLP 不保存到 LoRA safetensors，训练完即丢弃）
+    if ctx.sra_aligner is not None:
+        ctx.sra_aligner.remove_hooks()
+        ctx.sra_aligner = None
+
     # 清理进度显示
     if ctx.live:
         ctx.live.stop()

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -93,3 +93,22 @@ def run(ctx: TrainingContext) -> None:
     if getattr(args, "resume_lora", "") and Path(args.resume_lora).exists():
         ctx.injector.load(args.resume_lora)
         logger.info(f"将从已有 LoRA 继续训练: {args.resume_lora}")
+
+    # SRA v2 表征对齐（LoRA 注入后构造）
+    if getattr(args, "sra_enabled", False):
+        from training.sra_align import SRAAligner
+        model_channels = ctx.model.dim
+        block_idx = int(getattr(args, "sra_block", 4))
+        num_blocks = len(ctx.model.blocks)
+        if block_idx >= num_blocks:
+            logger.warning(f"sra_block={block_idx} >= 模型 blocks 数({num_blocks})，clamp 到 {num_blocks - 1}")
+            block_idx = num_blocks - 1
+        ctx.sra_aligner = SRAAligner(
+            model=ctx.model,
+            block_idx=block_idx,
+            patch_spatial=2,
+            model_channels=model_channels,
+            vae_channels=16,
+            device=ctx.device,
+            dtype=ctx.dtype,
+        )

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -97,7 +97,7 @@ def run(ctx: TrainingContext) -> None:
     # SRA v2 表征对齐（LoRA 注入后构造）
     if getattr(args, "sra_enabled", False):
         from training.sra_align import SRAAligner
-        model_channels = ctx.model.dim
+        model_channels = ctx.model.model_channels
         block_idx = int(getattr(args, "sra_block", 4))
         num_blocks = len(ctx.model.blocks)
         if block_idx >= num_blocks:

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -106,7 +106,8 @@ def run(ctx: TrainingContext) -> None:
         ctx.sra_aligner = SRAAligner(
             model=ctx.model,
             block_idx=block_idx,
-            patch_spatial=2,
+            patch_spatial=ctx.model.patch_spatial,
+            patch_temporal=ctx.model.patch_temporal,
             model_channels=model_channels,
             vae_channels=16,
             device=ctx.device,

--- a/runtime/training/phases/optimizer.py
+++ b/runtime/training/phases/optimizer.py
@@ -31,6 +31,12 @@ def run(ctx: TrainingContext) -> None:
     param_groups = ctx.injector.get_param_groups(ctx.weight_decay)
     ctx.optimizer_type = (getattr(args, "optimizer_type", "adamw") or "adamw").lower()
 
+    # SRA v2：projection MLP 的参数加入 optimizer（weight_decay=0，可选独立 lr）
+    if ctx.sra_aligner is not None:
+        sra_groups = ctx.sra_aligner.get_param_groups(lr=None)
+        param_groups = param_groups + sra_groups
+        logger.info(f"SRA v2: 已将 projection MLP 参数加入 optimizer ({sum(p.numel() for g in sra_groups for p in g['params'])/1e6:.1f}M params)")
+
     from training.optimizers import build_optimizer, validate_optimizer
     validate_optimizer(args)  # PPSF 检查 lr_scheduler=none 等启动期约束
     ctx.optimizer = build_optimizer(args, param_groups, args.learning_rate, ctx.weight_decay)

--- a/runtime/training/phases/resume.py
+++ b/runtime/training/phases/resume.py
@@ -63,6 +63,7 @@ def run(ctx: TrainingContext) -> None:
         ctx.start_epoch, ctx.global_step, ctx.loss_history, saved_monitor_state = load_training_state(
             args.resume_state, ctx.injector, ctx.optimizer, ctx.scheduler,
             timestep_sampler=ctx.timestep_sampler,
+            sra_aligner=ctx.sra_aligner,
         )
         ctx.emit(f"从断点恢复训练: epoch={ctx.start_epoch}, step={ctx.global_step}")
 

--- a/runtime/training/sra_align.py
+++ b/runtime/training/sra_align.py
@@ -1,0 +1,161 @@
+"""SRA v2: VAE Self-Representation Alignment for efficient LoRA training.
+
+Based on: "SRA 2: Variational Autoencoder Self-Representation Alignment for
+Efficient Diffusion Training" (CVPR 2026, arXiv:2601.17830).
+
+Aligns intermediate transformer block hidden states to the clean VAE latent
+via a lightweight projection MLP. Accelerates convergence and regularizes
+representations with ~4% extra GFLOPs and zero additional model forward passes.
+
+Usage:
+    aligner = SRAAligner(model, block_idx=4, patch_spatial=2, model_channels=2048)
+    # ... after model forward ...
+    align_loss = aligner.compute(clean_latents)
+    loss = denoising_loss + sra_weight * align_loss
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+logger = logging.getLogger(__name__)
+
+
+class SRAProjectionHead(nn.Module):
+    """5-layer MLP projecting block hidden states to VAE latent space."""
+
+    def __init__(self, in_dim: int, out_per_token: int):
+        super().__init__()
+        d1 = in_dim // 2
+        d2 = in_dim // 4
+        d3 = in_dim // 8
+        self.net = nn.Sequential(
+            nn.Linear(in_dim, d1),
+            nn.SiLU(),
+            nn.Linear(d1, d2),
+            nn.SiLU(),
+            nn.Linear(d2, d3),
+            nn.SiLU(),
+            nn.Linear(d3, d3),
+            nn.SiLU(),
+            nn.Linear(d3, out_per_token),
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        for m in self.net:
+            if isinstance(m, nn.Linear):
+                nn.init.xavier_uniform_(m.weight)
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.net(x)
+
+
+class SRAAligner:
+    """Captures intermediate block output and computes VAE alignment loss.
+
+    Registers a forward hook on model.blocks[block_idx]. After each model
+    forward pass, call .compute(clean_latents) to get the alignment loss.
+
+    The projection MLP is trained alongside the LoRA parameters but discarded
+    after training (not saved into the LoRA safetensors).
+    """
+
+    def __init__(
+        self,
+        model: nn.Module,
+        block_idx: int,
+        patch_spatial: int,
+        model_channels: int,
+        vae_channels: int = 16,
+        device: str = "cuda",
+        dtype: torch.dtype = torch.float32,
+    ):
+        self.block_idx = block_idx
+        self.patch_spatial = patch_spatial
+        self.vae_channels = vae_channels
+        self._cached_hidden: Optional[Tensor] = None
+
+        out_per_token = vae_channels * patch_spatial * patch_spatial
+        self.proj = SRAProjectionHead(model_channels, out_per_token).to(
+            device=device, dtype=dtype
+        )
+
+        self._hook_handle = model.blocks[block_idx].register_forward_hook(
+            self._hook_fn
+        )
+        n_params = sum(p.numel() for p in self.proj.parameters())
+        logger.info(
+            f"SRA v2: hook on block[{block_idx}], "
+            f"proj {model_channels} → {out_per_token}, "
+            f"{n_params / 1e6:.1f}M params"
+        )
+
+    def _hook_fn(self, module, input, output):
+        self._cached_hidden = output
+
+    def compute(self, clean_latents: Tensor) -> Tensor:
+        """Compute alignment loss between projected hidden state and VAE latents.
+
+        Args:
+            clean_latents: (B, C, T, H_lat, W_lat) — the original VAE-encoded latent.
+
+        Returns:
+            Scalar alignment loss.
+        """
+        hidden = self._cached_hidden
+        if hidden is None:
+            raise RuntimeError("SRAAligner.compute() called before model forward")
+
+        # hidden: (B, T_p, H_p, W_p, D) from block output
+        B, T_p, H_p, W_p, D = hidden.shape
+        ps = self.patch_spatial
+        C = self.vae_channels
+
+        # Project: (B, T_p, H_p, W_p, D) → (B, T_p, H_p, W_p, C*ps*ps)
+        projected = self.proj(hidden.float())
+
+        # Unpatchify to (B, C, T, H_lat, W_lat)
+        # reshape to (B, T_p, H_p, W_p, C, ps, ps)
+        projected = projected.view(B, T_p, H_p, W_p, C, ps, ps)
+        # rearrange: b t h w c p q -> b c t (h p) (w q)
+        projected = projected.permute(0, 4, 1, 2, 5, 3, 6)  # (B, C, T_p, H_p, ps, W_p, ps)
+        projected = projected.reshape(B, C, T_p, H_p * ps, W_p * ps)
+
+        target = clean_latents.detach().float()
+
+        # Handle potential shape mismatch (e.g. if patch_temporal != 1)
+        if projected.shape != target.shape:
+            raise RuntimeError(
+                f"SRA shape mismatch: projected {projected.shape} vs target {target.shape}"
+            )
+
+        return F.smooth_l1_loss(projected, target, beta=0.05)
+
+    def get_param_groups(self, lr: Optional[float] = None) -> list[dict]:
+        """Return optimizer param groups for the projection MLP."""
+        group = {"params": list(self.proj.parameters()), "weight_decay": 0.0}
+        if lr is not None:
+            group["lr"] = lr
+        return [group]
+
+    def remove_hooks(self):
+        """Remove the forward hook and free cached state."""
+        if self._hook_handle is not None:
+            self._hook_handle.remove()
+            self._hook_handle = None
+        self._cached_hidden = None
+
+    def train(self):
+        self.proj.train()
+
+    def eval(self):
+        self.proj.eval()

--- a/runtime/training/sra_align.py
+++ b/runtime/training/sra_align.py
@@ -75,16 +75,18 @@ class SRAAligner:
         block_idx: int,
         patch_spatial: int,
         model_channels: int,
+        patch_temporal: int = 1,
         vae_channels: int = 16,
         device: str = "cuda",
         dtype: torch.dtype = torch.float32,
     ):
         self.block_idx = block_idx
         self.patch_spatial = patch_spatial
+        self.patch_temporal = patch_temporal
         self.vae_channels = vae_channels
         self._cached_hidden: Optional[Tensor] = None
 
-        out_per_token = vae_channels * patch_spatial * patch_spatial
+        out_per_token = vae_channels * patch_temporal * patch_spatial * patch_spatial
         self.proj = SRAProjectionHead(model_channels, out_per_token).to(
             device=device, dtype=dtype
         )
@@ -102,11 +104,49 @@ class SRAAligner:
     def _hook_fn(self, module, input, output):
         self._cached_hidden = output
 
-    def compute(self, clean_latents: Tensor) -> Tensor:
+    def _hidden_as_target_grid(self, hidden: Tensor, target: Tensor) -> Tensor:
+        """Reshape captured tokens to the VAE latent patch grid.
+
+        In torch.compile native-flatten mode, block outputs are shaped as
+        (B, 1, seq_len, 1, D). Rebuilding the grid from clean_latents keeps SRA
+        independent of the model's internal flattening strategy.
+        """
+        if not isinstance(hidden, Tensor):
+            raise RuntimeError(f"SRA expected block tensor output, got {type(hidden)!r}")
+
+        B, _C, T, H, W = target.shape
+        ps = self.patch_spatial
+        pt = self.patch_temporal
+        if T % pt != 0 or H % ps != 0 or W % ps != 0:
+            raise RuntimeError(
+                f"SRA target shape {target.shape} is not divisible by "
+                f"patch_temporal={pt}, patch_spatial={ps}"
+            )
+
+        T_p, H_p, W_p = T // pt, H // ps, W // ps
+        B_h, T_h, H_h, W_h, D = hidden.shape
+        if B_h != B:
+            raise RuntimeError(f"SRA batch mismatch: hidden B={B_h} vs target B={B}")
+
+        expected_tokens = T_p * H_p * W_p
+        actual_tokens = T_h * H_h * W_h
+        if actual_tokens != expected_tokens:
+            raise RuntimeError(
+                f"SRA token mismatch: hidden grid {(T_h, H_h, W_h)} "
+                f"({actual_tokens}) vs target grid {(T_p, H_p, W_p)} "
+                f"({expected_tokens})"
+            )
+
+        if (T_h, H_h, W_h) == (T_p, H_p, W_p):
+            return hidden
+        return hidden.reshape(B, T_p, H_p, W_p, D)
+
+    def compute(self, clean_latents: Tensor, sample_weight: Optional[Tensor] = None) -> Tensor:
         """Compute alignment loss between projected hidden state and VAE latents.
 
         Args:
             clean_latents: (B, C, T, H_lat, W_lat) — the original VAE-encoded latent.
+            sample_weight: optional per-sample training weights, e.g. reg loss weights.
 
         Returns:
             Scalar alignment loss.
@@ -115,22 +155,24 @@ class SRAAligner:
         if hidden is None:
             raise RuntimeError("SRAAligner.compute() called before model forward")
 
+        target = clean_latents.detach().float()
+        hidden = self._hidden_as_target_grid(hidden, target)
+
         # hidden: (B, T_p, H_p, W_p, D) from block output
         B, T_p, H_p, W_p, D = hidden.shape
         ps = self.patch_spatial
+        pt = self.patch_temporal
         C = self.vae_channels
 
-        # Project: (B, T_p, H_p, W_p, D) → (B, T_p, H_p, W_p, C*ps*ps)
+        # Project: (B, T_p, H_p, W_p, D) → (B, T_p, H_p, W_p, C*pt*ps*ps)
         projected = self.proj(hidden.float())
 
         # Unpatchify to (B, C, T, H_lat, W_lat)
-        # reshape to (B, T_p, H_p, W_p, C, ps, ps)
-        projected = projected.view(B, T_p, H_p, W_p, C, ps, ps)
-        # rearrange: b t h w c p q -> b c t (h p) (w q)
-        projected = projected.permute(0, 4, 1, 2, 5, 3, 6)  # (B, C, T_p, H_p, ps, W_p, ps)
-        projected = projected.reshape(B, C, T_p, H_p * ps, W_p * ps)
-
-        target = clean_latents.detach().float()
+        # reshape to (B, T_p, H_p, W_p, C, pt, ps, ps)
+        projected = projected.view(B, T_p, H_p, W_p, C, pt, ps, ps)
+        # rearrange: b t h w c r p q -> b c (t r) (h p) (w q)
+        projected = projected.permute(0, 4, 1, 5, 2, 6, 3, 7)
+        projected = projected.reshape(B, C, T_p * pt, H_p * ps, W_p * ps)
 
         # Handle potential shape mismatch (e.g. if patch_temporal != 1)
         if projected.shape != target.shape:
@@ -138,7 +180,18 @@ class SRAAligner:
                 f"SRA shape mismatch: projected {projected.shape} vs target {target.shape}"
             )
 
-        return F.smooth_l1_loss(projected, target, beta=0.05)
+        loss_per_sample = F.smooth_l1_loss(
+            projected, target, beta=0.05, reduction="none"
+        ).mean(dim=tuple(range(1, projected.dim())))
+        if sample_weight is not None:
+            weight = sample_weight.to(device=loss_per_sample.device, dtype=loss_per_sample.dtype).view(-1)
+            if weight.numel() != loss_per_sample.numel():
+                raise RuntimeError(
+                    f"SRA sample_weight shape mismatch: {tuple(weight.shape)} "
+                    f"vs batch={loss_per_sample.numel()}"
+                )
+            loss_per_sample = loss_per_sample * weight
+        return loss_per_sample.mean()
 
     def get_param_groups(self, lr: Optional[float] = None) -> list[dict]:
         """Return optimizer param groups for the projection MLP."""
@@ -146,6 +199,25 @@ class SRAAligner:
         if lr is not None:
             group["lr"] = lr
         return [group]
+
+    def state_dict(self) -> dict:
+        """Return checkpointable SRA state.
+
+        Hooks and cached activations are runtime-only; only the trained
+        projection head and shape metadata need to survive resume.
+        """
+        return {
+            "block_idx": self.block_idx,
+            "patch_spatial": self.patch_spatial,
+            "patch_temporal": self.patch_temporal,
+            "vae_channels": self.vae_channels,
+            "proj": self.proj.state_dict(),
+        }
+
+    def load_state_dict(self, state: dict) -> None:
+        """Restore projection-head weights from a checkpoint."""
+        proj_state = state.get("proj", state)
+        self.proj.load_state_dict(proj_state)
 
     def remove_hooks(self):
         """Remove the forward hook and free cached state."""

--- a/runtime/training/state.py
+++ b/runtime/training/state.py
@@ -24,7 +24,7 @@ logger = logging.getLogger(__name__)
 def save_training_state(
     path, injector, optimizer, epoch, global_step,
     loss_history=None, rng_state=None, monitor_state=None,
-    scheduler=None, timestep_sampler=None,
+    scheduler=None, timestep_sampler=None, sra_aligner=None,
 ):
     """保存完整训练状态，支持断点续训。
 
@@ -46,6 +46,11 @@ def save_training_state(
     }
     if scheduler is not None:
         state["scheduler_state_dict"] = scheduler.state_dict()
+    if sra_aligner is not None and hasattr(sra_aligner, "state_dict"):
+        try:
+            state["sra_aligner_state"] = sra_aligner.state_dict()
+        except Exception as e:
+            logger.warning(f"sra_aligner.state_dict() 失败（跳过）: {e}")
     if timestep_sampler is not None and hasattr(timestep_sampler, "state_dict"):
         # hasattr 防御：Protocol 不提供 default dispatch，未来新加的 sampler 若忘记
         # 实现这两个 hook，要静默跳过而非崩溃（训练 8 小时不能因 resume hook 缺失废）
@@ -70,7 +75,7 @@ def save_training_state(
     logger.info(f"训练状态已保存: {path} (epoch={epoch}, step={global_step})")
 
 
-def load_training_state(path, injector, optimizer, scheduler=None, timestep_sampler=None):
+def load_training_state(path, injector, optimizer, scheduler=None, timestep_sampler=None, sra_aligner=None):
     """加载训练状态，返回 (epoch, global_step, loss_history, monitor_state)。
 
     timestep_sampler（ADR 0006 Addendum 1）：如 ckpt 含 timestep_sampler_state 且 sampler
@@ -90,6 +95,18 @@ def load_training_state(path, injector, optimizer, scheduler=None, timestep_samp
         logger.warning(
             f"resume LoRA: missing={missing}, unexpected={unexpected}（旧格式 ckpt？）"
         )
+
+    # 恢复 SRA v2 projection MLP（如启用）。必须在 optimizer state 恢复前完成，
+    # 保证后续训练从同一组投影权重继续，而不是随机新 MLP + 旧 optimizer moments。
+    if sra_aligner is not None:
+        if "sra_aligner_state" in state and hasattr(sra_aligner, "load_state_dict"):
+            try:
+                sra_aligner.load_state_dict(state["sra_aligner_state"])
+                logger.info("SRA v2 projection MLP 状态已恢复")
+            except Exception as e:
+                logger.warning(f"SRA v2 projection MLP 状态恢复失败（冷启动）: {e}")
+        else:
+            logger.warning("checkpoint 不含 SRA v2 状态；projection MLP 将冷启动")
 
     # 加载优化器状态
     optimizer.load_state_dict(state["optimizer_state_dict"])

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -654,11 +654,6 @@ class TrainingConfig(BaseModel):
         description="【SRA v2】对齐 loss 权重 λ：align_loss 乘以此值后加到总 loss。论文默认 1.0；LoRA 微调建议从 0.5-1.0 开始试",
         json_schema_extra=_meta("loss", show_when="sra_enabled==true", advanced=True),
     )
-    sra_decay_start_epoch: int = Field(
-        20, ge=0,
-        description="【SRA v2】对齐权重开始衰减的 epoch：超过此值后 λ 按指数衰减（避免后期对齐约束过强限制模型自由度）。短训练（<30 epoch）建议设为 epochs//3",
-        json_schema_extra=_meta("loss", show_when="sra_enabled==true", advanced=True),
-    )
 
     grad_clip_max_norm: float = Field(
         1.0, ge=0.0,

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -637,6 +637,29 @@ class TrainingConfig(BaseModel):
         description="【LeapAlign】轨迹相似度加权下限 τ：防止近乎相同的跳跃对被 1/d 过度放大。越小越激进。典型 0.05-0.2",
         json_schema_extra=_meta("loss", show_when="leap_traj_sim_weighting==true", advanced=True),
     )
+
+    # ----------------------------------------------------------- SRA v2 表征对齐
+    sra_enabled: bool = Field(
+        False,
+        description="【SRA v2 表征对齐】启用 VAE Self-Representation Alignment：将中间 transformer block 的 hidden state 对齐到 clean VAE latent，加速收敛并正则化表征。仅增加 ~4% GFLOPs（一个轻量 MLP），训练完自动丢弃",
+        json_schema_extra=_meta("loss"),
+    )
+    sra_block: int = Field(
+        4, ge=1, le=35,
+        description="【SRA v2】从哪一层 block 取中间表征做对齐（0-indexed）。论文建议浅层效果最好：1.3B 模型（28 blocks）推荐 2-6，14B 模型（36 blocks）推荐 4-8",
+        json_schema_extra=_meta("loss", show_when="sra_enabled==true", advanced=True),
+    )
+    sra_weight: float = Field(
+        1.0, ge=0.0,
+        description="【SRA v2】对齐 loss 权重 λ：align_loss 乘以此值后加到总 loss。论文默认 1.0；LoRA 微调建议从 0.5-1.0 开始试",
+        json_schema_extra=_meta("loss", show_when="sra_enabled==true", advanced=True),
+    )
+    sra_decay_start_epoch: int = Field(
+        20, ge=0,
+        description="【SRA v2】对齐权重开始衰减的 epoch：超过此值后 λ 按指数衰减（避免后期对齐约束过强限制模型自由度）。短训练（<30 epoch）建议设为 epochs//3",
+        json_schema_extra=_meta("loss", show_when="sra_enabled==true", advanced=True),
+    )
+
     grad_clip_max_norm: float = Field(
         1.0, ge=0.0,
         description="梯度裁剪最大范数：当本步所有可训练参数的梯度全局范数超过该值时按比例缩到该值，防止单步极端梯度把模型推飞；默认 1.0 适合绝大多数场景，bf16+DoRA/LoKr 不稳可降到 0.5，0=禁用",

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -607,6 +607,36 @@ class TrainingConfig(BaseModel):
         description="detail_inv_t 权重上限。默认 5.0；降低（如 3）减弱细节强化，提高（如 8）激进强化细节",
         json_schema_extra=_meta("loss", show_when="loss_weighting==detail_inv_t", advanced=True),
     )
+    leap_enabled: bool = Field(
+        False,
+        description="【LeapAlign 自蒸馏】启用两步跳跃自蒸馏（去奖励模型版）：每步用真实 latent 当 x0，per-sample 采两个时刻 (k>j) 做两步跳跃，loss=MSE(两步预测的 x̂0, 真实 x0)。本质是 shortcut/consistency 式自蒸馏，每步 2 次前向（约 2× 标准训练算力）。与 InfoNoise/loss_weighting 互斥",
+        json_schema_extra=_meta("loss"),
+    )
+    leap_ratio: float = Field(
+        1.0, ge=0.0, le=1.0,
+        description="【LeapAlign 混合训练】每步按此概率走 leap 自蒸馏、其余走传统 rectified flow：1.0 纯 leap（管全局结构）；0.0 纯传统（管细节锐度）；0.6 大头吃 leap 全局对齐、留点传统精修兜住细节。两股梯度叠在同一组 LoRA 权重上各取所长",
+        json_schema_extra=_meta("loss", show_when="leap_enabled==true", advanced=True),
+    )
+    leap_nested_grad_coe: float = Field(
+        0.3, ge=0.0, le=1.0,
+        description="【LeapAlign】梯度折扣 α（论文 Eq 9）：缩放第二跳对 x_j 的嵌套梯度。0=砍掉嵌套梯度（最省显存），1=不折扣（梯度最完整但易爆）。论文最优 0.3",
+        json_schema_extra=_meta("loss", show_when="leap_enabled==true", advanced=True),
+    )
+    leap_min_gap: float = Field(
+        0.1, ge=0.01, le=0.9,
+        description="【LeapAlign】两个采样时刻 (k,j) 的最小间隔：越大跳跃跨度越大、自蒸馏越激进但误差累积越多。典型 0.1-0.3",
+        json_schema_extra=_meta("loss", show_when="leap_enabled==true", advanced=True),
+    )
+    leap_traj_sim_weighting: bool = Field(
+        False,
+        description="【LeapAlign】轨迹相似度加权（论文 Eq 12）：跳跃越贴近真实路径权重越高，抑制大跨度跳跃的离谱预测主导 loss。默认关",
+        json_schema_extra=_meta("loss", show_when="leap_enabled==true", advanced=True),
+    )
+    leap_traj_sim_min: float = Field(
+        0.1, ge=1e-4,
+        description="【LeapAlign】轨迹相似度加权下限 τ：防止近乎相同的跳跃对被 1/d 过度放大。越小越激进。典型 0.05-0.2",
+        json_schema_extra=_meta("loss", show_when="leap_traj_sim_weighting==true", advanced=True),
+    )
     grad_clip_max_norm: float = Field(
         1.0, ge=0.0,
         description="梯度裁剪最大范数：当本步所有可训练参数的梯度全局范数超过该值时按比例缩到该值，防止单步极端梯度把模型推飞；默认 1.0 适合绝大多数场景，bf16+DoRA/LoKr 不稳可降到 0.5，0=禁用",
@@ -750,6 +780,36 @@ class TrainingConfig(BaseModel):
                 "（I-MMSE 推导假设标准高斯 noise）。请二选一：(a) 关闭 InfoNoise 保留噪声增强；"
                 "或 (b) 设 noise_enhancement_type=none 走 InfoNoise 自适应路径。"
             )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_leap_exclusive(self) -> "TrainingConfig":
+        """LeapAlign 自蒸馏与 InfoNoise / loss_weighting 互斥。
+
+        leap 路径每步 per-sample 采两个时刻 (k,j) 做两步跳跃，单步只有 (k,j) 这对
+        timestep，不存在标准路径里那个唯一的 t：
+        - InfoNoise：用单一 t 的 raw MSE 学 I-MMSE schedule，双 timestep 无从 record；
+          且 leap 的 loss 是 x̂0 自蒸馏 MSE，不是 v 预测 MSE，语义也不匹配。
+        - loss_weighting：min_snr / detail_inv_t / cosmap 全都按单一 t 算 SNR 权重，
+          双 timestep 没有定义；leap 自带 traj_sim_weighting 做轨迹质量加权。
+        故 leap 路径在 loop.py 里有意跳过这两个机制，这里强制配置层面关闭，避免用户
+        以为开了却被静默忽略。
+        """
+        if self.leap_enabled:
+            if self.infonoise_enabled:
+                raise ValueError(
+                    "leap_enabled=true 与 infonoise_enabled=true 互斥：leap 每步采两个时刻 "
+                    "(k,j) 做两步跳跃，没有 InfoNoise 学 I-MMSE 所需的单一 t，且 loss 是 x̂0 "
+                    "自蒸馏而非 v 预测 MSE。请二选一：(a) 关闭 leap 用 InfoNoise；"
+                    "或 (b) 设 infonoise_enabled=false 走 leap 自蒸馏。"
+                )
+            if self.loss_weighting != "none":
+                raise ValueError(
+                    f"leap_enabled=true 与 loss_weighting={self.loss_weighting!r} 互斥：loss 加权"
+                    "按单一 t 算 SNR 权重，leap 的双 timestep 无从定义；leap 用 "
+                    "leap_traj_sim_weighting 做轨迹质量加权。请二选一：(a) 关闭 leap；"
+                    "或 (b) 设 loss_weighting=none 走 leap 自蒸馏。"
+                )
         return self
 
     # ---------------------------------------------------------------- 输出/保存

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -654,6 +654,21 @@ class TrainingConfig(BaseModel):
         description="【SRA v2】对齐 loss 权重 λ：align_loss 乘以此值后加到总 loss。论文默认 1.0；LoRA 微调建议从 0.5-1.0 开始试",
         json_schema_extra=_meta("loss", show_when="sra_enabled==true", advanced=True),
     )
+    sra_decay_type: Literal["none", "linear", "cosine", "jump"] = Field(
+        "none",
+        description="【SRA v2】权重衰减方式：none 全程固定；linear 从起点线性降到 0；cosine 从起点余弦降到 0；jump 到起点直接关掉。实际权重 = sra_weight × 衰减系数",
+        json_schema_extra=_meta("loss", show_when="sra_enabled==true", advanced=True),
+    )
+    sra_decay_start_ratio: float = Field(
+        0.2, ge=0.0, le=1.0,
+        description="【SRA v2】衰减起点（训练总步数比例）。linear/cosine 在此之前保持满权重；jump 在此比例直接从 sra_weight 跳到 0",
+        json_schema_extra=_meta("loss", show_when="sra_enabled==true&&sra_decay_type!=none", advanced=True),
+    )
+    sra_decay_end_ratio: float = Field(
+        0.3, ge=0.0, le=1.0,
+        description="【SRA v2】衰减终点（训练总步数比例）。linear/cosine 到此比例降为 0；jump 不使用此字段",
+        json_schema_extra=_meta("loss", show_when="sra_enabled==true&&sra_decay_type!=none&&sra_decay_type!=jump", advanced=True),
+    )
 
     grad_clip_max_norm: float = Field(
         1.0, ge=0.0,
@@ -718,6 +733,16 @@ class TrainingConfig(BaseModel):
             raise ValueError(
                 f"detail_inv_t_min ({self.detail_inv_t_min}) 不能大于 "
                 f"detail_inv_t_max ({self.detail_inv_t_max})。"
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_sra_decay_range(self) -> "TrainingConfig":
+        """SRA linear/cosine 衰减需要 start <= end；jump 只读 start。"""
+        if self.sra_decay_type in {"linear", "cosine"} and self.sra_decay_start_ratio > self.sra_decay_end_ratio:
+            raise ValueError(
+                f"sra_decay_start_ratio ({self.sra_decay_start_ratio}) 不能大于 "
+                f"sra_decay_end_ratio ({self.sra_decay_end_ratio})。"
             )
         return self
 

--- a/tests/test_sra_align.py
+++ b/tests/test_sra_align.py
@@ -1,0 +1,116 @@
+"""SRA v2 regression tests.
+
+These tests use a tiny fake block stack instead of the real Anima model, so they
+cover SRA's shape/state contracts without loading model weights.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+import torch.nn as nn
+
+from training.sra_align import SRAAligner
+
+
+class _IdentityBlock(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+class _FakeModel(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.blocks = nn.ModuleList([_IdentityBlock()])
+
+
+class _StubInjector:
+    def state_dict(self) -> dict:
+        return {}
+
+    def load_state_dict(self, _state: dict, strict: bool = True):
+        return SimpleNamespace(missing_keys=[], unexpected_keys=[])
+
+
+def _new_aligner(seed: int = 0) -> tuple[_FakeModel, SRAAligner]:
+    torch.manual_seed(seed)
+    model = _FakeModel()
+    aligner = SRAAligner(
+        model=model,
+        block_idx=0,
+        patch_spatial=2,
+        patch_temporal=1,
+        model_channels=8,
+        vae_channels=16,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    return model, aligner
+
+
+def test_sra_compute_accepts_native_flatten_block_output() -> None:
+    model, aligner = _new_aligner()
+    target = torch.zeros(2, 16, 1, 4, 4)
+
+    # torch.compile native-flatten mode presents block output as
+    # (B, 1, seq_len, 1, D); SRA should rebuild the target patch grid.
+    hidden = torch.randn(2, 1, 4, 1, 8)
+    model.blocks[0](hidden)
+
+    loss = aligner.compute(target)
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+
+
+def test_sra_compute_applies_sample_weight() -> None:
+    model, aligner = _new_aligner()
+    target = torch.zeros(2, 16, 1, 4, 4)
+    hidden = torch.randn(2, 1, 4, 1, 8)
+    model.blocks[0](hidden)
+
+    loss = aligner.compute(target, sample_weight=torch.zeros(2))
+    assert loss.item() == 0.0
+
+
+def test_sra_weight_zero_is_preserved() -> None:
+    from training.loop import _resolve_sra_weight
+
+    assert _resolve_sra_weight(SimpleNamespace(sra_weight=0.0)) == 0.0
+    assert _resolve_sra_weight(SimpleNamespace(sra_weight=None)) == 1.0
+    assert _resolve_sra_weight(SimpleNamespace()) == 1.0
+
+
+def test_sra_state_roundtrip(tmp_path: Path) -> None:
+    from training.state import load_training_state, save_training_state
+
+    _model1, aligner1 = _new_aligner(seed=1)
+    with torch.no_grad():
+        for p in aligner1.proj.parameters():
+            p.uniform_(-0.25, 0.25)
+    optimizer1 = torch.optim.AdamW(aligner1.get_param_groups(), lr=1e-3)
+
+    state_path = tmp_path / "state.pt"
+    save_training_state(
+        state_path,
+        _StubInjector(),
+        optimizer1,
+        epoch=2,
+        global_step=42,
+        sra_aligner=aligner1,
+    )
+
+    _model2, aligner2 = _new_aligner(seed=2)
+    optimizer2 = torch.optim.AdamW(aligner2.get_param_groups(), lr=1e-3)
+    load_training_state(
+        state_path,
+        _StubInjector(),
+        optimizer2,
+        sra_aligner=aligner2,
+    )
+
+    sd1 = aligner1.state_dict()["proj"]
+    sd2 = aligner2.state_dict()["proj"]
+    assert sd1.keys() == sd2.keys()
+    for key in sd1:
+        assert torch.equal(sd1[key], sd2[key]), key

--- a/tests/test_sra_align.py
+++ b/tests/test_sra_align.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 import torch
 import torch.nn as nn
 
@@ -79,6 +80,44 @@ def test_sra_weight_zero_is_preserved() -> None:
     assert _resolve_sra_weight(SimpleNamespace(sra_weight=0.0)) == 0.0
     assert _resolve_sra_weight(SimpleNamespace(sra_weight=None)) == 1.0
     assert _resolve_sra_weight(SimpleNamespace()) == 1.0
+
+
+def test_sra_effective_weight_decay_modes() -> None:
+    from training.loop import _resolve_sra_effective_weight
+
+    base = dict(
+        sra_weight=0.1,
+        sra_decay_start_ratio=0.2,
+        sra_decay_end_ratio=0.4,
+    )
+
+    assert _resolve_sra_effective_weight(
+        SimpleNamespace(**base, sra_decay_type="none"), 50, 100,
+    ) == pytest.approx(0.1)
+    assert _resolve_sra_effective_weight(
+        SimpleNamespace(**base, sra_decay_type="linear"), 30, 100,
+    ) == pytest.approx(0.05)
+    assert _resolve_sra_effective_weight(
+        SimpleNamespace(**base, sra_decay_type="cosine"), 30, 100,
+    ) == pytest.approx(0.05)
+    assert _resolve_sra_effective_weight(
+        SimpleNamespace(**base, sra_decay_type="jump"), 19, 100,
+    ) == pytest.approx(0.1)
+    assert _resolve_sra_effective_weight(
+        SimpleNamespace(**base, sra_decay_type="jump"), 20, 100,
+    ) == pytest.approx(0.0)
+
+
+def test_sra_decay_schema_rejects_inverted_linear_range() -> None:
+    from studio.schema import TrainingConfig
+
+    with pytest.raises(Exception):
+        TrainingConfig(
+            sra_enabled=True,
+            sra_decay_type="linear",
+            sra_decay_start_ratio=0.5,
+            sra_decay_end_ratio=0.25,
+        )
 
 
 def test_sra_state_roundtrip(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Add LeapAlign two-step self-distillation training path with schema options and mutual-exclusion validation.
- Add optional SRA v2 VAE self-representation alignment, including projection state save/resume and loss weighting.
- Add targeted SRA unit coverage while keeping the branch scoped to training/schema changes.


## SRA v2
SRA 来自论文 **“SRA 2: Variational Autoencoder Self-Representation Alignment for Efficient Diffusion Training”**，代码注释标注为 CVPR 2026 / arXiv:2601.17830。核心思想是：训练扩散模型时，不只让最终预测去拟合 denoising 目标，还把某个中间 transformer block 的 hidden state 投影回 VAE latent 空间，让中间表征对齐 clean latent。

本分支实现的是 LoRA 训练适配版，新增在 `runtime/training/sra_align.py`。它通过 forward hook 捕获 `model.blocks[sra_block]` 的输出，再用一个 5 层 MLP projection head 把 hidden tokens 映射成 VAE latent patch。之后把投影结果 unpatchify 回 `(B, C, T, H, W)`，和真实 clean latents 做 `SmoothL1Loss(beta=0.05)`。

修改后的训练逻辑是：

- SRA 是可选辅助 loss，由 `sra_enabled` 开关控制，默认关闭。
- SRA 只接在标准 rectified flow 训练路径上，不接在 LeapAlign 路径上。
- 初始化发生在 LoRA 注入之后：`runtime/training/phases/models.py` 创建 `SRAAligner`，挂 hook 到指定 transformer block。
- projection MLP 参数会加入 optimizer，`weight_decay=0`，和 LoRA 一起训练。
- 每步标准训练 forward 后，`ctx.sra_aligner.compute(latents)` 计算中间表征到 clean latent 的对齐 loss。
- 总 loss 变成：`denoise_loss + effective_sra_weight * sra_align_loss`。
- `effective_sra_weight` 支持调度：`none`、`linear`、`cosine`、`jump`，通过训练总进度在指定 ratio 区间衰减到 0。
- SRA loss 支持 `batch["loss_weight"]`，所以正则集降权会同步作用到 SRA 对齐 loss。
- checkpoint 会保存 `sra_aligner_state`，resume 时先恢复 projection MLP，再恢复 optimizer state，避免 “新 MLP + 旧 optimizer moments” 的错配。
- 最终导出的 LoRA 不包含 SRA projection MLP。训练结束会 remove hook 并丢弃 projection head。

新增配置项在 `studio/domain/training.py`：

- `sra_enabled`
- `sra_block`
- `sra_weight`
- `sra_decay_type`
- `sra_decay_start_ratio`
- `sra_decay_end_ratio`

SRA 的定位是“低成本辅助对齐”：不增加第二次 diffusion model forward，主要额外开销是 projection MLP。它适合给标准训练路径加一个中间表征正则，帮助收敛和稳定，但它不是新的采样/时间步训练目标。

## LeapAlign
LeapAlign 来自 **LeapAlign 论文 arXiv:2604.15311v2 [CVPR2026] LeapAlign: Post-Training Flow Matching Models at Any Generation Step by Building Two-Step Trajectories**，原始实现注释里对照的是 `LeapAlign_Code/fastvideo/train_leapalign_flux.py`。原版核心是 two-step leap trajectory：在两个时间点之间做跳跃，用奖励模型评价生成结果，再优化轨迹。

本分支做的是“去奖励模型版”的 LoRA 训练适配，新增在 `runtime/training/leap.py`。关键改动是：不再 online rollout 完整采样轨迹，也不使用 reward model。因为训练数据本来就有真实图像对应的 clean latent `x0`，所以可以直接把 “奖励最大化” 改成 “两步跳跃预测的 `x_hat_0` 逼近真实 `x0`”。

本实现沿用项目的 rectified flow 约定：

- `t=0` 是数据端。
- `t=1` 是噪声端。
- `x_t = (1 - t) * x0 + t * noise`
- velocity 目标是 `v = noise - x0`
- 从时间 `a` 跳到 `b` 的一步预测是：`x_hat_b = x_a - (a - b) * v_theta(x_a, a)`

修改后的 LeapAlign 训练逻辑是：

- 每个 micro-batch 如果 `leap_enabled=true`，会按 `leap_ratio` 掷骰子决定本步走 LeapAlign 还是标准训练。
- `leap_ratio=1.0` 是纯 LeapAlign；`0.0` 等于只走标准训练；中间值是混合训练。
- 对每个样本随机采两个时间点 `(k, j)`，保证 `k > j` 且间隔至少 `leap_min_gap`。
- 构造真实带噪 latent：`x_k` 和 `x_j_real`。
- 第一次 forward：模型在 `x_k, t_k` 上预测 `v_k`，得到第一跳 `x_hat_j = x_k - (k - j) * v_k`。
- latent connector：前向数值使用真实 `x_j_real`，但梯度仍能从 `x_j` 回流到第一跳预测。
- nested gradient discount：用 `leap_nested_grad_coe` 控制第二跳对第一跳的嵌套梯度强度，默认 `0.3`。
- 第二次 forward：模型在 `x_j, t_j` 上预测 `v_j`，得到 `x_hat_0 = x_j - j * v_j`。
- loss 是 `MSE(x_hat_0, x0)`，也就是让两步跳跃后的预测回到真实 clean latent。
- 可选 `leap_traj_sim_weighting`：根据第一跳和第二跳偏离真实轨迹的距离做权重，距离越小权重越高，并用 `leap_traj_sim_min` 防止权重爆炸。
- LeapAlign 路径仍然尊重 batch 的 `loss_weight`，所以 reg 数据降权仍有效。

LeapAlign 路径显式跳过两个标准机制：

- 跳过 InfoNoise record，因为 LeapAlign 每步有 `(k, j)` 两个 timestep，不符合 InfoNoise 基于单一 `t` 记录 raw MSE 的语义。
- 跳过 `loss_weighting`，因为 `min_snr` / `detail_inv_t` / `cosmap` 都依赖单一 timestep，而 LeapAlign 的 loss 是双 timestep 自蒸馏目标。

因此 schema 里新增了互斥校验：`leap_enabled=true` 时不能同时启用 `infonoise_enabled`，也不能使用非 `none` 的 `loss_weighting`。

新增配置项：

- `leap_enabled`
- `leap_ratio`
- `leap_nested_grad_coe`
- `leap_min_gap`
- `leap_traj_sim_weighting`
- `leap_traj_sim_min`

## 二者关系
这两个功能都属于训练 loss / training objective 层面的增强，但接入方式不同。

LeapAlign 是替代或混合标准 denoising objective 的训练路径。它每次被选中时会做两次 model forward，目标从普通 velocity matching 变成两步跳跃自蒸馏。

SRA 是标准训练路径上的辅助对齐 loss。它依赖标准 forward 捕获中间 hidden state，不改变主 denoising objective，也不会在 LeapAlign 路径上启用。

所以组合关系是：

- `leap_enabled=false, sra_enabled=false`：完全原标准训练。
- `leap_enabled=false, sra_enabled=true`：标准训练 + SRA 中间表征对齐。
- `leap_enabled=true, sra_enabled=false`：按 `leap_ratio` 混合 LeapAlign 和标准训练。
- `leap_enabled=true, sra_enabled=true`：LeapAlign 被选中时只走 LeapAlign；标准路径被选中时才额外加 SRA。

这次 PR 的实际改动集中在 `runtime/training/leap.py`、`runtime/training/sra_align.py`、`runtime/training/loop.py`、训练 phases、state/resume、schema，以及 `tests/test_sra_align.py`。

## Test plan
- `python -m py_compile runtime/training/leap.py runtime/training/sra_align.py runtime/training/loop.py runtime/training/context.py runtime/training/phases/models.py runtime/training/phases/optimizer.py runtime/training/phases/resume.py runtime/training/state.py studio/domain/training.py tests/test_sra_align.py`
- `python -c "from studio.domain.training import TrainingConfig; print(TrainingConfig().model_dump().get('sra_enabled'), TrainingConfig().model_dump().get('leap_enabled'))"`
- `python -m pytest tests/test_sra_align.py` was attempted but could not run in the current local environment because `torch` is not installed.