### PR TITLE
feat(web): Generate 左侧配置分页 tab + 训练集 prompt 预览图

### DIFF
--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1262,6 +1262,9 @@
   "generate": {
     "singleMode": "Single",
     "xyMode": "XY Matrix",
+    "xyAxis": "{{label}} axis",
+    "xyRemoveAxisTitle": "Remove {{label}} axis (back to single axis)",
+    "xyRemoveAxisAria": "Remove {{label}} axis",
     "title": "Generate",
     "subtitle": "Standalone inference · Single / XY matrix / two-image compare (outputs are temporary and disappear when the page closes)",
     "promptRequired": "Enter at least one prompt",
@@ -1337,6 +1340,8 @@
     "selectedDatasetTagsLabel": "Selected tags (appended after the positive prompt when generating)",
     "selectedDatasetTagsPlaceholder": "No caption selected — click a row above to activate one",
     "selectedDatasetTagsAria": "Selected caption tags (read-only)",
+    "datasetPreviewAlt": "Training image preview",
+    "datasetPreviewEmpty": "Hover or select a row to preview",
     "replaceCurrentPrompt": "Replace current prompt",
     "appendToCurrentPrompt": "Append to current prompt",
     "weight": "Weight",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1262,6 +1262,9 @@
   "generate": {
     "singleMode": "单图",
     "xyMode": "XY 矩阵",
+    "xyAxis": "{{label}} 轴",
+    "xyRemoveAxisTitle": "移除 {{label}} 轴（退化到单轴）",
+    "xyRemoveAxisAria": "移除 {{label}} 轴",
     "title": "测试",
     "subtitle": "独立推理 · 单图 / XY 矩阵 / 双图对比（出图不保存，关页面即丢）",
     "promptRequired": "请输入至少一条提示词",
@@ -1337,6 +1340,8 @@
     "selectedDatasetTagsLabel": "已选 tags（点「生成」时接在正向之后）",
     "selectedDatasetTagsPlaceholder": "还没选 caption — 点上方列表里的一行激活",
     "selectedDatasetTagsAria": "已选 caption 的 tags（只读）",
+    "datasetPreviewAlt": "训练集图片预览",
+    "datasetPreviewEmpty": "悬停或选中一行看大图",
     "replaceCurrentPrompt": "替换当前提示词",
     "appendToCurrentPrompt": "追加到当前提示词",
     "weight": "权重",

--- a/studio/web/src/lib/useAutoGrowTextarea.ts
+++ b/studio/web/src/lib/useAutoGrowTextarea.ts
@@ -6,6 +6,10 @@ import { useLayoutEffect, type RefObject } from 'react'
  * 内容少时 scrollHeight 被 clientHeight 托底，正好回到 rows 最小高度。
  * 配合 className 加 resize-none overflow-hidden（手动拖拽会被下次输入覆盖，
  * 干脆禁掉；hidden 防止撑高瞬间滚动条闪烁）。
+ *
+ * 元素在 display:none 容器里时（如未激活的 tab 分页）scrollHeight=0，此时直接
+ * bail，别把高度压成 0；ResizeObserver 会在它重新可见（尺寸 0→实际）时回调重算，
+ * 避免切回该 tab 后 textarea 塌缩。
  */
 export function useAutoGrowTextarea(
   ref: RefObject<HTMLTextAreaElement>,
@@ -14,10 +18,19 @@ export function useAutoGrowTextarea(
   useLayoutEffect(() => {
     const el = ref.current
     if (!el) return
-    el.style.height = 'auto'
-    // scrollHeight 不含 border；box-sizing: border-box 下补回去，否则每次少
-    // 2px 出现滚动条
-    const border = el.offsetHeight - el.clientHeight
-    el.style.height = `${el.scrollHeight + border}px`
+    const fit = () => {
+      // offsetParent===null ⇒ 自身或祖先 display:none，scrollHeight 不可信，先不动高度
+      if (el.offsetParent === null) return
+      el.style.height = 'auto'
+      // scrollHeight 不含 border；box-sizing: border-box 下补回去，否则每次少
+      // 2px 出现滚动条
+      const border = el.offsetHeight - el.clientHeight
+      el.style.height = `${el.scrollHeight + border}px`
+    }
+    fit()
+    // 监听尺寸变化：tab 切换让元素从隐藏变可见时重算，宽度变化（换行影响高度）时也重算
+    const ro = new ResizeObserver(fit)
+    ro.observe(el)
+    return () => ro.disconnect()
   }, [ref, value])
 }

--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -76,6 +76,12 @@ async function waitForInitialLorasLoad() {
   )
 }
 
+// 正向 / 负向 textarea 现在归到左侧「提示词」分页 tab（默认 tab 是 LoRA）；
+// 要操作 prompt 的用例先切到这一页。
+async function openPromptsTab(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: '提示词' }))
+}
+
 describe('GeneratePage 端到端 smoke', () => {
   it('mode=single：enqueue payload 含 xy_matrix=null + 完整字段', async () => {
     const user = userEvent.setup()
@@ -118,8 +124,10 @@ describe('GeneratePage 端到端 smoke', () => {
   })
 
   it('多 prompt 轮换功能已隐藏：只有一个 textarea，"添加 prompt"按钮不存在', async () => {
+    const user = userEvent.setup()
     setup()
     await waitForInitialLorasLoad()
+    await openPromptsTab(user)
     // 单 textarea
     const promptInputs = screen.getAllByPlaceholderText('输入正向提示词…')
     expect(promptInputs.length).toBe(1)
@@ -130,6 +138,7 @@ describe('GeneratePage 端到端 smoke', () => {
   it('切到 xy 再切回 single：sidebar 已填的 prompts/seed 等保留', async () => {
     const user = userEvent.setup()
     setup()
+    await openPromptsTab(user)
 
     const promptArea = screen.getAllByPlaceholderText('输入正向提示词…')[0]
     await user.clear(promptArea)
@@ -226,6 +235,7 @@ describe('GeneratePage 端到端 smoke', () => {
     const user = userEvent.setup()
     const first = setup()
     await waitForInitialLorasLoad()
+    await openPromptsTab(user)
 
     const promptArea = screen.getAllByPlaceholderText('输入正向提示词…')[0]
     await user.clear(promptArea)
@@ -384,8 +394,9 @@ describe('GeneratePage 端到端 smoke', () => {
     // 因为 axis=lora_ckpt 渲染的是 AxisLoraCkptPicker（不是 text input）—— 直接
     // 看 X 轴 select 的 value（一行 select 元素，AxisCard.label='X'）。
     await waitFor(() => {
-      const xLabel = screen.getAllByText('X')[0]
-      const card = xLabel.closest('div.bg-sunken')!
+      const xLabel = screen.getAllByText('X 轴')[0]
+      // AxisCard 外框跟 LoRA 槽对齐用 bg-overlay（原 bg-sunken 在 dark 下近黑显突兀）
+      const card = xLabel.closest('div.bg-overlay')!
       const axisSelect = card.querySelector('select') as HTMLSelectElement
       expect(axisSelect.value).toBe('lora_ckpt')
     })

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -37,6 +37,7 @@ import PromptList from './generate/PromptList'
 import NegPromptInput from './generate/NegPromptInput'
 import SampleGallery from './generate/SampleGallery'
 import SidebarLoras from './generate/SidebarLoras'
+import SidebarSectionTabs, { type SidebarTab } from './generate/SidebarSectionTabs'
 import SidebarXYAxes from './generate/SidebarXYAxes'
 import StatusBadge from './generate/StatusBadge'
 import ViewModeTabs, { type ViewMode } from './generate/ViewModeTabs'
@@ -200,6 +201,8 @@ export default function GeneratePage() {
     batchIdx: null, batchTotal: null, currentStep: null, totalSteps: null,
   })
   const [datasetPickerOpen, setDatasetPickerOpen] = useState(false)
+  // 左侧配置区当前分页（LoRA/XY · 提示词 · 配置）。跨 session 记忆用户停留的页。
+  const [sidebarTab, setSidebarTab] = useLocalStorageState<SidebarTab>('studio:generate:sidebarTab', 'lora')
   const [logOpen, setLogOpen] = useState(false)
   // 训练 / reg-ai / 打标等 GPU 任务在跑时，禁用生成防 VRAM 竞争（driver 抢
   // 3D / Copy engine 触发图像渲染卡顿，甚至训练进程 OOM）。listQueue 默认
@@ -605,38 +608,45 @@ export default function GeneratePage() {
       {/* 三列各自独立滚动，整页固定高度 = viewport */}
       <div className="p-6 flex gap-4 items-stretch flex-wrap xl:flex-nowrap flex-1 min-h-0">
 
-          {/* 左：sidebar — 上半部分独立 scroll，Generate bar 固定底部始终可见 */}
-          <div className="flex flex-col gap-4 w-full xl:w-[420px] shrink-0 self-stretch min-h-0">
-          <div className="flex flex-col gap-4 flex-1 min-h-0 overflow-y-auto pr-2">
+          {/* 左：sidebar — 单卡片包裹；内容区独立 scroll，底部 footer 固定 tab + 生成按钮 */}
+          <div className="card flex flex-col w-full xl:w-[420px] shrink-0 self-stretch min-h-0 overflow-hidden">
+            {/* 内容区：三个 section 都常驻 DOM、用 display 切换（不卸载）—— 切 tab 不重渲不闪烁。
+                scrollbar-gutter: stable both-edges —— 两侧都常驻预留滚动条槽（槽在 padding 外侧、
+                靠 border），所以左右 18px 内边距恒对称，且滚动条出现时只占右槽、不挤压/不位移内容。 */}
+            <div
+              className="flex flex-col flex-1 min-h-0 overflow-y-auto"
+              style={{ padding: 18, scrollbarGutter: 'stable both-edges' }}
+            >
 
-            {/* mode=single：独立 LoRA 卡片；mode=xy：LoRA 选择合并到 XY 卡片顶部 */}
-            {mode === 'single' && (
-              <div className="card" style={{ padding: 18 }}>
-                <div className="flex items-baseline justify-between mb-3">
-                  <h3 className="m-0 text-md font-semibold">LoRA</h3>
-                  <span className="text-xs text-fg-tertiary">{t('generate.loraHint')}</span>
-                </div>
-                <SidebarLoras
+            {/* tab=lora：mode=single → LoRA 选择；mode=xy → XY 轴（顶部合并 LoRA 选择） */}
+            <div style={{ display: sidebarTab === 'lora' ? undefined : 'none' }}>
+              {mode === 'single' ? (
+                <>
+                  <div className="flex items-baseline justify-between mb-3">
+                    <h3 className="m-0 text-md font-semibold">LoRA</h3>
+                    <span className="text-xs text-fg-tertiary">{t('generate.loraHint')}</span>
+                  </div>
+                  <SidebarLoras
+                    loras={loras}
+                    onChange={setLoras}
+                    projectLoras={projectLoras}
+                  />
+                </>
+              ) : (
+                <SidebarXYAxes
+                  xDraft={xDraft}
+                  yDraft={yDraft}
+                  onXChange={setXDraft}
+                  onYChange={setYDraft}
                   loras={loras}
-                  onChange={setLoras}
+                  onLorasChange={setLoras}
                   projectLoras={projectLoras}
                 />
-              </div>
-            )}
+              )}
+            </div>
 
-            {mode === 'xy' && (
-              <SidebarXYAxes
-                xDraft={xDraft}
-                yDraft={yDraft}
-                onXChange={setXDraft}
-                onYChange={setYDraft}
-                loras={loras}
-                onLorasChange={setLoras}
-                projectLoras={projectLoras}
-              />
-            )}
-
-            <div className="card" style={{ padding: 18 }}>
+            {/* tab=prompts */}
+            <div style={{ display: sidebarTab === 'prompts' ? undefined : 'none' }}>
               <div className="flex items-baseline justify-between mb-3">
                 <h3 className="m-0 text-md font-semibold">{t('generate.prompts')}</h3>
                 {!datasetPickerOpen && (
@@ -667,7 +677,8 @@ export default function GeneratePage() {
               <NegPromptInput value={negPrompt} onChange={setNegPrompt} />
             </div>
 
-            <div className="card" style={{ padding: 18 }}>
+            {/* tab=config */}
+            <div style={{ display: sidebarTab === 'config' ? undefined : 'none' }}>
               <h3 className="m-0 text-md font-semibold mb-3">{t('generate.samplingParams')}</h3>
               <div className="flex flex-col gap-3">
                 <div>
@@ -760,48 +771,47 @@ export default function GeneratePage() {
               </div>
             </div>
 
-          </div>
-            {/* Generate bar：固定 sidebar 底部（在 scroll 区外），橙色大按钮 + 右侧 meta */}
+            </div>
+
+            {/* footer：分页 tab（segmented）+「开始生成」同处一个 footer、跟内容区共卡片，
+                border-top 分隔。tab 选中态用 sunken 轨道而非橙色，跟下方生成按钮区分开。 */}
             <div
-              className="flex items-center gap-3 shrink-0"
-              style={{
-                padding: '10px 12px',
-                borderRadius: 'var(--r-lg)',
-                border: '1px solid var(--border-subtle)',
-                background: 'var(--bg-elevated)',
-                marginRight: 8, // 跟内层 pr-2 对齐，按钮区不被 scrollbar 占地
-              }}
+              className="shrink-0 flex flex-col gap-2.5"
+              style={{ borderTop: '1px solid var(--border-subtle)', padding: 12 }}
             >
-              <button
-                className="btn btn-primary flex-1"
-                style={{ padding: 12, fontWeight: 600, justifyContent: 'center' }}
-                onClick={handleGenerate}
-                disabled={busy || activeBlockingTask !== null}
-                title={
-                  activeBlockingTask
-                    ? t('generate.blockedByActiveTask', { id: activeBlockingTask.id })
-                    : undefined
-                }
-              >
-                {generateLabel}
-              </button>
-              {cancelable && (
-                <button className="btn btn-ghost" onClick={handleCancel} title={t('generate.cancelCurrentTitle')}>
-                  {t('common.cancel')}
+              <SidebarSectionTabs tab={sidebarTab} onTabChange={setSidebarTab} mode={mode} />
+              <div className="flex items-center gap-3">
+                <button
+                  className="btn btn-primary flex-1"
+                  style={{ padding: 12, fontWeight: 600, justifyContent: 'center' }}
+                  onClick={handleGenerate}
+                  disabled={busy || activeBlockingTask !== null}
+                  title={
+                    activeBlockingTask
+                      ? t('generate.blockedByActiveTask', { id: activeBlockingTask.id })
+                      : undefined
+                  }
+                >
+                  {generateLabel}
                 </button>
-              )}
-              {!cancelable && (
-                <div className="font-mono text-xs text-fg-tertiary text-right" style={{ lineHeight: 1.3 }}>
-                  <div>{width}×{height}</div>
-                  <div>
-                    {busy
-                      ? t('generate.generating')
-                      : activeBlockingTask
-                        ? t('generate.blockedByActiveTaskHint', { id: activeBlockingTask.id })
-                        : t('generate.sharedGpu')}
+                {cancelable && (
+                  <button className="btn btn-ghost" onClick={handleCancel} title={t('generate.cancelCurrentTitle')}>
+                    {t('common.cancel')}
+                  </button>
+                )}
+                {!cancelable && (
+                  <div className="font-mono text-xs text-fg-tertiary text-right" style={{ lineHeight: 1.3 }}>
+                    <div>{width}×{height}</div>
+                    <div>
+                      {busy
+                        ? t('generate.generating')
+                        : activeBlockingTask
+                          ? t('generate.blockedByActiveTaskHint', { id: activeBlockingTask.id })
+                          : t('generate.sharedGpu')}
+                    </div>
                   </div>
-                </div>
-              )}
+                )}
+              </div>
             </div>
           </div>
 

--- a/studio/web/src/pages/tools/generate/AddSlotButton.tsx
+++ b/studio/web/src/pages/tools/generate/AddSlotButton.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react'
+
+/** Sidebar 里「+ 添加 …」幽灵按钮的统一样式 —— LoRA 槽（SidebarLoras）和 XY 的
+ *  「+ 添加 Y 轴」（SidebarXYAxes）共用，保证两处外观一致。
+ *  font-mono + sunken 底 + subtle 边，hover 提亮文字 / 边框。 */
+export default function AddSlotButton({
+  onClick, children,
+}: {
+  onClick: () => void
+  children: ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className="font-mono inline-flex items-center gap-1.5 self-start"
+      style={{
+        border: '1px solid var(--border-subtle)',
+        background: 'var(--bg-sunken)',
+        borderRadius: 'var(--r-md)',
+        padding: '6px 10px',
+        fontSize: 12,
+        color: 'var(--fg-tertiary)',
+        cursor: 'pointer',
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.color = 'var(--fg-primary)'
+        e.currentTarget.style.borderColor = 'var(--border-default)'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.color = 'var(--fg-tertiary)'
+        e.currentTarget.style.borderColor = 'var(--border-subtle)'
+      }}
+    >
+      {children}
+    </button>
+  )
+}

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
@@ -406,16 +406,20 @@ export default function InlineLoraPicker(props: Props) {
         </div>
       )}
 
-      {/* ckpt chip 列表 */}
-      <div className="flex flex-wrap gap-1.5 overflow-y-auto" style={{ maxHeight: 280, padding: 2 }}>
-        {loading && <div className="text-2xs text-fg-tertiary px-1 py-2">加载中…</div>}
+      {/* ckpt chip 列表 —— 等宽网格（auto-fill）：名字长短不一时也对齐成整齐的列，
+          长名在格内 truncate + title 看全名，避免散乱的 ragged 流式排布。 */}
+      <div
+        className="grid gap-1.5 overflow-y-auto"
+        style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))', maxHeight: 280, padding: 2 }}
+      >
+        {loading && <div className="text-2xs text-fg-tertiary px-1 py-2" style={{ gridColumn: '1 / -1' }}>加载中…</div>}
         {!loading && projects.length === 0 && (
-          <div className="text-fg-tertiary text-xs px-1 py-4 text-center w-full">
+          <div className="text-fg-tertiary text-xs px-1 py-4 text-center" style={{ gridColumn: '1 / -1' }}>
             还没有训练好的 LoRA —— 先去训练一个{onPickExternal ? '，或用「外部文件」' : ''}
           </div>
         )}
         {!loading && projects.length > 0 && pid !== null && vid !== null && ckpts.length === 0 && !error && (
-          <div className="text-2xs text-fg-tertiary px-1 py-4 text-center w-full">
+          <div className="text-2xs text-fg-tertiary px-1 py-4 text-center" style={{ gridColumn: '1 / -1' }}>
             该版本没扫到 ckpt 文件
           </div>
         )}
@@ -429,11 +433,11 @@ export default function InlineLoraPicker(props: Props) {
               type="button"
               onClick={() => onChipClick(c)}
               disabled={isExisting}
-              className="font-mono inline-flex items-center gap-1"
+              className="font-mono flex items-center gap-1 min-w-0"
               style={{
                 fontSize: 11,
-                padding: '3px 10px',
-                borderRadius: 999,
+                padding: '4px 8px',
+                borderRadius: 'var(--r-md)',
                 border: isPicked
                   ? '1px solid transparent'
                   : (isExisting ? '1px dashed var(--border-default)' : '1px solid var(--border-subtle)'),
@@ -444,17 +448,16 @@ export default function InlineLoraPicker(props: Props) {
                   ? 'var(--fg-tertiary)'
                   : (isPicked ? 'var(--accent)' : 'var(--fg-secondary)'),
                 cursor: isExisting ? 'not-allowed' : 'pointer',
-                whiteSpace: 'nowrap',
               }}
               title={c.path}
             >
-              <span>{marker}</span>
-              <span>{c.label}</span>
+              <span className="shrink-0">{marker}</span>
+              <span className="truncate flex-1 text-left">{c.label}</span>
             </button>
           )
         })}
         {!loading && ckpts.length > 0 && filtered.length === 0 && (
-          <div className="text-fg-tertiary text-xs px-1 py-4 text-center w-full">没有匹配的 ckpt</div>
+          <div className="text-fg-tertiary text-xs px-1 py-4 text-center" style={{ gridColumn: '1 / -1' }}>没有匹配的 ckpt</div>
         )}
       </div>
 

--- a/studio/web/src/pages/tools/generate/NumberListInput.tsx
+++ b/studio/web/src/pages/tools/generate/NumberListInput.tsx
@@ -3,22 +3,20 @@ import { useTranslation } from 'react-i18next'
 
 /** 数值列表输入：[输入框] [+ 添加] + 已加 chips（× 删除）。
  *
- * 替代 "0.6, 0.8, 1.0" 这种逗号分隔的 text input —— 用户反馈打错容易（少
- * 个逗号、多个空格、混入字母）。chips 输入避免格式错误，并直观看到已加值。
+ * 用 chips 直观看到已加的每个值，避免裸 "0.6, 0.8, 1.0" text input 打错难发现。
+ * 但输入框本身支持一次性粘贴 / 输入逗号（中英文）或空格分隔的多个值 ——
+ * 不在 onChange 拦截，点「+ 添加」/ Enter 时才拆分 + 逐个 Number() 校验，
+ * 有限数才入列（无效 token 直接忽略）。
  *
  * 内部仍把 chips 序列化成 ", " 分隔的 raw 字符串往外抛，与 schema
  * parseAxisValues 兼容（不改 backend）。
  */
 export default function NumberListInput({
   raw, onChange,
-  min = 0, max = 1, step = 0.05,
   placeholder = '0.85',
 }: {
   raw: string
   onChange: (raw: string) => void
-  min?: number
-  max?: number
-  step?: number
   placeholder?: string
 }) {
   const { t } = useTranslation()
@@ -26,16 +24,19 @@ export default function NumberListInput({
 
   const values = raw.split(',').map((s) => s.trim()).filter(Boolean)
 
+  // 转化时校验：按中英文逗号 / 空白拆 token，逐个 Number() 留有限数（保留原文本，
+  // 不强转规范化，"0.50" 仍显示 "0.50"）。一次性输入 "0.2, 0.3 0.4" → [0.2,0.3,0.4]。
+  const parseDraft = (s: string): string[] =>
+    s.split(/[,，\s]+/).map((x) => x.trim()).filter((x) => x && Number.isFinite(Number(x)))
+
   const addValue = () => {
-    const t = draft.trim()
-    if (!t) return
-    const n = Number(t)
-    if (!Number.isFinite(n)) return
-    if (values.includes(t)) {
-      setDraft('')
-      return
+    const parsed = parseDraft(draft)
+    if (parsed.length === 0) return
+    const merged = [...values]
+    for (const v of parsed) {
+      if (!merged.includes(v)) merged.push(v)
     }
-    onChange([...values, t].join(', '))
+    onChange(merged.join(', '))
     setDraft('')
   }
 
@@ -47,11 +48,9 @@ export default function NumberListInput({
     <div className="flex flex-col gap-1.5">
       <div className="flex gap-1.5 items-stretch">
         <input
-          type="number"
+          type="text"
+          inputMode="decimal"
           className="input font-mono text-xs flex-1"
-          min={min}
-          max={max}
-          step={step}
           placeholder={placeholder}
           value={draft}
           onChange={(e) => setDraft(e.target.value)}
@@ -65,7 +64,7 @@ export default function NumberListInput({
         <button
           type="button"
           onClick={addValue}
-          disabled={!draft.trim() || !Number.isFinite(Number(draft))}
+          disabled={parseDraft(draft).length === 0}
           className="font-mono"
           style={{
             border: '1px solid var(--border-subtle)',

--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
@@ -25,8 +25,13 @@ function migrateLegacyKey(legacyKey: string, newKey: string): void {
 export interface DatasetPick {
   projectId: number
   versionId: number
-  /** caption 文件名（含目录，例如 "5_concept/0001.txt"） */
+  /** 训练集图片文件名（CaptionEntry.name，例如 "0001.png"） */
   name: string
+  /**
+   * 图片所在子目录（CaptionEntry.folder，例如 "5_concept"）。可选：旧快照
+   * （加这个字段之前序列化的）没有它，缩略图就不渲染，不影响 tags 拼接。
+   */
+  folder?: string
   /** caption 文本拆出的 tag 列表，按训练集原始顺序 */
   tags: string[]
 }
@@ -77,6 +82,8 @@ export default function PromptFromDatasetPicker({
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [search, setSearch] = useState('')
+  // 鼠标悬停的 caption key，驱动底部大图预览（移开 → 回落到已选 value 的图）
+  const [hoveredKey, setHoveredKey] = useState<string | null>(null)
 
   // 1. 拉项目列表；若上次记的 pid 在新项目列表中不存在则清掉避免幽灵选择
   useEffect(() => {
@@ -135,6 +142,18 @@ export default function PromptFromDatasetPicker({
 
   const tagsText = value ? value.tags.join(', ') : ''
 
+  // 底部大图预览源：优先悬停行（浏览中 pid/vid），其次已选 value（用 value 自带
+  // 的 project/version/folder，跟浏览位置解耦）。旧快照的 value 没 folder → 不渲染。
+  const hoveredCaption = hoveredKey
+    ? captions.find((c) => `${c.folder}/${c.name}` === hoveredKey) ?? null
+    : null
+  const previewSrc =
+    hoveredCaption && pid && vid
+      ? api.versionThumbUrl(pid, vid, 'train', hoveredCaption.name, hoveredCaption.folder, 512)
+      : value && value.folder
+        ? api.versionThumbUrl(value.projectId, value.versionId, 'train', value.name, value.folder, 512)
+        : ''
+
   const handleRowClick = (c: CaptionEntry) => {
     if (
       value
@@ -151,6 +170,7 @@ export default function PromptFromDatasetPicker({
       projectId: pid,
       versionId: vid,
       name: c.name,
+      folder: c.folder,
       tags: c.tags,
     })
   }
@@ -223,7 +243,11 @@ export default function PromptFromDatasetPicker({
       {error && <div className="text-2xs text-err">{error}</div>}
 
       {/* caption 列表 */}
-      <div className="flex flex-col gap-px overflow-y-auto" style={{ maxHeight: 240 }}>
+      <div
+        className="flex flex-col gap-px overflow-y-auto"
+        style={{ maxHeight: 320 }}
+        onMouseLeave={() => setHoveredKey(null)}
+      >
         {loading && <div className="text-2xs text-fg-tertiary">{t('common.loading')}</div>}
         {!loading && pid && vid && captions.length === 0 && !error && (
           <div className="text-2xs text-fg-tertiary">{t('generate.noCaptions')}</div>
@@ -231,10 +255,16 @@ export default function PromptFromDatasetPicker({
         {!loading && filtered.map((c) => {
           const k = `${c.folder}/${c.name}`
           const active = selectedKeyInList === c.name
+          // 行内缩略图请求 64px（≈2× 显示尺寸）保证高 DPI 不糊；native lazy
+          // 让没滚到的行不发请求，长列表不会一次性把图全拉下来。
+          const thumb = pid && vid
+            ? api.versionThumbUrl(pid, vid, 'train', c.name, c.folder, 64)
+            : ''
           return (
             <button
               key={k}
               onClick={() => handleRowClick(c)}
+              onMouseEnter={() => setHoveredKey(k)}
               className="flex items-center gap-2 px-2 py-1.5 rounded text-xs text-left border-none transition-colors"
               style={{
                 background: active ? 'var(--accent-soft)' : 'transparent',
@@ -242,6 +272,16 @@ export default function PromptFromDatasetPicker({
                 cursor: 'pointer',
               }}
             >
+              {thumb && (
+                <img
+                  src={thumb}
+                  alt=""
+                  loading="lazy"
+                  className="shrink-0 rounded object-cover bg-sunken"
+                  style={{ width: 36, height: 36 }}
+                  onError={(e) => { e.currentTarget.style.visibility = 'hidden' }}
+                />
+              )}
               <span className="font-mono text-2xs shrink-0">{active ? '✓' : '+'}</span>
               <div className="flex-1 min-w-0">
                 <div className="font-medium truncate">{c.name}</div>
@@ -255,14 +295,37 @@ export default function PromptFromDatasetPicker({
       </div>
 
       <label className="caption block mt-1">{t('generate.selectedDatasetTagsLabel')}</label>
-      <textarea
-        className="input w-full font-mono text-xs resize-y"
-        rows={3}
-        value={tagsText}
-        readOnly
-        placeholder={t('generate.selectedDatasetTagsPlaceholder')}
-        aria-label={t('generate.selectedDatasetTagsAria')}
-      />
+      {/* 上：训练集大图（悬停行 / 已选行），跟生成结果肉眼比对；下：只读 tags。
+          object-contain 看全图（大预览惯例，对齐 TagEdit / Preprocess），不裁切。 */}
+      <div className="flex flex-col gap-2">
+        <div
+          className="rounded border border-subtle bg-sunken overflow-hidden flex items-center justify-center"
+          style={{ height: 240 }}
+        >
+          {previewSrc ? (
+            <img
+              src={previewSrc}
+              alt={t('generate.datasetPreviewAlt')}
+              loading="lazy"
+              className="w-full h-full object-contain"
+              onError={(e) => { e.currentTarget.style.visibility = 'hidden' }}
+            />
+          ) : (
+            <span className="text-2xs text-fg-tertiary px-1.5 text-center leading-snug">
+              {t('generate.datasetPreviewEmpty')}
+            </span>
+          )}
+        </div>
+        {/* 最小高度对齐「正向」(PromptList rows=5 text-sm)：5×20 行高 + .input 14 padding + 2 边框 = 116 */}
+        <textarea
+          className="input w-full font-mono text-xs resize-y"
+          style={{ minHeight: 116 }}
+          value={tagsText}
+          readOnly
+          placeholder={t('generate.selectedDatasetTagsPlaceholder')}
+          aria-label={t('generate.selectedDatasetTagsAria')}
+        />
+      </div>
     </div>
   )
 }

--- a/studio/web/src/pages/tools/generate/SidebarLoras.tsx
+++ b/studio/web/src/pages/tools/generate/SidebarLoras.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { LoraEntry } from '../../../api/client'
 import PathPicker from '../../../components/PathPicker'
+import AddSlotButton from './AddSlotButton'
 import InlineLoraPicker, { type PickedLora } from './InlineLoraPicker'
 import type { ProjectLora } from './types'
 
@@ -101,28 +102,7 @@ export default function SidebarLoras({
         )
       })}
 
-      <button
-        onClick={handleAddSlot}
-        className="font-mono inline-flex items-center gap-1.5 self-start"
-        style={{
-          border: '1px solid var(--border-subtle)',
-          background: 'var(--bg-sunken)',
-          borderRadius: 'var(--r-md)',
-          padding: '6px 10px',
-          fontSize: 12,
-          color: 'var(--fg-tertiary)',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.color = 'var(--fg-primary)'
-          e.currentTarget.style.borderColor = 'var(--border-default)'
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.color = 'var(--fg-tertiary)'
-          e.currentTarget.style.borderColor = 'var(--border-subtle)'
-        }}
-      >
-        + 添加 LoRA
-      </button>
+      <AddSlotButton onClick={handleAddSlot}>+ 添加 LoRA</AddSlotButton>
 
       {/* placeholder 卡片渲染：path='' && name 保留 */}
       {externalForIdx !== null && (

--- a/studio/web/src/pages/tools/generate/SidebarSectionTabs.tsx
+++ b/studio/web/src/pages/tools/generate/SidebarSectionTabs.tsx
@@ -1,0 +1,54 @@
+import { useTranslation } from 'react-i18next'
+import type { ViewMode } from './ViewModeTabs'
+
+export type SidebarTab = 'lora' | 'prompts' | 'config'
+
+/** 左侧配置区分页 segmented 控件：LoRA/XY · 提示词 · 配置。
+ *
+ * 三块原本竖向堆叠靠滚动浏览，改成三页平铺，控件放进底部 footer（「开始生成」上方）。
+ * 分段控件而非独立按钮：sunken 轨道把三段一起包住（未选中也有容器），等宽
+ * （flex-1）；选中段用 surface 底 + 细边 + 轻阴影抬起，**刻意不复用 btn-primary
+ * 橙色**，免得跟正下方的橙色「开始生成」按钮撞脸误认。第一段跟随 mode：
+ * single → LoRA，xy → XY。 */
+export default function SidebarSectionTabs({
+  tab, onTabChange, mode,
+}: {
+  tab: SidebarTab
+  onTabChange: (t: SidebarTab) => void
+  mode: ViewMode
+}) {
+  const { t } = useTranslation()
+  const seg = (key: SidebarTab, label: string) => {
+    const active = tab === key
+    return (
+      <button
+        onClick={() => onTabChange(key)}
+        aria-selected={active}
+        className="flex-1 min-w-0 truncate text-xs text-center transition-colors"
+        style={{
+          padding: '5px 8px',
+          borderRadius: 'var(--r-sm)',
+          border: `1px solid ${active ? 'var(--border-subtle)' : 'transparent'}`,
+          background: active ? 'var(--bg-surface)' : 'transparent',
+          color: active ? 'var(--fg-primary)' : 'var(--fg-tertiary)',
+          fontWeight: active ? 600 : 500,
+          boxShadow: active ? 'var(--sh-sm)' : 'none',
+          cursor: 'pointer',
+        }}
+      >
+        {label}
+      </button>
+    )
+  }
+  return (
+    <div
+      role="tablist"
+      className="flex items-center gap-1"
+      style={{ background: 'var(--bg-sunken)', borderRadius: 'var(--r-md)', padding: 3 }}
+    >
+      {seg('lora', mode === 'single' ? 'LoRA' : 'XY')}
+      {seg('prompts', t('generate.prompts'))}
+      {seg('config', t('generate.samplingParams'))}
+    </div>
+  )
+}

--- a/studio/web/src/pages/tools/generate/SidebarXYAxes.tsx
+++ b/studio/web/src/pages/tools/generate/SidebarXYAxes.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import type { LoraEntry, XYAxisType } from '../../../api/client'
 import PathPicker from '../../../components/PathPicker'
+import AddSlotButton from './AddSlotButton'
 import InlineLoraPicker from './InlineLoraPicker'
 import NumberListInput from './NumberListInput'
 import type { ProjectLora } from './types'
@@ -137,46 +139,55 @@ function AxisCard({
   onLorasChange: (l: LoraEntry[]) => void
   projectLoras: ProjectLora[]
 }) {
+  const { t } = useTranslation()
   const isCkpt = draft.axis === 'lora_ckpt'
 
+  // 背景 / padding 对齐 LoRA 槽的 InlineLoraPicker（bg-overlay + p-2.5）；不用 bg-sunken
+  // —— dark 下近黑，跟 LoRA 区不一致显突兀。
   return (
-    <div className="bg-sunken border border-subtle rounded-md px-2.5 py-2 flex flex-col gap-2">
-      <div className="flex items-center gap-2">
-        <span className="text-xs font-semibold text-fg-secondary shrink-0 w-4">{label}</span>
-        <select
-          className="input text-xs flex-1"
-          value={draft.axis}
-          onChange={(e) => {
-            const newAxis = e.target.value as XYAxisType
-            onChange({
-              ...draft,
-              axis: newAxis,
-              raw: newAxis === 'lora_ckpt' ? '' : draft.raw,
-              loraIndex: REQUIRES_LORA_INDEX.has(newAxis)
-                ? (loras.length > 0 ? 0 : null)
-                : null,
-            })
-          }}
-        >
-          {ALL_AXES.map((a) => (
-            <option key={a} value={a}>{axisLabel(a)}</option>
-          ))}
-        </select>
+    <div className="bg-overlay border border-subtle rounded-md p-2.5 flex flex-col gap-2">
+      {/* 轴名单独成行作整张卡的标题（下面的轴类型 dropdown + 取值都隶属它）；× 放这行
+          最右端、跟轴名分处两端 —— 之前单字母 "X" 跟下拉同行、像个关闭按钮，易混淆。 */}
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-xs font-semibold text-fg-secondary">
+          {t('generate.xyAxis', { label })}
+        </span>
         {onRemove && (
           <button
             onClick={onRemove}
             className="btn btn-ghost btn-sm text-fg-tertiary hover:text-err shrink-0 px-1.5"
-            title="移除 Y 轴（退化到单轴）"
-            aria-label="移除 Y 轴"
+            title={t('generate.xyRemoveAxisTitle', { label })}
+            aria-label={t('generate.xyRemoveAxisAria', { label })}
           >
             ×
           </button>
         )}
       </div>
 
-      {/* axis=lora_ckpt：多选 chip picker 直接产出 raw + loraIndex；
-          axis=lora_scale：纯数字（chip 列表），不再绑 LoRA；
-          axis=steps/cfg：文本输入。 */}
+      <select
+        className="input text-xs w-full"
+        value={draft.axis}
+        onChange={(e) => {
+          const newAxis = e.target.value as XYAxisType
+          onChange({
+            ...draft,
+            axis: newAxis,
+            raw: newAxis === 'lora_ckpt' ? '' : draft.raw,
+            loraIndex: REQUIRES_LORA_INDEX.has(newAxis)
+              ? (loras.length > 0 ? 0 : null)
+              : null,
+          })
+        }}
+      >
+        {ALL_AXES.map((a) => (
+          <option key={a} value={a}>{axisLabel(a)}</option>
+        ))}
+      </select>
+
+      {/* 用细线把轴类型 dropdown 跟取值分隔（不靠缩进、不占横向空间）；取值隶属上面
+          选中的轴类型：lora_ckpt → 多选 chip picker（产出 raw + loraIndex）；
+          lora_scale → 纯数字 chip（不绑 LoRA）；steps/cfg → 文本。 */}
+      <div className="divider" />
       {isCkpt ? (
         <AxisLoraCkptPicker
           draft={draft}
@@ -189,9 +200,6 @@ function AxisCard({
         <NumberListInput
           raw={draft.raw}
           onChange={(raw) => onChange({ ...draft, raw })}
-          min={0}
-          max={1.5}
-          step={0.05}
           placeholder="0.6, 0.8, 1.0"
         />
       ) : (
@@ -227,7 +235,8 @@ export default function SidebarXYAxes({
   projectLoras: ProjectLora[]
 }) {
   return (
-    <div className="card" style={{ padding: 18 }}>
+    // 外层不再套 .card —— 父级 sidebar 已是统一卡片，这里只做内容分组避免双重边框。
+    <div>
       <div className="flex items-center justify-between mb-3">
         <div className="text-md font-semibold">XY 轴</div>
       </div>
@@ -244,16 +253,15 @@ export default function SidebarXYAxes({
             loras={loras} onLorasChange={onLorasChange} projectLoras={projectLoras}
           />
         ) : (
-          <button
+          <AddSlotButton
             onClick={() => onYChange({
               axis: 'lora_scale',
               raw: '1',  // 一个值起步，用户自己 + 添加
               loraIndex: null,
             })}
-            className="btn btn-ghost btn-sm self-start text-xs text-fg-tertiary"
           >
             + 添加 Y 轴
-          </button>
+          </AddSlotButton>
         )}
       </div>
     </div>

--- a/studio/web/src/test/setup.ts
+++ b/studio/web/src/test/setup.ts
@@ -13,6 +13,16 @@ if (typeof globalThis.fetch === 'function') {
   vi.stubGlobal('fetch', vi.fn(async () => new Response('', { status: 404 })))
 }
 
+// jsdom 没有 ResizeObserver（useAutoGrowTextarea 等会 new 它撑高 textarea）；装个
+// no-op，避免组件 mount 时抛错。测试不校验自动撑高，回调不触发即可。
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+}
+
 // 把 tagDict store 预热到 'empty' 状态：useTagDict 的 useEffect 看到非 idle 就
 // 跳过 loadDict，避免组件 mount 时触发异步 fetch + act() warning。需要看 dict
 // ready 状态的具体测试可以 __setStateForTest 覆盖。


### PR DESCRIPTION
## 背景 / 动机

Generate 页左侧配置区原本是 LoRA/XY · 提示词 · 配置 三张卡片竖向堆叠，靠滚动浏览，竖向很长、找参数要翻。同时提示词选择器只有文本、跟生成结果对不上号；XY 轴卡片的轴标签是单字母 "X" 跟下拉和 × 同行，容易误认成关闭按钮，取值跟轴类型也看不出隶属。

## 改动概要

**配置区分页**
- 左侧整体收成**一张统一卡片**：内容区独立 scroll，底部 footer 固定放 segmented tab + 「开始生成」按钮。
- 三块拆成 **LoRA/XY · 提示词 · 配置** 三页 tab（放生成按钮上方），一次只显示一页。
- tab 用 `display` 切换、三页常驻 DOM **不卸载**，避免切换重渲闪烁；当前页持久化到 localStorage。
- segmented 控件用 sunken 轨道 + 选中段 surface 抬起，**刻意不复用橙色 `btn-primary`**，跟下方生成按钮区分。
- scroll 移进卡片内侧 + `scrollbar-gutter: stable both-edges`，左右 gap 不再受滚动条出现影响。

**提示词选择器（PromptFromDatasetPicker）**
- 列表每行加缩略图、底部加大图预览，跟右侧生成结果肉眼比对；上下布局，tags 框最小高度对齐「正向」输入框。

**XY 轴卡片整理**
- 轴名（`X 轴`/`Y 轴`，i18n）单独成行作卡片标题，× 移到该行右端，不再跟下拉同行；移除按钮 title/aria 也 i18n。
- 取值内容用细线（`.divider`）跟轴类型下拉分隔表达隶属（不用缩进、不占横向空间）。
- 外观对齐 LoRA 槽（`bg-overlay`，原 `bg-sunken` 在暗色近黑显突兀）。

**一致性 / 修复**
- 抽 `AddSlotButton`，让「+ 添加 Y 轴」跟「+ 添加 LoRA」共用同一样式。
- LoRA ckpt chip 改**等宽网格**（`auto-fill` + `truncate`），名字长短不再排布散乱；长名 title 看全名。
- 修 textarea 在隐藏 tab 里塌缩：`useAutoGrowTextarea` 加 `offsetParent` 守卫（隐藏时不压塌）+ `ResizeObserver`（重新可见时重算高度）。影响正向 / 负向两个输入框。
- XY 权重输入支持**逗号一次性输入**（`0.2, 0.3, 0.4`）：`NumberListInput` 改 text 输入，**转化时**按逗号/空白拆分 + 逐个 `Number()` 校验，不在 onChange 拦截。

## 测试方式

- 手测：三个 tab 切换、提示词预览、XY 轴布局、chip 排布、textarea 高度、逗号批量输入均确认正常。
- 自动：`npx vitest run` **381 全绿**（含 `Generate.test.tsx` 跟随 tab/标签调整）；`npm run lint` + `npx tsc --noEmit` clean。test setup 补了 `ResizeObserver` no-op（jsdom 无）。

## 截图

纯前端 UI 改动，建议拉分支本地跑 Generate 页查看（分页 tab / 预览图 / XY 轴卡片 / chip 网格）。如需我补截图可在 review 时贴。

🤖 Generated with [Claude Code](https://claude.com/claude-code)