### PR TITLE
fix(vae): proactive 分块 encode/decode 修大显存卡 VAE 卡死

### DIFF
--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -150,7 +150,8 @@ def main() -> None:
         )
 
     logger.info("加载 VAE...")
-    vae = _T.load_vae(vae_path, device, vae_dtype, repo_root)
+    vae = _T.load_vae(vae_path, device, vae_dtype, repo_root,
+                      tiling=str(cfg.get("vae_tiling", "auto")))
 
     logger.info("加载文本编码器...")
     qwen_model, qwen_tok, t5_tok = _T.load_text_encoders(

--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -437,7 +437,8 @@ def main() -> None:
         _T.enable_xformers(model)
 
     logger.info("加载 VAE...")
-    vae = _T.load_vae(vae_path, device, dtype, repo_root)
+    vae = _T.load_vae(vae_path, device, dtype, repo_root,
+                      tiling=str(cfg.get("vae_tiling", "auto")))
 
     logger.info("加载文本编码器...")
     qwen_model, qwen_tok, t5_tok = _T.load_text_encoders(

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -636,7 +636,8 @@ class CachedLatentDataset(Dataset):
         def _encode_pixels(pixel_tensors):
             pixels = torch.stack(pixel_tensors, dim=0).to(device, dtype=dtype)
             with torch.inference_mode():
-                latents = vae.model.encode(pixels.unsqueeze(2), vae.scale)
+                # 走 VAEWrapper.encode（含 auto/on 分块），大图/大 batch 不会撞 VRAM 崖
+                latents = vae.encode(pixels.unsqueeze(2))
             return latents.detach().cpu().float()
 
         def _flush(bucket_key):

--- a/runtime/training/models.py
+++ b/runtime/training/models.py
@@ -39,11 +39,13 @@ class VAEWrapper:
     `try` 整图，CUDA OOM 才走 cosine-blend 切块 decode（每 tile 64 latent /
     512 pixel，单 tile 工作峰值约 75MB）。
 
-    大显存路径永远在 `try` 一次就过、零成本；fallback 路径每张图慢 ~30%。
+    后续（VRAM 崖修复）：`decode()` / `encode()` 都按 `tiling`（auto/on/off）决策，
+    auto 在「已用 + 预计峰值」越过总显存阈值时主动分块——不只是等 OOM。大显存卡上
+    整图 op 接近占满显存会触发 WDDM 显存换页、单次 op 从 <1s 退化到上百秒，且不抛
+    干净 OOM，reactive 兜底救不了，故需 proactive。
 
-    现有训练代码（dataset 编 latent / phases/dataset.py 训练时重建预览）继续直
-    接调 `wrapper.model.encode/decode(z, wrapper.scale)`，保持现有行为不动 ——
-    encode 路径与训练侧低分辨率重建不会 OOM。
+    调用方应走 `wrapper.encode(pixels)` / `wrapper.decode(z)`（带分块决策），不要直接
+    调 `wrapper.model.encode/decode(...)`（绕过分块）。
     """
 
     # tile 几何：tile=512px / overlap=128px / 4-stage VAE 8× upsample
@@ -51,18 +53,70 @@ class VAEWrapper:
     _STRIDE_LATENT = 48
     _UPSAMPLE = 8
 
-    def __init__(self, model, mean, std):
+    # 整图 decode 峰值显存 ≈ _DECODE_PEAK_BYTES_PER_OUT_PX × (elem/4) × 输出像素 × B × T。
+    # 标定自 tools/spike/vae_stress.py（RTX 5090 / WAN VAE dim=96）：fp32 1024²≈10.4G、
+    # 1536²≈22.6G；bf16 减半。取 11000（实测 ~9.8k）留 ~12% 余量。
+    _DECODE_PEAK_BYTES_PER_OUT_PX = 11000
+    # 整图 encode 峰值 ≈ _ENCODE_PEAK_BYTES_PER_IN_PX × (elem/4) × 输入像素 × B × T。
+    # 标定自 tools/spike/vae_stress.py（fp32）：1024²≈5.5G、1536²≈11.6G、2048²≈20.3G。
+    _ENCODE_PEAK_BYTES_PER_IN_PX = 5500
+    # auto：当「当前已用 + 预计峰值」超过总显存此比例就分块。崖在 ~50% 而非满显存——
+    # fp32 1536²(峰值 22.6G / 总 31.8G = 71%) 即便「装得下」也会因 WDDM 显存换页退化到
+    # ~190s；fp32 1024²(10.4G / 33%) 正常。0.5 让快路径(fp32≤1024 / bf16≤1536)走整图，
+    # 把会撞崖的(大图、fp32、或叠加常驻模型)切到分块。
+    _TILE_VRAM_FRACTION = 0.5
+
+    def __init__(self, model, mean, std, tiling: str = "auto"):
         self.model = model
         self.mean = mean
         self.std = std
         self.scale = [mean, 1.0 / std]
+        # 分块模式：
+        #   auto（默认）= 按 free VRAM 估算，整图峰值逼近可用显存时主动分块；
+        #   on          = 始终分块（省显存，慢约 30%）；
+        #   off          = 整图，仅真 OOM 时回退分块（旧行为）。
+        # auto 解决大显存卡整图 decode 接近占满时触发「系统内存回退」→ 单次 decode
+        # 从 <1s 退化到上百秒的卡死（reactive OOM 兜底救不了，因为没抛干净 OOM）。
+        self.tiling = str(tiling or "auto").lower().strip()
+
+    def _est_decode_peak_bytes(self, z) -> int:
+        b, _c, t, H, W = z.shape
+        out_px = (H * self._UPSAMPLE) * (W * self._UPSAMPLE)
+        elem = z.element_size()  # 2=bf16/fp16, 4=fp32
+        return int(self._DECODE_PEAK_BYTES_PER_OUT_PX * (elem / 4.0) * out_px * b * max(1, t))
+
+    def _est_encode_peak_bytes(self, pixels) -> int:
+        b, _c, t, H, W = pixels.shape  # H/W 为像素分辨率
+        in_px = H * W
+        elem = pixels.element_size()
+        return int(self._ENCODE_PEAK_BYTES_PER_IN_PX * (elem / 4.0) * in_px * b * max(1, t))
+
+    @classmethod
+    def _should_auto_tile(cls, used_bytes: int, est_peak_bytes: int, total_bytes: int) -> bool:
+        """auto 判定：当前已用 + 预计 decode 峰值 是否越过总显存的分块阈值。"""
+        return (used_bytes + est_peak_bytes) > total_bytes * cls._TILE_VRAM_FRACTION
 
     def decode(self, z):
-        """latent → pixel；整图 OOM 时自动切块重试。
+        """latent → pixel；按 self.tiling 决定整图 / 分块。
 
         z: ``[b, 16, t, H, W]`` latent
         return: ``[b, 3, t, H*8, W*8]``（与底层 `WanVAE_.decode` 一致，未 clamp）
         """
+        if self.tiling == "on":
+            return self._tiled_decode(z)
+
+        if self.tiling == "auto" and z.is_cuda and torch.cuda.is_available():
+            free, total = torch.cuda.mem_get_info()
+            used = total - free
+            est = self._est_decode_peak_bytes(z)
+            if self._should_auto_tile(used, est, total):
+                logger.info(
+                    "VAE decode 主动分块（tiling=auto）：已用 %.1fG + 预计峰值 %.1fG > 总显存 %.1fG×%.2f",
+                    used / 1024 ** 3, est / 1024 ** 3, total / 1024 ** 3, self._TILE_VRAM_FRACTION,
+                )
+                return self._tiled_decode(z)
+
+        # off，或 auto 判定显存够：整图，仍保留 OOM 兜底（小显存卡的安全网）。
         try:
             return self.model.decode(z, self.scale)
         except torch.cuda.OutOfMemoryError:
@@ -74,6 +128,38 @@ class VAEWrapper:
                 (self._TILE_LATENT - self._STRIDE_LATENT) * self._UPSAMPLE,
             )
             return self._tiled_decode(z)
+
+    def encode(self, pixels):
+        """pixel → latent；按 self.tiling 决定整图 / 分块。
+
+        pixels: ``[b, 3, t, H, W]``（H/W 为像素分辨率，须为 8 的倍数）
+        return: ``[b, 16, t, H/8, W/8]`` latent（与 `WanVAE_.encode` 一致）
+        """
+        if self.tiling == "on":
+            return self._tiled_encode(pixels)
+
+        if self.tiling == "auto" and pixels.is_cuda and torch.cuda.is_available():
+            free, total = torch.cuda.mem_get_info()
+            used = total - free
+            est = self._est_encode_peak_bytes(pixels)
+            if self._should_auto_tile(used, est, total):
+                logger.info(
+                    "VAE encode 主动分块（tiling=auto）：已用 %.1fG + 预计峰值 %.1fG > 总显存 %.1fG×%.2f",
+                    used / 1024 ** 3, est / 1024 ** 3, total / 1024 ** 3, self._TILE_VRAM_FRACTION,
+                )
+                return self._tiled_encode(pixels)
+
+        try:
+            return self.model.encode(pixels, self.scale)
+        except torch.cuda.OutOfMemoryError:
+            torch.cuda.empty_cache()
+            logger.warning(
+                "VAE 整图 encode OOM，回退到 tiled encode "
+                "(tile=%dpx, overlap=%dpx)",
+                self._TILE_LATENT * self._UPSAMPLE,
+                (self._TILE_LATENT - self._STRIDE_LATENT) * self._UPSAMPLE,
+            )
+            return self._tiled_encode(pixels)
 
     @torch.no_grad()
     def _tiled_decode(self, z):
@@ -114,6 +200,45 @@ class VAEWrapper:
                 wsum[:, :, :, hp:hp + tile_h_px, wp:wp + tile_w_px] += mask
 
         return (acc / wsum).to(z.dtype)
+
+    @torch.no_grad()
+    def _tiled_encode(self, pixels):
+        """在 H/W 维度切块独立 encode，latent 空间 cosine blend 拼回。
+
+        - tile=512px / stride=384px / overlap=128px（= decode 的 64/48/16 latent ×8）
+        - 像素起点恒为 8 的倍数 → latent 位置为整数（_TILE/_STRIDE×8 与 H/W 均整除 8）
+        - blend 在 latent 空间（tile=64 latent，fade=16 latent），accumulator 走 fp32
+        - encode 非线性，拼接为近似（overlap+cosine 抹平 tile 边界），用于 latent 缓存足够
+        """
+        b, _c, t, H, W = pixels.shape
+        up = self._UPSAMPLE
+        tile_px = self._TILE_LATENT * up
+        stride_px = self._STRIDE_LATENT * up
+
+        eff_h = min(tile_px, H)
+        eff_w = min(tile_px, W)
+        hs = _tile_starts(H, eff_h, stride_px)
+        ws = _tile_starts(W, eff_w, stride_px)
+
+        lat_h, lat_w = H // up, W // up
+        tile_lh, tile_lw = eff_h // up, eff_w // up
+        overlap_lat = (tile_px - stride_px) // up
+
+        # encode 输出通道 = z_dim(16)。从第一个 tile 拿真实通道数更稳，但 WAN VAE 固定 16。
+        acc = torch.zeros(b, 16, t, lat_h, lat_w, dtype=torch.float32, device=pixels.device)
+        wsum = torch.zeros(1, 1, 1, lat_h, lat_w, dtype=torch.float32, device=pixels.device)
+
+        mask = _cosine_blend_mask(tile_lh, tile_lw, fade=overlap_lat, device=pixels.device)
+
+        for hi in hs:
+            for wi in ws:
+                px_tile = pixels[:, :, :, hi:hi + eff_h, wi:wi + eff_w]
+                z_tile = self.model.encode(px_tile, self.scale).float()
+                lh, lw = hi // up, wi // up
+                acc[:, :, :, lh:lh + tile_lh, lw:lw + tile_lw] += z_tile * mask
+                wsum[:, :, :, lh:lh + tile_lh, lw:lw + tile_lw] += mask
+
+        return (acc / wsum).to(pixels.dtype)
 
 
 def _tile_starts(size: int, tile: int, stride: int) -> list[int]:
@@ -263,8 +388,8 @@ def load_anima_model(transformer_path, device, dtype, repo_root, *, flash_attn: 
     return model
 
 
-def load_vae(vae_path, device, dtype, repo_root):
-    """加载 VAE。"""
+def load_vae(vae_path, device, dtype, repo_root, *, tiling: str = "auto"):
+    """加载 VAE。``tiling`` 透传给 VAEWrapper（auto/on/off）。"""
     wan_vae = load_module_from_path("wan_vae", repo_root / "wan" / "vae2_1.py")
     WanVAE = wan_vae.WanVAE_
 
@@ -291,7 +416,7 @@ def load_vae(vae_path, device, dtype, repo_root):
     ], dtype=dtype, device=device)
 
     logger.info("VAE 加载完成")
-    return VAEWrapper(model, mean, std)
+    return VAEWrapper(model, mean, std, tiling=tiling)
 
 
 def load_text_encoders(

--- a/runtime/training/models.py
+++ b/runtime/training/models.py
@@ -96,6 +96,19 @@ class VAEWrapper:
         """auto 判定：当前已用 + 预计 decode 峰值 是否越过总显存的分块阈值。"""
         return (used_bytes + est_peak_bytes) > total_bytes * cls._TILE_VRAM_FRACTION
 
+    def should_offload_for_whole_decode(self, z) -> bool:
+        """采样 decode 前是否值得把非活跃模块（DiT/Qwen）挪到 CPU 腾显存。
+
+        仅当「显存紧张（当前会分块）**且** 峰值仍在崖下」时 True：此时腾出常驻模块
+        就能整图 decode、保住 parity / 无 tile 缝。峰值已越崖（如 fp32 1536²）时 False
+        —— 腾显存也救不了整图（崖按总显存比例算、与 free 无关），交给分块更省系统内存。
+        """
+        if not (torch.is_tensor(z) and z.is_cuda and torch.cuda.is_available()):
+            return False
+        free, total = torch.cuda.mem_get_info()
+        est = self._est_decode_peak_bytes(z)
+        return self._should_auto_tile(total - free, est, total) and est < total * self._TILE_VRAM_FRACTION
+
     def decode(self, z):
         """latent → pixel；按 self.tiling 决定整图 / 分块。
 

--- a/runtime/training/phases/dataset.py
+++ b/runtime/training/phases/dataset.py
@@ -130,8 +130,9 @@ def run(ctx: TrainingContext) -> None:
             item0 = ctx.base_dataset[0]
             pixels0 = item0["pixel_values"].unsqueeze(0).to(ctx.device, dtype=ctx.dtype)  # [1,3,H,W]
             with torch.no_grad():
-                z0 = ctx.vae.model.encode(pixels0.unsqueeze(2), ctx.vae.scale)   # [1,16,1,h,w]
-                recon0 = ctx.vae.model.decode(z0, ctx.vae.scale).squeeze(2)      # [1,3,H,W]
+                # encode/decode 均走 VAEWrapper（含 auto/on 分块），避免大图整图 op 触发系统内存回退卡死
+                z0 = ctx.vae.encode(pixels0.unsqueeze(2))                        # [1,16,1,h,w]
+                recon0 = ctx.vae.decode(z0).squeeze(2)                           # [1,3,H,W]
                 recon0 = (recon0.clamp(-1, 1) + 1) / 2
             arr0 = (recon0[0].permute(1, 2, 0).detach().cpu().float().numpy() * 255).clip(0, 255).astype("uint8")
             Image.fromarray(arr0).save(ctx.sample_dir / "vae_roundtrip.png")

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -75,7 +75,8 @@ def run(ctx: TrainingContext) -> None:
         logger.info("attention_backend=none，flash_attn / xformers 都不启用，走 PyTorch SDPA")
 
     logger.info("加载 VAE...")
-    ctx.vae = load_vae(args.vae_path, ctx.device, ctx.dtype, ctx.repo_root)
+    ctx.vae = load_vae(args.vae_path, ctx.device, ctx.dtype, ctx.repo_root,
+                       tiling=getattr(args, "vae_tiling", "auto"))
 
     logger.info("加载文本编码器...")
     ctx.qwen_model, ctx.qwen_tok, ctx.t5_tok = load_text_encoders(

--- a/runtime/training/sampling.py
+++ b/runtime/training/sampling.py
@@ -77,18 +77,6 @@ def _module_device(module) -> torch.device | None:
     return param.device
 
 
-def _vae_param_dtype(vae) -> torch.dtype | None:
-    """取 VAE 权重 dtype——offload 只在 fp32 decode（Generate parity runtime）时
-    才值得做；bf16 VAE（训练预览 / RegAI）显存压力小，搬模型反而是纯开销。"""
-    inner = getattr(vae, "model", vae)
-    if not hasattr(inner, "parameters"):
-        return None
-    try:
-        return next(inner.parameters()).dtype
-    except Exception:
-        return None
-
-
 def _offload_modules_for_vae_decode(*modules) -> list[tuple[object, torch.device]]:
     """Move large, inactive modules off GPU while fp32 VAE decode runs."""
     offloaded: list[tuple[object, torch.device]] = []
@@ -443,14 +431,21 @@ def sample_image(
     del denoise_fn, x, cross_cond, cross_uncond, pad_mask, sigmas, empty_latent
     offloaded_modules: list[tuple[object, torch.device]] = []
     try:
-        # VAEWrapper.decode：整图 OOM 时自动 tile+cosine blend 回退（issue #200）。
-        # 大显存路径在 try 一次就过，零成本；fallback 路径每张图慢 ~30%。
-        # offload 仅在 fp32 VAE（Generate parity runtime）时做；bf16 VAE
-        # （训练预览 / RegAI）显存压力小，搬整个 DiT+Qwen 是纯开销。
-        vae_is_fp32 = _vae_param_dtype(vae) == torch.float32
-        if vae_is_fp32 and device_type == "cuda":
-            logger.info("[Debug] VAE decode: offloading inactive modules before fp32 decode")
-            offloaded_modules = _offload_modules_for_vae_decode(model, qwen_model)
+        # VAEWrapper.decode 按 tiling(auto/on/off) 决策整图/分块。
+        # offload 改为 free-VRAM 驱动、与分块统一（取代旧的「仅 fp32 才 offload」——dtype
+        # 不是显存压力的准确代理：bf16+大图/常驻同样会爆）。只在「腾出显存就能整图且快」
+        # 时才 offload：峰值本身已越过崖（如 fp32 1536²）时，腾显存也救不了整图（崖按总显存
+        # 比例算、与 free 无关，实测整图仍 ~190s），交给 wrapper 分块即可，避免白搬 DiT+Qwen
+        # 占系统内存。
+        if (device_type == "cuda" and torch.cuda.is_available()
+                and hasattr(vae, "_est_decode_peak_bytes")):
+            free, total = torch.cuda.mem_get_info()
+            est = vae._est_decode_peak_bytes(latents)
+            crowded = vae._should_auto_tile(total - free, est, total)         # 当前(含常驻)会触发分块
+            whole_fast_possible = est < total * type(vae)._TILE_VRAM_FRACTION  # 峰值在崖下：腾显存即可整图
+            if crowded and whole_fast_possible:
+                logger.info("[Debug] VAE decode: free VRAM 紧张但峰值在崖下，offload 非活跃模块以整图 decode")
+                offloaded_modules = _offload_modules_for_vae_decode(model, qwen_model)
         images = _decode_vae(vae, latents)
         images = images.squeeze(2)  # [B,C,H,W]
         images = (images.clamp(-1, 1) + 1) / 2
@@ -461,7 +456,7 @@ def sample_image(
         pil_image = Image.fromarray(img)
 
         del images, latents
-        if vae_is_fp32 and device_type == "cuda" and torch.cuda.is_available():
+        if device_type == "cuda" and torch.cuda.is_available():
             torch.cuda.empty_cache()
     except Exception as e:
         logger.error(f"[Debug] VAE decode failed: {e}")

--- a/runtime/training/sampling.py
+++ b/runtime/training/sampling.py
@@ -433,19 +433,13 @@ def sample_image(
     try:
         # VAEWrapper.decode 按 tiling(auto/on/off) 决策整图/分块。
         # offload 改为 free-VRAM 驱动、与分块统一（取代旧的「仅 fp32 才 offload」——dtype
-        # 不是显存压力的准确代理：bf16+大图/常驻同样会爆）。只在「腾出显存就能整图且快」
-        # 时才 offload：峰值本身已越过崖（如 fp32 1536²）时，腾显存也救不了整图（崖按总显存
-        # 比例算、与 free 无关，实测整图仍 ~190s），交给 wrapper 分块即可，避免白搬 DiT+Qwen
-        # 占系统内存。
-        if (device_type == "cuda" and torch.cuda.is_available()
-                and hasattr(vae, "_est_decode_peak_bytes")):
-            free, total = torch.cuda.mem_get_info()
-            est = vae._est_decode_peak_bytes(latents)
-            crowded = vae._should_auto_tile(total - free, est, total)         # 当前(含常驻)会触发分块
-            whole_fast_possible = est < total * type(vae)._TILE_VRAM_FRACTION  # 峰值在崖下：腾显存即可整图
-            if crowded and whole_fast_possible:
-                logger.info("[Debug] VAE decode: free VRAM 紧张但峰值在崖下，offload 非活跃模块以整图 decode")
-                offloaded_modules = _offload_modules_for_vae_decode(model, qwen_model)
+        # 不是显存压力的准确代理：bf16+大图/常驻同样会爆）：只在「腾出显存就能整图且快」时
+        # 才把 DiT+Qwen 挪到 CPU，避免峰值越崖时白搬占系统内存。决策见
+        # VAEWrapper.should_offload_for_whole_decode。
+        _should_offload = getattr(vae, "should_offload_for_whole_decode", None)
+        if device_type == "cuda" and callable(_should_offload) and _should_offload(latents):
+            logger.info("[Debug] VAE decode: 显存紧张且峰值在崖下，offload 非活跃模块以整图 decode")
+            offloaded_modules = _offload_modules_for_vae_decode(model, qwen_model)
         images = _decode_vae(vae, latents)
         images = images.squeeze(2)  # [B,C,H,W]
         images = (images.clamp(-1, 1) + 1) / 2

--- a/studio/domain/generate.py
+++ b/studio/domain/generate.py
@@ -64,6 +64,12 @@ class GenerateConfig(BaseModel):
         "bf16",
         description="VAE decode 精度：bf16 对齐 ComfyUI 现代 GPU 默认；fp32 全精度（decode 前会 offload 腾显存）",
     )
+    vae_tiling: Literal["auto", "on", "off"] = Field(
+        "auto",
+        description="VAE 分块 decode：auto=可用显存紧张时自动分块（推荐）；on=始终分块（省显存、慢约 30%）；"
+                    "off=整图，仅真正 OOM 时回退。fp32 / 高分辨率在大显存卡上整图 decode 会逼近占满显存、"
+                    "触发系统内存回退导致单次 decode 卡上百秒，auto 可避免",
+    )
     attention_backend: AttentionBackend = Field(
         "flash_attn",
         description="Attention backend：none（SDPA）/ xformers / flash_attn",

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -126,6 +126,13 @@ class TrainingConfig(BaseModel):
         description="VAE latent 缓存编码批次大小；0=跟随训练 batch size，显存不足时设为 1 逐张编码",
         json_schema_extra=_meta("system", advanced=True),
     )
+    vae_tiling: Literal["auto", "on", "off"] = Field(
+        "auto",
+        description="VAE 分块 decode：auto=可用显存紧张时自动分块（推荐）；on=始终分块（省显存、慢约 30%）；"
+                    "off=整图，仅真正 OOM 时回退。大显存卡整图 decode 接近占满显存时会触发系统内存回退、"
+                    "单次 decode 从不到 1 秒退化到上百秒，auto 可避免",
+        json_schema_extra=_meta("system", advanced=True),
+    )
 
     # ------------------------------------------------------------------- LoRA
     lora_type: Literal["lora", "lokr", "loha", "ortho", "tlora"] = Field(

--- a/tests/test_comfy_anima_text_encoding.py
+++ b/tests/test_comfy_anima_text_encoding.py
@@ -193,10 +193,10 @@ class AssertingVAEModel:
         self.decode_calls = 0
 
     def parameters(self):
-        # offload 只在 fp32 VAE（Generate parity runtime）时触发
         yield torch.zeros((), dtype=torch.float32)
 
     def decode(self, latents, scale):
+        # 包它的 TrackedVAE.should_offload_for_whole_decode=True → decode 时模型应已 offload 到 CPU
         self.decode_calls += 1
         assert next(self.anima_model.parameters()).device.type == "cpu"
         assert next(self.qwen_model.parameters()).device.type == "cpu"
@@ -210,6 +210,9 @@ class TrackedVAE:
     def __init__(self, anima_model: TinyTrackedAnimaModel, qwen_model: TinyTrackedQwenModel) -> None:
         self.model = AssertingVAEModel(anima_model, qwen_model)
 
+    def should_offload_for_whole_decode(self, z):
+        return True
+
 
 class FailingAssertingVAEModel(AssertingVAEModel):
     def decode(self, latents, scale):
@@ -222,6 +225,9 @@ class FailingTrackedVAE:
 
     def __init__(self, anima_model: TinyTrackedAnimaModel, qwen_model: TinyTrackedQwenModel) -> None:
         self.model = FailingAssertingVAEModel(anima_model, qwen_model)
+
+    def should_offload_for_whole_decode(self, z):
+        return True
 
 
 def _tokenized_non_eos(prompt: str) -> tuple[list[int], list[float]]:
@@ -590,7 +596,7 @@ def test_sample_image_restores_offloaded_modules_when_vae_decode_fails(monkeypat
 
 
 class NoOffloadAssertingVAEModel:
-    """bf16 VAE：decode 时模型必须仍在 CUDA（不应触发 offload）。"""
+    """should_offload_for_whole_decode=False：decode 时模型必须仍在 CUDA（不应触发 offload）。"""
 
     def __init__(self, anima_model: TinyTrackedAnimaModel, qwen_model: TinyTrackedQwenModel) -> None:
         self.anima_model = anima_model
@@ -614,9 +620,12 @@ class NoOffloadTrackedVAE:
     def __init__(self, anima_model: TinyTrackedAnimaModel, qwen_model: TinyTrackedQwenModel) -> None:
         self.model = NoOffloadAssertingVAEModel(anima_model, qwen_model)
 
+    def should_offload_for_whole_decode(self, z):
+        return False
+
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA-only VRAM offload behavior")
-def test_sample_image_skips_offload_for_bf16_vae(monkeypatch) -> None:
+def test_sample_image_skips_offload_when_vae_declines(monkeypatch) -> None:
     model = TinyTrackedAnimaModel().cuda()
     qwen_model = TinyTrackedQwenModel().cuda()
     vae = NoOffloadTrackedVAE(model, qwen_model)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -157,6 +157,10 @@ class _FakeVAE:
         self.model = _FakeVAEModel()
         self.scale = 1.0
 
+    def encode(self, pixels):
+        # 镜像 VAEWrapper.encode 的非分块路径（CPU 小图不触发分块）
+        return self.model.encode(pixels, self.scale)
+
 
 def test_cached_latent_encodes_both_flipped_and_unflipped_when_flip_aug(tmp_path: Path) -> None:
     """flip_augment=True → cache 阶段对每张图 encode 两次，npz 同时有 latent + latent_flipped。
@@ -243,6 +247,10 @@ class _CountingVAE:
     def __init__(self):
         self.model = _CountingVAEModel()
         self.scale = 1.0
+
+    def encode(self, pixels):
+        # 镜像 VAEWrapper.encode 的非分块路径（CPU 小图不触发分块）
+        return self.model.encode(pixels, self.scale)
 
 
 def test_cached_latent_dedupes_repeats_in_encode_pass(tmp_path: Path) -> None:

--- a/tests/test_vae_tiled_decode.py
+++ b/tests/test_vae_tiled_decode.py
@@ -310,6 +310,13 @@ def test_tiled_encode_reconstructs_full_for_linear_encoder() -> None:
     assert torch.allclose(tiled, full, atol=1e-4)
 
 
+def test_should_offload_for_whole_decode_false_on_cpu() -> None:
+    """CPU 张量（无 cuda）下不 offload：守卫返回 False，不触碰 mem_get_info。"""
+    wrapper = _make_wrapper(_RecordingModel())
+    z = torch.zeros(1, 16, 1, 128, 128)  # CPU
+    assert wrapper.should_offload_for_whole_decode(z) is False
+
+
 def test_est_encode_peak_scales_with_pixels_and_dtype() -> None:
     """encode 峰值估算 ∝ 输入像素 × 元素大小。fp32 1024² ≈ 5.5G，bf16 减半。"""
     wrapper = _make_wrapper(_RecordingModel())

--- a/tests/test_vae_tiled_decode.py
+++ b/tests/test_vae_tiled_decode.py
@@ -84,9 +84,26 @@ def test_cosine_blend_mask_zero_fade_all_ones() -> None:
 class _RecordingModel:
     """记录 decode 调用次数 + 形状的 mock；行为是 nearest upsample 8× + 取前 3 通道。"""
 
-    def __init__(self, oom_on_full: bool = False):
+    def __init__(self, oom_on_full: bool = False, oom_on_full_enc: bool = False):
         self.calls: list[tuple[int, ...]] = []
+        self.enc_calls: list[tuple[int, ...]] = []
         self.oom_on_full = oom_on_full
+        self.oom_on_full_enc = oom_on_full_enc
+
+    def encode(self, pixels: torch.Tensor, scale) -> torch.Tensor:
+        """线性 mock：8× avg_pool 下采样 + 3ch→16ch 补零（与 decode 的 nearest 互逆近似）。
+
+        avg_pool stride=8、tile 起点恒为 8 倍数 → 每个输出 latent 像素对应固定 8×8 输入块，
+        分块与整图逐块一致，blend 拼接可高精度复原。
+        """
+        self.enc_calls.append(tuple(pixels.shape))
+        b, _c, t, H, W = pixels.shape
+        if self.oom_on_full_enc and H >= 1024 and len(self.enc_calls) == 1:
+            raise torch.cuda.OutOfMemoryError("simulated OOM on full encode")
+        z = torch.nn.functional.avg_pool3d(pixels, kernel_size=(1, 8, 8))  # [b,3,t,H/8,W/8]
+        if z.shape[1] < 16:
+            z = torch.nn.functional.pad(z, (0, 0, 0, 0, 0, 0, 0, 16 - z.shape[1]))  # 3ch→16ch
+        return z
 
     def decode(self, z: torch.Tensor, scale) -> torch.Tensor:
         self.calls.append(tuple(z.shape))
@@ -177,3 +194,127 @@ def test_tiled_decode_handles_small_input_without_tiling() -> None:
     z = torch.randn(1, 16, 1, 32, 32)  # < tile=64
     out = wrapper._tiled_decode(z)
     assert out.shape == (1, 3, 1, 256, 256)
+
+
+# ---------------------------------------------------------------------------
+# tiling 模式（auto / on / off）+ 峰值估算 + auto 判定阈值
+# ---------------------------------------------------------------------------
+
+
+def test_tiling_on_always_tiles_no_full_call() -> None:
+    """tiling='on'：直接走 _tiled_decode，没有整图 decode 调用。
+
+    128 latent → tile 起点 [0,48,64] → 9 个 64×64 tile，且首调不是 128 整图。
+    """
+    model = _RecordingModel(oom_on_full=False)
+    wrapper = VAEWrapper(model, torch.zeros(16), torch.ones(16), tiling="on")
+    z = torch.zeros(1, 16, 1, 128, 128)
+    out = wrapper.decode(z)
+    assert out.shape == (1, 3, 1, 1024, 1024)
+    assert len(model.calls) == 9
+    assert all(s == (1, 16, 1, 64, 64) for s in model.calls)
+
+
+def test_tiling_off_uses_whole_image_then_oom_net() -> None:
+    """tiling='off'：整图优先；仍保留真 OOM 兜底分块（小显存安全网）。"""
+    model = _RecordingModel(oom_on_full=True)
+    wrapper = VAEWrapper(model, torch.zeros(16), torch.ones(16), tiling="off")
+    z = torch.zeros(1, 16, 1, 128, 128)
+    out = wrapper.decode(z)
+    assert out.shape == (1, 3, 1, 1024, 1024)
+    # 1 次失败整图 + 9 个 tile（OOM 兜底仍在）
+    assert model.calls[0] == (1, 16, 1, 128, 128)
+    assert len(model.calls) == 1 + 9
+
+
+def test_est_decode_peak_scales_with_pixels_and_dtype() -> None:
+    """峰值估算 ∝ 输出像素 × 元素大小。fp32 1024² ≈ 11.5G，bf16 减半。"""
+    model = _RecordingModel()
+    wrapper = _make_wrapper(model)
+    z32 = torch.zeros(1, 16, 1, 128, 128, dtype=torch.float32)   # 1024² 输出
+    est_fp32 = wrapper._est_decode_peak_bytes(z32)
+    assert est_fp32 == pytest.approx(11000 * 1024 * 1024, rel=1e-6)
+    z16 = torch.zeros(1, 16, 1, 128, 128, dtype=torch.bfloat16)
+    assert wrapper._est_decode_peak_bytes(z16) == pytest.approx(est_fp32 / 2, rel=1e-6)
+
+
+def test_should_auto_tile_threshold_matches_measured_cliff() -> None:
+    """auto 阈值复刻实测崖（RTX 5090 31.8G）：fp32 1536² 分块、其余快路径整图。"""
+    GB = 1024 ** 3
+    total = int(31.8 * GB)
+    model = _RecordingModel()
+    w = _make_wrapper(model)
+
+    def est(res, dtype):
+        h = res // 8
+        return w._est_decode_peak_bytes(torch.zeros(1, 16, 1, h, h, dtype=dtype))
+
+    light = int(2.2 * GB)  # 仅 VAE 常驻
+    # fp32 1024（实测 0.34s 整图安全）→ 不分块
+    assert not VAEWrapper._should_auto_tile(light, est(1024, torch.float32), total)
+    # fp32 1536（实测整图 196s）→ 分块
+    assert VAEWrapper._should_auto_tile(light, est(1536, torch.float32), total)
+    # bf16 1536（实测 0.4s 整图安全）→ 不分块
+    assert not VAEWrapper._should_auto_tile(light, est(1536, torch.bfloat16), total)
+    # bf16 1536 但叠加 ~12G 常驻模型（训练 sample 场景）→ 分块
+    heavy = int(13 * GB)
+    assert VAEWrapper._should_auto_tile(heavy, est(1536, torch.bfloat16), total)
+
+
+# ---------------------------------------------------------------------------
+# encode 分块（latent 缓存路径）
+# ---------------------------------------------------------------------------
+
+
+def test_encode_full_path_calls_model_once() -> None:
+    """CPU（非 cuda）走整图 encode：model.encode 只调一次。"""
+    model = _RecordingModel()
+    wrapper = _make_wrapper(model)
+    px = torch.randn(1, 3, 1, 256, 256)
+    z = wrapper.encode(px)
+    assert z.shape == (1, 16, 1, 32, 32)
+    assert len(model.enc_calls) == 1
+
+
+def test_encode_tiling_on_tiles_in_pixel_space() -> None:
+    """tiling='on'：1024px → 像素 tile=512/stride=384 起点 [0,384,512] → 9 个 512² tile。"""
+    model = _RecordingModel()
+    wrapper = VAEWrapper(model, torch.zeros(16), torch.ones(16), tiling="on")
+    px = torch.zeros(1, 3, 1, 1024, 1024)
+    z = wrapper.encode(px)
+    assert z.shape == (1, 16, 1, 128, 128)
+    assert len(model.enc_calls) == 9
+    assert all(s == (1, 3, 1, 512, 512) for s in model.enc_calls)
+
+
+def test_encode_oom_fallback_invokes_tiled_encode() -> None:
+    """整图 encode OOM → catch + tile 兜底（off 模式也保留安全网）。"""
+    model = _RecordingModel(oom_on_full_enc=True)
+    wrapper = VAEWrapper(model, torch.zeros(16), torch.ones(16), tiling="off")
+    px = torch.zeros(1, 3, 1, 1024, 1024)
+    z = wrapper.encode(px)
+    assert z.shape == (1, 16, 1, 128, 128)
+    assert model.enc_calls[0] == (1, 3, 1, 1024, 1024)  # 先试整图
+    assert len(model.enc_calls) == 1 + 9                 # 失败 + 9 tile
+
+
+def test_tiled_encode_reconstructs_full_for_linear_encoder() -> None:
+    """线性 encode（avg_pool）下，tile + cosine blend 拼接 ≈ 整图 encode。"""
+    model = _RecordingModel()
+    wrapper = _make_wrapper(model)
+    torch.manual_seed(0)
+    px = torch.randn(1, 3, 1, 1024, 1024)
+    full = wrapper.model.encode(px, wrapper.scale)
+    tiled = wrapper._tiled_encode(px)
+    assert tiled.shape == full.shape
+    assert torch.allclose(tiled, full, atol=1e-4)
+
+
+def test_est_encode_peak_scales_with_pixels_and_dtype() -> None:
+    """encode 峰值估算 ∝ 输入像素 × 元素大小。fp32 1024² ≈ 5.5G，bf16 减半。"""
+    wrapper = _make_wrapper(_RecordingModel())
+    px32 = torch.zeros(1, 3, 1, 1024, 1024, dtype=torch.float32)
+    est_fp32 = wrapper._est_encode_peak_bytes(px32)
+    assert est_fp32 == pytest.approx(5500 * 1024 * 1024, rel=1e-6)
+    px16 = torch.zeros(1, 3, 1, 1024, 1024, dtype=torch.bfloat16)
+    assert wrapper._est_encode_peak_bytes(px16) == pytest.approx(est_fp32 / 2, rel=1e-6)

--- a/tools/mem_probe.py
+++ b/tools/mem_probe.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""mem_probe —— 内存/显存峰值定位探针（Windows 优先）。
+
+目的：定位「训练 sample / 测试 generate 偶发卡死 + 系统提交虚拟内存暴涨 20-30G」。
+关键判据是：那一坨内存到底在 **GPU 侧**（被 WDDM 镜像成 system commit）还是
+**CPU/host 侧**。本探针每隔 --interval 秒同时采样：
+
+  - 系统提交（Commit Charge）：GetPerformanceInfo().CommitTotal —— 即任务管理器
+    「性能 > 内存 > 已提交」那条，也就是用户看到暴涨的那个数。
+  - 目标进程私有提交（PrivateUsage ≈ 任务管理器进程「提交大小」）。
+  - GPU 显存：NVML（无则回退 nvidia-smi），device 级 used/total + 尽量给 per-pid。
+
+每帧算 Δ（与上一帧之差）。当 |Δcommit| 或 |Δgpu_used| 超过 --spike-gb 时，打印
+醒目告警 + 一句**判据**：
+
+  - Δgpu ≈ Δcommit  → GPU 分配被 WDDM 镜像到 commit（显存侧爆，多半是某次卷积
+    workspace / 大 bucket 分辨率；8G 卡上会直接 OOM 走分块所以没事，大显存卡反而
+    吃满 commit 卡死）。
+  - Δcommit ≫ Δgpu  → CPU/host 侧分配（pinned 内存 / 巨大 CPU 张量 / 泄漏）。
+
+可选 --pyspy：抓到 spike 时自动 `py-spy dump --pid <pid>`，零侵入拿到当时正在
+执行的 Python 调用栈（需 `pip install py-spy`）。
+
+全程写 CSV（--out），事后可画图/比对。
+
+用法
+----
+1) 先把训练/出图跑起来，拿到那个 python 进程的 PID（任务管理器 / `tasklist`）。
+2) 另开一个终端：
+     python tools/mem_probe.py --pid <PID> --interval 0.25 --spike-gb 4 --pyspy
+   或不知道 PID 时按名字挑（选私有提交最大的 python）：
+     python tools/mem_probe.py --name python --interval 0.25 --spike-gb 4
+3) 复现卡死。看终端的 [SPIKE] 行 + 末尾 SUMMARY，或事后读 mem_probe.csv。
+
+依赖：psutil（强烈建议）。NVML(pynvml) 可选；没有就用 nvidia-smi。系统提交用
+ctypes 直接读，无需第三方。
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import ctypes
+import os
+import shutil
+import subprocess
+import sys
+import time
+from ctypes import wintypes
+
+GB = 1024.0 ** 3
+
+try:
+    import psutil  # type: ignore
+except Exception:  # noqa: BLE001
+    psutil = None
+
+
+# ---------------------------------------------------------------- 系统提交（Commit Charge）
+class _PERFORMANCE_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("cb", wintypes.DWORD),
+        ("CommitTotal", ctypes.c_size_t),
+        ("CommitLimit", ctypes.c_size_t),
+        ("CommitPeak", ctypes.c_size_t),
+        ("PhysicalTotal", ctypes.c_size_t),
+        ("PhysicalAvailable", ctypes.c_size_t),
+        ("SystemCache", ctypes.c_size_t),
+        ("KernelTotal", ctypes.c_size_t),
+        ("KernelPaged", ctypes.c_size_t),
+        ("KernelNonpaged", ctypes.c_size_t),
+        ("PageSize", ctypes.c_size_t),
+        ("HandleCount", wintypes.DWORD),
+        ("ProcessCount", wintypes.DWORD),
+        ("ThreadCount", wintypes.DWORD),
+    ]
+
+
+def system_commit_bytes() -> tuple[float, float, float]:
+    """返回 (CommitTotal, CommitLimit, CommitPeak) 字节。仅 Windows。"""
+    pi = _PERFORMANCE_INFORMATION()
+    pi.cb = ctypes.sizeof(pi)
+    ok = ctypes.windll.psapi.GetPerformanceInfo(ctypes.byref(pi), pi.cb)
+    if not ok:
+        raise ctypes.WinError()
+    ps = pi.PageSize
+    return pi.CommitTotal * ps, pi.CommitLimit * ps, pi.CommitPeak * ps
+
+
+# ---------------------------------------------------------------- 目标进程
+def resolve_pid(pid: int | None, name: str | None) -> int:
+    if pid:
+        return pid
+    if psutil is None:
+        sys.exit("未装 psutil 且未给 --pid，无法按名字查找。请装 psutil 或传 --pid。")
+    name_l = (name or "python").lower()
+    best, best_priv = None, -1
+    for p in psutil.process_iter(["name"]):
+        try:
+            if name_l in (p.info["name"] or "").lower():
+                priv = p.memory_info().private
+                if priv > best_priv:
+                    best, best_priv = p.pid, priv
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+    if best is None:
+        sys.exit(f"找不到名字含 '{name_l}' 的进程；用 --pid 指定。")
+    print(f"[mem_probe] 按名字 '{name_l}' 选中 PID={best}（私有提交最大）")
+    return best
+
+
+def proc_mem_bytes(proc) -> tuple[float, float]:
+    """(private/commit, working_set) 字节。"""
+    mi = proc.memory_info()
+    # psutil Windows: memory_info() 含 private(PrivateUsage) 与 rss(WorkingSet)
+    private = getattr(mi, "private", getattr(mi, "pagefile", mi.vms))
+    return float(private), float(mi.rss)
+
+
+# ---------------------------------------------------------------- GPU
+class _GpuReader:
+    def __init__(self, index: int):
+        self.index = index
+        self.nvml = None
+        self.handle = None
+        try:
+            import pynvml  # type: ignore
+            pynvml.nvmlInit()
+            self.nvml = pynvml
+            self.handle = pynvml.nvmlDeviceGetHandleByIndex(index)
+        except Exception:  # noqa: BLE001
+            self.nvml = None
+        self.smi = shutil.which("nvidia-smi")
+
+    def read(self, target_pid: int) -> tuple[float, float, float]:
+        """返回 (used, total, proc_used) 字节；proc_used 取不到时为 -1。"""
+        if self.nvml is not None:
+            try:
+                m = self.nvml.nvmlDeviceGetMemoryInfo(self.handle)
+                proc_used = -1.0
+                try:
+                    for pr in self.nvml.nvmlDeviceGetComputeRunningProcesses(self.handle):
+                        if pr.pid == target_pid and pr.usedGpuMemory not in (None, 0):
+                            proc_used = float(pr.usedGpuMemory)
+                except Exception:  # noqa: BLE001
+                    pass  # WDDM 下 per-pid 常不可用
+                return float(m.used), float(m.total), proc_used
+            except Exception:  # noqa: BLE001
+                pass
+        if self.smi:
+            try:
+                out = subprocess.check_output(
+                    [self.smi, f"--id={self.index}",
+                     "--query-gpu=memory.used,memory.total",
+                     "--format=csv,noheader,nounits"],
+                    text=True, timeout=5,
+                ).strip().splitlines()[0]
+                used_mb, total_mb = (float(x) for x in out.split(","))
+                return used_mb * 1024 * 1024, total_mb * 1024 * 1024, -1.0
+            except Exception:  # noqa: BLE001
+                pass
+        return -1.0, -1.0, -1.0
+
+
+# ---------------------------------------------------------------- 主循环
+def main() -> None:
+    # 控制台可能是 cp932/gbk 等非 utf-8（本机即 cp932）；中文 print 会 UnicodeEncodeError
+    # 把探针自己搞崩。统一改 utf-8 + errors=replace。
+    for _s in (sys.stdout, sys.stderr):
+        try:
+            _s.reconfigure(encoding="utf-8", errors="replace")  # py3.7+
+        except Exception:  # noqa: BLE001
+            pass
+
+    if os.name != "nt":
+        print("[mem_probe] 注意：系统提交读数走 Windows API；非 Windows 上仅 GPU/进程可用。")
+
+    ap = argparse.ArgumentParser(description="内存/显存峰值定位探针")
+    ap.add_argument("--pid", type=int, default=None, help="目标进程 PID")
+    ap.add_argument("--name", type=str, default="python", help="按名字找（--pid 优先）")
+    ap.add_argument("--gpu-index", type=int, default=0)
+    ap.add_argument("--interval", type=float, default=0.25, help="采样间隔秒")
+    ap.add_argument("--spike-gb", type=float, default=4.0, help="Δcommit/Δgpu 超过此值(GB)即告警")
+    ap.add_argument("--out", type=str, default="mem_probe.csv")
+    ap.add_argument("--pyspy", action="store_true", help="spike 时自动 py-spy dump 目标进程栈")
+    args = ap.parse_args()
+
+    pid = resolve_pid(args.pid, args.name)
+    if psutil is None:
+        sys.exit("本脚本需要 psutil 取进程内存：pip install psutil")
+    try:
+        proc = psutil.Process(pid)
+    except psutil.NoSuchProcess:
+        sys.exit(f"PID {pid} 不存在。")
+    gpu = _GpuReader(args.gpu_index)
+    pyspy = shutil.which("py-spy") if args.pyspy else None
+    if args.pyspy and not pyspy:
+        print("[mem_probe] 未找到 py-spy，--pyspy 忽略（pip install py-spy）")
+
+    fields = ["t_rel_s", "sys_commit_GB", "sys_commit_limit_GB", "sys_commit_pct",
+              "proc_private_GB", "proc_wset_GB", "gpu_used_GB", "gpu_total_GB",
+              "gpu_proc_GB", "d_commit_GB", "d_gpu_GB", "note"]
+    f = open(args.out, "w", newline="", encoding="utf-8")
+    w = csv.writer(f)
+    w.writerow(fields)
+
+    print(f"[mem_probe] PID={pid} GPU#{args.gpu_index} interval={args.interval}s "
+          f"spike>{args.spike_gb}G → {args.out}  (Ctrl+C 结束)")
+
+    t0 = time.perf_counter()
+    prev_commit = prev_gpu = None
+    peak = {"commit": 0.0, "private": 0.0, "gpu": 0.0}
+    spikes: list[str] = []
+
+    try:
+        while True:
+            if not proc.is_running():
+                print("[mem_probe] 目标进程已退出，停止。")
+                break
+            t = time.perf_counter() - t0
+            try:
+                commit, climit, cpeak = system_commit_bytes()
+            except Exception as e:  # noqa: BLE001
+                commit = climit = cpeak = -1.0
+                _ = e
+            try:
+                priv, wset = proc_mem_bytes(proc)
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                break
+            gused, gtotal, gproc = gpu.read(pid)
+
+            d_commit = (commit - prev_commit) / GB if prev_commit is not None and commit >= 0 else 0.0
+            d_gpu = (gused - prev_gpu) / GB if prev_gpu is not None and gused >= 0 else 0.0
+            prev_commit = commit if commit >= 0 else prev_commit
+            prev_gpu = gused if gused >= 0 else prev_gpu
+
+            peak["commit"] = max(peak["commit"], commit)
+            peak["private"] = max(peak["private"], priv)
+            peak["gpu"] = max(peak["gpu"], gused)
+
+            note = ""
+            if abs(d_commit) >= args.spike_gb or abs(d_gpu) >= args.spike_gb:
+                # 判据
+                if gused >= 0 and abs(d_gpu) >= args.spike_gb and abs(d_commit - d_gpu) <= max(2.0, 0.3 * abs(d_gpu)):
+                    verdict = "GPU侧(WDDM镜像到commit)"
+                elif abs(d_commit) >= args.spike_gb and (gused < 0 or abs(d_commit) - abs(d_gpu) >= args.spike_gb):
+                    verdict = "CPU/host侧"
+                else:
+                    verdict = "混合/待查"
+                note = f"SPIKE {verdict} dCommit={d_commit:+.1f}G dGPU={d_gpu:+.1f}G"
+                line = (f"[SPIKE] t={t:7.2f}s  {verdict}  "
+                        f"Δcommit={d_commit:+.1f}G  Δgpu={d_gpu:+.1f}G  "
+                        f"commit={commit/GB:.1f}G gpu_used={gused/GB if gused>=0 else -1:.1f}G "
+                        f"proc_priv={priv/GB:.1f}G")
+                print("\n" + "!" * 78 + "\n" + line + "\n" + "!" * 78)
+                spikes.append(line)
+                if pyspy:
+                    try:
+                        dump = subprocess.check_output(
+                            [pyspy, "dump", "--pid", str(pid), "--nonblocking"],
+                            text=True, timeout=15, stderr=subprocess.STDOUT)
+                        with open("mem_probe_pyspy.log", "a", encoding="utf-8") as pf:
+                            pf.write(f"\n===== SPIKE t={t:.2f}s {verdict} =====\n{dump}\n")
+                        print("[mem_probe] py-spy 栈已追加到 mem_probe_pyspy.log")
+                    except Exception as e:  # noqa: BLE001
+                        print(f"[mem_probe] py-spy dump 失败: {e}")
+
+            w.writerow([f"{t:.3f}",
+                        f"{commit/GB:.3f}" if commit >= 0 else "",
+                        f"{climit/GB:.3f}" if climit >= 0 else "",
+                        f"{100*commit/climit:.1f}" if climit > 0 else "",
+                        f"{priv/GB:.3f}", f"{wset/GB:.3f}",
+                        f"{gused/GB:.3f}" if gused >= 0 else "",
+                        f"{gtotal/GB:.3f}" if gtotal >= 0 else "",
+                        f"{gproc/GB:.3f}" if gproc >= 0 else "",
+                        f"{d_commit:+.3f}", f"{d_gpu:+.3f}", note])
+            f.flush()
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        print("\n[mem_probe] 手动停止。")
+    finally:
+        f.close()
+        print("\n" + "=" * 60 + "\nSUMMARY")
+        print(f"  峰值 系统提交 commit : {peak['commit']/GB:.1f} G")
+        print(f"  峰值 进程私有提交     : {peak['private']/GB:.1f} G")
+        print(f"  峰值 GPU used        : {peak['gpu']/GB:.1f} G" if peak['gpu'] >= 0 else "  GPU 不可读")
+        print(f"  CSV                  : {os.path.abspath(args.out)}")
+        if spikes:
+            print(f"  捕获 {len(spikes)} 次 spike：")
+            for s in spikes:
+                print("    " + s)
+        else:
+            print("  未捕获 spike（没复现，或 --spike-gb 设太高）。")
+        print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/spike/vae_stress.py
+++ b/tools/spike/vae_stress.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""VAE-only 显存/提交压力测试 —— 隔离 VAE，复现「偶发卡死 + commit 暴涨」。
+
+只加载 VAE（不加载 transformer/qwen，排除混淆），在递增分辨率/batch 下跑
+encode + decode（走 *raw* WanVAE_.model，不经 VAEWrapper 的 tile 回退，以便看到
+真实峰值 workspace）。每步进程内同时报：
+
+  - torch GPU：allocated / reserved / **本步峰值 reserved** / mem_get_info free
+  - 系统提交 commit（GetPerformanceInfo，复用 tools/mem_probe.py）
+
+熔断：commit 超 --max-commit-gb 立即停，保护机器。
+torch 显存历史全程记录，结束/Ctrl+Break 转储 snapshot（喂 pytorch.org/memory_viz）。
+
+跑（务必用 venv 解释器）：
+  venv/Scripts/python.exe tools/spike/vae_stress.py \
+      --vae models/vae/qwen_image_vae.safetensors \
+      --res 512,768,1024,1536,2048 --batch 1 --dtype bf16 --max-commit-gb 130
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+# ---- 复现 anima_generate 的 import 顺序：torch 先（expandable_segments 因此不自动生效）
+import torch  # noqa: E402
+
+_THIS = Path(__file__).resolve()
+_REPO = _THIS.parents[2]
+_RUNTIME = _REPO / "runtime"
+for _p in (_RUNTIME, _REPO):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+# 复用 mem_probe 的系统提交读数
+_mp_spec = importlib.util.spec_from_file_location("mem_probe", _REPO / "tools" / "mem_probe.py")
+_mp = importlib.util.module_from_spec(_mp_spec)
+_mp_spec.loader.exec_module(_mp)
+GB = 1024.0 ** 3
+
+
+def commit_gb() -> float:
+    try:
+        ct, _, _ = _mp.system_commit_bytes()
+        return ct / GB
+    except Exception:  # noqa: BLE001
+        return -1.0
+
+
+def gpu_line(tag: str) -> str:
+    a = torch.cuda.memory_allocated() / GB
+    r = torch.cuda.memory_reserved() / GB
+    mr = torch.cuda.max_memory_reserved() / GB
+    free, total = torch.cuda.mem_get_info()
+    return (f"{tag:18s} commit={commit_gb():6.1f}G | "
+            f"gpu_alloc={a:5.2f}G reserved={r:5.2f}G peakRsv={mr:5.2f}G "
+            f"free={free/GB:5.1f}/{total/GB:.1f}G")
+
+
+def main() -> None:
+    for _s in (sys.stdout, sys.stderr):
+        try:
+            _s.reconfigure(encoding="utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            pass
+
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--vae", default="models/vae/qwen_image_vae.safetensors")
+    ap.add_argument("--res", default="512,768,1024,1536,2048", help="逗号分隔的边长")
+    ap.add_argument("--batch", type=int, default=1)
+    ap.add_argument("--dtype", choices=["bf16", "fp32", "fp16"], default="bf16")
+    ap.add_argument("--mode", choices=["both", "encode", "decode"], default="both")
+    ap.add_argument("--max-commit-gb", type=float, default=130.0, help="commit 超此值即熔断")
+    ap.add_argument("--snapshot", default="G:/tmp/vae_mem.pickle")
+    ap.add_argument("--cudnn-benchmark", action="store_true")
+    args = ap.parse_args()
+
+    dtype = {"bf16": torch.bfloat16, "fp32": torch.float32, "fp16": torch.float16}[args.dtype]
+    torch.backends.cudnn.benchmark = bool(args.cudnn_benchmark)
+    device = "cuda"
+
+    print(gpu_line("[start]"))
+    print(f"torch {torch.__version__} cudnn {torch.backends.cudnn.version()} "
+          f"cudnn.benchmark={torch.backends.cudnn.benchmark} dtype={args.dtype} batch={args.batch}")
+
+    # torch 显存历史 + Ctrl+Break 转储
+    try:
+        torch.cuda.memory._record_memory_history(max_entries=200_000)
+    except Exception as e:  # noqa: BLE001
+        print(f"[warn] record_memory_history 不可用: {e}")
+
+    def _dump(*_):
+        try:
+            Path(args.snapshot).parent.mkdir(parents=True, exist_ok=True)
+            torch.cuda.memory._dump_snapshot(args.snapshot)
+            print(f"\n[snapshot] dumped {args.snapshot}")
+        except Exception as e:  # noqa: BLE001
+            print(f"[snapshot] fail: {e}")
+    if hasattr(signal, "SIGBREAK"):
+        signal.signal(signal.SIGBREAK, _dump)
+
+    # ---- 加载 VAE（用 app 同一条 load_vae 路径）
+    import anima_train as _T  # noqa: E402
+    repo_root = _T.find_diffusion_pipe_root()
+    vae_path = _T.resolve_path_best_effort(args.vae, [Path.cwd(), _REPO, repo_root])
+    print(f"[load] VAE {vae_path} (dtype={args.dtype}) ...")
+    t = time.perf_counter()
+    vae = _T.load_vae(vae_path, device, dtype, repo_root)
+    torch.cuda.synchronize()
+    print(gpu_line("[vae loaded]") + f"  load={time.perf_counter()-t:.1f}s")
+
+    resolutions = [int(x) for x in args.res.split(",") if x.strip()]
+    B = args.batch
+
+    for res in resolutions:
+        c0 = commit_gb()
+        if c0 >= args.max_commit_gb:
+            print(f"\n[ABORT] commit {c0:.1f}G ≥ 熔断阈值 {args.max_commit_gb}G，停止加压。")
+            break
+        print(f"\n--- res={res}x{res} batch={B} ---")
+        torch.cuda.reset_peak_memory_stats()
+        try:
+            if args.mode in ("encode", "both"):
+                px = torch.randn(B, 3, res, res, device=device, dtype=dtype).clamp(-1, 1)
+                torch.cuda.synchronize(); t = time.perf_counter(); c_pre = commit_gb()
+                with torch.no_grad():
+                    z = vae.model.encode(px.unsqueeze(2), vae.scale)  # [B,16,1,h,w]
+                torch.cuda.synchronize()
+                print(gpu_line(f"  encode {res}") +
+                      f"  Δcommit={commit_gb()-c_pre:+.1f}G  t={time.perf_counter()-t:.2f}s  z={tuple(z.shape)}")
+                del px
+            else:
+                h = res // 8
+                z = torch.randn(B, 16, 1, h, h, device=device, dtype=dtype)
+
+            if args.mode in ("decode", "both"):
+                torch.cuda.reset_peak_memory_stats()
+                torch.cuda.synchronize(); t = time.perf_counter(); c_pre = commit_gb()
+                with torch.no_grad():
+                    img = vae.model.decode(z, vae.scale)  # raw, 无 tile
+                torch.cuda.synchronize()
+                print(gpu_line(f"  decode {res}") +
+                      f"  Δcommit={commit_gb()-c_pre:+.1f}G  t={time.perf_counter()-t:.2f}s  img={tuple(img.shape)}")
+                del img
+            del z
+            torch.cuda.empty_cache()
+        except torch.cuda.OutOfMemoryError as e:
+            print(f"  [OOM] res={res}: {str(e)[:140]}")
+            torch.cuda.empty_cache()
+        except Exception as e:  # noqa: BLE001
+            print(f"  [ERR] res={res}: {type(e).__name__}: {str(e)[:180]}")
+            torch.cuda.empty_cache()
+
+    _dump()
+    print("\n" + gpu_line("[end]"))
+    print(f"提示：把 {args.snapshot} 拖到 https://pytorch.org/memory_viz 看最大分配调用栈。")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 背景 / 动机

社区与本地都遇到「训练 sample / 测试 generate 偶发卡死，且系统提交虚拟内存暴涨 20–30G」。本地用探针逐步定位（脚本见本 PR `tools/`）后确认真因：

**大显存卡（如 32G RTX 5090）整图 VAE encode/decode 的工作集逼近总显存 ~50% 时，即便「装得下」也会触发 Windows WDDM 显存换页**——单次 op 从 <1s 退化到上百秒、系统提交暴涨 20–30G。关键是这**不抛干净 CUDA OOM**，所以 #207（修 #200）的 reactive 分块（catch `OutOfMemoryError` 才分块）永远不触发。

> 悖论解释：8G/16G 卡上同样的 op 早早干净 OOM → 落到 #207 分块而正常；32G 卡勉强装下 / sysmem 换页不抛 OOM → 卡上百秒。大显存反而绕过了救济，故表现为「偶发」（只有跨过显存崖的分辨率/bucket/batch 才发作）。

实测（RTX 5090 31.8G，fp32 VAE）：

| op | 修前 | 修后 |
|---|---|---|
| decode 1536² | 196s（峰值 22.6G） | **0.99s**（分块，峰值 3.2G） |
| encode 2048² | 103s（峰值 20.3G） | **0.95s**（分块，峰值 1.8G） |
| 快路径 fp32≤1024 / bf16≤1536 | 正常 | 仍整图，**无 30% 惩罚** |

## 关联

- **issue #200**（8GB 小显存 1024² reg 生成整图 decode OOM）—— 本 PR 在其基础上把分块从 **reactive（catch OOM 才分块）扩展为 proactive（按 free-VRAM 预判）+ 覆盖 encode**，专治 #200 的 reactive 兜底救不了的大显存「不抛 OOM 的显存换页卡死」。
- #207 是 #200 的 reactive 分块实现（本 PR 的扩展基础）。

## 改动概要

- **`VAEWrapper.decode/encode` 改 proactive**：新增 `tiling` 模式 `auto`/`on`/`off`。`auto` 按「当前已用 + 预计峰值 > 总显存 × 0.5」决策（`mem_get_info` 实时 free，**天然计入常驻模型**，所以训练 sample 的 bf16 + DiT/Qwen 常驻场景也能正确分块）。崖在 ~50% 而非满显存（实测）；峰值估算式标定自 `tools/spike/vae_stress.py`。判定抽成纯函数 `_should_auto_tile`，CI 无 GPU 也能测。
- **encode 也分块**（原本只有 decode，对应 #200/#207 只做了 decode）：`_tiled_encode` 像素空间切 512px/stride 384、latent 空间 cosine blend。`CachedLatentDataset`（latent 缓存）+ roundtrip 自检改走 `wrapper.encode`。
- **generate decode 前的模块 offload 统一为 free-VRAM 驱动**（删 `_vae_param_dtype` 的 dtype 闸门，抽成公开方法 `VAEWrapper.should_offload_for_whole_decode`）：仅在「腾出显存就能整图且快」时才 offload 非活跃模块；峰值已越崖时整图照样卡 → 交给分块，避免白搬 DiT+Qwen 占系统内存（也呼应原始的 commit 担忧）。
- **新增 `vae_tiling` 配置**（`TrainingConfig` / `GenerateConfig`，默认 `auto`），经 `argparse_bridge` 自动到 `args.vae_tiling`。
- **诊断/标定脚本**：`tools/mem_probe.py`（系统提交 vs GPU 显存切分 + py-spy on spike）、`tools/spike/vae_stress.py`（VAE 隔离压测，复现并标定崖）。

候选方案对比（为何不走 PR #203 的「decode 前把 transformer 搬 CPU」）：offload 到 CPU 会**增加系统内存压力**（正是用户原始症状），且峰值越崖时即便腾出显存整图仍卡；proactive 分块把模型留在 GPU、只切块，是更优解。

## 测试

- `tests/test_vae_tiled_decode.py` 新增：encode 分块（on/off/OOM 兜底/线性重建）、decode mode（on/off）、峰值估算、`_should_auto_tile` 阈值复刻实测崖、`should_offload_for_whole_decode` CPU 守卫。
- `tests/test_datasets.py` 的 fake VAE 补 `encode()`；`tests/test_comfy_anima_text_encoding.py` 的 offload 测试改用 `should_offload_for_whole_decode` 返回值驱动。
- 本地相关 + 横切安全网（`test_route_snapshot` / `test_studio_configs`）全绿；与新合入的 SRA v2（#279）共存验证（`test_sra_align` 一起跑过）。
- GPU 端到端实测见上表（auto 正确分块大图、快路径不分块）。

## 来源声明

分块逻辑在仓库**既有 #207 tiled decode**（修 #200）基础上扩展（同一 `VAEWrapper`），无外部代码移植。
