### PR TITLE
fix(web): 修 Generate 提示词选择器切换 project/version 时缩略图集体 404

### DIFF
--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.test.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.test.tsx
@@ -99,4 +99,28 @@ describe('PromptFromDatasetPicker — thumbnail / pid·vid 同步', () => {
     expect(src).toContain('name=b_v12.png')
     expect(src).not.toContain('name=a_v11.png')
   })
+
+  it('新版本 captions 加载失败时旧行缩略图仍锚定旧 (pid,vid)（不套 live vid 出 404）', async () => {
+    vi.spyOn(api, 'listProjects').mockResolvedValue(projects)
+    vi.spyOn(api, 'getProject').mockResolvedValue(projectDetail)
+    // v1(11) 正常；切到 v2(12) 的 captions 失败 → 旧行继续显示，live vid 已是 12 但
+    // captions / loaded 仍是 v1(11)。缩略图绑 loaded 才对；用 live vid 就 404 黑图。
+    vi.spyOn(api, 'listCaptionsFull').mockImplementation((_pid, vid) =>
+      vid === 11
+        ? Promise.resolve({ folder: null, items: [cap('only.png', 'x')] })
+        : Promise.reject(new Error('boom'))
+    )
+
+    const user = await selectProjectAndV1()
+    await waitFor(() => expect(screen.getByText('only.png')).toBeInTheDocument())
+
+    await user.selectOptions(screen.getByLabelText('选择版本'), '12')
+    await waitFor(() => expect(api.listCaptionsFull).toHaveBeenCalledWith(1, 12))
+
+    // v2 captions 失败、旧行未清空仍可见；缩略图必须仍指 v1(11)，不能跟 live vid 漂到 12
+    expect(screen.getByText('only.png')).toBeInTheDocument()
+    const src = rowThumb().getAttribute('src') ?? ''
+    expect(src).toContain('/versions/11/thumb')
+    expect(src).not.toContain('/versions/12/thumb')
+  })
 })

--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.test.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.test.tsx
@@ -1,0 +1,102 @@
+import { act, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { api, type CaptionEntry, type ProjectDetail, type ProjectSummary } from '../../../api/client'
+import PromptFromDatasetPicker from './PromptFromDatasetPicker'
+
+// 测试范围：缩略图 URL（versionThumbUrl(pid, vid, …, c.name, c.folder)）拼的是
+// 实时 pid/vid + caption 行名；两者只要不同步，整列 thumb 就指向别的 project 的
+// 文件 → 404 黑图（线上现象：切到没切过的 project 时集体失效，刷新自愈）。根因是
+// captions effect 没 stale-response 守卫，旧 (pid,vid) 的迟到响应覆盖当前 captions。
+
+type CaptionsResult = { folder: null; items: CaptionEntry[] }
+
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  const promise = new Promise<T>((r) => { resolve = r })
+  return { promise, resolve }
+}
+
+function cap(name: string, tag: string): CaptionEntry {
+  return {
+    name, folder: '2_data', tag_count: 1, tags_preview: [tag],
+    has_caption: true, tags: [tag], format: 'txt',
+  }
+}
+
+const projects = [{ id: 1, slug: 'a', title: 'projA' }] as unknown as ProjectSummary[]
+// 组件只读 p.versions 的 id/label
+const projectDetail = {
+  id: 1, slug: 'a', title: 'projA',
+  versions: [{ id: 11, label: 'v1' }, { id: 12, label: 'v2' }],
+} as unknown as ProjectDetail
+
+function rowThumb() {
+  // 行内缩略图 alt="" → 隐式 role=presentation，getByRole('img') 取不到；直接选元素。
+  // 底部大预览仅在 hover / 已选 value 时渲染，本测试都没有，故首个 img 即行缩略图。
+  const img = document.querySelector('img')
+  if (!img) throw new Error('no row thumbnail rendered')
+  return img as HTMLImageElement
+}
+
+describe('PromptFromDatasetPicker — thumbnail / pid·vid 同步', () => {
+  beforeEach(() => { localStorage.clear() })
+  afterEach(() => { vi.restoreAllMocks(); localStorage.clear() })
+
+  async function selectProjectAndV1() {
+    const user = userEvent.setup()
+    render(<PromptFromDatasetPicker value={null} onChange={vi.fn()} onClose={vi.fn()} />)
+    await screen.findByRole('option', { name: 'projA' })
+    await user.selectOptions(screen.getByLabelText('选择项目'), '1')
+    // getProject(1) → vid 落到 v1(11) → captions effect 拉 (1, 11)
+    await waitFor(() => expect(api.listCaptionsFull).toHaveBeenCalledWith(1, 11))
+    return user
+  }
+
+  it('行缩略图 URL 锚定当前 (pid, vid) + 行文件名', async () => {
+    vi.spyOn(api, 'listProjects').mockResolvedValue(projects)
+    vi.spyOn(api, 'getProject').mockResolvedValue(projectDetail)
+    vi.spyOn(api, 'listCaptionsFull').mockResolvedValue({ folder: null, items: [cap('only.png', 'x')] })
+
+    await selectProjectAndV1()
+
+    await waitFor(() => expect(screen.getByText('only.png')).toBeInTheDocument())
+    const src = rowThumb().getAttribute('src') ?? ''
+    expect(src).toContain('/projects/1/versions/11/thumb')
+    expect(src).toContain('name=only.png')
+    expect(src).toContain('folder=2_data')
+  })
+
+  it('迟到的旧响应不覆盖当前 captions（regression：thumb 集体 404 黑图）', async () => {
+    vi.spyOn(api, 'listProjects').mockResolvedValue(projects)
+    vi.spyOn(api, 'getProject').mockResolvedValue(projectDetail)
+
+    // v1(11) 的 captions 故意慢，模拟切到 v2 后才迟到返回
+    const d11 = deferred<CaptionsResult>()
+    const d12 = deferred<CaptionsResult>()
+    vi.spyOn(api, 'listCaptionsFull').mockImplementation((_pid, vid) =>
+      vid === 11 ? d11.promise : d12.promise
+    )
+
+    const user = await selectProjectAndV1()
+
+    // 切到 v2(12)：触发新 captions 请求，旧 (1,11) effect cleanup 应置 cancelled
+    await user.selectOptions(screen.getByLabelText('选择版本'), '12')
+    await waitFor(() => expect(api.listCaptionsFull).toHaveBeenCalledWith(1, 12))
+
+    // 新请求先回：列表 = v2 文件
+    await act(async () => { d12.resolve({ folder: null, items: [cap('b_v12.png', 'y')] }) })
+    await waitFor(() => expect(screen.getByText('b_v12.png')).toBeInTheDocument())
+
+    // 旧请求迟到：守卫住的话应被忽略，不得把列表覆盖回 v1 文件
+    await act(async () => { d11.resolve({ folder: null, items: [cap('a_v11.png', 'x')] }) })
+
+    expect(screen.getByText('b_v12.png')).toBeInTheDocument()
+    expect(screen.queryByText('a_v11.png')).not.toBeInTheDocument()
+    // 缩略图也必须仍锚定当前 v2 + v2 文件名（错配就是 404 黑图的来源）
+    const src = rowThumb().getAttribute('src') ?? ''
+    expect(src).toContain('/versions/12/thumb')
+    expect(src).toContain('name=b_v12.png')
+    expect(src).not.toContain('name=a_v11.png')
+  })
+})

--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
@@ -100,8 +100,12 @@ export default function PromptFromDatasetPicker({
   // 2. 选项目后拉版本列表；优先复用 vid（如果该版本在新项目里仍存在）
   useEffect(() => {
     if (!pid) { setVersions([]); setVid(null); return }
+    // 同款 stale-response 守卫：连切 project 时旧 getProject 晚返回会把别的
+    // project 的 versions / 默认 vid 灌进来，间接喂给上面的 captions effect。
+    let cancelled = false
     void api.getProject(pid)
       .then((p) => {
+        if (cancelled) return
         const vs = p.versions.map((v) => ({ id: v.id, label: v.label }))
         setVersions(vs)
         if (vs.length > 0) {
@@ -110,7 +114,8 @@ export default function PromptFromDatasetPicker({
           setVid(null)
         }
       })
-      .catch((e) => setError(String(e)))
+      .catch((e) => { if (!cancelled) setError(String(e)) })
+    return () => { cancelled = true }
     // 同上：vid 只在 effect 内部读，不进依赖
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pid])
@@ -118,11 +123,25 @@ export default function PromptFromDatasetPicker({
   // 3. 选版本后拉 captions
   useEffect(() => {
     if (!pid || !vid) { setCaptions([]); return }
+    // stale-response 守卫：快速切 project/version 时旧请求可能晚于新请求返回，
+    // 没守卫就会把旧 captions 覆盖回去、与当前 pid/vid 错配 —— 行内/预览缩略图
+    // URL（versionThumbUrl(pid, vid, …, c.name, c.folder)）于是拿当前 pid/vid 去
+    // 找别的 project 的文件名，整列 thumb 404。对齐 InlineLoraPicker 同款守卫。
+    let cancelled = false
     setLoading(true)
     setError(null)
     void api.listCaptionsFull(pid, vid)
-      .then((r) => { setCaptions(r.items); setLoading(false) })
-      .catch((e) => { setError(String(e)); setLoading(false) })
+      .then((r) => {
+        if (cancelled) return
+        setCaptions(r.items)
+        setLoading(false)
+      })
+      .catch((e) => {
+        if (cancelled) return
+        setError(String(e))
+        setLoading(false)
+      })
+    return () => { cancelled = true }
   }, [pid, vid])
 
   const filtered = useMemo(() => {

--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
@@ -79,6 +79,11 @@ export default function PromptFromDatasetPicker({
   }, [value?.projectId, value?.versionId])  // eslint-disable-line react-hooks/exhaustive-deps
   const [versions, setVersions] = useState<Array<{ id: number; label: string }>>([])
   const [captions, setCaptions] = useState<CaptionEntry[]>([])
+  // captions 实际所属的 (pid, vid)。行内/预览缩略图 URL 一律用它、不用实时 pid/vid —
+  // 切 project/version 的那一帧旧 captions 仍在渲染，若套实时 pid/vid 就会把旧文件名
+  // 拼到新 project 上整列 404（黑图）。绑到来源后，旧图在被新数据替换前始终用自己的
+  // (pid, vid)，永远指得回真实文件。捕获响应时与 captions 原子写入，二者不会脱节。
+  const [loaded, setLoaded] = useState<{ pid: number; vid: number } | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [search, setSearch] = useState('')
@@ -122,11 +127,11 @@ export default function PromptFromDatasetPicker({
 
   // 3. 选版本后拉 captions
   useEffect(() => {
-    if (!pid || !vid) { setCaptions([]); return }
+    if (!pid || !vid) { setCaptions([]); setLoaded(null); return }
     // stale-response 守卫：快速切 project/version 时旧请求可能晚于新请求返回，
-    // 没守卫就会把旧 captions 覆盖回去、与当前 pid/vid 错配 —— 行内/预览缩略图
-    // URL（versionThumbUrl(pid, vid, …, c.name, c.folder)）于是拿当前 pid/vid 去
-    // 找别的 project 的文件名，整列 thumb 404。对齐 InlineLoraPicker 同款守卫。
+    // 没守卫就会把旧 captions 覆盖回去、与当前选择错配（显示别的 project 的图）。
+    // 对齐 InlineLoraPicker 同款守卫。captions 与其来源 (pid, vid) 一起写，供
+    // 缩略图 URL 锚定（见 `loaded` 注释），二者原子更新不脱节。
     let cancelled = false
     setLoading(true)
     setError(null)
@@ -134,6 +139,7 @@ export default function PromptFromDatasetPicker({
       .then((r) => {
         if (cancelled) return
         setCaptions(r.items)
+        setLoaded({ pid, vid })
         setLoading(false)
       })
       .catch((e) => {
@@ -153,11 +159,12 @@ export default function PromptFromDatasetPicker({
     )
   }, [captions, search])
 
-  // 当前 list 中匹配选中 caption 的 key（仅当浏览中的 pid/vid 与 value 一致才高亮）
+  // 当前 list 中匹配选中 caption 的 key（仅当已加载的 captions 与 value 同属一个
+  // (pid, vid) 才高亮 —— 用 loaded 而非实时 pid/vid，跟列表/缩略图保持同一来源）
   const selectedKeyInList = useMemo(() => {
-    if (!value || value.projectId !== pid || value.versionId !== vid) return null
+    if (!value || !loaded || value.projectId !== loaded.pid || value.versionId !== loaded.vid) return null
     return value.name
-  }, [value, pid, vid])
+  }, [value, loaded])
 
   const tagsText = value ? value.tags.join(', ') : ''
 
@@ -167,27 +174,29 @@ export default function PromptFromDatasetPicker({
     ? captions.find((c) => `${c.folder}/${c.name}` === hoveredKey) ?? null
     : null
   const previewSrc =
-    hoveredCaption && pid && vid
-      ? api.versionThumbUrl(pid, vid, 'train', hoveredCaption.name, hoveredCaption.folder, 512)
+    hoveredCaption && loaded
+      ? api.versionThumbUrl(loaded.pid, loaded.vid, 'train', hoveredCaption.name, hoveredCaption.folder, 512)
       : value && value.folder
         ? api.versionThumbUrl(value.projectId, value.versionId, 'train', value.name, value.folder, 512)
         : ''
 
   const handleRowClick = (c: CaptionEntry) => {
+    // 行属于 loaded 这一组 captions，选中也要落到 loaded 的 (pid, vid)，不能用
+    // 实时 pid/vid（切换瞬间二者可能不一致，否则会把别的 project 写进 datasetPick）。
+    if (!loaded) return
     if (
       value
-      && value.projectId === pid
-      && value.versionId === vid
+      && value.projectId === loaded.pid
+      && value.versionId === loaded.vid
       && value.name === c.name
     ) {
       // 反选
       onChange(null)
       return
     }
-    if (!pid || !vid) return
     onChange({
-      projectId: pid,
-      versionId: vid,
+      projectId: loaded.pid,
+      versionId: loaded.vid,
       name: c.name,
       folder: c.folder,
       tags: c.tags,
@@ -275,9 +284,10 @@ export default function PromptFromDatasetPicker({
           const k = `${c.folder}/${c.name}`
           const active = selectedKeyInList === c.name
           // 行内缩略图请求 64px（≈2× 显示尺寸）保证高 DPI 不糊；native lazy
-          // 让没滚到的行不发请求，长列表不会一次性把图全拉下来。
-          const thumb = pid && vid
-            ? api.versionThumbUrl(pid, vid, 'train', c.name, c.folder, 64)
+          // 让没滚到的行不发请求，长列表不会一次性把图全拉下来。URL 用 loaded
+          // 而非实时 pid/vid，保证文件名与 (pid, vid) 同属一组、不会错配 404。
+          const thumb = loaded
+            ? api.versionThumbUrl(loaded.pid, loaded.vid, 'train', c.name, c.folder, 64)
             : ''
           return (
             <button


### PR DESCRIPTION
## 背景 / 动机

Generate 页提示词选择器（`PromptFromDatasetPicker`，#280 引入行内缩略图 + 大图预览）切到本会话**没访问过的 project / 连切版本**后，整列缩略图集体变黑图；刷新自愈。

根因是 **caption 列表与生成缩略图 URL 用的 `(pid, vid)` 错配**：

- 行内/预览缩略图走 `versionThumbUrl(pid, vid, …, c.name, c.folder)`，把**实时 `pid/vid`** 和 **caption 行**拼在一起，但二者是两块没有不变式绑定的 state。
- 列表加载 effect 无 stale-response 守卫：快速切换时旧 `(pid, vid)` 的 `listCaptionsFull` 迟到返回会**覆盖**当前 `captions`，于是 `captions` 是别的 project 的文件名、`pid/vid` 是当前 project → 每张 thumb 都拿当前 `pid/vid` 去找别 project 的文件 → 404。
- 即便加了守卫，切 project 的**那一帧**（`setPid` 后、`loading` 置位前）旧 captions 仍渲染，仍会用实时 `pid/vid` 拼出一批 404。

> 实测佐证：某次 404 URL 是 `…/projects/21/versions/32/thumb?…name=6862724.png…`，但 `6862724.png` 实际属于 project 4 —— caption 与 `pid/vid` 来源不一致。

## 改动概要

1. **stale-response 守卫**（`2ea05e0`）：captions effect 与 getProject effect 各加 `let cancelled` + cleanup，迟到响应直接忽略（对齐同目录 `InlineLoraPicker` 同款写法），保证状态始终对应**最新选择**。
2. **缩略图来源绑定**（`426fc62`）：新增原子状态 `loaded = { pid, vid }`，捕获 captions 响应时与 `setCaptions` 一起写；行内/预览缩略图、行高亮、选中回填一律改用 `loaded` 而非实时 `pid/vid`。旧图在被新数据替换前始终用自己的 `(pid, vid)`，永不错配。

仅前端、纯 bug fix；未顺手改无关代码。bug 在 dev 周期内（#280 未发版）引入，按规范不写 release_notes / CHANGELOG / ADR。

## 测试方式

- 新增 `PromptFromDatasetPicker.test.tsx`（3 个），覆盖：缩略图锚定当前来源、迟到旧响应不覆盖当前 captions、新版本加载失败时旧行缩略图仍锚定旧 `(pid, vid)`。
- **真·regression 双重确认**：分别临时回退 stale-guard 与 loaded-binding，对应测试如实复现 `…versions/12…name=旧文件` 的错配 404，还原后转绿。
- `npx vitest run`（studio/web）→ 39 文件 384 测试全过；`npm run lint` 干净；`npx tsc --noEmit` 0 错。
- 手测：dev（5173）切到没访问过的 project、连切版本，缩略图不再变黑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)