### PR TITLE
fix(upload): 修浏览器上传 zip 在 py<3.11 因 SpooledTemporaryFile 无 seekable 报错

### DIFF
--- a/studio/api/routers/projects/ingestion.py
+++ b/studio/api/routers/projects/ingestion.py
@@ -197,8 +197,10 @@ async def upload_local_files(
         raise HTTPException(404, f"项目不存在: id={pid}")
     pdir = projects.project_dir(p["id"], p["slug"]) / "download"
 
-    # 流式：直接传 SpooledTemporaryFile，不读进 bytes 对象。f.file 是 seekable
-    # 的（zipfile.ZipFile 要求），FastAPI 写完后 cursor 不保证在 0 → 手动 seek。
+    # 流式：直接传 SpooledTemporaryFile，不读进 bytes 对象。FastAPI 写完后
+    # cursor 不保证在 0 → 手动 seek。注意 py<3.11 的 SpooledTemporaryFile 没有
+    # seekable()/readable()/writable()，service 层 _ensure_seekable() 会按需包
+    # 一层适配器（zipfile.zf.open() 要求 seekable），这里直接传裸流即可。
     pairs: list[tuple[str, BinaryIO]] = []
     for f in files:
         f.file.seek(0)

--- a/studio/services/dataset/uploads.py
+++ b/studio/services/dataset/uploads.py
@@ -85,6 +85,50 @@ def _is_image_ext(name: str) -> bool:
     return Path(name).suffix.lower() in ALLOWED_IMAGE_EXTS
 
 
+class _SeekableStream:
+    """给缺失 seekable/readable/writable 的流补上这三个 IOBase 谓词方法，其余透传。
+
+    Python < 3.11 的 `SpooledTemporaryFile`（FastAPI `UploadFile.file` 的实际
+    类型）只显式转发 read/seek/tell 给底层 `_file`，却漏了这三个谓词方法（3.11
+    才让它继承 io.IOBase 补全）。`zipfile.ZipFile` 构造与 `infolist()` 只用
+    seek/read，都正常；但 `zf.open()` 经 `_SharedFile` 取 `fileobj.seekable`
+    → AttributeError —— 表现为「打开 zip」成功、开始读内层图片时才炸。
+
+    底层 `_file`（spool 内的 BytesIO 或已 rollover 的真临时文件）本身支持 seek，
+    所以零拷贝包一层即可，保住上层流式上传「不把整包读进内存」的初衷。
+    """
+
+    def __init__(self, stream: BinaryIO) -> None:
+        self._stream = stream
+
+    def seekable(self) -> bool:
+        return True
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def __getattr__(self, name: str):  # seek/read/tell/close 等透传给底层流
+        return getattr(self._stream, name)
+
+
+def _ensure_seekable(stream: BinaryIO) -> BinaryIO:
+    """zipfile 需要 `fileobj.seekable()`；老 SpooledTemporaryFile 没有 → 包一层。
+
+    真文件 / BytesIO / 3.11+ 的 SpooledTemporaryFile 已实现则原样返回，不包。
+    """
+    probe = getattr(stream, "seekable", None)
+    if callable(probe):
+        try:
+            probe()
+            return stream
+        except Exception:  # noqa: BLE001 — 任何异常都按"谓词不可用"降级包一层
+            pass
+    return _SeekableStream(stream)
+
+
 def _unique_target(dest_dir: Path, name: str) -> Path:
     """目标已存在时加 `_1` / `_2` ... 后缀直到不冲突。
 
@@ -241,7 +285,7 @@ def accept_one(
     if suffix == ZIP_EXT:
         t_zip_start = time.monotonic()
         try:
-            with zipfile.ZipFile(src_stream) as zf:
+            with zipfile.ZipFile(_ensure_seekable(src_stream)) as zf:
                 infos = [info for info in zf.infolist() if not info.is_dir()]
                 image_count = sum(
                     1 for info in infos

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -96,6 +96,41 @@ def test_zip_extracts_jpg_png(tmp_path: Path) -> None:
     assert not (tmp_path / "sub").exists()
 
 
+def test_zip_stream_without_seekable_predicate(tmp_path: Path) -> None:
+    """回归 (#hotfix)：Python<3.11 的 SpooledTemporaryFile（FastAPI UploadFile.file
+    的实际类型，含文档支持的最低版本 3.10）没有 seekable()/readable()/writable()。
+
+    路由把它直接交给 zipfile 时，构造 + infolist() 正常（日志「打开 zip」打得出来），
+    但 zf.open() 经 _SharedFile 取 fileobj.seekable → AttributeError —— 表现为
+    「打开 zip 后开始读内层图片才炸」。accept_one 必须包一层适配器扛住。
+
+    CI 跑 3.12（SpooledTemporaryFile 已有 seekable），故用一个故意不实现这三个
+    谓词方法的假流来稳定复现，与 Python 版本无关。
+    """
+    blob = _zip_bytes({"a.png": b"AA", "sub/b.jpg": b"BB"})
+
+    class _Pre311Spool:
+        # 仿 py<3.11 的 SpooledTemporaryFile：转发 read/seek/tell，无谓词方法
+        def __init__(self, data: bytes) -> None:
+            self._buf = io.BytesIO(data)
+
+        def read(self, *a):
+            return self._buf.read(*a)
+
+        def seek(self, *a):
+            return self._buf.seek(*a)
+
+        def tell(self):
+            return self._buf.tell()
+
+    stream = _Pre311Spool(blob)
+    assert not hasattr(stream, "seekable"), "前置：假流必须确实缺失 seekable 才能复现"
+    out = uploads.accept_one("pack.zip", stream, tmp_path)
+    assert sorted(out.added) == ["a.png", "b.jpg"]
+    assert (tmp_path / "a.png").read_bytes() == b"AA"
+    assert (tmp_path / "b.jpg").read_bytes() == b"BB"
+
+
 def test_zip_skip_dup_in_zip(tmp_path: Path) -> None:
     (tmp_path / "x.png").write_bytes(b"existing")
     blob = _zip_bytes({"x.png": b"new"})


### PR DESCRIPTION
> Hotfix（绕过 dev，base=master）。

## 为什么不能等下次 release

此 bug 已随 **0.13.1** 的流式上传改动（`eb10abf`）发布，现存于 **v0.13.1 / v0.13.2**。在 README 承诺的最低版本 **Python 3.10** 上，从训练集页面用浏览器上传图片 zip 会报错中断、无法导入 —— 属于已发布版本的核心功能损坏，应尽快出 PATCH，不宜等下次常规 release。

## 背景 / 根因

```
AttributeError: 'SpooledTemporaryFile' object has no attribute 'seekable'
```

FastAPI `UploadFile.file` 的实际类型是 `SpooledTemporaryFile`，而 **`seekable()/readable()/writable()` 是 Python 3.11 才补上的**（3.11 起才完整继承 `io.IOBase`）。Python 3.10 没有这三个方法 → 流式上传把它直接交给 `zipfile` 时：

- `zipfile.ZipFile()` 构造 + `infolist()` 只用 seek/read → 正常（日志「打开 zip (N entries)」打得出来）
- `zf.open(info)` 经 `_SharedFile` 取 `fileobj.seekable` → `AttributeError`
- 表现为「打开 zip 成功、开始读内层图片才卡住」（3.11+ 不受影响）

**测试为何没抓到（三处全绕开）**：① 现有测试全用 `io.BytesIO`（永远 seekable）；② CI 跑 3.12（已有 seekable）；③ 流式改动才引入裸流直喂。

## 改动概要

- `studio/services/dataset/uploads.py`：新增零拷贝适配器 `_SeekableStream` + `_ensure_seekable()`，**仅在流缺 `seekable` 时**包一层补齐三个谓词方法（真文件 / BytesIO / 3.11+ SpooledTemporaryFile 原样返回）。底层 `_file` 本身可 seek，零拷贝，**保住流式上传不把整包读进内存的初衷**（未采用「复制到 NamedTemporaryFile」那种多一次磁盘 I/O 的方案）。
- `studio/api/routers/projects/ingestion.py`：修正一条已失准的注释。
- `tests/test_uploads.py`：加回归测试，用故意不实现谓词的假流复现，**与运行的 Python 版本无关**（CI 3.12 也守得住）。

排查范围：只有 `ingestion.upload_local_files → uploads.accept_one` 把裸 `SpooledTemporaryFile` 喂 zipfile；`exports.py` import-bundle/import-train、`presets.py` import 都先 chunk-read 进 `NamedTemporaryFile` 再交真实 Path，天然免疫，未改动。

## 测试方式

本地 venv（Python 3.13）：`tests/test_uploads.py`（含新回归测试）+ 横切安全网 `tests/test_route_snapshot.py tests/test_studio_configs.py` + `tests/test_project_endpoints.py` —— 合计 80 passed。另在 Python 3.9 手工复现：未打 fix 时 `infolist()` 成功、`zf.open()` 抛与用户一致的 `AttributeError`；打 fix 后正常读完所有 entry。

非 UI 改动，无截图。