### PR TITLE
feat(web): 项目卡片支持编辑标题/备注，操作图标改为 hover 显示

### DIFF
--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -636,7 +636,10 @@
     "archived": "Archived: {{title}}",
     "unarchiveTitle": "Restore project",
     "unarchiveConfirm": "Restore project \"{{title}}\" to the project list?",
-    "unarchived": "Restored: {{title}}"
+    "unarchived": "Restored: {{title}}",
+    "editProject": "Edit project",
+    "edited": "Saved \"{{title}}\"",
+    "editSlugNote": "slug and output name stay fixed"
   },
   "queue": {
     "title": "Queue",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -636,7 +636,10 @@
     "archived": "已归档: {{title}}",
     "unarchiveTitle": "恢复项目",
     "unarchiveConfirm": "把项目「{{title}}」恢复回项目列表？",
-    "unarchived": "已恢复: {{title}}"
+    "unarchived": "已恢复: {{title}}",
+    "editProject": "编辑项目",
+    "edited": "已保存「{{title}}」",
+    "editSlugNote": "slug 与输出名固定不变"
   },
   "queue": {
     "title": "队列",

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -45,6 +45,7 @@ export default function ProjectsPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [creating, setCreating] = useState(false)
+  const [editing, setEditing] = useState<ProjectSummary | null>(null)
   const [busy, setBusy] = useState(false)
   const [importing, setImporting] = useState(false)
   const [showImportDialog, setShowImportDialog] = useState(false)
@@ -89,6 +90,22 @@ export default function ProjectsPage() {
       toast(t('projects.created', { title: p.title }), 'success')
       setCreating(false)
       navigate(`/projects/${p.id}`)
+    } catch (e) {
+      toast(String(e), 'error')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // 改 title/note 只动展示用元数据；slug（磁盘路径 / LoRA 输出名锚点）不可改。
+  const handleEdit = async (patch: { title: string; note: string }) => {
+    if (!editing) return
+    setBusy(true)
+    try {
+      const p = await api.updateProject(editing.id, { title: patch.title, note: patch.note })
+      toast(t('projects.edited', { title: p.title }), 'success')
+      setEditing(null)
+      await refresh()
     } catch (e) {
       toast(String(e), 'error')
     } finally {
@@ -299,6 +316,7 @@ export default function ProjectsPage() {
                 project={p}
                 archived={showArchived}
                 onClick={() => openProject(p)}
+                onEdit={(e) => { e.preventDefault(); e.stopPropagation(); setEditing(p) }}
                 onArchive={(e) => handleArchive(p, e)}
                 onUnarchive={(e) => handleUnarchive(p, e)}
                 onDelete={(e) => handleDelete(p, e)}
@@ -313,6 +331,15 @@ export default function ProjectsPage() {
           busy={busy}
           onCancel={() => setCreating(false)}
           onSubmit={handleCreate}
+        />
+      )}
+
+      {editing && (
+        <EditProjectDialog
+          project={editing}
+          busy={busy}
+          onCancel={() => setEditing(null)}
+          onSubmit={handleEdit}
         />
       )}
 
@@ -474,6 +501,7 @@ function ProjectCard({
   project: p,
   archived = false,
   onClick,
+  onEdit,
   onArchive,
   onUnarchive,
   onDelete,
@@ -482,6 +510,7 @@ function ProjectCard({
   /** 已归档卡片：半透明 + ↺ 恢复（在 × 左边）+ × 真删；普通卡片 × = 归档。 */
   archived?: boolean
   onClick: () => void
+  onEdit?: (e: React.MouseEvent) => void
   onArchive?: (e: React.MouseEvent) => void
   onUnarchive?: (e: React.MouseEvent) => void
   onDelete?: (e: React.MouseEvent) => void
@@ -494,7 +523,7 @@ function ProjectCard({
       onClick={onClick}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      className={`p-[18px] text-left rounded-lg cursor-pointer flex flex-col gap-3.5 relative w-full ${hovered ? 'border-dim shadow-sm bg-surface' : 'border border-subtle bg-surface'} ${archived ? 'opacity-70' : ''}`}
+      className={`group p-[18px] text-left rounded-lg cursor-pointer flex flex-col gap-3.5 relative w-full ${hovered ? 'border-dim shadow-sm bg-surface' : 'border border-subtle bg-surface'} ${archived ? 'opacity-70' : ''}`}
       style={{ transition: 'border-color 0.15s, box-shadow 0.15s, opacity 0.15s' }}
     >
       {/* ADR-0007 §11.8-E: 右上角 = active version status；去 stage badge / 时间 / 产物 */}
@@ -524,6 +553,19 @@ function ProjectCard({
           <span className="text-fg-tertiary italic text-xs">{t('projects.noActiveVersion')}</span>
         )}
         <span className="flex-1" />
+        {/* 操作图标默认隐藏，hover / 键盘聚焦卡片时淡入，减少常驻视觉噪声 */}
+        <div className="flex gap-3 items-center opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100">
+        <button
+          onClick={onEdit}
+          className="bg-transparent border-none px-1.5 py-0.5 rounded-sm text-fg-tertiary text-xs cursor-pointer"
+          title={t('projects.editProject')}
+          aria-label={`${t('projects.editProject')} ${p.title}`}
+        >
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 20h9" />
+            <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4 12.5-12.5z" />
+          </svg>
+        </button>
         {archived ? (
           <>
             <button
@@ -553,6 +595,7 @@ function ProjectCard({
             ×
           </button>
         )}
+        </div>
       </div>
     </button>
   )
@@ -639,6 +682,85 @@ function NewProjectDialog({
             disabled={busy || !form.title.trim()}
           >
             {busy ? t('projects.creating') : t('common.create')}
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+// ── Edit Project Dialog ─────────────────────────────────────────
+// 只改 title / note；slug 不可改（磁盘路径 / LoRA 输出名锚点）。
+
+function EditProjectDialog({
+  project,
+  busy,
+  onCancel,
+  onSubmit,
+}: {
+  project: ProjectSummary
+  busy: boolean
+  onCancel: () => void
+  onSubmit: (patch: { title: string; note: string }) => void
+}) {
+  const { t } = useTranslation()
+  const [title, setTitle] = useState(project.title)
+  const [note, setNote] = useState(project.note ?? '')
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) return
+    onSubmit({ title, note })
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-center justify-center bg-black/45"
+      onClick={onCancel}
+    >
+      <form
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={submit}
+        className="bg-surface border border-dim rounded-xl p-7 flex flex-col gap-[18px] shadow-lg"
+        style={{ width: '90%', maxWidth: 440 }}
+      >
+        <h2 className="m-0 text-xl font-semibold">{t('projects.editProject')}</h2>
+
+        <FieldLabel label={t('projects.newProjectTitle')} hint="title">
+          <input
+            autoFocus
+            className="input"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={t('projects.titlePlaceholder')}
+          />
+        </FieldLabel>
+
+        <FieldLabel label={t('common.notes')} hint="note（可选）">
+          <textarea
+            className="input"
+            value={note}
+            onChange={(e) => setNote(e.target.value)}
+            placeholder={t('projects.notesPlaceholder')}
+            rows={3}
+            style={{ resize: 'vertical' }}
+          />
+        </FieldLabel>
+
+        <p className="m-0 text-xs text-fg-tertiary">
+          <span className="font-mono">{project.slug}</span>
+          {' · '}
+          {t('projects.editSlugNote')}
+        </p>
+
+        <div className="flex gap-2 justify-end">
+          <button type="button" className="btn btn-secondary" onClick={onCancel}>{t('common.cancel')}</button>
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={busy || !title.trim()}
+          >
+            {busy ? t('common.saving') : t('common.save')}
           </button>
         </div>
       </form>


### PR DESCRIPTION
## 背景 / 动机

issue #274 反馈两点：

1. **项目备注创建后无法修改** —— 备注可用于搜索/分类（`filterProjects` 已匹配 title/slug/note），但没有编辑入口。本 PR 解决这一项。
2. 删除已归档项目后 id 序号继续递增 —— 经 issue 讨论，id 是稳定主键（versions / project_jobs 外键引用它），留空隙是正确行为，且实际只在 URL 露出。**按讨论保持现状，本 PR 不动 id。**

## 改动概要

- **项目卡片新增编辑入口**：`ProjectCard` 加铅笔按钮，打开 `EditProjectDialog` 编辑 **title + note**，复用既有 `api.updateProject`（`PATCH /api/projects/{pid}`，后端 `_UPDATABLE = {title, note, active_version_id}` 早已支持）。
- `slug` 不可改：它是磁盘路径（`{id}-{slug}`）和 LoRA 输出名（`{slug}_{label}`）的锚点，title 纯属展示元数据 —— 改 title 不影响任何产物文件名 / 路径 / safetensors metadata，prompt picker 也按数字 id 引用、实时读 title。弹窗内展示 slug 并提示「slug 与输出名固定不变」。
- **操作图标改为 hover 显示**：把卡片底部（编辑 / 归档 / 恢复 / 删除）收进 `opacity-0 group-hover:opacity-100 group-focus-within:opacity-100` 容器。新增编辑图标后常驻图标偏多，hover/键盘聚焦时才淡入更清爽；用 `group-focus-within` 而非纯鼠标 hover，键盘 tab 到卡片也能显示，不藏死操作。
- i18n 新增 `projects.editProject` / `edited` / `editSlugNote`（zh + en），其余复用现有 key。

> 说明（AGENTS.md §4.2）：本 PR 含两处改动（编辑功能 + hover 收纳），但二者都只动 `ProjectCard` 同一区域，且 hover 收纳正是新增编辑图标导致卡片变挤后的直接收尾，强耦合、同模块、动机连续，故合在一个 PR。

## 测试方式

- `npm run lint` / `npx tsc --noEmit` / `npx vitest run`（39 文件 384 测试）全绿。
- 编辑弹窗与既有 `NewProjectDialog`（创建用，同样无独立组件测试）同构；hover 收纳为纯 CSS。沿用本页「纯函数 `filterProjects` 有单测、对话框无单测」的既有约定，未新增组件测试。如需补一条编辑流程的 component test 可加。
- 手测：点铅笔 → 改 title/note → 保存 → 列表刷新、toast、卡片更新；清空备注可移除；hover/聚焦淡入正常。

## 截图

UI 改动（铅笔按钮 + 编辑弹窗 + hover 淡入）。headless 环境未截图，可在本地 `npm run dev` 补 —— 需要的话我可以起服务截一组贴上来。

Closes #274