### PR TITLE
fix(web): 暂停按钮 is_pausable 跨页 SSE 刷新，恢复/启动后不再需切页

### DIFF
--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -122,11 +122,14 @@ export default function QueuePage() {
 
   useEventStream(
     (evt) => {
-      // ADR 0006 PR-4 — train_loop_started 不改 task.status 但要让 UI 看到
-      // is_pausable=true（解锁暂停按钮）；queue_hold_changed 要刷 banner。
+      // ADR 0006 PR-4 — train_loop_started / auto_epoch_backup_written 都不改
+      // task.status 但要让 UI 看到 is_pausable=true（解锁暂停按钮）：is_task_pausable
+      // 要 train_loop_started + 首个 epoch backup 落盘二者都满足，真正翻 true 的
+      // 是后者，所以两个事件都得 reload；queue_hold_changed 要刷 banner。
       if (
         evt.type === 'task_state_changed' ||
         evt.type === 'train_loop_started' ||
+        evt.type === 'auto_epoch_backup_written' ||
         evt.type === 'queue_hold_changed'
       ) {
         if (evt.type === 'queue_hold_changed') {

--- a/studio/web/src/pages/QueueDetail.test.tsx
+++ b/studio/web/src/pages/QueueDetail.test.tsx
@@ -3,12 +3,12 @@
  *  目前只覆盖 SnapshotConfigTab 的 refetch trap：父组件每 2s 浅 clone task
  *  做 elapsed time tick，旧实现 [task] 作 deps 会让 snapshot config 也跟着
  *  2s 重拉 —— 浏览器卡顿、loading flash。 */
-import { render, waitFor } from '@testing-library/react'
-import { MemoryRouter } from 'react-router-dom'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ToastProvider } from '../components/Toast'
 import type { Task } from '../api/client'
-import { SnapshotConfigTab } from './QueueDetail'
+import QueueDetailPage, { SnapshotConfigTab } from './QueueDetail'
 
 const SNAPSHOT_URL_PREFIX = '/api/queue/'
 const SNAPSHOT_URL_SUFFIX = '/snapshot/config'
@@ -107,5 +107,115 @@ describe('SnapshotConfigTab', () => {
     )
 
     await waitFor(() => expect(snapshotCallCount()).toBe(2))
+  })
+})
+
+// ── 暂停按钮的 SSE 刷新（QueueDetailPage header）─────────────────────────────
+//
+// regression：恢复 / 启动后 is_pausable 由 train_loop_started + auto_epoch_backup_written
+// 翻 true，但 header 共享的 task 之前只在 task_state_changed 时 reload，漏听这两个
+// 事件 → 暂停按钮一直不出现，必须切到 /queue 再回来（整页重挂）才有。
+//
+// jsdom 默认没有 EventSource（useEventStream 内部 typeof 守卫会短路），这里塞个
+// fake 让 hook 真订阅，再手动驱动一条事件验证组件会重新 getTask 并显示按钮。
+class FakeEventSource {
+  static instances: FakeEventSource[] = []
+  static readonly OPEN = 1
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  readyState = FakeEventSource.OPEN
+  constructor(public url: string) { FakeEventSource.instances.push(this) }
+  close(): void { this.readyState = 2 }
+  emit(evt: unknown): void { this.onmessage?.({ data: JSON.stringify(evt) }) }
+}
+
+const QUEUE_ITEM_URL = '/api/queue/119'
+
+function queueItemResponse(task: Task) {
+  return {
+    ok: true, status: 200,
+    json: async () => task,
+    text: async () => JSON.stringify(task),
+    headers: new Headers({ 'content-type': 'application/json' }),
+  } as Response
+}
+
+function renderDetailPage() {
+  return render(
+    <MemoryRouter initialEntries={['/queue/119']}>
+      <ToastProvider>
+        <Routes>
+          <Route path="/queue/:id" element={<QueueDetailPage />} />
+        </Routes>
+      </ToastProvider>
+    </MemoryRouter>
+  )
+}
+
+function getTaskCalls(): number {
+  return fetchMock.mock.calls.filter(([u]) => u === QUEUE_ITEM_URL).length
+}
+
+describe('QueueDetailPage 暂停按钮 SSE 刷新', () => {
+  beforeEach(() => {
+    FakeEventSource.instances = []
+    vi.stubGlobal('EventSource', FakeEventSource)
+  })
+
+  it('auto_epoch_backup_written 事件触发重拉 → 暂停按钮出现', async () => {
+    // getTask：首拉 is_pausable=false（train loop / 首个 epoch backup 未就绪），
+    // 之后拉 is_pausable=true（首个 epoch backup 已落盘）。
+    let pausable = false
+    fetchMock.mockImplementation((url: string) => {
+      if (url === QUEUE_ITEM_URL) {
+        return Promise.resolve(queueItemResponse(makeTask({
+          id: 119, status: 'running', is_pausable: pausable,
+        })))
+      }
+      return Promise.resolve({
+        ok: false, status: 404, json: async () => null, text: async () => '',
+        headers: new Headers(),
+      } as Response)
+    })
+
+    renderDetailPage()
+
+    // 初始：running header 已渲染（PID 卡片），但 is_pausable=false → 暂停按钮不在
+    await waitFor(() => expect(screen.getByText('取消任务')).toBeInTheDocument())
+    expect(screen.queryByTestId('detail-pause-btn')).not.toBeInTheDocument()
+
+    // 后端首个 epoch backup 落盘 → is_pausable 升级；推一条 SSE 事件
+    pausable = true
+    await waitFor(() => expect(FakeEventSource.instances.length).toBeGreaterThan(0))
+    FakeEventSource.instances[0].emit({ type: 'auto_epoch_backup_written', task_id: 119 })
+
+    // 重拉后暂停按钮出现（不依赖切页重挂）
+    await waitFor(() => expect(screen.getByTestId('detail-pause-btn')).toBeInTheDocument())
+  })
+
+  it('其它 task 的事件不会触发重拉', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === QUEUE_ITEM_URL) {
+        return Promise.resolve(queueItemResponse(makeTask({
+          id: 119, status: 'running', is_pausable: false,
+        })))
+      }
+      return Promise.resolve({
+        ok: false, status: 404, json: async () => null, text: async () => '',
+        headers: new Headers(),
+      } as Response)
+    })
+
+    renderDetailPage()
+    await waitFor(() => expect(screen.getByText('取消任务')).toBeInTheDocument())
+    const before = getTaskCalls()
+
+    await waitFor(() => expect(FakeEventSource.instances.length).toBeGreaterThan(0))
+    // 别的 task（task_id=999）的 backup 事件 — 不应触发本页重拉
+    FakeEventSource.instances[0].emit({ type: 'auto_epoch_backup_written', task_id: 999 })
+    await new Promise((r) => setTimeout(r, 150))
+
+    expect(getTaskCalls()).toBe(before)
   })
 })

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -117,17 +117,50 @@ export default function QueueDetailPage() {
     }
   }, [location.hash])
 
+  // reload 串行号：SSE 事件密集时多个 getTask 并发在飞，HTTP 响应可能乱序回来。
+  // 只让「最后发起」的那次写 state，避免旧快照覆盖新状态（典型故障：恢复后
+  // is_pausable / status 被一个更早发出、更晚到达的响应拍回旧值，header 的
+  // 暂停 / 取消按钮状态错乱）。
+  const reloadSeq = useRef(0)
   const reload = useCallback(async () => {
     if (!Number.isFinite(taskId)) return
-    try { const t = await api.getTask(taskId); setTask(t); setError(null) }
-    catch (e) { setError(String(e)) }
+    const seq = ++reloadSeq.current
+    try {
+      const t = await api.getTask(taskId)
+      if (seq === reloadSeq.current) { setTask(t); setError(null) }
+    } catch (e) {
+      if (seq === reloadSeq.current) setError(String(e))
+    }
   }, [taskId])
 
   useEffect(() => { void reload() }, [reload])
 
+  // SSE → 刷新 task。除了 status 变化（task_state_changed），还要监听解锁暂停
+  // 按钮的两个信号：train_loop_started（进主循环）+ auto_epoch_backup_written
+  // （首个 epoch backup 落盘）—— is_task_pausable 要二者都满足才 true（core.py
+  // §is_task_pausable）。漏听这两个事件会让恢复 / 启动后暂停按钮一直不出现，
+  // 必须切到 /queue 再回来（整页重挂触发一次干净 reload）才有。Queue.tsx 已
+  // 在听 train_loop_started，这里之前漏了。100ms 防抖把启动瞬间的事件风暴
+  // （pending → running → train_loop_started → auto_epoch_backup_written）合并
+  // 成一次拉取。
+  const reloadTimer = useRef<number | null>(null)
   useEventStream((evt) => {
-    if (evt.type === 'task_state_changed' && evt.task_id === taskId) void reload()
+    if (evt.task_id !== taskId) return
+    if (
+      evt.type === 'task_state_changed' ||
+      evt.type === 'train_loop_started' ||
+      evt.type === 'auto_epoch_backup_written'
+    ) {
+      if (reloadTimer.current) return
+      reloadTimer.current = window.setTimeout(() => {
+        reloadTimer.current = null
+        void reload()
+      }, 100)
+    }
   })
+  useEffect(() => () => {
+    if (reloadTimer.current) window.clearTimeout(reloadTimer.current)
+  }, [])
 
   useEffect(() => {
     if (task?.status !== 'running') return

--- a/studio/web/src/pages/project/Overview.test.tsx
+++ b/studio/web/src/pages/project/Overview.test.tsx
@@ -1,0 +1,121 @@
+/** ProjectOverview 组件级 regression test。
+ *
+ *  覆盖训练态 StatusBanner 的暂停按钮实时刷新：latestTask 是 Overview 内独立
+ *  local state（不是 project prop），Layout 的 version_state_changed reload 碰
+ *  不到它。暂停按钮门控的 is_pausable 由 train_loop_started + 首个 epoch 的
+ *  auto_epoch_backup_written 翻 true —— Overview 必须自己订阅这些 SSE 事件重拉
+ *  latestTask，否则暂停按钮训练期一直不出现，得切版本 / 刷新页面才有。
+ *
+ *  jsdom 默认没有 EventSource（useEventStream 内部 typeof 守卫会短路），这里塞
+ *  个 fake 让 hook 真订阅，再手动驱动事件验证组件会重拉 listQueue 并显示按钮。 */
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Outlet, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider } from '../../components/Toast'
+import { api, type ProjectDetail, type Task, type Version } from '../../api/client'
+import ProjectOverview from './Overview'
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = []
+  static readonly OPEN = 1
+  onopen: (() => void) | null = null
+  onmessage: ((e: { data: string }) => void) | null = null
+  onerror: (() => void) | null = null
+  readyState = FakeEventSource.OPEN
+  constructor(public url: string) { FakeEventSource.instances.push(this) }
+  close(): void { this.readyState = 2 }
+  emit(evt: unknown): void { this.onmessage?.({ data: JSON.stringify(evt) }) }
+}
+
+function makeVersion(overrides: Partial<Version> = {}): Version {
+  return {
+    id: 7, project_id: 3, label: 'v1', config_name: 'train',
+    status: 'training', phase: 'ready', last_failure_reason: null,
+    created_at: 1000, output_lora_path: null, note: null, trigger_word: '',
+    ...overrides,
+  }
+}
+
+function makeProject(overrides: Partial<ProjectDetail> = {}): ProjectDetail {
+  return {
+    id: 3, slug: 'proj', title: 'Proj', active_version_id: 7,
+    active_version_label: 'v1', active_version_status: 'training',
+    active_version_phase: null, created_at: 1000, updated_at: 1000,
+    archived_at: null, note: null,
+    download_image_count: 0, preprocess_image_count: 0,
+    versions: [makeVersion()],
+    ...overrides,
+  }
+}
+
+function makeTrainTask(is_pausable: boolean): Task {
+  return {
+    id: 42, name: 'train', config_name: 'train', status: 'running', priority: 0,
+    created_at: 1000, started_at: 1100, finished_at: null, pid: 1234,
+    exit_code: null, output_dir: null, error_msg: null,
+    project_id: 3, version_id: 7, is_pausable,
+  }
+}
+
+function renderOverview(project: ProjectDetail) {
+  const ctxValue = {
+    project,
+    activeVersion: project.versions[0] ?? null,
+    reload: async () => {},
+    onCreateVersion: () => {},
+    creatingVersionBusy: false,
+  }
+  return render(
+    <MemoryRouter initialEntries={['/projects/3']}>
+      <ToastProvider>
+        <Routes>
+          <Route element={<Outlet context={ctxValue} />}>
+            <Route path="/projects/:id" element={<ProjectOverview />} />
+          </Route>
+        </Routes>
+      </ToastProvider>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  FakeEventSource.instances = []
+  vi.stubGlobal('EventSource', FakeEventSource)
+  // detail tab 的 getCuration / listCaptionsFull 等都有 .catch —— 统一 404 让它们
+  // 安静失败，不污染测试；listQueue 单独 spy 控制返回。
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+    ok: false, status: 404, json: async () => null, text: async () => '',
+    headers: new Headers(),
+  } as Response)))
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('ProjectOverview 训练态暂停按钮 SSE 刷新', () => {
+  it('auto_epoch_backup_written 事件触发重拉 latestTask → 暂停按钮出现', async () => {
+    // listQueue：首拉 is_pausable=false（首个 epoch backup 未落盘），之后 true。
+    let pausable = false
+    const listSpy = vi.spyOn(api, 'listQueue')
+      .mockImplementation(async () => [makeTrainTask(pausable)])
+
+    renderOverview(makeProject())
+
+    // 训练 banner 已渲染（取消训练按钮随 taskId 出现），但 is_pausable=false →
+    // 暂停按钮不在。
+    await waitFor(() => expect(screen.getByText('取消训练')).toBeInTheDocument())
+    expect(screen.queryByText('暂停')).not.toBeInTheDocument()
+    const callsBefore = listSpy.mock.calls.length
+
+    // 后端首个 epoch backup 落盘 → is_pausable 升级；推一条 SSE 事件。
+    pausable = true
+    await waitFor(() => expect(FakeEventSource.instances.length).toBeGreaterThan(0))
+    FakeEventSource.instances[0].emit({ type: 'auto_epoch_backup_written', task_id: 42 })
+
+    // 重拉后暂停按钮出现（不依赖切版本 / 刷新页面）。
+    await waitFor(() => expect(screen.getByText('暂停')).toBeInTheDocument())
+    expect(listSpy.mock.calls.length).toBeGreaterThan(callsBefore)
+  })
+})

--- a/studio/web/src/pages/project/Overview.tsx
+++ b/studio/web/src/pages/project/Overview.tsx
@@ -10,7 +10,7 @@
  *  Live 训练进度 (step/total/ETA) 不实装 —— 需 SSE/monitor state 整合，留 follow-up。
  *  "复制配置开新版本" / "调小 batch 重训" 需新后端 API，渲染为占位按钮 toast 提示。
  */
-import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate, useOutletContext } from 'react-router-dom'
 import {
@@ -32,6 +32,7 @@ import { OutputsTab } from '../QueueDetail'
 import { arBucket } from '../../lib/aspectRatio'
 import { computePixelHist } from '../../lib/pixelBins'
 import { useProjectCtx } from '../../context/ProjectContext'
+import { useEventStream } from '../../lib/useEventStream'
 import { useToast } from '../../components/Toast'
 
 type OverviewTab = 'details' | 'tasks' | 'output'
@@ -1224,20 +1225,49 @@ export default function ProjectOverview() {
 
   // 拉 selected version 的最新 task — banner 状态叙事 + CTA 数据源
   const [latestTask, setLatestTask] = useState<Task | null>(null)
-  useEffect(() => {
+  // seq 守卫：SSE 防抖重拉与切版本拉取可能并发，旧响应不许覆盖新状态。
+  const latestSeqRef = useRef(0)
+  const reloadLatestTask = useCallback(async () => {
     if (!selectedVid) { setLatestTask(null); return }
-    let cancelled = false
-    void api.listQueue()
-      .then((items) => {
-        if (cancelled) return
-        const list = items
-          .filter((tk) => tk.project_id === project.id && tk.version_id === selectedVid)
-          .sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))
-        setLatestTask(list[0] ?? null)
-      })
-      .catch(() => { if (!cancelled) setLatestTask(null) })
-    return () => { cancelled = true }
+    const seq = ++latestSeqRef.current
+    try {
+      const items = await api.listQueue()
+      if (seq !== latestSeqRef.current) return
+      const list = items
+        .filter((tk) => tk.project_id === project.id && tk.version_id === selectedVid)
+        .sort((a, b) => (b.created_at ?? 0) - (a.created_at ?? 0))
+      setLatestTask(list[0] ?? null)
+    } catch {
+      if (seq === latestSeqRef.current) setLatestTask(null)
+    }
   }, [project.id, selectedVid])
+
+  useEffect(() => { void reloadLatestTask() }, [reloadLatestTask])
+
+  // latestTask 是独立 local state（不是 project prop）—— Layout 的
+  // version_state_changed reload 只刷 project，碰不到它。但训练态 banner 的
+  // 暂停按钮（latestTask.is_pausable）要靠 train_loop_started +
+  // auto_epoch_backup_written 翻 true，task 生命周期变化（新任务启动 / 结束落
+  // finished_at·error_msg）也得让 banner 的 CTA 跟上，所以这几个事件都要重拉。
+  // 不订阅就会出现「暂停按钮一直不出现」「完成/失败 banner 时间停在 —」等
+  // 滞后，必须切版本 / 刷新页面才更新。100ms 防抖合并启动瞬间的事件风暴。
+  const latestReloadTimer = useRef<number | null>(null)
+  useEventStream((evt) => {
+    if (
+      evt.type === 'task_state_changed' ||
+      evt.type === 'train_loop_started' ||
+      evt.type === 'auto_epoch_backup_written'
+    ) {
+      if (latestReloadTimer.current) return
+      latestReloadTimer.current = window.setTimeout(() => {
+        latestReloadTimer.current = null
+        void reloadLatestTask()
+      }, 100)
+    }
+  })
+  useEffect(() => () => {
+    if (latestReloadTimer.current) window.clearTimeout(latestReloadTimer.current)
+  }, [])
 
   const [activeTab, setActiveTab] = useState<OverviewTab>('details')
 


### PR DESCRIPTION
## 背景 / 动机

用户反馈：中途恢复（terminal/paused → resume）训练后，监控界面的暂停按钮不出现，**切到队列页再切回来才有**。

排查后发现是一类跨页 bug：暂停按钮门控字段 `is_pausable` 由 server enrich，后端 `is_task_pausable`（`studio/supervisor/core.py`）要求 **`train_loop_started` 且 `last_auto_epoch_state_path`（首个 epoch backup 落盘）都满足**才为 true。前端漏听了让它翻 true 的 SSE 事件，导致按钮状态滞后，必须整页重挂（切页 / 切版本 / 刷新）才更新。

三页的具体缺口：

| 页面 | 缺口 |
|---|---|
| `QueueDetail.tsx` header | SSE handler 只听 `task_state_changed`，`train_loop_started` / `auto_epoch_backup_written` 全忽略 |
| `Queue.tsx` 顶部暂停 | 漏听 `auto_epoch_backup_written`——`train_loop_started` 时 `is_pausable` 还是 false，真正翻 true 的是首个 epoch backup |
| `Overview.tsx` 训练态 banner | `latestTask` 是组件内独立 local state，`Layout` 的 `version_state_changed` reload 碰不到它，且**零 SSE 订阅** → 暂停按钮训练期基本不出现，完成/失败 banner 的 `finished_at`/`error_msg` 也滞后 |

## 改动概要

- 三页统一在 `task_state_changed` + `train_loop_started` + `auto_epoch_backup_written` 三个事件上重拉 task（按 `task_id` 过滤，`QueueDetail`；`Overview` 抽出 `reloadLatestTask`），100ms 防抖合并启动瞬间的事件风暴。
- `reload()` 加单调 seq 守卫：启动瞬间多个 `getTask`/`listQueue` 并发在飞，旧响应乱序回来不再覆盖新状态（防 `is_pausable`/`status` 被拍回旧值）。
- 其余同类按钮已核对无问题：取消任务 / paused 的继续·取消 / terminal 继续训练 都由 `task_state_changed` 正确驱动；`/tools/monitor` 无操作按钮；Generate 取消是出图任务、无 pause 概念。

## 测试方式

- 新增 fake-`EventSource` 回归测试覆盖 `QueueDetail` / `Overview`：验证收到 `auto_epoch_backup_written` 会重拉并显示暂停按钮（不依赖切页重挂），且别的 task 的事件不误触发。Overview 测试已验证「禁掉监听即 fail」，确实守得住。
- `npx vitest run`：40 文件 / 387 测试全过；`npm run lint` + `tsc --noEmit` 干净。

## 截图

行为类（按钮显隐时机），无静态截图。复现：恢复一个 failed/canceled 任务 → 进监控页 → 首个 epoch backup 落盘后暂停按钮应自动出现，无需切页。

🤖 Generated with [Claude Code](https://claude.com/claude-code)