### PR TITLE
fix(setup): flash_attn wheel 自动选最新可用版本（不再首选最旧）

### DIFF
--- a/studio/services/runtime/flash_attention.py
+++ b/studio/services/runtime/flash_attention.py
@@ -140,21 +140,23 @@ def detect_env() -> dict[str, Any]:
 
 
 def _parse_wheel(name: str) -> Optional[dict[str, str]]:
-    """从 wheel 文件名解析出 cuda / torch / python / platform 标签。
+    """从 wheel 文件名解析出 version / cuda / torch / python / platform 标签。
 
     例：flash_attn-2.8.3+cu130torch2.11-cp312-cp312-win_amd64.whl
-    → {cuda: "cu130", torch: "torch2.11", python: "cp312", platform: "win_amd64"}
+    → {version: "2.8.3", cuda: "cu130", torch: "torch2.11", python: "cp312",
+       platform: "win_amd64"}
     """
     m = re.search(
-        r"\+(cu\d+)(torch[\d.]+)-(cp\d+)-cp\d+-([\w]+)\.whl$", name
+        r"flash_attn-([^+]+)\+(cu\d+)(torch[\d.]+)-(cp\d+)-cp\d+-([\w]+)\.whl$", name
     )
     if not m:
         return None
     return {
-        "cuda": m.group(1),
-        "torch": m.group(2),
-        "python": m.group(3),
-        "platform": m.group(4),
+        "version": m.group(1),
+        "cuda": m.group(2),
+        "torch": m.group(3),
+        "python": m.group(4),
+        "platform": m.group(5),
     }
 
 
@@ -162,6 +164,14 @@ def _cuda_major(tag: str) -> int:
     """cu130 → 13，cu124 → 12；解析失败返回 -1。"""
     m = re.search(r"cu(\d+)", tag)
     return int(m.group(1)) // 10 if m else -1
+
+
+def _version_key(version: str) -> tuple[int, ...]:
+    """flash_attn 版本字符串 → 可比较的整数元组，用于评分相同的候选间偏向更新版本。
+
+    例：'2.8.3' → (2, 8, 3)；'2.7.4.post1' → (2, 7, 4, 1)；解析不出 → ()。
+    """
+    return tuple(int(x) for x in re.findall(r"\d+", version or ""))
 
 
 def find_candidates(
@@ -240,13 +250,22 @@ def find_candidates(
             candidates.append({
                 "url": asset["browser_download_url"],
                 "name": asset["name"],
+                "version": tags["version"],
                 "score": score,
                 "notes": notes,
                 "usable": usable,
                 "tags": tags,
             })
 
-    return sorted(candidates, key=lambda x: -x["score"]), None
+    # 评分相同（同 python/cuda/torch）时偏向更新的 flash 版本。旧实现只按 score 排，平手
+    # 退回 GitHub asset 顺序（恰好最旧在前）→ 自动安装首选最旧 wheel；而比该 wheel 更新的
+    # GPU 架构上（如 Blackwell sm_120）旧 wheel 没有对应 kernel，flash 全程回退 SDPA。把
+    # 版本作为次级 key（高于 asset 顺序、低于 score）即可让 find_best_wheel 选到最新可用版本。
+    return sorted(
+        candidates,
+        key=lambda x: (x["score"], _version_key(x["version"])),
+        reverse=True,
+    ), None
 
 
 def find_best_wheel(env: dict[str, Any]) -> Optional[str]:

--- a/tests/test_flash_attention_setup.py
+++ b/tests/test_flash_attention_setup.py
@@ -24,6 +24,7 @@ def test_parse_wheel_canonical() -> None:
     """官方命名：flash_attn-2.8.3+cu130torch2.11-cp312-cp312-win_amd64.whl"""
     tags = fa._parse_wheel("flash_attn-2.8.3+cu130torch2.11-cp312-cp312-win_amd64.whl")
     assert tags == {
+        "version": "2.8.3",
         "cuda": "cu130",
         "torch": "torch2.11",
         "python": "cp312",
@@ -314,6 +315,36 @@ def test_find_candidates_cuda_major_diff_negative_score(
     # 大版本不同：Python +20, CUDA -5 = 15
     assert candidates[0]["score"] == 15
     assert any("CUDA 大版本不同" in n for n in candidates[0]["notes"])
+
+
+def test_find_candidates_prefers_newest_version_on_tie(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """同 python/cuda/torch、仅 flash 版本不同 → 评分相同，应选最新版本。
+
+    回归（autodl 5090）：旧实现平手时退回 GitHub asset 顺序（最旧在前），自动安装首选
+    2.6.3；但 2.6.3 没有 Blackwell(sm_120) kernel → flash 在 5090 上全程回退 SDPA。
+    """
+    payload = [{
+        "assets": [
+            {"name": "flash_attn-2.6.3+cu128torch2.11-cp312-cp312-linux_x86_64.whl",
+             "browser_download_url": "https://x/2.6.3.whl"},
+            {"name": "flash_attn-2.7.4+cu128torch2.11-cp312-cp312-linux_x86_64.whl",
+             "browser_download_url": "https://x/2.7.4.whl"},
+            {"name": "flash_attn-2.8.3+cu128torch2.11-cp312-cp312-linux_x86_64.whl",
+             "browser_download_url": "https://x/2.8.3.whl"},
+        ],
+    }]
+    _mock_releases(monkeypatch, payload)
+    env = {
+        "platform": "linux_x86_64", "torch_tag": "torch2.11",
+        "cuda_tag": "cu128", "python_tag": "cp312",
+    }
+    candidates, err = fa.find_candidates(env)
+    assert err is None
+    # 评分全相同（python+cuda 精确）→ 版本降序：2.8.3 在前
+    assert [c["version"] for c in candidates] == ["2.8.3", "2.7.4", "2.6.3"]
+    assert fa.find_best_wheel(env) == "https://x/2.8.3.whl"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景 / 动机
一台 autodl 5090 (Blackwell, sm_120) 实例，安装引导给装了 flash_attn **2.6.3**（候选里最旧的）。2.6.3 没有 sm_120 kernel → 训练/采样时 flash_attn 全程回退、刷 `FlashAttention only supports Ampere GPUs or newer`（误导消息：5090 比 Ampere 新，真实含义是该 wheel 没有这张卡的 kernel）。根因是 wheel 自动选版的排序 bug。

## 根因
`find_candidates` 评分只算 python(+20) + cuda(+20)，**从不解析/比较 flash 版本**。同环境（cp312 / cu128 / torch2.11）三个 wheel（2.6.3 / 2.7.4 / 2.8.3）评分相同 → `sorted(key=-score)` 稳定排序平手退回 GitHub asset 顺序（字母升序 = 最旧在前）→ `find_best_wheel` 取第一个 = 2.6.3。

## 改动概要
- `_parse_wheel` 解析出 `version`
- 新增 `_version_key`（`"2.8.3"→(2,8,3)`，`"2.7.4.post1"→(2,7,4,1)`）
- `find_candidates` 排序改 `(score, version)` 双键降序：评分仍是主键（cuda/python 匹配优先级不变），**平手时偏向更新版本**
- 效果：自动安装选 2.8.3；UI 候选列表也变最新在前

## 测试
- 新增回归测试 `test_find_candidates_prefers_newest_version_on_tie`（复刻 autodl 场景：三版本平手 → 必须选 2.8.3）
- `test_parse_wheel_canonical` 更新含 version
- `pytest tests/test_flash_attention_setup.py -q` → 31 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
