### PR TITLE
fix(train): SRA v2 对齐 loss 加 per-sample 标准化防尺度失衡崩坏

### DIFF
--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -113,4 +113,5 @@ def run(ctx: TrainingContext) -> None:
             vae_channels=16,
             device=ctx.device,
             dtype=ctx.dtype,
+            normalize=bool(getattr(args, "sra_normalize", True)),
         )

--- a/runtime/training/sra_align.py
+++ b/runtime/training/sra_align.py
@@ -79,11 +79,15 @@ class SRAAligner:
         vae_channels: int = 16,
         device: str = "cuda",
         dtype: torch.dtype = torch.float32,
+        normalize: bool = True,
+        norm_eps: float = 1e-5,
     ):
         self.block_idx = block_idx
         self.patch_spatial = patch_spatial
         self.patch_temporal = patch_temporal
         self.vae_channels = vae_channels
+        self.normalize = normalize
+        self.norm_eps = norm_eps
         self._cached_hidden: Optional[Tensor] = None
 
         out_per_token = vae_channels * patch_temporal * patch_spatial * patch_spatial
@@ -98,11 +102,28 @@ class SRAAligner:
         logger.info(
             f"SRA v2: hook on block[{block_idx}], "
             f"proj {model_channels} → {out_per_token}, "
-            f"{n_params / 1e6:.1f}M params"
+            f"{n_params / 1e6:.1f}M params, normalize={normalize}"
         )
 
     def _hook_fn(self, module, input, output):
         self._cached_hidden = output
+
+    def _standardize(self, x: Tensor) -> Tensor:
+        """Per-sample z-score over all feature dims (channel + spatial/temporal).
+
+        The original SRA 2 paper aligns to raw SD-VAE latents (≈unit scale) during
+        from-scratch SiT pretraining, so it needs no normalization. This project
+        fine-tunes a LoRA on a video model whose latents live on a different scale;
+        without standardization the smooth-L1 align loss sits several orders of
+        magnitude above the (already-converged) denoising loss and collapses
+        training. Standardizing both projected and target keeps the objective on
+        a structural, scale-invariant footing — the same intuition behind the
+        cosine variant the paper ablates (Tab. 4), while retaining smooth-L1.
+        """
+        dims = tuple(range(1, x.dim()))
+        mean = x.mean(dim=dims, keepdim=True)
+        std = x.std(dim=dims, keepdim=True)
+        return (x - mean) / (std + self.norm_eps)
 
     def _hidden_as_target_grid(self, hidden: Tensor, target: Tensor) -> Tensor:
         """Reshape captured tokens to the VAE latent patch grid.
@@ -180,6 +201,10 @@ class SRAAligner:
                 f"SRA shape mismatch: projected {projected.shape} vs target {target.shape}"
             )
 
+        if self.normalize:
+            projected = self._standardize(projected)
+            target = self._standardize(target)
+
         loss_per_sample = F.smooth_l1_loss(
             projected, target, beta=0.05, reduction="none"
         ).mean(dim=tuple(range(1, projected.dim())))
@@ -211,6 +236,7 @@ class SRAAligner:
             "patch_spatial": self.patch_spatial,
             "patch_temporal": self.patch_temporal,
             "vae_channels": self.vae_channels,
+            "normalize": self.normalize,
             "proj": self.proj.state_dict(),
         }
 

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -677,6 +677,11 @@ class TrainingConfig(BaseModel):
         description="【SRA v2】对齐 loss 权重 λ：align_loss 乘以此值后加到总 loss。trainer 默认 0.2，过大会导致异常",
         json_schema_extra=_meta("loss", show_when="sra_enabled==true", advanced=True),
     )
+    sra_normalize: bool = Field(
+        True,
+        description="【SRA v2】对 projected/target 各自做 per-sample z-score 标准化后再算 smooth-L1（论文 cosine 消融的同族思路：幅度无关、只对齐结构）。原论文用 SD-VAE（latent ~单位尺度）从零训练故不归一化；本项目视频 VAE latent 尺度不同 + LoRA 微调，关闭会导致 align loss 比 denoise 高几个量级并很快崩坏。建议保持开启",
+        json_schema_extra=_meta("loss", show_when="sra_enabled==true", advanced=True),
+    )
     sra_decay_type: Literal["none", "linear", "cosine", "jump"] = Field(
         "linear",
         description="【SRA v2】权重衰减方式：none 全程固定；linear 从起点线性降到 0；cosine 从起点余弦降到 0；jump 到起点直接关掉。实际权重 = sra_weight × 衰减系数",

--- a/tests/test_sra_align.py
+++ b/tests/test_sra_align.py
@@ -34,7 +34,7 @@ class _StubInjector:
         return SimpleNamespace(missing_keys=[], unexpected_keys=[])
 
 
-def _new_aligner(seed: int = 0) -> tuple[_FakeModel, SRAAligner]:
+def _new_aligner(seed: int = 0, normalize: bool = True) -> tuple[_FakeModel, SRAAligner]:
     torch.manual_seed(seed)
     model = _FakeModel()
     aligner = SRAAligner(
@@ -46,6 +46,7 @@ def _new_aligner(seed: int = 0) -> tuple[_FakeModel, SRAAligner]:
         vae_channels=16,
         device="cpu",
         dtype=torch.float32,
+        normalize=normalize,
     )
     return model, aligner
 
@@ -62,6 +63,26 @@ def test_sra_compute_accepts_native_flatten_block_output() -> None:
     loss = aligner.compute(target)
     assert loss.ndim == 0
     assert torch.isfinite(loss)
+
+
+def test_sra_normalize_keeps_loss_order_one_for_large_targets() -> None:
+    # A large-magnitude target (e.g. a video-VAE latent) blows the un-normalized
+    # smooth-L1 align loss several orders of magnitude above the denoise loss.
+    # Standardizing both sides keeps it on an O(1) structural footing.
+    big_target = torch.randn(2, 16, 1, 4, 4) * 50.0
+    hidden = torch.randn(2, 1, 4, 1, 8)
+
+    model_n, aligner_norm = _new_aligner(normalize=True)
+    model_n.blocks[0](hidden)
+    loss_norm = aligner_norm.compute(big_target)
+
+    model_r, aligner_raw = _new_aligner(normalize=False)
+    model_r.blocks[0](hidden)
+    loss_raw = aligner_raw.compute(big_target)
+
+    assert torch.isfinite(loss_norm)
+    assert loss_norm.item() < 5.0
+    assert loss_raw.item() > 10.0 * loss_norm.item()
 
 
 def test_sra_compute_applies_sample_weight() -> None:


### PR DESCRIPTION
## 背景

SRA v2（CVPR 2026, arXiv:2601.17830, Eq.7）用 smooth-L1 直接对**裸 VAE latent** 对齐。论文用 SD-VAE 从零预训练，latent ≈单位尺度，所以无需归一化也能跑，λ=1.0。

## 问题

本项目场景与论文不同：

- 用的是**视频 VAE**（latent 尺度与 SD-VAE 不同）；
- 是 **LoRA 微调**（base 去噪已收敛、denoise 梯度很小）。

实测开启 SRA v2 后，`sra_align_loss` 比 `denoise_loss` 高**几个量级**（~60 vs ~0.06），几个 epoch 内拟合后**快速崩坏**；且收敛对优化器尺度高度敏感（自适应优化器十几步对齐、Lion 等 sign 优化器一百多步），暴露出对齐目标未归一化、量级失控。

## 改动

新增 schema 字段 `sra_normalize`（默认开），在算 smooth-L1 前对 `projected` / `target` **各自做 per-sample z-score 标准化**：

- 把对齐目标拉回 O(1)、条件数变好，让 λ 重新可解释、优化器选择不再敏感；
- 思路与论文消融里的 **cosine 变体（Tab.4，幅度无关、只对齐结构）**同族，但保留论文默认的 smooth-L1 主损失；
- 默认开（裸模式对本项目 VAE 明显不稳）；是 opt-in 功能 `sra_enabled` 的内部行为，可通过 `sra_normalize=false` 退回原行为。

未改 `sra_weight` 默认值（沿用 dev 已有的 0.2），保持本 PR 只做"加归一化"一件事。

## Test plan

- [x] `pytest tests/test_sra_align.py` → 7 passed
- [x] 新增回归测试 `test_sra_normalize_keeps_loss_order_one_for_large_targets`：大尺度 target 下归一化把 loss 压到 O(1)，且裸模式 > 10× 归一化模式
