### PR TITLE
fix(web): LLM tagger 提示词模板输入一个字就失焦

### DIFF
--- a/studio/web/src/components/LLMMessagesEditor.test.tsx
+++ b/studio/web/src/components/LLMMessagesEditor.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+import LLMMessagesEditor from './LLMMessagesEditor'
+import type { LLMMessage } from '../api/client'
+
+// 受控 textarea：父组件持 state，把每次编辑写回，模拟真实 Settings 用法。
+function Harness() {
+  const [messages, setMessages] = useState<LLMMessage[]>([
+    { type: 'text', role: 'system', content: '' },
+    { type: 'text', role: 'user', content: '' },
+  ])
+  return <LLMMessagesEditor messages={messages} onChange={setMessages} />
+}
+
+describe('LLMMessagesEditor', () => {
+  // regression：不可变更新换掉 message 对象引用后，若没把稳定 id 迁到新对象，
+  // idOf 会发新 id → key 变 → SortableMessage（含 textarea）重挂 → 输入一个字
+  // 就失焦、无法连续输入。
+  it('编辑消息内容时 textarea 不重挂、保持焦点、可连续输入', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    // 两条消息 → 两个 textarea；第二个是 user 消息体。
+    const before = screen.getAllByRole('textbox')[1] as HTMLTextAreaElement
+    before.focus()
+    expect(before).toHaveFocus()
+
+    await user.type(before, 'hello')
+
+    const after = screen.getAllByRole('textbox')[1] as HTMLTextAreaElement
+    expect(after).toBe(before)         // 同一 DOM 节点 —— 没有重挂
+    expect(after).toHaveFocus()        // 焦点保留
+    expect(after).toHaveValue('hello') // 连续多字符全部落入（不止首字）
+  })
+})

--- a/studio/web/src/components/LLMMessagesEditor.tsx
+++ b/studio/web/src/components/LLMMessagesEditor.tsx
@@ -69,7 +69,15 @@ export default function LLMMessagesEditor({ messages, onChange, disabled }: Prop
   }
 
   const updateMsg = (i: number, patch: Partial<LLMMessage>) => {
-    onChange(messages.map((m, idx) => (idx === i ? { ...m, ...patch } : m)))
+    onChange(messages.map((m, idx) => {
+      if (idx !== i) return m
+      const updated = { ...m, ...patch }
+      // 不可变更新会换掉对象引用；把稳定 id 一并迁到新对象上，否则 idOf
+      // 会发新 id → key 变 → 整个 SortableMessage（含 textarea）重挂、输入失焦。
+      const id = idRefs.current.get(m)
+      if (id) idRefs.current.set(updated, id)
+      return updated
+    }))
   }
 
   const deleteMsg = (i: number) => {


### PR DESCRIPTION
## 背景 / 动机

LLM tagger 预设的提示词模板（Settings → LLM tagger 工作台）和打标页里，提示词输入框**打一个字就失焦、无法连续输入**。

## 根因

`LLMMessagesEditor` 用 `WeakMap`（按 message 对象身份）给每行算稳定 id 当 React `key`。但每次敲键 `updateMsg` 走 `{ ...m, ...patch }` 造新对象，新对象不在 WeakMap 里 → `idOf` 发新 id → `key` 变 → React 把整行 `SortableMessage`（含 textarea）卸载重建 → 正在输入的 textarea 被销毁、失焦。textarea 是受控的，第一下就触发。

> 换成「保存按钮」无济于事：受控 textarea 每次敲键还是会换 message 对象、key 还是会变、还是会重挂失焦。要靠去 onChange 修就得改非受控，会丢掉脏值追踪/预览，比 bug 更伤。

## 改动

`updateMsg` 里把旧对象的稳定 id 迁到新对象上，`key` 不再随内容变。拖拽排序 / 新增 / 删除本就正常（对象引用保留或新建），只补编辑这一步。

## 影响范围

共享组件，Settings（LLM tagger 工作台）+ 打标页两处一起修好。

## 测试

- 新增 `LLMMessagesEditor.test.tsx` 回归测试：聚焦 → 连打多字 → 断言同一 DOM 节点、仍聚焦、值为完整字符串。临时回退修复该测试失败在「同一 DOM 节点」断言（已验证能抓到），还原转绿。
- `studio/web` 全量 vitest 388 passed；`npm run lint` + `npx tsc --noEmit` 干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)