### PR TITLE
fix(setup): onnxruntime-directml 永久误报「需重启 Studio」

### DIFF
--- a/studio/services/runtime/onnxruntime.py
+++ b/studio/services/runtime/onnxruntime.py
@@ -408,18 +408,25 @@ def current_runtime() -> dict[str, Any]:
     except ImportError:
         pass
 
-    # 检测「pip 装的包名/版本」 vs 「进程里 import 的版本」不一致
-    # （onnxruntime 是 C extension，pip 重装不会热替换已 import 的 .pyd）
+    # 检测「pip 装的包」与「进程里已 import 的 native 模块」不一致 —— onnxruntime
+    # 是 C extension，pip 卸装重装不会热替换已 import 的 .pyd，必须重启才换 EP。
+    #
+    # 判定只看「装的包类型 ↔ 进程里实际加载的 EP」，**不比版本号字符串**：
+    # onnxruntime-directml 的 dist 版本（如 1.24.4）与它内部捆绑的 onnxruntime 核心
+    # 版本（ort.__version__，如 1.27.0）是两条独立版本线、天然不相等；比版本号会让
+    # DirectML 用户永久误报「需重启」，重启多少次都消不掉。EP 一致性才是可靠信号，
+    # 也正是本功能的目的（让 EP 切换生效）。
+    _ACCEL_EPS = ("CUDAExecutionProvider", "DmlExecutionProvider")
     restart_required = False
     if installed_pkg is not None and process_version is not None:
-        # 版本号不一致直接判定 stale
-        if installed_ver != process_version:
-            restart_required = True
-        # 包名 vs EP：装了 GPU 包应有 CUDAExecutionProvider；装了 DirectML 包应有
-        # DmlExecutionProvider；CPU 包不会有任何加速 EP
-        elif installed_pkg == GPU_PACKAGE and "CUDAExecutionProvider" not in providers:
+        if installed_pkg == GPU_PACKAGE and "CUDAExecutionProvider" not in providers:
+            # 装了 GPU 包但进程没 CUDA EP → 仍在跑旧（CPU / DirectML）包
             restart_required = True
         elif installed_pkg == DIRECTML_PACKAGE and "DmlExecutionProvider" not in providers:
+            # 装了 DirectML 包但进程没 Dml EP → 仍在跑旧（CPU / GPU）包
+            restart_required = True
+        elif installed_pkg == CPU_PACKAGE and any(ep in providers for ep in _ACCEL_EPS):
+            # 装了 CPU 包但进程还有加速 EP → 仍在跑旧（GPU / DirectML）包
             restart_required = True
 
     return {

--- a/tests/test_onnxruntime_setup.py
+++ b/tests/test_onnxruntime_setup.py
@@ -197,15 +197,44 @@ def test_install_runtime_install_failure_raises(
 # ---------------------------------------------------------------------------
 
 
-def test_current_runtime_flags_restart_when_dist_version_mismatches_process(
+def test_current_runtime_no_restart_when_directml_version_decoupled_from_core(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """pip 装了 onnxruntime-gpu==1.25.1，但已 import 的进程内还是旧 1.18.0 →
-    restart_required=True（C extension 不能热替换）。"""
-    monkeypatch.setattr(ors, "_query_dist_info", lambda: ("onnxruntime-gpu", "1.25.1"))
+    """regression：onnxruntime-directml 的 dist 版本（1.24.4）与它捆绑的 onnxruntime
+    核心 ort.__version__（1.27.0）是两条独立版本线、天然不等。只要 Dml EP 已加载就
+    不该报需重启 —— 否则 DirectML 用户重启再多次也消不掉「需重启 Studio」红条
+    （比版本号字符串判定 stale 的旧逻辑就是这么误报的）。"""
+    monkeypatch.setattr(ors, "_query_dist_info", lambda: ("onnxruntime-directml", "1.24.4"))
     fake_ort = MagicMock()
-    fake_ort.get_available_providers.return_value = ["AzureExecutionProvider", "CPUExecutionProvider"]
-    fake_ort.__version__ = "1.18.0"
+    fake_ort.get_available_providers.return_value = ["DmlExecutionProvider", "CPUExecutionProvider"]
+    fake_ort.__version__ = "1.27.0"
+    monkeypatch.setitem(__import__("sys").modules, "onnxruntime", fake_ort)
+    rt = ors.current_runtime()
+    assert rt["restart_required"] is False
+    assert rt["directml_available"] is True
+
+
+def test_current_runtime_flags_restart_when_directml_pkg_but_no_dml_ep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """装了 DirectML 包但进程没 Dml EP（仍在跑旧 CPU 包）→ 需重启。"""
+    monkeypatch.setattr(ors, "_query_dist_info", lambda: ("onnxruntime-directml", "1.24.4"))
+    fake_ort = MagicMock()
+    fake_ort.get_available_providers.return_value = ["CPUExecutionProvider"]
+    fake_ort.__version__ = "1.27.0"
+    monkeypatch.setitem(__import__("sys").modules, "onnxruntime", fake_ort)
+    rt = ors.current_runtime()
+    assert rt["restart_required"] is True
+
+
+def test_current_runtime_flags_restart_when_cpu_pkg_but_process_has_accel_ep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """装了 CPU 包但进程里还残留加速 EP（如刚从 DirectML 切回 CPU 未重启）→ 需重启。"""
+    monkeypatch.setattr(ors, "_query_dist_info", lambda: ("onnxruntime", "1.18.0"))
+    fake_ort = MagicMock()
+    fake_ort.get_available_providers.return_value = ["DmlExecutionProvider", "CPUExecutionProvider"]
+    fake_ort.__version__ = "1.27.0"
     monkeypatch.setitem(__import__("sys").modules, "onnxruntime", fake_ort)
     rt = ors.current_runtime()
     assert rt["restart_required"] is True


### PR DESCRIPTION
## 背景 / 动机

ONNX Runtime 卡片（Settings → ONNX Runtime）持续显示「需重启 Studio / 已装新 onnxruntime 包，但当前进程仍在用旧的」，但用户早已装好、重启过很多次，红条永远消不掉。

## 根因（已在装了 onnxruntime-directml 的机器上实测确认）

`current_runtime()` 判 `restart_required` 时比较 dist-info 版本与进程里 `onnxruntime.__version__`：

- dist-info `onnxruntime-directml` == **1.24.4**（wrapper 包版本）
- `onnxruntime.__version__` == **1.27.0**（捆绑的核心版本）

这两个是独立版本线、天然不等 → `installed_ver != process_version` 永远 True → 永久误报需重启。DirectML EP 其实已正常加载（providers 含 `DmlExecutionProvider`）。

## 改动

`restart_required` 改为只看「装的包类型 ↔ 进程实际加载的 EP」一致性，不再比版本号字符串：

- 装 GPU 包但无 `CUDAExecutionProvider` → 需重启
- 装 DirectML 包但无 `DmlExecutionProvider` → 需重启
- 装 CPU 包但进程仍残留加速 EP（CUDA / Dml）→ 需重启（新增分支，替代原版本号比较覆盖的「降级到 CPU 未重启」场景）

这正是本功能的目的（让 EP 切换生效）；同包小版本升级不再误报。

## 测试

- 改 / 加 4 个 `current_runtime` 测试：directml 版本解耦不报重启（regression）、directml 包缺 Dml EP 报重启、CPU 包残留加速 EP 报重启、保留 GPU 有 / 无 CUDA EP 两例。
- `tests/test_onnxruntime_setup.py` + 横切 `test_route_snapshot` / `test_studio_configs` 共 69 passed。
- 在实际装了 onnxruntime-directml 1.24.4（核心 1.27.0）的机器上跑 `current_runtime()` → `restart_required=False`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)