### PR TITLE
feat(api): ADR 0009 Phase 2 — 错误信封统一 + 全量语义 code i18n

### DIFF
--- a/docs/adr/0009-logging-error-system.md
+++ b/docs/adr/0009-logging-error-system.md
@@ -179,7 +179,7 @@ api/middleware/  ────►  api/exception_handlers  ────►  domai
 
 **关键**：Phase 1 多写 ~30 行（handler 同时填两个 key），给前端 toast trace_id body 可见性提前 3 release。
 
-> **进度（2026-06-19 更新）**：实际只有 Phase 1 跟 0.12.0 发布。Phase 2/3 滑期 —— 前端 `client.ts` 仍以 `body.detail` 为主错误文案来源、未迁到 `body.error.*`，故 Phase 3 删 `detail` 会丢 toast 文案、被 Phase 2 阻塞。目标版本已下调（原 0.13.0 / 0.14.0 → 现 0.15.0 / 0.16.0）。详细待办与现状见 [`docs/todo/error-envelope-detail-key-removal.md`](../todo/error-envelope-detail-key-removal.md)。
+> **进度（2026-06-19 更新）**：Phase 1 随 0.12.0 发布；Phase 2/3 曾滑期（目标下调到 0.15.0 / 0.16.0）。**Phase 2 已实现**（分支 `feat/error-envelope-i18n`，待并入 0.15.0）：HTTPException backstop handler 让 `body.error` 全覆盖 + ~330 处 raise 迁 `DomainError` 带语义 code + 前端按 code 查 `errors.*` i18n（删 4 个中文子串匹配 helper）。实现与本表略有出入（用 backstop handler 替代 deprecation log，且全量迁移而非渐进）。Phase 3（删 legacy `detail`）现可安全做。详见 [`docs/todo/error-envelope-detail-key-removal.md`](../todo/error-envelope-detail-key-removal.md)。
 
 ---
 

--- a/docs/todo/error-envelope-detail-key-removal.md
+++ b/docs/todo/error-envelope-detail-key-removal.md
@@ -2,7 +2,7 @@
 
 **创建于** 2026-06-19
 **触发** 0.14.0 发版核对时发现 [ADR 0009](../adr/0009-logging-error-system.md) §错误 envelope 渐进迁移的 Phase 2/3 早已滑期：ADR 当时把 Phase 2 排到 0.13.0、Phase 3 排到 0.14.0，但实际只有 Phase 1 跟 0.12.0 发出去了，后两阶段一直没人做。已把目标版本下调（Phase 2 → 0.15.0、Phase 3 → 0.16.0）并立此条防再忘。
-**当前状态** 🟡 Phase 1 已发布（0.12.0 起 dual-write）；Phase 2 待做（**下个版本 0.15.0**）；Phase 3 被 Phase 2 阻塞。
+**当前状态** 🟢 Phase 2 已实现（分支 `feat/error-envelope-i18n`，待并入 0.15.0）；Phase 1 已发布；Phase 3 待做——前端已主读 `body.error.*`，删 legacy `detail` 现在安全（仅余 fallback + RequestValidationError 的 422 list）。
 
 ---
 
@@ -26,12 +26,25 @@ API 错误信封从老格式 `{"detail": <str>}` 渐进迁到新结构化 `{"err
 
 所以现在删 `detail` key（Phase 3）会让所有错误 toast 丢文案。**必须先做 Phase 2**（前端迁到 `error.*` + 后端加 deprecation log），Phase 3 才安全。
 
-## Phase 2 待办（下个版本 0.15.0）
+## Phase 2 已完成（分支 feat/error-envelope-i18n）
 
-- [ ] 前端 `client.ts`：把错误文案主来源从 `body.detail` 改读 `body.error.message`，`body.detail` 退为 fallback；保留 `ApiError.traceId` 现有逻辑。核对所有 callsite（`e.detail` / `e.detail.error` 等结构化用法）。
-- [ ] 后端：给老 `raise HTTPException` 路径加一次性 deprecation log（标识仍走 legacy detail-only 形态的 endpoint），方便盘点残留。
-- [ ] 把还在 `raise HTTPException(...)` 的 router 逐步迁到 `DomainError`（走 dual-write handler），减少 Phase 3 时的 detail-only 残留面。
-- [ ] 测试：更新依赖 `body.detail` 的断言（ADR 记为 5 文件 11 处）改读 `body.error.*`。
+实现与原计划略有出入（更优）：用 HTTPException **backstop handler** 代替「deprecation log」，
+一步让 `body.error` 全覆盖；并做了**全量**迁移而非渐进。
+
+- [x] 前端 `client.ts`：4 处 fetch/XHR 错误解析收口为 `makeApiError`，主读 `body.error.code`
+      查 `errors.*` i18n（带 details 插值），`body.detail` 退 fallback；结构化数据经
+      `err.detail`(=error.details) 给 callsite（Presets 冲突 / Settings 运行中任务已迁）。
+- [x] 后端：注册 HTTPException backstop handler（`exception_handlers.py`）→ `body.error` 覆盖所有
+      错误响应，detail 原样保留。
+- [x] ~330 处 raise（HTTPException + service 异常）迁到 `DomainError` 子类带语义 code + details；
+      删 4 个中文子串匹配 helper（`_preset/_project/_curation/_duplicate_err_code`）；router 不再转
+      HTTPException。新增 `errors.*` locale（120 code，中英，从 CATALOG 生成）。
+- [x] 测试：18 文件断言对齐新信封（子类 + code + error.details）；preset 冲突 400→409。
+- [x] 修 `preprocess_worker` 两处 `except PreprocessError`（迁移后改抛 InvalidPathError/
+      ValidationError，原 catch 漏接会崩 job）→ 放宽 `except DomainError`。
+
+设计目录（code → en/zh 总表 + 每处映射）见 `tmp/error_i18n/CATALOG.md`（gitignored 草稿，
+Phase 3 / 后续错误 i18n 可复用，必要时移入 docs/）。
 
 ## Phase 3 待办（0.16.0，Phase 2 落地后）
 

--- a/studio/api/deps.py
+++ b/studio/api/deps.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 
 from typing import Optional
 
-from fastapi import HTTPException
-
+from ..domain.errors import DomainError
 from ..supervisor import Supervisor
 
 
@@ -23,7 +22,10 @@ def _supervisor() -> Supervisor:
     from .app import app
     sup: Optional[Supervisor] = getattr(app.state, "supervisor", None)
     if sup is None:
-        raise HTTPException(503, "supervisor not running")
+        raise DomainError(
+            "The service is still starting; try again in a moment",
+            code="system.starting", http_status=503,
+        )
     return sup
 
 

--- a/studio/api/errors.py
+++ b/studio/api/errors.py
@@ -8,9 +8,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from fastapi import HTTPException
-
-from ..services.presets import io as presets_io
+from ..domain.errors import ConflictError, InvalidPathError, ValidationError
 from ..paths import DATA_EXPORTS, safe_join, validate_path_component
 
 
@@ -19,7 +17,7 @@ def _safe_join_or_400(base: Path, *parts: str) -> Path:
     try:
         return safe_join(base, *parts)
     except ValueError as exc:
-        raise HTTPException(400, f"invalid path: {exc}") from exc
+        raise InvalidPathError("Invalid path", details={"reason": str(exc)}) from exc
 
 
 def _validate_component_or_400(name: str) -> None:
@@ -27,7 +25,7 @@ def _validate_component_or_400(name: str) -> None:
     try:
         validate_path_component(name)
     except ValueError as exc:
-        raise HTTPException(400, f"invalid path: {exc}") from exc
+        raise InvalidPathError("Invalid path", details={"reason": str(exc)}) from exc
 
 
 def _data_export_path(filename: str, suffixes: tuple[str, ...] = (".zip",)) -> Path:
@@ -35,7 +33,10 @@ def _data_export_path(filename: str, suffixes: tuple[str, ...] = (".zip",)) -> P
     allowed = tuple(s.lower() for s in suffixes)
     if allowed and path.suffix.lower() not in allowed:
         label = " / ".join(allowed)
-        raise HTTPException(400, f"请选择 {label} 文件")
+        raise ValidationError(
+            f"Select a {label} file",
+            code="file.ext_invalid", details={"types": label}, http_status=400,
+        )
     return path
 
 
@@ -51,7 +52,10 @@ def _unique_data_export_path(
         candidate = _data_export_path(f"{stem}-{i}{suffix}", suffixes)
         if not candidate.exists():
             return candidate
-    raise HTTPException(409, f"导出文件名冲突过多: {filename}")
+    raise ConflictError(
+        f'Too many files named "{filename}"; rename and try again',
+        code="export.name_conflict", details={"name": filename},
+    )
 
 
 def _export_result(path: Path) -> dict[str, Any]:
@@ -62,29 +66,3 @@ def _export_result(path: Path) -> dict[str, Any]:
         "size": st.st_size,
         "mtime": st.st_mtime,
     }
-
-
-def _preset_err_code(exc: presets_io.PresetError) -> None:
-    """PR-2 C4: 把 PresetError 的 message 字符串匹配映射写到 exc.http_status + exc.code，
-    让 DomainError handler 翻 dual-write envelope。
-
-    callsite 模式：
-        except PresetError as exc:
-            _preset_err_code(exc)  # mutate exc.http_status + exc.code
-            raise  # handler 翻 envelope（自带 trace_id）
-
-    PR-2 C5 / 0.13.x 的目标：service 内 raise PresetError(msg, http_status=N,
-    code="preset.xxx") 直接带这些属性，router 不再需要这个 helper + try/except。
-    """
-    msg = str(exc)
-    if "不存在" in msg:
-        exc.http_status = 404
-        exc.code = "preset.not_found"
-    elif "非法预设名" in msg:
-        exc.http_status = 400
-        exc.code = "preset.name_invalid"
-    elif "已存在" in msg:
-        exc.http_status = 400
-        exc.code = "preset.exists"
-    else:
-        exc.http_status = 422

--- a/studio/api/exception_handlers.py
+++ b/studio/api/exception_handlers.py
@@ -26,9 +26,11 @@ HTTPException 不重新注册 — starlette 默认 handler 已经处理（仅返
 
 dual-write 渐进迁移路径（ADR-0009 §错误 envelope 渐进迁移）：
   Phase 1 (0.12.0): dual-write 同时填 detail + error —— 已发布
-  Phase 2 (0.15.0): raise HTTPException 加 deprecation log；前端迁 body.error.*
-  Phase 3 (0.16.0): handler 删 detail key
-  Phase 2/3 滑期，进度/阻塞见 docs/todo/error-envelope-detail-key-removal.md
+  Phase 2 (0.15.0): HTTPException backstop handler（本文件）让 body.error 全覆盖；
+    ~330 处 raise 迁 DomainError 带语义 code + details；前端按 code 查 errors.* i18n
+    —— 已实现
+  Phase 3 (待): handler 删 legacy detail key（前端已主读 error.*，仅余 fallback）
+  详见 docs/todo/error-envelope-detail-key-removal.md
 """
 from __future__ import annotations
 

--- a/studio/api/exception_handlers.py
+++ b/studio/api/exception_handlers.py
@@ -38,6 +38,7 @@ from typing import Any, Dict, Optional
 from fastapi import FastAPI, Request
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 from ..domain.errors import DomainError
 from ..infrastructure.logging import get_trace_id
@@ -95,6 +96,36 @@ async def _request_validation_handler(
     return JSONResponse(status_code=422, content={"detail": exc.errors()})
 
 
+async def _http_exception_handler(
+    req: Request, exc: StarletteHTTPException,
+) -> JSONResponse:
+    """ADR-0009 Phase 2：给裸 HTTPException 也补 error 信封，让 body.error 覆盖
+    所有错误响应（前端可一律读 body.error.code → i18n，detail 仅作 fallback）。
+
+    - detail 是 str → message=detail，code=`http.<status>`（无语义 code 的兜底；
+      已迁移到 DomainError 的端点带语义 code，不走这里；剩下的多是框架/未迁移）。
+    - detail 是 dict/list（旧结构化 detail）→ 原样保留 detail（前端结构化 callsite
+      依赖），旁边合成 error。
+    保留 exc.headers（如 401 WWW-Authenticate）。
+    """
+    detail = exc.detail
+    code = f"http.{exc.status_code}"
+    trace_id = _trace_id_from(req)
+    if isinstance(detail, str):
+        message = detail
+    elif isinstance(detail, dict):
+        message = str(detail.get("message") or detail.get("error") or "Request failed")
+    else:
+        message = "Request failed"
+    body: Dict[str, Any] = {
+        "detail": detail,
+        "error": {"code": code, "message": message, "trace_id": trace_id},
+    }
+    return JSONResponse(
+        status_code=exc.status_code, content=body, headers=getattr(exc, "headers", None),
+    )
+
+
 async def _fallback_handler(req: Request, exc: Exception) -> JSONResponse:
     # 未捕获异常 — 进 logger.exception 带完整 traceback + trace_id 给开发查；
     # response body 脱敏不含 traceback 防 leak。
@@ -114,9 +145,11 @@ async def _fallback_handler(req: Request, exc: Exception) -> JSONResponse:
 def register_exception_handlers(app: FastAPI) -> None:
     """app.py 启动时调一次。
 
-    顺序无关（FastAPI 按异常类型最具体匹配）。HTTPException **不**注册 — 让
-    starlette 默认 handler 跑（保现有 175 处 raise HTTPException 形状不变）。
+    顺序无关（FastAPI 按异常类型最具体匹配）。HTTPException 注册 backstop handler
+    （ADR-0009 Phase 2）：未迁移到 DomainError 的裸 HTTPException 也补上 error 信封，
+    detail 原样保留不破现有形状。
     """
     app.add_exception_handler(DomainError, _domain_error_handler)
     app.add_exception_handler(RequestValidationError, _request_validation_handler)
+    app.add_exception_handler(StarletteHTTPException, _http_exception_handler)
     app.add_exception_handler(Exception, _fallback_handler)

--- a/studio/api/routers/browse.py
+++ b/studio/api/routers/browse.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from fastapi.responses import FileResponse
 
 from .. import errors as _errors
+from ...domain.errors import InvalidPathError, NotFoundError
 from ...services.dataset import browse, scan as datasets
 from ...infrastructure.paths import REPO_ROOT
 
@@ -40,10 +41,7 @@ def browse_dir(path: str = "") -> dict[str, Any]:
     target = Path(path) if path else REPO_ROOT
     if not target.is_absolute():
         target = (REPO_ROOT / target).resolve()
-    try:
-        return browse.list_dir(target, allow_outside_repo=True)
-    except browse.BrowseError as exc:
-        raise HTTPException(404, str(exc)) from exc
+    return browse.list_dir(target, allow_outside_repo=True)
 
 
 @router.get("/api/datasets/thumbnail")
@@ -58,7 +56,9 @@ def get_dataset_thumbnail(folder: str, name: str) -> FileResponse:
     try:
         p.relative_to(REPO_ROOT.resolve())
     except ValueError:
-        raise HTTPException(403, "thumbnail path outside repo")
+        raise InvalidPathError("Invalid path", http_status=403) from None
     if not p.exists() or p.suffix.lower() not in datasets.IMAGE_EXTS:
-        raise HTTPException(404)
+        raise NotFoundError(
+            "Thumbnail not found", code="dataset.thumbnail_not_found",
+        )
     return FileResponse(p)

--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -37,6 +37,12 @@ from ..errors import _validate_component_or_400
 from ..schemas.generate import GenerateRequest
 from ... import db, secrets
 from ...domain import GenerateConfig
+from ...domain.errors import (
+    ConflictError,
+    ForbiddenError,
+    NotFoundError,
+    ValidationError,
+)
 from ...domain.comfy_parity import force_comfy_parity_runtime_config
 from ...infrastructure.event_bus import bus
 from ...infrastructure.paths import STUDIO_DATA
@@ -250,7 +256,10 @@ def get_generate_task(task_id: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task or task.get("task_type") != "generate":
-        raise HTTPException(404)
+        raise NotFoundError(
+            "Task not found", code="task.not_found",
+            details={"task_id": task_id}, http_status=404,
+        )
     return task
 
 
@@ -279,7 +288,10 @@ def install_taeflux() -> dict[str, Any]:
         return {"ok": True, "noop": True}
     ok = _md.download_taeflux()
     if not ok:
-        raise HTTPException(500, "download failed; check server log")
+        raise ValidationError(
+            "Failed to download the preview model; check the server log",
+            code="generate.preview_model_download_failed", http_status=500,
+        )
     return {"ok": True}
 
 
@@ -316,7 +328,10 @@ def unload_daemon() -> dict[str, Any]:
     from ...services.inference.daemon import get_daemon
     daemon = get_daemon()
     if daemon.is_busy:
-        raise HTTPException(409, "daemon is busy, cannot unload")
+        raise ConflictError(
+            "Inference service is busy; try again after the current task finishes",
+            code="generate.daemon_busy", http_status=409,
+        )
     if not daemon.is_model_loaded:
         return {"ok": True, "noop": True}
     daemon.request_unload()
@@ -333,11 +348,17 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
     """
     _validate_component_or_400(filename)
     if not filename.lower().endswith(".png"):
-        raise HTTPException(400, "only .png supported")
+        raise ValidationError(
+            "Select a .png file", code="file.ext_invalid",
+            details={"types": ".png"}, http_status=400,
+        )
     from ...services.inference import disk_cache as generate_cache
     data = generate_cache.get_image(task_id, filename)
     if data is None:
-        raise HTTPException(404)
+        raise NotFoundError(
+            "Image not found", code="image.not_found",
+            details={"task_id": task_id, "filename": filename}, http_status=404,
+        )
     # 用 no-store 不是 _thumb_response 那套 no-cache + ETag：
     # generate cache 同 (task_id, filename) 内容会随重跑覆盖（用户改 prompt 重生成），
     # 没有稳定 ETag 可发；用 no-store 让浏览器每次都重拉，永远拿到最新结果。
@@ -508,9 +529,17 @@ def _decode_params_field(raw: str, field: str) -> dict[str, Any]:
     try:
         decoded = json.loads(raw)
     except json.JSONDecodeError as e:
-        raise HTTPException(400, f"{field}: invalid JSON ({e})")
+        raise ValidationError(
+            "Image parameters are not valid JSON",
+            code="generate.params_invalid",
+            details={"field": field, "reason": str(e)}, http_status=400,
+        ) from e
     if not isinstance(decoded, dict):
-        raise HTTPException(400, f"{field}: must be a JSON object")
+        raise ValidationError(
+            "Image parameters are not valid JSON",
+            code="generate.params_invalid",
+            details={"field": field}, http_status=400,
+        )
     return decoded
 
 
@@ -541,12 +570,21 @@ async def save_test_image(
     server 端 enrich 强制 schema_version/created_at/task_id/mode。
     """
     if mode not in ("single", "xy"):
-        raise HTTPException(400, f"unsupported mode: {mode}")
+        raise ValidationError(
+            f"Unsupported mode: {mode}", code="generate.mode_invalid",
+            details={"mode": mode}, http_status=400,
+        )
     if not secrets.load().generate.save_test_images:
-        raise HTTPException(403, "save_test_images is disabled")
+        raise ForbiddenError(
+            "Saving test images is disabled",
+            code="generate.save_disabled", http_status=403,
+        )
     raw = await image.read()
     if not raw:
-        raise HTTPException(400, "empty image body")
+        raise ValidationError(
+            "The uploaded image is empty",
+            code="generate.empty_image", http_status=400,
+        )
 
     if mode == "single":
         if cells or cells_manifest:
@@ -893,7 +931,11 @@ def get_disk_image(date_str: str, mode: str, filename: str) -> Any:
     """读落盘测试图（前端历史栏点击磁盘 entry 时大图来源）。"""
     path = _resolve_disk_png(date_str, mode, filename)
     if not path.is_file():
-        raise HTTPException(404)
+        raise NotFoundError(
+            "Image not found", code="image.not_found",
+            details={"date": date_str, "mode": mode, "filename": filename},
+            http_status=404,
+        )
     # 落盘图内容稳定（序号递增不覆盖），可强 cache
     return FileResponse(
         path, media_type="image/png",
@@ -914,14 +956,22 @@ def get_disk_thumb(
     """
     path = _resolve_disk_png(date_str, mode, filename)
     if not path.is_file():
-        raise HTTPException(404)
+        raise NotFoundError(
+            "Image not found", code="image.not_found",
+            details={"date": date_str, "mode": mode, "filename": filename},
+            http_status=404,
+        )
     try:
         st = path.stat()
         etag = hashlib.sha1(
             f"{st.st_mtime}:{st.st_size}:{w}".encode("utf-8")
         ).hexdigest()[:16]
-    except OSError:
-        raise HTTPException(404)
+    except OSError as exc:
+        raise NotFoundError(
+            "Image not found", code="image.not_found",
+            details={"date": date_str, "mode": mode, "filename": filename},
+            http_status=404,
+        ) from exc
     # 这里没有直接读 request header，由 FastAPI / Starlette 处理 304 略复杂；
     # 简化方案：返 ETag + Cache-Control，浏览器自管 304 转换（max-age 内不再请求）
     try:
@@ -979,7 +1029,11 @@ def get_disk_xy_image(date_str: str, folder: str, filename: str) -> Any:
     """读 XY 文件夹下的 composite 或 cell PNG（PreviewXYGrid 回看 + 拖进 Comfy 复用）。"""
     path = _resolve_disk_xy_cell(date_str, folder, filename)
     if not path.is_file():
-        raise HTTPException(404)
+        raise NotFoundError(
+            "Image not found", code="image.not_found",
+            details={"date": date_str, "folder": folder, "filename": filename},
+            http_status=404,
+        )
     return FileResponse(
         path, media_type="image/png",
         headers={"Cache-Control": "public, max-age=3600"},
@@ -994,14 +1048,22 @@ def get_disk_xy_thumb(
     """XY 文件夹下文件的 PIL 缩略图（历史栏 thumb_url 用 composite）。"""
     path = _resolve_disk_xy_cell(date_str, folder, filename)
     if not path.is_file():
-        raise HTTPException(404)
+        raise NotFoundError(
+            "Image not found", code="image.not_found",
+            details={"date": date_str, "folder": folder, "filename": filename},
+            http_status=404,
+        )
     try:
         st = path.stat()
         etag = hashlib.sha1(
             f"{st.st_mtime}:{st.st_size}:{w}".encode("utf-8")
         ).hexdigest()[:16]
-    except OSError:
-        raise HTTPException(404)
+    except OSError as exc:
+        raise NotFoundError(
+            "Image not found", code="image.not_found",
+            details={"date": date_str, "folder": folder, "filename": filename},
+            http_status=404,
+        ) from exc
     try:
         from PIL import Image
         with Image.open(path) as img:

--- a/studio/api/routers/installs.py
+++ b/studio/api/routers/installs.py
@@ -34,6 +34,7 @@ from ..schemas.installs import (
     WD14InstallRequest,
 )
 from ... import secrets
+from ...domain.errors import DomainError, ValidationError
 from ...services.runtime import (
     flash_attention as flash_attention_setup,
     onnxruntime as onnxruntime_setup,
@@ -65,7 +66,11 @@ def wd14_install(body: WD14InstallRequest) -> dict[str, Any]:
     显式提示。
     """
     if body.target not in ("auto", "gpu", "cpu", "directml"):
-        raise HTTPException(400, "target must be auto|gpu|cpu|directml")
+        raise ValidationError(
+            "Unsupported runtime target",
+            code="install.target_invalid",
+            details={"target": body.target}, http_status=400,
+        )
     try:
         res = onnxruntime_setup.install_runtime(body.target)
     except RuntimeError as exc:
@@ -109,7 +114,11 @@ def torch_reinstall(body: TorchReinstallRequest) -> dict[str, Any]:
     try:
         tag = torch_setup._decide_target_tag(body.target)
     except ValueError as exc:
-        raise HTTPException(400, str(exc)) from exc
+        raise ValidationError(
+            "Unsupported runtime target",
+            code="install.target_invalid",
+            details={"target": body.target}, http_status=400,
+        ) from exc
     pending_install.register_torch_reinstall(body.target)
     return {
         "pending": True,
@@ -237,7 +246,10 @@ def refresh_llm_tagger_models(body: LLMModelsRefreshRequest) -> dict[str, Any]:
         else body.api_key.strip()
     )
     if not base_url:
-        raise HTTPException(400, "base_url is required")
+        raise ValidationError(
+            "API base URL is required",
+            code="llm_tagger.base_url_required", http_status=400,
+        )
     try:
         model_ids = llm_tagger_svc.fetch_openai_compatible_models(
             base_url,
@@ -245,7 +257,11 @@ def refresh_llm_tagger_models(body: LLMModelsRefreshRequest) -> dict[str, Any]:
             timeout=body.timeout or target.timeout,
         )
     except Exception as exc:  # noqa: BLE001
-        raise HTTPException(502, str(exc)) from exc
+        raise DomainError(
+            f"Could not reach the model service: {exc}",
+            code="llm_tagger.connect_failed",
+            details={"reason": str(exc)}, http_status=502,
+        ) from exc
     selected = target.model if target.model in model_ids else (model_ids[0] if model_ids else target.model)
     preset_patch: dict[str, Any] = {
         "id": target.id,
@@ -283,9 +299,15 @@ def test_llm_tagger_connection(body: LLMConnectionTestRequest) -> dict[str, Any]
         merged["api_key"] = body.api_key
     cfg = secrets.LLMPresetConfig(**merged)
     if not cfg.base_url.strip():
-        raise HTTPException(400, "base_url is required")
+        raise ValidationError(
+            "API base URL is required",
+            code="llm_tagger.base_url_required", http_status=400,
+        )
     if not cfg.model.strip():
-        raise HTTPException(400, "model is required")
+        raise ValidationError(
+            "A model must be selected",
+            code="llm_tagger.model_required", http_status=400,
+        )
     return llm_tagger_svc.test_openai_compatible_connection(
         cfg.base_url,
         cfg.api_key,

--- a/studio/api/routers/jobs.py
+++ b/studio/api/routers/jobs.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from ..deps import _supervisor
 from ... import db
+from ...domain.errors import ConflictError, NotFoundError, ValidationError
 from ...services.projects import jobs as project_jobs
 
 router = APIRouter()
@@ -27,7 +28,7 @@ def get_job_endpoint(jid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, jid)
     if not job:
-        raise HTTPException(404, f"job 不存在: id={jid}")
+        raise NotFoundError("Job not found", code="job.not_found", details={"job_id": jid})
     return job
 
 
@@ -36,7 +37,7 @@ def get_job_log(jid: int, tail: int = 0) -> dict[str, Any]:
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, jid)
     if not job:
-        raise HTTPException(404, f"job 不存在: id={jid}")
+        raise NotFoundError("Job not found", code="job.not_found", details={"job_id": jid})
     log_path = Path(job.get("log_path") or "")
     if not log_path.exists():
         return {"job_id": jid, "content": "", "size": 0}
@@ -58,8 +59,13 @@ def cancel_job_endpoint(jid: int) -> dict[str, Any]:
         with db.connection_for() as conn:
             job = project_jobs.get_job(conn, jid)
         if not job:
-            raise HTTPException(404, f"job 不存在: id={jid}")
+            raise NotFoundError("Job not found", code="job.not_found", details={"job_id": jid})
         if job["status"] in project_jobs.TERMINAL_STATUSES:
-            raise HTTPException(400, f"job 已 {job['status']}")
-        raise HTTPException(409, "cancel rejected (state mismatch)")
+            raise ValidationError(
+                "This job has already finished",
+                code="job.already_finished", http_status=400,
+            )
+        raise ConflictError(
+            "Cannot cancel this job in its current state", code="job.cancel_rejected",
+        )
     return {"job_id": jid, "canceled": True}

--- a/studio/api/routers/models.py
+++ b/studio/api/routers/models.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from ..schemas.models import ModelDownloadRequest
+from ...domain.errors import ValidationError
 from ...services import models as model_downloader
 
 router = APIRouter()
@@ -41,6 +42,9 @@ def start_model_download(body: ModelDownloadRequest) -> dict[str, Any]:
     try:
         key = model_downloader.trigger(body.model_id, body.variant)
     except ValueError as exc:
-        raise HTTPException(400, str(exc)) from exc
+        raise ValidationError(
+            f"Invalid model selection: {exc}",
+            code="model.invalid", details={"reason": str(exc)}, http_status=400,
+        ) from exc
     snap = model_downloader.get_status_snapshot()
     return {"key": key, "status": snap.get(key, {}).get("status", "running")}

--- a/studio/api/routers/presets.py
+++ b/studio/api/routers/presets.py
@@ -19,11 +19,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, File, HTTPException, Request, UploadFile
+from fastapi import APIRouter, File, Request, UploadFile
 from fastapi.responses import FileResponse, RedirectResponse
 
 from .. import errors as _errors
-from ..errors import _preset_err_code as _err_code
+from ...domain.errors import (
+    ConflictError,
+    NotFoundError,
+    ValidationError,
+)
 from ..schemas.presets import (
     DuplicateRequest,
     PresetExportBody,
@@ -75,55 +79,43 @@ def list_presets_endpoint() -> dict[str, Any]:
 
 @router.get("/api/presets/{name}")
 def get_preset(name: str, warnings: bool = False) -> dict[str, Any]:
-    try:
-        if warnings:
-            config, dropped, defaulted = presets_io.read_preset_with_warnings(name)
-            return {
-                "config": config,
-                "dropped_fields": dropped,
-                "defaulted_fields": defaulted,
-            }
-        return presets_io.read_preset(name)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    if warnings:
+        config, dropped, defaulted = presets_io.read_preset_with_warnings(name)
+        return {
+            "config": config,
+            "dropped_fields": dropped,
+            "defaulted_fields": defaulted,
+        }
+    return presets_io.read_preset(name)
 
 
 @router.put("/api/presets/{name}")
 def put_preset(name: str, body: dict[str, Any]) -> dict[str, str]:
-    try:
-        path = presets_io.write_preset(name, body)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    path = presets_io.write_preset(name, body)
     return {"name": name, "path": str(path)}
 
 
 @router.delete("/api/presets/{name}")
 def delete_preset_endpoint(name: str) -> dict[str, str]:
-    try:
-        presets_io.delete_preset(name)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    presets_io.delete_preset(name)
     return {"deleted": name}
 
 
 @router.post("/api/presets/{name}/duplicate")
 def duplicate_preset_endpoint(name: str, body: DuplicateRequest) -> dict[str, str]:
-    try:
-        path = presets_io.duplicate_preset(name, body.new_name)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    path = presets_io.duplicate_preset(name, body.new_name)
     return {"name": body.new_name, "path": str(path)}
 
 
 @router.get("/api/presets/{name}/download")
 def download_preset(name: str) -> FileResponse:
     """端到端文件 I/O：直接返回 `studio_data/presets/{name}.yaml` 原文件。"""
-    try:
-        path = presets_io.preset_path(name)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    path = presets_io.preset_path(name)
     if not path.exists():
-        raise HTTPException(status_code=404, detail=f"预设不存在: {name}")
+        raise NotFoundError(
+            f'Preset "{name}" not found',
+            code="preset.not_found", details={"name": name},
+        )
     return FileResponse(path, media_type="application/yaml", filename=f"{name}.yaml")
 
 
@@ -131,11 +123,8 @@ def download_preset(name: str) -> FileResponse:
 def export_preset_to_data_exports(name: str, body: PresetExportBody) -> dict[str, Any]:
     """把当前预设表单完整参数校验后保存到 data_exports/。"""
     DATA_EXPORTS.mkdir(parents=True, exist_ok=True)
-    try:
-        dest = _errors._unique_data_export_path(f"{name}.yaml", (".yaml", ".yml"))
-        path = presets_io.write_preset(dest.stem, body.config, DATA_EXPORTS)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    dest = _errors._unique_data_export_path(f"{name}.yaml", (".yaml", ".yml"))
+    path = presets_io.write_preset(dest.stem, body.config, DATA_EXPORTS)
     return _errors._export_result(path)
 
 
@@ -144,26 +133,26 @@ def import_preset_from_data_exports(body: PresetImportBody) -> dict[str, Any]:
     """从 data_exports/ 里的 yaml/json 预设导入到用户预设池。"""
     src = _errors._data_export_path(body.filename, (".yaml", ".yml", ".json"))
     if not src.exists():
-        raise HTTPException(404, f"文件不存在: {body.filename}")
+        raise NotFoundError(
+            f'File "{body.filename}" not found',
+            code="file.not_found", details={"filename": body.filename},
+        )
     if not src.is_file():
-        raise HTTPException(400, "请选择文件")
-    try:
-        config, suggested = presets_io.parse_preset_bytes(src.read_bytes(), src.name)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+        raise ValidationError(
+            "Select a file", code="file.required", http_status=400,
+        )
+    config, suggested = presets_io.parse_preset_bytes(src.read_bytes(), src.name)
     if presets_io.preset_path(suggested).exists():
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "message": f"预设已存在: {suggested}",
+        raise ConflictError(
+            f'Preset "{suggested}" already exists',
+            code="preset.exists",
+            details={
+                "name": suggested,
                 "config": config,
                 "suggested_name": suggested,
             },
         )
-    try:
-        path = presets_io.write_preset(suggested, config)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    path = presets_io.write_preset(suggested, config)
     return {"name": suggested, "path": str(path)}
 
 
@@ -173,26 +162,31 @@ def import_preset_from_path(body: PresetImportFromPathBody) -> dict[str, Any]:
     from pathlib import Path
     src = Path(body.path)
     if not src.is_file():
-        raise HTTPException(400, f"文件不存在或不可读: {body.path}")
+        raise NotFoundError(
+            f'File "{src.name}" not found or not readable',
+            code="file.not_found",
+            details={"filename": src.name, "path": body.path},
+            http_status=400,
+        )
     if src.suffix.lower() not in (".yaml", ".yml", ".json"):
-        raise HTTPException(400, "请选择 .yaml / .yml / .json 文件")
-    try:
-        config, suggested = presets_io.parse_preset_bytes(src.read_bytes(), src.name)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+        raise ValidationError(
+            "Select a .yaml, .yml, or .json file",
+            code="file.ext_invalid",
+            details={"types": ".yaml, .yml, .json"},
+            http_status=400,
+        )
+    config, suggested = presets_io.parse_preset_bytes(src.read_bytes(), src.name)
     if presets_io.preset_path(suggested).exists():
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "message": f"预设已存在: {suggested}",
+        raise ConflictError(
+            f'Preset "{suggested}" already exists',
+            code="preset.exists",
+            details={
+                "name": suggested,
                 "config": config,
                 "suggested_name": suggested,
             },
         )
-    try:
-        path = presets_io.write_preset(suggested, config)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    path = presets_io.write_preset(suggested, config)
     return {"name": suggested, "path": str(path)}
 
 
@@ -207,23 +201,18 @@ async def import_preset(file: UploadFile = File(...)) -> dict[str, Any]:
     解析/校验失败 → 400/422。
     """
     raw = await file.read()
-    try:
-        config, suggested = presets_io.parse_preset_bytes(raw, file.filename or "")
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    config, suggested = presets_io.parse_preset_bytes(raw, file.filename or "")
     if presets_io.preset_path(suggested).exists():
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "message": f"预设已存在: {suggested}",
+        raise ConflictError(
+            f'Preset "{suggested}" already exists',
+            code="preset.exists",
+            details={
+                "name": suggested,
                 "config": config,
                 "suggested_name": suggested,
             },
         )
-    try:
-        path = presets_io.write_preset(suggested, config)
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+    path = presets_io.write_preset(suggested, config)
     return {"name": suggested, "path": str(path)}
 
 

--- a/studio/api/routers/projects/_shared.py
+++ b/studio/api/routers/projects/_shared.py
@@ -8,34 +8,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from fastapi import HTTPException
-
 from .... import db
+from ....domain.errors import NotFoundError
 from ....services.projects import projects, versions
 from ....infrastructure.event_bus import bus
 from ....services import version_config
-
-
-def _project_err_code(exc: Exception) -> None:
-    """PR-2 C4: mutate ProjectError/VersionError exc.http_status + exc.code，
-    让 DomainError handler 翻 dual-write envelope。
-
-    callsite 模式：
-        except (ProjectError, VersionError) as exc:
-            _project_err_code(exc); raise
-    """
-    msg = str(exc)
-    if "不存在" in msg:
-        exc.http_status = 404
-        exc.code = "project.not_found"
-    elif "已存在" in msg:
-        exc.http_status = 400
-        exc.code = "project.exists"
-    elif "非法" in msg or "不能为空" in msg:
-        exc.http_status = 400
-        exc.code = "project.invalid"
-    else:
-        exc.http_status = 422
 
 
 def _project_payload(p: dict[str, Any]) -> dict[str, Any]:
@@ -83,7 +60,10 @@ def _version_dir_or_404(pid: int, vid: int) -> tuple[dict[str, Any], dict[str, A
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found",
+                details={"id": vid},
+            )
         p = projects.get_project(conn, pid)
     assert p is not None
     return p, v, versions.version_dir(p["id"], p["slug"], v["label"])
@@ -94,7 +74,10 @@ def _version_train_dir_or_404(pid: int, vid: int) -> tuple[dict[str, Any], dict[
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found",
+                details={"id": vid},
+            )
         p = projects.get_project(conn, pid)
     assert p is not None
     return p, v, versions.version_dir(p["id"], p["slug"], v["label"]) / "train"
@@ -103,12 +86,13 @@ def _version_train_dir_or_404(pid: int, vid: int) -> tuple[dict[str, Any], dict[
 def _project_and_version_or_404(
     pid: int, vid: int,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    """version_config domain 的双对象解析（含 VersionConfigError → 404 包装）。"""
+    """version_config domain 的双对象解析。
+
+    VersionConfigError（project/version not_found，已带 code + http_status=404）
+    直接冒泡到全局 DomainError handler。
+    """
     with db.connection_for() as conn:
-        try:
-            return version_config.get_project_and_version(conn, pid, vid)
-        except version_config.VersionConfigError as exc:
-            raise HTTPException(404, str(exc)) from exc
+        return version_config.get_project_and_version(conn, pid, vid)
 
 
 def _reg_dir(vdir: Path) -> Path:

--- a/studio/api/routers/projects/crud.py
+++ b/studio/api/routers/projects/crud.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 
 from typing import Any, Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
+from ....domain.errors import NotFoundError
 from ...schemas.projects import (
     ProjectCreate,
     ProjectUpdate,
@@ -33,7 +34,6 @@ from ...schemas.projects import (
     VersionUpdate,
 )
 from ._shared import (
-    _project_err_code,
     _project_payload,
     _publish_project_state,
     _publish_version_state,
@@ -74,20 +74,14 @@ def list_projects_endpoint() -> dict[str, Any]:
 @router.post("/api/projects")
 def create_project_endpoint(body: ProjectCreate) -> dict[str, Any]:
     with db.connection_for() as conn:
-        try:
-            p = projects.create_project(
-                conn, title=body.title, slug=body.slug, note=body.note
-            )
-        except projects.ProjectError as exc:
-            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+        p = projects.create_project(
+            conn, title=body.title, slug=body.slug, note=body.note
+        )
         if body.initial_version_label:
-            try:
-                versions.create_version(
-                    conn, project_id=p["id"], label=body.initial_version_label
-                )
-            except versions.VersionError as exc:
-                # 项目已建好；版本失败给前端但保留项目
-                _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+            # 项目已建好；版本失败时 VersionError 带 code 直接冒泡到全局 handler
+            versions.create_version(
+                conn, project_id=p["id"], label=body.initial_version_label
+            )
         p = projects.get_project(conn, p["id"])
     assert p is not None
     _publish_project_state(p)
@@ -99,7 +93,9 @@ def get_project_endpoint(pid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
     if not p:
-        raise HTTPException(404, f"项目不存在: id={pid}")
+        raise NotFoundError(
+            "Project not found", code="project.not_found", details={"id": pid},
+        )
     return _project_payload(p)
 
 
@@ -107,10 +103,8 @@ def get_project_endpoint(pid: int) -> dict[str, Any]:
 def patch_project_endpoint(pid: int, body: ProjectUpdate) -> dict[str, Any]:
     fields = body.model_dump(exclude_unset=True)
     with db.connection_for() as conn:
-        try:
-            p = projects.update_project(conn, pid, **fields)
-        except projects.ProjectError as exc:
-            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+        # ProjectError（含 _must_get 的 project.not_found）带 code 直接冒泡
+        p = projects.update_project(conn, pid, **fields)
     _publish_project_state(p)
     return _project_payload(p)
 
@@ -119,10 +113,7 @@ def patch_project_endpoint(pid: int, body: ProjectUpdate) -> dict[str, Any]:
 def archive_project_endpoint(pid: int) -> dict[str, Any]:
     """归档：列表软隐藏，目录 / versions / 任务全部原样，可随时取消。"""
     with db.connection_for() as conn:
-        try:
-            p = projects.set_archived(conn, pid, True)
-        except projects.ProjectError as exc:
-            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+        p = projects.set_archived(conn, pid, True)
     _publish_project_state(p)
     return _project_payload(p)
 
@@ -130,10 +121,7 @@ def archive_project_endpoint(pid: int) -> dict[str, Any]:
 @router.post("/api/projects/{pid}/unarchive")
 def unarchive_project_endpoint(pid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
-        try:
-            p = projects.set_archived(conn, pid, False)
-        except projects.ProjectError as exc:
-            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+        p = projects.set_archived(conn, pid, False)
     _publish_project_state(p)
     return _project_payload(p)
 
@@ -141,10 +129,7 @@ def unarchive_project_endpoint(pid: int) -> dict[str, Any]:
 @router.delete("/api/projects/{pid}")
 def delete_project_endpoint(pid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
-        try:
-            projects.delete_project(conn, pid)
-        except projects.ProjectError as exc:
-            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+        projects.delete_project(conn, pid)
     return {"deleted": pid}
 
 
@@ -155,7 +140,10 @@ def delete_project_endpoint(pid: int) -> dict[str, Any]:
 def list_versions_endpoint(pid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         if not projects.get_project(conn, pid):
-            raise HTTPException(404, f"项目不存在: id={pid}")
+            raise NotFoundError(
+                "Project not found", code="project.not_found",
+                details={"id": pid},
+            )
         vs = versions.list_versions(conn, pid)
         p = projects.get_project(conn, pid)
     assert p is not None
@@ -184,7 +172,10 @@ def list_project_state_ckpts(pid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
         if not p:
-            raise HTTPException(404, f"项目不存在: id={pid}")
+            raise NotFoundError(
+                "Project not found", code="project.not_found",
+                details={"id": pid},
+            )
         return {"groups": versions.list_project_state_ckpts(conn, p)}
 
 
@@ -197,7 +188,10 @@ def list_project_lora_ckpts(pid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
         if not p:
-            raise HTTPException(404, f"项目不存在: id={pid}")
+            raise NotFoundError(
+                "Project not found", code="project.not_found",
+                details={"id": pid},
+            )
         return {"groups": versions.list_project_lora_ckpts(conn, p)}
 
 
@@ -205,17 +199,19 @@ def list_project_lora_ckpts(pid: int) -> dict[str, Any]:
 def create_version_endpoint(pid: int, body: VersionCreate) -> dict[str, Any]:
     with db.connection_for() as conn:
         if not projects.get_project(conn, pid):
-            raise HTTPException(404, f"项目不存在: id={pid}")
-        try:
-            v = versions.create_version(
-                conn,
-                project_id=pid,
-                label=body.label,
-                fork_from_version_id=body.fork_from_version_id,
-                note=body.note,
+            raise NotFoundError(
+                "Project not found", code="project.not_found",
+                details={"id": pid},
             )
-        except versions.VersionError as exc:
-            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+        # VersionError（label_invalid / label_exists / fork_source_invalid 等）
+        # 带 code 直接冒泡到全局 DomainError handler
+        v = versions.create_version(
+            conn,
+            project_id=pid,
+            label=body.label,
+            fork_from_version_id=body.fork_from_version_id,
+            note=body.note,
+        )
     _publish_version_state(v)
     return v
 
@@ -226,7 +222,9 @@ def get_version_endpoint(pid: int, vid: int) -> dict[str, Any]:
         v = versions.get_version(conn, vid)
         p = projects.get_project(conn, pid)
     if not v or v["project_id"] != pid:
-        raise HTTPException(404, f"版本不存在: id={vid}")
+        raise NotFoundError(
+            "Version not found", code="version.not_found", details={"id": vid},
+        )
     assert p is not None
     return {**v, "stats": versions.stats_for_version(p, v)}
 
@@ -239,11 +237,12 @@ def patch_version_endpoint(
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
-        try:
-            v = versions.update_version(conn, vid, **fields)
-        except versions.VersionError as exc:
-            _project_err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
+            raise NotFoundError(
+                "Version not found", code="version.not_found",
+                details={"id": vid},
+            )
+        # VersionError（label_invalid / label_exists 等）带 code 直接冒泡
+        v = versions.update_version(conn, vid, **fields)
     _publish_version_state(v)
     return v
 
@@ -253,7 +252,10 @@ def delete_version_endpoint(pid: int, vid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found",
+                details={"id": vid},
+            )
         versions.delete_version(conn, vid)
     return {"deleted": vid}
 
@@ -263,7 +265,10 @@ def activate_version_endpoint(pid: int, vid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found",
+                details={"id": vid},
+            )
         v = versions.activate_version(conn, vid)
         p = projects.get_project(conn, pid)
     assert p is not None
@@ -299,7 +304,10 @@ def advance_phase_endpoint(pid: int, vid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found",
+                details={"id": vid},
+            )
         advanced, result, new_phase = versions_phase.advance_phase(conn, vid)
         v_after = versions.get_version(conn, vid)
     if advanced and v_after is not None:
@@ -313,7 +321,10 @@ def skip_phase_endpoint(pid: int, vid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found",
+                details={"id": vid},
+            )
         advanced, result, new_phase = versions_phase.skip_phase(conn, vid)
         v_after = versions.get_version(conn, vid)
     if advanced and v_after is not None:

--- a/studio/api/routers/projects/curation.py
+++ b/studio/api/routers/projects/curation.py
@@ -24,6 +24,7 @@ from fastapi.responses import FileResponse
 
 from ...errors import _safe_join_or_400
 from ...responses import _thumb_response
+from ....domain.errors import DomainError, NotFoundError, ValidationError
 from ...schemas.curation import (
     CopyRequest,
     DeleteFilesRequest,
@@ -59,7 +60,9 @@ def delete_project_files(
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
     if not p:
-        raise HTTPException(404, f"项目不存在: id={pid}")
+        raise NotFoundError(
+            "Project not found", code="project.not_found", details={"id": pid},
+        )
     pdir = projects.project_dir(p["id"], p["slug"]) / "download"
     if not pdir.exists():
         return {"deleted": [], "missing": list(body.names)}
@@ -75,7 +78,12 @@ def delete_project_files(
         try:
             f.unlink()
         except OSError as exc:
-            raise HTTPException(500, f"删除失败 {name}: {exc}") from exc
+            raise DomainError(
+                f'Failed to delete "{name}": {exc}',
+                code="dataset.delete_failed",
+                details={"name": name, "reason": str(exc)},
+                http_status=500,
+            ) from exc
         # 清理同 stem 的 metadata（best-effort，失败仅日志）
         stem = f.stem
         for ext in META_EXTS:
@@ -92,13 +100,17 @@ def delete_project_files(
 @router.get("/api/projects/{pid}/files")
 def list_files(pid: int, bucket: str = "download") -> dict[str, Any]:
     if bucket != "download":
-        raise HTTPException(
-            400, f"PP2 仅支持 bucket=download（PP3 会加 train/reg/samples）",
+        raise ValidationError(
+            "Unsupported image set",
+            code="dataset.image_set_invalid",
+            details={"bucket": bucket}, http_status=400,
         )
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
     if not p:
-        raise HTTPException(404, f"项目不存在: id={pid}")
+        raise NotFoundError(
+            "Project not found", code="project.not_found", details={"id": pid},
+        )
     pdir = projects.project_dir(p["id"], p["slug"]) / "download"
     items: list[dict[str, Any]] = []
     if pdir.exists():
@@ -140,11 +152,17 @@ def project_thumb(
     源文件 mtime 变化会自动 invalidate（hash 变）。
     """
     if bucket not in ("download", "preprocess"):
-        raise HTTPException(400, f"unknown bucket: {bucket}")
+        raise ValidationError(
+            "Unsupported image set",
+            code="dataset.image_set_invalid",
+            details={"bucket": bucket}, http_status=400,
+        )
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
     if not p:
-        raise HTTPException(404, f"项目不存在: id={pid}")
+        raise NotFoundError(
+            "Project not found", code="project.not_found", details={"id": pid},
+        )
     pdir = projects.project_dir(p["id"], p["slug"])
 
     if bucket == "preprocess":
@@ -179,7 +197,9 @@ def project_thumb(
 
     if not f.exists() or f.suffix.lower() not in datasets.IMAGE_EXTS:
         logger.info("thumb 404: pid=%s bucket=%s name=%s -> %s", pid, bucket, name, f)
-        raise HTTPException(404)
+        raise NotFoundError(
+            "Thumbnail not found", code="dataset.thumbnail_not_found",
+        )
     return _thumb_response(f, size)
 
 
@@ -223,46 +243,10 @@ def get_latest_version_job(pid: int, vid: int, kind: str) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _curation_err_code(exc: curation.CurationError) -> None:
-    """PR-2 C5: 同 _preset_err_code — mutate exc.http_status + exc.code 让
-    DomainError handler 翻 dual-write envelope。callsite: `_curation_err_code(exc); raise`."""
-    msg = str(exc)
-    if "不存在" in msg:
-        exc.http_status = 404
-        exc.code = "curation.not_found"
-    elif "已存在" in msg:
-        exc.http_status = 400
-        exc.code = "curation.exists"
-    elif "非法" in msg:
-        exc.http_status = 400
-        exc.code = "curation.invalid"
-    else:
-        exc.http_status = 422
-
-
 @router.get("/api/projects/{pid}/versions/{vid}/curation")
 def get_curation(pid: int, vid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
-        try:
-            return curation.curation_view(conn, pid, vid)
-        except curation.CurationError as exc:
-            _curation_err_code(exc); raise  # PR-2 C5
-
-
-def _duplicate_err_code(exc: duplicate_finder.DuplicateFinderError) -> None:
-    """PR-2 C5: 同 _curation_err_code — mutate exc.http_status + exc.code。"""
-    msg = str(exc)
-    if "not found" in msg or "不存在" in msg:
-        exc.http_status = 404
-        exc.code = "duplicate.not_found"
-    elif "invalid" in msg or "非法" in msg:
-        exc.http_status = 400
-        exc.code = "duplicate.invalid"
-    elif "not installed" in msg:
-        exc.http_status = 422
-        exc.code = "duplicate.not_installed"
-    else:
-        exc.http_status = 422
+        return curation.curation_view(conn, pid, vid)
 
 
 # ---------------------------------------------------------------------------
@@ -279,10 +263,14 @@ def _resolve_pv_or_404_dup(
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
         if not p:
-            raise HTTPException(404, f"项目不存在: id={pid}")
+            raise NotFoundError(
+                "Project not found", code="project.not_found", details={"id": pid},
+            )
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found", details={"id": vid},
+            )
     return p, v
 
 
@@ -351,7 +339,7 @@ def scan_preprocess_duplicates_train(
                 "status": "failed",
                 "text": str(exc),
             })
-            _curation_err_code(exc); raise
+            raise
         except duplicate_finder.DuplicateFinderError as exc:
             bus.publish({
                 "type": "duplicate_scan_progress",
@@ -360,7 +348,7 @@ def scan_preprocess_duplicates_train(
                 "status": "failed",
                 "text": str(exc),
             })
-            _duplicate_err_code(exc); raise
+            raise
 
 
 @router.post("/api/projects/{pid}/versions/{vid}/preprocess/duplicates/apply")
@@ -371,15 +359,10 @@ def apply_preprocess_duplicates_train(
     `names` 是 train rel path（`"1_data/X.png"`）。物理文件不动。"""
     _resolve_pv_or_404_dup(pid, vid)
     with db.connection_for() as conn:
-        try:
-            result = duplicate_finder.apply_train_duplicate_removals(
-                conn, pid, vid, names=body.names,
-            )
-            project = projects.get_project(conn, pid)
-        except curation.CurationError as exc:
-            _curation_err_code(exc); raise
-        except duplicate_finder.DuplicateFinderError as exc:
-            _duplicate_err_code(exc); raise
+        result = duplicate_finder.apply_train_duplicate_removals(
+            conn, pid, vid, names=body.names,
+        )
+        project = projects.get_project(conn, pid)
     if project:
         _publish_project_state(project)
     return result
@@ -396,12 +379,9 @@ def copy_to_train(
     Curation 操作）。前端 Curation 选 download 原图加入 train 直接 work。
     """
     with db.connection_for() as conn:
-        try:
-            result = curation.copy_download_to_train(
-                conn, pid, vid, body.files, body.dest_folder,
-            )
-        except curation.CurationError as exc:
-            _curation_err_code(exc); raise  # PR-2 C5
+        result = curation.copy_download_to_train(
+            conn, pid, vid, body.files, body.dest_folder,
+        )
     return result
 
 
@@ -410,12 +390,9 @@ def remove_from_train(
     pid: int, vid: int, body: RemoveRequest,
 ) -> dict[str, Any]:
     with db.connection_for() as conn:
-        try:
-            result = curation.remove_from_train(
-                conn, pid, vid, body.folder, body.files,
-            )
-        except curation.CurationError as exc:
-            _curation_err_code(exc); raise  # PR-2 C5
+        result = curation.remove_from_train(
+            conn, pid, vid, body.folder, body.files,
+        )
     return result
 
 
@@ -424,20 +401,23 @@ def folder_op(
     pid: int, vid: int, body: FolderOp,
 ) -> dict[str, Any]:
     with db.connection_for() as conn:
-        try:
-            if body.op == "create":
-                p = curation.create_folder(conn, pid, vid, body.name)
-                return {"path": str(p)}
-            if body.op == "rename":
-                if not body.new_name:
-                    raise HTTPException(400, "rename 需要 new_name")
-                p = curation.rename_folder(
-                    conn, pid, vid, body.name, body.new_name,
+        if body.op == "create":
+            p = curation.create_folder(conn, pid, vid, body.name)
+            return {"path": str(p)}
+        if body.op == "rename":
+            if not body.new_name:
+                raise ValidationError(
+                    "A new name is required to rename a folder",
+                    code="curation.new_name_required", http_status=400,
                 )
-                return {"path": str(p)}
-            if body.op == "delete":
-                curation.delete_folder(conn, pid, vid, body.name)
-                return {"deleted": body.name}
-            raise HTTPException(400, f"unknown op: {body.op}")
-        except curation.CurationError as exc:
-            _curation_err_code(exc); raise  # PR-2 C5
+            p = curation.rename_folder(
+                conn, pid, vid, body.name, body.new_name,
+            )
+            return {"path": str(p)}
+        if body.op == "delete":
+            curation.delete_folder(conn, pid, vid, body.name)
+            return {"deleted": body.name}
+        raise ValidationError(
+            f"Unknown folder operation: {body.op}",
+            code="curation.op_invalid", details={"op": body.op}, http_status=400,
+        )

--- a/studio/api/routers/projects/exports.py
+++ b/studio/api/routers/projects/exports.py
@@ -18,11 +18,12 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, File, HTTPException, UploadFile
+from fastapi import APIRouter, BackgroundTasks, File, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import FileResponse
 
 from ...errors import _data_export_path, _export_result, _unique_data_export_path
+from ....domain.errors import NotFoundError, ValidationError
 from ...schemas.exports import BundleImportBody, BundleOptionsBody
 from ._shared import (
     _project_payload,
@@ -54,7 +55,9 @@ def export_version_train_zip(
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found", details={"id": vid},
+            )
         p = projects.get_project(conn, pid)
         assert p is not None
 
@@ -71,7 +74,7 @@ def export_version_train_zip(
                 "version_id": vid,
                 "error": str(exc),
             })
-            raise HTTPException(400, str(exc)) from exc
+            raise
         except Exception as exc:
             tmp_path.unlink(missing_ok=True)
             bus.publish({
@@ -120,7 +123,9 @@ def export_version_bundle(
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found", details={"id": vid},
+            )
         p = projects.get_project(conn, pid)
         assert p is not None
 
@@ -132,7 +137,7 @@ def export_version_bundle(
         except train_io.TrainIOError as exc:
             tmp_path.unlink(missing_ok=True)
             bus.publish({"type": "version_bundle_zip_failed", "project_id": pid, "version_id": vid, "error": str(exc)})
-            raise HTTPException(400, str(exc)) from exc
+            raise
         except Exception as exc:
             tmp_path.unlink(missing_ok=True)
             bus.publish({"type": "version_bundle_zip_failed", "project_id": pid, "version_id": vid, "error": str(exc)})
@@ -159,7 +164,9 @@ def export_version_bundle_to_data_exports(
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found", details={"id": vid},
+            )
         p = projects.get_project(conn, pid)
         assert p is not None
         DATA_EXPORTS.mkdir(parents=True, exist_ok=True)
@@ -169,7 +176,7 @@ def export_version_bundle_to_data_exports(
         except train_io.TrainIOError as exc:
             dest.unlink(missing_ok=True)
             bus.publish({"type": "version_bundle_zip_failed", "project_id": pid, "version_id": vid, "error": str(exc)})
-            raise HTTPException(400, str(exc)) from exc
+            raise
         except Exception as exc:
             dest.unlink(missing_ok=True)
             bus.publish({"type": "version_bundle_zip_failed", "project_id": pid, "version_id": vid, "error": str(exc)})
@@ -192,16 +199,22 @@ def _bundle_import_payload(result: dict[str, Any]) -> dict[str, Any]:
 
 def _import_bundle_from_path(dest: Path, original: str) -> dict[str, Any]:
     if not dest.exists():
-        raise HTTPException(404, f"文件不存在: {original}")
+        raise NotFoundError(
+            f"Path not found: {original}",
+            code="path.not_found", details={"path": original},
+        )
     if not dest.is_file():
-        raise HTTPException(400, "请选择 zip 文件")
+        raise ValidationError(
+            "Selected path is not a file",
+            code="path.not_a_file", http_status=400,
+        )
     if dest.suffix.lower() != ".zip":
-        raise HTTPException(400, "请选择 .zip 文件")
+        raise ValidationError(
+            "Select a .zip file",
+            code="file.ext_invalid", details={"types": ".zip"}, http_status=400,
+        )
     with db.connection_for() as conn:
-        try:
-            result = train_io.import_bundle(conn, dest, USER_PRESETS_DIR)
-        except train_io.TrainIOError as exc:
-            raise HTTPException(400, str(exc)) from exc
+        result = train_io.import_bundle(conn, dest, USER_PRESETS_DIR)
     return _bundle_import_payload(result)
 
 
@@ -227,9 +240,14 @@ async def import_bundle_upload(file: UploadFile = File(...)) -> dict[str, Any]:
     run_in_threadpool 否则卡死 event loop（详见 ingestion.upload_local_files）。
     """
     if not file.filename:
-        raise HTTPException(400, "缺少上传文件")
+        raise ValidationError(
+            "No files uploaded", code="dataset.no_files", http_status=400,
+        )
     if Path(file.filename).suffix.lower() != ".zip":
-        raise HTTPException(400, "请选择 .zip 文件")
+        raise ValidationError(
+            "Select a .zip file",
+            code="file.ext_invalid", details={"types": ".zip"}, http_status=400,
+        )
     tmp = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
     try:
         while True:
@@ -256,7 +274,9 @@ async def import_train_zip(file: UploadFile = File(...)) -> dict[str, Any]:
     （详见 ingestion.upload_local_files 的根因说明）。
     """
     if not file.filename:
-        raise HTTPException(400, "缺少上传文件")
+        raise ValidationError(
+            "No files uploaded", code="dataset.no_files", http_status=400,
+        )
     tmp = tempfile.NamedTemporaryFile(suffix=".zip", delete=False)
     try:
         # UploadFile 内部本就是 SpooledTemporaryFile，大文件会落临时盘
@@ -270,10 +290,7 @@ async def import_train_zip(file: UploadFile = File(...)) -> dict[str, Any]:
 
         def _do_import() -> dict[str, Any]:
             with db.connection_for() as conn:
-                try:
-                    return train_io.import_train(conn, tmp_path)
-                except train_io.TrainIOError as exc:
-                    raise HTTPException(400, str(exc)) from exc
+                return train_io.import_train(conn, tmp_path)
 
         result = await run_in_threadpool(_do_import)
     finally:

--- a/studio/api/routers/projects/ingestion.py
+++ b/studio/api/routers/projects/ingestion.py
@@ -28,10 +28,15 @@ import logging
 from pathlib import Path
 from typing import Any, BinaryIO
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, File, UploadFile
 from fastapi.concurrency import run_in_threadpool
 
 from ...errors import _validate_component_or_400  # noqa: F401  reserved for future use
+from ....domain.errors import (
+    ConflictError,
+    NotFoundError,
+    ValidationError,
+)
 from ...schemas.ingestion import (
     DownloadRequest,
     EstimateRequest,
@@ -67,17 +72,26 @@ def estimate_download(pid: int, body: EstimateRequest) -> dict[str, Any]:
     返回 -1 表示未知（API 不支持精确计数）；前端按「下载全部」处理。
     """
     if body.api_source not in {"gelbooru", "danbooru"}:
-        raise HTTPException(400, f"不支持的 api_source: {body.api_source}")
+        raise ValidationError(
+            f"Unsupported image source: {body.api_source}",
+            code="download.source_unsupported",
+            details={"source": body.api_source}, http_status=400,
+        )
     if not body.tag.strip():
-        raise HTTPException(400, "tag 不能为空")
+        raise ValidationError(
+            "Tag is required", code="download.tag_required", http_status=400,
+        )
     if not secrets.has_credentials_for(body.api_source):
-        raise HTTPException(
-            400,
-            f"未配置 {body.api_source} 凭据，请先到「设置」页填写",
+        raise ValidationError(
+            f"No {body.api_source} credentials configured; add them on the Settings page",
+            code="download.credentials_missing",
+            details={"source": body.api_source}, http_status=400,
         )
     with db.connection_for() as conn:
         if not projects.get_project(conn, pid):
-            raise HTTPException(404, f"项目不存在: id={pid}")
+            raise NotFoundError(
+                "Project not found", code="project.not_found", details={"id": pid},
+            )
     sec = secrets.load()
     if body.api_source == "danbooru":
         opts = downloader.DownloadOptions(
@@ -110,20 +124,32 @@ def estimate_download(pid: int, body: EstimateRequest) -> dict[str, Any]:
 @router.post("/api/projects/{pid}/download")
 def start_download(pid: int, body: DownloadRequest) -> dict[str, Any]:
     if not body.tag.strip():
-        raise HTTPException(400, "tag 不能为空")
+        raise ValidationError(
+            "Tag is required", code="download.tag_required", http_status=400,
+        )
     if body.count < 1:
-        raise HTTPException(400, "count 必须 >= 1")
+        raise ValidationError(
+            "Download count must be at least 1",
+            code="download.count_invalid", http_status=400,
+        )
     if body.api_source not in {"gelbooru", "danbooru"}:
-        raise HTTPException(400, f"不支持的 api_source: {body.api_source}")
+        raise ValidationError(
+            f"Unsupported image source: {body.api_source}",
+            code="download.source_unsupported",
+            details={"source": body.api_source}, http_status=400,
+        )
     if not secrets.has_credentials_for(body.api_source):
-        raise HTTPException(
-            400,
-            f"未配置 {body.api_source} 凭据，请先到「设置」页填写",
+        raise ValidationError(
+            f"No {body.api_source} credentials configured; add them on the Settings page",
+            code="download.credentials_missing",
+            details={"source": body.api_source}, http_status=400,
         )
 
     with db.connection_for() as conn:
         if not projects.get_project(conn, pid):
-            raise HTTPException(404, f"项目不存在: id={pid}")
+            raise NotFoundError(
+                "Project not found", code="project.not_found", details={"id": pid},
+            )
         job = project_jobs.create_job(
             conn,
             project_id=pid,
@@ -190,11 +216,15 @@ async def upload_local_files(
     用户 server 控制台 + studio.log 都能看到进度，不再是"卡 100% 几十分钟无反馈"。
     """
     if not files:
-        raise HTTPException(400, "没有上传文件")
+        raise ValidationError(
+            "No files uploaded", code="dataset.no_files", http_status=400,
+        )
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
     if not p:
-        raise HTTPException(404, f"项目不存在: id={pid}")
+        raise NotFoundError(
+            "Project not found", code="project.not_found", details={"id": pid},
+        )
     pdir = projects.project_dir(p["id"], p["slug"]) / "download"
 
     # 流式：直接传 SpooledTemporaryFile，不读进 bytes 对象。FastAPI 写完后
@@ -233,16 +263,24 @@ def upload_local_file_from_path(pid: int, body: UploadFromPathBody) -> dict[str,
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
     if not p:
-        raise HTTPException(404, f"项目不存在: id={pid}")
+        raise NotFoundError(
+            "Project not found", code="project.not_found", details={"id": pid},
+        )
     src = Path(body.path)
     if not src.is_absolute():
         src = (REPO_ROOT / src).resolve()
     else:
         src = src.resolve()
     if not src.exists():
-        raise HTTPException(404, f"文件不存在: {body.path}")
+        raise NotFoundError(
+            f"Path not found: {body.path}",
+            code="path.not_found", details={"path": body.path},
+        )
     if not src.is_file():
-        raise HTTPException(400, "请选择文件")
+        raise ValidationError(
+            "Selected path is not a file",
+            code="path.not_a_file", http_status=400,
+        )
     pdir = projects.project_dir(p["id"], p["slug"]) / "download"
     sec = secrets.load()
 
@@ -271,7 +309,9 @@ def upload_local_file_from_path(pid: int, body: UploadFromPathBody) -> dict[str,
 def download_status(pid: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         if not projects.get_project(conn, pid):
-            raise HTTPException(404, f"项目不存在: id={pid}")
+            raise NotFoundError(
+                "Project not found", code="project.not_found", details={"id": pid},
+            )
         job = project_jobs.latest_for(conn, project_id=pid, kind="download")
     if not job:
         return {"job": None, "log_tail": ""}
@@ -299,10 +339,14 @@ def _resolve_pv_or_404(pid: int, vid: int) -> tuple[dict[str, Any], dict[str, An
     with db.connection_for() as conn:
         p = projects.get_project(conn, pid)
         if not p:
-            raise HTTPException(404, f"项目不存在: id={pid}")
+            raise NotFoundError(
+                "Project not found", code="project.not_found", details={"id": pid},
+            )
         v = versions.get_version(conn, vid)
         if not v or v["project_id"] != pid:
-            raise HTTPException(404, f"版本不存在: id={vid}")
+            raise NotFoundError(
+                "Version not found", code="version.not_found", details={"id": vid},
+            )
     return p, v
 
 
@@ -316,42 +360,58 @@ def start_preprocess_train(
     job.version_id 派发到 _run_upscale_train。
     """
     if body.mode not in ("all", "selected", "all_force"):
-        raise HTTPException(400, f"未知 mode: {body.mode}")
+        raise ValidationError(
+            f"Invalid preprocess mode: {body.mode}",
+            code="preprocess.mode_invalid",
+            details={"mode": body.mode}, http_status=400,
+        )
     if body.tile_size <= 0:
-        raise HTTPException(400, "tile_size 必须 > 0")
+        raise ValidationError(
+            "Tile size must be greater than 0",
+            code="preprocess.tile_size_invalid", http_status=400,
+        )
     if body.device not in ("auto", "cuda", "cpu"):
-        raise HTTPException(400, f"未知 device: {body.device}")
+        raise ValidationError(
+            f"Invalid device: {body.device}",
+            code="preprocess.device_invalid",
+            details={"device": body.device}, http_status=400,
+        )
     if body.target_area is not None and (
         body.target_area < 256 * 256 or body.target_area > 4096 * 4096
     ):
-        raise HTTPException(400, f"target_area 超出范围: {body.target_area}")
+        raise ValidationError(
+            f"Target area is out of range: {body.target_area}",
+            code="preprocess.target_area_out_of_range",
+            details={"value": body.target_area}, http_status=400,
+        )
     try:
         target = model_downloader.upscaler_target(body.model)
     except ValueError as exc:
-        raise HTTPException(400, f"未知放大器: {body.model}") from exc
+        raise NotFoundError(
+            f'Upscaler "{body.model}" not found',
+            code="upscaler.not_found", details={"name": body.model},
+        ) from exc
     if not target.exists():
-        raise HTTPException(
-            409,
-            f"放大器权重未下载: {body.model}（请先到「设置 → 预处理」下载）",
+        raise ConflictError(
+            f'Upscaler weights for "{body.model}" are not downloaded; '
+            "download them under Settings → Preprocess",
+            code="upscaler.not_downloaded", details={"name": body.model},
         )
 
     p, v = _resolve_pv_or_404(pid, vid)
     with db.connection_for() as conn:
-        try:
-            job = preprocess_svc.start_job_train(
-                conn,
-                project_id=pid,
-                version_id=vid,
-                mode=body.mode,
-                names=body.names,
-                model=body.model,
-                tile_size=body.tile_size,
-                tile_pad=body.tile_pad,
-                device=body.device,
-                target_area=body.target_area,
-            )
-        except preprocess_svc.PreprocessError as exc:
-            raise HTTPException(400, str(exc)) from exc
+        job = preprocess_svc.start_job_train(
+            conn,
+            project_id=pid,
+            version_id=vid,
+            mode=body.mode,
+            names=body.names,
+            model=body.model,
+            tile_size=body.tile_size,
+            tile_pad=body.tile_pad,
+            device=body.device,
+            target_area=body.target_area,
+        )
     _publish_job_state(job)
     return job
 
@@ -422,19 +482,19 @@ def start_preprocess_crop_train(
     """train scope: 创建 crop job。`crops` 的源文件名是 train rel path
     （`"1_data/X.png"`，跟 list_crop_workspace_train 返回 `name` 一致）。"""
     if not body.crops:
-        raise HTTPException(400, "crops 不能为空")
+        raise ValidationError(
+            "No crop regions provided",
+            code="preprocess.crops_required", http_status=400,
+        )
     _resolve_pv_or_404(pid, vid)
     crops_payload: dict[str, list[dict[str, Any]]] = {
         name: [r.model_dump() for r in rects]
         for name, rects in body.crops.items()
     }
     with db.connection_for() as conn:
-        try:
-            job = preprocess_svc.start_crop_job_train(
-                conn, project_id=pid, version_id=vid, crops=crops_payload,
-            )
-        except preprocess_svc.PreprocessError as exc:
-            raise HTTPException(400, str(exc)) from exc
+        job = preprocess_svc.start_crop_job_train(
+            conn, project_id=pid, version_id=vid, crops=crops_payload,
+        )
     _publish_job_state(job)
     return job
 
@@ -463,10 +523,7 @@ def restore_preprocess_files_train(
     if not body.names:
         return {"restored": [], "missing": [], "no_origin": []}
     p, v = _resolve_pv_or_404(pid, vid)
-    try:
-        res = preprocess_svc.restore_products_train(p, v["label"], body.names)
-    except preprocess_svc.PreprocessError as exc:
-        raise HTTPException(400, str(exc)) from exc
+    res = preprocess_svc.restore_products_train(p, v["label"], body.names)
     if res["restored"]:
         _publish_project_state(p)
     return res

--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -40,7 +40,7 @@ from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
 
 from ...deps import _resolve_anima_model_paths
-from ...errors import _preset_err_code as _err_code, _safe_join_or_400
+from ...errors import _safe_join_or_400
 from ..logs import read_task_log
 from ...responses import _thumb_response
 from ...schemas.training import (
@@ -63,6 +63,12 @@ from ._shared import (
     _version_train_dir_or_404,
 )
 from .... import db
+from ....domain.errors import (
+    ConflictError,
+    InvalidPathError,
+    NotFoundError,
+    ValidationError,
+)
 from ....services.presets import io as presets_io
 from ....services.projects import jobs as project_jobs, projects, versions
 from ....services.dataset import scan as datasets
@@ -88,11 +94,21 @@ logger = logging.getLogger(__name__)
 @router.post("/api/projects/{pid}/versions/{vid}/tag")
 def start_tag(pid: int, vid: int, body: TagJobRequest) -> dict[str, Any]:
     if body.tagger not in VALID_TAGGER_NAMES:
-        raise HTTPException(400, f"unknown tagger: {body.tagger}")
+        raise ValidationError(
+            f'Unknown tagger: "{body.tagger}"',
+            code="tag.tagger_invalid", details={"name": body.tagger},
+            http_status=400,
+        )
     if body.output_format not in {"txt", "json"}:
-        raise HTTPException(400, "output_format must be txt|json")
+        raise ValidationError(
+            "Output format must be txt or json",
+            code="tag.output_format_invalid", http_status=400,
+        )
     if body.on_existing not in {"overwrite", "skip", "append"}:
-        raise HTTPException(400, "on_existing must be overwrite|skip|append")
+        raise ValidationError(
+            "On-existing mode must be overwrite, skip, or append",
+            code="tag.on_existing_invalid", http_status=400,
+        )
     _, v, _ = _version_train_dir_or_404(pid, vid)
 
     # 触发词：先 strip，落到 version 表（持久化，TagEdit / Train 都能读），再
@@ -162,7 +178,11 @@ def get_caption_endpoint(
     try:
         return tagedit.read_one(train, folder, filename)
     except FileNotFoundError as exc:
-        raise HTTPException(404, str(exc)) from exc
+        raise NotFoundError(
+            "Image not found",
+            code="image.not_found",
+            details={"folder": folder, "filename": filename},
+        ) from exc
 
 
 @router.put("/api/projects/{pid}/versions/{vid}/captions/{folder}/{filename}")
@@ -174,7 +194,11 @@ def put_caption_endpoint(
     try:
         return tagedit.write_one(train, folder, filename, body.tags)
     except FileNotFoundError as exc:
-        raise HTTPException(404, str(exc)) from exc
+        raise NotFoundError(
+            "Image not found",
+            code="image.not_found",
+            details={"folder": folder, "filename": filename},
+        ) from exc
 
 
 @router.post("/api/projects/{pid}/versions/{vid}/captions/snapshot")
@@ -192,24 +216,14 @@ def list_caption_snapshots(pid: int, vid: int) -> dict[str, Any]:
 @router.post("/api/projects/{pid}/versions/{vid}/captions/snapshots/{sid}/restore")
 def restore_caption_snapshot(pid: int, vid: int, sid: str) -> dict[str, Any]:
     _, _, vdir = _version_dir_or_404(pid, vid)
-    try:
-        return caption_snapshot.restore_snapshot(vdir, sid)
-    except FileNotFoundError as exc:
-        raise HTTPException(404, str(exc)) from exc
-    except caption_snapshot.SnapshotError as exc:
-        raise HTTPException(400, str(exc)) from exc
+    return caption_snapshot.restore_snapshot(vdir, sid)
 
 
 @router.delete("/api/projects/{pid}/versions/{vid}/captions/snapshots/{sid}")
 def delete_caption_snapshot(pid: int, vid: int, sid: str) -> dict[str, Any]:
     _, _, vdir = _version_dir_or_404(pid, vid)
-    try:
-        caption_snapshot.delete_snapshot(vdir, sid)
-        return {"deleted": sid}
-    except FileNotFoundError as exc:
-        raise HTTPException(404, str(exc)) from exc
-    except caption_snapshot.SnapshotError as exc:
-        raise HTTPException(400, str(exc)) from exc
+    caption_snapshot.delete_snapshot(vdir, sid)
+    return {"deleted": sid}
 
 
 @router.post("/api/projects/{pid}/versions/{vid}/captions/commit")
@@ -251,13 +265,19 @@ def batch_caption_endpoint(
         return {"op": op, "affected": tagedit.remove_tags(scope, train, body.tags or [])}
     if op == "replace":
         if not body.old or not body.new:
-            raise HTTPException(400, "replace 需要 old 和 new")
+            raise ValidationError(
+                "Replace requires both the old and new tag",
+                code="tag.replace_args_required", http_status=400,
+            )
         return {"op": op, "affected": tagedit.replace_tag(scope, train, body.old, body.new)}
     if op == "dedupe":
         return {"op": op, "affected": tagedit.dedupe(scope, train)}
     if op == "stats":
         return {"op": op, "items": tagedit.stats(scope, train, top=max(1, body.top))}
-    raise HTTPException(400, f"unknown op: {op}")
+    raise ValidationError(
+        f'Unknown operation: "{op}"',
+        code="tag.op_invalid", details={"op": op}, http_status=400,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -310,25 +330,46 @@ _REG_TAGGER_ALLOWED = {"wd14", "cltagger"}
 @router.post("/api/projects/{pid}/versions/{vid}/reg/build")
 def start_reg_build(pid: int, vid: int, body: RegBuildRequest) -> dict[str, Any]:
     if body.api_source not in {"gelbooru", "danbooru"}:
-        raise HTTPException(400, "api_source must be gelbooru|danbooru")
+        raise ValidationError(
+            "Image source must be Gelbooru or Danbooru",
+            code="reg.api_source_invalid", http_status=400,
+        )
     if body.postprocess_method not in {"smart", "stretch", "crop"}:
-        raise HTTPException(400, "postprocess_method must be smart|stretch|crop")
+        raise ValidationError(
+            "Postprocess method must be smart, stretch, or crop",
+            code="reg.postprocess_method_invalid", http_status=400,
+        )
     if not (0.05 <= body.postprocess_max_crop_ratio <= 0.5):
-        raise HTTPException(400, "postprocess_max_crop_ratio must be 0.05–0.5")
+        raise ValidationError(
+            "Max crop ratio must be between 0.05 and 0.5",
+            code="reg.crop_ratio_out_of_range", http_status=400,
+        )
     if body.aspect_ratio_filter_enabled and not (
         0.0 < body.min_aspect_ratio < body.max_aspect_ratio
     ):
-        raise HTTPException(400, "min_aspect_ratio must be < max_aspect_ratio (both > 0)")
+        raise ValidationError(
+            "Min aspect ratio must be less than max aspect ratio, "
+            "and both must be greater than 0",
+            code="reg.aspect_ratio_invalid", http_status=400,
+        )
     if body.auto_tag_kind not in _REG_TAGGER_ALLOWED:
-        raise HTTPException(
-            422,
-            f"auto_tag_kind must be one of {sorted(_REG_TAGGER_ALLOWED)}",
+        _allowed = sorted(_REG_TAGGER_ALLOWED)
+        raise ValidationError(
+            f"Auto-tag mode must be one of: {_allowed}",
+            code="reg.auto_tag_kind_invalid", details={"allowed": _allowed},
+            http_status=422,
         )
     # B1 — build_mode + target_count 校验
     if body.build_mode not in {"mirror", "flat"}:
-        raise HTTPException(422, "build_mode must be 'mirror' or 'flat'")
+        raise ValidationError(
+            "Build mode must be mirror or flat",
+            code="reg.build_mode_invalid", http_status=422,
+        )
     if body.target_count is not None and body.target_count <= 0:
-        raise HTTPException(422, "target_count must be > 0 or null")
+        raise ValidationError(
+            "Target count must be greater than 0 or empty",
+            code="reg.target_count_invalid", http_status=422,
+        )
     _, v, vdir = _version_dir_or_404(pid, vid)
     train = vdir / "train"
     has_image = train.exists() and any(
@@ -336,7 +377,10 @@ def start_reg_build(pid: int, vid: int, body: RegBuildRequest) -> dict[str, Any]
         for f in train.rglob("*")
     )
     if not has_image:
-        raise HTTPException(400, "train 还没有图片，先去 ① 整理 / ② 下载")
+        raise ValidationError(
+            "Add images to the training set first",
+            code="train.no_images", http_status=400,
+        )
 
     with db.connection_for() as conn:
         job = project_jobs.create_job(
@@ -370,14 +414,16 @@ def start_reg_build(pid: int, vid: int, body: RegBuildRequest) -> dict[str, Any]
 def get_reg_caption(pid: int, vid: int, path: str) -> dict[str, Any]:
     """读 reg 集中单张图的 caption。`path` 是相对 reg/ 的路径（含子文件夹）。"""
     if not path:
-        raise HTTPException(400, "invalid path")
+        raise InvalidPathError("Invalid path", code="path.invalid")
     _, _, vdir = _version_dir_or_404(pid, vid)
     rdir = _reg_dir(vdir)
     # path 允许含 `/` 子目录；按分隔符拆成片段交给 safe_join 做组件校验 + containment
     parts = [p for p in path.replace("\\", "/").split("/") if p]
     img = _safe_join_or_400(rdir, *parts)
     if not img.exists() or img.suffix.lower() not in datasets.IMAGE_EXTS:
-        raise HTTPException(404, "image not found")
+        raise NotFoundError(
+            "Image not found", code="image.not_found", details={"path": path},
+        )
     return {"path": path, "tags": tagedit.read_tags(img)}
 
 
@@ -392,7 +438,10 @@ def reg_generate_prior(pid: int, vid: int, body: RegAiRequest) -> dict[str, Any]
         for f in train.rglob("*")
     )
     if not has_image:
-        raise HTTPException(400, "train 还没有图片，请先完成 Step 1（下载）或 Step 2（筛选）")
+        raise ValidationError(
+            "Add images to the training set first",
+            code="train.no_images", http_status=400,
+        )
 
     rdir = _reg_dir(vdir)
     rdir.mkdir(parents=True, exist_ok=True)
@@ -463,7 +512,9 @@ def get_reg_prior_task(pid: int, vid: int, task_id: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task or task.get("task_type") != "reg_ai":
-        raise HTTPException(404)
+        raise NotFoundError(
+            "Task not found", code="task.not_found", details={"id": task_id},
+        )
     return task
 
 
@@ -510,11 +561,15 @@ def delete_reg_files(
     走 _safe_join_or_400 抛 400。
     """
     if not body.relative_paths:
-        raise HTTPException(400, "relative_paths is empty")
+        raise ValidationError(
+            "No files selected", code="reg.paths_empty", http_status=400,
+        )
     _, _, vdir = _version_dir_or_404(pid, vid)
     rdir = _reg_dir(vdir)
     if not rdir.exists():
-        raise HTTPException(404, "reg dir not found")
+        raise NotFoundError(
+            "Regularization set not found", code="reg.not_found",
+        )
 
     # 端点入口：每条路径走 _safe_join_or_400 防 traversal；合法的转回 rdir
     # 相对形式喂给 reg_dedup.purge_paths。worker 走 dedup.scan_for_dedup
@@ -545,7 +600,9 @@ def dedup_purge_reg(pid: int, vid: int) -> dict[str, Any]:
     _, _, vdir = _version_dir_or_404(pid, vid)
     rdir = _reg_dir(vdir)
     if not rdir.exists():
-        raise HTTPException(404, "reg dir not found")
+        raise NotFoundError(
+            "Regularization set not found", code="reg.not_found",
+        )
 
     to_delete = reg_dedup.scan_for_dedup(rdir)
     scanned = sum(
@@ -596,7 +653,11 @@ def get_version_config_endpoint(pid: int, vid: int) -> dict[str, Any]:
     try:
         cfg, dropped, defaulted = version_config.read_version_config_with_warnings(project, ver)
     except version_config.VersionConfigError as exc:
-        raise HTTPException(422, str(exc)) from exc
+        raise ValidationError(
+            f"Training configuration is invalid: {exc}",
+            code="version.config_invalid", details={"reason": str(exc)},
+            http_status=422,
+        ) from exc
     return {
         "has_config": True,
         "config": cfg,
@@ -625,7 +686,11 @@ def put_version_config_endpoint(
         )
         cfg = version_config.read_version_config(project, ver)
     except version_config.VersionConfigError as exc:
-        raise HTTPException(400, str(exc)) from exc
+        raise ValidationError(
+            f"Training configuration is invalid: {exc}",
+            code="version.config_invalid", details={"reason": str(exc)},
+            http_status=400,
+        ) from exc
     return {"has_config": True, "config": cfg}
 
 
@@ -639,10 +704,12 @@ def fork_preset_for_version_endpoint(
         cfg, dropped, defaulted = preset_flow.fork_preset_for_version_with_warnings(
             body.name, project, ver
         )
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     except version_config.VersionConfigError as exc:
-        raise HTTPException(400, str(exc)) from exc
+        raise ValidationError(
+            f"Training configuration is invalid: {exc}",
+            code="version.config_invalid", details={"reason": str(exc)},
+            http_status=400,
+        ) from exc
     # 同步 versions.config_name = 来源 preset 名（informational only）
     with db.connection_for() as conn:
         versions.update_version(conn, vid, config_name=body.name)
@@ -665,10 +732,12 @@ def save_version_config_as_preset_endpoint(
         cfg = preset_flow.save_version_config_as_preset(
             project, ver, body.name, overwrite=body.overwrite,
         )
-    except presets_io.PresetError as exc:
-        _err_code(exc); raise  # PR-2 C4: DomainError handler 翻 envelope
     except version_config.VersionConfigError as exc:
-        raise HTTPException(400, str(exc)) from exc
+        raise ValidationError(
+            f"Training configuration is invalid: {exc}",
+            code="version.config_invalid", details={"reason": str(exc)},
+            http_status=400,
+        ) from exc
     return {"saved_preset": body.name, "config": cfg}
 
 
@@ -682,8 +751,9 @@ def enqueue_version_training(pid: int, vid: int) -> dict[str, Any]:
     """
     project, ver = _project_and_version_or_404(pid, vid)
     if not version_config.has_version_config(project, ver):
-        raise HTTPException(
-            400, "请先在 ⑥ 训练页选预设并保存配置后再入队",
+        raise ValidationError(
+            "Training configuration is not set for this version",
+            code="version.config_missing", http_status=400,
         )
     cfg_path = version_config.version_config_path(project, ver)
 
@@ -696,10 +766,11 @@ def enqueue_version_training(pid: int, vid: int) -> dict[str, Any]:
             (vid,),
         ).fetchone()
         if active:
-            raise HTTPException(
-                409,
-                f"该版本已有 active task #{active['id']}（{active['status']}），"
-                "请等其完成或取消",
+            raise ConflictError(
+                "This version already has a running task; "
+                "wait for it to finish or cancel it",
+                code="version.has_active_task",
+                details={"task_id": active["id"], "status": active["status"]},
             )
 
         # 创建 task
@@ -740,16 +811,18 @@ def version_thumb(
     size: int = 256,
 ) -> FileResponse:
     if bucket not in {"train", "reg", "samples"}:
-        raise HTTPException(400, f"非法 bucket: {bucket}")
+        raise InvalidPathError("Invalid path", code="path.invalid")
     with db.connection_for() as conn:
         v = versions.get_version(conn, vid)
         p = projects.get_project(conn, pid)
     if not v or not p or v["project_id"] != pid:
-        raise HTTPException(404, "版本不存在")
+        raise NotFoundError(
+            "Version not found", code="version.not_found", details={"id": vid},
+        )
     vdir = versions.version_dir(p["id"], p["slug"], v["label"]) / bucket
     if bucket in {"train", "reg"}:
         if not folder:
-            raise HTTPException(400, "invalid folder")
+            raise InvalidPathError("Invalid path", code="path.invalid")
         f = _safe_join_or_400(vdir, folder, name)
     else:
         f = _safe_join_or_400(vdir, name)
@@ -758,5 +831,5 @@ def version_thumb(
             "version thumb 404: pid=%s vid=%s bucket=%s folder=%s name=%s -> %s",
             pid, vid, bucket, folder, name, f,
         )
-        raise HTTPException(404)
+        raise NotFoundError("Image not found", code="image.not_found")
     return _thumb_response(f, size)

--- a/studio/api/routers/queue/io.py
+++ b/studio/api/routers/queue/io.py
@@ -15,11 +15,12 @@ import json as _json
 import time
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from fastapi.responses import Response
 
 from ...schemas.queue import ImportRequest
 from .... import db
+from ....domain.errors import NotFoundError, ValidationError
 from ....services.presets import io as presets_io
 from ....services import queue_io, task_snapshot
 from ....infrastructure.event_bus import bus
@@ -39,8 +40,11 @@ def export_queue(ids: str = "") -> Response:
     if ids.strip():
         try:
             id_list = [int(x) for x in ids.split(",") if x.strip()]
-        except ValueError:
-            raise HTTPException(400, "ids must be comma-separated integers")
+        except ValueError as exc:
+            raise ValidationError(
+                "The selected task IDs are not valid",
+                code="queue.export_ids_invalid", http_status=400,
+            ) from exc
     else:
         with db.connection_for() as conn:
             id_list = [t["id"] for t in db.list_tasks(conn)]
@@ -65,7 +69,11 @@ def import_queue(body: ImportRequest) -> dict[str, Any]:
     try:
         return queue_io.import_tasks(body.payload)
     except (ValueError, presets_io.PresetError) as exc:
-        raise HTTPException(400, str(exc)) from exc
+        raise ValidationError(
+            f"Could not import the queue: {exc}",
+            code="queue.import_invalid", details={"reason": str(exc)},
+            http_status=400,
+        ) from exc
 
 
 @router.get("/api/queue/{task_id}/snapshot/config")
@@ -78,8 +86,11 @@ def get_task_snapshot_config(task_id: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task:
-        raise HTTPException(404, "task not found")
+        raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
     data = task_snapshot.read_snapshot_config(task_id)
     if data is None:
-        raise HTTPException(404, "snapshot not found")
+        raise NotFoundError(
+            "No saved configuration for this task",
+            code="task.snapshot_not_found", details={"task_id": task_id},
+        )
     return data

--- a/studio/api/routers/queue/lifecycle.py
+++ b/studio/api/routers/queue/lifecycle.py
@@ -24,6 +24,12 @@ from fastapi import APIRouter, HTTPException
 from ...deps import _supervisor
 from ...schemas.queue import EnqueueRequest, ReorderRequest
 from .... import db
+from ....domain.errors import (
+    ConflictError,
+    NotFoundError,
+    PresetNotFoundError,
+    ValidationError,
+)
 from ....infrastructure.event_bus import bus
 from ....paths import USER_PRESETS_DIR, task_dir
 
@@ -73,7 +79,11 @@ def list_queue(
     `?include_generate=true` 兜底。
     """
     if status and status not in db.VALID_STATUSES:
-        raise HTTPException(400, f"unknown status: {status}")
+        raise ValidationError(
+            f"Unsupported status filter: {status}",
+            code="queue.status_filter_invalid", details={"status": status},
+            http_status=400,
+        )
     with db.connection_for() as conn:
         items = db.list_tasks(conn, status=status)
     if not include_generate:
@@ -96,7 +106,10 @@ def list_queue(
 def enqueue(body: EnqueueRequest) -> dict[str, Any]:
     cfg_path = USER_PRESETS_DIR / f"{body.config_name}.yaml"
     if not cfg_path.exists():
-        raise HTTPException(404, f"preset not found: {body.config_name}")
+        raise PresetNotFoundError(
+            f'Preset "{body.config_name}" not found',
+            code="preset.not_found", details={"name": body.config_name},
+        )
     name = body.name or body.config_name
     with db.connection_for() as conn:
         task_id = db.create_task(
@@ -152,7 +165,7 @@ def get_queue_item(task_id: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task:
-        raise HTTPException(404)
+        raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
     # ADR 0006 PR-4 — is_pausable 信号让 UI 决定是否显示暂停按钮（§8.1）。
     # 仅 supervisor 跑得起来时计算；空载（test / 启动期）默认 False。
     try:
@@ -170,10 +183,15 @@ def cancel_task(task_id: int) -> dict[str, Any]:
         with db.connection_for() as conn:
             task = db.get_task(conn, task_id)
         if not task:
-            raise HTTPException(404)
+            raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
         if task["status"] in db.TERMINAL_STATUSES:
-            raise HTTPException(400, f"task already {task['status']}")
-        raise HTTPException(409, "cancel rejected (state mismatch)")
+            raise ValidationError(
+                "This task has already finished",
+                code="task.already_finished", http_status=400,
+            )
+        raise ConflictError(
+            "Cannot cancel this task in its current state", code="task.cancel_rejected",
+        )
     return {"task_id": task_id, "canceled": True}
 
 
@@ -190,8 +208,12 @@ def pause_task(task_id: int) -> dict[str, Any]:
         with db.connection_for() as conn:
             task = db.get_task(conn, task_id)
         if not task:
-            raise HTTPException(404, "task not found")
-        raise HTTPException(409, reason or "pause rejected")
+            raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
+        raise ConflictError(
+            "Cannot pause this task right now",
+            code="task.pause_rejected",
+            details={"reason": reason} if reason else None,
+        )
     return {"task_id": task_id, "pause_pending": True}
 
 
@@ -218,28 +240,25 @@ def resume_task(task_id: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
         if not task:
-            raise HTTPException(404, "task not found")
+            raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
         status = task["status"]
         if status not in RESUMABLE_STATUSES:
-            raise HTTPException(
-                409,
-                f"task status is {status!r}, not resumable "
-                f"(expected one of {', '.join(RESUMABLE_STATUSES)})",
+            raise ConflictError(
+                "This task cannot be resumed",
+                code="task.not_resumable", details={"status": status},
             )
         state_path, config_path = _resume_source_paths(task)
         if not state_path or not Path(state_path).exists():
-            raise HTTPException(
-                409,
-                f"resume state file missing: {state_path!r}; "
-                f"use ResumeFieldPicker to start a fresh task from another .pt",
+            raise ConflictError(
+                "The saved training state is missing; start a new run instead",
+                code="task.resume_state_missing",
             )
         if config_path and not Path(config_path).exists():
             # snapshot 缺失虽然不致命（bootstrap_phase 会沿用 args.config yaml），
             # 但 resume 语义会漂；按 ADR §5.7 严格 freeze 原则，拒绝继续。
-            raise HTTPException(
-                409,
-                f"resume config snapshot missing: {config_path!r}; "
-                f"cannot guarantee config freeze, refusing to resume",
+            raise ConflictError(
+                "The saved training state is missing; start a new run instead",
+                code="task.resume_state_missing",
             )
         fields: dict[str, Any] = dict(
             status="pending",
@@ -293,9 +312,12 @@ def retry_task(task_id: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         original = db.get_task(conn, task_id)
         if not original:
-            raise HTTPException(404)
+            raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
         if original["status"] not in db.TERMINAL_STATUSES:
-            raise HTTPException(400, "only terminal tasks can be retried")
+            raise ValidationError(
+                "Only finished tasks can be retried",
+                code="task.not_retryable", http_status=400,
+            )
         new_id = db.create_task(
             conn,
             name=original["name"],
@@ -320,9 +342,12 @@ def delete_queue_item(task_id: int) -> dict[str, Any]:
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
         if not task:
-            raise HTTPException(404)
+            raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
         if task["status"] not in db.TERMINAL_STATUSES:
-            raise HTTPException(400, "only terminal tasks can be deleted")
+            raise ValidationError(
+                "Only finished tasks can be deleted",
+                code="task.not_deletable", http_status=400,
+            )
         db.delete_task(conn, task_id)
     # task-scoped 档案（snapshot/config.yaml / monitor/state.json / samples/ /
     # run.log）跟 task DB 行同生命周期 —— 删 task 一并清。老 task 散在

--- a/studio/api/routers/queue/outputs.py
+++ b/studio/api/routers/queue/outputs.py
@@ -25,6 +25,11 @@ from fastapi.responses import FileResponse
 from ...errors import _export_result, _safe_join_or_400, _unique_data_export_path
 from ...schemas.queue import DeleteOutputsBody, ExportOutputsBody
 from .... import db
+from ....domain.errors import (
+    ForbiddenError,
+    NotFoundError,
+    ValidationError,
+)
 from ....services.projects import projects, versions
 from ....infrastructure.event_bus import bus
 from ....paths import DATA_EXPORTS
@@ -57,13 +62,19 @@ def _select_task_output_files(task_id: int, files: Optional[list[str]] = None) -
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task:
-        raise HTTPException(404)
+        raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
     out_dir = _task_output_dir(task)
     if not out_dir or not out_dir.exists():
-        raise HTTPException(404, "no output dir")
+        raise NotFoundError(
+            "This task has no output files",
+            code="task.no_outputs", details={"task_id": task_id},
+        )
     all_files = _iter_task_output_files(out_dir, task_id)
     if not all_files:
-        raise HTTPException(404, "empty output dir")
+        raise NotFoundError(
+            "This task has no output files",
+            code="task.no_outputs", details={"task_id": task_id},
+        )
     if not files:
         return task, all_files, False
     by_path = {_task_output_relpath(out_dir, f): f for f in all_files}
@@ -77,9 +88,14 @@ def _select_task_output_files(task_id: int, files: Optional[list[str]] = None) -
         else:
             missing.append(name)
     if missing:
-        raise HTTPException(404, f"file(s) not found: {', '.join(missing)}")
+        raise NotFoundError(
+            f"Some files are no longer available: {', '.join(missing)}",
+            code="task.output_files_missing", details={"files": missing},
+        )
     if not selected:
-        raise HTTPException(400, "empty files list")
+        raise ValidationError(
+            "No files selected", code="task.empty_selection", http_status=400,
+        )
     return task, selected, True
 
 
@@ -156,7 +172,7 @@ def list_task_outputs(task_id: int, request: Request) -> dict[str, Any]:
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task:
-        raise HTTPException(404)
+        raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
     out_dir = _task_output_dir(task)
     files: list[dict[str, Any]] = []
     if out_dir and out_dir.exists():
@@ -195,7 +211,9 @@ def download_task_outputs_zip(
     import tempfile
     wanted = [n for n in files.split(",") if n] if files else None
     if files is not None and not wanted:
-        raise HTTPException(400, "empty files list")
+        raise ValidationError(
+            "No files selected", code="task.empty_selection", http_status=400,
+        )
     task, selected, partial = _select_task_output_files(task_id, wanted)
     out_dir = _task_output_dir(task)
     assert out_dir is not None  # _select_task_output_files 已经校验
@@ -259,13 +277,19 @@ def download_task_output(task_id: int, filename: str) -> FileResponse:
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task:
-        raise HTTPException(404)
+        raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
     out_dir = _task_output_dir(task)
     if not out_dir or not out_dir.exists():
-        raise HTTPException(404, "no output dir")
+        raise NotFoundError(
+            "This task has no output files",
+            code="task.no_outputs", details={"task_id": task_id},
+        )
     f = _safe_output_relpath_or_400(out_dir, filename)
     if not f.exists() or not f.is_file():
-        raise HTTPException(404, "file not found")
+        raise NotFoundError(
+            f"Some files are no longer available: {filename}",
+            code="task.output_files_missing", details={"files": [filename]},
+        )
     return FileResponse(
         f,
         media_type="application/octet-stream",
@@ -284,7 +308,9 @@ def delete_task_output_files(
     任何一个不存在 → 404 拒绝整批，避免半删状态。
     """
     if not body.files:
-        raise HTTPException(400, "empty files list")
+        raise ValidationError(
+            "No files selected", code="task.empty_selection", http_status=400,
+        )
     task, selected, _ = _select_task_output_files(task_id, body.files)
     deleted: list[str] = []
     out_dir = _task_output_dir(task)
@@ -306,16 +332,20 @@ def open_task_folder(task_id: int, request: Request) -> dict[str, Any]:
     看不到，反而是远程命令执行入口；这里直接 403 拒绝。
     """
     if not _is_loopback(request):
-        raise HTTPException(
-            403, "open-folder is only available for local (loopback) requests"
+        raise ForbiddenError(
+            "Opening the folder is only available on the local machine",
+            code="system.open_folder_local_only",
         )
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
     if not task:
-        raise HTTPException(404)
+        raise NotFoundError("Task not found", code="task.not_found", details={"task_id": task_id})
     out_dir = _task_output_dir(task)
     if not out_dir or not out_dir.exists():
-        raise HTTPException(404, "no output dir")
+        raise NotFoundError(
+            "This task has no output files",
+            code="task.no_outputs", details={"task_id": task_id},
+        )
     try:
         import platform
         import subprocess as _sub

--- a/studio/api/routers/samples.py
+++ b/studio/api/routers/samples.py
@@ -10,12 +10,13 @@ import logging
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 from fastapi.responses import FileResponse
 
 from .. import errors as _errors
 from ..responses import _thumb_response
 from ... import db
+from ...domain.errors import NotFoundError
 from ...paths import OUTPUT_DIR, task_samples_dir
 
 router = APIRouter()
@@ -54,7 +55,7 @@ def get_sample(
                 (task_id,),
             ).fetchone()
         if not row or not row["monitor_state_path"]:
-            raise HTTPException(404)
+            raise NotFoundError("Sample image not found", code="sample.not_found")
         monitor_dir = Path(row["monitor_state_path"]).parent
         candidates = [
             # task-scoped 档案 —— 新 task 写在这（migration 之后唯一目标）
@@ -80,11 +81,11 @@ def get_sample(
                 "sample 404: task_id=%s file=%s tried=%s",
                 task_id, filename, [str(p) for p in candidates],
             )
-            raise HTTPException(404)
+            raise NotFoundError("Sample image not found", code="sample.not_found")
     else:
         path = OUTPUT_DIR / "samples" / filename
         if not path.exists():
-            raise HTTPException(404)
+            raise NotFoundError("Sample image not found", code="sample.not_found")
         resolved = path
 
     # w 给了走缩略图；w<=0 或没给 → 原图。复用 thumb_cache，盘上落 .jpg；

--- a/studio/api/routers/studio_data.py
+++ b/studio/api/routers/studio_data.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from ..schemas.studio_data import StudioDataMigrateRequest
+from ...domain.errors import ConflictError, ValidationError
 from ...infrastructure.paths import DEFAULT_STUDIO_DATA, STUDIO_DATA
 from ...services import studio_data as svc
 from .system import _check_no_running_tasks
@@ -43,9 +44,16 @@ def studio_data_migrate(body: StudioDataMigrateRequest) -> dict[str, Any]:
     try:
         svc.start_migration(Path(body.target))
     except ValueError as exc:
-        raise HTTPException(status_code=422, detail=str(exc)) from exc
+        raise ValidationError(
+            f"Invalid target location: {exc}",
+            code="studio_data.target_invalid",
+            details={"reason": str(exc)}, http_status=422,
+        ) from exc
     except RuntimeError as exc:
-        raise HTTPException(status_code=409, detail=str(exc)) from exc
+        raise ConflictError(
+            "A data migration is already in progress",
+            code="studio_data.migration_busy",
+        ) from exc
     return {"ok": True}
 
 

--- a/studio/api/routers/system.py
+++ b/studio/api/routers/system.py
@@ -32,10 +32,11 @@ import time
 from dataclasses import asdict
 from typing import Any
 
-from fastapi import APIRouter, BackgroundTasks, HTTPException
+from fastapi import APIRouter, BackgroundTasks
 
 from ..schemas.system import UpdateRequest
 from ... import db
+from ...domain.errors import ConflictError, DomainError, ValidationError
 from ...paths import REPO_ROOT
 from ...services import release_notes as release_notes_svc
 from ...services.runtime import updater
@@ -80,11 +81,10 @@ def _check_no_running_tasks() -> None:
     with db.connection_for() as conn:
         running = db.list_tasks(conn, status="running")
     if running:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "running_tasks_present",
-                "message": "有任务正在运行，请先取消 / 等待完成",
+        raise ValidationError(
+            "Tasks are running; cancel or wait for them to finish first",
+            code="system.tasks_running",
+            details={
                 "tasks": [
                     {
                         "id": t["id"],
@@ -94,6 +94,7 @@ def _check_no_running_tasks() -> None:
                     for t in running
                 ],
             },
+            http_status=422,
         )
 
 
@@ -125,7 +126,11 @@ def system_update_check(channel: str = "master", force: bool = False) -> dict[st
     dev 通道每次都 fetch，不缓存（开发者主动触发，避免污染 master 信号）。
     """
     if channel not in ("master", "dev"):
-        raise HTTPException(400, f"invalid channel: {channel}")
+        raise ValidationError(
+            f"Unsupported update channel: {channel}",
+            code="system.channel_invalid",
+            details={"channel": channel}, http_status=400,
+        )
     return asdict(updater.check_update(channel=channel, use_cache=not force))
 
 
@@ -140,12 +145,9 @@ def system_update(body: UpdateRequest, background: BackgroundTasks) -> dict[str,
 
     cur = updater.current_version()
     if cur.is_dirty:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "dirty_working_tree",
-                "message": "本地有未提交的修改，请先 commit / stash",
-            },
+        raise ValidationError(
+            "Local changes are uncommitted; commit or stash them before updating",
+            code="system.working_tree_dirty", http_status=422,
         )
 
     updater.request_update(body.target)
@@ -166,22 +168,16 @@ def system_rollback(background: BackgroundTasks) -> dict[str, Any]:
 
     cur = updater.current_version()
     if cur.is_dirty:
-        raise HTTPException(
-            status_code=422,
-            detail={
-                "error": "dirty_working_tree",
-                "message": "本地有未提交的修改，请先 commit / stash",
-            },
+        raise ValidationError(
+            "Local changes are uncommitted; commit or stash them before updating",
+            code="system.working_tree_dirty", http_status=422,
         )
 
     target = updater.request_rollback()
     if target is None:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "error": "no_rollback_target",
-                "message": ".last_version 不存在或 commit 已不在仓库里（被 GC？）",
-            },
+        raise ConflictError(
+            "No previous version is available to roll back to",
+            code="system.no_rollback_target",
         )
 
     background.add_task(_raise_sigint_after_response)
@@ -329,9 +325,10 @@ def system_init_git() -> dict[str, Any]:
 
     result = updater.bootstrap_git_repo()
     if not result.ok:
-        raise HTTPException(
-            status_code=500,
-            detail={"error": "bootstrap_failed", "message": result.error or "未知错误"},
+        raise DomainError(
+            f"Failed to initialize the Git repository: {result.error or 'unknown error'}",
+            code="system.git_init_failed",
+            details={"reason": result.error or "unknown error"}, http_status=500,
         )
 
     return {"ok": True, "already_initialized": False, **asdict(result)}

--- a/studio/api/routers/tag_dictionary.py
+++ b/studio/api/routers/tag_dictionary.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, File, HTTPException, UploadFile
+from fastapi import APIRouter, File, UploadFile
 from fastapi.responses import JSONResponse
 
+from ...domain.errors import DomainError, NotFoundError, ValidationError
 from ...infrastructure import tag_dictionary as td
 
 router = APIRouter()
@@ -28,7 +29,9 @@ def get_meta() -> dict[str, Any]:
 def get_data() -> JSONResponse:
     loaded = td.load_active()
     if loaded is None:
-        raise HTTPException(status_code=404, detail="tag dictionary not initialized")
+        raise NotFoundError(
+            "Tag dictionary is not loaded", code="tag.dictionary_not_loaded",
+        )
     entries, meta = loaded
     # `Cache-Control: public, max-age=300` 让浏览器 5 分钟内不重发；上传/reset 后
     # 后端没有 ETag，前端通过 meta.downloaded_at 比对决定是否强刷。
@@ -46,7 +49,11 @@ async def upload(file: UploadFile = File(...)) -> dict[str, Any]:
     try:
         meta = td.apply_uploaded(content, file.filename or "user-upload")
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        raise ValidationError(
+            f"Invalid tag dictionary file: {exc}",
+            code="tag.dictionary_upload_invalid",
+            details={"reason": str(exc)}, http_status=400,
+        ) from exc
     return {"loaded": True, "meta": meta}
 
 
@@ -55,5 +62,9 @@ def reset() -> dict[str, Any]:
     try:
         meta = td.reset_to_default()
     except RuntimeError as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+        raise DomainError(
+            f"Failed to download the default tag dictionary: {exc}",
+            code="tag.dictionary_download_failed",
+            details={"reason": str(exc)}, http_status=502,
+        ) from exc
     return {"loaded": True, "meta": meta}

--- a/studio/api/routers/tagger.py
+++ b/studio/api/routers/tagger.py
@@ -7,8 +7,9 @@ from __future__ import annotations
 
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
+from ...domain.errors import ValidationError
 from ...services.tagging.base import VALID_TAGGER_NAMES, get_tagger
 
 router = APIRouter()
@@ -17,7 +18,10 @@ router = APIRouter()
 @router.get("/api/tagger/{name}/check")
 def check_tagger(name: str) -> dict[str, Any]:
     if name not in VALID_TAGGER_NAMES:
-        raise HTTPException(400, f"unknown tagger: {name}")
+        raise ValidationError(
+            f'Unknown tagger: "{name}"',
+            code="tag.tagger_invalid", details={"name": name}, http_status=400,
+        )
     try:
         t = get_tagger(name)
     except Exception as exc:  # noqa: BLE001

--- a/studio/api/routers/upscalers.py
+++ b/studio/api/routers/upscalers.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter
 
 from ..schemas.models import UpscalerCustomDownloadRequest, UpscalerSelectRequest
 from ... import secrets
+from ...domain.errors import InvalidPathError, NotFoundError, ValidationError
 from ...services import models as model_downloader
 
 router = APIRouter()
@@ -27,17 +28,20 @@ def select_upscaler(body: UpscalerSelectRequest) -> dict[str, Any]:
     """
     label = body.label.strip()
     if not label:
-        raise HTTPException(400, "label 不能为空")
+        raise ValidationError(
+            "Upscaler name is required", code="upscaler.label_required", http_status=400,
+        )
     valid = label in model_downloader.UPSCALER_VARIANTS
     if not valid:
         # custom 文件名：必须已经在磁盘上
         try:
             target = model_downloader.upscaler_target(label)
         except ValueError as exc:
-            raise HTTPException(400, str(exc)) from exc
+            raise InvalidPathError("Invalid path", details={"reason": str(exc)}) from exc
         if not target.exists():
-            raise HTTPException(
-                404, f"放大器不存在: {label}（既非预设也未在 upscalers/ 找到）"
+            raise NotFoundError(
+                f'Upscaler "{label}" not found',
+                code="upscaler.not_found", details={"name": label},
             )
     cur = secrets.load()
     new_models = cur.models.model_copy(update={"selected_upscaler": label})
@@ -56,14 +60,22 @@ def start_upscaler_custom_download(
     过滤 + catalog 状态匹配。
     """
     if body.source not in ("hf", "ms"):
-        raise HTTPException(400, f"未知下载源: {body.source}")
+        raise ValidationError(
+            f"Unsupported download source: {body.source}",
+            code="upscaler.download_source_invalid",
+            details={"source": body.source}, http_status=400,
+        )
     if not body.repo_id.strip() or not body.filename.strip():
-        raise HTTPException(400, "repo_id / filename 不能为空")
+        raise ValidationError(
+            "Repository ID and file name are required",
+            code="upscaler.download_fields_required", http_status=400,
+        )
     save_name = Path(body.filename).name
     if not save_name.lower().endswith(model_downloader.UPSCALER_EXTS):
-        raise HTTPException(
-            400,
-            f"仅支持 {model_downloader.UPSCALER_EXTS} 扩展名",
+        _exts = " / ".join(model_downloader.UPSCALER_EXTS)
+        raise ValidationError(
+            f"Select a {_exts} file",
+            code="file.ext_invalid", details={"types": _exts}, http_status=400,
         )
     key = f"upscaler:custom:{save_name}"
     model_downloader.start_download_async(

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -65,7 +65,7 @@ class BundleOptions:
     include_config: bool = False
 
 
-from studio.domain.errors import DomainError
+from studio.domain.errors import DomainError, NotFoundError
 
 
 class TrainIOError(DomainError):
@@ -91,14 +91,22 @@ def export_train(
     """
     v = versions.get_version(conn, version_id)
     if not v:
-        raise TrainIOError(f"版本不存在: id={version_id}")
+        raise NotFoundError(
+            "Version not found", code="version.not_found",
+            details={"id": version_id},
+        )
     p = projects.get_project(conn, v["project_id"])
     if not p:
-        raise TrainIOError(f"项目不存在: id={v['project_id']}")
+        raise NotFoundError(
+            "Project not found", code="project.not_found",
+            details={"id": v["project_id"]},
+        )
 
     train_dir = versions.version_dir(p["id"], p["slug"], v["label"]) / "train"
     if not train_dir.exists():
-        raise TrainIOError("train/ 目录不存在")
+        raise TrainIOError(
+            "No images to export", code="dataset.export_empty", http_status=400,
+        )
 
     concepts: list[dict[str, Any]] = []
     image_count = 0
@@ -127,7 +135,9 @@ def export_train(
             image_count += cnt
 
     if image_count == 0:
-        raise TrainIOError("train/ 下无图片，无可导出内容")
+        raise TrainIOError(
+            "No images to export", code="dataset.export_empty", http_status=400,
+        )
 
     manifest = {
         "schema_version": SCHEMA_VERSION,
@@ -186,9 +196,16 @@ def _read_manifest(zf: zipfile.ZipFile) -> dict[str, Any]:
         with zf.open(MANIFEST_NAME) as fh:
             return json.loads(fh.read().decode("utf-8"))
     except KeyError as exc:
-        raise TrainIOError("zip 缺少 manifest.json") from exc
+        raise TrainIOError(
+            "Import file is invalid: missing manifest",
+            code="dataset.import_invalid", http_status=400,
+        ) from exc
     except (json.JSONDecodeError, UnicodeDecodeError) as exc:
-        raise TrainIOError(f"manifest.json 解析失败: {exc}") from exc
+        raise TrainIOError(
+            f"Import file is invalid: {exc}",
+            code="dataset.import_invalid",
+            details={"reason": str(exc)}, http_status=400,
+        ) from exc
 
 
 def _resolve_slug_conflict(
@@ -218,7 +235,9 @@ def import_train(
     返回 {"project": {...}, "version": {...}, "stats": {...}}。
     """
     if not zip_path.exists():
-        raise TrainIOError(f"zip 不存在: {zip_path}")
+        raise NotFoundError(
+            "File not found", code="file.not_found", http_status=404,
+        )
 
     try:
         with zipfile.ZipFile(zip_path, "r") as zf:
@@ -237,12 +256,16 @@ def import_train(
                 inner = _safe_arc(info.filename)
                 if inner is None:
                     raise TrainIOError(
-                        f"非法路径: {info.filename!r}（仅允许 train/{{folder}}/{{file}}）"
+                        "Import file contains an invalid path",
+                        code="dataset.import_invalid", http_status=400,
                     )
                 entries.append((info, inner))
 
             if not entries:
-                raise TrainIOError("zip 中无可导入内容")
+                raise TrainIOError(
+                    "Import file contains nothing to import",
+                    code="dataset.import_empty", http_status=400,
+                )
 
             # 建 project + v1（用 DAO，自动建目录树）
             slug = _resolve_slug_conflict(conn, base_slug)
@@ -260,11 +283,18 @@ def import_train(
                 folder, filename = inner.split("/", 1)
                 # 文件名再保险一层 + containment check
                 if filename.startswith("."):
-                    raise TrainIOError(f"非法文件名: {filename!r}")
+                    raise TrainIOError(
+                        "Import file contains an invalid filename",
+                        code="dataset.import_invalid", http_status=400,
+                    )
                 try:
                     target = safe_join(train_dir, folder, filename)
                 except ValueError as exc:
-                    raise TrainIOError(f"非法文件名: {filename!r} ({exc})") from exc
+                    raise TrainIOError(
+                        "Import file contains an invalid filename",
+                        code="dataset.import_invalid",
+                        details={"reason": str(exc)}, http_status=400,
+                    ) from exc
                 target.parent.mkdir(parents=True, exist_ok=True)
                 seen_folders.add(folder)
                 with zf.open(info) as src, target.open("wb") as dst:
@@ -293,7 +323,10 @@ def import_train(
             assert v is not None and p is not None
 
     except zipfile.BadZipFile as exc:
-        raise TrainIOError(f"zip 损坏: {exc}") from exc
+        raise TrainIOError(
+            "Import file is corrupt", code="dataset.import_corrupt",
+            http_status=400,
+        ) from exc
 
     stats = {
         "image_count": image_count,
@@ -402,14 +435,24 @@ def export_bundle(
     返回 {"manifest": {...}, "size_bytes": int}。
     """
     if not opts.train and not opts.reg and not opts.include_config:
-        raise TrainIOError("至少选择一项导出内容（训练集 / 正则集 / 训练配置）")
+        raise TrainIOError(
+            "Select at least one item to export (training set, regularization "
+            "set, or training configuration)",
+            code="dataset.export_nothing_selected", http_status=400,
+        )
 
     v = versions.get_version(conn, version_id)
     if not v:
-        raise TrainIOError(f"版本不存在: id={version_id}")
+        raise NotFoundError(
+            "Version not found", code="version.not_found",
+            details={"id": version_id},
+        )
     p = projects.get_project(conn, v["project_id"])
     if not p:
-        raise TrainIOError(f"项目不存在: id={v['project_id']}")
+        raise NotFoundError(
+            "Project not found", code="project.not_found",
+            details={"id": v["project_id"]},
+        )
 
     vdir = versions.version_dir(p["id"], p["slug"], v["label"])
     payload: list[tuple[Path, str]] = []
@@ -420,7 +463,10 @@ def export_bundle(
     if opts.train:
         tp, train_stats = _collect_train(vdir / "train", opts.train_captions)
         if not tp:
-            raise TrainIOError("train/ 下无图片，无可导出内容")
+            raise TrainIOError(
+                "No images to export", code="dataset.export_empty",
+                http_status=400,
+            )
         payload.extend(tp)
 
     # --- reg section ---
@@ -570,7 +616,9 @@ def import_bundle(
     返回 {"project": {...}, "version": {...}, "stats": {...}}。
     """
     if not zip_path.exists():
-        raise TrainIOError(f"zip 不存在: {zip_path}")
+        raise NotFoundError(
+            "File not found", code="file.not_found", http_status=404,
+        )
 
     try:
         with zipfile.ZipFile(zip_path, "r") as zf:
@@ -596,11 +644,15 @@ def import_bundle(
                     inner = _safe_arc(info.filename)
                     if inner is None:
                         raise TrainIOError(
-                            f"非法路径: {info.filename!r}（仅允许 train/{{folder}}/{{file}}）"
+                            "Import file contains an invalid path",
+                            code="dataset.import_invalid", http_status=400,
                         )
                     entries_v1.append((info, inner))
                 if not entries_v1:
-                    raise TrainIOError("zip 中无可导入内容")
+                    raise TrainIOError(
+                        "Import file contains nothing to import",
+                        code="dataset.import_empty", http_status=400,
+                    )
 
                 slug = _resolve_slug_conflict(conn, base_slug)
                 p = projects.create_project(conn, title=title, slug=slug,
@@ -613,7 +665,10 @@ def import_bundle(
                 for info, inner in entries_v1:
                     folder, filename = inner.split("/", 1)
                     if filename.startswith("."):
-                        raise TrainIOError(f"非法文件名: {filename!r}")
+                        raise TrainIOError(
+                            "Import file contains an invalid filename",
+                            code="dataset.import_invalid", http_status=400,
+                        )
                     target = safe_join(train_dir, folder, filename)
                     target.parent.mkdir(parents=True, exist_ok=True)
                     seen_folders.add(folder)
@@ -647,7 +702,10 @@ def import_bundle(
                     continue
                 result = _safe_arc_bundle(info.filename)
                 if result is None:
-                    raise TrainIOError(f"非法路径: {info.filename!r}")
+                    raise TrainIOError(
+                        "Import file contains an invalid path",
+                        code="dataset.import_invalid", http_status=400,
+                    )
                 section, inner = result
                 if section == "train":
                     train_entries.append((info, inner))
@@ -657,7 +715,10 @@ def import_bundle(
                     preset_entries.append((info, inner))
 
             if not train_entries and not reg_entries and not preset_entries:
-                raise TrainIOError("bundle 中无可导入内容")
+                raise TrainIOError(
+                    "Import file contains nothing to import",
+                    code="dataset.import_empty", http_status=400,
+                )
 
             slug = _resolve_slug_conflict(conn, base_slug)
             p = projects.create_project(conn, title=title, slug=slug,
@@ -672,7 +733,10 @@ def import_bundle(
                 for info, inner in train_entries:
                     folder, filename = inner.split("/", 1)
                     if filename.startswith("."):
-                        raise TrainIOError(f"非法文件名: {filename!r}")
+                        raise TrainIOError(
+                            "Import file contains an invalid filename",
+                            code="dataset.import_invalid", http_status=400,
+                        )
                     target = safe_join(train_dir, folder, filename)
                     target.parent.mkdir(parents=True, exist_ok=True)
                     seen_train.add(folder)
@@ -690,10 +754,16 @@ def import_bundle(
                     else:
                         parts = inner.split("/", 1)
                         if len(parts) != 2:
-                            raise TrainIOError(f"非法 reg 路径: {inner!r}")
+                            raise TrainIOError(
+                                "Import file contains an invalid path",
+                                code="dataset.import_invalid", http_status=400,
+                            )
                         folder, filename = parts
                         if filename.startswith("."):
-                            raise TrainIOError(f"非法文件名: {filename!r}")
+                            raise TrainIOError(
+                                "Import file contains an invalid filename",
+                                code="dataset.import_invalid", http_status=400,
+                            )
                         target = safe_join(reg_dir, folder, filename)
                         target.parent.mkdir(parents=True, exist_ok=True)
                         if target.suffix.lower() in IMAGE_EXTS:
@@ -770,7 +840,10 @@ def import_bundle(
             assert v is not None and p is not None
 
     except zipfile.BadZipFile as exc:
-        raise TrainIOError(f"zip 损坏: {exc}") from exc
+        raise TrainIOError(
+            "Import file is corrupt", code="dataset.import_corrupt",
+            http_status=400,
+        ) from exc
 
     return {
         "project": p,

--- a/studio/services/dataset/browse.py
+++ b/studio/services/dataset/browse.py
@@ -11,7 +11,13 @@ from typing import Any
 from ...paths import REPO_ROOT
 
 
-from studio.domain.errors import DomainError
+from studio.domain.errors import (
+    DomainError,
+    ForbiddenError,
+    InvalidPathError,
+    NotFoundError,
+    ValidationError,
+)
 
 
 class BrowseError(DomainError):
@@ -33,7 +39,7 @@ def list_dir(target: Path, *, allow_outside_repo: bool = False) -> dict[str, Any
         try:
             target.relative_to(REPO_ROOT.resolve())
         except ValueError:
-            raise BrowseError(f"path outside repo: {target}")
+            raise InvalidPathError("Invalid path")
 
     selected: str | None = None
     if target.exists() and not target.is_dir():
@@ -41,9 +47,12 @@ def list_dir(target: Path, *, allow_outside_repo: bool = False) -> dict[str, Any
         target = target.parent
 
     if not target.exists():
-        raise BrowseError(f"path does not exist: {target}")
+        raise NotFoundError("Path not found", code="path.not_found")
     if not target.is_dir():
-        raise BrowseError(f"not a directory: {target}")
+        raise ValidationError(
+            "Path is not a directory",
+            code="path.not_a_directory", http_status=400,
+        )
 
     entries: list[dict[str, Any]] = []
     try:
@@ -57,7 +66,9 @@ def list_dir(target: Path, *, allow_outside_repo: bool = False) -> dict[str, Any
                 "type": "dir" if is_dir else "file",
             })
     except PermissionError:
-        raise BrowseError(f"permission denied: {target}")
+        raise ForbiddenError(
+            "Permission denied", code="path.permission_denied",
+        )
 
     parent = target.parent.as_posix() if target.parent != target else None
     return {

--- a/studio/services/dataset/curation.py
+++ b/studio/services/dataset/curation.py
@@ -51,19 +51,26 @@ class CurationError(DomainError):
 def _validate_folder(name: str) -> None:
     if not _FOLDER_PATTERN.fullmatch(name):
         raise CurationError(
-            f"非法文件夹名: {name!r}（Kohya 风格 N_xxx 或纯字母数字）"
+            f'Invalid folder name: "{name}"',
+            code="curation.folder_name_invalid", details={"name": name},
         )
 
 
 def _validate_filename(name: str) -> None:
     if not _FILE_PATTERN.fullmatch(name) or ".." in name:
-        raise CurationError(f"非法文件名: {name!r}")
+        raise CurationError(
+            f'Invalid file name: "{name}"',
+            code="curation.file_name_invalid", details={"name": name},
+        )
 
 
 def _project_dir(conn, project_id: int) -> tuple[dict[str, Any], Path]:
     p = projects.get_project(conn, project_id)
     if not p:
-        raise CurationError(f"项目不存在: id={project_id}")
+        raise CurationError(
+            "Project not found", code="project.not_found",
+            details={"id": project_id}, http_status=404,
+        )
     return p, projects.project_dir(p["id"], p["slug"])
 
 
@@ -72,10 +79,16 @@ def _version_train_dir(conn, project_id: int, version_id: int) -> tuple[
 ]:
     p = projects.get_project(conn, project_id)
     if not p:
-        raise CurationError(f"项目不存在: id={project_id}")
+        raise CurationError(
+            "Project not found", code="project.not_found",
+            details={"id": project_id}, http_status=404,
+        )
     v = versions.get_version(conn, version_id)
     if not v or v["project_id"] != project_id:
-        raise CurationError(f"版本不存在: id={version_id}")
+        raise CurationError(
+            "Version not found", code="version.not_found",
+            details={"id": version_id}, http_status=404,
+        )
     train_dir = versions.version_dir(p["id"], p["slug"], v["label"]) / "train"
     return p, v, train_dir
 
@@ -377,7 +390,10 @@ def create_folder(conn, project_id: int, version_id: int, name: str) -> Path:
     _, _, train = _version_train_dir(conn, project_id, version_id)
     target = train / name
     if target.exists():
-        raise CurationError(f"文件夹已存在: {name}")
+        raise CurationError(
+            f'Folder "{name}" already exists',
+            code="curation.folder_exists", details={"name": name},
+        )
     target.mkdir(parents=True, exist_ok=False)
     return target
 
@@ -393,9 +409,16 @@ def rename_folder(
     src = train / name
     dst = train / new_name
     if not src.exists():
-        raise CurationError(f"文件夹不存在: {name}")
+        raise CurationError(
+            f'Folder "{name}" not found',
+            code="curation.folder_not_found", details={"name": name},
+            http_status=404,
+        )
     if dst.exists():
-        raise CurationError(f"目标已存在: {new_name}")
+        raise CurationError(
+            f'Folder "{new_name}" already exists',
+            code="curation.folder_exists", details={"name": new_name},
+        )
     src.rename(dst)
     return dst
 
@@ -406,7 +429,11 @@ def delete_folder(conn, project_id: int, version_id: int, name: str) -> None:
     _, _, train = _version_train_dir(conn, project_id, version_id)
     target = train / name
     if not target.exists():
-        raise CurationError(f"文件夹不存在: {name}")
+        raise CurationError(
+            f'Folder "{name}" not found',
+            code="curation.folder_not_found", details={"name": name},
+            http_status=404,
+        )
     shutil.rmtree(target)
 
 

--- a/studio/services/preprocess/core.py
+++ b/studio/services/preprocess/core.py
@@ -55,7 +55,7 @@ PRODUCT_SUFFIX = ".png"
 MIN_CROP_NORM = 0.02
 
 
-from studio.domain.errors import DomainError
+from studio.domain.errors import DomainError, InvalidPathError, NotFoundError, ValidationError
 
 
 class PreprocessError(DomainError):
@@ -113,7 +113,7 @@ _SAFE_NAME_FORBIDDEN = ("/", "\\", "..")
 
 def _validate_name(name: str) -> None:
     if not name or any(t in name for t in _SAFE_NAME_FORBIDDEN):
-        raise PreprocessError(f"非法文件名: {name!r}")
+        raise InvalidPathError("Invalid path", details={"name": name})
 
 
 def _validate_rel_name(name: str) -> None:
@@ -122,12 +122,12 @@ def _validate_rel_name(name: str) -> None:
     严格 2 段 + 拒 `..` / 反斜杠 / 绝对路径 / 空段，防 path traversal。
     """
     if not name:
-        raise PreprocessError(f"非法 rel name: {name!r}")
+        raise InvalidPathError("Invalid path", details={"name": name})
     if "\\" in name or name.startswith("/"):
-        raise PreprocessError(f"非法 rel name: {name!r}")
+        raise InvalidPathError("Invalid path", details={"name": name})
     parts = name.split("/")
     if len(parts) != 2 or not parts[0] or not parts[1] or ".." in parts:
-        raise PreprocessError(f"非法 rel name（要求 folder/image）: {name!r}")
+        raise InvalidPathError("Invalid path", details={"name": name})
 
 
 def _validate_rect(rect: dict[str, Any]) -> dict[str, float]:
@@ -138,15 +138,19 @@ def _validate_rect(rect: dict[str, Any]) -> dict[str, float]:
         w = float(rect["w"])
         h = float(rect["h"])
     except (KeyError, TypeError, ValueError) as exc:
-        raise PreprocessError(f"裁剪 rect 缺字段或类型错: {rect!r}") from exc
+        raise ValidationError(
+            "Invalid crop region",
+            code="preprocess.crop_rect_invalid", http_status=400,
+        ) from exc
     # clamp 到 [0,1]，但保留 w/h 下限校验
     x = max(0.0, min(1.0, x))
     y = max(0.0, min(1.0, y))
     w = max(0.0, min(1.0 - x, w))
     h = max(0.0, min(1.0 - y, h))
     if w < MIN_CROP_NORM or h < MIN_CROP_NORM:
-        raise PreprocessError(
-            f"裁剪框过小（最小 {MIN_CROP_NORM}）: {rect!r}"
+        raise ValidationError(
+            "Crop region is too small",
+            code="preprocess.crop_too_small", http_status=400,
         )
     return {"x": x, "y": y, "w": w, "h": h}
 
@@ -318,14 +322,20 @@ def resolve_targets_train(
         return sorted(existing)
     if mode == "selected":
         if not names:
-            raise PreprocessError("mode=selected 时 names 不能为空")
+            raise ValidationError(
+                "No images selected",
+                code="preprocess.selection_empty", http_status=400,
+            )
         chosen: list[str] = []
         for n in names:
             _validate_rel_name(n)
             if n in existing:
                 chosen.append(n)
         return sorted(set(chosen))
-    raise PreprocessError(f"未知 mode: {mode!r}")
+    raise ValidationError(
+        f"Invalid preprocess mode: {mode}",
+        code="preprocess.mode_invalid", details={"mode": mode}, http_status=400,
+    )
 
 
 def start_job_train(
@@ -345,11 +355,20 @@ def start_job_train(
     """
     p = projects.get_project(conn, project_id)
     if not p:
-        raise PreprocessError(f"项目不存在: id={project_id}")
+        raise NotFoundError(
+            "Project not found",
+            code="project.not_found", details={"id": project_id},
+        )
     if mode not in ("all", "selected", "all_force"):
-        raise PreprocessError(f"未知 mode: {mode!r}")
+        raise ValidationError(
+            f"Invalid preprocess mode: {mode}",
+            code="preprocess.mode_invalid", details={"mode": mode}, http_status=400,
+        )
     if mode == "selected" and not names:
-        raise PreprocessError("mode=selected 必须给 names")
+        raise ValidationError(
+            "No images selected",
+            code="preprocess.selection_empty", http_status=400,
+        )
     if names:
         for n in names:
             _validate_rel_name(n)
@@ -384,18 +403,32 @@ def start_crop_job_train(
     """train scope crop job。`crops` 的源文件名为 `train/` 下当前文件名。"""
     p = projects.get_project(conn, project_id)
     if not p:
-        raise PreprocessError(f"项目不存在: id={project_id}")
+        raise NotFoundError(
+            "Project not found",
+            code="project.not_found", details={"id": project_id},
+        )
     if not isinstance(crops, dict) or not crops:
-        raise PreprocessError("crops 不能为空")
+        raise ValidationError(
+            "No crop regions provided",
+            code="preprocess.crops_required", http_status=400,
+        )
     sanitized: dict[str, list[dict[str, Any]]] = {}
     for name, rects in crops.items():
         _validate_rel_name(name)
         if not isinstance(rects, list) or not rects:
-            raise PreprocessError(f"{name!r} 的 rects 为空")
+            raise ValidationError(
+                "Invalid crop region",
+                code="preprocess.crop_rect_invalid",
+                details={"name": name}, http_status=400,
+            )
         out_rects: list[dict[str, Any]] = []
         for r in rects:
             if not isinstance(r, dict):
-                raise PreprocessError(f"{name!r} 含非法 rect: {r!r}")
+                raise ValidationError(
+                    "Invalid crop region",
+                    code="preprocess.crop_rect_invalid",
+                    details={"name": name}, http_status=400,
+                )
             clean = _validate_rect(r)
             label = r.get("label")
             if label is not None:

--- a/studio/services/preprocess/duplicates.py
+++ b/studio/services/preprocess/duplicates.py
@@ -86,7 +86,7 @@ DEFAULT_CROP_EARLY_ACCEPT_SCORE = 0.88
 MatchScope = Literal["strict", "both"]
 
 
-from studio.domain.errors import DomainError
+from studio.domain.errors import DomainError, InvalidPathError, NotFoundError, ValidationError
 
 
 class DuplicateFinderError(DomainError):
@@ -255,7 +255,9 @@ class UnionFind:
 def _require_imagehash() -> None:
     if imagehash is None:
         raise DuplicateFinderError(
-            "ImageHash is not installed. Please install imagehash>=4.3.0."
+            "Duplicate detection requires the imagehash package, "
+            "which is not installed",
+            code="duplicate.not_installed", http_status=422,
         ) from _IMAGEHASH_IMPORT_ERROR
 
 
@@ -272,20 +274,34 @@ def parse_tile_grids(value: str | list[int] | tuple[int, ...]) -> tuple[int, ...
         try:
             grid = int(part)
         except ValueError as exc:
-            raise DuplicateFinderError(f"invalid tile grid: {part}") from exc
+            raise DuplicateFinderError(
+                f"Invalid tile grid value: {part}",
+                code="duplicate.tile_grid_invalid",
+                details={"value": part}, http_status=400,
+            ) from exc
         if grid < 2 or grid > 12:
-            raise DuplicateFinderError("tile grids must be between 2 and 12")
+            raise DuplicateFinderError(
+                "Tile grid must be between 2 and 12",
+                code="duplicate.tile_grid_out_of_range", http_status=400,
+            )
         if grid not in grids:
             grids.append(grid)
     if not grids:
-        raise DuplicateFinderError("at least one tile grid is required")
+        raise DuplicateFinderError(
+            "At least one tile grid is required",
+            code="duplicate.tile_grid_required", http_status=400,
+        )
     return tuple(grids)
 
 
 def options_from_payload(payload: dict[str, Any]) -> DuplicateOptions:
     match_scope = payload.get("match_scope", "both")
     if match_scope not in ("strict", "both"):
-        raise DuplicateFinderError(f"invalid match scope: {match_scope!r}")
+        raise DuplicateFinderError(
+            f"Invalid match scope: {match_scope}",
+            code="duplicate.match_scope_invalid",
+            details={"value": match_scope}, http_status=400,
+        )
     return DuplicateOptions(
         match_scope=match_scope,
         hash_size=max(0, int(payload.get("hash_size", DEFAULT_HASH_SIZE))),
@@ -363,8 +379,9 @@ def _resolve_train_sources(
 
     version = ver.get_version(conn, version_id)
     if not version or version["project_id"] != project_id:
-        raise DuplicateFinderError(
-            f"version not found / mismatch: id={version_id}"
+        raise NotFoundError(
+            "Version not found",
+            code="version.not_found", details={"id": version_id},
         )
     label = version["label"]
     train_dir = project_dir / "versions" / label / "train"
@@ -485,23 +502,25 @@ def apply_train_duplicate_removals(
 
     project = projects.get_project(conn, project_id)
     if not project:
-        raise DuplicateFinderError(f"project not found: id={project_id}")
+        raise NotFoundError(
+            "Project not found",
+            code="project.not_found", details={"id": project_id},
+        )
     version = ver.get_version(conn, version_id)
     if not version or version["project_id"] != project_id:
-        raise DuplicateFinderError(
-            f"version not found / mismatch: id={version_id}"
+        raise NotFoundError(
+            "Version not found",
+            code="version.not_found", details={"id": version_id},
         )
 
     project_dir = projects.project_dir(project["id"], project["slug"])
     # 校验 rel path 形式（跟 core._validate_rel_name 一致：两段、无 ..）
     for raw_name in names:
         if not raw_name or "\\" in raw_name or raw_name.startswith("/"):
-            raise DuplicateFinderError(f"非法 rel name: {raw_name!r}")
+            raise InvalidPathError("Invalid path", details={"name": raw_name})
         parts = raw_name.split("/")
         if len(parts) != 2 or not parts[0] or not parts[1] or ".." in parts:
-            raise DuplicateFinderError(
-                f"非法 rel name（要求 folder/image）: {raw_name!r}"
-            )
+            raise InvalidPathError("Invalid path", details={"name": raw_name})
     return preprocess_manifest.train_mark_duplicate_removed(
         project_dir, version["label"], names,
     )

--- a/studio/services/presets/__init__.py
+++ b/studio/services/presets/__init__.py
@@ -85,6 +85,11 @@ def save_version_config_as_preset(
 
     target_path = presets_io._preset_path(target_preset_name)  # 校验名字合法
     if target_path.exists() and not overwrite:
-        raise presets_io.PresetError(f"预设已存在: {target_preset_name}")
+        raise presets_io.PresetError(
+            f'Preset "{target_preset_name}" already exists',
+            code="preset.exists",
+            details={"name": target_preset_name},
+            http_status=409,
+        )
     presets_io.write_preset(target_preset_name, cleaned)
     return presets_io.read_preset(target_preset_name)

--- a/studio/services/presets/io.py
+++ b/studio/services/presets/io.py
@@ -76,7 +76,12 @@ def _absolutize_model_paths(data: dict[str, Any]) -> dict[str, Any]:
 
 def _validate_name(name: str) -> None:
     if not NAME_PATTERN.fullmatch(name):
-        raise PresetError(f"非法预设名: {name!r}（只允许字母/数字/下划线/连字符）")
+        raise PresetError(
+            f'Invalid preset name "{name}"; use letters, digits, underscore, or hyphen',
+            code="preset.name_invalid",
+            details={"name": name},
+            http_status=400,
+        )
 
 
 def _preset_path(name: str, base: Path | None = None) -> Path:
@@ -98,13 +103,27 @@ def parse_preset_bytes(raw: bytes, filename: str) -> tuple[dict[str, Any], str]:
     try:
         text = raw.decode("utf-8")
     except UnicodeDecodeError as exc:
-        raise PresetError(f"文件不是 UTF-8: {exc}") from exc
+        raise PresetError(
+            "Preset file is not valid UTF-8",
+            code="preset.invalid",
+            details={"reason": str(exc)},
+            http_status=400,
+        ) from exc
     try:
         data = yaml.safe_load(text) or {}
     except yaml.YAMLError as exc:
-        raise PresetError(f"YAML/JSON 解析失败: {exc}") from exc
+        raise PresetError(
+            f"Preset file could not be parsed: {exc}",
+            code="preset.invalid",
+            details={"reason": str(exc)},
+            http_status=400,
+        ) from exc
     if not isinstance(data, dict):
-        raise PresetError("预设格式错误（顶层不是 mapping）")
+        raise PresetError(
+            "Preset file format is invalid",
+            code="preset.invalid",
+            http_status=400,
+        )
     cfg, _, _ = _tolerant_validate(data)
     stem = re.sub(r"\.(ya?ml|json)$", "", filename, flags=re.I)
     suggested = re.sub(r"[^A-Za-z0-9_-]+", "-", stem).strip("-") or "imported"
@@ -171,7 +190,12 @@ def _tolerant_validate(raw: dict[str, Any]) -> tuple[TrainingConfig, list[str], 
                     data["infonoise_enabled"] = False
                     defaulted.append("infonoise_enabled")
                     continue
-                raise PresetError(f"预设校验失败: {exc}") from exc
+                raise PresetError(
+                    f"Preset validation failed: {exc}",
+                    code="preset.invalid",
+                    details={"reason": str(exc)},
+                    http_status=400,
+                ) from exc
             for f in bad_fields:
                 data[f] = getattr(defaults, f)
                 defaulted.append(str(f))
@@ -184,10 +208,20 @@ def read_preset(name: str, base: Path | None = None) -> dict[str, Any]:
     """读取并容错校验预设。未知字段丢弃，非法值回退默认。"""
     path = _preset_path(name, base)
     if not path.exists():
-        raise PresetError(f"预设不存在: {name}")
+        raise PresetError(
+            f'Preset "{name}" not found',
+            code="preset.not_found",
+            details={"name": name},
+            http_status=404,
+        )
     raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     if not isinstance(raw, dict):
-        raise PresetError(f"预设格式错误（顶层不是 mapping）: {name}")
+        raise PresetError(
+            "Preset file format is invalid",
+            code="preset.invalid",
+            details={"name": name},
+            http_status=400,
+        )
     cfg, _, _ = _tolerant_validate(raw)
     return _absolutize_model_paths(cfg.model_dump(mode="python"))
 
@@ -197,10 +231,20 @@ def read_preset_with_warnings(
 ) -> tuple[dict[str, Any], list[str], list[str]]:
     path = _preset_path(name, base)
     if not path.exists():
-        raise PresetError(f"预设不存在: {name}")
+        raise PresetError(
+            f'Preset "{name}" not found',
+            code="preset.not_found",
+            details={"name": name},
+            http_status=404,
+        )
     raw = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     if not isinstance(raw, dict):
-        raise PresetError(f"预设格式错误（顶层不是 mapping）: {name}")
+        raise PresetError(
+            "Preset file format is invalid",
+            code="preset.invalid",
+            details={"name": name},
+            http_status=400,
+        )
     cfg, dropped, defaulted = _tolerant_validate(raw)
     return _absolutize_model_paths(cfg.model_dump(mode="python")), dropped, defaulted
 
@@ -215,7 +259,12 @@ def write_preset(name: str, data: dict[str, Any], base: Path | None = None) -> P
     try:
         cfg = TrainingConfig.model_validate(data)
     except ValidationError as exc:
-        raise PresetError(f"预设校验失败: {exc}") from exc
+        raise PresetError(
+            f"Preset validation failed: {exc}",
+            code="preset.invalid",
+            details={"reason": str(exc)},
+            http_status=400,
+        ) from exc
     dumped = _absolutize_model_paths(cfg.model_dump(mode="python"))
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -228,7 +277,12 @@ def write_preset(name: str, data: dict[str, Any], base: Path | None = None) -> P
 def delete_preset(name: str, base: Path | None = None) -> None:
     path = _preset_path(name, base)
     if not path.exists():
-        raise PresetError(f"预设不存在: {name}")
+        raise PresetError(
+            f'Preset "{name}" not found',
+            code="preset.not_found",
+            details={"name": name},
+            http_status=404,
+        )
     path.unlink()
 
 
@@ -236,8 +290,18 @@ def duplicate_preset(src: str, dst: str, base: Path | None = None) -> Path:
     src_path = _preset_path(src, base)
     dst_path = _preset_path(dst, base)
     if not src_path.exists():
-        raise PresetError(f"源预设不存在: {src}")
+        raise PresetError(
+            f'Source preset "{src}" not found',
+            code="preset.not_found",
+            details={"name": src},
+            http_status=404,
+        )
     if dst_path.exists():
-        raise PresetError(f"目标已存在: {dst}")
+        raise PresetError(
+            f'Preset "{dst}" already exists',
+            code="preset.exists",
+            details={"name": dst},
+            http_status=409,
+        )
     dst_path.write_bytes(src_path.read_bytes())
     return dst_path

--- a/studio/services/projects/projects.py
+++ b/studio/services/projects/projects.py
@@ -97,7 +97,9 @@ def create_project(
 ) -> dict[str, Any]:
     title = (title or "").strip()
     if not title:
-        raise ProjectError("title 不能为空")
+        raise ProjectError(
+            "Project title is required", code="project.title_required",
+        )
     base_slug = slug or slugify(title)
     final_slug = _unique_slug(conn, base_slug)
     now = time.time()
@@ -129,7 +131,10 @@ def get_project(
 def _must_get(conn: sqlite3.Connection, project_id: int) -> dict[str, Any]:
     p = get_project(conn, project_id)
     if not p:
-        raise ProjectError(f"项目不存在: id={project_id}")
+        raise ProjectError(
+            "Project not found", code="project.not_found",
+            details={"id": project_id}, http_status=404,
+        )
     return p
 
 

--- a/studio/services/projects/versions.py
+++ b/studio/services/projects/versions.py
@@ -401,7 +401,10 @@ def get_version(
 def _must_get(conn: sqlite3.Connection, version_id: int) -> dict[str, Any]:
     v = get_version(conn, version_id)
     if not v:
-        raise VersionError(f"版本不存在: id={version_id}")
+        raise VersionError(
+            "Version not found", code="version.not_found",
+            details={"id": version_id}, http_status=404,
+        )
     return v
 
 
@@ -438,24 +441,36 @@ def create_version(
     """
     p = projects.get_project(conn, project_id)
     if not p:
-        raise VersionError(f"项目不存在: id={project_id}")
+        raise VersionError(
+            "Project not found", code="project.not_found",
+            details={"id": project_id}, http_status=404,
+        )
     if not _VALID_LABEL.fullmatch(label):
         raise VersionError(
-            f"非法 label: {label!r}（仅允许字母/数字/下划线/连字符/点）"
+            f'Invalid version label "{label}"; use letters, digits, '
+            "underscore, hyphen, or dot",
+            code="version.label_invalid", details={"name": label},
+            http_status=400,
         )
     # 唯一性
     if conn.execute(
         "SELECT 1 FROM versions WHERE project_id = ? AND label = ?",
         (project_id, label),
     ).fetchone():
-        raise VersionError(f"label 已存在: {label!r}")
+        raise VersionError(
+            f'Version label "{label}" already exists',
+            code="version.label_exists", details={"name": label},
+            http_status=400,
+        )
 
     src_config_name: Optional[str] = None
     if fork_from_version_id is not None:
         src = get_version(conn, fork_from_version_id)
         if not src or src["project_id"] != project_id:
             raise VersionError(
-                f"fork 源不存在或不属于当前项目: id={fork_from_version_id}"
+                "The version to copy from was not found in this project",
+                code="version.fork_source_invalid",
+                details={"id": fork_from_version_id}, http_status=404,
             )
         src_config_name = src["config_name"]
 

--- a/studio/services/tagging/caption_snapshot.py
+++ b/studio/services/tagging/caption_snapshot.py
@@ -19,7 +19,7 @@ CAPTION_EXTS = (".txt", ".json")
 SNAPSHOT_DIRNAME = "caption_snapshots"
 
 
-from studio.domain.errors import DomainError
+from studio.domain.errors import DomainError, NotFoundError
 
 
 class SnapshotError(DomainError):
@@ -75,7 +75,10 @@ def create_snapshot(version_dir: Path) -> dict[str, Any]:
         suffix += 1
         zip_path = out_dir / f"{sid}_{suffix}.zip"
         if suffix > 9:
-            raise SnapshotError("snapshot id 冲突过多")
+            raise SnapshotError(
+                "Could not allocate a snapshot id; please retry",
+                code="snapshot.id_collision",
+            )
 
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
         for arcname, src in _iter_caption_files(train_dir):
@@ -101,13 +104,24 @@ def _resolve_snapshot(version_dir: Path, sid: str) -> Path:
     try:
         validate_path_component(sid)
     except ValueError as exc:
-        raise SnapshotError(f"非法 id: {sid} ({exc})") from exc
+        raise SnapshotError(
+            "Invalid snapshot id",
+            code="snapshot.invalid", details={"id": sid, "reason": str(exc)},
+            http_status=400,
+        ) from exc
     try:
         p = safe_join(snapshot_root(version_dir), f"{sid}.zip")
     except ValueError as exc:
-        raise SnapshotError(f"非法 id: {sid} ({exc})") from exc
+        raise SnapshotError(
+            "Invalid snapshot id",
+            code="snapshot.invalid", details={"id": sid, "reason": str(exc)},
+            http_status=400,
+        ) from exc
     if not p.exists():
-        raise FileNotFoundError(f"snapshot not found: {sid}")
+        raise NotFoundError(
+            "Snapshot not found",
+            code="snapshot.not_found", details={"id": sid},
+        )
     return p
 
 

--- a/studio/services/version_config.py
+++ b/studio/services/version_config.py
@@ -122,11 +122,15 @@ def read_version_config_with_warnings(
     p = version_config_path(project, version)
     if not p.exists():
         raise VersionConfigError(
-            f"版本未配置训练参数: project={project['id']} version={version['label']}"
+            "Training configuration is not set for this version",
+            code="version.config_missing",
         )
     raw = yaml.safe_load(p.read_text(encoding="utf-8")) or {}
     if not isinstance(raw, dict):
-        raise VersionConfigError("config.yaml 顶层不是 mapping")
+        raise VersionConfigError(
+            "Training configuration is invalid",
+            code="version.config_invalid",
+        )
     cfg, dropped, defaulted = _tolerant_validate(raw)
     return _absolutize_model_paths(cfg.model_dump(mode="python")), dropped, defaulted
 
@@ -179,10 +183,14 @@ def get_project_and_version(
     from ..services.projects import versions as _versions
     p = _projects.get_project(conn, project_id)
     if not p:
-        raise VersionConfigError(f"项目不存在: id={project_id}")
+        raise VersionConfigError(
+            "Project not found", code="project.not_found",
+            details={"id": project_id}, http_status=404,
+        )
     v = _versions.get_version(conn, version_id)
     if not v or v["project_id"] != project_id:
         raise VersionConfigError(
-            f"版本不存在或不属当前项目: id={version_id}"
+            "Version not found", code="version.not_found",
+            details={"id": version_id}, http_status=404,
         )
     return p, v

--- a/studio/web/src/api/client.test.ts
+++ b/studio/web/src/api/client.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { makeApiError } from './client'
+
+// ADR-0009 Phase 2：makeApiError 统一把后端错误信封解析成 ApiError。
+// 测试 locale = zh（setup.ts），故本地化断言用中文。
+describe('makeApiError', () => {
+  it('body.error.code → errors.<code> i18n 本地化 + details 插值', () => {
+    const e = makeApiError(404, 'Not Found', {
+      detail: 'Preset "foo" not found',
+      error: { code: 'preset.not_found', message: 'Preset "foo" not found', details: { name: 'foo' }, trace_id: 'abc123' },
+    })
+    expect(e.message).toBe('预设「foo」不存在')
+    expect(e.code).toBe('preset.not_found')
+    expect(e.traceId).toBe('abc123')
+    expect(e.status).toBe(404)
+  })
+
+  it('未知 code → 回退 error.message（defaultValue）', () => {
+    const e = makeApiError(400, 'Bad Request', {
+      detail: 'something specific',
+      error: { code: 'http.400', message: 'something specific', trace_id: 't1' },
+    })
+    expect(e.message).toBe('something specific')
+    expect(e.code).toBe('http.400')
+  })
+
+  it('无 error 信封、detail 为 string → 用 detail 作文案（老路径 fallback）', () => {
+    const e = makeApiError(400, 'Bad Request', { detail: 'legacy message' })
+    expect(e.message).toBe('legacy message')
+    expect(e.code).toBeUndefined()
+  })
+
+  it('结构化 detail（409 冲突）→ 挂到 err.detail 给 callsite', () => {
+    const e = makeApiError(409, 'Conflict', {
+      detail: { message: 'exists', config: { a: 1 }, suggested_name: 'foo-2' },
+      error: { code: 'preset.exists', message: 'Preset "foo" already exists', details: { name: 'foo' }, trace_id: 't2' },
+    })
+    expect(e.message).toBe('预设「foo」已存在')
+    expect(e.detail).toEqual({ message: 'exists', config: { a: 1 }, suggested_name: 'foo-2' })
+  })
+
+  it('非 JSON body（null）→ statusText 兜底 + header trace', () => {
+    const e = makeApiError(500, 'Internal Server Error', null, 'hdr-trace')
+    expect(e.message).toBe('500 Internal Server Error')
+    expect(e.traceId).toBe('hdr-trace')
+  })
+})

--- a/studio/web/src/api/client.test.ts
+++ b/studio/web/src/api/client.test.ts
@@ -30,13 +30,18 @@ describe('makeApiError', () => {
     expect(e.code).toBeUndefined()
   })
 
-  it('结构化 detail（409 冲突）→ 挂到 err.detail 给 callsite', () => {
+  it('结构化数据在 error.details（409 冲突）→ 挂到 err.detail 给 callsite', () => {
     const e = makeApiError(409, 'Conflict', {
-      detail: { message: 'exists', config: { a: 1 }, suggested_name: 'foo-2' },
-      error: { code: 'preset.exists', message: 'Preset "foo" already exists', details: { name: 'foo' }, trace_id: 't2' },
+      detail: 'Preset "foo" already exists',
+      error: {
+        code: 'preset.exists',
+        message: 'Preset "foo" already exists',
+        details: { name: 'foo', config: { a: 1 }, suggested_name: 'foo-2' },
+        trace_id: 't2',
+      },
     })
     expect(e.message).toBe('预设「foo」已存在')
-    expect(e.detail).toEqual({ message: 'exists', config: { a: 1 }, suggested_name: 'foo-2' })
+    expect(e.detail).toEqual({ name: 'foo', config: { a: 1 }, suggested_name: 'foo-2' })
   })
 
   it('非 JSON body（null）→ statusText 兜底 + header trace', () => {

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -5,6 +5,7 @@
 // window.onerror 上报时带上（让开发者在 server log 能 join "前端崩前最后一次
 // API 失败" 跟 "用户实际看到的 toast"）。
 import { setLastApiTraceId } from '../lib/errors/report'
+import i18n from '../i18n'
 
 export interface HealthResponse {
   status: string
@@ -1449,8 +1450,68 @@ export interface ImportResult {
  */
 export type ApiError = Error & {
   status?: number
+  /** ADR-0009 Phase 2: 后端 body.error.code（语义错误码），前端按它查 errors.* i18n。 */
+  code?: string
   detail?: unknown
   traceId?: string
+}
+
+/**
+ * ADR-0009 Phase 2 统一错误解析：所有 fetch / XHR 失败路径共用，保证 toast 文案
+ * 一致且可本地化。
+ *
+ * 优先 `body.error`：用 `error.code` 查 `errors.<code>` i18n（带 `error.details`
+ * 插值，缺词条则回退 `error.message` 英文）。`body.detail` 退为 fallback —— 结构化
+ * detail（如 409 冲突的 config/suggested_name）仍挂到 `err.detail` 给 callsite；
+ * 没有 error 信封时（RequestValidationError 422 list / 极老路径）才用 detail 取文案。
+ */
+export function makeApiError(
+  status: number,
+  statusText: string,
+  body: unknown,
+  headerTraceId?: string | null,
+): ApiError {
+  let message = `${status} ${statusText}`
+  let code: string | undefined
+  let detail: unknown = null
+  let traceId: string | undefined
+  const b = body as {
+    detail?: unknown
+    error?: { code?: unknown; message?: unknown; trace_id?: unknown; details?: unknown }
+  } | null | undefined
+  const err = b?.error
+  if (err && typeof err === 'object') {
+    code = typeof err.code === 'string' ? err.code : undefined
+    const enMsg =
+      typeof err.message === 'string' && err.message ? err.message : message
+    const params =
+      err.details && typeof err.details === 'object'
+        ? (err.details as Record<string, unknown>)
+        : {}
+    message = code ? i18n.t(`errors.${code}`, { ...params, defaultValue: enMsg }) : enMsg
+    if (typeof err.trace_id === 'string') traceId = err.trace_id
+  }
+  if (b && b.detail !== undefined) {
+    if (!err) {
+      if (typeof b.detail === 'string') {
+        message = b.detail
+      } else if (b.detail && typeof b.detail === 'object') {
+        detail = b.detail
+        const dm = (b.detail as { message?: unknown }).message
+        if (typeof dm === 'string') message = dm
+      }
+    } else if (b.detail && typeof b.detail === 'object') {
+      detail = b.detail
+    }
+  }
+  if (!traceId && headerTraceId) traceId = headerTraceId
+  if (traceId) setLastApiTraceId(traceId)
+  const e = new Error(message) as ApiError
+  e.status = status
+  e.code = code
+  e.detail = detail
+  e.traceId = traceId
+  return e
 }
 
 /**
@@ -1480,39 +1541,8 @@ async function req<T>(
     ...init,
   })
   if (!resp.ok) {
-    let detail = `${resp.status} ${resp.statusText}`
-    let rawDetail: unknown = null
-    let traceId: string | undefined
-    try {
-      const body = await resp.json()
-      if (typeof body?.detail === 'string') {
-        detail = body.detail
-      } else if (body?.detail && typeof body.detail === 'object') {
-        rawDetail = body.detail
-        // 结构化 detail：取 .message 作为可读字符串；callsite 想拿完整结构走 e.detail
-        detail = (body.detail as { message?: string }).message ?? JSON.stringify(body.detail)
-      }
-      // ADR-0009 dual-write envelope: body.error.trace_id 优先
-      const errStruct = (body as { error?: { trace_id?: string } } | undefined)?.error
-      if (errStruct?.trace_id) {
-        traceId = errStruct.trace_id
-      }
-    } catch {
-      // body 不是 JSON / 解析失败：保持 statusText 默认
-    }
-    // header 兜底（DomainError dual-write 路径或 HTTPException 路径都有）
-    if (!traceId) {
-      traceId = resp.headers.get('X-Trace-Id') ?? undefined
-    }
-    if (traceId) {
-      // 写入 atom 给 ErrorBoundary / window.onerror 上报时附带
-      setLastApiTraceId(traceId)
-    }
-    const err = new Error(detail) as ApiError
-    err.status = resp.status
-    err.detail = rawDetail
-    err.traceId = traceId
-    throw err
+    const body = await resp.json().catch(() => null)
+    throw makeApiError(resp.status, resp.statusText, body, resp.headers.get('X-Trace-Id'))
   }
   if (resp.status === 204) return undefined as T
   return (await resp.json()) as T
@@ -1558,33 +1588,15 @@ async function xhrUpload<T>(
         }
         return
       }
-      let detail = `${xhr.status} ${xhr.statusText}`
-      let rawDetail: unknown = null
-      let traceId: string | undefined
+      let parsed: unknown = null
       try {
-        const j = JSON.parse(text)
-        if (typeof j?.detail === 'string') {
-          detail = j.detail
-        } else if (j?.detail && typeof j.detail === 'object') {
-          rawDetail = j.detail
-          detail = (j.detail as { message?: string }).message ?? JSON.stringify(j.detail)
-        }
-        // ADR-0009 PR-3 C3: dual-write envelope body.error.trace_id
-        const errStruct = (j as { error?: { trace_id?: string } })?.error
-        if (errStruct?.trace_id) traceId = errStruct.trace_id
+        parsed = JSON.parse(text)
       } catch {
-        /* body 不是 JSON：保持 statusText */
+        /* body 不是 JSON：makeApiError 用 statusText 兜底 */
       }
-      // header 兜底
-      if (!traceId) {
-        traceId = xhr.getResponseHeader('X-Trace-Id') ?? undefined
-      }
-      if (traceId) setLastApiTraceId(traceId)
-      const err = new Error(detail) as ApiError
-      err.status = xhr.status
-      err.detail = rawDetail
-      err.traceId = traceId
-      reject(err)
+      reject(
+        makeApiError(xhr.status, xhr.statusText, parsed, xhr.getResponseHeader('X-Trace-Id')),
+      )
     }
     xhr.onerror = () => reject(new Error('network error'))
     xhr.send(body)
@@ -1677,21 +1689,8 @@ export const api = {
     fd.append('file', file, file.name)
     const resp = await fetch('/api/presets/import', { method: 'POST', body: fd })
     if (!resp.ok) {
-      let message = `${resp.status} ${resp.statusText}`
-      let rawDetail: unknown = null
-      try {
-        const body = await resp.json()
-        if (typeof body?.detail === 'string') {
-          message = body.detail
-        } else if (body?.detail && typeof body.detail === 'object') {
-          rawDetail = body.detail
-          message = (body.detail as { message?: string }).message ?? JSON.stringify(body.detail)
-        }
-      } catch { /* body 非 JSON,保留 statusText */ }
-      const err = new Error(message) as ApiError
-      err.status = resp.status
-      err.detail = rawDetail
-      throw err
+      const body = await resp.json().catch(() => null)
+      throw makeApiError(resp.status, resp.statusText, body, resp.headers.get('X-Trace-Id'))
     }
     return (await resp.json()) as { name: string; path: string }
   },
@@ -1729,20 +1728,8 @@ export const api = {
     fd.append('file', file, file.name)
     const resp = await fetch('/api/tag-dictionary/upload', { method: 'POST', body: fd })
     if (!resp.ok) {
-      let message = `${resp.status} ${resp.statusText}`
-      let rawDetail: unknown = null
-      try {
-        const body = await resp.json()
-        if (typeof body?.detail === 'string') message = body.detail
-        else if (body?.detail && typeof body.detail === 'object') {
-          rawDetail = body.detail
-          message = (body.detail as { message?: string }).message ?? JSON.stringify(body.detail)
-        }
-      } catch { /* 非 JSON，保留 statusText */ }
-      const err = new Error(message) as ApiError
-      err.status = resp.status
-      err.detail = rawDetail
-      throw err
+      const body = await resp.json().catch(() => null)
+      throw makeApiError(resp.status, resp.statusText, body, resp.headers.get('X-Trace-Id'))
     }
     return (await resp.json()) as TagDictionaryMetaResponse
   },

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1490,6 +1490,9 @@ export function makeApiError(
         : {}
     message = code ? i18n.t(`errors.${code}`, { ...params, defaultValue: enMsg }) : enMsg
     if (typeof err.trace_id === 'string') traceId = err.trace_id
+    // 结构化数据现在挂在 error.details（如 409 冲突的 config/suggested_name、
+    // running_tasks 列表），callsite 经 err.detail 读到。
+    if (err.details && typeof err.details === 'object') detail = err.details
   }
   if (b && b.detail !== undefined) {
     if (!err) {
@@ -1500,7 +1503,7 @@ export function makeApiError(
         const dm = (b.detail as { message?: unknown }).message
         if (typeof dm === 'string') message = dm
       }
-    } else if (b.detail && typeof b.detail === 'object') {
+    } else if (detail === null && b.detail && typeof b.detail === 'object') {
       detail = b.detail
     }
   }

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -2366,5 +2366,181 @@
         "description": "4x-AnimeSharp — upscales training images during preprocessing"
       }
     }
+  },
+  "errors": {
+    "path": {
+      "invalid": "Invalid path",
+      "not_found": "Path not found",
+      "not_a_file": "Selected path is not a file",
+      "not_a_directory": "Path is not a directory",
+      "permission_denied": "Permission denied"
+    },
+    "file": {
+      "not_found": "File \"{{filename}}\" not found",
+      "required": "Select a file",
+      "ext_invalid": "Select a {{types}} file"
+    },
+    "image": {
+      "not_found": "Image not found"
+    },
+    "project": {
+      "not_found": "Project not found",
+      "title_required": "Project title is required"
+    },
+    "version": {
+      "not_found": "Version not found",
+      "label_invalid": "Invalid version label \"{{name}}\"; use letters, digits, underscore, hyphen, or dot",
+      "label_exists": "Version label \"{{name}}\" already exists",
+      "fork_source_invalid": "The version to copy from was not found in this project",
+      "config_missing": "Training configuration is not set for this version",
+      "config_invalid": "Training configuration is invalid: {{reason}}",
+      "has_active_task": "This version already has a running task; wait for it to finish or cancel it"
+    },
+    "preset": {
+      "not_found": "Preset \"{{name}}\" not found",
+      "exists": "Preset \"{{name}}\" already exists",
+      "name_invalid": "Invalid preset name \"{{name}}\"; use letters, digits, underscore, or hyphen",
+      "invalid": "Preset file is invalid: {{reason}}"
+    },
+    "dataset": {
+      "no_files": "No files uploaded",
+      "export_empty": "No images to export",
+      "export_nothing_selected": "Select at least one item to export (training set, regularization set, or training configuration)",
+      "import_invalid": "Import file is invalid: {{reason}}",
+      "import_empty": "Import file contains nothing to import",
+      "import_corrupt": "Import file is corrupt",
+      "delete_failed": "Failed to delete \"{{name}}\": {{reason}}",
+      "thumbnail_not_found": "Thumbnail not found",
+      "image_set_invalid": "Unsupported image set"
+    },
+    "download": {
+      "source_unsupported": "Unsupported image source: {{source}}",
+      "tag_required": "Tag is required",
+      "credentials_missing": "No {{source}} credentials configured; add them on the Settings page",
+      "count_invalid": "Download count must be at least 1"
+    },
+    "preprocess": {
+      "mode_invalid": "Invalid preprocess mode: {{mode}}",
+      "tile_size_invalid": "Tile size must be greater than 0",
+      "device_invalid": "Invalid device: {{device}}",
+      "target_area_out_of_range": "Target area is out of range: {{value}}",
+      "crops_required": "No crop regions provided",
+      "crop_rect_invalid": "Invalid crop region",
+      "crop_too_small": "Crop region is too small",
+      "selection_empty": "No images selected"
+    },
+    "upscaler": {
+      "not_found": "Upscaler \"{{name}}\" not found",
+      "not_downloaded": "Upscaler weights for \"{{name}}\" are not downloaded; download them under Settings → Preprocess",
+      "label_required": "Upscaler name is required",
+      "download_source_invalid": "Unsupported download source: {{source}}",
+      "download_fields_required": "Repository ID and file name are required"
+    },
+    "curation": {
+      "folder_name_invalid": "Invalid folder name: \"{{name}}\"",
+      "file_name_invalid": "Invalid file name: \"{{name}}\"",
+      "folder_exists": "Folder \"{{name}}\" already exists",
+      "folder_not_found": "Folder \"{{name}}\" not found",
+      "new_name_required": "A new name is required to rename a folder",
+      "op_invalid": "Unknown folder operation: {{op}}"
+    },
+    "duplicate": {
+      "not_installed": "Duplicate detection requires the imagehash package, which is not installed",
+      "tile_grid_invalid": "Invalid tile grid value: {{value}}",
+      "tile_grid_out_of_range": "Tile grid must be between 2 and 12",
+      "tile_grid_required": "At least one tile grid is required",
+      "match_scope_invalid": "Invalid match scope: {{value}}"
+    },
+    "tag": {
+      "tagger_invalid": "Unknown tagger: \"{{name}}\"",
+      "output_format_invalid": "Output format must be txt or json",
+      "on_existing_invalid": "On-existing mode must be overwrite, skip, or append",
+      "replace_args_required": "Replace requires both the old and new tag",
+      "op_invalid": "Unknown operation: \"{{op}}\"",
+      "dictionary_not_loaded": "Tag dictionary is not loaded",
+      "dictionary_upload_invalid": "Invalid tag dictionary file: {{reason}}",
+      "dictionary_download_failed": "Failed to download the default tag dictionary: {{reason}}"
+    },
+    "reg": {
+      "not_found": "Regularization set not found",
+      "paths_empty": "No files selected",
+      "api_source_invalid": "Image source must be Gelbooru or Danbooru",
+      "postprocess_method_invalid": "Postprocess method must be smart, stretch, or crop",
+      "crop_ratio_out_of_range": "Max crop ratio must be between 0.05 and 0.5",
+      "aspect_ratio_invalid": "Min aspect ratio must be less than max aspect ratio, and both must be greater than 0",
+      "auto_tag_kind_invalid": "Auto-tag mode must be one of: {{allowed}}",
+      "build_mode_invalid": "Build mode must be mirror or flat",
+      "target_count_invalid": "Target count must be greater than 0 or empty"
+    },
+    "train": {
+      "no_images": "Add images to the training set first"
+    },
+    "snapshot": {
+      "not_found": "Snapshot not found",
+      "invalid": "Invalid snapshot id",
+      "id_collision": "Could not allocate a snapshot id; please retry"
+    },
+    "task": {
+      "not_found": "Task not found",
+      "already_finished": "This task has already finished",
+      "cancel_rejected": "Cannot cancel this task in its current state",
+      "pause_rejected": "Cannot pause this task right now",
+      "not_resumable": "This task cannot be resumed",
+      "resume_state_missing": "The saved training state is missing; start a new run instead",
+      "not_retryable": "Only finished tasks can be retried",
+      "not_deletable": "Only finished tasks can be deleted",
+      "no_outputs": "This task has no output files",
+      "output_files_missing": "Some files are no longer available: {{files}}",
+      "empty_selection": "No files selected",
+      "snapshot_not_found": "No saved configuration for this task"
+    },
+    "sample": {
+      "not_found": "Sample image not found"
+    },
+    "queue": {
+      "status_filter_invalid": "Unsupported status filter: {{status}}",
+      "export_ids_invalid": "The selected task IDs are not valid",
+      "import_invalid": "Could not import the queue: {{reason}}"
+    },
+    "job": {
+      "not_found": "Job not found",
+      "already_finished": "This job has already finished",
+      "cancel_rejected": "Cannot cancel this job in its current state"
+    },
+    "generate": {
+      "daemon_busy": "Inference service is busy; try again after the current task finishes",
+      "params_invalid": "Image parameters are not valid JSON",
+      "mode_invalid": "Unsupported mode: {{mode}}",
+      "save_disabled": "Saving test images is disabled",
+      "empty_image": "The uploaded image is empty",
+      "preview_model_download_failed": "Failed to download the preview model; check the server log"
+    },
+    "model": {
+      "invalid": "Invalid model selection: {{reason}}"
+    },
+    "install": {
+      "target_invalid": "Unsupported runtime target"
+    },
+    "llm_tagger": {
+      "base_url_required": "API base URL is required",
+      "connect_failed": "Could not reach the model service: {{reason}}",
+      "model_required": "A model must be selected"
+    },
+    "system": {
+      "starting": "The service is still starting; try again in a moment",
+      "tasks_running": "Tasks are running; cancel or wait for them to finish first",
+      "channel_invalid": "Unsupported update channel: {{channel}}",
+      "working_tree_dirty": "Local changes are uncommitted; commit or stash them before updating",
+      "no_rollback_target": "No previous version is available to roll back to",
+      "git_init_failed": "Failed to initialize the Git repository: {{reason}}",
+      "open_folder_local_only": "Opening the folder is only available on the local machine"
+    },
+    "studio_data": {
+      "target_invalid": "Invalid target location: {{reason}}",
+      "migration_busy": "A data migration is already in progress"
+    },
+    "export": {
+      "name_conflict": "Too many files named \"{{name}}\"; rename and try again"
+    }
   }
 }

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -2366,5 +2366,181 @@
         "description": "4x-AnimeSharp,预处理时把训练图放大"
       }
     }
+  },
+  "errors": {
+    "path": {
+      "invalid": "路径无效",
+      "not_found": "路径不存在",
+      "not_a_file": "所选路径不是文件",
+      "not_a_directory": "路径不是目录",
+      "permission_denied": "没有访问该路径的权限"
+    },
+    "file": {
+      "not_found": "文件「{{filename}}」不存在",
+      "required": "请选择文件",
+      "ext_invalid": "请选择 {{types}} 文件"
+    },
+    "image": {
+      "not_found": "图片不存在"
+    },
+    "project": {
+      "not_found": "项目不存在",
+      "title_required": "项目标题不能为空"
+    },
+    "version": {
+      "not_found": "版本不存在",
+      "label_invalid": "版本标签「{{name}}」格式无效，仅允许字母、数字、下划线、连字符与点",
+      "label_exists": "版本标签「{{name}}」已存在",
+      "fork_source_invalid": "找不到要复制的源版本，或它不属于当前项目",
+      "config_missing": "该版本尚未配置训练参数",
+      "config_invalid": "训练配置无效：{{reason}}",
+      "has_active_task": "该版本已有正在进行的任务，请等其完成或取消"
+    },
+    "preset": {
+      "not_found": "预设「{{name}}」不存在",
+      "exists": "预设「{{name}}」已存在",
+      "name_invalid": "预设名「{{name}}」格式无效，仅允许字母、数字、下划线与连字符",
+      "invalid": "预设文件无效：{{reason}}"
+    },
+    "dataset": {
+      "no_files": "没有上传文件",
+      "export_empty": "没有可导出的内容",
+      "export_nothing_selected": "请至少选择一项导出内容（训练集、正则集或训练配置）",
+      "import_invalid": "导入文件无效：{{reason}}",
+      "import_empty": "导入文件中没有可导入的内容",
+      "import_corrupt": "导入文件已损坏",
+      "delete_failed": "删除「{{name}}」失败：{{reason}}",
+      "thumbnail_not_found": "缩略图不存在",
+      "image_set_invalid": "不支持的图片集"
+    },
+    "download": {
+      "source_unsupported": "不支持的图源：{{source}}",
+      "tag_required": "标签不能为空",
+      "credentials_missing": "未配置 {{source}} 凭据，请先在「设置」页填写",
+      "count_invalid": "下载数量至少为 1"
+    },
+    "preprocess": {
+      "mode_invalid": "预处理模式无效：{{mode}}",
+      "tile_size_invalid": "分块尺寸必须大于 0",
+      "device_invalid": "设备无效：{{device}}",
+      "target_area_out_of_range": "目标面积超出范围：{{value}}",
+      "crops_required": "裁剪区域不能为空",
+      "crop_rect_invalid": "裁剪区域无效",
+      "crop_too_small": "裁剪区域过小",
+      "selection_empty": "未选择图片"
+    },
+    "upscaler": {
+      "not_found": "放大模型「{{name}}」不存在",
+      "not_downloaded": "放大模型「{{name}}」权重未下载，请先在「设置 → 预处理」下载",
+      "label_required": "请填写放大模型名称",
+      "download_source_invalid": "不支持的下载源：{{source}}",
+      "download_fields_required": "请填写仓库 ID 和文件名"
+    },
+    "curation": {
+      "folder_name_invalid": "文件夹名称无效：「{{name}}」",
+      "file_name_invalid": "文件名无效：「{{name}}」",
+      "folder_exists": "文件夹「{{name}}」已存在",
+      "folder_not_found": "文件夹「{{name}}」不存在",
+      "new_name_required": "重命名文件夹需要填写新名称",
+      "op_invalid": "未知的文件夹操作：{{op}}"
+    },
+    "duplicate": {
+      "not_installed": "去重功能依赖 imagehash 组件，但尚未安装",
+      "tile_grid_invalid": "分块网格值无效：{{value}}",
+      "tile_grid_out_of_range": "分块网格必须在 2 到 12 之间",
+      "tile_grid_required": "至少需要一个分块网格",
+      "match_scope_invalid": "匹配范围无效：{{value}}"
+    },
+    "tag": {
+      "tagger_invalid": "打标器「{{name}}」不支持",
+      "output_format_invalid": "输出格式必须为 txt 或 json",
+      "on_existing_invalid": "已有标签处理方式必须为覆盖、跳过或追加",
+      "replace_args_required": "替换操作需要同时填写原标签和新标签",
+      "op_invalid": "不支持的操作：「{{op}}」",
+      "dictionary_not_loaded": "标签词典尚未加载",
+      "dictionary_upload_invalid": "标签词典文件无效：{{reason}}",
+      "dictionary_download_failed": "默认标签词典下载失败：{{reason}}"
+    },
+    "reg": {
+      "not_found": "正则集不存在",
+      "paths_empty": "未选择任何文件",
+      "api_source_invalid": "图源必须为 Gelbooru 或 Danbooru",
+      "postprocess_method_invalid": "后处理方式必须为 smart、stretch 或 crop",
+      "crop_ratio_out_of_range": "最大裁剪比例必须在 0.05 到 0.5 之间",
+      "aspect_ratio_invalid": "最小宽高比必须小于最大宽高比，且两者均大于 0",
+      "auto_tag_kind_invalid": "自动打标方式必须为以下之一：{{allowed}}",
+      "build_mode_invalid": "构建方式必须为 mirror 或 flat",
+      "target_count_invalid": "目标数量必须大于 0 或留空"
+    },
+    "train": {
+      "no_images": "训练集还没有图片，请先下载或筛选"
+    },
+    "snapshot": {
+      "not_found": "快照不存在",
+      "invalid": "快照标识无效",
+      "id_collision": "无法分配快照编号，请重试"
+    },
+    "task": {
+      "not_found": "任务不存在",
+      "already_finished": "该任务已结束",
+      "cancel_rejected": "当前状态下无法取消该任务",
+      "pause_rejected": "当前无法暂停该任务",
+      "not_resumable": "该任务无法继续训练",
+      "resume_state_missing": "恢复点已丢失，请重新发起训练",
+      "not_retryable": "仅已结束的任务可重试",
+      "not_deletable": "仅已结束的任务可删除",
+      "no_outputs": "该任务没有输出文件",
+      "output_files_missing": "部分文件已不存在：{{files}}",
+      "empty_selection": "未选择任何文件",
+      "snapshot_not_found": "该任务没有关联配置"
+    },
+    "sample": {
+      "not_found": "采样图不存在"
+    },
+    "queue": {
+      "status_filter_invalid": "不支持的状态筛选：{{status}}",
+      "export_ids_invalid": "所选任务编号无效",
+      "import_invalid": "队列导入失败：{{reason}}"
+    },
+    "job": {
+      "not_found": "任务不存在",
+      "already_finished": "该任务已结束",
+      "cancel_rejected": "当前状态下无法取消该任务"
+    },
+    "generate": {
+      "daemon_busy": "推理服务忙，请在当前任务结束后重试",
+      "params_invalid": "图片参数不是合法 JSON",
+      "mode_invalid": "不支持的模式：{{mode}}",
+      "save_disabled": "测试出图落盘已关闭",
+      "empty_image": "上传的图片为空",
+      "preview_model_download_failed": "预览模型下载失败，请查看服务端日志"
+    },
+    "model": {
+      "invalid": "模型选择无效：{{reason}}"
+    },
+    "install": {
+      "target_invalid": "不支持的运行时目标"
+    },
+    "llm_tagger": {
+      "base_url_required": "请填写 API 地址",
+      "connect_failed": "无法连接模型服务：{{reason}}",
+      "model_required": "请选择模型"
+    },
+    "system": {
+      "starting": "服务正在启动，请稍后重试",
+      "tasks_running": "有任务正在运行，请先取消或等待完成",
+      "channel_invalid": "不支持的更新通道：{{channel}}",
+      "working_tree_dirty": "本地有未提交的修改，请先提交或暂存",
+      "no_rollback_target": "没有可回滚的上一版本",
+      "git_init_failed": "初始化 Git 仓库失败：{{reason}}",
+      "open_folder_local_only": "仅本机访问时可打开文件夹"
+    },
+    "studio_data": {
+      "target_invalid": "目标位置无效：{{reason}}",
+      "migration_busy": "数据迁移已在进行中"
+    },
+    "export": {
+      "name_conflict": "导出文件名「{{name}}」冲突过多，请重命名后重试"
+    }
   }
 }

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -3470,15 +3470,15 @@ function VersionSection() {
 
   // 公用的 422 / 其它错误分流（update 和 rollback 都用）
   const _formatActionError = (e: unknown, action: string): string => {
-    const err = e as Error & { status?: number; detail?: { error?: string; tasks?: { name: string; id?: number }[] } }
-    if (err.status === 422 && err.detail?.error === 'running_tasks_present') {
-      const names = (err.detail.tasks ?? []).map((task) => task.name || `task#${task.id ?? '?'}`).join(', ')
+    const err = e as Error & { status?: number; code?: string; detail?: { tasks?: { name: string; id?: number }[] } }
+    if (err.code === 'system.tasks_running') {
+      const names = (err.detail?.tasks ?? []).map((task) => task.name || `task#${task.id ?? '?'}`).join(', ')
       return t('settings.taskRunningCancelFirst', { names })
     }
-    if (err.status === 422 && err.detail?.error === 'dirty_working_tree') {
+    if (err.code === 'system.working_tree_dirty') {
       return t('settings.dirtyWorkingTree')
     }
-    if (err.status === 409 && err.detail?.error === 'no_rollback_target') {
+    if (err.code === 'system.no_rollback_target') {
       return t('settings.noRollbackTarget')
     }
     return t('settings.triggerActionFailed', { action, error: err.message ?? String(e) })
@@ -4766,9 +4766,9 @@ function StorageSection() {
     try {
       await api.restartServer()
     } catch (e) {
-      const err = e as Error & { status?: number; detail?: { error?: string; tasks?: { name: string; id?: number }[] } }
-      if (err.status === 422 && err.detail?.error === 'running_tasks_present') {
-        const names = (err.detail.tasks ?? []).map((task) => task.name || `task#${task.id ?? '?'}`).join(', ')
+      const err = e as Error & { status?: number; code?: string; detail?: { tasks?: { name: string; id?: number }[] } }
+      if (err.code === 'system.tasks_running') {
+        const names = (err.detail?.tasks ?? []).map((task) => task.name || `task#${task.id ?? '?'}`).join(', ')
         toast(t('settings.taskRunningCancelFirst', { names }), 'error')
       } else {
         toast(t('settings.restartTriggerFailed', { error: err.message ?? String(e) }), 'error')
@@ -4850,9 +4850,9 @@ function ServiceSection() {
     try {
       await api.restartServer()
     } catch (e) {
-      const err = e as Error & { status?: number; detail?: { error?: string; tasks?: { name: string; id?: number }[] } }
-      if (err.status === 422 && err.detail?.error === 'running_tasks_present') {
-        const names = (err.detail.tasks ?? []).map((task) => task.name || `task#${task.id ?? '?'}`).join(', ')
+      const err = e as Error & { status?: number; code?: string; detail?: { tasks?: { name: string; id?: number }[] } }
+      if (err.code === 'system.tasks_running') {
+        const names = (err.detail?.tasks ?? []).map((task) => task.name || `task#${task.id ?? '?'}`).join(', ')
         toast(t('settings.taskRunningCancelFirst', { names }), 'error')
       } else {
         toast(t('settings.restartTriggerFailed', { error: err.message ?? String(e) }), 'error')

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -28,6 +28,7 @@ from PIL import Image
 logger = logging.getLogger(__name__)
 
 from studio import db
+from studio.domain.errors import DomainError
 from studio.services.preprocess import core as preprocess
 from studio.services.projects import jobs as project_jobs, projects, versions
 from studio.services import models as model_downloader
@@ -158,7 +159,7 @@ def _run_upscale_train(
         sources = preprocess.resolve_targets_train(
             project, version["label"], mode=mode, names=names
         )
-    except preprocess.PreprocessError as exc:
+    except DomainError as exc:
         log(f"[error] 解析目标失败: {exc}")
         return 1
 
@@ -324,7 +325,7 @@ def _run_crop_train(
         is_last = idx == total
         try:
             preprocess._validate_rel_name(src_rel)
-        except preprocess.PreprocessError as exc:
+        except DomainError as exc:
             log(f"[skip] {src_rel}: {exc}")
             skipped += 1
             emit_throttled(

--- a/tests/test_browse.py
+++ b/tests/test_browse.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from studio import server
+from studio.domain.errors import InvalidPathError, NotFoundError
 from studio.services.dataset import browse
 
 
@@ -51,7 +52,7 @@ def test_list_dir_rejects_outside_repo(fake_repo: Path, tmp_path: Path) -> None:
     """lib 层默认仍然挡外部路径；server 端显式 opt-in 才放行。"""
     outside = tmp_path / "outside"
     outside.mkdir()
-    with pytest.raises(browse.BrowseError, match="outside repo"):
+    with pytest.raises(InvalidPathError, match="Invalid path"):
         browse.list_dir(outside)
 
 
@@ -63,7 +64,7 @@ def test_list_dir_allows_outside_when_opted_in(fake_repo: Path, tmp_path: Path) 
 
 
 def test_list_dir_missing_path(fake_repo: Path) -> None:
-    with pytest.raises(browse.BrowseError, match="does not exist"):
+    with pytest.raises(NotFoundError, match="Path not found"):
         browse.list_dir(fake_repo / "nope")
 
 

--- a/tests/test_c4_c5_envelope_e2e.py
+++ b/tests/test_c4_c5_envelope_e2e.py
@@ -43,8 +43,9 @@ def test_preset_not_found_envelope_dual_write(client: TestClient) -> None:
     resp = client.get("/api/presets/__nonexistent__")
     assert resp.status_code == 404
     body = resp.json()
-    # legacy contract
-    assert body["detail"] == "预设不存在: __nonexistent__" or "不存在" in body["detail"]
+    # legacy contract — detail 现在是英文兜底，含资源名 + "not found"
+    assert "not found" in body["detail"]
+    assert "__nonexistent__" in body["detail"]
     # 新结构化（C2 dual-write）
     assert "error" in body
     assert body["error"]["code"] == "preset.not_found"  # C4 _preset_err_code mutate

--- a/tests/test_caption_snapshot.py
+++ b/tests/test_caption_snapshot.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from studio.domain.errors import NotFoundError
 from studio.services.tagging import caption_snapshot
 
 
@@ -63,8 +64,9 @@ def test_restore_does_not_touch_images(tmp_path: Path) -> None:
 
 
 def test_restore_missing_id(tmp_path: Path) -> None:
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(NotFoundError) as exc:
         caption_snapshot.restore_snapshot(tmp_path, "9999999999")
+    assert exc.value.code == "snapshot.not_found"
 
 
 def test_restore_rejects_path_traversal(tmp_path: Path) -> None:

--- a/tests/test_curation.py
+++ b/tests/test_curation.py
@@ -67,7 +67,7 @@ def test_remove_reports_missing(env) -> None:
 def test_create_folder(env) -> None:
     with db.connection_for(env["db"]) as conn:
         curation.create_folder(conn, env["p"]["id"], env["v"]["id"], "10_x")
-        with pytest.raises(curation.CurationError, match="已存在"):
+        with pytest.raises(curation.CurationError, match="already exists"):
             curation.create_folder(
                 conn, env["p"]["id"], env["v"]["id"], "10_x"
             )

--- a/tests/test_duplicates_train_scope.py
+++ b/tests/test_duplicates_train_scope.py
@@ -12,6 +12,7 @@ import pytest
 from PIL import Image
 
 from studio import db
+from studio.domain.errors import InvalidPathError, NotFoundError
 from studio.services.preprocess import duplicates as duplicate_finder
 from studio.services.preprocess import manifest as preprocess_manifest
 from studio.services.projects import projects, versions
@@ -89,7 +90,7 @@ def test_resolve_train_sources_empty_when_no_train(env) -> None:
 
 
 def test_resolve_train_sources_mismatched_version_raises(env) -> None:
-    """version_id 跟 project_id 不一致 → DuplicateFinderError。"""
+    """version_id 跟 project_id 不一致 → NotFoundError(version.not_found)。"""
     # 另开一个 project + version
     with db.connection_for(env["db"]) as conn:
         other_p = projects.create_project(conn, title="Other")
@@ -97,10 +98,11 @@ def test_resolve_train_sources_mismatched_version_raises(env) -> None:
             conn, project_id=other_p["id"], label="v1"
         )
     with db.connection_for(env["db"]) as conn:
-        with pytest.raises(duplicate_finder.DuplicateFinderError):
+        with pytest.raises(NotFoundError) as exc:
             duplicate_finder._resolve_train_sources(
                 conn, env["p"]["id"], other_v["id"], env["pdir"],
             )
+        assert exc.value.code == "version.not_found"
 
 
 # ---------------------------------------------------------------------------
@@ -129,21 +131,23 @@ def test_apply_train_duplicate_marks_manifest(env) -> None:
 
 def test_apply_train_duplicate_rejects_invalid_rel_name(env) -> None:
     with db.connection_for(env["db"]) as conn:
-        with pytest.raises(duplicate_finder.DuplicateFinderError):
+        with pytest.raises(InvalidPathError) as exc:
             duplicate_finder.apply_train_duplicate_removals(
                 conn, env["p"]["id"], env["v"]["id"],
                 names=["../etc/passwd"],
             )
+        assert exc.value.code == "path.invalid"
 
 
 def test_apply_train_duplicate_rejects_flat_name(env) -> None:
     """rel path 必须含 folder 前缀（两段格式）。"""
     with db.connection_for(env["db"]) as conn:
-        with pytest.raises(duplicate_finder.DuplicateFinderError):
+        with pytest.raises(InvalidPathError) as exc:
             duplicate_finder.apply_train_duplicate_removals(
                 conn, env["p"]["id"], env["v"]["id"],
                 names=["X.png"],  # 平铺，缺 folder
             )
+        assert exc.value.code == "path.invalid"
 
 
 def test_apply_train_duplicate_mismatched_version_raises(env) -> None:
@@ -153,10 +157,11 @@ def test_apply_train_duplicate_mismatched_version_raises(env) -> None:
             conn, project_id=other_p["id"], label="v1"
         )
     with db.connection_for(env["db"]) as conn:
-        with pytest.raises(duplicate_finder.DuplicateFinderError):
+        with pytest.raises(NotFoundError) as exc:
             duplicate_finder.apply_train_duplicate_removals(
                 conn, env["p"]["id"], other_v["id"],
                 names=["1_data/A.png"],
             )
+        assert exc.value.code == "version.not_found"
 
 

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -153,25 +153,31 @@ def test_domain_error_4xx_logs_info_not_exception(
 
 
 def test_http_exception_string_detail_preserved(client: TestClient) -> None:
-    """raise HTTPException(detail='str') 仍返 {detail: str}，handler 不截胡。"""
+    """ADR-0009 Phase 2：raise HTTPException(detail='str') 的 detail 原样保留（老
+    路径不破），且 backstop handler 旁边补 error 信封（code=http.<status>）。"""
     resp = client.get("/raise_http")
     assert resp.status_code == 400
     body = resp.json()
-    assert body == {"detail": "legacy http err string"}, (
-        f"HTTPException 形状必须不变，实际 {body}"
-    )
-    # 应该 *没有* error 字段（不被 DomainError handler 处理）
-    assert "error" not in body
+    # detail 形状不变（前端 fallback + 老 callsite 依赖）
+    assert body["detail"] == "legacy http err string"
+    # Phase 2：error 信封补齐，前端可一律读 body.error
+    assert body["error"]["code"] == "http.400"
+    assert body["error"]["message"] == "legacy http err string"
+    assert body["error"]["trace_id"] is not None
 
 
 def test_http_exception_dict_detail_preserved(client: TestClient) -> None:
-    """raise HTTPException(detail={"error": "x", ...}) 仍 {detail: {...}}。
-
-    test_studio_server.py 7 处断言 body['detail']['error'] 走这条；不能变。
-    """
+    """ADR-0009 Phase 2：raise HTTPException(detail={...}) 的 dict detail 原样保留
+    （test_studio_server.py 7 处断言 body['detail']['error'] 依赖此，不能变），
+    并旁边合成 error（message 取 detail.message/error 兜底）。"""
     resp = client.get("/raise_http_dict")
     body = resp.json()
-    assert body == {"detail": {"error": "running_tasks_present", "count": 3}}
+    # 结构化 detail 原样保留
+    assert body["detail"] == {"error": "running_tasks_present", "count": 3}
+    # Phase 2：合成 error 信封
+    assert body["error"]["code"] == "http.400"
+    assert body["error"]["message"] == "running_tasks_present"
+    assert body["error"]["trace_id"] is not None
 
 
 def test_http_exception_still_has_trace_id_header(client: TestClient) -> None:

--- a/tests/test_generate_save_metadata.py
+++ b/tests/test_generate_save_metadata.py
@@ -55,9 +55,12 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient,
 
     monkeypatch.setattr(_gen.secrets, "load", lambda: _FakeSecrets())
 
+    from studio.api.exception_handlers import register_exception_handlers
+
     app = FastAPI()
+    register_exception_handlers(app)
     app.include_router(_gen.router)
-    return TestClient(app), test_dir
+    return TestClient(app, raise_server_exceptions=False), test_dir
 
 
 def _open_png_text(path: Path) -> dict[str, str]:
@@ -183,6 +186,7 @@ def test_save_rejects_invalid_params_json(client) -> None:
         files={"image": ("a.png", _png_bytes(), "image/png")},
     )
     assert r.status_code == 400
+    assert r.json()["error"]["code"] == "generate.params_invalid"
 
 
 def test_save_rejects_non_object_params(client) -> None:
@@ -193,6 +197,7 @@ def test_save_rejects_non_object_params(client) -> None:
         files={"image": ("a.png", _png_bytes(), "image/png")},
     )
     assert r.status_code == 400
+    assert r.json()["error"]["code"] == "generate.params_invalid"
 
 
 def test_disk_history_lists_entries_from_png_metadata(client) -> None:
@@ -476,9 +481,13 @@ def test_save_disabled_returns_403(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         generate = _FakeGenCfg()
 
     monkeypatch.setattr(_gen.secrets, "load", lambda: _FakeSecrets())
+
+    from studio.api.exception_handlers import register_exception_handlers
+
     app = FastAPI()
+    register_exception_handlers(app)
     app.include_router(_gen.router)
-    tc = TestClient(app)
+    tc = TestClient(app, raise_server_exceptions=False)
 
     r = tc.post(
         "/api/generate/save",
@@ -486,6 +495,7 @@ def test_save_disabled_returns_403(tmp_path: Path, monkeypatch: pytest.MonkeyPat
         files={"image": ("a.png", _png_bytes(), "image/png")},
     )
     assert r.status_code == 403
+    assert r.json()["error"]["code"] == "generate.save_disabled"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_preprocess_train_core.py
+++ b/tests/test_preprocess_train_core.py
@@ -15,6 +15,7 @@ import pytest
 from PIL import Image
 
 from studio import db
+from studio.domain.errors import InvalidPathError, ValidationError
 from studio.services.preprocess import core as preprocess
 from studio.services.preprocess import manifest as preprocess_manifest
 from studio.services.projects import jobs as project_jobs, projects, versions
@@ -203,15 +204,17 @@ def test_resolve_targets_selected_intersects_train(isolated) -> None:
 
 def test_resolve_targets_selected_empty_names_raises(isolated) -> None:
     p = isolated["project"]
-    with pytest.raises(preprocess.PreprocessError):
+    with pytest.raises(ValidationError) as exc:
         preprocess.resolve_targets_train(p, "v1", mode="selected", names=[])
+    assert exc.value.code == "preprocess.selection_empty"
 
 
 def test_resolve_targets_unknown_mode_raises(isolated) -> None:
-    with pytest.raises(preprocess.PreprocessError):
+    with pytest.raises(ValidationError) as exc:
         preprocess.resolve_targets_train(
             isolated["project"], "v1", mode="bogus"
         )
+    assert exc.value.code == "preprocess.mode_invalid"
 
 
 def test_resolve_targets_name_with_traversal_rejected(isolated) -> None:
@@ -219,10 +222,11 @@ def test_resolve_targets_name_with_traversal_rejected(isolated) -> None:
     p = isolated["project"]
     sub = isolated["sub"]
     _write_png(sub / "X.png")
-    with pytest.raises(preprocess.PreprocessError):
+    with pytest.raises(InvalidPathError) as exc:
         preprocess.resolve_targets_train(
             p, "v1", mode="selected", names=["../etc/passwd"]
         )
+    assert exc.value.code == "path.invalid"
 
 
 # ---------------------------------------------------------------------------
@@ -252,11 +256,12 @@ def test_start_job_train_selected_requires_names(isolated) -> None:
     p = isolated["project"]
     v = isolated["version"]
     with db.connection_for(isolated["db"]) as conn:
-        with pytest.raises(preprocess.PreprocessError):
+        with pytest.raises(ValidationError) as exc:
             preprocess.start_job_train(
                 conn, project_id=p["id"], version_id=v["id"],
                 mode="selected",
             )
+        assert exc.value.code == "preprocess.selection_empty"
 
 
 def test_start_crop_job_train_validates_rects(isolated) -> None:
@@ -270,11 +275,12 @@ def test_start_crop_job_train_validates_rects(isolated) -> None:
             crops={_rel("X.png"): [{"x": 0.1, "y": 0.1, "w": 0.5, "h": 0.5}]},
         )
         assert job["version_id"] == v["id"]
-        with pytest.raises(preprocess.PreprocessError):
+        with pytest.raises(ValidationError) as exc:
             preprocess.start_crop_job_train(
                 conn, project_id=p["id"], version_id=v["id"],
                 crops={_rel("X.png"): [{"x": 0, "y": 0, "w": 0.001, "h": 0.5}]},
             )
+        assert exc.value.code == "preprocess.crop_too_small"
 
 
 # ---------------------------------------------------------------------------
@@ -410,5 +416,6 @@ def test_restore_products_train_no_origin_when_download_missing(isolated) -> Non
 
 def test_restore_products_train_validates_name(isolated) -> None:
     p = isolated["project"]
-    with pytest.raises(preprocess.PreprocessError):
+    with pytest.raises(InvalidPathError) as exc:
         preprocess.restore_products_train(p, "v1", ["../etc"])
+    assert exc.value.code == "path.invalid"

--- a/tests/test_presets_io.py
+++ b/tests/test_presets_io.py
@@ -42,7 +42,7 @@ def test_write_invalid_rejected(presets_dir: Path) -> None:
 
 def test_name_validation(presets_dir: Path) -> None:
     for bad in ("../escape", "name with space", "name/sub", "name.dot"):
-        with pytest.raises(presets_io.PresetError, match="非法预设名"):
+        with pytest.raises(presets_io.PresetError, match="Invalid preset name"):
             presets_io.write_preset(bad, _payload())
 
 
@@ -62,7 +62,7 @@ def test_delete(presets_dir: Path) -> None:
 
 
 def test_delete_missing_raises(presets_dir: Path) -> None:
-    with pytest.raises(presets_io.PresetError, match="不存在"):
+    with pytest.raises(presets_io.PresetError, match="not found"):
         presets_io.delete_preset("ghost")
 
 
@@ -78,7 +78,7 @@ def test_duplicate(presets_dir: Path) -> None:
 def test_duplicate_conflict(presets_dir: Path) -> None:
     presets_io.write_preset("a", _payload())
     presets_io.write_preset("b", _payload())
-    with pytest.raises(presets_io.PresetError, match="已存在"):
+    with pytest.raises(presets_io.PresetError, match="already exists"):
         presets_io.duplicate_preset("a", "b")
 
 
@@ -132,7 +132,7 @@ def test_parse_migrates_legacy_attention_fields() -> None:
 def test_parse_rejects_non_mapping() -> None:
     # 顶层是 list 不是 dict
     raw = b"- foo\n- bar\n"
-    with pytest.raises(presets_io.PresetError, match="不是 mapping"):
+    with pytest.raises(presets_io.PresetError, match="Preset file format is invalid"):
         presets_io.parse_preset_bytes(raw, "list.yaml")
 
 
@@ -160,7 +160,7 @@ def test_parse_empty_filename_fallback() -> None:
 
 def test_preset_path_is_public_alias() -> None:
     assert presets_io.preset_path("foo").name == "foo.yaml"
-    with pytest.raises(presets_io.PresetError, match="非法预设名"):
+    with pytest.raises(presets_io.PresetError, match="Invalid preset name"):
         presets_io.preset_path("bad/name")
 
 

--- a/tests/test_projects.py
+++ b/tests/test_projects.py
@@ -109,5 +109,5 @@ def test_delete_removes_dir_and_row(isolated) -> None:
 
 def test_delete_missing_raises(isolated) -> None:
     with db.connection_for(isolated["db"]) as conn:
-        with pytest.raises(projects.ProjectError, match="不存在"):
+        with pytest.raises(projects.ProjectError, match="not found"):
             projects.delete_project(conn, 9999)

--- a/tests/test_resume_path.py
+++ b/tests/test_resume_path.py
@@ -485,8 +485,9 @@ def _import_server_module():
     重 import server。
     """
     try:
-        from fastapi import HTTPException
+        from fastapi import HTTPException  # noqa: F401  (kept for back-compat)
         from studio.api.routers.queue.lifecycle import resume_task as _resume_task
+        from studio.domain.errors import ConflictError, NotFoundError
     except ImportError:
         pytest.skip("fastapi not installed; cannot import resume endpoint")
 
@@ -494,16 +495,21 @@ def _import_server_module():
         pass
 
     shim = _ServerShim()
+    # ADR 0009 Phase 2: resume_task now raises studio.domain.errors.* (DomainError
+    # subclasses with .http_status / .message / .code), not fastapi HTTPException.
     shim.HTTPException = HTTPException
+    shim.NotFoundError = NotFoundError
+    shim.ConflictError = ConflictError
     shim.resume_task = _resume_task
     return shim
 
 
 def test_resume_endpoint_rejects_unknown_task(server_env) -> None:
     server = _import_server_module()
-    with pytest.raises(server.HTTPException) as exc:
+    with pytest.raises(server.NotFoundError) as exc:
         server.resume_task(99999)
-    assert exc.value.status_code == 404
+    assert exc.value.http_status == 404
+    assert exc.value.code == "task.not_found"
 
 
 def test_resume_endpoint_rejects_non_resumable_status(server_env) -> None:
@@ -513,10 +519,10 @@ def test_resume_endpoint_rejects_non_resumable_status(server_env) -> None:
     with db.connection_for(server_env["db"]) as conn:
         tid = db.create_task(conn, name="t", config_name="c")
         # pending status
-    with pytest.raises(server.HTTPException) as exc:
+    with pytest.raises(server.ConflictError) as exc:
         server.resume_task(tid)
-    assert exc.value.status_code == 409
-    assert "not resumable" in exc.value.detail
+    assert exc.value.http_status == 409
+    assert exc.value.code == "task.not_resumable"
 
 
 def test_resume_endpoint_rejects_when_state_file_missing(server_env) -> None:
@@ -525,10 +531,11 @@ def test_resume_endpoint_rejects_when_state_file_missing(server_env) -> None:
     cfg_json = server_env["root"] / "pause_step_100.config.json"
     cfg_json.write_text("{}", encoding="utf-8")  # state missing, config exists
     tid = _create_paused_task(server_env, state_pt, cfg_json)
-    with pytest.raises(server.HTTPException) as exc:
+    with pytest.raises(server.ConflictError) as exc:
         server.resume_task(tid)
-    assert exc.value.status_code == 409
-    assert "missing" in exc.value.detail
+    assert exc.value.http_status == 409
+    assert exc.value.code == "task.resume_state_missing"
+    assert "missing" in exc.value.message
 
 
 def test_resume_endpoint_rejects_when_config_snapshot_missing(server_env) -> None:
@@ -537,10 +544,12 @@ def test_resume_endpoint_rejects_when_config_snapshot_missing(server_env) -> Non
     cfg_json = server_env["root"] / "pause_step_100.config.json"
     state_pt.write_bytes(b"")  # state exists, config missing
     tid = _create_paused_task(server_env, state_pt, cfg_json)
-    with pytest.raises(server.HTTPException) as exc:
+    with pytest.raises(server.ConflictError) as exc:
         server.resume_task(tid)
-    assert exc.value.status_code == 409
-    assert "snapshot missing" in exc.value.detail
+    assert exc.value.http_status == 409
+    # config snapshot missing reuses the resume_state_missing code (CATALOG: the
+    # frozen config is part of the saved training state).
+    assert exc.value.code == "task.resume_state_missing"
 
 
 def test_resume_endpoint_success_flips_status_keeps_paused_fields(server_env) -> None:

--- a/tests/test_studio_configs.py
+++ b/tests/test_studio_configs.py
@@ -206,7 +206,8 @@ def test_api_duplicate_conflict(client: TestClient) -> None:
     client.put("/api/presets/x", json=payload)
     client.put("/api/presets/y", json=payload)
     resp = client.post("/api/presets/x/duplicate", json={"new_name": "y"})
-    assert resp.status_code == 400
+    assert resp.status_code == 409
+    assert resp.json()["error"]["code"] == "preset.exists"
 
 
 def test_api_delete_missing(client: TestClient) -> None:
@@ -342,10 +343,11 @@ def test_import_returns_409_on_conflict(
         files={"file": ("clash.yaml", yaml_bytes2, "application/yaml")},
     )
     assert resp2.status_code == 409, resp2.text
-    detail = resp2.json()["detail"]
-    assert isinstance(detail, dict)
-    assert detail["suggested_name"] == "clash"
-    assert detail["config"]["epochs"] == 42
+    error = resp2.json()["error"]
+    assert error["code"] == "preset.exists"
+    details = error["details"]
+    assert details["suggested_name"] == "clash"
+    assert details["config"]["epochs"] == 42
     # 没覆盖原文件
     assert (presets_dir / "clash.yaml").stat().st_mtime == on_disk_mtime
     assert client.get("/api/presets/clash").json()["epochs"] != 42

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -138,7 +138,9 @@ def test_torch_reinstall_invalid_target_returns_400(
     )
     resp = client.post("/api/torch/reinstall", json={"target": "xpu"})
     assert resp.status_code == 400
-    assert "非法 target" in resp.json()["detail"]
+    body = resp.json()
+    assert body["error"]["code"] == "install.target_invalid"
+    assert body["error"]["details"]["target"] == "xpu"
 
 
 def test_flash_attention_status_returns_env_and_candidates(
@@ -639,9 +641,9 @@ def test_system_update_rejects_when_running_task(
     resp = client.post("/api/system/update", json={"target": "origin/master"})
     assert resp.status_code == 422
     body = resp.json()
-    assert body["detail"]["error"] == "running_tasks_present"
-    assert len(body["detail"]["tasks"]) == 1
-    assert body["detail"]["tasks"][0]["id"] == tid
+    assert body["error"]["code"] == "system.tasks_running"
+    assert len(body["error"]["details"]["tasks"]) == 1
+    assert body["error"]["details"]["tasks"][0]["id"] == tid
 
 
 def test_system_update_rejects_when_dirty(
@@ -658,7 +660,7 @@ def test_system_update_rejects_when_dirty(
     resp = client.post("/api/system/update", json={"target": "origin/master"})
     assert resp.status_code == 422
     body = resp.json()
-    assert body["detail"]["error"] == "dirty_working_tree"
+    assert body["error"]["code"] == "system.working_tree_dirty"
 
 
 def test_system_update_writes_pending_and_restart_flag(
@@ -706,7 +708,7 @@ def test_system_restart_rejects_when_running_task(
 
     resp = client.post("/api/system/restart")
     assert resp.status_code == 422
-    assert resp.json()["detail"]["error"] == "running_tasks_present"
+    assert resp.json()["error"]["code"] == "system.tasks_running"
 
 
 # ---------------------------------------------------------------------------
@@ -800,7 +802,7 @@ def test_system_rollback_409_when_no_target(
 
     resp = client.post("/api/system/rollback")
     assert resp.status_code == 409
-    assert resp.json()["detail"]["error"] == "no_rollback_target"
+    assert resp.json()["error"]["code"] == "system.no_rollback_target"
 
 
 def test_system_rollback_rejects_dirty(
@@ -817,7 +819,7 @@ def test_system_rollback_rejects_dirty(
 
     resp = client.post("/api/system/rollback")
     assert resp.status_code == 422
-    assert resp.json()["detail"]["error"] == "dirty_working_tree"
+    assert resp.json()["error"]["code"] == "system.working_tree_dirty"
 
 
 def test_system_rollback_rejects_running_task(
@@ -833,7 +835,7 @@ def test_system_rollback_rejects_running_task(
 
     resp = client.post("/api/system/rollback")
     assert resp.status_code == 422
-    assert resp.json()["detail"]["error"] == "running_tasks_present"
+    assert resp.json()["error"]["code"] == "system.tasks_running"
 
 
 def test_system_rollback_success_writes_flag(

--- a/tests/test_task_snapshot.py
+++ b/tests/test_task_snapshot.py
@@ -125,7 +125,9 @@ def test_endpoint_404_when_snapshot_missing(client: TestClient, isolated) -> Non
     tid = _create_task(isolated)
     resp = client.get(f"/api/queue/{tid}/snapshot/config")
     assert resp.status_code == 404
-    assert "snapshot" in resp.json()["detail"].lower()
+    # ADR 0009 Phase 2: assert the structured error code (the English detail is
+    # "No saved configuration for this task"; the i18n code is the stable contract).
+    assert resp.json()["error"]["code"] == "task.snapshot_not_found"
 
 
 def test_endpoint_returns_snapshot_data(

--- a/tests/test_terminal_resume.py
+++ b/tests/test_terminal_resume.py
@@ -214,11 +214,14 @@ def server_env(env, monkeypatch):
 
 def _lifecycle():
     try:
-        from fastapi import HTTPException
+        import fastapi  # noqa: F401  (ensure the web stack is installed)
         from studio.api.routers.queue import lifecycle
+        from studio.domain.errors import ConflictError
     except ImportError:
         pytest.skip("fastapi not installed")
-    return lifecycle, HTTPException
+    # ADR 0009 Phase 2: resume_task now raises studio.domain.errors.ConflictError
+    # (.http_status / .message / .code) on rejection, not fastapi HTTPException.
+    return lifecycle, ConflictError
 
 
 def test_resume_failed_task_with_recovery_point(server_env) -> None:
@@ -275,38 +278,40 @@ def test_resume_canceled_task_with_recovery_point(server_env) -> None:
 
 def test_resume_failed_without_recovery_point_409(server_env) -> None:
     """failed 但首 epoch 没跑完（last_state_path NULL）→ 409 引导 ResumeFieldPicker。"""
-    lifecycle, HTTPException = _lifecycle()
+    lifecycle, ConflictError = _lifecycle()
     tid = _create_task(server_env, status="failed")
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(ConflictError) as exc:
         lifecycle.resume_task(tid)
-    assert exc.value.status_code == 409
-    assert "missing" in exc.value.detail
+    assert exc.value.http_status == 409
+    assert exc.value.code == "task.resume_state_missing"
+    assert "missing" in exc.value.message
 
 
 def test_resume_failed_with_deleted_state_file_409(server_env) -> None:
     """DB 有路径但文件被外部删 → 409。"""
-    lifecycle, HTTPException = _lifecycle()
+    lifecycle, ConflictError = _lifecycle()
     tid = _create_task(
         server_env, status="failed",
         last_state_path="/nonexistent/auto_epoch_state.pt",
         last_config_path="/nonexistent/auto_epoch_state.config.json",
     )
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(ConflictError) as exc:
         lifecycle.resume_task(tid)
-    assert exc.value.status_code == 409
+    assert exc.value.http_status == 409
+    assert exc.value.code == "task.resume_state_missing"
 
 
 def test_resume_done_task_rejected(server_env) -> None:
     """done 不可 resume（语义是重训，走 retry / ResumeFieldPicker）。"""
-    lifecycle, HTTPException = _lifecycle()
+    lifecycle, ConflictError = _lifecycle()
     tid = _create_task(server_env, status="done")
     pt, cfg = _write_recovery_pair(server_env["root"], tid)
     with db.connection_for(server_env["db"]) as conn:
         db.update_task(conn, tid, last_state_path=str(pt), last_config_path=str(cfg))
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(ConflictError) as exc:
         lifecycle.resume_task(tid)
-    assert exc.value.status_code == 409
-    assert "not resumable" in exc.value.detail
+    assert exc.value.http_status == 409
+    assert exc.value.code == "task.not_resumable"
 
 
 def test_resume_failed_with_bogus_version_id_no_crash(server_env) -> None:

--- a/tests/test_train_endpoints.py
+++ b/tests/test_train_endpoints.py
@@ -270,7 +270,8 @@ def test_save_as_preset_existing_409(client: TestClient, env) -> None:
         f"/api/projects/{pid}/versions/{vid}/config/save_as_preset",
         json={"name": "tpl"},  # 同名 + 不带 overwrite
     )
-    assert r.status_code == 400  # presets_io.PresetError("已存在") → _err_code 400
+    assert r.status_code == 409  # preset.exists → ConflictError (CATALOG 改 400→409)
+    assert r.json()["error"]["code"] == "preset.exists"
     # overwrite=True 应允许
     r2 = client.post(
         f"/api/projects/{pid}/versions/{vid}/config/save_as_preset",

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from studio import db
+from studio.domain.errors import NotFoundError
 from studio.services.projects import projects, versions
 from studio.services.data_io import train_io
 
@@ -113,7 +114,9 @@ def test_export_empty_train_raises(isolated, tmp_path: Path) -> None:
 
 
 def test_export_missing_version(isolated, tmp_path: Path) -> None:
-    with db.connection_for(isolated["db"]) as conn, pytest.raises(train_io.TrainIOError):
+    with db.connection_for(isolated["db"]) as conn, pytest.raises(
+        NotFoundError, match="Version not found"
+    ):
         train_io.export_train(conn, 9999, tmp_path / "x.zip")
 
 

--- a/tests/test_versions.py
+++ b/tests/test_versions.py
@@ -60,7 +60,7 @@ def test_create_version_rejects_duplicate_label(isolated) -> None:
     p = _new_project(isolated)
     with db.connection_for(isolated["db"]) as conn:
         versions.create_version(conn, project_id=p["id"], label="baseline")
-        with pytest.raises(versions.VersionError, match="已存在"):
+        with pytest.raises(versions.VersionError, match="already exists"):
             versions.create_version(conn, project_id=p["id"], label="baseline")
 
 
@@ -177,7 +177,7 @@ def test_fork_rejects_alien_source(isolated) -> None:
     b = _new_project(isolated, title="B")
     with db.connection_for(isolated["db"]) as conn:
         src = versions.create_version(conn, project_id=a["id"], label="baseline")
-        with pytest.raises(versions.VersionError, match="fork"):
+        with pytest.raises(versions.VersionError, match="copy from"):
             versions.create_version(
                 conn,
                 project_id=b["id"],


### PR DESCRIPTION
## 背景 / 动机

ADR 0009 的错误 envelope 渐进迁移此前只有 Phase 1（dual-write）随 0.12.0 发布，Phase 2/3 滑期。本 PR 实现 **Phase 2**：让 `body.error`（语义 `code` + `message` + `trace_id` + `details`）覆盖所有错误响应，前端按 `code` 查 i18n 渲染**本地化错误文案**——解决「中英双语 app 但错误 toast 写死中文、英文用户看到中文」的真问题。

## 设计（6 agent 双审 + 对账产出的 CATALOG 为依据）

先用多 agent 把 337 处错误现场（241 HTTPException + 96 service DomainError）审成 code→{en,zh} 目录（`tmp/error_i18n/CATALOG.md`，含跨组一致性裁决），再据此实现。

## 改动

**地基**
- 注册 HTTPException **backstop handler**：裸 HTTPException 也补 `error` 信封（`code=http.<status>`），`detail` 原样保留（8 处结构化 dict + 7 处 `body['detail']['error']` 断言不破）→ `body.error` 全覆盖。
- 前端 4 处 fetch/XHR 错误解析收口为 `makeApiError`：主读 `body.error.code` 查 `errors.<code>`（带 `details` 插值，缺词条回退英文 `message`），`detail` 退 fallback；`error.details` 经 `err.detail` 给结构化 callsite。
- 新增 `errors.*` locale（**120 code，中英**，从 CATALOG 生成）。

**迁移（9 agent 并行 + 人工整合）**
- ~330 处 raise（HTTPException + service 异常）→ `DomainError` 子类带英文 message + 语义 code + details。
- 删 4 个中文子串匹配 helper（`_preset / _project / _curation / _duplicate_err_code`）；router 不再转 HTTPException，DomainError 直接冒泡。
- 修 `preprocess_worker` 两处 `except PreprocessError`（迁移后改抛 `InvalidPathError/ValidationError`，原 catch 漏接会崩 job）→ `except DomainError`。
- 前端 consumer：Presets 导入冲突、Settings 运行中任务两处改读 `code` / `error.details`。
- preset 冲突状态 400→409（语义修正，对齐既有 `_409` 测试）。

**零回归**：`t('errors.'+code, {defaultValue: message})` 的 fallback —— 未覆盖的 code 照显原 message。

## 测试

- 后端：**2362 passed**（1 个 Windows taskkill 计时 flake，隔离跑过；与本改动无关）。18 个测试文件断言对齐新信封（子类 + code + error.details），无放水。
- 前端：**393 passed**，`npm run lint` + `tsc --noEmit` 干净。新增 `makeApiError` 单测 5 条。

## 后续

Phase 3（handler 删 legacy `detail` key）现在可安全做——前端已主读 `body.error.*`。见 `docs/todo/error-envelope-detail-key-removal.md`。

> 注：本 PR 较大但为一个内聚迁移（源码 + 测试断言强耦合，拆开会有非绿中间态）。分支保留了 地基 / upscalers 模板 / 全量迁移 / docs 四个 commit 颗粒度。

🤖 Generated with [Claude Code](https://claude.com/claude-code)