### PR TITLE
refactor(api): ADR 0009 Phase 3 — 移除 error envelope 的 legacy detail key

### DIFF
--- a/docs/adr/0009-logging-error-system.md
+++ b/docs/adr/0009-logging-error-system.md
@@ -175,11 +175,11 @@ api/middleware/  ────►  api/exception_handlers  ────►  domai
 |---|---|---|---|
 | Phase 1 | 0.12.0 | dual-write：`{"detail": <legacy>, "error": {"code", "message", "trace_id"}}` | 优先读 `body.error.trace_id` 显 toast；fallback 读 `body.detail` |
 | Phase 2 | 0.15.0 | 所有 `raise HTTPException` 加 deprecation log；front-end 完成全量迁移到 `body.error.*` | 删 `client.ts` 内 `body.detail` 解析路径，只剩单一 `ApiError` |
-| Phase 3 | 0.16.0 | handler 删 `detail` key；测试 5 文件 11 处迁完 | — |
+| Phase 3 | 0.15.0 | handler 删 `detail` key，错误响应只发 `error`（RequestValidationError 的 422 list 除外）| — |
 
 **关键**：Phase 1 多写 ~30 行（handler 同时填两个 key），给前端 toast trace_id body 可见性提前 3 release。
 
-> **进度（2026-06-19 更新）**：Phase 1 随 0.12.0 发布；Phase 2/3 曾滑期（目标下调到 0.15.0 / 0.16.0）。**Phase 2 已实现**（分支 `feat/error-envelope-i18n`，待并入 0.15.0）：HTTPException backstop handler 让 `body.error` 全覆盖 + ~330 处 raise 迁 `DomainError` 带语义 code + 前端按 code 查 `errors.*` i18n（删 4 个中文子串匹配 helper）。实现与本表略有出入（用 backstop handler 替代 deprecation log，且全量迁移而非渐进）。Phase 3（删 legacy `detail`）现可安全做。详见 [`docs/todo/error-envelope-detail-key-removal.md`](../todo/error-envelope-detail-key-removal.md)。
+> **进度（2026-06-19 完成）**：三阶段全部落地，随 0.15.0 发布。Phase 1（0.12.0 dual-write）→ Phase 2（PR #294：backstop handler 让 `body.error` 全覆盖 + ~330 处 raise 迁 `DomainError` 带语义 code + 前端按 code 查 `errors.*` i18n，删 4 个中文子串匹配 helper）→ Phase 3（分支 `feat/error-envelope-phase3`：删 legacy `detail`，错误响应只发 `error`）。实现与本表略有出入（backstop handler 替代 deprecation log、全量迁移而非渐进、Phase 3 提前到 0.15.0）。详见 [`docs/todo/error-envelope-detail-key-removal.md`](../todo/error-envelope-detail-key-removal.md)。
 
 ---
 

--- a/docs/todo/error-envelope-detail-key-removal.md
+++ b/docs/todo/error-envelope-detail-key-removal.md
@@ -2,7 +2,7 @@
 
 **创建于** 2026-06-19
 **触发** 0.14.0 发版核对时发现 [ADR 0009](../adr/0009-logging-error-system.md) §错误 envelope 渐进迁移的 Phase 2/3 早已滑期：ADR 当时把 Phase 2 排到 0.13.0、Phase 3 排到 0.14.0，但实际只有 Phase 1 跟 0.12.0 发出去了，后两阶段一直没人做。已把目标版本下调（Phase 2 → 0.15.0、Phase 3 → 0.16.0）并立此条防再忘。
-**当前状态** 🟢 Phase 2 已实现（分支 `feat/error-envelope-i18n`，待并入 0.15.0）；Phase 1 已发布；Phase 3 待做——前端已主读 `body.error.*`，删 legacy `detail` 现在安全（仅余 fallback + RequestValidationError 的 422 list）。
+**当前状态** ✅ 全部完成。Phase 1 已发布（0.12.0）；Phase 2 已合 dev（PR #294）；**Phase 3 已实现**（分支 `feat/error-envelope-phase3`，删 legacy `detail` key，错误响应只发 `error`；唯一例外 RequestValidationError 的 422 list）。三阶段随 0.15.0 一起发布后本条可归档。
 
 ---
 
@@ -46,11 +46,11 @@ API 错误信封从老格式 `{"detail": <str>}` 渐进迁到新结构化 `{"err
 设计目录（code → en/zh 总表 + 每处映射）见 `tmp/error_i18n/CATALOG.md`（gitignored 草稿，
 Phase 3 / 后续错误 i18n 可复用，必要时移入 docs/）。
 
-## Phase 3 待办（0.16.0，Phase 2 落地后）
+## Phase 3 已完成（分支 feat/error-envelope-phase3，提前到 0.15.0）
 
-- [ ] `exception_handlers.py` 的 `_error_envelope` 删 `detail` key，只留 `error`。
-- [ ] RequestValidationError handler 仍保 starlette 默认 `{"detail": [...]}`（pydantic body 校验，前端有专门处理）——这条不在本迁移范围。
-- [ ] 收尾测试 + ADR 0009 状态更新。
+- [x] `exception_handlers.py`：`_error_envelope` + Exception fallback + HTTPException backstop 都只发 `error`，删顶层 `detail`。backstop 的 dict/list detail 改放 error.details。
+- [x] RequestValidationError handler 保 `{"detail": [...]}`（唯一保留 detail 的路径）。
+- [x] 收尾：~8 测试文件断言迁到 error 信封；error_response_baseline 契约测试改锁 error key；ADR / 注释更新。前端无需改（makeApiError 早已主读 error）。
 
 ## 同步点
 

--- a/studio/api/exception_handlers.py
+++ b/studio/api/exception_handlers.py
@@ -1,35 +1,30 @@
 """统一 exception handler 注册（ADR-0009 §4 / PR-2 C2）。
 
-3 个 handler:
+4 个 handler（Phase 3 起：错误响应只发 `error` 信封，legacy `detail` 已移除）:
 
-  1. DomainError → dual-write envelope:
-        {"detail": <message>,                # legacy contract（前端 client.ts
-                                              #   3 处解析点 + 5 测试 11 处断言）
-         "error": {"code", "message", "trace_id", "details"?}}  # 新结构化
+  1. DomainError → `{"error": {"code", "message", "trace_id", "details"?}}`。
      4xx 不打 stack，5xx 才打 logger.exception（ADR-0009 §4.1）。
 
   2. RequestValidationError → 保 starlette 默认 `{"detail": [...]}` 不动
-     （pydantic body 校验失败 — 前端有专门处理；改 envelope 破现状）。
+     （pydantic body 校验失败 — 前端有专门处理；这是唯一保留 detail 的路径）。
      middleware 已经自动加 X-Trace-Id header。
 
-  3. Exception fallback → 500 + dual-write envelope，message 脱敏：
-        {"detail": "Internal Server Error",
-         "error": {"code": "internal.server_error",
+  3. HTTPException（backstop）→ 给未迁移 / 框架 HTTPException 也补 `{"error": {...}}`
+     （code=`http.<status>`）；dict/list detail 放进 error.details。
+
+  4. Exception fallback → 500 + `{"error": {...}}`，message 脱敏：
+        {"error": {"code": "internal.server_error",
                    "message": "Internal Server Error (see trace_id in server log)",
                    "trace_id": "..."}}
      原始 traceback **不**进 response（防 leak）；进 studio.log 让开发者按
      trace_id grep。
 
-HTTPException 不重新注册 — starlette 默认 handler 已经处理（仅返 `{"detail":
-<orig>}`），X-Trace-Id header 由 TraceIdMiddleware 自动加。不动它保现有
-175 处 raise HTTPException(...) 完全不破。
-
-dual-write 渐进迁移路径（ADR-0009 §错误 envelope 渐进迁移）：
+ADR-0009 §错误 envelope 渐进迁移（完成）：
   Phase 1 (0.12.0): dual-write 同时填 detail + error —— 已发布
-  Phase 2 (0.15.0): HTTPException backstop handler（本文件）让 body.error 全覆盖；
-    ~330 处 raise 迁 DomainError 带语义 code + details；前端按 code 查 errors.* i18n
-    —— 已实现
-  Phase 3 (待): handler 删 legacy detail key（前端已主读 error.*，仅余 fallback）
+  Phase 2 (0.15.0): backstop handler 让 body.error 全覆盖 + ~330 处 raise 迁 DomainError
+    带语义 code + 前端按 code 查 errors.* i18n —— 已实现
+  Phase 3 (0.15.0): 删 legacy detail key，错误响应只发 error（RequestValidationError
+    的 422 list 除外）—— 本次
   详见 docs/todo/error-envelope-detail-key-removal.md
 """
 from __future__ import annotations
@@ -65,7 +60,7 @@ def _error_envelope(
     details: Optional[Dict[str, Any]] = None,
     req: Optional[Request] = None,
 ) -> Dict[str, Any]:
-    """dual-write body: detail (legacy str) + error (structured)。"""
+    """单一 error 信封（ADR-0009 Phase 3：legacy `detail` key 已移除，只发 error）。"""
     err: Dict[str, Any] = {
         "code": code,
         "message": message,
@@ -73,7 +68,7 @@ def _error_envelope(
     }
     if details:
         err["details"] = details
-    return {"detail": message, "error": err}
+    return {"error": err}
 
 
 async def _domain_error_handler(req: Request, exc: DomainError) -> JSONResponse:
@@ -101,30 +96,32 @@ async def _request_validation_handler(
 async def _http_exception_handler(
     req: Request, exc: StarletteHTTPException,
 ) -> JSONResponse:
-    """ADR-0009 Phase 2：给裸 HTTPException 也补 error 信封，让 body.error 覆盖
-    所有错误响应（前端可一律读 body.error.code → i18n，detail 仅作 fallback）。
+    """ADR-0009 Phase 2/3：给裸 HTTPException 也补 error 信封，让 body.error 覆盖
+    所有错误响应（Phase 3 起只发 error，不再 dual-write legacy detail）。前端一律
+    读 body.error.code → i18n。
 
-    - detail 是 str → message=detail，code=`http.<status>`（无语义 code 的兜底；
-      已迁移到 DomainError 的端点带语义 code，不走这里；剩下的多是框架/未迁移）。
-    - detail 是 dict/list（旧结构化 detail）→ 原样保留 detail（前端结构化 callsite
-      依赖），旁边合成 error。
+    - detail 是 str → message=detail，code=`http.<status>`（无语义 code 兜底；
+      已迁移到 DomainError 的端点带语义 code，不走这里；剩下多是框架/未迁移）。
+    - detail 是 dict/list（罕见，业务迁移后已无来源）→ 放进 error.details 保留结构，
+      message 取 dict.message/error 兜底。
     保留 exc.headers（如 401 WWW-Authenticate）。
     """
     detail = exc.detail
-    code = f"http.{exc.status_code}"
-    trace_id = _trace_id_from(req)
-    if isinstance(detail, str):
-        message = detail
-    elif isinstance(detail, dict):
-        message = str(detail.get("message") or detail.get("error") or "Request failed")
-    else:
-        message = "Request failed"
-    body: Dict[str, Any] = {
-        "detail": detail,
-        "error": {"code": code, "message": message, "trace_id": trace_id},
+    err: Dict[str, Any] = {
+        "code": f"http.{exc.status_code}",
+        "message": "Request failed",
+        "trace_id": _trace_id_from(req),
     }
+    if isinstance(detail, str):
+        err["message"] = detail
+    elif isinstance(detail, dict):
+        err["message"] = str(detail.get("message") or detail.get("error") or "Request failed")
+        err["details"] = detail
+    elif detail is not None:
+        err["details"] = {"detail": detail}
     return JSONResponse(
-        status_code=exc.status_code, content=body, headers=getattr(exc, "headers", None),
+        status_code=exc.status_code, content={"error": err},
+        headers=getattr(exc, "headers", None),
     )
 
 

--- a/tests/test_c4_c5_envelope_e2e.py
+++ b/tests/test_c4_c5_envelope_e2e.py
@@ -39,17 +39,15 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
 # ── preset 404 路径（C4 batch 1）───────────────────────────────────────
 
 
-def test_preset_not_found_envelope_dual_write(client: TestClient) -> None:
+def test_preset_not_found_envelope(client: TestClient) -> None:
     resp = client.get("/api/presets/__nonexistent__")
     assert resp.status_code == 404
     body = resp.json()
-    # legacy contract — detail 现在是英文兜底，含资源名 + "not found"
-    assert "not found" in body["detail"]
-    assert "__nonexistent__" in body["detail"]
-    # 新结构化（C2 dual-write）
-    assert "error" in body
-    assert body["error"]["code"] == "preset.not_found"  # C4 _preset_err_code mutate
-    assert body["error"]["message"] == body["detail"]
+    # Phase 3：只发 error 信封，无 legacy detail
+    assert "detail" not in body
+    assert body["error"]["code"] == "preset.not_found"
+    assert "not found" in body["error"]["message"]
+    assert "__nonexistent__" in body["error"]["message"]
     # trace_id 跟 header 一致
     assert body["error"]["trace_id"] == resp.headers[TRACE_HEADER]
 
@@ -61,6 +59,7 @@ def test_preset_name_invalid_envelope_400(client: TestClient) -> None:
     # 我们接受 400 或 404；锁 envelope 形态
     body = resp.json()
     assert resp.status_code in (400, 404, 422)
-    assert "detail" in body
+    # Phase 3：error 信封（422 RequestValidationError 仍是 detail list）
+    assert "error" in body or isinstance(body.get("detail"), list)
     # 4xx 全部应该有 trace_id header（middleware）
     assert TRACE_HEADER in resp.headers

--- a/tests/test_download_endpoints.py
+++ b/tests/test_download_endpoints.py
@@ -102,7 +102,7 @@ def test_start_download_requires_credentials(
         json={"tag": "x", "count": 1, "api_source": "gelbooru"},
     )
     assert resp.status_code == 400
-    assert "gelbooru" in resp.json()["detail"]
+    assert "gelbooru" in resp.json()["error"]["message"]
 
 
 def test_start_download_danbooru_does_not_require_credentials(

--- a/tests/test_error_response_baseline.py
+++ b/tests/test_error_response_baseline.py
@@ -1,12 +1,12 @@
-"""PR-LOG-1 安全网 — 锁错误响应 envelope 形状（防 PR-LOG-4 破前端 contract）。
+"""安全网 — 锁错误响应 envelope 形状（ADR-0009）。
 
 策略：调若干已知会 4xx 的端点，断言：
   (a) status code 是预期
-  (b) response.json() 顶层有 "detail" key
-  (c) detail 是 str 或 dict（非 list 非 None）
+  (b) response.json() 顶层有 "error" key（{code, message, trace_id, details?}）
+  (c) ADR-0009 Phase 3：顶层不再有 legacy "detail" key
 
-不锁 detail 内容文案（PR 期间允许改）；不锁额外字段（PR-LOG-4 dual-write 会新增 "error" 平行 key）。
-未来 PR-LOG-4 合完应该仍能通过本测试（dual-write 保 detail 形态不变）。
+例外：RequestValidationError（pydantic body 校验，422）仍保 `{"detail": [...]}`
+（前端专门处理），见 test_validation_error_returns_422_with_detail。
 """
 from __future__ import annotations
 
@@ -37,33 +37,36 @@ def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TestClient:
     return TestClient(server.app)
 
 
-def _assert_detail_envelope(body: dict, status: int) -> None:
-    assert "detail" in body, f"missing 'detail' key in {status} response: {body!r}"
-    d = body["detail"]
-    assert isinstance(d, (str, dict)), (
-        f"detail must be str or dict (前端 client.ts 只 handle 这两态), got {type(d).__name__}: {d!r}"
+def _assert_error_envelope(body: dict, status: int) -> None:
+    assert "detail" not in body, f"Phase 3：错误响应不应再有 legacy detail key: {body!r}"
+    assert "error" in body, f"missing 'error' key in {status} response: {body!r}"
+    err = body["error"]
+    assert isinstance(err, dict) and isinstance(err.get("code"), str), (
+        f"error 必须是 {{code, message, trace_id}}，got {err!r}"
     )
+    assert isinstance(err.get("message"), str)
+    assert err.get("trace_id")
 
 
-def test_preset_not_found_returns_404_with_detail(client: TestClient, tmp_path: Path,
-                                                   monkeypatch: pytest.MonkeyPatch) -> None:
+def test_preset_not_found_returns_404_with_error(client: TestClient, tmp_path: Path,
+                                                  monkeypatch: pytest.MonkeyPatch) -> None:
     from studio.services.presets import io as presets_io
     monkeypatch.setattr(presets_io, "USER_PRESETS_DIR", tmp_path / "presets")
     resp = client.get("/api/presets/__definitely_does_not_exist_xxx__")
     assert resp.status_code == 404, f"expected 404, got {resp.status_code} body={resp.text!r}"
-    _assert_detail_envelope(resp.json(), resp.status_code)
+    _assert_error_envelope(resp.json(), resp.status_code)
 
 
-def test_preset_invalid_name_returns_400_with_detail(client: TestClient, tmp_path: Path,
-                                                       monkeypatch: pytest.MonkeyPatch) -> None:
+def test_preset_invalid_name_returns_400_with_error(client: TestClient, tmp_path: Path,
+                                                     monkeypatch: pytest.MonkeyPatch) -> None:
     from studio.services.presets import io as presets_io
     monkeypatch.setattr(presets_io, "USER_PRESETS_DIR", tmp_path / "presets")
-    # 路径分隔符是非法字符之一，触发 PresetError "非法预设名"
+    # 路径分隔符是非法字符之一，触发 preset 名校验
     resp = client.put("/api/presets/bad..name/with/slash", json={"foo": "bar"})
     assert resp.status_code in (400, 404, 422), (
         f"expected 4xx, got {resp.status_code} body={resp.text!r}"
     )
-    _assert_detail_envelope(resp.json(), resp.status_code)
+    _assert_error_envelope(resp.json(), resp.status_code)
 
 
 def test_unknown_task_log_returns_empty_not_error(client: TestClient) -> None:

--- a/tests/test_exception_handlers.py
+++ b/tests/test_exception_handlers.py
@@ -84,14 +84,12 @@ def test_domain_error_returns_subclass_http_status(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
-def test_domain_error_body_has_detail_legacy(client: TestClient) -> None:
-    """前端 client.ts 老路径读 body.detail 是 string — dual-write 保这条。"""
+def test_domain_error_body_has_no_legacy_detail(client: TestClient) -> None:
+    """ADR-0009 Phase 3：错误响应只发 error 信封，legacy detail key 已移除。"""
     resp = client.get("/raise_domain")
     body = resp.json()
-    assert "detail" in body
-    assert body["detail"] == "preset 'foo' does not exist", (
-        "detail 必须是 message 字符串（前端 client.ts:1233-1238 兜底）"
-    )
+    assert "detail" not in body
+    assert body["error"]["message"] == "preset 'foo' does not exist"
 
 
 def test_domain_error_body_has_error_struct(client: TestClient) -> None:
@@ -149,34 +147,30 @@ def test_domain_error_4xx_logs_info_not_exception(
     assert errors == [], "4xx 不应 logger.exception（业务正常路径，不该 ERROR 噪音）"
 
 
-# ── HTTPException 形态保护（前端 client.ts 老路径不破）────────────────
+# ── HTTPException backstop（Phase 3：包成 error 信封，不再发 legacy detail）──
 
 
-def test_http_exception_string_detail_preserved(client: TestClient) -> None:
-    """ADR-0009 Phase 2：raise HTTPException(detail='str') 的 detail 原样保留（老
-    路径不破），且 backstop handler 旁边补 error 信封（code=http.<status>）。"""
+def test_http_exception_string_wrapped_in_error(client: TestClient) -> None:
+    """ADR-0009 Phase 3：裸 HTTPException(detail='str') 经 backstop 包成 error 信封
+    （code=http.<status>，message=detail），不再发 legacy detail key。"""
     resp = client.get("/raise_http")
     assert resp.status_code == 400
     body = resp.json()
-    # detail 形状不变（前端 fallback + 老 callsite 依赖）
-    assert body["detail"] == "legacy http err string"
-    # Phase 2：error 信封补齐，前端可一律读 body.error
+    assert "detail" not in body
     assert body["error"]["code"] == "http.400"
     assert body["error"]["message"] == "legacy http err string"
     assert body["error"]["trace_id"] is not None
 
 
-def test_http_exception_dict_detail_preserved(client: TestClient) -> None:
-    """ADR-0009 Phase 2：raise HTTPException(detail={...}) 的 dict detail 原样保留
-    （test_studio_server.py 7 处断言 body['detail']['error'] 依赖此，不能变），
-    并旁边合成 error（message 取 detail.message/error 兜底）。"""
+def test_http_exception_dict_detail_into_error_details(client: TestClient) -> None:
+    """ADR-0009 Phase 3：HTTPException(detail={...}) 的结构化 detail 进 error.details，
+    顶层 legacy detail 已移除（业务迁移后已无 dict-detail 来源，仅 backstop 兜底）。"""
     resp = client.get("/raise_http_dict")
     body = resp.json()
-    # 结构化 detail 原样保留
-    assert body["detail"] == {"error": "running_tasks_present", "count": 3}
-    # Phase 2：合成 error 信封
+    assert "detail" not in body
     assert body["error"]["code"] == "http.400"
     assert body["error"]["message"] == "running_tasks_present"
+    assert body["error"]["details"] == {"error": "running_tasks_present", "count": 3}
     assert body["error"]["trace_id"] is not None
 
 
@@ -190,12 +184,11 @@ def test_http_exception_still_has_trace_id_header(client: TestClient) -> None:
 # ── Exception fallback ────────────────────────────────────────────────
 
 
-def test_uncaught_exception_returns_500_dual_envelope(client: TestClient) -> None:
+def test_uncaught_exception_returns_500_error_envelope(client: TestClient) -> None:
     resp = client.get("/raise_uncaught")
     assert resp.status_code == 500
     body = resp.json()
-    assert "detail" in body
-    assert "error" in body
+    assert "detail" not in body
     assert body["error"]["code"] == "internal.server_error"
     assert body["error"]["trace_id"] is not None
 
@@ -252,6 +245,7 @@ def test_existing_preset_404_path_still_works(
     resp = c.get("/api/presets/__nonexistent__")
     assert resp.status_code == 404
     body = resp.json()
-    # 现状（PR-2 C3 前）：presets.py 还在 raise HTTPException —— 形状保持 {detail: str}
-    assert "detail" in body
-    assert isinstance(body["detail"], str)
+    # Phase 3：错误响应只发 error 信封（preset 已迁 DomainError，带语义 code）
+    assert "detail" not in body
+    assert body["error"]["code"] == "preset.not_found"
+    assert isinstance(body["error"]["message"], str)

--- a/tests/test_service_errors_inherit_domain.py
+++ b/tests/test_service_errors_inherit_domain.py
@@ -63,7 +63,7 @@ def test_raise_service_error_caught_by_handler_via_isinstance(tmp_path) -> None:
     resp = c.get("/raise_preset_err")
     assert resp.status_code == 400
     body = resp.json()
-    assert body["detail"] == "preset 'x' missing"
+    assert "detail" not in body  # Phase 3：只发 error 信封
     assert body["error"]["code"] == "preset.error"
     assert body["error"]["message"] == "preset 'x' missing"
     assert body["error"]["trace_id"] is not None

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -255,7 +255,7 @@ def test_flash_attention_install_failure_returns_500(
     monkeypatch.setattr(flash_attention_setup, "install", boom)
     resp = client.post("/api/flash-attention/install", json={"url": "https://x/bad.whl"})
     assert resp.status_code == 500
-    assert "bad wheel" in resp.json()["detail"]
+    assert "bad wheel" in resp.json()["error"]["message"]
 
 
 def test_state_missing_returns_empty(client: TestClient, isolated_paths: dict[str, Path]) -> None:

--- a/tests/test_tag_dictionary.py
+++ b/tests/test_tag_dictionary.py
@@ -366,7 +366,8 @@ def test_reset_endpoint_502_on_network_error(
     monkeypatch.setattr(td.requests, "get", _boom)
     r = client.post("/api/tag-dictionary/reset")
     assert r.status_code == 502
-    assert "network unreachable" in r.json()["detail"]
+    err = r.json()["error"]
+    assert "network unreachable" in (err.get("message", "") + str(err.get("details", "")))
 
 
 def test_reset_endpoint_success(

--- a/tests/test_task_snapshot.py
+++ b/tests/test_task_snapshot.py
@@ -118,7 +118,7 @@ def _create_task(isolated, name: str = "t1") -> int:
 def test_endpoint_404_when_task_missing(client: TestClient) -> None:
     resp = client.get("/api/queue/99999/snapshot/config")
     assert resp.status_code == 404
-    assert "task" in resp.json()["detail"].lower()
+    assert resp.json()["error"]["code"] == "task.not_found"
 
 
 def test_endpoint_404_when_snapshot_missing(client: TestClient, isolated) -> None:


### PR DESCRIPTION
## 背景

ADR 0009 envelope 迁移的收尾。Phase 2（PR #294,已合 dev）让 `body.error` 覆盖所有错误响应、前端按 code 本地化。Phase 3 移除 dual-write 的 legacy `detail` key——前端早已主读 `body.error.*`,删它现在安全。

## 改动

- `exception_handlers.py`:DomainError handler + Exception fallback + HTTPException backstop **只发 `{"error": {...}}`**,删顶层 `detail`。backstop 的 dict/list detail 改放 `error.details`。
- **唯一例外**:RequestValidationError（pydantic body 校验 422）仍保 `{"detail": [...]}`（前端专门处理）。
- **前端无需改**:`makeApiError` 早已主读 `body.error`,`detail` 仅作 422-list fallback。
- 测试:~8 个文件断言迁到 error 信封;`test_error_response_baseline`(契约锁)改锁 `error` key。

## 测试

- 后端 **2362 passed**(1 个 Windows taskkill 计时 flake,隔离过)。
- 前端 **393 passed**,tsc 干净。

ADR 0009 envelope 三阶段(0.12.0 dual-write → code i18n → 删 detail)至此**全部完成**,随 0.15.0 发布。todo/ADR 已标完成。

🤖 Generated with [Claude Code](https://claude.com/claude-code)