### PR TITLE
feat(tagger): 支持 CLTagger v2

### DIFF
--- a/studio/infrastructure/secrets.py
+++ b/studio/infrastructure/secrets.py
@@ -380,6 +380,7 @@ class CLTaggerConfig(BaseModel):
     model_path: str = "cl_tagger_1_02/model.onnx"
     tag_mapping_path: str = "cl_tagger_1_02/tag_mapping.json"
     local_dir: Optional[str] = None
+    variant_local_dirs: dict[str, str] = Field(default_factory=dict)
     threshold_general: float = 0.35
     threshold_character: float = 0.6
     # CLTagger 模型输出 7 个 category：General / Character 走阈值过滤，其余 5 个

--- a/studio/services/models/catalog.py
+++ b/studio/services/models/catalog.py
@@ -102,6 +102,7 @@ def build_catalog(root: Optional[Path] = None) -> dict[str, Any]:
         mp = preset["model_path"]
         tmp = preset["tag_mapping_path"]
         target_root = cltagger_target_root(r, model_id)
+        version_dir = target_root / Path(mp).parent
         file_names = [mp, tmp, *preset.get("extra_files", [])]
         files = [{"name": f, **_file_status(target_root / f)} for f in file_names]
         all_exist = all(f["exists"] for f in files)
@@ -113,6 +114,8 @@ def build_catalog(root: Optional[Path] = None) -> dict[str, Any]:
             "tag_mapping_path": tmp,
             "description": preset.get("description", ""),
             "target_dir": str(target_root),
+            "local_dir": str(target_root),
+            "version_dir": str(version_dir),
             "is_current": (
                 cl_cfg.model_id == model_id
                 and cl_cfg.model_path == mp
@@ -221,6 +224,7 @@ def build_catalog(root: Optional[Path] = None) -> dict[str, Any]:
             "description": "cella110n CLTagger ONNX",
             "repo": cl_cfg.model_id,
             "target_dir": str(cl_root),
+            "current_local_dir": cl_cfg.local_dir,
             "current_model_path": cl_cfg.model_path,
             "current_tag_mapping_path": cl_cfg.tag_mapping_path,
             "variants": cl_variants,

--- a/studio/services/models/catalog.py
+++ b/studio/services/models/catalog.py
@@ -97,18 +97,27 @@ def build_catalog(root: Optional[Path] = None) -> dict[str, Any]:
     # CLTagger 版本预设（CLTAGGER_VERSIONS 写死的子目录布局）。
     cl_root = cltagger_target_root(r, cl_cfg.model_id)
     cl_variants = []
-    for label, (mp, tmp) in CLTAGGER_VERSIONS.items():
-        files = [
-            {"name": mp, **_file_status(cl_root / mp)},
-            {"name": tmp, **_file_status(cl_root / tmp)},
-        ]
+    for label, preset in CLTAGGER_VERSIONS.items():
+        model_id = preset["model_id"]
+        mp = preset["model_path"]
+        tmp = preset["tag_mapping_path"]
+        target_root = cltagger_target_root(r, model_id)
+        file_names = [mp, tmp, *preset.get("extra_files", [])]
+        files = [{"name": f, **_file_status(target_root / f)} for f in file_names]
         all_exist = all(f["exists"] for f in files)
         total_size = sum(f["size"] for f in files)
         cl_variants.append({
             "label": label,
+            "model_id": model_id,
             "model_path": mp,
             "tag_mapping_path": tmp,
-            "is_current": cl_cfg.model_path == mp and cl_cfg.tag_mapping_path == tmp,
+            "description": preset.get("description", ""),
+            "target_dir": str(target_root),
+            "is_current": (
+                cl_cfg.model_id == model_id
+                and cl_cfg.model_path == mp
+                and cl_cfg.tag_mapping_path == tmp
+            ),
             "exists": all_exist,
             "size": total_size,
             "files": files,

--- a/studio/services/models/downloader.py
+++ b/studio/services/models/downloader.py
@@ -152,7 +152,16 @@ def download_cltagger(
     on_log(f"\n📥 CLTagger → {target_root}")
     target_root.mkdir(parents=True, exist_ok=True)
     ok = True
-    for f in (cfg.model_path, cfg.tag_mapping_path):
+    files = [cfg.model_path, cfg.tag_mapping_path]
+    for preset in CLTAGGER_VERSIONS.values():
+        if (
+            preset["model_id"] == cfg.model_id
+            and preset["model_path"] == cfg.model_path
+            and preset["tag_mapping_path"] == cfg.tag_mapping_path
+        ):
+            files.extend(preset.get("extra_files", []))
+            break
+    for f in dict.fromkeys(files):
         if not _sources.download_flat(cfg.model_id, f, target_root / f, on_log=on_log):
             ok = False
     return ok
@@ -393,7 +402,6 @@ def trigger(model_id: str, variant: Optional[str] = None) -> str:
         return key
     if model_id == "cltagger":
         cfg = secrets.load().cltagger
-        target = cltagger_target_root(root, cfg.model_id)
         # variant 可指定预设 label（覆盖 cfg 当前的 model_path），便于 UI 一键
         # 下载非"当前选中"的版本。未指定时用 cfg 当前路径。
         if variant:
@@ -401,11 +409,17 @@ def trigger(model_id: str, variant: Optional[str] = None) -> str:
             if preset is None:
                 raise ValueError(f"unknown cltagger variant {variant!r}")
             cfg = secrets.CLTaggerConfig(
-                **{**cfg.model_dump(), "model_path": preset[0], "tag_mapping_path": preset[1]}
+                **{
+                    **cfg.model_dump(),
+                    "model_id": preset["model_id"],
+                    "model_path": preset["model_path"],
+                    "tag_mapping_path": preset["tag_mapping_path"],
+                }
             )
             key = f"cltagger:{variant}"
         else:
             key = "cltagger"
+        target = cltagger_target_root(root, cfg.model_id)
         start_download_async(
             key, lambda log: download_cltagger(target, cfg, on_log=log)
         )

--- a/studio/services/models/paths.py
+++ b/studio/services/models/paths.py
@@ -60,14 +60,26 @@ TAEFLUX_FILES = [
     "config.json",
 ]
 
-# CLTagger 子目录布局：仓库内 cl_tagger_1_02/model.onnx 等。新版本（1.03 等）
-# 出现时往这里加一行；UI 自动作为 radio 选项暴露。
-# label → (model_path, tag_mapping_path)
-CLTAGGER_VERSIONS: dict[str, tuple[str, str]] = {
-    "cl_tagger_1_02": (
-        "cl_tagger_1_02/model.onnx",
-        "cl_tagger_1_02/tag_mapping.json",
-    ),
+# CLTagger 子目录布局。UI 会自动把这里的 label 暴露成 radio 选项。
+# label → repo/model/mapping/files metadata
+CLTAGGER_VERSIONS: dict[str, dict[str, Any]] = {
+    "v2_01a": {
+        "model_id": "cella110n/cl_tagger_v2",
+        "model_path": "v2_01a/model.onnx",
+        "tag_mapping_path": "v2_01a/model_vocabulary.json",
+        "extra_files": [
+            "v2_01a/model.onnx.data",
+            "v2_01a/model_metadata.json",
+        ],
+        "description": "CL Tagger v2 provisional SigLIP2 ONNX",
+    },
+    "cl_tagger_1_02": {
+        "model_id": "cella110n/cl_tagger",
+        "model_path": "cl_tagger_1_02/model.onnx",
+        "tag_mapping_path": "cl_tagger_1_02/tag_mapping.json",
+        "extra_files": [],
+        "description": "CLTagger 1.02 ONNX",
+    },
 }
 
 # WD14 模型常驻文件名（HF SmilingWolf/* 仓库顶层都是这两个）。

--- a/studio/services/tagging/cltagger.py
+++ b/studio/services/tagging/cltagger.py
@@ -40,6 +40,7 @@ class CLTagger(OnnxTaggerBase):
         self._labels: _LabelData | None = None
         self._input_size: int = 448
         self._input_layout: str = "nchw"
+        self._color_order: str = "bgr"
 
     def _cfg(self) -> "secrets.CLTaggerConfig":
         base = secrets.load().cltagger.model_dump()
@@ -57,18 +58,49 @@ class CLTagger(OnnxTaggerBase):
             return Path(cfg.local_dir)
         return model_downloader.cltagger_target_root(model_downloader.models_root(), cfg.model_id)
 
+    def _expected_extra_paths(self, base: Path) -> list[Path]:
+        cfg = self._cfg()
+        return [
+            base / f
+            for preset in model_downloader.CLTAGGER_VERSIONS.values()
+            if (
+                preset["model_id"] == cfg.model_id
+                and preset["model_path"] == cfg.model_path
+                and preset["tag_mapping_path"] == cfg.tag_mapping_path
+            )
+            for f in preset.get("extra_files", [])
+        ]
+
+    def _missing_local_files_message(self, model_path: Path, mapping_path: Path) -> str:
+        base = self._compute_base()
+        paths = [model_path, mapping_path, *self._expected_extra_paths(base)]
+        if self._cfg().local_dir:
+            flat_model = base / Path(self._cfg().model_path).name
+            flat_mapping = base / Path(self._cfg().tag_mapping_path).name
+            if flat_model.exists() and flat_mapping.exists():
+                paths = [
+                    flat_model,
+                    flat_mapping,
+                    *[base / Path(p).name for p in self._expected_extra_paths(base)],
+                ]
+        missing = [str(p) for p in paths if not p.exists()]
+        missing = list(dict.fromkeys(missing))
+        return "local_dir 缺少 CLTagger 模型文件: " + " / ".join(missing)
+
     def _local_model_files_status(self) -> tuple[Path, Path, bool]:
         cfg = self._cfg()
         base = self._compute_base()
         model_path = base / cfg.model_path
         mapping_path = base / cfg.tag_mapping_path
+        extra_paths = self._expected_extra_paths(base)
         if model_path.exists() and mapping_path.exists():
-            return model_path, mapping_path, True
+            return model_path, mapping_path, all(p.exists() for p in extra_paths)
         if cfg.local_dir:
             flat_model = base / Path(cfg.model_path).name
             flat_mapping = base / Path(cfg.tag_mapping_path).name
+            flat_extra = [base / Path(p).name for p in extra_paths]
             if flat_model.exists() and flat_mapping.exists():
-                return flat_model, flat_mapping, True
+                return flat_model, flat_mapping, all(p.exists() for p in flat_extra)
         return model_path, mapping_path, False
 
     def _resolve_model_files(self) -> tuple[Path, Path]:
@@ -77,16 +109,16 @@ class CLTagger(OnnxTaggerBase):
         if ok:
             return model_path, mapping_path
         if cfg.local_dir:
-            raise FileNotFoundError(
-                "local_dir 缺少 CLTagger 模型文件或 tag_mapping.json: "
-                f"{model_path} / {mapping_path}"
-            )
+            raise FileNotFoundError(self._missing_local_files_message(model_path, mapping_path))
         model_downloader.download_cltagger(self._compute_base(), cfg, on_log=logger.info)
         missing: list[str] = []
         if not model_path.exists():
             missing.append(f"model: {model_path}")
         if not mapping_path.exists():
             missing.append(f"mapping: {mapping_path}")
+        for p in self._expected_extra_paths(self._compute_base()):
+            if not p.exists():
+                missing.append(f"extra: {p}")
         if missing:
             raise FileNotFoundError(
                 f"CLTagger 下载后仍缺少 {', '.join(missing)}（请到设置→模型管理查看下载日志）"
@@ -100,10 +132,7 @@ class CLTagger(OnnxTaggerBase):
             return False, str(exc)
         if not ok:
             if self._cfg().local_dir:
-                return False, (
-                    "local_dir 缺少 CLTagger 模型文件或 tag_mapping.json: "
-                    f"{model_path} / {mapping_path}"
-                )
+                return False, self._missing_local_files_message(model_path, mapping_path)
             return False, f"需下载模型: {model_path.parent.name}"
         return True, f"模型: {model_path.parent.name}"
 
@@ -117,6 +146,7 @@ class CLTagger(OnnxTaggerBase):
         self._input_layout = self._infer_input_layout(input_meta.shape)
         self._input_size = self._infer_input_size(input_meta.shape, self._input_layout)
         self._labels = self._load_tag_mapping(mapping_path)
+        self._color_order = "rgb" if mapping_path.name == "model_vocabulary.json" else "bgr"
 
     @staticmethod
     def _infer_input_layout(shape: list[object]) -> str:
@@ -149,6 +179,10 @@ class CLTagger(OnnxTaggerBase):
         raw = json.loads(mapping_path.read_text(encoding="utf-8"))
         if isinstance(raw, dict) and "idx_to_tag" in raw:
             idx_to_tag = {int(k): str(v) for k, v in raw["idx_to_tag"].items()}
+            tag_to_category = {str(k): str(v) for k, v in raw.get("tag_to_category", {}).items()}
+        elif isinstance(raw, dict) and "tag_to_idx" in raw:
+            tag_to_idx = {str(k): int(v) for k, v in raw["tag_to_idx"].items()}
+            idx_to_tag = {idx: tag for tag, idx in tag_to_idx.items()}
             tag_to_category = {str(k): str(v) for k, v in raw.get("tag_to_category", {}).items()}
         elif isinstance(raw, dict):
             idx_to_tag = {}
@@ -186,7 +220,8 @@ class CLTagger(OnnxTaggerBase):
             img = canvas
         img = img.resize((size, size), Image.Resampling.BICUBIC)
         arr = np.asarray(img, dtype=np.float32) / 255.0
-        arr = arr[..., ::-1]  # RGB -> BGR
+        if self._color_order == "bgr":
+            arr = arr[..., ::-1]  # RGB -> BGR for CLTagger 1.x
         if self._input_layout == "nchw":
             arr = arr.transpose(2, 0, 1)
             mean = np.array([0.5, 0.5, 0.5], dtype=np.float32).reshape(3, 1, 1)

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -226,6 +226,7 @@ export interface CLTaggerConfig {
   model_path: string
   tag_mapping_path: string
   local_dir: string | null
+  variant_local_dirs: Record<string, string>
   threshold_general: number
   threshold_character: number
   add_copyright_tag: boolean

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -525,6 +525,8 @@ export interface CLTaggerVariantInfo {
   tag_mapping_path: string
   description?: string
   target_dir?: string
+  local_dir?: string
+  version_dir?: string
   is_current: boolean
   exists: boolean
   size: number
@@ -537,6 +539,7 @@ export interface CLTaggerCatalog {
   description: string
   repo: string
   target_dir: string
+  current_local_dir: string | null
   current_model_path: string
   current_tag_mapping_path: string
   variants: CLTaggerVariantInfo[]

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -520,8 +520,11 @@ export interface WD14Catalog {
 
 export interface CLTaggerVariantInfo {
   label: string
+  model_id: string
   model_path: string
   tag_mapping_path: string
+  description?: string
+  target_dir?: string
   is_current: boolean
   exists: boolean
   size: number

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -898,6 +898,7 @@ export default function SettingsPage() {
             update('cltagger', 'model_id', v.model_id)
             update('cltagger', 'model_path', v.model_path)
             update('cltagger', 'tag_mapping_path', v.tag_mapping_path)
+            update('cltagger', 'local_dir', v.local_dir ?? v.target_dir ?? null)
           }}
           modelId={draft.cltagger.model_id}
           onModelIdChange={(id) => update('cltagger', 'model_id', id)}
@@ -1696,6 +1697,7 @@ function CLTaggerModelCard({
           const isSel =
             v.model_path === currentModelPath &&
             v.tag_mapping_path === currentTagMappingPath
+          const manualDir = v.version_dir ?? v.target_dir
           return (
             <li key={v.label} className={`flex items-center gap-2 text-xs px-1.5 py-1 rounded-sm ${
               isSel ? 'bg-accent-soft border border-accent' : 'bg-transparent border border-transparent'
@@ -1706,7 +1708,14 @@ function CLTaggerModelCard({
                 style={{ accentColor: 'var(--accent)' }}
                 title={t('settings.selectClTaggerVersion')}
               />
-              <code className="font-mono text-fg-primary flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{v.label}</code>
+              <div className="flex flex-col flex-1 min-w-0">
+                <code className="font-mono text-fg-primary overflow-hidden text-ellipsis whitespace-nowrap">{v.label}</code>
+                {manualDir && (
+                  <span className="text-[10px] text-fg-tertiary overflow-hidden text-ellipsis whitespace-nowrap" title={manualDir}>
+                    files: <code>{manualDir}</code>
+                  </span>
+                )}
+              </div>
               <ModelStatusBadge
                 exists={v.exists} size={v.size} status={dl?.status}
                 fileCount={v.files.length}

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -895,6 +895,7 @@ export default function SettingsPage() {
           currentModelPath={draft.cltagger.model_path}
           currentTagMappingPath={draft.cltagger.tag_mapping_path}
           onSelectVariant={(v: CLTaggerVariantInfo) => {
+            update('cltagger', 'model_id', v.model_id)
             update('cltagger', 'model_path', v.model_path)
             update('cltagger', 'tag_mapping_path', v.tag_mapping_path)
           }}

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -845,10 +845,10 @@ export default function SettingsPage() {
           t={t}
         />
         <SettingsField label="local_dir" desc={t('settings.blankAutoHfDownload')}>
-          <SettingsInput
+          <input
             type="text"
             value={draft.wd14.local_dir ?? ''}
-            onChange={(v) => update('wd14', 'local_dir', v || null)}
+            onChange={(e) => update('wd14', 'local_dir', e.target.value || null)}
             className={textInputClass}
           />
         </SettingsField>
@@ -905,10 +905,10 @@ export default function SettingsPage() {
           t={t}
         />
         <SettingsField label="local_dir" desc={t('settings.blankAutoHfDownload')}>
-          <SettingsInput
+          <input
             type="text"
             value={draft.cltagger.local_dir ?? ''}
-            onChange={(v) => update('cltagger', 'local_dir', v || null)}
+            onChange={(e) => update('cltagger', 'local_dir', e.target.value || null)}
             className={textInputClass}
           />
         </SettingsField>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -253,6 +253,7 @@ const EMPTY: Secrets = {
     model_path: 'cl_tagger_1_02/model.onnx',
     tag_mapping_path: 'cl_tagger_1_02/tag_mapping.json',
     local_dir: null,
+    variant_local_dirs: {},
     threshold_general: 0.35,
     threshold_character: 0.6,
     add_copyright_tag: true,
@@ -389,6 +390,65 @@ export default function SettingsPage() {
   /** 更新 Secrets 顶层非对象字段（如 download_source）。 */
   const updateTop = <K extends keyof Secrets>(key: K, value: Secrets[K]) => {
     setDraft((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const currentCLTaggerVariant = useMemo(() => {
+    const variants = catalog?.cltagger?.variants ?? []
+    return variants.find((v) =>
+      v.model_id === draft.cltagger.model_id &&
+      v.model_path === draft.cltagger.model_path &&
+      v.tag_mapping_path === draft.cltagger.tag_mapping_path
+    ) ?? null
+  }, [
+    catalog?.cltagger?.variants,
+    draft.cltagger.model_id,
+    draft.cltagger.model_path,
+    draft.cltagger.tag_mapping_path,
+  ])
+
+  const updateCLTaggerLocalDir = (value: string) => {
+    const localDir = value || null
+    const label = currentCLTaggerVariant?.label
+    setDraft((prev) => {
+      const nextVariantLocalDirs = { ...(prev.cltagger.variant_local_dirs ?? {}) }
+      if (label) {
+        if (value) nextVariantLocalDirs[label] = value
+        else delete nextVariantLocalDirs[label]
+      }
+      return {
+        ...prev,
+        cltagger: {
+          ...prev.cltagger,
+          local_dir: localDir,
+          variant_local_dirs: nextVariantLocalDirs,
+        },
+      }
+    })
+  }
+
+  const selectCLTaggerVariant = (variant: CLTaggerVariantInfo) => {
+    const currentLabel = currentCLTaggerVariant?.label
+    setDraft((prev) => {
+      const nextVariantLocalDirs = { ...(prev.cltagger.variant_local_dirs ?? {}) }
+      if (currentLabel && prev.cltagger.local_dir) {
+        nextVariantLocalDirs[currentLabel] = prev.cltagger.local_dir
+      }
+      const nextLocalDir = nextVariantLocalDirs[variant.label]
+        ?? variant.local_dir
+        ?? variant.target_dir
+        ?? null
+      return {
+        ...prev,
+        cltagger: {
+          ...prev.cltagger,
+          model_id: variant.model_id,
+          model_path: variant.model_path,
+          tag_mapping_path: variant.tag_mapping_path,
+          local_dir: nextLocalDir,
+          variant_local_dirs: nextVariantLocalDirs,
+        },
+      }
+    })
   }
 
   const save = async () => {
@@ -895,10 +955,7 @@ export default function SettingsPage() {
           currentModelPath={draft.cltagger.model_path}
           currentTagMappingPath={draft.cltagger.tag_mapping_path}
           onSelectVariant={(v: CLTaggerVariantInfo) => {
-            update('cltagger', 'model_id', v.model_id)
-            update('cltagger', 'model_path', v.model_path)
-            update('cltagger', 'tag_mapping_path', v.tag_mapping_path)
-            update('cltagger', 'local_dir', v.local_dir ?? v.target_dir ?? null)
+            selectCLTaggerVariant(v)
           }}
           modelId={draft.cltagger.model_id}
           onModelIdChange={(id) => update('cltagger', 'model_id', id)}
@@ -908,7 +965,7 @@ export default function SettingsPage() {
           <input
             type="text"
             value={draft.cltagger.local_dir ?? ''}
-            onChange={(e) => update('cltagger', 'local_dir', e.target.value || null)}
+            onChange={(e) => updateCLTaggerLocalDir(e.target.value)}
             className={textInputClass}
           />
         </SettingsField>

--- a/tests/test_cltagger_tagger.py
+++ b/tests/test_cltagger_tagger.py
@@ -73,6 +73,30 @@ def test_is_available_does_not_download_when_model_missing(
     assert called["download"] is False
 
 
+def test_v2_local_dir_requires_external_data(isolated_secrets: Path) -> None:
+    model_dir = isolated_secrets / "cl_v2"
+    model_dir.mkdir(parents=True, exist_ok=True)
+    (model_dir / "model.onnx").write_bytes(b"fake-onnx")
+    (model_dir / "model_vocabulary.json").write_text(
+        json.dumps({
+            "idx_to_tag": {"0": "general_tag"},
+            "tag_to_category": {"general_tag": "General"},
+        }),
+        encoding="utf-8",
+    )
+    secrets.update({
+        "cltagger": {
+            "model_id": "cella110n/cl_tagger_v2",
+            "model_path": "v2_01a/model.onnx",
+            "tag_mapping_path": "v2_01a/model_vocabulary.json",
+            "local_dir": str(model_dir),
+        }
+    })
+    ok, msg = cltagger_tagger.CLTagger().is_available()
+    assert ok is False
+    assert "local_dir 缺少" in msg
+
+
 def test_postprocess_uses_character_threshold_and_optional_categories(
     isolated_secrets: Path,
 ) -> None:
@@ -196,6 +220,32 @@ def test_load_tag_mapping_supports_inline_object_schema(tmp_path: Path) -> None:
     assert labels.categories == ["General", "Character", "General", "General"]
 
 
+def test_load_tag_mapping_supports_v2_vocabulary_schema(tmp_path: Path) -> None:
+    """CLTagger v2 uses model_vocabulary.json with tag_to_idx / idx_to_tag."""
+    mapping_path = tmp_path / "model_vocabulary.json"
+    mapping_path.write_text(
+        json.dumps({
+            "tag_to_idx": {
+                "general_tag": 0,
+                "hero_name": 1,
+            },
+            "idx_to_tag": {
+                "0": "general_tag",
+                "1": "hero_name",
+            },
+            "tag_to_category": {
+                "general_tag": "General",
+                "hero_name": "Character",
+            },
+            "categories": ["General", "Character"],
+        }),
+        encoding="utf-8",
+    )
+    labels = cltagger_tagger.CLTagger._load_tag_mapping(mapping_path)
+    assert labels.names == ["general_tag", "hero_name"]
+    assert labels.categories == ["General", "Character"]
+
+
 def test_preprocess_supports_nhwc_layout(isolated_secrets: Path) -> None:
     t = cltagger_tagger.CLTagger()
     t._input_size = 4
@@ -204,3 +254,14 @@ def test_preprocess_supports_nhwc_layout(isolated_secrets: Path) -> None:
     assert arr.shape == (4, 4, 3)
     assert arr[0, 0, 0] == pytest.approx(-1.0, abs=1e-4)  # B
     assert arr[0, 0, 2] == pytest.approx(1.0, abs=1e-4)   # R
+
+
+def test_preprocess_v2_keeps_rgb_order(isolated_secrets: Path) -> None:
+    t = cltagger_tagger.CLTagger()
+    t._input_size = 4
+    t._input_layout = "nchw"
+    t._color_order = "rgb"
+    arr = t._preprocess(Image.new("RGB", (8, 8), (255, 0, 0)))
+    assert arr.shape == (3, 4, 4)
+    assert arr[0, 0, 0] == pytest.approx(1.0, abs=1e-4)   # R
+    assert arr[2, 0, 0] == pytest.approx(-1.0, abs=1e-4)  # B

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -314,6 +314,51 @@ def test_download_qwen3_modelscope_builds_complete_directory(
         assert (qwen_dir / f).read_text(encoding="utf-8") == f
 
 
+def test_download_cltagger_v2_downloads_external_data(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLTagger v2 ONNX uses external weights, so model.onnx.data is required."""
+    from studio import secrets
+
+    cfg = secrets.CLTaggerConfig(
+        model_id="cella110n/cl_tagger_v2",
+        model_path="v2_01a/model.onnx",
+        tag_mapping_path="v2_01a/model_vocabulary.json",
+    )
+    calls: list[tuple[str, str, str]] = []
+
+    def fake_download_flat(repo_id, repo_subpath, target, *, on_log=print):
+        calls.append((repo_id, repo_subpath, str(target)))
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"x")
+        return True
+
+    monkeypatch.setattr(model_downloader, "download_flat", fake_download_flat)
+    ok = model_downloader.download_cltagger(tmp_path, cfg, on_log=lambda _l: None)
+    assert ok
+    assert [(repo, path) for repo, path, _ in calls] == [
+        ("cella110n/cl_tagger_v2", "v2_01a/model.onnx"),
+        ("cella110n/cl_tagger_v2", "v2_01a/model_vocabulary.json"),
+        ("cella110n/cl_tagger_v2", "v2_01a/model.onnx.data"),
+        ("cella110n/cl_tagger_v2", "v2_01a/model_metadata.json"),
+    ]
+
+
+def test_build_catalog_includes_cltagger_v2_variant(
+    tmp_path: "Path", monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from studio import secrets
+
+    monkeypatch.setattr(secrets, "load", lambda: secrets.Secrets())
+    cat = model_downloader.build_catalog(tmp_path)
+    variants = cat["cltagger"]["variants"]
+    v2 = next(v for v in variants if v["label"] == "v2_01a")
+    assert v2["model_id"] == "cella110n/cl_tagger_v2"
+    assert v2["model_path"] == "v2_01a/model.onnx"
+    assert v2["tag_mapping_path"] == "v2_01a/model_vocabulary.json"
+    assert "v2_01a/model.onnx.data" in [f["name"] for f in v2["files"]]
+
+
 # ---------------------------------------------------------------------------
 # 预处理放大器
 # ---------------------------------------------------------------------------

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -356,7 +356,14 @@ def test_build_catalog_includes_cltagger_v2_variant(
     assert v2["model_id"] == "cella110n/cl_tagger_v2"
     assert v2["model_path"] == "v2_01a/model.onnx"
     assert v2["tag_mapping_path"] == "v2_01a/model_vocabulary.json"
+    assert v2["local_dir"] == str(tmp_path / "cltagger" / "cella110n_cl_tagger_v2")
+    assert v2["version_dir"] == str(tmp_path / "cltagger" / "cella110n_cl_tagger_v2" / "v2_01a")
     assert "v2_01a/model.onnx.data" in [f["name"] for f in v2["files"]]
+
+    v1 = next(v for v in variants if v["label"] == "cl_tagger_1_02")
+    assert v1["local_dir"] == str(tmp_path / "cltagger" / "cella110n_cl_tagger")
+    assert v1["version_dir"] == str(tmp_path / "cltagger" / "cella110n_cl_tagger" / "cl_tagger_1_02")
+    assert v1["local_dir"] != v2["local_dir"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -58,7 +58,24 @@ def test_cltagger_defaults_use_1_02(secrets_file: Path) -> None:
     assert s.cltagger.model_id == "cella110n/cl_tagger"
     assert s.cltagger.model_path == "cl_tagger_1_02/model.onnx"
     assert s.cltagger.tag_mapping_path == "cl_tagger_1_02/tag_mapping.json"
+    assert s.cltagger.variant_local_dirs == {}
     assert s.cltagger.threshold_character == pytest.approx(0.6)
+
+
+def test_cltagger_variant_local_dirs_persist(secrets_file: Path) -> None:
+    secrets.update({
+        "cltagger": {
+            "local_dir": "/models/cltagger-v2",
+            "variant_local_dirs": {
+                "v2_01a": "/models/cltagger-v2",
+                "cl_tagger_1_02": "/models/cltagger-102",
+            },
+        }
+    })
+    s = secrets.load()
+    assert s.cltagger.local_dir == "/models/cltagger-v2"
+    assert s.cltagger.variant_local_dirs["v2_01a"] == "/models/cltagger-v2"
+    assert s.cltagger.variant_local_dirs["cl_tagger_1_02"] == "/models/cltagger-102"
 
 
 def test_llm_tagger_defaults(secrets_file: Path) -> None:


### PR DESCRIPTION
## 概要

本 PR 为 CLTagger 增加 v2 模型支持，并保持对现有 cl_tagger_1_02 的兼容。

主要变更：

- 在模型 catalog / downloader / path resolver 中加入 `cella110n/cl_tagger_v2` 的 `v2_01a` variant。
- 兼容 v2 的文件布局：`model.onnx`、`model.onnx.data`、`model_vocabulary.json`、`model_metadata.json`。
- 设置页支持在 CLTagger 1.02 与 v2 之间切换，并显示当前 variant 对应的本地文件目录。
- 为不同 CLTagger variant 分别持久化 `local_dir`，避免切换版本后两个版本共用或覆盖同一路径。
- 补充 CLTagger v2、模型下载 catalog、secrets 持久化相关测试。

## 说明

这个 PR 是从自用组合分支中单独拆出的 CLTagger v2 部分，不包含 LoRA eval / PR138 的指标相关改动，便于单独审查。

## 测试

- `npm run build`（通过）
- `git diff --check`（通过）
- `python -m py_compile studio/infrastructure/secrets.py studio/services/models/catalog.py studio/services/models/downloader.py studio/services/models/paths.py studio/services/tagging/cltagger.py`（通过，使用 Codex bundled Python）

未运行：

- `pytest tests/test_cltagger_tagger.py tests/test_model_downloader.py tests/test_secrets.py`：当前本地 Python 环境没有安装 pytest。