### PR TITLE
feat(settings): 模型根目录挪到「系统 → 存储位置」+ 迁移功能

### DIFF
--- a/studio/api/app.py
+++ b/studio/api/app.py
@@ -29,6 +29,7 @@ from .routers import (
     jobs,
     logs,
     models,
+    models_storage,
     presets,
     root,
     samples,
@@ -84,6 +85,7 @@ app.include_router(tag_dictionary.router)
 app.include_router(installs.router)
 # PR-6 commit 4: system router（11 routes: restart / update / rollback / preflight / etc.）
 app.include_router(studio_data.router)
+app.include_router(models_storage.router)
 app.include_router(system.router)
 # PR-6 commit 5: generate router（8 routes: 出图 + daemon 状态 + TAEFlux）
 app.include_router(generate.router)

--- a/studio/api/routers/models_storage.py
+++ b/studio/api/routers/models_storage.py
@@ -1,0 +1,64 @@
+"""模型根目录存储位置 —— 查询 / 迁移到自定义目录（镜像 studio_data，无需重启）。
+
+3 routes：
+    GET  /api/models-root/info            当前/默认位置 + 全量扫描（文件数/字节）
+    POST /api/models-root/migrate         校验 + 起后台复制线程（进度走 SSE）
+    GET  /api/models-root/migrate_status  迁移状态快照（modal 重开 / SSE 漏事件兜底）
+
+迁移协议：复制完成后更新 `secrets.models.root`，**立即生效**（`models_root()` 现读
+secret，无指针文件、无需重启）。旧目录保留不删。进度事件：
+`models_root_migrate_progress` / `_done`。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter
+
+from ..schemas.models_storage import ModelsRootMigrateRequest
+from ...domain.errors import ConflictError, ValidationError
+from ...services import models_storage as svc
+from ...services.models import models_root
+from .system import _check_no_running_tasks
+
+router = APIRouter()
+
+
+@router.get("/api/models-root/info")
+def models_root_info(scan: bool = True) -> dict[str, Any]:
+    """当前 / 默认位置；scan=true 时附全量扫描（大目录可能要数秒，前端确认 modal
+    加载态等它；Settings 页仅显示路径用 scan=false 免扫盘）。"""
+    current = models_root()
+    default = svc.default_models_root()
+    return {
+        "current": str(current),
+        "default": str(default),
+        "is_custom": current.resolve() != default.resolve(),
+        "scan": svc.scan_models_root() if scan else None,
+    }
+
+
+@router.post("/api/models-root/migrate")
+def models_root_migrate(body: ModelsRootMigrateRequest) -> dict[str, Any]:
+    """起迁移。约束：无 running task（复制期间训练继续读权重 / move 语义不安全）。"""
+    _check_no_running_tasks()
+    try:
+        svc.start_migration(Path(body.target))
+    except ValueError as exc:
+        raise ValidationError(
+            f"Invalid target location: {exc}",
+            code="models_root.target_invalid",
+            details={"reason": str(exc)}, http_status=422,
+        ) from exc
+    except RuntimeError as exc:
+        raise ConflictError(
+            "A models-root migration is already in progress",
+            code="models_root.migration_busy",
+        ) from exc
+    return {"ok": True}
+
+
+@router.get("/api/models-root/migrate_status")
+def models_root_migrate_status() -> dict[str, Any]:
+    return svc.migration_status()

--- a/studio/api/schemas/models_storage.py
+++ b/studio/api/schemas/models_storage.py
@@ -1,0 +1,9 @@
+"""模型根目录迁移请求模型。"""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class ModelsRootMigrateRequest(BaseModel):
+    """迁移目标父目录（绝对路径；数据落 `target/models/`，目标不要求为空）。"""
+    target: str

--- a/studio/services/models_storage.py
+++ b/studio/services/models_storage.py
@@ -1,0 +1,262 @@
+"""模型根目录迁移 —— 扫描体积 + 后台复制到自定义位置（镜像 studio_data 迁移）。
+
+流程（前端 Settings → 系统 → 存储位置 → 模型根目录）：
+1. GET  /api/models-root/info          —— 当前/默认位置 + 全量扫描（文件数/字节数/顶层明细）
+2. POST /api/models-root/migrate       —— 校验后起后台线程复制；进度走 SSE
+3. 复制完成 → 更新 `secrets.models.root` → **立即生效**（`models_root()` 每次现读
+   secret，无需重启；区别于 studio_data 的指针文件 + 重启）
+
+设计要点（与 `studio_data.py` 一致）：
+- **目标是父目录**：用户选任意目录，数据落 `目标/models/`；目标本身不要求为空，只
+  要求落地子目录不存在或为空（不 merge 进已有数据）。
+- **只复制不删除**：旧目录原样保留（用户决策；已有 version 的 yaml 里烤死的旧绝对
+  路径仍可解析）。失败时清掉复制了一半的落地目录，secret 不动，等于什么都没发生。
+- **单飞**：模块级 lock + 状态单例。
+- 模型权重无 sqlite/wal，直接 `shutil.copy2`，无 `.db` backup 分支。
+"""
+from __future__ import annotations
+
+import logging
+import shutil
+import threading
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+from .. import secrets
+from ..infrastructure.event_bus import bus
+from ..infrastructure.paths import REPO_ROOT
+from .models import models_root
+
+logger = logging.getLogger(__name__)
+
+PROGRESS_INTERVAL_SECONDS = 0.2
+
+# 落地子目录名固定 —— 不跟随当前位置的目录名（自定义位置可能叫别的）。
+DATA_DIR_NAME = "models"
+
+Publish = Callable[[dict[str, Any]], None]
+
+
+def default_models_root() -> Path:
+    """`secrets.models.root` 未设时的默认落点（同 `models_root()` 的回退）。"""
+    return REPO_ROOT / "models"
+
+
+# ---------------------------------------------------------------------------
+# 扫描
+# ---------------------------------------------------------------------------
+
+def scan_models_root(root: Path | None = None) -> dict[str, Any]:
+    """全量扫描模型根目录：总文件数 / 总字节数 + 顶层条目明细（确认 modal 显示用）。
+
+    目录不存在时返回全 0（还没下载过任何模型）。
+    """
+    base = root if root is not None else models_root()
+    entries: list[dict[str, Any]] = []
+    total_files = 0
+    total_bytes = 0
+    if not base.is_dir():
+        return {"total_files": 0, "total_bytes": 0, "entries": []}
+    for child in sorted(base.iterdir(), key=lambda p: p.name.lower()):
+        files = 0
+        size = 0
+        if child.is_dir():
+            for f in child.rglob("*"):
+                if not f.is_file():
+                    continue
+                files += 1
+                try:
+                    size += f.stat().st_size
+                except OSError:
+                    pass
+        elif child.is_file():
+            files = 1
+            try:
+                size = child.stat().st_size
+            except OSError:
+                size = 0
+        entries.append({
+            "name": child.name,
+            "is_dir": child.is_dir(),
+            "files": files,
+            "bytes": size,
+        })
+        total_files += files
+        total_bytes += size
+    return {"total_files": total_files, "total_bytes": total_bytes, "entries": entries}
+
+
+# ---------------------------------------------------------------------------
+# 迁移状态（单例）
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MigrationStatus:
+    state: str = "idle"          # idle / running / done / error
+    target: str = ""
+    total_files: int = 0
+    total_bytes: int = 0
+    done_files: int = 0
+    done_bytes: int = 0
+    current_file: str = ""       # 相对路径，进度展示用
+    error: str = ""
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+_status = MigrationStatus()
+_status_lock = threading.Lock()
+
+
+def migration_status() -> dict[str, Any]:
+    with _status_lock:
+        return _status.as_dict()
+
+
+def _set_status(**kw: Any) -> None:
+    with _status_lock:
+        for k, v in kw.items():
+            setattr(_status, k, v)
+
+
+# ---------------------------------------------------------------------------
+# 校验 + 启动
+# ---------------------------------------------------------------------------
+
+def validate_target(target: Path, *, source: Path | None = None) -> Path:
+    """迁移目标校验，不合法抛 ValueError（caller 转 422）；返回实际落地目录。
+
+    target 是用户选的任意目录，数据落 `target/models/`，所以 target 本身不要求
+    为空。规则：绝对路径；target 已存在时必须是目录；落地目录不等于当前位置；
+    落地目录与当前位置互不嵌套；落地目录不存在或为空。
+    """
+    src = (source if source is not None else models_root()).resolve()
+    if not target.is_absolute():
+        raise ValueError("目标必须是绝对路径")
+    if target.exists() and not target.is_dir():
+        raise ValueError("目标已存在且不是目录")
+    dst = target.resolve() / DATA_DIR_NAME
+    if dst == src:
+        raise ValueError("目标与当前模型根目录位置相同")
+    for a, b in ((dst, src), (src, dst)):
+        try:
+            a.relative_to(b)
+        except ValueError:
+            continue
+        raise ValueError("目标目录与当前模型根目录互相嵌套")
+    if dst.exists():
+        if not dst.is_dir():
+            raise ValueError(f"目标下已存在同名文件 {DATA_DIR_NAME}")
+        if any(dst.iterdir()):
+            raise ValueError(f"目标下已存在非空 {DATA_DIR_NAME} 目录")
+    return dst
+
+
+def start_migration(
+    target: Path,
+    *,
+    source: Path | None = None,
+    publish: Publish = bus.publish,
+) -> None:
+    """校验 + 起后台复制线程。已有迁移在跑时抛 RuntimeError（caller 转 409）。
+
+    source 参数仅测试注入用；生产走默认（当前 `models_root()`）。
+    """
+    src = (source if source is not None else models_root()).resolve()
+    dst = validate_target(target, source=src)
+    with _status_lock:
+        if _status.state == "running":
+            raise RuntimeError("已有迁移正在进行")
+        _status.state = "running"
+        _status.target = str(dst)
+        _status.total_files = 0
+        _status.total_bytes = 0
+        _status.done_files = 0
+        _status.done_bytes = 0
+        _status.current_file = ""
+        _status.error = ""
+    t = threading.Thread(
+        target=_run_migration,
+        args=(src, dst, publish),
+        name="models-root-migration",
+        daemon=True,
+    )
+    t.start()
+
+
+def _update_models_root_secret(new_root: Path) -> None:
+    """复制成功后把 `secrets.models.root` 指到新落地目录（立即生效，无需重启）。"""
+    cur = secrets.load()
+    new_models = cur.models.model_copy(update={"root": str(new_root)})
+    secrets.save(cur.model_copy(update={"models": new_models}))
+
+
+# ---------------------------------------------------------------------------
+# 复制线程
+# ---------------------------------------------------------------------------
+
+def _run_migration(src: Path, dst: Path, publish: Publish) -> None:
+    try:
+        files = [f for f in sorted(src.rglob("*")) if f.is_file()]
+        total_bytes = 0
+        for f in files:
+            try:
+                total_bytes += f.stat().st_size
+            except OSError:
+                pass
+        _set_status(total_files=len(files), total_bytes=total_bytes)
+
+        dst.mkdir(parents=True, exist_ok=True)
+        last_pub = 0.0
+        done_files = 0
+        done_bytes = 0
+        for f in files:
+            rel = f.relative_to(src)
+            out = dst / rel
+            out.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                size = f.stat().st_size
+                shutil.copy2(f, out)
+            except FileNotFoundError:
+                # 扫描后被删（如临时文件）—— 跳过，进度可能停在 <100%，无碍
+                logger.info("迁移期间文件消失，跳过: %s", rel)
+                continue
+            done_files += 1
+            done_bytes += size
+            now = time.monotonic()
+            if now - last_pub >= PROGRESS_INTERVAL_SECONDS:
+                last_pub = now
+                _set_status(done_files=done_files, done_bytes=done_bytes, current_file=str(rel))
+                publish({
+                    "type": "models_root_migrate_progress",
+                    "done_files": done_files,
+                    "total_files": len(files),
+                    "done_bytes": done_bytes,
+                    "total_bytes": total_bytes,
+                    "current_file": str(rel),
+                })
+
+        # 复制完整 → 切 secret（立即生效）
+        _update_models_root_secret(dst)
+        _set_status(state="done", done_files=done_files, done_bytes=done_bytes, current_file="")
+        publish({
+            "type": "models_root_migrate_done",
+            "ok": True,
+            "target": str(dst),
+            "done_files": done_files,
+            "done_bytes": done_bytes,
+        })
+        logger.info(
+            "模型根目录迁移完成: %s → %s（%d 文件），已更新 secrets.models.root（立即生效）",
+            src, dst, done_files,
+        )
+    except Exception as exc:
+        logger.exception("模型根目录迁移失败: %s → %s", src, dst)
+        # dst 开始前为空 / 不存在（validate_target 保证），整树清掉等于回到迁移前；
+        # secret 未动；用户的 target 父目录不受影响。
+        shutil.rmtree(dst, ignore_errors=True)
+        _set_status(state="error", error=str(exc))
+        publish({"type": "models_root_migrate_done", "ok": False, "error": str(exc)})

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1674,6 +1674,31 @@ export interface StudioDataMigrateStatus {
   error: string
 }
 
+/** 模型根目录存储位置：和 studio_data 同结构（迁移确认 modal 复用展示）。 */
+export interface ModelsRootInfo {
+  current: string
+  default: string
+  is_custom: boolean
+  /** 请求带 scan=false 时为 null（Settings 页仅显示路径，免扫盘） */
+  scan: {
+    total_files: number
+    total_bytes: number
+    entries: StudioDataScanEntry[]
+  } | null
+}
+
+/** 模型根目录迁移状态快照（实时进度走 SSE `models_root_migrate_progress` / `_done`）。 */
+export interface ModelsRootMigrateStatus {
+  state: 'idle' | 'running' | 'done' | 'error'
+  target: string
+  total_files: number
+  total_bytes: number
+  done_files: number
+  done_bytes: number
+  current_file: string
+  error: string
+}
+
 export const api = {
   health: () => req<HealthResponse>('/api/health'),
   systemStats: () => req<SystemStats>('/api/system/stats'),
@@ -2671,6 +2696,18 @@ export const api = {
     }),
   getStudioDataMigrateStatus: () =>
     req<StudioDataMigrateStatus>('/api/studio-data/migrate_status'),
+
+  // 模型根目录存储位置（镜像 studio_data，但迁移完无需重启，立即生效）----------
+  getModelsRootInfo: (withScan = true) =>
+    req<ModelsRootInfo>(`/api/models-root/info?scan=${withScan}`),
+  // 422 = 目标不合法 / 有 running task；409 = 已有迁移在跑。
+  startModelsRootMigrate: (target: string) =>
+    req<{ ok: boolean }>('/api/models-root/migrate', {
+      method: 'POST',
+      body: JSON.stringify({ target }),
+    }),
+  getModelsRootMigrateStatus: () =>
+    req<ModelsRootMigrateStatus>('/api/models-root/migrate_status'),
 
   // System lifecycle (ADR 0002) ----------------------------------------
   // 重启 server。后端写 tmp/restart + 给自己发 SIGINT 触发 uvicorn graceful

--- a/studio/web/src/components/ModelsRootMigrateModal.tsx
+++ b/studio/web/src/components/ModelsRootMigrateModal.tsx
@@ -1,0 +1,226 @@
+/** 模型根目录迁移确认 + 进度 modal（Settings → 系统 → 存储位置 → 模型根目录）。
+ *
+ * 镜像 StudioDataMigrateModal，区别：复制完 **立即生效、无需重启**（models_root()
+ * 现读 secrets.models.root）。所以 done 态不给「立即重启」，只给「完成」+ 关闭，
+ * 并回调 onDone 让父级刷新当前路径显示。
+ *
+ * 四态：loading（拉 info 扫描）→ confirm（文件数/大小/顶层明细 + 确认）→
+ * running（进度条，SSE 驱动）→ done / error。running 期间 modal 不可关。
+ */
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { api, type ModelsRootInfo } from '../api/client'
+import { formatBytes } from '../lib/useUploadProgress'
+import { useEventStream } from '../lib/useEventStream'
+
+type Phase = 'loading' | 'confirm' | 'running' | 'done' | 'error'
+
+interface Progress {
+  doneFiles: number
+  totalFiles: number
+  doneBytes: number
+  totalBytes: number
+  currentFile: string
+}
+
+const EMPTY_PROGRESS: Progress = {
+  doneFiles: 0, totalFiles: 0, doneBytes: 0, totalBytes: 0, currentFile: '',
+}
+
+export default function ModelsRootMigrateModal({ target, onClose, onDone }: {
+  target: string
+  onClose: () => void
+  /** 迁移成功后回调（父级据此重新拉 getModelsRootInfo 刷新当前路径，无需重启） */
+  onDone: () => void
+}) {
+  const { t } = useTranslation()
+  // 用户选的是父目录，后端实际把数据复制到 target/models/（display 用，
+  // API 仍传 target，由后端拼接）
+  const sep = target.includes('\\') ? '\\' : '/'
+  const destination = target.endsWith(sep) ? `${target}models` : `${target}${sep}models`
+  const [phase, setPhase] = useState<Phase>('loading')
+  const [info, setInfo] = useState<ModelsRootInfo | null>(null)
+  const [progress, setProgress] = useState<Progress>(EMPTY_PROGRESS)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    let cancelled = false
+    void api.getModelsRootInfo().then((i) => {
+      if (cancelled) return
+      setInfo(i)
+      setPhase('confirm')
+    }).catch((e) => {
+      if (cancelled) return
+      setError(String(e))
+      setPhase('error')
+    })
+    return () => { cancelled = true }
+  }, [])
+
+  // SSE：实时进度 + 完成事件（只在 running 态响应，防外部杂音翻状态）
+  useEventStream((evt) => {
+    if (evt.type === 'models_root_migrate_progress') {
+      setProgress({
+        doneFiles: Number(evt.done_files) || 0,
+        totalFiles: Number(evt.total_files) || 0,
+        doneBytes: Number(evt.done_bytes) || 0,
+        totalBytes: Number(evt.total_bytes) || 0,
+        currentFile: typeof evt.current_file === 'string' ? evt.current_file : '',
+      })
+    } else if (evt.type === 'models_root_migrate_done') {
+      setPhase((p) => {
+        if (p !== 'running') return p
+        if (evt.ok) { onDone(); return 'done' }
+        setError(typeof evt.error === 'string' ? evt.error : 'unknown')
+        return 'error'
+      })
+    }
+  }, {
+    // SSE 断线重连期间 done 事件会丢，running 态会卡死（modal 不可关）——
+    // 重连时冷拉一次状态快照补齐
+    onOpen: () => {
+      void api.getModelsRootMigrateStatus().then((s) => {
+        setPhase((p) => {
+          if (p !== 'running') return p
+          if (s.state === 'done') { onDone(); return 'done' }
+          if (s.state === 'error') { setError(s.error); return 'error' }
+          return p
+        })
+      }).catch(() => { /* 下次重连再试 */ })
+    },
+  })
+
+  const handleStart = async () => {
+    setPhase('running')
+    setProgress(EMPTY_PROGRESS)
+    try {
+      await api.startModelsRootMigrate(target)
+    } catch (e) {
+      setError(String(e))
+      setPhase('error')
+    }
+  }
+
+  const closable = phase !== 'running'
+  const pct = progress.totalBytes > 0
+    ? Math.min(100, Math.round((progress.doneBytes / progress.totalBytes) * 100))
+    : 0
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
+      onClick={closable ? onClose : undefined}
+    >
+      <div
+        className="bg-elevated border border-dim rounded-lg shadow-xl w-[560px] max-h-[80vh] flex flex-col overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="px-4 py-3 border-b border-subtle flex items-center gap-2 shrink-0">
+          <h3 className="m-0 text-sm font-semibold flex-1 text-fg-primary">
+            {t('settings.storage.modelsMigrateTitle')}
+          </h3>
+          {closable && (
+            <button className="btn btn-ghost text-xs" onClick={onClose} aria-label={t('common.close')}>×</button>
+          )}
+        </header>
+
+        <div className="p-4 flex flex-col gap-3 overflow-y-auto">
+          {phase === 'loading' && (
+            <div className="text-sm text-fg-tertiary py-6 text-center">
+              {t('settings.storage.scanning')}
+            </div>
+          )}
+
+          {phase === 'confirm' && info?.scan && (
+            <>
+              <div className="text-xs text-fg-secondary flex flex-col gap-1">
+                <div>
+                  <span className="text-fg-tertiary">{t('settings.storage.from')}</span>{' '}
+                  <code className="font-mono">{info.current}</code>
+                </div>
+                <div>
+                  <span className="text-fg-tertiary">{t('settings.storage.to')}</span>{' '}
+                  <code className="font-mono">{destination}</code>
+                </div>
+              </div>
+              <div className="text-sm font-semibold">
+                {t('settings.storage.totalLine', {
+                  files: info.scan.total_files,
+                  size: formatBytes(info.scan.total_bytes),
+                })}
+              </div>
+              <div
+                className="bg-sunken border border-subtle rounded-md text-xs font-mono overflow-y-auto"
+                style={{ maxHeight: 200 }}
+              >
+                {info.scan.entries.map((e) => (
+                  <div key={e.name} className="flex justify-between gap-2 px-2.5 py-1 border-b border-subtle last:border-b-0">
+                    <span className="truncate">{e.is_dir ? `${e.name}/` : e.name}</span>
+                    <span className="text-fg-tertiary shrink-0">
+                      {t('settings.storage.entryMeta', { files: e.files, size: formatBytes(e.bytes) })}
+                    </span>
+                  </div>
+                ))}
+              </div>
+              <div className="text-xs text-fg-tertiary">
+                {t('settings.storage.modelsKeepOriginalNote')}
+              </div>
+            </>
+          )}
+
+          {phase === 'running' && (
+            <>
+              <div className="text-sm">{t('settings.storage.migrating')}</div>
+              <div className="h-2 rounded-full bg-sunken border border-subtle overflow-hidden">
+                <div
+                  className="h-full rounded-full"
+                  style={{
+                    width: `${pct}%`,
+                    background: 'var(--accent)',
+                    transition: 'width 200ms linear',
+                  }}
+                />
+              </div>
+              <div className="text-xs text-fg-tertiary font-mono flex justify-between gap-2">
+                <span className="truncate">{progress.currentFile}</span>
+                <span className="shrink-0">
+                  {progress.doneFiles}/{progress.totalFiles} · {formatBytes(progress.doneBytes)}/{formatBytes(progress.totalBytes)} · {pct}%
+                </span>
+              </div>
+            </>
+          )}
+
+          {phase === 'done' && (
+            <>
+              <div className="text-sm text-ok">{t('settings.storage.doneTitle')}</div>
+              <div className="text-xs text-fg-secondary">
+                {t('settings.storage.modelsDoneNote')}
+              </div>
+            </>
+          )}
+
+          {phase === 'error' && (
+            <div className="text-sm text-err break-all">
+              {t('settings.storage.failed', { error })}
+            </div>
+          )}
+        </div>
+
+        <footer className="px-4 py-3 border-t border-subtle flex justify-end gap-2 shrink-0">
+          {phase === 'confirm' && (
+            <>
+              <button className="btn btn-ghost" onClick={onClose}>{t('common.cancel')}</button>
+              <button className="btn btn-primary" onClick={() => void handleStart()}>
+                {t('settings.storage.startMigrate')}
+              </button>
+            </>
+          )}
+          {(phase === 'done' || phase === 'error') && (
+            <button className="btn btn-primary" onClick={onClose}>{t('common.close')}</button>
+          )}
+        </footer>
+      </div>
+    </div>
+  )
+}

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -877,7 +877,12 @@
       "doneRestartNote": "Restart Studio to start using the new location. The original data is kept; delete it yourself once you have verified everything.",
       "failed": "Migration failed: {{error}}",
       "startMigrate": "Start migration",
-      "restartNow": "Restart now"
+      "restartNow": "Restart now",
+      "modelsRootLabel": "Models root directory",
+      "modelsRootHelp": "Holds downloaded model weights (Anima / VAE / text encoder / tokenizer / WD14, etc.); defaults to models/ in the app root. Changing the location copies existing weights into a models subdirectory of the chosen directory and takes effect immediately (no restart); the original is kept.",
+      "modelsMigrateTitle": "Migrate models root",
+      "modelsKeepOriginalNote": "Data at the original location is kept, not deleted. Takes effect immediately after copying — no restart needed.",
+      "modelsDoneNote": "Switched to the new models root, effective immediately (no restart). The original data is kept; delete it yourself once verified."
     },
     "gelbooru": "Gelbooru",
     "danbooru": "Danbooru",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -877,7 +877,12 @@
       "doneRestartNote": "重启 Studio 后开始使用新位置；原位置数据已保留，确认无误后可自行删除。",
       "failed": "迁移失败：{{error}}",
       "startMigrate": "开始迁移",
-      "restartNow": "立即重启"
+      "restartNow": "立即重启",
+      "modelsRootLabel": "模型根目录",
+      "modelsRootHelp": "存放下载的 Anima / VAE / 文本编码器 / tokenizer / WD14 等模型权重，默认在程序根目录的 models/。更改位置会把现有权重复制到所选目录的 models 子目录并立即生效（无需重启），原数据保留不删除。",
+      "modelsMigrateTitle": "迁移模型根目录",
+      "modelsKeepOriginalNote": "原位置数据不会被删除。复制完成后立即生效，无需重启。",
+      "modelsDoneNote": "已切换到新模型根目录，立即生效（无需重启）；原位置数据已保留，确认无误后可自行删除。"
     },
     "gelbooru": "Gelbooru",
     "danbooru": "Danbooru",

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -13,6 +13,7 @@ import {
   type Secrets,
   type SecretsPatch,
   type StudioDataInfo,
+  type ModelsRootInfo,
   type DevCommit,
   type DevCommitsResult,
   type PreflightResult,
@@ -35,6 +36,7 @@ import { InfoButton } from '../../components/InfoButton'
 import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
 import PathPicker from '../../components/PathPicker'
 import StudioDataMigrateModal from '../../components/StudioDataMigrateModal'
+import ModelsRootMigrateModal from '../../components/ModelsRootMigrateModal'
 import { TagListInput } from '../../components/TagsInput'
 import { useShowTagTranslation } from '../../tagDict/showToggle'
 import { useTagDict, reloadDict } from '../../tagDict/store'
@@ -1844,33 +1846,20 @@ function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, catalog
   t: TFunction
 }) {
   const { toast } = useToast()
-  const [rootDraft, setRootDraft] = useState<string>('')
-  const [serverRoot, setServerRoot] = useState<string | null>(null)
-  const [savingRoot, setSavingRoot] = useState(false)
   const [selectedAnima, setSelectedAnima] = useState<string>('1.0')
   const [autoSyncPaths, setAutoSyncPaths] = useState<boolean>(true)
   const [savingAutoSync, setSavingAutoSync] = useState(false)
-  const [secretsLoaded, setSecretsLoaded] = useState(false)
   const [showPicker, setShowPicker] = useState(false)
   const [addingCustom, setAddingCustom] = useState(false)
 
-  // 一次性拉一份 secrets 取 models.root + selected_anima + auto_sync_paths
-  // （这几项走独立 PUT，不进 SettingsPage 的全局 dirty 流程）。catalog 由父级注入。
+  // 一次性拉 secrets 取 selected_anima + auto_sync_paths（独立 PUT，不进全局 dirty
+  // 流程）。模型根目录已挪到「系统 → 存储位置」，不再在此渲染。
   useEffect(() => {
     void api.getSecrets().then((sec) => {
-      setServerRoot(sec.models?.root ?? null)
       setSelectedAnima(sec.models?.selected_anima ?? '1.0')
       setAutoSyncPaths(sec.models?.auto_sync_paths ?? true)
-      setSecretsLoaded(true)
-    }).catch(() => { setSecretsLoaded(true) })
+    }).catch(() => { /* 显示用，拉不到不阻塞 */ })
   }, [])
-
-  // secrets + catalog 都到位后，把输入框预填成「已保存值」或「实际默认绝对路径」。
-  // 用 prev !== '' 当作"已初始化 / 用户已编辑"的标志，避免覆盖用户输入。
-  useEffect(() => {
-    if (!secretsLoaded || !catalog) return
-    setRootDraft((prev) => (prev !== '' ? prev : (serverRoot ?? catalog.models_root ?? '')))
-  }, [secretsLoaded, catalog, serverRoot])
 
   const pickAnima = async (variant: string) => {
     if (variant === selectedAnima) return
@@ -1882,21 +1871,6 @@ function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, catalog
     } catch (e) {
       toast(String(e), 'error')
       void reloadCatalog()
-    }
-  }
-
-  const saveRoot = async () => {
-    const v = rootDraft.trim()
-    setSavingRoot(true)
-    try {
-      await api.updateSecrets({ models: { root: v ? v : null } })
-      toast(v ? t('settings.modelRootSaved', { path: v }) : t('settings.modelRootDefault'), 'success')
-      setServerRoot(v ? v : null)
-      await reloadCatalog()
-    } catch (e) {
-      toast(String(e), 'error')
-    } finally {
-      setSavingRoot(false)
     }
   }
 
@@ -1948,7 +1922,6 @@ function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, catalog
     }
   }
 
-  const rootDirty = rootDraft.trim() !== (serverRoot ?? '')
   const error = catalogError
 
   return (
@@ -1957,24 +1930,6 @@ function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, catalog
         opt={catalog?.download_source_options?.training}
         onChange={(s) => void setSource('training', s)}
       />
-      <SettingsField label={t('settings.modelsRoot')}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-          <input
-            type="text"
-            value={rootDraft}
-            onChange={(e) => setRootDraft(e.target.value)}
-            className={`${textInputClass} flex-1`}                                  />
-          <button onClick={saveRoot} disabled={!rootDirty || savingRoot} className="btn btn-primary btn-sm"
-            title={rootDirty ? t('settings.savePathConfig') : t('settings.notModified')}>
-            {savingRoot ? t('common.saving') : t('settings.savePath')}
-          </button>
-          <button onClick={() => setRootDraft(serverRoot ?? (catalog?.models_root ?? ''))} disabled={!rootDirty || savingRoot}
-            className="px-2 py-0.5 text-fg-tertiary bg-transparent border-none cursor-pointer rounded-sm"
-            style={{ opacity: !rootDirty ? 0.3 : 1 }}
-          >↻</button>
-        </div>
-      </SettingsField>
-
       <SettingsField
         label={t('settings.autoSyncPathsLabel')}
         helpTooltip={<p>{t('settings.autoSyncPathsHelp')}</p>}
@@ -2119,7 +2074,7 @@ function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, catalog
       )}
       {showPicker && (
         <PathPicker
-          initialPath={serverRoot ?? catalog?.models_root ?? undefined}
+          initialPath={catalog?.models_root ?? undefined}
           onPick={(p) => void addCustom(p)}
           onClose={() => setShowPicker(false)}
         />
@@ -4900,6 +4855,10 @@ function StorageSection() {
   // 不存在"后台迁移中"的游离状态，section 无需跟踪迁移进度）
   const [migrateTarget, setMigrateTarget] = useState<string | null>(null)
   const [restartBusy, setRestartBusy] = useState(false)
+  // 模型根目录（同区块第二张卡；迁移完无需重启，立即生效）
+  const [modelsInfo, setModelsInfo] = useState<ModelsRootInfo | null>(null)
+  const [modelsPickerOpen, setModelsPickerOpen] = useState(false)
+  const [modelsMigrateTarget, setModelsMigrateTarget] = useState<string | null>(null)
 
   useEffect(() => {
     let cancelled = false
@@ -4907,6 +4866,13 @@ function StorageSection() {
       if (!cancelled) setInfo(i)
     }).catch(() => { /* section 显示用，拉不到不阻塞页面 */ })
     return () => { cancelled = true }
+  }, [])
+
+  const refreshModelsInfo = () => {
+    void api.getModelsRootInfo(false).then(setModelsInfo).catch(() => { /* 显示用 */ })
+  }
+  useEffect(() => {
+    refreshModelsInfo()
   }, [])
 
   // done 态「立即重启」：modal 上下文已是确认语境，不再二次 confirm
@@ -4958,6 +4924,28 @@ function StorageSection() {
         </div>
       </SettingsField>
 
+      <SettingsField
+        label={t('settings.storage.modelsRootLabel')}
+        helpTooltip={<p>{t('settings.storage.modelsRootHelp')}</p>}
+      >
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-2 min-w-0">
+            <code className="font-mono text-xs truncate">{modelsInfo?.current ?? '…'}</code>
+            {modelsInfo && (
+              <span className="text-2xs text-fg-tertiary shrink-0">
+                {modelsInfo.is_custom ? t('settings.storage.customBadge') : t('settings.storage.defaultBadge')}
+              </span>
+            )}
+          </div>
+          <button
+            className="btn btn-secondary btn-sm self-start"
+            onClick={() => setModelsPickerOpen(true)}
+          >
+            {t('settings.storage.changeLocation')}
+          </button>
+        </div>
+      </SettingsField>
+
       {pickerOpen && (
         <PathPicker
           dirOnly
@@ -4975,6 +4963,26 @@ function StorageSection() {
           target={migrateTarget}
           onClose={() => setMigrateTarget(null)}
           onRestart={() => void handleRestart()}
+        />
+      )}
+
+      {modelsPickerOpen && (
+        <PathPicker
+          dirOnly
+          initialPath={modelsInfo?.current}
+          onPick={(path) => {
+            setModelsPickerOpen(false)
+            setModelsMigrateTarget(path)
+          }}
+          onClose={() => setModelsPickerOpen(false)}
+        />
+      )}
+
+      {modelsMigrateTarget != null && (
+        <ModelsRootMigrateModal
+          target={modelsMigrateTarget}
+          onClose={() => setModelsMigrateTarget(null)}
+          onDone={refreshModelsInfo}
         />
       )}
     </SettingsSection>

--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 183,
+  "count": 186,
   "routes": [
     {
       "path": "/",
@@ -287,6 +287,30 @@
         "GET"
       ],
       "name": "get_log",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/models-root/info",
+      "methods": [
+        "GET"
+      ],
+      "name": "models_root_info",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/models-root/migrate",
+      "methods": [
+        "POST"
+      ],
+      "name": "models_root_migrate",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/models-root/migrate_status",
+      "methods": [
+        "GET"
+      ],
+      "name": "models_root_migrate_status",
       "type": "APIRoute"
     },
     {

--- a/tests/test_models_storage.py
+++ b/tests/test_models_storage.py
@@ -1,0 +1,153 @@
+"""模型根目录迁移服务（studio.services.models_storage）单测。
+
+只测纯函数（scan / validate_target / _run_migration 直调，避免线程 flaky）：
+复制 + 更新 secrets.models.root + 失败回滚 + 校验规则 + 单飞。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from studio.services import models_storage as ms
+
+
+def _make_src(root: Path) -> Path:
+    """造一个有几个文件 + 子目录的源模型根目录。"""
+    (root / "diffusion_models").mkdir(parents=True)
+    (root / "diffusion_models" / "anima.safetensors").write_bytes(b"x" * 100)
+    (root / "vae").mkdir()
+    (root / "vae" / "vae.safetensors").write_bytes(b"y" * 50)
+    (root / "top.txt").write_text("hi", encoding="utf-8")
+    return root
+
+
+@pytest.fixture
+def reset_status():
+    ms._set_status(state="idle", target="", error="")
+    yield
+    ms._set_status(state="idle", target="", error="")
+
+
+def _fake_secrets_store(monkeypatch, old_root: Path):
+    from studio import secrets
+    state = {"s": secrets.Secrets(models={"root": str(old_root)})}
+    monkeypatch.setattr(secrets, "load", lambda: state["s"])
+    monkeypatch.setattr(secrets, "save", lambda s: state.update(s=s))
+    return state
+
+
+# ---------------------------------------------------------------------------
+# scan
+# ---------------------------------------------------------------------------
+
+def test_scan_empty_or_missing_dir(tmp_path: Path) -> None:
+    assert ms.scan_models_root(tmp_path / "nope") == {
+        "total_files": 0, "total_bytes": 0, "entries": []
+    }
+
+
+def test_scan_counts_files_and_bytes(tmp_path: Path) -> None:
+    src = _make_src(tmp_path / "models")
+    res = ms.scan_models_root(src)
+    assert res["total_files"] == 3
+    assert res["total_bytes"] == 100 + 50 + 2
+    by_name = {e["name"]: e for e in res["entries"]}
+    assert by_name["diffusion_models"]["is_dir"] is True
+    assert by_name["diffusion_models"]["files"] == 1
+    assert by_name["diffusion_models"]["bytes"] == 100
+    assert by_name["top.txt"]["is_dir"] is False
+
+
+# ---------------------------------------------------------------------------
+# validate_target
+# ---------------------------------------------------------------------------
+
+def test_validate_returns_models_subdir(tmp_path: Path) -> None:
+    src = tmp_path / "cur"
+    src.mkdir()
+    target = tmp_path / "newroot"
+    assert ms.validate_target(target, source=src) == target.resolve() / "models"
+
+
+def test_validate_rejects_relative(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        ms.validate_target(Path("relative/dir"), source=tmp_path / "cur")
+
+
+def test_validate_rejects_same_as_current(tmp_path: Path) -> None:
+    # 当前 root = parent/models；target=parent → dst=parent/models == src
+    parent = tmp_path / "p"
+    src = parent / "models"
+    src.mkdir(parents=True)
+    with pytest.raises(ValueError):
+        ms.validate_target(parent, source=src)
+
+
+def test_validate_rejects_nested(tmp_path: Path) -> None:
+    src = tmp_path / "cur" / "models"
+    src.mkdir(parents=True)
+    with pytest.raises(ValueError):
+        ms.validate_target(src / "sub", source=src)
+
+
+def test_validate_rejects_nonempty_dst(tmp_path: Path) -> None:
+    src = tmp_path / "cur"
+    src.mkdir()
+    target = tmp_path / "newroot"
+    dst = target / "models"
+    dst.mkdir(parents=True)
+    (dst / "existing.bin").write_bytes(b"z")
+    with pytest.raises(ValueError):
+        ms.validate_target(target, source=src)
+
+
+# ---------------------------------------------------------------------------
+# _run_migration（直调，同步）
+# ---------------------------------------------------------------------------
+
+def test_run_migration_copies_and_updates_secret(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reset_status
+) -> None:
+    src = _make_src(tmp_path / "old" / "models")
+    dst = tmp_path / "new" / "models"
+    state = _fake_secrets_store(monkeypatch, tmp_path / "old" / "models")
+    events: list[dict] = []
+
+    ms._run_migration(src, dst, publish=events.append)
+
+    assert (dst / "diffusion_models" / "anima.safetensors").read_bytes() == b"x" * 100
+    assert (dst / "vae" / "vae.safetensors").exists()
+    assert (dst / "top.txt").read_text(encoding="utf-8") == "hi"
+    # secret 切到新 root（立即生效，无需重启）
+    assert state["s"].models.root == str(dst)
+    assert any(e["type"] == "models_root_migrate_done" and e["ok"] for e in events)
+    assert ms.migration_status()["state"] == "done"
+
+
+def test_run_migration_rollback_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reset_status
+) -> None:
+    src = _make_src(tmp_path / "old" / "models")
+    dst = tmp_path / "new" / "models"
+    state = _fake_secrets_store(monkeypatch, tmp_path / "old" / "models")
+    orig_root = state["s"].models.root
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+    monkeypatch.setattr(ms.shutil, "copy2", boom)
+
+    events: list[dict] = []
+    ms._run_migration(src, dst, publish=events.append)
+
+    # dst 整树清掉（回滚），secret 未动
+    assert not dst.exists()
+    assert state["s"].models.root == orig_root
+    assert any(e["type"] == "models_root_migrate_done" and not e["ok"] for e in events)
+    assert ms.migration_status()["state"] == "error"
+
+
+def test_start_migration_single_flight(tmp_path: Path, reset_status) -> None:
+    ms._set_status(state="running")
+    with pytest.raises(RuntimeError):
+        ms.start_migration(tmp_path / "newroot", source=tmp_path / "cur")


### PR DESCRIPTION
## 背景 / 动机

「模型根目录」(`secrets.models.root`) 此前是「训练」tab 模型区块里的纯文本输入框，改了只更新配置、**不搬已下载的权重**。把它挪到「系统 → 存储位置」（和 studio_data 并列），并加上**和 studio_data 一样的迁移功能**（扫描确认 + SSE 进度条把已下载权重复制到新位置）。

关键差异：模型根目录**无需重启**——`models_root()` 每次现读 `secrets.models.root`，复制完更新 secret 即刻生效（studio_data 要重启是因为它是 import 时求值的指针文件）。

## 改动概要

**后端**
- `studio/services/models_storage.py`：镜像 `studio_data.py` 迁移基建（`scan_models_root` / `validate_target` / `start_migration` / `_run_migration`）。落地 `target/models/`；**复制 + 保留旧目录**（旧 training version 的 yaml 里烤死的旧绝对路径仍可解析）；复制完更新 `secrets.models.root`，无指针 / 无重启 / 无 sqlite backup；失败 `rmtree` 回滚。
- `routers/models_storage.py` + schema + `app.py` 注册：`GET /api/models-root/info`、`POST /api/models-root/migrate`（`_check_no_running_tasks`）、`GET /api/models-root/migrate_status`；事件 `models_root_migrate_progress` / `_done`。

**前端**
- `ModelsRootMigrateModal.tsx`：镜像 `StudioDataMigrateModal`，done 态去掉「立即重启」、改「立即生效」并回调父级刷新当前路径。
- `StorageSection` 加「模型根目录」卡（当前路径 + custom/default badge + 更改位置 → PathPicker → 迁移 modal）；`ModelsSection`（训练 tab）删掉原模型根目录输入框 + `saveRoot`。
- `client.ts`：`ModelsRootInfo` / `ModelsRootMigrateStatus` 类型 + `getModelsRootInfo` / `startModelsRootMigrate` / `getModelsRootMigrateStatus`。
- i18n zh/en：复用 `settings.storage.*` + 新增 models 专用文案（无重启措辞）。

## 测试方式

- `tests/test_models_storage.py`（10 条）：scan、validate_target（拒非绝对 / dst==src / 嵌套 / 非空 dst）、`_run_migration` 复制 + 更新 secret + 失败回滚、单飞。
- 安全网：`test_route_snapshot`（含 3 条新路由）+ `test_studio_configs` 全过。
- 前端：`vitest` 402 全过、`tsc --noEmit`、`eslint` 干净。

## 端到端

设置 → 系统 → 存储位置出现「模型根目录」卡；更改位置 → 扫描确认 → 进度条 → 完成后 `secrets.models.root` 指到 `目标/models`，新位置有权重副本、旧目录保留，catalog 立即变新路径（无需重启）。有运行中任务时迁移返回 409。

🤖 Generated with [Claude Code](https://claude.com/claude-code)