### PR TITLE
fix(train): grad_accum 尾组不满也 step + 按实际 batch 数归一

### DIFF
--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -88,11 +88,40 @@ def _resolve_sra_effective_weight(args: Any, global_step: int, total_steps: int 
     return base * max(0.0, min(1.0, scale))
 
 
+def _accumulation_step(batch_idx, dl_len, grad_accum):
+    """返回 (group_size, is_group_end)：该 micro-batch 所在梯度累积组的实际大小，
+    以及它是否是该组最后一个（触发 optimizer.step / zero_grad）。
+
+    对齐 kohya-ss / HF Trainer：
+    - epoch 最后一个 batch 即使凑不满 grad_accum 也 step —— 否则尾部 `len % ga` 个
+      batch 的梯度会被丢（单 epoch）或泄漏进下一 epoch 第一个 step（多 epoch，因为
+      zero_grad 只在 step 后调）。
+    - 不满的尾组按**实际** micro-batch 数归一（group_size），而非恒 ÷grad_accum，
+      免得末步梯度被削弱。
+
+    dl_len=None（dataloader 无 __len__）时回退旧行为（恒 grad_accum，仅整除处 step）。
+    """
+    if dl_len is None or grad_accum <= 1:
+        return grad_accum, (batch_idx + 1) % grad_accum == 0
+    remainder = dl_len % grad_accum
+    in_tail = remainder != 0 and batch_idx >= dl_len - remainder
+    group_size = remainder if in_tail else grad_accum
+    is_group_end = (batch_idx + 1) % grad_accum == 0 or (batch_idx + 1) == dl_len
+    return group_size, is_group_end
+
+
 def run(ctx: TrainingContext) -> None:
     """跑训练直到 args.epochs 或 args.max_steps 上限。"""
     args = ctx.args
 
     step_start_time = time.perf_counter()
+
+    # dataloader 每 epoch 的 batch 数（用于尾组「不满也 step」+ 按实际大小归一）。
+    # 少数无 __len__ 的 dataloader 回退旧行为（见 _accumulation_step）。
+    try:
+        dl_len = len(ctx.dataloader)
+    except TypeError:
+        dl_len = None
 
     for epoch in range(ctx.start_epoch, args.epochs):
         ctx.current_epoch = epoch
@@ -326,11 +355,13 @@ def run(ctx: TrainingContext) -> None:
                 ctx.optimizer.zero_grad()
                 continue
 
-            # 反向传播
-            loss = loss / args.grad_accum
+            # 反向传播。尾组（len % grad_accum）不满时按实际 micro-batch 数归一，
+            # 且 epoch 末批不满也 step —— 修尾批丢弃 + 跨 epoch 梯度泄漏（见 _accumulation_step）。
+            group_size, is_group_end = _accumulation_step(batch_idx, dl_len, args.grad_accum)
+            loss = loss / group_size
             loss.backward()
 
-            if (batch_idx + 1) % args.grad_accum == 0:
+            if is_group_end:
                 # NaN 梯度检测：跳过本次 update，清零继续
                 has_nan_grad = any(
                     p.grad is not None and not torch.isfinite(p.grad).all()
@@ -353,7 +384,7 @@ def run(ctx: TrainingContext) -> None:
                 ctx.timestep_sampler.maybe_refresh(ctx.global_step)
 
                 # 记录 loss 历史
-                loss_val = float(loss.item() * args.grad_accum)
+                loss_val = float(loss.item() * group_size)
                 denoise_loss_val = (
                     float(denoise_loss_log.item())
                     if denoise_loss_log is not None else loss_val

--- a/runtime/training/phases/optimizer.py
+++ b/runtime/training/phases/optimizer.py
@@ -52,7 +52,10 @@ def run(ctx: TrainingContext) -> None:
 
     # 计算总步数
     try:
-        ctx.steps_per_epoch = len(ctx.dataloader) // args.grad_accum
+        # ceil：最后一组不满 grad_accum 也算一个 update step（loop 末批会 step），
+        # 与 _accumulation_step 的「尾组不满也 step」一致，scheduler 步数才对得上。
+        _dl_len = len(ctx.dataloader)
+        ctx.steps_per_epoch = (_dl_len + args.grad_accum - 1) // args.grad_accum
     except Exception:
         ctx.steps_per_epoch = None
 

--- a/tests/test_grad_accum_tail.py
+++ b/tests/test_grad_accum_tail.py
@@ -1,0 +1,71 @@
+"""grad_accum 尾组处理回归（runtime/training/loop.py::_accumulation_step）。
+
+修复：epoch 最后一个 batch 即使凑不满 grad_accum 也 step（对齐 kohya-ss / HF
+Trainer）—— 否则尾部 `len % ga` 个 batch 的梯度被丢（单 epoch）或泄漏进下一 epoch
+第一个 step（多 epoch）；不满的尾组按实际 micro-batch 数归一。
+
+用 AST 抽函数独立执行（_accumulation_step 是纯函数、无依赖），避免 import 整个
+training 栈（torch + 模型）。同 test_find_diffusion_pipe_root 的轻量做法。
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+SRC = Path(__file__).resolve().parent.parent / "runtime" / "training" / "loop.py"
+
+
+def _load_fn():
+    tree = ast.parse(SRC.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == "_accumulation_step":
+            mod = ast.Module(body=[node], type_ignores=[])
+            ns: dict = {}
+            exec(compile(mod, "<test>", "exec"), ns)
+            return ns["_accumulation_step"]
+    raise RuntimeError("_accumulation_step not found in loop.py")
+
+
+_accumulation_step = _load_fn()
+
+
+def _plan(dl_len, ga):
+    return [_accumulation_step(i, dl_len, ga) for i in range(dl_len)]
+
+
+def _step_idxs(plan):
+    return [i for i, (_, end) in enumerate(plan) if end]
+
+
+def test_divisible_unchanged():
+    # 8 batch / ga4：两组满，在 idx3/idx7 step，group_size 恒 4（行为不变）
+    plan = _plan(8, 4)
+    assert _step_idxs(plan) == [3, 7]
+    assert all(gs == 4 for gs, _ in plan)
+
+
+def test_tail_steps_and_normalizes_by_actual_size():
+    # 7 batch / ga4：idx3 step(满组4) + idx6 step(尾组3) —— 尾批不再被丢
+    plan = _plan(7, 4)
+    assert _step_idxs(plan) == [3, 6]
+    assert [gs for gs, _ in plan] == [4, 4, 4, 4, 3, 3, 3]
+
+
+def test_fewer_batches_than_ga_still_trains():
+    # 3 batch / ga4：旧 floor=0 步（完全不训练！）；现 1 步、group_size=3
+    plan = _plan(3, 4)
+    assert _step_idxs(plan) == [2]
+    assert all(gs == 3 for gs, _ in plan)
+
+
+def test_ga_one_steps_every_batch():
+    plan = _plan(5, 1)
+    assert all(end for _, end in plan)
+    assert all(gs == 1 for gs, _ in plan)
+
+
+def test_no_len_falls_back_to_old_behavior():
+    # dl_len=None：恒 grad_accum，仅整除处 step（不知末批，无法尾处理）
+    assert _accumulation_step(3, None, 4) == (4, True)
+    assert _accumulation_step(4, None, 4) == (4, False)
+    assert _accumulation_step(6, None, 4) == (4, False)  # 尾批但无 len → 旧行为不 step


### PR DESCRIPTION
## 背景 / 动机

数据集每 epoch 的 batch 数不被 `grad_accum` 整除时，尾部 `len % grad_accum` 个 batch 的梯度被浪费。`loop.py` 只在 `(batch_idx+1) % grad_accum == 0` 时 `optimizer.step()` + `zero_grad()`，epoch 边界没有 flush。后果：

- **单 / 末 epoch**：尾批 `backward()` 了但永不 step，梯度被丢。极端情况：3 张图 / `grad_accum=4` → `floor(3/4)=0` 步，**整个 epoch 完全不训练**。
- **多 epoch（真 bug）**：尾批梯度没 `zero_grad`，泄漏进下一 epoch 第一个 step，并按 `grad_accum` 错误归一（跨 epoch 污染）。

调研了其他 trainer：kohya-ss / HF Trainer 都是「epoch 最后一个 batch 不满也 step」（kohya 用 `ceil` + Accelerate `accumulate` 在末批 sync）；没有 trainer 靠「复制 batch 凑满 ga」（会重复样本、引入 bias）。

## 改动

- `loop.py`：抽纯函数 `_accumulation_step(batch_idx, dl_len, grad_accum) -> (group_size, is_group_end)`：
  - epoch 末批即使不满 `grad_accum` 也 step（修丢弃 + 跨 epoch 泄漏）。
  - 不满的尾组按**实际** micro-batch 数（`group_size`）归一，而非恒 `÷grad_accum`，末步梯度不被削弱。
  - dataloader 无 `__len__` 时回退旧行为。
- `phases/optimizer.py`：`steps_per_epoch` 由 `len // ga` 改 `ceil(len/ga)`，与「尾组也 step」一致，scheduler 步数对得上。

## 测试

- `tests/test_grad_accum_tail.py`（5 条，AST 抽函数独立执行、不 import torch 栈）：整除不变 / 7÷4 尾组 step 且按 3 归一 / 3÷4 仍训练 1 步 / ga=1 每批 step / 无 len 回退。
- 回归：`test_plugin_registry`、`test_resume_phase`、`test_datasets`、`test_bucket_batch_sampler`、`test_optimizer_utils`、`test_sra_align` 全过（74 passed）。

## 影响

行为变更：小数据集 / `len` 不整除 `grad_accum` 时每 epoch 多一个 update step（之前被丢的尾组现在生效）。对已能整除或 `grad_accum=1` 的配置无影响。

🤖 Generated with [Claude Code](https://claude.com/claude-code)