### PR TITLE
fix(web): 训练监控页采样图角标完善 + 删除坏掉的独立监控按钮

### DIFF
--- a/studio/web/src/components/MonitorDashboard.tsx
+++ b/studio/web/src/components/MonitorDashboard.tsx
@@ -341,32 +341,35 @@ function SampleViewer({ samples, taskId }: {
             m.epoch != null ? `ep ${m.epoch}` : null,
             m.step != null ? `step ${m.step}` : null,
           ].filter(Boolean).join(' · ') || fn
+          // 角标放缩略图下面一行，不压在 64px 小图上（盖住看不清）。
+          const thumbCaption = [
+            m.epoch != null ? `ep${m.epoch}` : null,
+            m.step != null ? `${m.step}` : null,
+          ].filter(Boolean).join('·')
           return (
             <button
               key={`${fn}-${i}`}
               onClick={() => setActive(i)}
-              className={[
-                'shrink-0 rounded-sm overflow-hidden border transition-colors relative',
-                isActive ? 'border-accent ring-2 ring-accent-soft' : 'border-subtle hover:border-bold',
-                'cursor-pointer p-0 bg-sunken',
-              ].join(' ')}
+              className="shrink-0 flex flex-col items-center gap-0.5 p-0 bg-transparent border-none cursor-pointer"
               title={thumbTitle}
-              style={{ width: 64, height: 64 }}
             >
-              <img
-                src={thumbUrl}
-                alt=""
-                loading="lazy"
-                className="w-full h-full object-cover block"
-              />
-              {m.epoch != null && (
-                <span className="absolute top-0 inset-x-0 bg-black/55 text-accent text-[10px] font-mono text-center leading-tight py-0.5">
-                  ep {m.epoch.toLocaleString()}
-                </span>
-              )}
-              {m.step != null && (
-                <span className="absolute bottom-0 inset-x-0 bg-black/55 text-white text-[10px] font-mono text-center leading-tight py-0.5">
-                  {m.step.toLocaleString()}
+              <div
+                className={[
+                  'rounded-sm overflow-hidden border transition-colors bg-sunken',
+                  isActive ? 'border-accent ring-2 ring-accent-soft' : 'border-subtle hover:border-bold',
+                ].join(' ')}
+                style={{ width: 64, height: 64 }}
+              >
+                <img
+                  src={thumbUrl}
+                  alt=""
+                  loading="lazy"
+                  className="w-full h-full object-cover block"
+                />
+              </div>
+              {thumbCaption && (
+                <span className={`text-[10px] font-mono leading-tight text-center ${isActive ? 'text-fg-primary' : 'text-fg-tertiary'}`}>
+                  {thumbCaption}
                 </span>
               )}
             </button>

--- a/studio/web/src/components/MonitorDashboard.tsx
+++ b/studio/web/src/components/MonitorDashboard.tsx
@@ -529,15 +529,6 @@ export default function MonitorDashboard({ taskId }: { taskId: number }) {
             )}
           </>
         )}
-        <span className="flex-1" />
-        <a
-          href={`/tools/monitor?task=${taskId}`}
-          target="_blank"
-          rel="noopener"
-          className="text-fg-tertiary no-underline hover:text-fg-primary transition-colors"
-        >
-          独立监控 ↗
-        </a>
       </div>
 
       {/* 6 stat cards */}

--- a/studio/web/src/components/MonitorDashboard.tsx
+++ b/studio/web/src/components/MonitorDashboard.tsx
@@ -260,6 +260,19 @@ function ChartSvg({ data, W, H, rawColor, smoothColor, fillColor, emaAlpha, yFor
 
 // ── SampleViewer（单图 + 左右切换） ──────────────────────────────────────
 
+// monitor 给每张图都记了触发那一刻的 global_step，所以 step 始终能显示；epoch 只有
+// 按 epoch 采样（文件名 epoch_N.png）的图才有，从文件名解析。两个都返回 → 角标 / 标题
+// 「step 一直显示、ep 有就附加」，不用点开看文件名才知道是第几 epoch。
+function sampleMarks(s: { path: string; step?: number }): { step: number | null; epoch: number | null } {
+  const fn = s.path.split(/[\\/]/).pop() ?? s.path
+  const ep = /^epoch_(\d+)/i.exec(fn)
+  const st = /^step_(\d+)/i.exec(fn)
+  return {
+    epoch: ep ? Number(ep[1]) : null,
+    step: st ? Number(st[1]) : (s.step != null ? s.step : null),
+  }
+}
+
 function SampleViewer({ samples, taskId }: {
   samples: Array<{ path: string; step?: number }>
   taskId: number
@@ -305,6 +318,11 @@ function SampleViewer({ samples, taskId }: {
   const cur = list[active]
   const filename = cur.path.split(/[\\/]/).pop() ?? cur.path
   const fullUrl = api.sampleImageUrl(filename, taskId)
+  const curM = sampleMarks(cur)
+  const markText = [
+    curM.epoch != null ? `ep ${curM.epoch.toLocaleString()}` : null,
+    curM.step != null ? `step ${curM.step.toLocaleString()}` : null,
+  ].filter(Boolean).join(' · ')
 
   return (
     <div className="flex flex-col gap-2.5 w-full flex-1">
@@ -318,6 +336,11 @@ function SampleViewer({ samples, taskId }: {
           const fn = s.path.split(/[\\/]/).pop() ?? s.path
           const thumbUrl = api.sampleImageUrl(fn, taskId, 128)
           const isActive = i === active
+          const m = sampleMarks(s)
+          const thumbTitle = [
+            m.epoch != null ? `ep ${m.epoch}` : null,
+            m.step != null ? `step ${m.step}` : null,
+          ].filter(Boolean).join(' · ') || fn
           return (
             <button
               key={`${fn}-${i}`}
@@ -327,7 +350,7 @@ function SampleViewer({ samples, taskId }: {
                 isActive ? 'border-accent ring-2 ring-accent-soft' : 'border-subtle hover:border-bold',
                 'cursor-pointer p-0 bg-sunken',
               ].join(' ')}
-              title={s.step != null ? `step ${s.step}` : fn}
+              title={thumbTitle}
               style={{ width: 64, height: 64 }}
             >
               <img
@@ -336,9 +359,14 @@ function SampleViewer({ samples, taskId }: {
                 loading="lazy"
                 className="w-full h-full object-cover block"
               />
-              {s.step != null && (
+              {m.epoch != null && (
+                <span className="absolute top-0 inset-x-0 bg-black/55 text-accent text-[10px] font-mono text-center leading-tight py-0.5">
+                  ep {m.epoch.toLocaleString()}
+                </span>
+              )}
+              {m.step != null && (
                 <span className="absolute bottom-0 inset-x-0 bg-black/55 text-white text-[10px] font-mono text-center leading-tight py-0.5">
-                  {s.step.toLocaleString()}
+                  {m.step.toLocaleString()}
                 </span>
               )}
             </button>
@@ -362,9 +390,14 @@ function SampleViewer({ samples, taskId }: {
           onClick={() => setZoomOpen(true)}
           className="absolute inset-0 w-full h-full object-contain cursor-zoom-in"
         />
-        {cur.step != null && (
+        {(curM.epoch != null || curM.step != null) && (
           <div className="absolute bottom-2.5 left-1/2 -translate-x-1/2 border border-subtle rounded-sm px-2.5 py-0.5 text-xs font-mono text-fg-secondary bg-surface/85">
-            step <strong className="text-accent">{cur.step.toLocaleString()}</strong>
+            {curM.epoch != null && (
+              <>ep <strong className="text-accent">{curM.epoch.toLocaleString()}</strong>{curM.step != null && ' · '}</>
+            )}
+            {curM.step != null && (
+              <>step <strong className="text-accent">{curM.step.toLocaleString()}</strong></>
+            )}
             <span className="text-fg-tertiary ml-2">{active + 1} / {list.length}</span>
           </div>
         )}
@@ -374,9 +407,7 @@ function SampleViewer({ samples, taskId }: {
       {zoomOpen && (
         <ImagePreviewModal
           src={fullUrl}
-          caption={cur.step != null
-            ? `step ${cur.step.toLocaleString()} · ${active + 1} / ${list.length} · ${filename}`
-            : `${filename} · ${active + 1} / ${list.length}`}
+          caption={[markText, `${active + 1} / ${list.length}`, filename].filter(Boolean).join(' · ')}
           hasPrev={active > 0}
           hasNext={active < list.length - 1}
           onClose={() => setZoomOpen(false)}

--- a/studio/web/src/pages/tools/Monitor.tsx
+++ b/studio/web/src/pages/tools/Monitor.tsx
@@ -6,8 +6,7 @@ export default function MonitorPage() {
   const [health, setHealth] = useState<HealthResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [tasks, setTasks] = useState<Task[]>([])
-  // `?task=N` 来自 MonitorDashboard 的「独立监控」按钮（旧 monitor_smooth.html 替代品），
-  // 让独立窗口直接锁定到 dashboard 当前的 task。
+  // `?task=N` 深链：直接把监控页锁定到指定 task（书签 / 外部链接用）。
   const initialTaskId = useMemo<number | null>(() => {
     if (typeof window === 'undefined') return null
     const raw = new URLSearchParams(window.location.search).get('task')


### PR DESCRIPTION
## 背景 / 动机

训练监控页几个小问题：采样图的 epoch 只藏在文件名里，要点开放大看文件名才知道是第几 epoch；缩略图角标压在 64px 小图上、盖住画面；「独立监控」按钮因漏了 `/studio` base 前缀一直跳到错误页（已坏很久）。

## 改动概要

- **采样图角标显示 epoch + step**：monitor 给每张图都记了触发那刻的 `global_step`（step 一直能显示），但 epoch 只藏在文件名 `epoch_N.png`。现在从文件名解析 epoch，与 step 一起显示——step 一直显示、ep 有就附加。大图下方角标 / 放大标题：`ep N · step N · i/总数`（非 epoch 采样则只有 step）。
- **缩略图角标移到图下方一行**：64px 缩略图上叠 ep/step 角标会盖住本就很小的图，改成在缩略图下面一行紧凑显示（epoch 采样 `ep3·1500` / step 采样 `1500`），图保持干净；hover `title` 仍给完整 `ep N · step N`。
- **删除坏掉的「独立监控」按钮**：原生 `<a href="/tools/monitor?task=N">` 用了从根开始的绝对路径，漏掉 app 的 `/studio` base 前缀（Vite `base:/studio/` + Router `basename:/studio`），点击落到 `/tools/monitor` 命中「public base URL /studio/」错误页。侧边栏「监控」本就有入口（带任务选择），该弹出按钮冗余，删除 + 清理右对齐的 `flex-1` spacer。`Monitor` 页的 `?task=` 深链保留（书签 / 外链可用）。

## 测试方式
- `tsc --noEmit` + `eslint src` clean，全量 `vitest` 401 passed。
- 手测：dev server 训练监控页核对采样缩略图 / 大图角标 / 放大标题；确认「独立监控」按钮已移除、侧边栏「监控」正常打开。

## 截图
建议补采样图角标（epoch 采样 + step 采样各一）前后截图。（无法在 CI 侧生成，待作者本地补。）
