### PR TITLE
fix(system): 自更新忽略 npm 自动改写的 package-lock.json + 脏工作区可确认强制覆盖

### DIFF
--- a/studio/api/routers/system.py
+++ b/studio/api/routers/system.py
@@ -144,13 +144,15 @@ def system_update(body: UpdateRequest, background: BackgroundTasks) -> dict[str,
     _check_no_running_tasks()
 
     cur = updater.current_version()
-    if cur.is_dirty:
+    # force=True：用户在 UI 上已确认"强制覆盖本地改动"，跳过 dirty 闸；启动期
+    # apply_pending 的 git reset --hard 会丢弃这些未提交改动（不可恢复）。
+    if cur.is_dirty and not body.force:
         raise ValidationError(
             "Local changes are uncommitted; commit or stash them before updating",
             code="system.working_tree_dirty", http_status=422,
         )
 
-    updater.request_update(body.target)
+    updater.request_update(body.target, force=body.force)
     background.add_task(_raise_sigint_after_response)
     return {"ok": True, "message": f"update scheduled → {body.target}"}
 
@@ -240,8 +242,12 @@ def system_preflight(target: str = "origin/master") -> dict[str, Any]:
     checks: list[dict[str, str]] = []
 
     if cur.is_dirty:
-        checks.append({"key": "dirty", "level": "err",
-                       "label": "工作树有未提交修改 — 操作会被拒绝"})
+        # warn 而非 err：dirty 不再硬阻断，前端确认时弹"强制覆盖"modal，确认后
+        # 带 force 提交 → reset --hard 覆盖本地改动。running task / self_update 等
+        # 才是不可绕过的 err。（package-lock.json 等自动 churn 已在 updater 的
+        # dirty 判定里剔除，不会走到这。）
+        checks.append({"key": "dirty", "level": "warn",
+                       "label": "工作树有未提交修改 — 确认更新会覆盖这些改动"})
     else:
         checks.append({"key": "dirty", "level": "ok",
                        "label": "工作树干净 · 无未提交改动"})
@@ -285,6 +291,9 @@ def system_preflight(target: str = "origin/master") -> dict[str, Any]:
         "target_resolved": target_resolved,
         "checks": checks,
         "blocking": blocking,
+        # 工作树脏（真实改动；自动 churn 已剔除）。前端据此在确认时弹"强制覆盖"
+        # modal —— dirty 是 warn 不进 blocking，但仍需用户显式确认才覆盖。
+        "working_tree_dirty": cur.is_dirty,
         "requirements_diff": {
             "added": req_diff.added,
             "removed": req_diff.removed,

--- a/studio/api/schemas/system.py
+++ b/studio/api/schemas/system.py
@@ -6,3 +6,4 @@ from pydantic import BaseModel
 
 class UpdateRequest(BaseModel):
     target: str = "origin/master"  # ref / commit sha / origin/branch
+    force: bool = False            # True = 覆盖 dirty 工作树（用户已确认强制覆盖）

--- a/studio/services/runtime/updater.py
+++ b/studio/services/runtime/updater.py
@@ -14,6 +14,7 @@
 | --- | --- | --- |
 | `tmp/restart` | 需要重启 | server → cli.py / wrapper |
 | `studio_data/.update_pending` | 启动期要 git pull，内容是 target ref | server → cli.py |
+| `studio_data/.update_force` | 存在 = 允许覆盖 dirty 工作树（用户确认强制覆盖） | server → cli.py |
 | `studio_data/.update_cache` | 自动检查结果缓存（TTL 24h） | check_update() 自管 |
 | `studio_data/.last_version` | 上一版 commit（rollback 用，PR-C 启用） | apply_pending |
 | `studio_data/.update_log` | 最近一次 update 的日志（PR-C 展示） | apply_pending |
@@ -45,6 +46,16 @@ UPDATE_CACHE = STUDIO_DATA / ".update_cache"
 LAST_VERSION = STUDIO_DATA / ".last_version"
 UPDATE_LOG = STUDIO_DATA / ".update_log"
 UPDATE_STATUS = STUDIO_DATA / ".update_status"   # PR-C：结构化最近一次 update 结果
+UPDATE_FORCE = STUDIO_DATA / ".update_force"     # 存在 = 本次 pending 允许覆盖 dirty 工作树
+
+# npm 等工具会按本机版本自动改写的 tracked 文件（用户没动过）。最典型的是
+# package-lock.json：新版 npm 启动 npm install 时会往每个条目补 "peer": true 之类
+# 的元数据，导致 working tree 凭空 dirty → 自更新 precondition 把更新闸死。这类
+# churn 不算用户的真实改动：reset --hard 会照常覆盖、npm install 会重新生成，丢了
+# 零损失，所以 dirty 判定时剔除。新增此类文件往这里加一行即可。
+_GENERATED_DIRTY_ALLOWLIST = frozenset({
+    "studio/web/package-lock.json",
+})
 
 UPDATE_CACHE_TTL_SECONDS = 24 * 3600
 GIT_FETCH_TIMEOUT = 30.0
@@ -159,6 +170,33 @@ def _git(*args: str, timeout: float = 15.0) -> tuple[int, str, str]:
 # 稳定版 tag 形如 v0.8.0。HEAD 命中这种 tag 就归类 stable。
 # 第四段（如 v0.8.0-rc1）暂时不在版本面板的"稳定版"语义里，先归 custom。
 _RELEASE_TAG_RE = re.compile(r"^v\d+\.\d+\.\d+$")
+
+
+def _porcelain_dirty_paths() -> list[str]:
+    """`git status --porcelain` 里"已修改的 tracked 文件"路径，剔除 allowlist。
+
+    返回剩余路径列表；空列表 = 工作树干净（dirty 判定的事实来源）。
+
+    - `--untracked-files=no`：untracked 文件（临时笔记 / 没进 gitignore 的草稿）
+      不影响 git reset --hard，原地保留，不算 dirty。
+    - allowlist（package-lock.json 等）剔除：见 `_GENERATED_DIRTY_ALLOWLIST`。
+    - porcelain 行格式 `XY <path>`；重命名 `XY <old> -> <new>` 取新名；git 对含
+      特殊字符的路径会加引号，去掉再比。porcelain 路径恒用正斜杠（跨平台一致）。
+    """
+    rc, out, _ = _git("status", "--porcelain", "--untracked-files=no")
+    if rc != 0 or not out:
+        return []
+    paths: list[str] = []
+    for line in out.splitlines():
+        path = line[3:].strip()
+        if " -> " in path:                 # 重命名：取箭头右侧的新路径
+            path = path.split(" -> ", 1)[1].strip()
+        if len(path) >= 2 and path[0] == '"' and path[-1] == '"':
+            path = path[1:-1]              # 去引号（core.quotepath 对非 ASCII 加引号）
+        if path in _GENERATED_DIRTY_ALLOWLIST:
+            continue
+        paths.append(path)
+    return paths
 
 
 # ----- zip 用户检测 + 一键 init（0.8.1 hotfix）---------------------------
@@ -328,10 +366,9 @@ def current_version() -> VersionInfo:
     rc, tag, _ = _git("describe", "--tags", "--exact-match", "HEAD")
     exact_tag = tag if rc == 0 else None
 
-    # --untracked-files=no：untracked 文件（pr18_review.md / 临时笔记 / 没进 gitignore
-    # 的草稿等）不影响 git reset --hard，它们会原地保留。dirty 仅指"修改了 tracked 文件"。
-    rc, status, _ = _git("status", "--porcelain", "--untracked-files=no")
-    is_dirty = rc == 0 and bool(status)
+    # dirty 仅指"修改了 tracked 文件（剔除 untracked 与 npm 等自动 churn 的
+    # allowlist 文件）"。详见 _porcelain_dirty_paths。
+    is_dirty = bool(_porcelain_dirty_paths())
 
     installed_kind, installed_label, stable_version = _classify_install(
         commit=commit,
@@ -688,10 +725,25 @@ def dev_commits(limit: int = 10) -> DevCommitsResult:
     return DevCommitsResult(commits=commits, fetched=fetched, error=fetch_error_msg)
 
 
-def request_update(target: str = "origin/master") -> None:
-    """server 端调：写 .update_pending + tmp/restart 让 cli.py 启动期接管。"""
+def request_update(target: str = "origin/master", force: bool = False) -> None:
+    """server 端调：写 .update_pending + tmp/restart 让 cli.py 启动期接管。
+
+    force=True 时额外写 .update_force marker：启动期 apply_pending 会跳过 dirty
+    工作树 precondition，让 git reset --hard 覆盖掉本地未提交改动（用户在 UI
+    上显式确认"强制覆盖"后才会走到这里）。
+    """
     UPDATE_PENDING.parent.mkdir(parents=True, exist_ok=True)
     UPDATE_PENDING.write_text(target, encoding="utf-8")
+    if force:
+        UPDATE_FORCE.parent.mkdir(parents=True, exist_ok=True)
+        UPDATE_FORCE.touch()
+    elif UPDATE_FORCE.exists():
+        # 上一次请求可能写过 force marker 但没走到 apply_pending（比如又点了普通
+        # 更新覆盖）；不带 force 的新请求必须清掉旧 marker，避免误用。
+        try:
+            UPDATE_FORCE.unlink()
+        except OSError:
+            pass
     RESTART_FLAG.parent.mkdir(parents=True, exist_ok=True)
     RESTART_FLAG.touch()
 
@@ -726,13 +778,14 @@ def apply_pending(emit: Callable[[str], None] = print) -> bool:
         return False
 
     target = UPDATE_PENDING.read_text(encoding="utf-8-sig").strip() or "origin/master"
-    emit(f"[updater] applying pending update → {target}")
+    force = UPDATE_FORCE.exists()
+    emit(f"[updater] applying pending update → {target}{' (force)' if force else ''}")
 
     started_at = time.time()
     cur = current_version()
     log_lines: list[str] = [
         f"=== {time.strftime('%Y-%m-%d %H:%M:%S')} update {cur.commit_short} → {target} ===",
-        f"branch={cur.branch} tag={cur.tag or '-'} dirty={cur.is_dirty}",
+        f"branch={cur.branch} tag={cur.tag or '-'} dirty={cur.is_dirty} force={force}",
     ]
 
     # 保存上一版本（rollback 用）
@@ -764,11 +817,15 @@ def apply_pending(emit: Callable[[str], None] = print) -> bool:
             pass
         return True
 
-    # 1. precondition：working tree 干净
-    if cur.is_dirty:
+    # 1. precondition：working tree 干净（force 时跳过 —— 用户已在 UI 显式确认
+    #    覆盖；下面的 git reset --hard 会丢弃这些本地改动，不可恢复）。
+    if cur.is_dirty and not force:
         log_lines.append("[abort] working tree dirty")
         emit("[updater] working tree dirty, aborting update")
         return _done("aborted", "working tree dirty", cur.commit, False)
+    if cur.is_dirty and force:
+        log_lines.append("[force] working tree dirty; reset --hard 将覆盖本地未提交改动")
+        emit("[updater] working tree dirty but force requested, discarding local changes")
 
     # 2. git fetch
     log_lines.append("[git] fetch origin")
@@ -918,17 +975,18 @@ def _write_cache(result: UpdateCheckResult) -> None:
 
 
 def _finalize(log_lines: list[str]) -> None:
-    """写 update.log + 清 .update_pending 标志。"""
+    """写 update.log + 清 .update_pending / .update_force 标志。"""
     try:
         UPDATE_LOG.parent.mkdir(parents=True, exist_ok=True)
         UPDATE_LOG.write_text("\n".join(log_lines) + "\n", encoding="utf-8")
     except OSError:
         pass
-    try:
-        if UPDATE_PENDING.exists():
-            UPDATE_PENDING.unlink()
-    except OSError:
-        pass
+    for flag in (UPDATE_PENDING, UPDATE_FORCE):
+        try:
+            if flag.exists():
+                flag.unlink()
+        except OSError:
+            pass
 
 
 def _write_status(status: UpdateStatus) -> None:

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -2724,11 +2724,12 @@ export const api = {
   },
 
   // 请求 update：写 .update_pending + 触发 SIGINT 重启。
-  // 422 = running task 或 dirty working tree。
-  performSystemUpdate: (target: string = 'origin/master') =>
+  // 422 = running task 或 dirty working tree（force=true 时跳过 dirty 闸，
+  // reset --hard 覆盖本地未提交改动；用户需先在 UI 确认强制覆盖）。
+  performSystemUpdate: (target: string = 'origin/master', force = false) =>
     req<{ ok: boolean; message: string }>('/api/system/update', {
       method: 'POST',
-      body: JSON.stringify({ target }),
+      body: JSON.stringify({ target, force }),
     }),
 
   // 回滚到 .last_version 记录的上一版本（PR-C）。
@@ -2899,6 +2900,9 @@ export interface PreflightResult {
   target_resolved: string | null
   checks: PreflightCheck[]
   blocking: boolean
+  /** 工作树有未提交改动（自动 churn 已剔除）。true → 确认时弹"强制覆盖" modal。
+   *  dirty 是 warn 不进 blocking，但仍需用户显式确认才会带 force 覆盖。 */
+  working_tree_dirty: boolean
   requirements_diff: PreflightRequirementsDiff
 }
 

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1193,6 +1193,8 @@
     "upToDate": "Already up to date",
     "checkUpdateFailed": "Failed to check updates: {{error}}",
     "dirtyWorkingTree": "Local uncommitted changes exist; commit or stash first",
+    "forceUpdateConfirm": "The working tree has uncommitted local changes. Continuing will force-overwrite them with the target version (git reset --hard); those changes will be discarded and cannot be recovered. Continue?",
+    "forceUpdateConfirmOk": "Force-overwrite and update",
     "noRollbackTarget": "No rollback target (first startup / .last_version was cleaned)",
     "triggerActionFailed": "Failed to trigger {{action}}: {{error}}",
     "actionUpdate": "update",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1193,6 +1193,8 @@
     "upToDate": "已是最新版本",
     "checkUpdateFailed": "检查更新失败: {{error}}",
     "dirtyWorkingTree": "本地有未提交修改，请先 commit 或 stash",
+    "forceUpdateConfirm": "工作区有未提交的本地改动。继续更新会用目标版本强制覆盖（git reset --hard），这些改动将被丢弃且无法恢复。确定继续吗？",
+    "forceUpdateConfirmOk": "强制覆盖并更新",
     "noRollbackTarget": "没有可回滚的版本（首次启动 / .last_version 已被清理）",
     "triggerActionFailed": "触发{{action}}失败: {{error}}",
     "actionUpdate": "更新",

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -3369,7 +3369,9 @@ async function pollHealthThenReload(
 function VersionSection() {
   const { t } = useTranslation()
   const { toast } = useToast()
-  // chunk 4：dialog 模态被 inline preview 面板取代，VersionSection 不再用 dialog
+  // chunk 4：update 预览走 inline preview 面板（不用 dialog）。例外：工作树 dirty
+  // 时确认更新前要弹一个"强制覆盖"确认 modal，复用 useDialog().confirm。
+  const dialog = useDialog()
   const [version, setVersion] = useState<SystemVersion | null>(null)
   const [check, setCheck] = useState<SystemUpdateCheck | null>(null)
   const [status, setStatus] = useState<SystemUpdateStatus | null>(null)
@@ -3531,11 +3533,22 @@ function VersionSection() {
   const confirmPreview = async () => {
     if (!pendingTarget) return
     const t = pendingTarget
+    // 工作树脏（真实改动，自动 churn 已在后端剔除）→ 弹确认 modal。reset --hard
+    // 会丢弃这些未提交改动且不可恢复，必须用户显式点确认才带 force。取消则留在
+    // preview 不动。(i18n 用 i18n.t —— 此作用域 t 已被 pendingTarget 遮蔽。)
+    const force = preflight?.working_tree_dirty === true
+    if (force) {
+      const ok = await dialog.confirm(i18n.t('settings.forceUpdateConfirm'), {
+        tone: 'warn',
+        okText: i18n.t('settings.forceUpdateConfirmOk'),
+      })
+      if (!ok) return
+    }
     if (t.kind === 'master') setMasterState('progress')
     else setDevState('progress')
     setBusy(true)
     try {
-      await api.performSystemUpdate(t.ref)
+      await api.performSystemUpdate(t.ref, force)
     } catch (e) {
       toast(_formatActionError(e, t.kind === 'master' ? i18n.t('settings.actionUpdate') : i18n.t('settings.actionSwitch')), 'error')
       setBusy(false)

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -663,6 +663,34 @@ def test_system_update_rejects_when_dirty(
     assert body["error"]["code"] == "system.working_tree_dirty"
 
 
+def test_system_update_force_bypasses_dirty(
+    client: TestClient,
+    isolated_paths: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """force=True：dirty 工作树不再 422，写 pending + force marker（启动期
+    apply_pending 会 reset --hard 覆盖本地改动）。"""
+    from studio.services.runtime import updater
+    dirty = updater.VersionInfo(
+        version="0.6.0", commit="abc", commit_short="abc", commit_time_iso="",
+        branch="master", tag=None, is_dirty=True,
+    )
+    monkeypatch.setattr(updater, "current_version", lambda: dirty)
+    pending = tmp_path / ".update_pending"
+    force_flag = tmp_path / ".update_force"
+    restart_flag = tmp_path / "tmp" / "restart"
+    monkeypatch.setattr(updater, "UPDATE_PENDING", pending)
+    monkeypatch.setattr(updater, "UPDATE_FORCE", force_flag)
+    monkeypatch.setattr(updater, "RESTART_FLAG", restart_flag)
+    monkeypatch.setattr("studio.api.routers.system._raise_sigint_after_response", lambda: None)
+
+    resp = client.post("/api/system/update", json={"target": "origin/master", "force": True})
+    assert resp.status_code == 200
+    assert pending.read_text(encoding="utf-8") == "origin/master"
+    assert force_flag.exists()
+
+
 def test_system_update_writes_pending_and_restart_flag(
     client: TestClient,
     isolated_paths: dict[str, Path],
@@ -895,12 +923,14 @@ def test_preflight_clean_no_running_no_diff(
     assert keys == ["dirty", "running_tasks", "requirements_diff", "last_version"]
 
 
-def test_preflight_dirty_blocks(
+def test_preflight_dirty_warns_overridable(
     client: TestClient,
     isolated_paths: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """is_dirty=True → dirty check level=err，blocking=True。"""
+    """is_dirty=True → dirty check level=warn（不再硬阻断），working_tree_dirty=True，
+    blocking=False（仅 dirty 时）。前端据此弹"强制覆盖"确认 modal，确认后带 force
+    提交。running task / self_update 等才是不可绕过的 err。"""
     from studio.services.runtime import updater
     monkeypatch.setattr(updater, "current_version", lambda: updater.VersionInfo(
         version="0.6.0", commit="x", commit_short="x", commit_time_iso="",
@@ -911,9 +941,10 @@ def test_preflight_dirty_blocks(
     monkeypatch.setattr(updater, "target_has_self_update", lambda _ref: True)
 
     body = client.get("/api/system/preflight?target=origin/master").json()
-    assert body["blocking"] is True
+    assert body["blocking"] is False
+    assert body["working_tree_dirty"] is True
     dirty_check = next(c for c in body["checks"] if c["key"] == "dirty")
-    assert dirty_check["level"] == "err"
+    assert dirty_check["level"] == "warn"
 
 
 def test_preflight_running_tasks_block(

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -31,6 +31,7 @@ def _isolate_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     避免污染开发机的标志文件。"""
     monkeypatch.setattr(updater, "RESTART_FLAG", tmp_path / "tmp" / "restart")
     monkeypatch.setattr(updater, "UPDATE_PENDING", tmp_path / ".update_pending")
+    monkeypatch.setattr(updater, "UPDATE_FORCE", tmp_path / ".update_force")
     monkeypatch.setattr(updater, "UPDATE_CACHE", tmp_path / ".update_cache")
     monkeypatch.setattr(updater, "LAST_VERSION", tmp_path / ".last_version")
     monkeypatch.setattr(updater, "UPDATE_LOG", tmp_path / ".update_log")
@@ -56,6 +57,54 @@ def test_current_version_smoke() -> None:
 
 
 # ---------------------------------------------------------------------------
+# _porcelain_dirty_paths — allowlist 剔除（自动 churn 文件不算 dirty）
+# ---------------------------------------------------------------------------
+
+def test_porcelain_dirty_paths_clean(monkeypatch: pytest.MonkeyPatch) -> None:
+    """git status --porcelain 输出空 → 工作树干净。"""
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "", ""))
+    assert updater._porcelain_dirty_paths() == []
+
+
+def test_porcelain_dirty_paths_excludes_lockfile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """唯一改动是 package-lock.json（npm 按本机版本自动 churn）→ 视为干净。
+
+    用户报的 bug：新 npm 启动期改写 lockfile 补 "peer": true → working tree
+    凭空 dirty → 自更新 precondition 闸死。allowlist 剔除后不再触发。
+    """
+    monkeypatch.setattr(
+        updater, "_git",
+        lambda *a, **k: (0, " M studio/web/package-lock.json", ""),
+    )
+    assert updater._porcelain_dirty_paths() == []
+
+
+def test_porcelain_dirty_paths_keeps_real_changes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """lockfile churn + 真实手改文件混在一起 → 只剩真实改动，仍算 dirty。"""
+    out = " M studio/web/package-lock.json\n M runtime/anima_train.py"
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, out, ""))
+    assert updater._porcelain_dirty_paths() == ["runtime/anima_train.py"]
+
+
+def test_porcelain_dirty_paths_rename_uses_new_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """重命名行 `R  old -> new` 取箭头右侧的新路径。"""
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "R  a/old.py -> a/new.py", ""))
+    assert updater._porcelain_dirty_paths() == ["a/new.py"]
+
+
+def test_current_version_clean_when_only_lockfile_churn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """current_version().is_dirty 跟随 _porcelain_dirty_paths：仅 lockfile churn →
+    is_dirty=False（这条把"自更新被 lockfile 卡死"的回归守住）。"""
+    monkeypatch.setattr(updater, "_porcelain_dirty_paths", lambda: [])
+    monkeypatch.setattr(updater, "git_repo_status",
+                        lambda: updater.GitRepoStatus(True, True, True))
+    monkeypatch.setattr(updater, "_git", lambda *a, **k: (0, "abc123def456", ""))
+    assert updater.current_version().is_dirty is False
+    monkeypatch.setattr(updater, "_porcelain_dirty_paths", lambda: ["runtime/x.py"])
+    assert updater.current_version().is_dirty is True
+
+
+# ---------------------------------------------------------------------------
 # request_update / has_pending
 # ---------------------------------------------------------------------------
 
@@ -73,6 +122,25 @@ def test_request_update_writes_flags(_isolate_flags: Path) -> None:
 def test_request_update_custom_target(_isolate_flags: Path) -> None:
     updater.request_update("abc1234567")
     assert updater.UPDATE_PENDING.read_text(encoding="utf-8") == "abc1234567"
+
+
+def test_request_update_no_force_marker_by_default(_isolate_flags: Path) -> None:
+    updater.request_update("origin/master")
+    assert not updater.UPDATE_FORCE.exists()
+
+
+def test_request_update_force_writes_marker(_isolate_flags: Path) -> None:
+    updater.request_update("origin/master", force=True)
+    assert updater.UPDATE_FORCE.exists()
+
+
+def test_request_update_clears_stale_force_marker(_isolate_flags: Path) -> None:
+    """上次写过 force marker 但没消费；本次普通（非 force）请求必须清掉它，
+    避免普通更新被误判成 force 覆盖 dirty 工作树。"""
+    updater.UPDATE_FORCE.parent.mkdir(parents=True, exist_ok=True)
+    updater.UPDATE_FORCE.touch()
+    updater.request_update("origin/master")  # force 默认 False
+    assert not updater.UPDATE_FORCE.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +180,43 @@ def test_apply_pending_dirty_tree_aborts(
     assert "[abort] working tree dirty" in log
     # 不应该调任何 git 命令（fetch / reset / pull 都不该跑）
     assert git_calls == []
+
+
+def test_apply_pending_force_overwrites_dirty(
+    _isolate_flags: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """force marker 存在时，dirty 工作树**不**中止：照常 git fetch + reset --hard
+    （覆盖本地改动），收尾清掉 force marker，status=ok。"""
+    fake = updater.VersionInfo(
+        version="0.0.0", commit="abc", commit_short="abc",
+        commit_time_iso="", branch="master", tag=None, is_dirty=True,
+        installed_kind="custom", installed_label="自定义（master @ abc）",
+        stable_version=None,
+    )
+    monkeypatch.setattr(updater, "current_version", lambda: fake)
+    monkeypatch.setattr(updater, "_requirements_marker_stale", lambda: False)
+    monkeypatch.setattr(updater, "_package_json_changed", lambda: False)
+
+    git_calls: list[tuple] = []
+    def _fake_git(*args, **kwargs):
+        git_calls.append(args)
+        return 0, "", ""
+    monkeypatch.setattr(updater, "_git", _fake_git)
+
+    updater.request_update("origin/master", force=True)
+    result = updater.apply_pending(emit=lambda _: None)
+
+    assert result is True
+    # 没 abort：fetch + reset --hard 都跑了
+    assert any(c[:2] == ("fetch", "origin") for c in git_calls), "force 路径应当 git fetch"
+    assert any(c[0] == "reset" and "--hard" in c for c in git_calls), "force 路径应当 reset --hard"
+    # force marker + pending 都清了
+    assert not updater.UPDATE_FORCE.exists()
+    assert not updater.UPDATE_PENDING.exists()
+    st = updater.last_status()
+    assert st is not None and st.status == "ok"
+    log = updater.UPDATE_LOG.read_text(encoding="utf-8")
+    assert "[force]" in log and "[abort]" not in log
 
 
 def test_apply_pending_records_last_version(


### PR DESCRIPTION
## 背景 / 动机

多名用户报告「设置 → 系统 → 更新用不了」。排查发现 `git diff` 里 `studio/web/package-lock.json` 凭空有改动——全是给各依赖条目追加 `"peer": true`，用户并没有手动改过任何东西。

根因:新版 npm 在启动期 `npm install`(`cli.py` bootstrap / web dist 重建)时会**按本机 npm 版本自动改写** lockfile,补 `peer` 之类的元数据。这让一个 tracked 文件凭空变 dirty → 自更新的「工作树必须干净」precondition 直接把更新闸死(服务端 `POST /api/system/update` 返 422 `system.working_tree_dirty`,preflight 也把 dirty 标 `err` 禁用确认按钮)。

这与 `updater.py` 里 `bootstrap_git_repo` 注释提到的 v0.8.1 zip 用户踩坑同类,只是当时只给 zip 路径用 `reset --hard` 兜了,**git-clone 用户的正常自更新路径没被救到**。

## 改动概要

自更新走的是 `git fetch` + `git reset --hard target`(非 merge),**永远不会 conflict**——dirty 闸的目的是防止 reset --hard 静默覆盖用户的真实改动,而非避免冲突。据此两段修复:

**1. allowlist(根治大多数报告)**
- `updater.py`:新增 `_GENERATED_DIRTY_ALLOWLIST = {"studio/web/package-lock.json"}` + `_porcelain_dirty_paths()` helper(解析 `git status --porcelain`,剔除 allowlist 与 untracked,处理重命名/引号路径);`current_version().is_dirty` 改用它。**仅 lockfile churn 时 `is_dirty=False`,自更新不再被卡。** reset --hard 会覆盖、npm install 会重生成,丢这点 churn 零损失。

**2. 脏工作区强制覆盖逃生口(真有手改时)**
- `updater.py`:新增 `.update_force` marker;`request_update(target, force)` 按需写/清;`apply_pending` 读 force,仅 `dirty and not force` 才 abort,force 时记日志后照常 reset --hard;`_finalize` 收尾清 marker。
- `system.py` / `schemas/system.py`:`UpdateRequest` 加 `force`;`system_update` 在 force 时跳过 dirty 422;**preflight 的 dirty 从 `err` 降为 `warn`**(不再硬阻断)+ 新增 `working_tree_dirty` 字段。`running_tasks` / `self_update_compat` 等仍是不可绕过的 `err`。
- 前端 `client.ts`:`performSystemUpdate(target, force)` + `PreflightResult.working_tree_dirty`。
- `Settings.tsx`:VersionSection 确认更新时,若 `working_tree_dirty` 则弹 `dialog.confirm`(warn 调性、「强制覆盖并更新」按钮),取消留在 preview,确认才带 `force=true`。**rollback 共用 confirmPreview/performSystemUpdate,自动一并覆盖。**
- i18n en/zh 各加 `settings.forceUpdateConfirm` + `forceUpdateConfirmOk`。

## 测试方式

自动测试覆盖:
- `tests/test_updater.py`:`_porcelain_dirty_paths` allowlist 4 条(clean / 仅 lockfile→clean / lockfile+真文件→dirty / 重命名取新名)+ `current_version` is_dirty 跟随 helper + force marker 3 条 + `apply_pending` force 覆盖 dirty(不 abort、跑 reset --hard、清 marker、status=ok)。
- `tests/test_studio_server.py`:`test_preflight_dirty_blocks` 重写为 `..._warns_overridable`(warn + `working_tree_dirty` + blocking=False)+ 新增 `test_system_update_force_bypasses_dirty`。

本地结果:
- 后端 `pytest tests/` 全量 **2452 passed**(含横切 `test_route_snapshot` / `test_studio_configs`)。
- 前端 `tsc -b` ✓、`eslint` ✓、`vitest` **401 passed**。

UI 改动是确认更新时多一个「强制覆盖」确认 modal(仅工作区真有手改时出现);未在真实跑起来的 webui 上截图,逻辑由上述自动测试 + tsc/lint 覆盖。
