### PR TITLE
feat(web): 灯箱/全屏预览底部显示「N / M」图片计数

### DIFF
--- a/studio/web/src/components/ImagePreviewModal.tsx
+++ b/studio/web/src/components/ImagePreviewModal.tsx
@@ -9,6 +9,9 @@ interface Props {
   /** Split 布局时右侧图顶部的小 label（如 "处理后"）。 */
   compareLabel?: string
   caption?: string
+  /** 列表中的 0-based 位置；与 total 同传时底部显示 "index+1 / total" 计数。 */
+  index?: number
+  total?: number
   hasPrev?: boolean
   hasNext?: boolean
   onClose: () => void
@@ -25,6 +28,8 @@ export default function ImagePreviewModal({
   srcLabel,
   compareLabel,
   caption,
+  index,
+  total,
   hasPrev,
   hasNext,
   onClose,
@@ -56,6 +61,8 @@ export default function ImagePreviewModal({
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
   }, [hasPrev, hasNext, onPrev, onNext, onClose, onAccept, onDelete])
+
+  const counter = index != null && total != null ? `${index + 1} / ${total}` : null
 
   return (
     <div
@@ -113,8 +120,9 @@ export default function ImagePreviewModal({
           />
         )}
       </div>
-      {(caption || shortcutHint) && (
+      {(counter || caption || shortcutHint) && (
         <div className="shrink-0 border-t border-white/10 bg-black px-4 py-2 flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs text-slate-400">
+          {counter && <div className="font-mono text-slate-300">{counter}</div>}
           {caption && <div className="font-mono text-slate-300">{caption}</div>}
           {shortcutHint && <div>{shortcutHint}</div>}
         </div>

--- a/studio/web/src/components/MonitorDashboard.tsx
+++ b/studio/web/src/components/MonitorDashboard.tsx
@@ -972,7 +972,9 @@ function SampleViewer({ samples, taskId }: {
       {zoomOpen && (
         <ImagePreviewModal
           src={fullUrl}
-          caption={[markText, `${active + 1} / ${list.length}`, filename].filter(Boolean).join(' · ')}
+          caption={[markText, filename].filter(Boolean).join(' · ')}
+          index={active}
+          total={list.length}
           hasPrev={active > 0}
           hasNext={active < list.length - 1}
           onClose={() => setZoomOpen(false)}

--- a/studio/web/src/pages/project/Overview.tsx
+++ b/studio/web/src/pages/project/Overview.tsx
@@ -827,6 +827,8 @@ function TrainSetCard({ project, version }: { project: ProjectDetail; version: V
         <ImagePreviewModal
           src={previewSrc}
           caption={previewItem.name}
+          index={previewIdx}
+          total={items.length}
           hasPrev={previewIdx > 0}
           hasNext={previewIdx < items.length - 1}
           onClose={() => setPreviewIdx(null)}

--- a/studio/web/src/pages/project/steps/Curation.tsx
+++ b/studio/web/src/pages/project/steps/Curation.tsx
@@ -813,6 +813,8 @@ export default function CurationPage() {
         <ImagePreviewModal
           src={preview.url}
           caption={preview.caption}
+          index={preview.index}
+          total={preview.list.length}
           hasPrev={preview.index > 0}
           hasNext={preview.index < preview.list.length - 1}
           onClose={() => setPreview(null)}

--- a/studio/web/src/pages/project/steps/Download.tsx
+++ b/studio/web/src/pages/project/steps/Download.tsx
@@ -329,6 +329,8 @@ export default function DownloadPage() {
       <ImagePreviewModal
         src={api.projectThumbUrl(project.id, files[previewIdx].name, 'download', 1600)}
         caption={files[previewIdx].name}
+        index={previewIdx}
+        total={files.length}
         hasPrev={previewIdx > 0}
         hasNext={previewIdx < files.length - 1}
         onClose={() => setPreviewIdx(null)}

--- a/studio/web/src/pages/project/steps/Preprocess.tsx
+++ b/studio/web/src/pages/project/steps/Preprocess.tsx
@@ -480,6 +480,8 @@ export default function PreprocessPage() {
           caption={`${visibleRows[previewIdx].name} · ${
             visibleRows[previewIdx].status === 'processed' ? '✓ 已处理' : '⊘ 未处理'
           }`}
+          index={previewIdx}
+          total={visibleRows.length}
           hasPrev={previewIdx > 0}
           hasNext={previewIdx < visibleRows.length - 1}
           onClose={() => setPreviewIdx(null)}

--- a/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
@@ -285,6 +285,8 @@ export default function PreprocessDuplicatesPage() {
         <ImagePreviewModal
           src={api.versionThumbUrl(project.id, vid, 'train', filename, folder, 1600)}
           caption={rel}
+          index={previewIdx}
+          total={previewNames.length}
           hasPrev={previewIdx > 0}
           hasNext={previewIdx < previewNames.length - 1}
           onClose={() => setPreviewIdx(null)}

--- a/studio/web/src/pages/project/steps/PreprocessOverview.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessOverview.tsx
@@ -331,6 +331,8 @@ export default function PreprocessOverviewPage() {
           srcLabel={previewItem.compareSrc ? t('preprocessOverview.compareOriginal') : undefined}
           compareLabel={previewItem.compareSrc ? t('preprocessOverview.compareProcessed') : undefined}
           caption={previewItem.caption}
+          index={previewIdx!}
+          total={items.length}
           hasPrev={previewIdx! > 0}
           hasNext={previewIdx! < items.length - 1}
           onClose={() => setPreviewIdx(null)}

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -526,6 +526,8 @@ export default function RegularizationPage() {
         <ImagePreviewModal
           src={regOrigUrl(project.id, vid, reg.files[previewIdx])}
           caption={previewCaption}
+          index={previewIdx}
+          total={reg.files.length}
           hasPrev={previewIdx > 0}
           hasNext={previewIdx < reg.files.length - 1}
           onClose={() => setPreviewIdx(null)}

--- a/studio/web/src/pages/tools/generate/FullscreenViewer.tsx
+++ b/studio/web/src/pages/tools/generate/FullscreenViewer.tsx
@@ -10,7 +10,7 @@ import { useTranslation } from 'react-i18next'
  *   shortcutHint 不传时按当前可用方向动态拼接（避免在单行 / 单列 / 角落格上撒谎）
  */
 export default function FullscreenViewer({
-  src, alt, caption, onClose,
+  src, alt, caption, index, total, onClose,
   hasPrev, hasNext, hasUp, hasDown,
   onPrev, onNext, onUp, onDown,
   shortcutHint,
@@ -18,6 +18,9 @@ export default function FullscreenViewer({
   src: string
   alt?: string
   caption?: string
+  /** 列表中的 0-based 位置；与 total 同传时底部显示 "index+1 / total" 计数。 */
+  index?: number
+  total?: number
   onClose: () => void
   hasPrev?: boolean
   hasNext?: boolean
@@ -70,6 +73,8 @@ export default function FullscreenViewer({
     const nav = dirs.length > 0 ? t('generate.fullscreenNavPrefix', { dirs: dirs.join(' / ') }) : ''
     return `${nav}${t('generate.fullscreenCloseHint')}`
   }, [shortcutHint, hasPrev, hasNext, hasUp, hasDown, t])
+
+  const counter = index != null && total != null ? `${index + 1} / ${total}` : null
 
   return (
     <div
@@ -141,6 +146,11 @@ export default function FullscreenViewer({
         {caption && (
           <div className="text-xs text-fg-secondary font-mono text-center">
             {caption}
+          </div>
+        )}
+        {counter && (
+          <div className="text-xs text-fg-secondary font-mono text-center">
+            {counter}
           </div>
         )}
         <div className="text-2xs text-fg-tertiary">

--- a/studio/web/src/pages/tools/generate/PreviewXYGrid.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewXYGrid.tsx
@@ -317,6 +317,8 @@ export default function PreviewXYGrid({
             src={s.imageUrl ?? api.generateSampleUrl(taskId, fn)}
             alt={fn}
             caption={captionParts.join(' · ')}
+            index={fullscreenIdx}
+            total={samples.length}
             onClose={() => setFullscreenIdx(null)}
             hasPrev={fullscreenNeighbors?.left != null}
             hasNext={fullscreenNeighbors?.right != null}


### PR DESCRIPTION
## 背景 / 动机

多个图片浏览场景（下载页、预处理、curation、正则集、训练集卡片、训练采样图、XY 网格）都用 `ImagePreviewModal` / `FullscreenViewer` 看大图，可以用 ←/→ 在序列里翻页，但底部没有「当前在第几张 / 共几张」的指示，翻到一半不知道位置。

`MonitorDashboard` 的采样查看器此前是把 `N / M` 硬拼进 caption 字符串临时顶上，形式不统一、也没法复用到其它页面。

## 改动概要

- `ImagePreviewModal` / `FullscreenViewer` 新增可选 prop `index`（0-based）+ `total`；两者同传时在底部渲染独立的「`index+1` / `total`」计数行（mono 字体）。只传其一或都不传则不显示，对未接入的调用点零影响。
- 接入所有顺序浏览的调用点：`Download` / `Preprocess` / `PreprocessDuplicates` / `PreprocessOverview` / `Curation` / `Regularization` / `Overview`(训练集卡片) / `PreviewXYGrid`(采样全屏)。
- `MonitorDashboard` 采样查看器从「把计数塞进 caption」改为走新 prop，caption 只留 mark / 文件名。
- `PreviewCompare`（XY 的 A/B 并排对比）是在两张选定图之间切换、非顺序浏览列表，显示「1 / 2」会误导，**故意未接入**。

## 测试方式

- 前端三件套全绿：`npx tsc --noEmit`、`npm run lint`、`npx vitest run`（44 文件 / 408 测试通过，含 `PreviewCompare.test.tsx` 确认对比视图未受影响）。
- 纯前端、纯叠加式 prop，无 schema / API / 后端改动。

## 截图

UI 改动（大图底部多一行计数）。截图待补。