### PR TITLE
feat(web): 测试页 XY 结果开始后冻结 + 历史栏虚拟滚动

### DIFF
--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -5,6 +5,14 @@ import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { ToastProvider } from '../../components/Toast'
 import GeneratePage from './Generate'
+import { useMonitorProgress } from '../../lib/useMonitorProgress'
+
+// monitorState 来自 SSE，smoke 里不驱动 —— 默认返回空 state（samples=[]，等同
+// 既有行为）。#1 冻结用例单独 mockReturnValue 注入 XY samples。
+vi.mock('../../lib/useMonitorProgress', () => {
+  const NULL_MONITOR = { state: null }
+  return { useMonitorProgress: vi.fn(() => NULL_MONITOR) }
+})
 
 const fetchMock = vi.fn()
 let lastEnqueueBody: Record<string, unknown> | null = null
@@ -12,6 +20,8 @@ let lastEnqueueBody: Record<string, unknown> | null = null
 beforeEach(() => {
   lastEnqueueBody = null
   window.localStorage.clear()
+  // 每个用例重置 monitor mock 到默认空 state（隔离 #1 用例注入的 samples）
+  vi.mocked(useMonitorProgress).mockReturnValue({ state: null } as never)
   vi.stubGlobal('fetch', fetchMock)
   fetchMock.mockReset()
   fetchMock.mockImplementation((url: string, init?: RequestInit) => {
@@ -402,5 +412,40 @@ describe('GeneratePage 端到端 smoke', () => {
     })
     // 原 "20, 25, 30" 文本框该消失（切到 lora_ckpt 渲染的是 picker）
     expect(screen.queryByDisplayValue(/20, 25, 30/)).not.toBeInTheDocument()
+  })
+
+  // ---- #1：XY 开始后改轴只影响下次，不串改右侧已出结果 ----
+  it('XY 开始后改 X 轴：sidebar 改了但右侧结果网格冻结（30 列仍在）', async () => {
+    // 注入 3 个 cell 的 XY samples（X=steps 20/25/30，无 Y 轴）
+    vi.mocked(useMonitorProgress).mockReturnValue({
+      state: {
+        samples: [
+          { path: 'cell x0 y0.png', xy: { xi: 0, yi: 0, xv: 20, yv: null } },
+          { path: 'cell x1 y0.png', xy: { xi: 1, yi: 0, xv: 25, yv: null } },
+          { path: 'cell x2 y0.png', xy: { xi: 2, yi: 0, xv: 30, yv: null } },
+        ],
+      },
+    } as never)
+    seedPrefs({ mode: 'xy' })  // 默认 X=steps raw "20, 25, 30"
+    const user = userEvent.setup()
+    setup()
+    await waitForInitialLorasLoad()
+
+    // 开始生成（3 张）→ dispatch 定格本次运行态 run
+    await user.click(await screen.findByRole('button', { name: /开始生成 · 3 张/ }))
+    await waitFor(() => expect(lastEnqueueBody).not.toBeNull())
+
+    // 网格渲染出 steps 三档表头（20/25/30）
+    await waitFor(() => expect(screen.getByText('30')).toBeInTheDocument())
+
+    // 取消 30 那一档：X 轴 raw "20, 25, 30" → "20, 25"
+    const axisInput = screen.getByDisplayValue('20, 25, 30')
+    await user.clear(axisInput)
+    await user.type(axisInput, '20, 25')
+
+    // live sidebar 确实改成了 "20, 25"（下次生成会用它）……
+    await waitFor(() => expect(axisInput).toHaveValue('20, 25'))
+    // ……但右侧已出结果网格冻结：仍含 "30" 表头，未被 live 编辑串改
+    expect(screen.getByText('30')).toBeInTheDocument()
   })
 })

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -191,6 +191,17 @@ export default function GeneratePage() {
   // 没法重试也没法取消（status=failed 时 cancelable=false）
   const [submitting, setSubmitting] = useState(false)
   const [currentTask, setCurrentTask] = useState<Task | null>(null)
+  // #1：本次生成「运行态」定格。dispatch 成功时把当时的 XY 轴 + 完整参数
+  // 快照冻进这里；活动结果网格 / 双图对比 / 完成入库三处都读它，而不是读
+  // live xDraft/yDraft/prefs。这样任务开始后改 sidebar（取消某个 XY LoRA、
+  // 调参数等）只影响「下次生成」，不会串改已出 / 在出的右侧结果与入库元数据。
+  // taskId 不匹配当前任务时回退 live（如刷新后中途回看的边缘场景，无回归）。
+  const [run, setRun] = useState<{
+    taskId: number
+    xDraft: XYAxisDraft
+    yDraft: XYAxisDraft | null
+    snapshot: GenerateParamsSnapshot
+  } | null>(null)
   // 本次出图临时选用的底模（null = 跟随设置页 selected_anima）。不进 prefs
   // 持久化：每次进页面都回到「设置页默认底模」，符合「默认用设置里的」。
   const [baseModel, setBaseModel] = useState<string | null>(null)
@@ -243,6 +254,12 @@ export default function GeneratePage() {
   // 用 useMemo 稳定引用：monitorState 不变时 samples 引用不变，避免下方
   // useEffect 把 samples 当依赖触发不必要的重跑
   const samples = useMemo(() => monitorState?.samples ?? [], [monitorState])
+
+  // #1：活动结果网格用「dispatch 时定格的轴」(run) 而非 live xDraft/yDraft。
+  // run 对应当前任务时取冻结值（任务开始后改 sidebar 不串改右侧）；否则回退 live。
+  const frozenRun = run && currentTask && run.taskId === currentTask.id ? run : null
+  const gridXDraft = frozenRun ? frozenRun.xDraft : xDraft
+  const gridYDraft = frozenRun ? frozenRun.yDraft : yDraft
 
   // XY mode 时，按钮显示「生成 N×M=K 张」
   const xyCellCount = useMemo(() => {
@@ -331,6 +348,12 @@ export default function GeneratePage() {
     if (snap?.taskId === currentTask.id) return
     lastSnapshotRef.current = { taskId: currentTask.id, mode }
     const taskId = currentTask.id
+    // #1：入库元数据（落盘 / cache 的 xyMeta + 参数快照）用本次运行态定格 run，
+    // 而非 live prefs —— 任务开始后改 sidebar 不污染已生成结果的入库轴与参数。
+    // run 不匹配当前任务时回退 live（刷新后中途完成的边缘场景）。
+    const runFrozen = run && run.taskId === currentTask.id ? run : null
+    const metaXDraft = runFrozen ? runFrozen.xDraft : xDraft
+    const metaYDraft = runFrozen ? runFrozen.yDraft : yDraft
     // 选封面 sample
     let coverIdx = 0
     // XY：找 (xi=0, yi=0) 那张；找不到 fallback 0
@@ -351,9 +374,9 @@ export default function GeneratePage() {
     // commit: xy 历史回看用 PreviewXYGrid 重建网格 → 入库时收集 axis + sample 元数据
     let xyMeta: import('./generate/useGenerateHistory').HistoryXYMeta | undefined
     if (mode === 'xy') {
-      const xValues = xDraft.raw.split(',').map((s) => s.trim()).filter(Boolean)
-      const yValues = yDraft
-        ? yDraft.raw.split(',').map((s) => s.trim()).filter(Boolean)
+      const xValues = metaXDraft.raw.split(',').map((s) => s.trim()).filter(Boolean)
+      const yValues = metaYDraft
+        ? metaYDraft.raw.split(',').map((s) => s.trim()).filter(Boolean)
         : [null as string | null]
       const xySamples = samples
         .filter((s): s is typeof s & { xy: NonNullable<typeof s.xy> } => s.xy != null)
@@ -365,20 +388,17 @@ export default function GeneratePage() {
           },
         }))
       xyMeta = {
-        xAxis: xDraft.axis, yAxis: yDraft?.axis ?? null,
+        xAxis: metaXDraft.axis, yAxis: metaYDraft?.axis ?? null,
         xValues, yValues, samples: xySamples,
       }
     }
     // 参数快照（落盘 PNG metadata + cache entry 共用，回填用）。
+    // #1：优先用 dispatch 时定格的完整快照（runFrozen.snapshot）——任务开始后
+    // 改任意参数都不污染落盘 / cache 元数据。run 缺失时（边缘）回退按 live 现构造，
+    // xy_draft 用上面定格的轴 metaXDraft/metaYDraft。
     // LoRA 只存 name + ids（不存 path 避免泄露 / 跨机器死链）；回填时通过
     // projectLoras 用 ids → path resolve。
-    const snapshotLoras: SnapshotLora[] = loras.map((l) => ({
-      name: loraBasename(l.path),
-      scale: l.scale,
-      project_id: l.project_id ?? null,
-      version_id: l.version_id ?? null,
-    }))
-    const params: GenerateParamsSnapshot = {
+    const params: GenerateParamsSnapshot = runFrozen?.snapshot ?? {
       schema_version: PARAMS_SNAPSHOT_VERSION,
       mode,
       prompts,
@@ -389,11 +409,16 @@ export default function GeneratePage() {
       scheduler,
       count, seed,
       base_model: baseModel,
-      loras: snapshotLoras,
+      loras: loras.map((l) => ({
+        name: loraBasename(l.path),
+        scale: l.scale,
+        project_id: l.project_id ?? null,
+        version_id: l.version_id ?? null,
+      })),
       xy_draft: mode === 'xy'
         ? {
-            x: transformAxisRawForSnapshot(xDraft),
-            y: yDraft ? transformAxisRawForSnapshot(yDraft) : null,
+            x: transformAxisRawForSnapshot(metaXDraft),
+            y: metaYDraft ? transformAxisRawForSnapshot(metaYDraft) : null,
           }
         : null,
       dataset_pick: datasetPick,
@@ -427,7 +452,7 @@ export default function GeneratePage() {
         await history.refreshCache()
       }
     })()
-  }, [currentTask, samples, mode, selectedIndices, history, xDraft, yDraft,
+  }, [currentTask, samples, mode, selectedIndices, history, run, xDraft, yDraft,
       prompts, negPrompt, width, height, steps, cfgScale, samplerName, scheduler, count, seed, baseModel, loras, datasetPick])
 
   const handleHistorySelect = (entry: HistoryEntry) => {
@@ -513,6 +538,7 @@ export default function GeneratePage() {
 
     setSubmitting(true)
     setCurrentTask(null)
+    setRun(null)  // #1：清掉上一次的运行态定格，本次 enqueue 成功后重新冻结
     // monitorState 由 useMonitorProgress hook 自动随 currentTask 切 null → 清空
     setSelectedIndices([])  // 新一轮生成 — 旧选择已失效
     setProgress({ batchIdx: null, batchTotal: null, currentStep: null, totalSteps: null })
@@ -575,6 +601,14 @@ export default function GeneratePage() {
       // 早期失败会马上发 SSE，handler 拿 taskIdRef 还是 null → 漏事件）
       taskIdRef.current = task.id
       setCurrentTask(task)
+      // #1：定格本次运行态。xDraft/yDraft 是 {axis,raw,loraIndex} 纯原始对象，
+      // 浅拷贝即可隔离后续 sidebar 编辑；snapshot 复用上面已构造的 dispatchSnapshot。
+      setRun({
+        taskId: task.id,
+        xDraft: { ...xDraft },
+        yDraft: yDraft ? { ...yDraft } : null,
+        snapshot: dispatchSnapshot,
+      })
       toast(t('generate.taskEnqueued', { id: task.id }), 'success')
     } catch (e) {
       toast(String(e), 'error')
@@ -931,16 +965,16 @@ export default function GeneratePage() {
                   samples={samples}
                   taskId={currentTask.id}
                   selectedIndices={selectedIndices as [number, number]}
-                  xDraft={xDraft}
-                  yDraft={yDraft}
+                  xDraft={gridXDraft}
+                  yDraft={gridYDraft}
                   onBack={() => setSelectedIndices([])}
                 />
               ) : mode === 'xy' ? (
                 <PreviewXYGrid
                   samples={samples}
                   taskId={currentTask.id}
-                  xDraft={xDraft}
-                  yDraft={yDraft}
+                  xDraft={gridXDraft}
+                  yDraft={gridYDraft}
                   onCellClick={handleCellClick}
                   selectedIndices={selectedIndices}
                 />

--- a/studio/web/src/pages/tools/generate/PreviewHistoryRail.tsx
+++ b/studio/web/src/pages/tools/generate/PreviewHistoryRail.tsx
@@ -8,9 +8,24 @@
  * - 点击 → onSelect(entry) 给父组件
  * - 顶部 [刷新] 按钮 → 调 refresh() 重拉 disk-history（多 tab 同步 / 外部改
  *   studio_data 后用户主动同步）
+ *
+ * 虚拟滚动（#2）：图多了（落盘历史累积成百上千张）整列全量渲染会卡 —— 一次性
+ * 挂出所有 thumbnail 节点 + 触发全部缩略图请求。改成定高窗口化：只渲染滚动可见
+ * 区间（+overscan）的项，外层用 total×stride 的占位高度撑出正确滚动条。item 用
+ * 绝对定位放到 idx×stride，省去 flex gap 的累计误差。
  */
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { entryBadge, entryDisplayLabel, entryThumbUrl, type HistoryEntry } from './entryAdapter'
+
+// item 56px 方形 + 4px 间距 = 60px stride（与旧 gap-1 视觉一致）
+const ITEM_SIZE = 56
+const ITEM_STRIDE = 60
+// 上下各多渲染几行，滚动时不露白
+const OVERSCAN = 4
+// mount 前 / jsdom 无布局（clientHeight=0）时的视口兜底高度：先从宽渲染，
+// ResizeObserver 测到真实高度后收敛（仿 PreviewXYGrid 的 maxW 兜底）。
+const VIEWPORT_FALLBACK = 2000
 
 interface Props {
   entries: HistoryEntry[]
@@ -24,16 +39,40 @@ export default function PreviewHistoryRail({
   entries, mode, onSelect, onRefresh, loading,
 }: Props) {
   const { t } = useTranslation()
-  const list = entries.filter((e) => e.mode === mode)
+  const list = useMemo(() => entries.filter((e) => e.mode === mode), [entries, mode])
+
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const [scrollTop, setScrollTop] = useState(0)
+  const [viewportH, setViewportH] = useState(VIEWPORT_FALLBACK)
+
+  useEffect(() => {
+    const el = scrollRef.current
+    if (!el) return
+    const update = () => setViewportH(el.clientHeight || VIEWPORT_FALLBACK)
+    update()
+    // jsdom 没有 ResizeObserver；测试 env 降级为 window resize 监听
+    if (typeof ResizeObserver !== 'undefined') {
+      const ro = new ResizeObserver(update)
+      ro.observe(el)
+      return () => ro.disconnect()
+    }
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
+
+  const total = list.length
+  const start = Math.max(0, Math.floor(scrollTop / ITEM_STRIDE) - OVERSCAN)
+  const end = Math.min(total, Math.ceil((scrollTop + viewportH) / ITEM_STRIDE) + OVERSCAN)
+  const slice = list.slice(start, end)
 
   return (
     <div
       className="card flex flex-col gap-1 self-stretch"
-      style={{ width: 80, padding: 8, overflowY: 'auto' }}
+      style={{ width: 80, padding: 8 }}
     >
       {onRefresh && (
         <button
-          className="btn btn-ghost text-2xs"
+          className="btn btn-ghost text-2xs shrink-0"
           style={{ padding: '1px 4px' }}
           onClick={() => void onRefresh()}
           disabled={loading}
@@ -42,16 +81,36 @@ export default function PreviewHistoryRail({
           {loading ? t('generate.checkingShort') : t('generate.refreshHistory')}
         </button>
       )}
-      {list.length === 0 ? (
+      {total === 0 ? (
         <div className="text-fg-tertiary text-2xs text-center pt-3">{t('generate.noHistory')}</div>
       ) : (
-        list.map((entry) => (
-          <HistoryItem
-            key={entry.id}
-            entry={entry}
-            onSelect={() => onSelect(entry)}
-          />
-        ))
+        <div
+          ref={scrollRef}
+          className="flex-1 min-h-0 overflow-y-auto"
+          onScroll={(e) => setScrollTop(e.currentTarget.scrollTop)}
+        >
+          {/* 占位高度 = total×stride 撑出真实滚动条；可见项绝对定位到各自 idx */}
+          <div style={{ height: total * ITEM_STRIDE, position: 'relative' }}>
+            {slice.map((entry, i) => {
+              const idx = start + i
+              return (
+                <div
+                  key={entry.id}
+                  style={{
+                    position: 'absolute',
+                    top: idx * ITEM_STRIDE,
+                    left: 0,
+                    right: 0,
+                    display: 'flex',
+                    justifyContent: 'center',
+                  }}
+                >
+                  <HistoryItem entry={entry} onSelect={() => onSelect(entry)} />
+                </div>
+              )
+            })}
+          </div>
+        </div>
       )}
     </div>
   )
@@ -67,7 +126,7 @@ function HistoryItem({ entry, onSelect }: ItemProps) {
   return (
     <div
       className="relative rounded-sm border border-subtle hover:border-strong cursor-pointer overflow-hidden"
-      style={{ width: 56, height: 56, flexShrink: 0 }}
+      style={{ width: ITEM_SIZE, height: ITEM_SIZE, flexShrink: 0 }}
       onClick={onSelect}
       title={`${entryDisplayLabel(entry)} · ${new Date(entry.createdAt).toLocaleString()}`}
     >


### PR DESCRIPTION
测试页（Generate）两处优化，合一个 PR。

## #1 XY 结果开始生成后冻结，改轴只影响下次

**背景**：XY 模式下，活动结果网格(`PreviewXYGrid`)与完成入库的元数据都直接读 live `xDraft/yDraft`(sidebar 可编辑 prefs)。任务跑起来 / 刚跑完后在 XY LoRA picker 里取消某一档(如 ep10)，会让 `xValues` 少一项 → 网格整列错位、已生成 / 正在出的那张图消失。`save_test_images` 开着时，落盘历史 entry 的轴也会被一并污染(cache 路径已用 dispatch 时的 snapshot，不受影响)。

**改动**：dispatch 成功时把本次的 `xDraft/yDraft` + 完整参数快照定格进 `run` state；活动网格 / 双图对比 / 完成入库三处改读 `run` 而非 live draft。live draft 只留给「下次生成」和按钮张数(`xyCellCount` 本就该反映下次点击)。任务开始后改 sidebar 只影响下次出图，不串改已出结果与入库元数据。`run` 不匹配当前任务时回退 live(刷新后中途完成的边缘场景，无回归)。

## #2 历史栏虚拟滚动

**背景**：落盘历史累积成百上千张后，历史栏(`PreviewHistoryRail`)把所有 entry 拍平成一条竖列全量渲染，一次性挂出全部 thumbnail 节点并触发全部缩略图请求，进页面 / 刷新明显卡顿。

**改动**：改成定高窗口化(固定 60px stride)，按滚动位置只渲染可见区间(+overscan)的项，外层用 `total×stride` 占位高度撑出正确滚动条，可见项绝对定位到各自 idx。`ResizeObserver` 测视口高度(jsdom 无布局时走兜底 + window resize 降级)。refresh 按钮从随列表滚走改为固定顶部。

> 后端 `disk-history` 仍每次全量扫描所有日期文件夹读 PNG header，是另一处加载成本，本 PR 不动 —— 按日期分桶扫描 / 日期切换 UI 留待后续(历史栏 80px 太窄，暂不塞日期控件)。

## 测试方式

- 新增 #1 回归测试：mock `useMonitorProgress` 注入 3 cell 的 XY samples，dispatch 后把 X 轴 raw `20, 25, 30` → `20, 25`，断言 sidebar live 值已变但右侧网格仍含 `30` 表头(冻结)。
- 前端三件套全绿：`npx tsc --noEmit`、`npm run lint`、`npx vitest run`(44 文件 / 409 测试通过)。
- 纯前端改动，无 schema / API / 后端变更。

## 截图

UI 行为改动(XY 结果稳定性 + 历史栏滚动)。截图待补。