### PR TITLE
fix(web): 补 AI 先验取消、设置抽屉点侧栏收起、版本更新内容防跳

### DIFF
--- a/studio/web/src/App.tsx
+++ b/studio/web/src/App.tsx
@@ -62,9 +62,10 @@ function QueueDetailRedirect({ tab }: { tab: 'log' | 'monitor' }) {
 }
 
 /** Sidebar + Topbar 外壳；所有路由 element 渲染进 <Outlet />。
- *  SettingsDrawer 挂在主内容列内（含 Topbar），用 absolute 定位铺满该列 —— 这样
- *  backdrop 自然不会盖到左侧 Sidebar，sidebar 上的导航 / 主题切换照常可用。
- *  列父级 position:relative 给 drawer 的 absolute inset-0 做锚点。 */
+ *  SettingsDrawer 用 fixed inset-0 铺满整个 viewport（含左侧 Sidebar）—— 这样点
+ *  backdrop 的任意位置（包括 Sidebar 区域）都会收起抽屉。
+ *  列父级 position:relative 保留作 <main> 内 absolute 元素（如任务日志抽屉贴底
+ *  footer）的定位锚点。 */
 function RootLayout() {
   return (
     <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -69,7 +69,7 @@ export default function SettingsDrawer() {
   return (
     <div
       aria-hidden={!isOpen}
-      className={`absolute inset-0 z-30 ${active ? '' : 'pointer-events-none'}`}
+      className={`fixed inset-0 z-40 ${active ? '' : 'pointer-events-none'}`}
     >
       {/* backdrop：absolute 铺满 viewport，让 panel slide-in 中途不会从右边露出底页。
        *  之前用 flex + flex-1 时 backdrop 只占 panel 左边那条，panel 滑动期间右侧

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -401,6 +401,12 @@ export default function RegularizationPage() {
           lines: aiLogs,
           startedAt: aiTask.started_at,
           finishedAt: aiTask.finished_at,
+          onCancel: () => {
+            void api
+              .cancelTask(aiTask.id)
+              .then(() => toast(t('reg.cancelToast'), 'success'))
+              .catch((e) => toast(String(e), 'error'))
+          },
         },
       ]}
       actions={

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -3526,6 +3526,9 @@ function VersionSection() {
   const [version, setVersion] = useState<SystemVersion | null>(null)
   const [check, setCheck] = useState<SystemUpdateCheck | null>(null)
   const [status, setStatus] = useState<SystemUpdateStatus | null>(null)
+  // status 是否已拉过（成功 / 失败都置 true）。回滚提示行占位骨架靠它判「加载中」，
+  // 不能直接判 status===null —— 拉取失败时 status 永远 null，骨架会永久不消失。
+  const [statusLoaded, setStatusLoaded] = useState(false)
   const [prefs, setPrefs] = useState<SystemPrefsConfig | null>(null)
   const [devCheck, setDevCheck] = useState<SystemUpdateCheck | null>(null)
   // chunk 2 — 当前显示的 release notes（hasUpdate 时为 target tag，否则 current tag）
@@ -3569,7 +3572,7 @@ function VersionSection() {
         void api.checkSystemUpdate('master').then((r) => { if (!cancelled) setCheck(r) }).catch(() => { /* silent */ })
       }
     })()
-    void api.getSystemUpdateStatus().then(setStatus).catch(() => { /* silent */ })
+    void api.getSystemUpdateStatus().then(setStatus).catch(() => { /* silent */ }).finally(() => setStatusLoaded(true))
     void api.getSecrets().then((s) => setPrefs(s.system)).catch(() => { /* silent */ })
     return () => { cancelled = true }
   }, [])
@@ -3989,6 +3992,7 @@ function VersionSection() {
               version={version}
               check={check}
               status={status}
+              statusLoaded={statusLoaded}
               hasUpdate={masterHasUpdate}
               hasRollback={hasRollback}
               statusBadFailed={statusBadFailed}
@@ -4106,6 +4110,7 @@ type MasterCardProps = {
   version: SystemVersion | null
   check: SystemUpdateCheck | null
   status: SystemUpdateStatus | null
+  statusLoaded: boolean
   hasUpdate: boolean
   hasRollback: boolean
   statusBadFailed: boolean
@@ -4510,7 +4515,16 @@ function MasterCard(p: MasterCardProps) {
         </div>
       </div>
 
-      {p.hasRollback && p.status?.rollback_target && (() => {
+      {!p.statusLoaded ? (
+        // status 加载中：回滚提示行占位骨架（与真实行同高），有可回滚版本时平滑
+        // 填入而非弹入把下方内容顶开；几乎总有可回滚版本（除从未更新过的首版）
+        <div className="vs-rollback-collapse" aria-hidden="true">
+          <span className="vs-rollback-summary vs-rollback-sk">
+            <span className="vs-caret">▸</span>
+            <span className="vs-rollback-sk-bar" />
+          </span>
+        </div>
+      ) : p.hasRollback && p.status?.rollback_target ? (() => {
         // rollback 显示优先 tag（"v0.6.0"），否则 sha 前 8 位
         const sha = p.status.rollback_target
         const tag = p.status.rollback_target_tag
@@ -4537,7 +4551,7 @@ function MasterCard(p: MasterCardProps) {
             </div>
           </details>
         )
-      })()}
+      })() : null}
     </div>
   )
 }

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type RefObject } from 'react'
 import type { TFunction } from 'i18next'
 import { Trans, useTranslation } from 'react-i18next'
 import {
@@ -3847,6 +3847,15 @@ function VersionSection() {
     }
   }, [allReleaseNotes])
 
+  // 预取全量历史 release notes：进入版本 section 即后台拉一次，让「更新日志」
+  // modal 一打开就有完整版本列表，避免 ‹ › 切换按钮延迟出现把控制栏撑大。
+  useEffect(() => {
+    if (allReleaseNotes !== null) return
+    void api.getAllReleaseNotes()
+      .then((r) => setAllReleaseNotes(r.versions))
+      .catch(() => setAllReleaseNotes([]))
+  }, [allReleaseNotes])
+
   // release notes 拉对应 tag：stable 通道有更新时展示目标版本，否则展示当前
   // 已装版本；dev 通道不展示 release notes（dev 是滚动的，没有版本号语义）
   const displayedTag = showDevView
@@ -4241,35 +4250,29 @@ function ProgressPane({ fromLabel, toLabel }: { fromLabel: string; toLabel: stri
   )
 }
 
+// inline「更新内容」预览固定渲染 RN_MAX_ITEMS 条 + 1 条「详细内容」入口共
+// RN_SLOTS 个行槽位：加载中填骨架行、有数据填真实 entry、不足填空占位行。
+// 高度恒由固定行数撑出（不靠像素估算），异步拉取 / 切换显示版本时列表都不撑大。
+const RN_SLOTS = RN_MAX_ITEMS + 1
+
 function MasterReleaseNotes({
   notes, onShowDetail,
 }: { notes: ReleaseNotes | null; onShowDetail: () => void }) {
   const { t } = useTranslation()
+  const loading = notes === null
   const entries = notes?.found ? notes.entries : []
   const total = entries.length
-  if (total === 0) {
-    return (
-      <ul className="vs-change-list">
-        <li>
-          <span className="vs-glyph">▸</span>
-          <span className="vs-txt">
-            {notes && !notes.found
-              ? <Trans i18nKey="settings.releaseNoEntry" components={{ code: <code /> }} />
-              : <Trans i18nKey="settings.releaseSeeChangelog" components={{ code: <code /> }} />}
-          </span>
-        </li>
-      </ul>
-    )
-  }
   const shown = entries.slice(0, RN_MAX_ITEMS)
   const overflow = total - shown.length
   // 任意 entry 有 detail → 即使全部顶层 entries 都显示，"详细内容" 入口仍有意义
   const anyDetail = entries.some((e) => !!e.detail)
   const showDetailLink = overflow > 0 || anyDetail
-  return (
-    <ul className="vs-change-list">
-      {shown.map((e, i) => (
-        <li key={i}>
+
+  const rows: ReactNode[] = []
+  if (!loading) {
+    shown.forEach((e, i) => {
+      rows.push(
+        <li key={`e${i}`}>
           <span
             className={`vs-pill ${KIND_PILL_CLASS[e.kind] || 'vs-pill-info'}`}
             style={{ flexShrink: 0 }}
@@ -4279,9 +4282,11 @@ function MasterReleaseNotes({
           </span>
           <span className="vs-txt">{e.summary}</span>
         </li>
-      ))}
-      {showDetailLink && (
-        <li>
+      )
+    })
+    if (showDetailLink) {
+      rows.push(
+        <li key="detail">
           <span className="vs-glyph">·</span>
           <span className="vs-txt" style={{ color: 'var(--fg-tertiary)' }}>
             {overflow > 0 && t('settings.moreItems', { count: overflow })}
@@ -4295,7 +4300,40 @@ function MasterReleaseNotes({
             </button>
           </span>
         </li>
-      )}
+      )
+    } else if (total === 0) {
+      rows.push(
+        <li key="hint">
+          <span className="vs-glyph">▸</span>
+          <span className="vs-txt">
+            {notes && !notes.found
+              ? <Trans i18nKey="settings.releaseNoEntry" components={{ code: <code /> }} />
+              : <Trans i18nKey="settings.releaseSeeChangelog" components={{ code: <code /> }} />}
+          </span>
+        </li>
+      )
+    }
+  }
+  // 补足到固定行数：加载态填骨架行、否则填空占位行 —— 保证列表高度恒定（无像素估算）
+  while (rows.length < RN_SLOTS) {
+    const i = rows.length
+    rows.push(
+      loading ? (
+        <li key={`sk${i}`} className="vs-rn-sk" aria-hidden="true">
+          <span className="vs-rn-sk-pill" />
+          <span className="vs-rn-sk-bar" />
+        </li>
+      ) : (
+        <li key={`pad${i}`} className="vs-rn-empty" aria-hidden="true">
+          &nbsp;
+        </li>
+      )
+    )
+  }
+
+  return (
+    <ul className="vs-change-list" aria-busy={loading || undefined}>
+      {rows}
     </ul>
   )
 }
@@ -4842,28 +4880,28 @@ function ReleaseNotesDetailModal({
       >
         {/* 顶部控制栏：左右切换 + 关闭，放在 title 上方独立一行 */}
         <div className="flex items-center gap-1 border-b border-subtle px-3 py-2">
+          {/* ‹ › 始终渲染（单版本时 disabled）：让控制栏高度从 modal 打开就固定，
+              不因 allNotes 异步到位后切换按钮才出现而撑大 */}
+          <button
+            type="button"
+            onClick={goOlder}
+            disabled={!hasOlder}
+            className={navBtnCls}
+            aria-label={t('settings.releaseNotesOlder')}
+            title={t('settings.releaseNotesOlder')}
+          >‹</button>
+          <button
+            type="button"
+            onClick={goNewer}
+            disabled={!hasNewer}
+            className={navBtnCls}
+            aria-label={t('settings.releaseNotesNewer')}
+            title={t('settings.releaseNotesNewer')}
+          >›</button>
           {total > 1 && (
-            <>
-              <button
-                type="button"
-                onClick={goOlder}
-                disabled={!hasOlder}
-                className={navBtnCls}
-                aria-label={t('settings.releaseNotesOlder')}
-                title={t('settings.releaseNotesOlder')}
-              >‹</button>
-              <button
-                type="button"
-                onClick={goNewer}
-                disabled={!hasNewer}
-                className={navBtnCls}
-                aria-label={t('settings.releaseNotesNewer')}
-                title={t('settings.releaseNotesNewer')}
-              >›</button>
-              <span className="text-2xs text-fg-dim font-mono ml-1">
-                {t('settings.releaseNotesPosition', { index: idx + 1, total })}
-              </span>
-            </>
+            <span className="text-2xs text-fg-dim font-mono ml-1">
+              {t('settings.releaseNotesPosition', { index: idx + 1, total })}
+            </span>
           )}
           <div className="flex-1" />
           <button

--- a/studio/web/src/styles/version-section.css
+++ b/studio/web/src/styles/version-section.css
@@ -296,7 +296,7 @@
 }
 .vs-change-list .vs-rn-sk-pill,
 .vs-change-list .vs-rn-sk-bar {
-  background: var(--overlay);
+  background: var(--bg-overlay);
   animation: vs-rn-pulse 1.3s ease-in-out infinite;
 }
 .vs-change-list .vs-rn-sk-pill {
@@ -407,6 +407,22 @@
   margin-top: 0;
   padding-top: 0;
   border-top: 0;
+}
+/* status 加载中的回滚提示行占位骨架：复用 .vs-rollback-collapse 的 dashed 分隔
+   与间距、复用 .vs-rollback-summary 的字号/行高（caret 真实渲染撑出相同行框），
+   内部 bar 替代文字 —— 与真实行同高，status resolve 后平滑填入不顶下方内容。 */
+.vs-rollback-summary.vs-rollback-sk { cursor: default; }
+.vs-rollback-summary.vs-rollback-sk .vs-caret { opacity: 0.4; }
+.vs-rollback-sk-bar {
+  height: 0.8em;
+  width: 170px;
+  max-width: 60%;
+  border-radius: 4px;
+  background: var(--bg-overlay);
+  animation: vs-rn-pulse 1.3s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .vs-rollback-sk-bar { animation: none; }
 }
 
 /* ==================== inline rollback affordance（master 卡底） ==================== */

--- a/studio/web/src/styles/version-section.css
+++ b/studio/web/src/styles/version-section.css
@@ -286,6 +286,43 @@
   min-width: 0;
   word-break: break-word;
 }
+/* release notes「更新内容」固定渲染 RN_MAX_ITEMS + 1 行：加载中是骨架行、
+   数据不足时是空占位行（&nbsp; 撑高），都与真实 entry 同行高 —— 列表高度由
+   固定行数自然撑出（不靠像素估算），点检查更新异步拉取 / 切换显示版本时都不
+   撑大。 */
+.vs-change-list .vs-rn-sk {
+  align-items: center;
+  min-height: 1.55em; /* = li line-height，对齐真实 entry 单行高度 */
+}
+.vs-change-list .vs-rn-sk-pill,
+.vs-change-list .vs-rn-sk-bar {
+  background: var(--overlay);
+  animation: vs-rn-pulse 1.3s ease-in-out infinite;
+}
+.vs-change-list .vs-rn-sk-pill {
+  flex-shrink: 0;
+  width: 46px;
+  height: 15px;
+  border-radius: 999px;
+}
+.vs-change-list .vs-rn-sk-bar {
+  flex: 1;
+  height: 11px;
+  border-radius: 4px;
+}
+/* 文本骨架宽度错落，避免一刀切 */
+.vs-change-list .vs-rn-sk:nth-child(2) .vs-rn-sk-bar { max-width: 82%; }
+.vs-change-list .vs-rn-sk:nth-child(3) .vs-rn-sk-bar { max-width: 66%; }
+.vs-change-list .vs-rn-sk:nth-child(4) .vs-rn-sk-bar { max-width: 90%; }
+.vs-change-list .vs-rn-sk:nth-child(5) .vs-rn-sk-bar { max-width: 74%; }
+@media (prefers-reduced-motion: reduce) {
+  .vs-change-list .vs-rn-sk-pill,
+  .vs-change-list .vs-rn-sk-bar { animation: none; }
+}
+@keyframes vs-rn-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.45; }
+}
 
 /* ==================== 卡底操作 ==================== */
 .vs-chan-foot {


### PR DESCRIPTION
## 背景 / 动机

开发测试中发现 generate / settings 几处 UX 毛病：

1. 正则集「AI 先验生成」运行中**没有取消按钮**（booru 抓取有）。https://github.com/WalkingMeatAxolotl/AnimaLoraStudio/issues/318
2. 设置抽屉的蒙版**只盖主内容区**，点左侧 Sidebar 不会收起抽屉。
3. 版本升级「更新内容」每次读数据**高度跳动**；历史版本切换按钮**延迟出现并把控制栏撑大**。
4. 版本页加载态仍有跳动：「更新内容」骨架因配色引用未定义 token 而**透明**（看着是空白、骨架方案像没生效）；卡底「历史版本可切回」行随 `status` 异步到位后**弹入**、把下方内容顶下去。

## 改动概要

### 1. 正则 AI 先验补取消按钮（`Regularization.tsx`）
- `reg_ai` 是 task，日志抽屉的 logSource 漏配 `onCancel`，运行中无法取消；`reg_build`（job）一直有。
- 补上 `onCancel` 调 `cancelTask`，与隔壁 `reg_build` 写法对称。`TaskLogDrawer` 渲染条件是 `live && onCancel`，补上后 pending/running 即出现取消按钮。

### 2. 设置抽屉点侧栏也收起（`SettingsDrawer.tsx` / `App.tsx`）
- 抽屉外层 `absolute inset-0`（锚主内容列）→ `fixed inset-0 z-40`（锚 viewport），蒙版铺满整屏含 Sidebar，点任意处（含侧栏）都收起。
- `z-40` 盖过无 `z-index` 的 Sidebar/Topbar，又低于设置内部弹窗的 `z-50`（PathPicker / 各 Modal 仍正确浮在抽屉之上）。
- `App.tsx` 注释同步更新；主内容列 `position: relative` 保留（`<main>` 内贴底任务日志抽屉的定位锚点）。

### 3. 版本「更新内容」防跳 + 历史版本切换（`Settings.tsx` / `version-section.css`）
- **inline 更新内容**：`MasterReleaseNotes` 改成固定渲染 `RN_MAX_ITEMS + 1` 个行槽位（加载中→骨架行 / 有数据→真实 entry / 不足→空占位行）。高度由固定行数自然撑出（无像素估算），异步拉取或在「当前版本 ↔ 目标版本」间切换显示时不再跳。骨架带脉冲动画并尊重 `prefers-reduced-motion`。
- **历史版本切换 modal**（`ReleaseNotesDetailModal`）：
  - 进 version section 即**预加载**全量 release notes（`getAllReleaseNotes`），modal 一打开就有完整版本列表，‹ › 立即可用。
  - 控制栏 ‹ › 改成**常驻**（单版本/数据未到时 `disabled`），控制栏高度从打开就固定，不再因切换按钮异步出现（且 ‹ › btn 比 × 高）而撑大。

### 4. 版本页加载态防跳修复（`Settings.tsx` / `version-section.css`）
- **更新内容骨架配色**：第 3 节的加载骨架背景误用了 `var(--overlay)` —— 项目无此 token，CSS 自定义属性未定义且无 fallback → 整条 `background` 声明被丢弃、骨架条**透明**，加载窗口看着是「中间一片空白」而非骨架（骨架 `<li>` 实际已渲染、行高也占住了，只是画不出颜色）。改用项目实际 token `var(--bg-overlay)`，骨架可见、加载态的预留空间随之显现。
- **卡底「历史版本可切回」占位骨架**：该行依赖独立异步的 `status`，`status` 到位后才在卡片最底部弹入、把下方内容顶下去。新增 `statusLoaded` 标志 gate 一行**同高**占位骨架（复用 `.vs-rollback-collapse` 容器 + `.vs-rollback-summary` 行框，caret 真实渲染撑出相同行高），`status` resolve 后平滑填入不跳。用 `statusLoaded`（成功 / 失败都置 true）而非直接判 `status === null`：拉取失败时 `status` 永远为 null，否则骨架会永久驻留。仅「从未更新过的首版」无回滚目标时加载完会收起一行。

> 两处骨架统一用 `var(--bg-overlay)` + `vs-rn-pulse` 脉冲，且尊重 `prefers-reduced-motion`。修饰类 `.vs-rn-sk` 只作用于 release notes 列表，未动同样用 `.vs-change-list` 的 DevCard commit 空占位。

## 测试

- `npm run build`（`eslint src` + `tsc -b` + `vite build`）**全绿**。
- 涉及组件（Regularization / SettingsDrawer / Settings VersionSection）无既有单测；本次为 UI 行为调整，未新增测试。
- 手动验证：serve dist 需 `npm run build` + **硬刷新**（dist 哈希变），或用 `studio dev` HMR。

## 截图

UI 改动，建议本地 `studio dev` 查看：
- 设置抽屉点 Sidebar 区域即收起
- 版本「更新内容」加载 / 切换显示版本时高度恒定不跳；加载窗口可见**脉冲骨架**（数据快时一闪而过，可 DevTools 限速观察）
- release notes 详情 modal 的 ‹ › 一打开即在、不再撑大
- 卡底「历史版本可切回」加载时**同高占位**、不再弹入把下方内容顶下去

_注：按约定 dev feature PR 不动 release_notes.yaml / CHANGELOG，留给 release 时统一整理。_
