### PR TITLE
fix(vae): 缓存分块日志不刷屏 + 主动分块决策降为 debug

### DIFF
--- a/runtime/training/models.py
+++ b/runtime/training/models.py
@@ -78,6 +78,21 @@ class VAEWrapper:
         # auto 解决大显存卡整图 decode 接近占满时触发「系统内存回退」→ 单次 decode
         # 从 <1s 退化到上百秒的卡死（reactive OOM 兜底救不了，因为没抛干净 OOM）。
         self.tiling = str(tiling or "auto").lower().strip()
+        # 分块决策 / OOM 回退日志去重：latent 缓存逐 bucket 调 encode（200 张不同尺寸
+        # 的图 → 200 次调用），每次都记会刷屏。同一 wrapper 实例下每种事件只记一次。
+        self._logged_once: set[str] = set()
+
+    def _log_once(self, key: str, log_fn, msg: str, *args) -> None:
+        """同一 wrapper 实例下，相同 ``key`` 的日志只发一次（其余静默）。
+
+        缓存阶段 transformer/Qwen 已驻留 GPU（models_phase 早于 dataset_phase），
+        free 显存低 → auto 判定对几乎每张图都分块。分块本身是对的（整图 op 会把
+        占用推过 WDDM 显存换页崖），只是逐图重复记日志没有信息量，故去重。
+        """
+        if key in self._logged_once:
+            return
+        self._logged_once.add(key)
+        log_fn(msg, *args)
 
     def _est_decode_peak_bytes(self, z) -> int:
         b, _c, t, H, W = z.shape
@@ -123,7 +138,10 @@ class VAEWrapper:
             used = total - free
             est = self._est_decode_peak_bytes(z)
             if self._should_auto_tile(used, est, total):
-                logger.info(
+                # debug 级：缓存阶段模型驻留 → free 低 → 几乎张张分块属正常，
+                # 默认不显示，免得「已用 X > 总显存」被误读成显存不足。
+                self._log_once(
+                    "auto_decode", logger.debug,
                     "VAE decode 主动分块（tiling=auto）：已用 %.1fG + 预计峰值 %.1fG > 总显存 %.1fG×%.2f",
                     used / 1024 ** 3, est / 1024 ** 3, total / 1024 ** 3, self._TILE_VRAM_FRACTION,
                 )
@@ -134,9 +152,10 @@ class VAEWrapper:
             return self.model.decode(z, self.scale)
         except torch.cuda.OutOfMemoryError:
             torch.cuda.empty_cache()
-            logger.warning(
+            self._log_once(
+                "oom_decode", logger.warning,
                 "VAE 整图 decode OOM，回退到 tiled decode "
-                "(tile=%dpx, overlap=%dpx)",
+                "(tile=%dpx, overlap=%dpx)（同类后续不再重复）",
                 self._TILE_LATENT * self._UPSAMPLE,
                 (self._TILE_LATENT - self._STRIDE_LATENT) * self._UPSAMPLE,
             )
@@ -156,7 +175,10 @@ class VAEWrapper:
             used = total - free
             est = self._est_encode_peak_bytes(pixels)
             if self._should_auto_tile(used, est, total):
-                logger.info(
+                # debug 级：缓存阶段模型驻留 → free 低 → 几乎张张分块属正常，
+                # 默认不显示，免得「已用 X > 总显存」被误读成显存不足。
+                self._log_once(
+                    "auto_encode", logger.debug,
                     "VAE encode 主动分块（tiling=auto）：已用 %.1fG + 预计峰值 %.1fG > 总显存 %.1fG×%.2f",
                     used / 1024 ** 3, est / 1024 ** 3, total / 1024 ** 3, self._TILE_VRAM_FRACTION,
                 )
@@ -166,9 +188,10 @@ class VAEWrapper:
             return self.model.encode(pixels, self.scale)
         except torch.cuda.OutOfMemoryError:
             torch.cuda.empty_cache()
-            logger.warning(
+            self._log_once(
+                "oom_encode", logger.warning,
                 "VAE 整图 encode OOM，回退到 tiled encode "
-                "(tile=%dpx, overlap=%dpx)",
+                "(tile=%dpx, overlap=%dpx)（同类后续不再重复）",
                 self._TILE_LATENT * self._UPSAMPLE,
                 (self._TILE_LATENT - self._STRIDE_LATENT) * self._UPSAMPLE,
             )

--- a/tests/test_vae_tiled_decode.py
+++ b/tests/test_vae_tiled_decode.py
@@ -10,6 +10,8 @@
 """
 from __future__ import annotations
 
+import logging
+
 import pytest
 import torch
 
@@ -325,3 +327,32 @@ def test_est_encode_peak_scales_with_pixels_and_dtype() -> None:
     assert est_fp32 == pytest.approx(5500 * 1024 * 1024, rel=1e-6)
     px16 = torch.zeros(1, 3, 1, 1024, 1024, dtype=torch.bfloat16)
     assert wrapper._est_encode_peak_bytes(px16) == pytest.approx(est_fp32 / 2, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 分块决策 / OOM 回退日志去重（缓存逐图调用不刷屏）
+# ---------------------------------------------------------------------------
+
+
+def test_log_once_same_key_logs_only_first(caplog) -> None:
+    """同一 key 调多次只记一次：latent 缓存逐 bucket 调 encode 不刷屏。"""
+    wrapper = _make_wrapper(_RecordingModel())
+    logger = logging.getLogger("training.models")
+    with caplog.at_level(logging.INFO, logger="training.models"):
+        for i in range(200):
+            wrapper._log_once("auto_encode", logger.info, "主动分块 #%d", i)
+    hits = [r for r in caplog.records if "主动分块" in r.getMessage()]
+    assert len(hits) == 1
+    assert "#0" in hits[0].getMessage()  # 记的是首次那条
+
+
+def test_log_once_distinct_keys_each_logged_once(caplog) -> None:
+    """不同事件（encode/decode 决策、OOM 回退）各自独立去重，互不抑制。"""
+    wrapper = _make_wrapper(_RecordingModel())
+    logger = logging.getLogger("training.models")
+    with caplog.at_level(logging.WARNING, logger="training.models"):
+        wrapper._log_once("auto_encode", logger.warning, "encode 分块")
+        wrapper._log_once("auto_decode", logger.warning, "decode 分块")
+        wrapper._log_once("auto_encode", logger.warning, "encode 分块")  # 重复，抑制
+    msgs = [r.getMessage() for r in caplog.records]
+    assert msgs == ["encode 分块", "decode 分块"]


### PR DESCRIPTION
## 背景 / 动机

用户训练时反馈两个现象：
1. **日志刷屏** —— 200 张图的训练，log 里刷出 200 条 VAE 分块决策日志。
2. **误导** —— 显存「7/32」就触发分块，且日志写着「已用 X > 总显存」，看着像显存不足，让用户困惑。

查清根因（同一处）：`anima_train.py` 里 `phases.models.run` 早于 `phases.dataset.run` → **做 latent 缓存时 transformer/Qwen 已驻留 GPU**（吃掉大半显存）→ free 显存低 → auto 判定 `used + est_peak > total×0.5` 对几乎每张图恒为 True → 张张分块。

**分块本身是对的**：此时整图 VAE op 会把占用推过 WDDM 显存换页崖（实测 190s/张，见 #281），分块在救场。问题只在日志层面 —— 逐 bucket 调 `vae.encode()`（不同尺寸图各成一批）→ 每次都打日志 → 刷屏 + 误导。

## 改动概要

只动日志，**不动经 RTX 5090 实测标定的阈值**：

1. 新增 `VAEWrapper._log_once`：同一 wrapper 实例下，`auto_encode` / `auto_decode` / `oom_encode` / `oom_decode` 四类事件各只记一次 → 缓存逐图调用不再刷屏。
2. 主动分块决策日志 `logger.info` → `logger.debug`：缓存阶段 free 低本属正常，「已用 X > 总显存」默认不显示（免被误读成显存不足），需要排查时开 debug 仍可见。
3. OOM 实际回退保留 `logger.warning`（真发生了 OOM 值得提示），同样去重。

> 另评估过「缓存前把 transformer/Qwen offload 到 CPU、腾显存让 VAE 整图 encode」的更深优化，权衡后本 PR 不做（需 ~25G 空闲内存 + 改动较大）。

## 测试

- `tests/test_vae_tiled_decode.py` 新增 2 例覆盖 `_log_once` 去重（同 key 只记一次 / 不同 key 各自独立）。
- 本地跑相关测试 + 横切安全网：`pytest tests/test_vae_tiled_decode.py tests/test_route_snapshot.py tests/test_studio_configs.py` → **54 passed**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)