### PR TITLE
fix(training): fp16 dtype mapping and GradScaler for V100

### DIFF
--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -33,6 +33,10 @@ class TrainingContext:
     config_dir: Optional[Path] = None
     device: str = "cpu"
     dtype: torch.dtype = torch.float32
+    # VAE 工作精度，独立于训练 dtype。fp16 训练时 VAE 仍走 fp32：V100/Turing 等需要
+    # fp16 的卡没有 bf16，而 fp16 VAE encode/decode 易溢出成 NaN（黑图 / latent 全 NaN
+    # → 训练步全跳）。bootstrap 据 dtype 推导；对齐 ComfyUI vae_dtype() 与出图侧 vae_precision。
+    vae_dtype: torch.dtype = torch.float32
     output_dir: Optional[Path] = None
     sample_dir: Optional[Path] = None
     wandb_monitor: Any = None         # observability.WandBMonitor
@@ -98,6 +102,7 @@ class TrainingContext:
     # → supervisor 标 canceled 而非 paused（无可恢复进度）。
     last_auto_epoch_state_path: Optional[Path] = None
     last_auto_epoch_config_path: Optional[Path] = None
+    scaler: Any = None  # torch.cuda.amp.GradScaler，仅 fp16 时非 None
 
     # ─── 共用方法 ───
 

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -359,9 +359,14 @@ def run(ctx: TrainingContext) -> None:
             # 且 epoch 末批不满也 step —— 修尾批丢弃 + 跨 epoch 梯度泄漏（见 _accumulation_step）。
             group_size, is_group_end = _accumulation_step(batch_idx, dl_len, args.grad_accum)
             loss = loss / group_size
-            loss.backward()
+            if ctx.scaler is not None:
+                ctx.scaler.scale(loss).backward()
+            else:
+                loss.backward()
 
             if is_group_end:
+                if ctx.scaler is not None:
+                    ctx.scaler.unscale_(ctx.optimizer)
                 # NaN 梯度检测：跳过本次 update，清零继续
                 has_nan_grad = any(
                     p.grad is not None and not torch.isfinite(p.grad).all()
@@ -370,11 +375,17 @@ def run(ctx: TrainingContext) -> None:
                 if has_nan_grad:
                     logger.warning(f"step {ctx.global_step}: 梯度含 NaN/Inf，跳过 optimizer.step()")
                     ctx.optimizer.zero_grad()
+                    if ctx.scaler is not None:
+                        ctx.scaler.update()
                     continue
 
                 if ctx.grad_clip > 0:
                     torch.nn.utils.clip_grad_norm_(ctx.trainable_params, max_norm=ctx.grad_clip)
-                ctx.optimizer.step()
+                if ctx.scaler is not None:
+                    ctx.scaler.step(ctx.optimizer)
+                    ctx.scaler.update()
+                else:
+                    ctx.optimizer.step()
                 if ctx.scheduler is not None and ctx.optimizer_type != "prodigy_plus_schedulefree":
                     ctx.scheduler.step()
                 ctx.optimizer.zero_grad()
@@ -532,6 +543,7 @@ def run(ctx: TrainingContext) -> None:
                             ctx.loss_history, monitor_state=monitor_data, scheduler=ctx.scheduler,
                             timestep_sampler=ctx.timestep_sampler,
                             sra_aligner=ctx.sra_aligner,
+                            scaler=ctx.scaler,
                         )
                         # 同时保存 LoRA 权重
                         lora_path = ctx.output_dir / f"{args.output_name}_step{ctx.global_step}.safetensors"
@@ -597,6 +609,7 @@ def run(ctx: TrainingContext) -> None:
                         ctx.loss_history, monitor_state=monitor_data, scheduler=ctx.scheduler,
                         timestep_sampler=ctx.timestep_sampler,
                         sra_aligner=ctx.sra_aligner,
+                        scaler=ctx.scaler,
                     )
                     lora_path = ctx.output_dir / f"{args.output_name}_epoch{ctx.current_epoch}.safetensors"
                     if not lora_path.exists():
@@ -628,6 +641,7 @@ def run(ctx: TrainingContext) -> None:
                     monitor_state=monitor_data, scheduler=ctx.scheduler,
                     timestep_sampler=ctx.timestep_sampler,
                     sra_aligner=ctx.sra_aligner,
+                    scaler=ctx.scaler,
                 )
             ctx.wandb_monitor.upload_state_auto(auto_state_path)
             # 更新 ctx 字段供 handle_interrupt emit pause_state 用

--- a/runtime/training/models.py
+++ b/runtime/training/models.py
@@ -71,6 +71,9 @@ class VAEWrapper:
         self.mean = mean
         self.std = std
         self.scale = [mean, 1.0 / std]
+        # VAE 权重精度（mean/std 与 model 同 dtype）。encode/decode 入口按此 cast 输入，
+        # 这样 fp16 训练 + fp32 VAE 时调用方传 fp16 latent / pixel 也不会 dtype mismatch。
+        self.dtype = mean.dtype
         # 分块模式：
         #   auto（默认）= 按 free VRAM 估算，整图峰值逼近可用显存时主动分块；
         #   on          = 始终分块（省显存，慢约 30%）；
@@ -130,6 +133,7 @@ class VAEWrapper:
         z: ``[b, 16, t, H, W]`` latent
         return: ``[b, 3, t, H*8, W*8]``（与底层 `WanVAE_.decode` 一致，未 clamp）
         """
+        z = z.to(self.dtype)  # 对齐 VAE 权重精度（fp16 训练 / fp32 VAE；dtype 一致时为 no-op）
         if self.tiling == "on":
             return self._tiled_decode(z)
 
@@ -167,6 +171,7 @@ class VAEWrapper:
         pixels: ``[b, 3, t, H, W]``（H/W 为像素分辨率，须为 8 的倍数）
         return: ``[b, 16, t, H/8, W/8]`` latent（与 `WanVAE_.encode` 一致）
         """
+        pixels = pixels.to(self.dtype)  # 对齐 VAE 权重精度（同 decode；dtype 一致时为 no-op）
         if self.tiling == "on":
             return self._tiled_encode(pixels)
 

--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -176,7 +176,16 @@ def run(ctx: TrainingContext) -> None:
     _resolve_sample_seed(args)
 
     ctx.device = "cuda" if torch.cuda.is_available() else "cpu"
-    ctx.dtype = torch.bfloat16 if args.mixed_precision == "bf16" else torch.float32
+    if args.mixed_precision == "bf16":
+        ctx.dtype = torch.bfloat16
+    elif args.mixed_precision == "fp16":
+        ctx.dtype = torch.float16
+        ctx.scaler = torch.cuda.amp.GradScaler()
+    else:
+        ctx.dtype = torch.float32
+    # VAE 精度与训练精度解耦：fp16 路径下 VAE 仍用 fp32（见 TrainingContext.vae_dtype）；
+    # bf16/fp32 时 VAE 跟随主精度不变。
+    ctx.vae_dtype = torch.float32 if ctx.dtype == torch.float16 else ctx.dtype
 
     # 创建输出目录
     ctx.output_dir = Path(args.output_dir)

--- a/runtime/training/phases/dataset.py
+++ b/runtime/training/phases/dataset.py
@@ -105,12 +105,12 @@ def run(ctx: TrainingContext) -> None:
         if cache_batch_size <= 0:
             cache_batch_size = int(getattr(args, "batch_size", 1) or 1)
         ctx.dataset = CachedLatentDataset(
-            ctx.dataset, ctx.vae, ctx.device, ctx.dtype,
+            ctx.dataset, ctx.vae, ctx.device, ctx.vae_dtype,
             cache_batch_size=cache_batch_size,
         )
     if ctx.reg_dataset is not None and ctx.use_cached:
         ctx.reg_dataset = CachedLatentDataset(
-            ctx.reg_dataset, ctx.vae, ctx.device, ctx.dtype,
+            ctx.reg_dataset, ctx.vae, ctx.device, ctx.vae_dtype,
             cache_batch_size=cache_batch_size,
         )
 

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -75,7 +75,7 @@ def run(ctx: TrainingContext) -> None:
         logger.info("attention_backend=none，flash_attn / xformers 都不启用，走 PyTorch SDPA")
 
     logger.info("加载 VAE...")
-    ctx.vae = load_vae(args.vae_path, ctx.device, ctx.dtype, ctx.repo_root,
+    ctx.vae = load_vae(args.vae_path, ctx.device, ctx.vae_dtype, ctx.repo_root,
                        tiling=getattr(args, "vae_tiling", "auto"))
 
     logger.info("加载文本编码器...")

--- a/runtime/training/phases/resume.py
+++ b/runtime/training/phases/resume.py
@@ -64,6 +64,7 @@ def run(ctx: TrainingContext) -> None:
             args.resume_state, ctx.injector, ctx.optimizer, ctx.scheduler,
             timestep_sampler=ctx.timestep_sampler,
             sra_aligner=ctx.sra_aligner,
+            scaler=ctx.scaler,
         )
         ctx.emit(f"从断点恢复训练: epoch={ctx.start_epoch}, step={ctx.global_step}")
 

--- a/runtime/training/state.py
+++ b/runtime/training/state.py
@@ -25,6 +25,7 @@ def save_training_state(
     path, injector, optimizer, epoch, global_step,
     loss_history=None, rng_state=None, monitor_state=None,
     scheduler=None, timestep_sampler=None, sra_aligner=None,
+    scaler=None,
 ):
     """保存完整训练状态，支持断点续训。
 
@@ -61,6 +62,10 @@ def save_training_state(
             sampler_state = None
         if sampler_state:  # 空 dict（baseline）不存
             state["timestep_sampler_state"] = sampler_state
+    if scaler is not None:
+        # fp16 GradScaler 的 scale 因子 / growth tracker。resume 不带 → 重置成默认 2^16，
+        # 头几步重新溢出空跳直到收敛。bf16/fp32 时 ctx.scaler 为 None，跳过不存。
+        state["scaler_state"] = scaler.state_dict()
     # ADR 0006 Addendum 2：tmp + os.replace 原子落盘。auto_epoch_state.pt 是
     # 覆盖式单文件恢复点，直接 torch.save 在断电 / 强杀砸中写盘窗口时会把
     # 唯一恢复点写成半截；先写 sibling tmp 再 rename，旧文件要么完整保留
@@ -75,7 +80,7 @@ def save_training_state(
     logger.info(f"训练状态已保存: {path} (epoch={epoch}, step={global_step})")
 
 
-def load_training_state(path, injector, optimizer, scheduler=None, timestep_sampler=None, sra_aligner=None):
+def load_training_state(path, injector, optimizer, scheduler=None, timestep_sampler=None, sra_aligner=None, scaler=None):
     """加载训练状态，返回 (epoch, global_step, loss_history, monitor_state)。
 
     timestep_sampler（ADR 0006 Addendum 1）：如 ckpt 含 timestep_sampler_state 且 sampler
@@ -117,6 +122,14 @@ def load_training_state(path, injector, optimizer, scheduler=None, timestep_samp
             scheduler.load_state_dict(state["scheduler_state_dict"])
         except Exception as e:
             logger.warning(f"调度器状态恢复失败（将从头开始）: {e}")
+
+    # 恢复 GradScaler（fp16）。老 ckpt / bf16·fp32 run 无此 key → 保持默认 scale 冷启动。
+    if scaler is not None and "scaler_state" in state:
+        try:
+            scaler.load_state_dict(state["scaler_state"])
+            logger.info("GradScaler 状态已恢复")
+        except Exception as e:
+            logger.warning(f"GradScaler 状态恢复失败（按默认 scale 冷启动）: {e}")
 
     # 恢复随机数状态
     if "rng_state" in state:


### PR DESCRIPTION
## 背景

PR #316（V100 fp16 dtype 映射 + GradScaler 修复）当时被误合进了 **master**，没进 dev。`git cherry origin/dev origin/master` 确认 dev 缺这个修复。按 CONTRIBUTING Hotfix §5，dev 缺修复 → 下次 dev→master 发版会出现「这个 bug 又回来了」。本 PR 把 #316 回流到 dev。

## 改动

cherry-pick master 上的 `1f1342c4`（保留原作者），内容与 #316 一致、无额外改动：

- `runtime/training/` 8 个文件，fp16 路径的 dtype 映射 + GradScaler 持久化（V100 等 fp16 卡）

master 上的 `1f1342c4` 保留不动（v0.15.0 + 1 commit，下次发版自然吸收）；本 PR 只把改动补进 dev。

## 测试

- cherry-pick 到当前 dev 无冲突
- 训练 / resume / optimizer / lycoris / bootstrap / snapshot + 横切安全网（route_snapshot / studio_configs）：**506 passed**

Ref #316

🤖 Generated with [Claude Code](https://claude.com/claude-code)
