### PR TITLE
feat(settings): 全局设置页统一 instant-apply 保存语义（替代页面级 dirty/save 条）

### DIFF
--- a/docs/todo/settings-instant-apply.md
+++ b/docs/todo/settings-instant-apply.md
@@ -1,0 +1,104 @@
+# 设置页统一为 instant-apply（即时生效）
+
+**状态**：设计定稿，待实现（2026-06-27）
+**分支**：`feat/settings-instant-apply`（从 `refactor/settings-split` 切出）
+**前置**：`refactor/settings-split`（Settings.tsx 5206→1044 行拆分，已 commit `11e4cb4a`）
+
+---
+
+## 1. 背景与动机
+
+全局设置页约 130 个可改控件，目前混用 6 种提交/持久化模式（逐控件审计已做）：
+
+| 模式 | 含义 | 进全局 dirty |
+|---|---|:---:|
+| M1 | 文本框本地缓冲，**失焦/Enter** 才写 draft | ✅ |
+| M2 | onChange **即时**写 draft（含逐字文本框） | ✅ |
+| M3 | onChange **即时 PUT，绕过 draft**（下载源等） | ❌ |
+| M4 | 专用端点 PUT/POST/DELETE（custom 模型、字典） | ❌ |
+| M5 | localStorage 即时（主题/语言/密度） | ❌ |
+| M6 | runtime 动作（下载/安装/迁移/重启） | ❌ |
+
+**痛点**：① 文本框 M1（失焦）vs M2（逐字）不统一，外观无区分；② 下载源等 M3 永不进 dirty，与同卡片其他字段语义割裂；③ training/system tab 的配置几乎全走即时 PUT，而隔壁外观相同的开关却走 draft；④ M1 失焦提交有「打字没失焦就切 tab → 静默丢失」隐患；⑤「撤销更改」对已即时落盘的 M3/M4 无效。
+
+## 2. 调研结论（deep-research，24/25 条经 3 票对抗验证）
+
+业界共识一句话：**保存语义按「控件类型」决定，不按「页面」决定；操作系统级设置的默认是即时生效。**
+
+一手出处：
+- Apple HIG [Settings](https://developer.apple.com/design/human-interface-guidelines/settings)：整页无 Save/Apply/Cancel、无「未保存改动」概念。
+- GNOME HIG：强制 instant-apply 为 preference 窗口默认；当前版明确「文本设置在 **Return 或失焦时**提交，**绝不逐字**」。仅两种情况允许显式 Apply：操作 >1 秒，或须原子同时生效防不稳定状态。
+- Microsoft Fluent 2：「理想体验里改动自动保存」，显式 Save 仅 autosave 不可能时的 fallback。Material 3：「开关效果应立即开始，无需保存」。
+- NN/g：不反对即时生效，但**强制要求**配套 ① 清晰的「已保存」反馈 ② 风险改动给撤销/取消路径。
+- GitHub Primer 是唯一异见（表单默认显式保存），代表 web 表单 / 网络保存世界观——不适用本地单机工具。
+
+**决策**：本地单机 + 配置即文件（`secrets.json` 原子写、无网络往返、无多端冲突），显式保存的核心理由都不成立，且页面长得就像 OS 设置 → **统一走 instant-apply**。
+
+## 3. 目标心智模型：3 类控件（6 模式收敛）
+
+| 类 | 控件 | 提交时机 | 收敛自 |
+|---|---|---|---|
+| **A 即时** | 开关/Bool/select/radio/分段/下载源 | onChange 立即 commit | M2 + M3 + M5(secrets 部分) |
+| **B 失焦** | 所有文本/数字框（密钥/阈值/路径/URL/model_id） | 本地缓冲，**onBlur/Enter** commit + 校验，**绝不逐字** | M1 泛化 + 逐字 M2 纠正 |
+| **C 按钮** | runtime 动作 + 专用端点 | 显式点击（破坏性的先 confirm） | M6 + M4 |
+
+要纠正成 B 类（当前是逐字 M2）的：HF 自定义 URL、Eval/CLTagger 的 model_id 输入、testing 的 idle_timeout/preview number 框、**LLMTaggerWorkspace 全部输入**（含 slider/number/textarea）。
+
+## 4. 机制
+
+### 4.1 `commitField` 统一入口
+关键洞察：现有的 `setDownloadSource`（SettingsData.tsx，M3）**就是 instant-apply 的原型**——乐观更新 + PUT 单字段。把它泛化成 `commitField(section, key, value)`，放在 `SettingsData` Provider：
+1. 乐观更新 `secrets` state（`setSecrets`）
+2. PUT 只带改动的那个 leaf（复用 `buildPatch` 的单字段 diff 能力）
+3. 成功 → 更新「已保存」状态；失败 → 回滚乐观更新 + 错误反馈
+- **删除**全局 `draft` / `dirty` / `save` / `revert` / 底部保存条 / dirty badge（PR2 废弃，方向反了）。
+- 控件直接读 `secrets`（不再有 draft），写走 `commitField`。
+
+### 4.2 文本框（B 类）
+- `SettingsInput` / `SensitiveInput` 保留内部本地 useState 缓冲，onBlur/Enter → `commitField`（仅提交目标从 draft 改成 commitField）。
+- `TagListInput` 改失焦提交（去掉逐字 onChange）。
+- 切 tab / 关抽屉前 flush 未提交的 input（消除「失焦丢编辑」隐患）。
+
+### 4.3 状态反馈（NN/g 要求）
+PageHeader 角落一个低调全局指示：`idle`（无）/ `保存中…` / `已保存 HH:MM` / `保存失败（点重试）`。不按控件逐个标，符合 autosave 惯例。
+
+### 4.4 破坏性操作 → 事前 confirm 弹窗（NN/g 撤销路径）
+| 操作 | 在哪 | confirm |
+|---|---|:---:|
+| 删除自定义 LLM preset | LLM workspace | ✅ |
+| 重置 builtin preset 到默认 | LLM workspace | ✅ |
+| 恢复 tag 词典默认（覆盖用户字典） | 打标·字典 | ✅ |
+| 移除 custom 本地模型（移除注册，文件不删） | 训练·模型 | ✅ |
+| 上传 tag 词典（覆盖当前） | 打标·字典 | ❌ 选文件已显式，meta 提示覆盖 |
+| 切下载源 / 主模型 / 更新通道 / 候选增删 | 多处 | ❌ 改回即可 |
+| runtime 重装 / 更新 / 回滚 / 迁移 / 重启 | tagging/training/system | 已有 confirm/preview |
+
+### 4.5 不变项
+- M4 专用端点（custom 模型增删、`selectUpscaler`、字典上传/重置）：保留——它们不是 `secrets` leaf，本就该走独立端点，instant-apply 下天然一致。
+- M5 localStorage（主题/语言/密度）：保留即时。
+- M6 runtime 动作：保留按钮形态，视觉上与设置控件区分。
+
+## 5. 失败与并发处理
+- **PUT 失败**：回滚乐观更新到改前值 + 状态指示「保存失败」+ toast 后端原因。
+- **并发 PUT**：不同字段并发互不冲突（后端 deep-merge）；同字段快速改用 last-write-wins 或串行队列（实现时定，见 open questions）。
+- **校验**：数字 clamp 沿用现有；URL/格式等基本校验在提交前，复杂校验依赖后端拒绝 + 回滚。
+
+## 6. 实施分阶段（同一分支多 commit，最终一个 PR squash 到 dev）
+
+> 统一保存语义是一个内聚 unit，不拆多 PR——否则中间态会出现「一半 instant 一半 draft」更乱。
+
+1. **commit①**：本设计文档。
+2. **commit②**：`commitField` 机制 + 全局状态指示 + `fields.tsx` 控件层（B 类失焦化、A 类即时）+ dataset/credentials 试点切换。
+3. **commit③**：铺开 monitor / tagging / training / testing / preprocess（A/B 收敛 + 4 项破坏性 confirm）。
+4. **commit④**：LLMTaggerWorkspace 全部文本框失焦化。
+5. **commit⑤**：删除遗留 draft/dirty/save 死代码 + 更新 `Settings.test.tsx`（原测试基于「改值→点保存」，要改成「改值→即时 PUT」断言）。
+
+## 7. Open questions
+- 全局状态指示的确切位置（PageHeader 现有 topRight/actions 区？）与文案。
+- 同字段快速连改的 PUT 竞态策略：串行队列 vs last-write-wins vs 短 debounce。
+- 失焦提交的 flush 时机（切 tab / 关抽屉 / 组件卸载）如何稳妥触发，避免 React 卸载时 onBlur 不触发。
+- 前端前置校验的范围（哪些值得前端拦，哪些交后端）。
+
+## 参考
+- 逐控件审计（9 agent，session scratchpad）：`settings-input-audit.md`
+- 调研报告：deep-research task `wft7gpq4k`（一手出处见 §2）

--- a/studio/web/src/components/LLMMessagesEditor.tsx
+++ b/studio/web/src/components/LLMMessagesEditor.tsx
@@ -15,7 +15,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { useRef } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { LLMMessage } from '../api/client'
 
@@ -145,6 +145,12 @@ function SortableMessage({
   t: ReturnType<typeof useTranslation>['t']
 }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id })
+  // 本地缓冲：逐字只更新本地，失焦(onBlur)才把 content 上抛父（instant-apply 下避免逐字 PUT）。
+  // 外部 message.content（落盘后回流）变化时同步本地。role 切换仍即时，不走缓冲。
+  const [draft, setDraft] = useState(message.content)
+  useEffect(() => {
+    setDraft(message.content)
+  }, [message.content])
   const style: React.CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -267,8 +273,9 @@ function SortableMessage({
         </div>
       ) : (
         <textarea
-          value={message.content}
-          onChange={(e) => onChange({ content: e.target.value })}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={() => { if (draft !== message.content) onChange({ content: draft }) }}
           disabled={disabled}
           rows={3}
           className="w-full bg-transparent border-0 outline-none text-sm text-fg-primary block"

--- a/studio/web/src/components/LLMTaggerWorkspace.tsx
+++ b/studio/web/src/components/LLMTaggerWorkspace.tsx
@@ -11,7 +11,7 @@
  */
 import type { TFunction } from 'i18next'
 import { Trans, useTranslation } from 'react-i18next'
-import { useMemo } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import type { LLMPreset } from '../api/client'
 import LLMMessagesEditor from './LLMMessagesEditor'
 
@@ -317,10 +317,10 @@ function ConnectionSection({
             />
           )}
         >
-          <input
+          <BufferedInput
             type="text"
             value={preset.base_url}
-            onChange={(e) => onUpdate('base_url', e.target.value)}
+            onCommit={(v) => onUpdate('base_url', v)}
             placeholder="https://api.openai.com/v1"
             style={inputStyle}
             onFocus={(e) => e.currentTarget.style.boxShadow = '0 0 0 3px var(--accent-soft)'}
@@ -360,10 +360,10 @@ function ConnectionSection({
                 ))}
               </select>
             ) : (
-              <input
+              <BufferedInput
                 type="text"
                 value={preset.model}
-                onChange={(e) => onUpdate('model', e.target.value)}
+                onCommit={(v) => onUpdate('model', v)}
                 placeholder={t('llmWorkspace.modelPlaceholder')}
                 style={{ ...inputStyle, paddingRight: 130 }}
               />
@@ -469,49 +469,49 @@ function SamplingSection({ preset, onUpdate, bottomBorder }: {
         </Field>
         <Row2>
           <Field label="Timeout" optional="s">
-            <input
+            <BufferedInput
               type="number" min={5} max={600}
               value={preset.timeout}
-              onChange={(e) => onUpdate('timeout', Math.max(5, Number(e.target.value) || 5))}
+              onCommit={(v) => onUpdate('timeout', Math.max(5, Number(v) || 5))}
               style={inputStyle}
             />
           </Field>
           <Field label="Max retries">
-            <input
+            <BufferedInput
               type="number" min={1} max={10}
               value={preset.max_retries}
-              onChange={(e) => onUpdate('max_retries', Math.max(1, Number(e.target.value) || 1))}
+              onCommit={(v) => onUpdate('max_retries', Math.max(1, Number(v) || 1))}
               style={inputStyle}
             />
           </Field>
         </Row2>
         <Row2>
           <Field label="Concurrency" optional="requests">
-            <input
+            <BufferedInput
               type="number" min={1} max={8}
               value={preset.concurrency}
-              onChange={(e) => onUpdate('concurrency',
-                Math.max(1, Math.min(8, Number(e.target.value) || 1)))}
+              onCommit={(v) => onUpdate('concurrency',
+                Math.max(1, Math.min(8, Number(v) || 1)))}
               style={inputStyle}
             />
           </Field>
           <Field label="Max/min" optional="0 = no limit">
-            <input
+            <BufferedInput
               type="number" min={0} max={3600}
               value={preset.max_requests_per_minute}
-              onChange={(e) => onUpdate('max_requests_per_minute',
-                Math.max(0, Math.min(3600, Math.round(Number(e.target.value) || 0))))}
+              onCommit={(v) => onUpdate('max_requests_per_minute',
+                Math.max(0, Math.min(3600, Math.round(Number(v) || 0))))}
               style={inputStyle}
             />
           </Field>
         </Row2>
         <Row2>
           <Field label="Requests/sec" optional="0 = no limit">
-            <input
+            <BufferedInput
               type="number" min={0} max={60} step={0.1}
               value={preset.requests_per_second}
-              onChange={(e) => onUpdate('requests_per_second',
-                Math.max(0, Math.min(60, Number(e.target.value) || 0)))}
+              onCommit={(v) => onUpdate('requests_per_second',
+                Math.max(0, Math.min(60, Number(v) || 0)))}
               style={inputStyle}
             />
           </Field>
@@ -538,20 +538,20 @@ function ImageSection({ preset, onUpdate, bottomBorder }: {
         </Field>
         <Row2>
           <Field label="JPEG quality">
-            <input
+            <BufferedInput
               type="number" min={1} max={100}
               value={preset.jpeg_quality}
-              onChange={(e) => onUpdate('jpeg_quality',
-                Math.max(1, Math.min(100, Number(e.target.value) || 85)))}
+              onCommit={(v) => onUpdate('jpeg_quality',
+                Math.max(1, Math.min(100, Number(v) || 85)))}
               style={inputStyle}
             />
           </Field>
           <Field label="Max size" optional="MB">
-            <input
+            <BufferedInput
               type="number" min={0.1} max={25} step={0.1}
               value={preset.max_image_mb}
-              onChange={(e) => onUpdate('max_image_mb',
-                Math.max(0.1, Number(e.target.value) || 5))}
+              onCommit={(v) => onUpdate('max_image_mb',
+                Math.max(0.1, Number(v) || 5))}
               style={inputStyle}
             />
           </Field>
@@ -944,20 +944,34 @@ function SliderRow({ value, min, max, step, onChange, integer }: {
   integer?: boolean
 }) {
   const clamp = (v: number) => Math.max(min, Math.min(max, v))
+  // 本地缓冲：range 拖动 / number 输入只更新本地显示，松手或失焦才上抛 onChange。
+  // 外部 value（落盘后回流）变化时同步本地。range 与 number 共享同一 local。
+  const [local, setLocal] = useState(value)
+  useEffect(() => {
+    setLocal(value)
+  }, [value])
+  const commit = (raw: number) => {
+    const c = clamp(raw)
+    if (c !== value) onChange(c)
+  }
   return (
     <div className="grid items-center" style={{ gridTemplateColumns: '1fr 64px', gap: 10 }}>
       <input
         type="range"
         min={min} max={max} step={step ?? 1}
-        value={value}
-        onChange={(e) => onChange(clamp(Number(e.target.value)))}
+        value={local}
+        onChange={(e) => setLocal(clamp(Number(e.target.value)))}
+        onPointerUp={(e) => commit(Number(e.currentTarget.value))}
+        onKeyUp={(e) => commit(Number(e.currentTarget.value))}
         style={{ width: '100%', accentColor: 'var(--accent)' }}
       />
       <input
         type="number"
         min={min} max={max} step={step ?? 1}
-        value={integer ? Math.round(value) : value}
-        onChange={(e) => onChange(clamp(Number(e.target.value)))}
+        value={integer ? Math.round(local) : local}
+        onChange={(e) => setLocal(Number(e.target.value))}
+        onBlur={(e) => commit(Number(e.currentTarget.value))}
+        onKeyDown={(e) => { if (e.key === 'Enter') e.currentTarget.blur() }}
         style={{
           background: 'var(--bg-sunken)',
           border: '1px solid var(--border-subtle)',
@@ -981,18 +995,64 @@ function SensitiveInput({ value, serverValue, onChange }: {
   onChange: (v: string) => void
 }) {
   const { t } = useTranslation()
-  const masked = value === MASK
+  // 本地缓冲 + 失焦提交：逐字只更新本地，blur/Enter 才上抛（instant-apply 下避免逐字 PUT）。
+  const [localValue, setLocalValue] = useState(value)
+  useEffect(() => {
+    setLocalValue(value)
+  }, [value])
+  const masked = localValue === MASK
+  const handleBlur = () => {
+    if (localValue !== value) onChange(localValue)
+  }
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') e.currentTarget.blur()
+  }
   return (
     <input
       type="password"
-      value={masked ? '' : value}
+      value={masked ? '' : localValue}
       placeholder={serverValue === MASK ? t('llmWorkspace.secretSavedPlaceholder') : ''}
-      onChange={(e) => onChange(e.target.value || MASK)}
+      onChange={(e) => setLocalValue(e.target.value || MASK)}
+      onBlur={handleBlur}
+      onKeyDown={handleKeyDown}
       autoComplete="new-password"
       data-lpignore="true"
       data-1p-ignore
       data-form-type="other"
       style={inputStyle}
+    />
+  )
+}
+
+// 文本 / 数字通用的本地缓冲输入：逐字只更新本地 state，失焦(onBlur)或 Enter 才把
+// 原始字符串交给 onCommit（调用方在 onCommit 内套用原有的 Number()/clamp/取整逻辑）。
+// instant-apply 重构下用来把"每个字符上抛父"压成"失焦提交一次"。
+type BufferedInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'value' | 'onChange'
+> & {
+  value: string | number
+  onCommit: (raw: string) => void
+}
+
+function BufferedInput({ value, onCommit, onBlur, onKeyDown, ...rest }: BufferedInputProps) {
+  const [local, setLocal] = useState(String(value))
+  useEffect(() => {
+    setLocal(String(value))
+  }, [value])
+  return (
+    <input
+      {...rest}
+      value={local}
+      onChange={(e) => setLocal(e.target.value)}
+      onBlur={(e) => {
+        if (local !== String(value)) onCommit(local)
+        onBlur?.(e)
+      }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') e.currentTarget.blur()
+        onKeyDown?.(e)
+      }}
     />
   )
 }

--- a/studio/web/src/components/TagsInput.tsx
+++ b/studio/web/src/components/TagsInput.tsx
@@ -19,12 +19,15 @@ export function parseTags(s: string): string[] {
  * blur 时文本归整成 `tags.join(', ')`，再进编辑态看到的是规范形式。
  * 给自带外层 label 的场景（Settings 的 SettingsField）直接用这个；要 140px
  * grid label 的用下面的 {@link TagsInput}。 */
-export function TagListInput({ value, onChange, placeholder, disabled, className = '' }: {
+export function TagListInput({ value, onChange, placeholder, disabled, className = '', commitOnBlur = false }: {
   value: string[]
   onChange: (v: string[]) => void
   placeholder?: string
   disabled?: boolean
   className?: string
+  /** true：编辑过程只更新本地文本，blur 时才上抛父一次（instant-apply 设置页用，
+   *  避免逐字 commit → 逐字 PUT）。默认 false 保持逐字上抛（打标页等本地编辑场景）。 */
+  commitOnBlur?: boolean
 }) {
   const [text, setText] = useState(value.join(', '))
   const [editing, setEditing] = useState(false)
@@ -41,7 +44,7 @@ export function TagListInput({ value, onChange, placeholder, disabled, className
       const cleanAfter = after.replace(/^[,，]\s*/, '')
       const next = `${before}${suggestion.tag}, ${cleanAfter}`
       setText(next)
-      onChange(parseTags(next))
+      if (!commitOnBlur) onChange(parseTags(next))
       // cursor 移动到新插入 tag 后的 ", " 之后
       const newCursor = before.length + suggestion.tag.length + 2
       // 等 React 刷完再 setSelectionRange，否则受控更新会把 cursor 拉到末尾
@@ -55,9 +58,10 @@ export function TagListInput({ value, onChange, placeholder, disabled, className
   // 外部改 value（restore 默认 / 切表单）且与当前文本解析结果不一致 → 重新同步
   // 文本。自己打字触发的 value 变化进不来（那时 parseTags(text) 恒等 value）。
   useEffect(() => {
+    if (editing) return  // 编辑中不被外部 value 冲掉本地文本（commitOnBlur 下尤其必要）
     if (JSON.stringify(parseTags(text)) !== JSON.stringify(value)) setText(value.join(', '))
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [value])
+  }, [value, editing])
 
   // 进入编辑态 → 把光标放进 input。
   useEffect(() => {
@@ -74,7 +78,7 @@ export function TagListInput({ value, onChange, placeholder, disabled, className
           placeholder={placeholder}
           onChange={(e) => {
             setText(e.target.value)
-            onChange(parseTags(e.target.value))
+            if (!commitOnBlur) onChange(parseTags(e.target.value))
             suggest.notifyChange()
           }}
           onKeyDown={(e) => { suggest.handleKeyDown(e) }}
@@ -84,8 +88,9 @@ export function TagListInput({ value, onChange, placeholder, disabled, className
           onBlur={() => {
             suggest.notifyBlur()
             // blur 归整：下划线→空格（跟训练 caption 同形，后端匹配也已 _/空格不敏感），
-            // chip 统一展示空格形式
-            const canon = value.map((t) => t.replace(/_/g, ' '))
+            // chip 统一展示空格形式。commitOnBlur 模式此时才把完整 tags 上抛父一次。
+            const source = commitOnBlur ? parseTags(text) : value
+            const canon = source.map((t) => t.replace(/_/g, ' '))
             if (JSON.stringify(canon) !== JSON.stringify(value)) onChange(canon)
             setText(canon.join(', '))
             setEditing(false)

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -913,6 +913,11 @@
     "languageEn": "English",
     "title": "Settings",
     "pageIndex": "Page index",
+    "saveStatus": {
+      "saving": "Saving…",
+      "saved": "Saved {{time}}",
+      "error": "Save failed"
+    },
     "downloadStarted": "Started downloading {{name}}",
     "saved": "Saved",
     "saveFailed": "Save failed",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -848,6 +848,7 @@
       "uploadHint": "CSV / TXT format: one line per `english_tag,zh1 zh2`. Replaces (not merges) the current dictionary. Max 10MB / 200k entries.",
       "resetButton": "Restore default dictionary",
       "resetHint": "Re-download the ffdkj Danbooru tag Chinese translation table from GitHub (~30MB, top 200k tags by popularity, updated daily)",
+      "confirmReset": "Restore default dictionary? The current one will be overwritten.",
       "resetOk": "Default dictionary restored",
       "resetFail": "Reset failed",
       "uploadOk": "Loaded {{name}}",
@@ -919,6 +920,9 @@
       "error": "Save failed"
     },
     "downloadStarted": "Started downloading {{name}}",
+    "confirmDeletePreset": "Delete preset \"{{label}}\"? This cannot be undone.",
+    "confirmResetPreset": "Reset preset \"{{label}}\" to default? Your changes will be lost.",
+    "confirmRemoveLocalModel": "Remove local model \"{{name}}\"? Unregisters only; the file is not deleted.",
     "saved": "Saved",
     "saveFailed": "Save failed",
     "newPresetName": "New preset name",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -913,6 +913,11 @@
     "languageEn": "English",
     "title": "设置",
     "pageIndex": "本页索引",
+    "saveStatus": {
+      "saving": "保存中…",
+      "saved": "已保存 {{time}}",
+      "error": "保存失败"
+    },
     "downloadStarted": "开始下载 {{name}}",
     "saved": "已保存",
     "saveFailed": "保存失败",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -848,6 +848,7 @@
       "uploadHint": "CSV / TXT 格式：每行 `english_tag,中文1 中文2`。上传后替换当前词典（不合并）。最大 10MB / 20 万条。",
       "resetButton": "恢复默认词典",
       "resetHint": "从 GitHub 重新下载 ffdkj Danbooru 标签中文翻译表（约 30MB，收录热度前 20 万条，每日更新）",
+      "confirmReset": "恢复默认词典？当前词典会被覆盖。",
       "resetOk": "已恢复默认词典",
       "resetFail": "恢复失败",
       "uploadOk": "已加载 {{name}}",
@@ -919,6 +920,9 @@
       "error": "保存失败"
     },
     "downloadStarted": "开始下载 {{name}}",
+    "confirmDeletePreset": "删除预设「{{label}}」？此操作不可撤销。",
+    "confirmResetPreset": "把预设「{{label}}」重置为默认？你对它的修改会丢失。",
+    "confirmRemoveLocalModel": "移除本地模型「{{name}}」？仅取消登记，不会删除文件。",
     "saved": "已保存",
     "saveFailed": "保存失败",
     "newPresetName": "新预设名称",

--- a/studio/web/src/index.css
+++ b/studio/web/src/index.css
@@ -17,3 +17,14 @@ input[type='radio'] {
 .overflow-y-auto {
   scrollbar-gutter: stable;
 }
+
+/* 设置页「已保存」指示：每次保存（React key 变 → 重挂载）重播，从 accent 色
+   淡入再渐变回常态色——让同一分钟内的连续保存也有一眼可见的反馈。 */
+@keyframes settings-saved-flash {
+  0% { color: var(--accent); opacity: 0.5; }
+  100% { color: var(--fg-tertiary); opacity: 1; }
+}
+.settings-saved-flash {
+  color: var(--fg-tertiary);
+  animation: settings-saved-flash 0.9s ease-out;
+}

--- a/studio/web/src/lib/SettingsData.tsx
+++ b/studio/web/src/lib/SettingsData.tsx
@@ -13,18 +13,46 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useRef,
   useState,
   type ReactNode,
 } from 'react'
 import { useTranslation } from 'react-i18next'
-import { api, type ModelsCatalog, type Secrets } from '../api/client'
+import { api, type ModelsCatalog, type Secrets, type SecretsPatch } from '../api/client'
 import { useToast } from '../components/Toast'
 import { useEventStream } from './useEventStream'
+
+// 全局「已保存」状态指示（instant-apply 下取代旧的保存按钮 dirty 态）。
+export type SaveStatus =
+  | { state: 'idle' }
+  | { state: 'saving' }
+  | { state: 'saved'; at: number }
+  | { state: 'error'; error: string }
+
+// 把单字段 patch 浅合并进本地 secrets（乐观更新用）。secrets 是两层结构
+// （section → fields），顶层标量字段（如 download_source）直接覆盖。
+function mergePatchLocal(base: Secrets, patch: SecretsPatch): Secrets {
+  const out = { ...base } as Record<string, unknown>
+  for (const key of Object.keys(patch)) {
+    const pv = (patch as Record<string, unknown>)[key]
+    const bv = out[key]
+    if (pv && typeof pv === 'object' && !Array.isArray(pv)
+        && bv && typeof bv === 'object' && !Array.isArray(bv)) {
+      out[key] = { ...(bv as object), ...(pv as object) }
+    } else {
+      out[key] = pv
+    }
+  }
+  return out as unknown as Secrets
+}
 
 interface SettingsData {
   secrets: Secrets | null
   secretsError: string | null
   setSecrets: (s: Secrets) => void
+  /** instant-apply 统一写入入口：乐观更新 + 串行 PUT 单字段 patch。 */
+  commitSecrets: (patch: SecretsPatch) => void
+  saveStatus: SaveStatus
   catalog: ModelsCatalog | null
   catalogError: string | null
   reloadCatalog: () => Promise<ModelsCatalog | null>
@@ -43,6 +71,10 @@ export function SettingsDataProvider({ children }: { children: ReactNode }) {
   const [catalog, setCatalog] = useState<ModelsCatalog | null>(null)
   const [catalogError, setCatalogError] = useState<string | null>(null)
   const [downloadBusy, setDownloadBusy] = useState<Set<string>>(new Set())
+  const [saveStatus, setSaveStatus] = useState<SaveStatus>({ state: 'idle' })
+  // 串行 PUT 队列 + in-flight 计数：保证顺序避免后端读改写竞态。
+  const saveQueueRef = useRef<Promise<unknown>>(Promise.resolve())
+  const pendingRef = useRef(0)
 
   useEffect(() => {
     api.getSecrets()
@@ -106,9 +138,34 @@ export function SettingsDataProvider({ children }: { children: ReactNode }) {
     }
   }, [reloadCatalog, toast])
 
+  // instant-apply 统一写入：乐观更新本地 secrets 让控件立即反映，PUT 单字段
+  // patch 入串行队列。队列全部清空后用后端权威结果回写一次（拿 validator
+  // 规范化 + 敏感字段 mask）——避免连改多个字段时早 PUT 的权威结果覆盖掉
+  // 后面字段的乐观值（中途闪回）。失败时重拉 secrets 恢复一致。
+  const commitSecrets = useCallback((patch: SecretsPatch) => {
+    setSecrets((s) => (s ? mergePatchLocal(s, patch) : s))
+    setSaveStatus({ state: 'saving' })
+    pendingRef.current += 1
+    saveQueueRef.current = saveQueueRef.current
+      .then(() => api.updateSecrets(patch))
+      .then((authoritative) => {
+        pendingRef.current -= 1
+        if (pendingRef.current === 0) {
+          setSecrets(authoritative)
+          setSaveStatus({ state: 'saved', at: Date.now() })
+        }
+      })
+      .catch((e) => {
+        pendingRef.current -= 1
+        setSaveStatus({ state: 'error', error: String(e) })
+        toast(String(e), 'error')
+        api.getSecrets().then((s) => setSecrets(s)).catch(() => {})
+      })
+  }, [toast])
+
   return (
     <Ctx.Provider value={{
-      secrets, secretsError, setSecrets,
+      secrets, secretsError, setSecrets, commitSecrets, saveStatus,
       catalog, catalogError, reloadCatalog,
       downloadBusy, startDownload, setDownloadSource,
     }}>

--- a/studio/web/src/lib/SettingsData.tsx
+++ b/studio/web/src/lib/SettingsData.tsx
@@ -150,10 +150,10 @@ export function SettingsDataProvider({ children }: { children: ReactNode }) {
       .then(() => api.updateSecrets(patch))
       .then((authoritative) => {
         pendingRef.current -= 1
-        if (pendingRef.current === 0) {
-          setSecrets(authoritative)
-          setSaveStatus({ state: 'saved', at: Date.now() })
-        }
+        // 每个 PUT 完成都刷新「已保存」时间戳，让连续保存每次都有可见反馈；
+        // 权威结果只在队列清空时回写一次，避免中途覆盖后续字段的乐观值。
+        if (pendingRef.current === 0) setSecrets(authoritative)
+        setSaveStatus({ state: 'saved', at: Date.now() })
       })
       .catch((e) => {
         pendingRef.current -= 1

--- a/studio/web/src/lib/SettingsData.tsx
+++ b/studio/web/src/lib/SettingsData.tsx
@@ -52,6 +52,8 @@ interface SettingsData {
   setSecrets: (s: Secrets) => void
   /** instant-apply 统一写入入口：乐观更新 + 串行 PUT 单字段 patch。 */
   commitSecrets: (patch: SecretsPatch) => void
+  /** 包装一次性即时 PUT（下载源 / 主模型 / upscaler 等独立保存），驱动 saveStatus 指示。 */
+  runSave: <T>(fn: () => Promise<T>) => Promise<T>
   saveStatus: SaveStatus
   catalog: ModelsCatalog | null
   catalogError: string | null
@@ -129,14 +131,28 @@ export function SettingsDataProvider({ children }: { children: ReactNode }) {
   // draft）。刻意不 setSecrets —— 否则会让 SettingsPage 的 draft/server 失同步，
   // 表单 Save 时把这次改动 clobber 回去。dropdown 当前值读 catalog（reloadCatalog
   // 刷新），不依赖表单 secrets。
+  // 即时保存包装：给「不进 commitSecrets 队列」的独立 PUT（下载源 / 主模型 /
+  // upscaler / auto_sync 等切换类）也驱动右上角 saveStatus 指示，反馈统一。
+  const runSave = useCallback(async <T,>(fn: () => Promise<T>): Promise<T> => {
+    setSaveStatus({ state: 'saving' })
+    try {
+      const r = await fn()
+      setSaveStatus({ state: 'saved', at: Date.now() })
+      return r
+    } catch (e) {
+      setSaveStatus({ state: 'error', error: String(e) })
+      throw e
+    }
+  }, [])
+
   const setDownloadSource = useCallback(async (type: string, source: string) => {
     try {
-      await api.updateSecrets({ download_sources: { [type]: source } })
+      await runSave(() => api.updateSecrets({ download_sources: { [type]: source } }))
       await reloadCatalog()
     } catch (e) {
       toast(String(e), 'error')
     }
-  }, [reloadCatalog, toast])
+  }, [runSave, reloadCatalog, toast])
 
   // instant-apply 统一写入：乐观更新本地 secrets 让控件立即反映，PUT 单字段
   // patch 入串行队列。队列全部清空后用后端权威结果回写一次（拿 validator
@@ -165,7 +181,7 @@ export function SettingsDataProvider({ children }: { children: ReactNode }) {
 
   return (
     <Ctx.Provider value={{
-      secrets, secretsError, setSecrets, commitSecrets, saveStatus,
+      secrets, secretsError, setSecrets, commitSecrets, runSave, saveStatus,
       catalog, catalogError, reloadCatalog,
       downloadBusy, startDownload, setDownloadSource,
     }}>

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -302,11 +302,8 @@ describe('SettingsPage (PP0)', () => {
     const userInput = await screen.findByDisplayValue('alice')
     await user.clear(userInput)
     await user.type(userInput, 'bob')
-
-    // 主表单 Save 按钮文案就是「保存」；Models 区块的「保存路径」按钮
-    // 也含「保存」字样，正则匹配会撞 → 用精确名定位主按钮。
-    const saveBtn = screen.getByRole('button', { name: '保存' })
-    await user.click(saveBtn)
+    // instant-apply：文本框失焦即提交，无显式保存按钮
+    await user.tab()
 
     await waitFor(() => {
       const putCall = fetchMock.mock.calls.find(
@@ -380,7 +377,7 @@ describe('SettingsPage (PP0)', () => {
     const v2Row = screen.getByText('cl_tagger_v2_v2_01a').closest('li')
     expect(v2Row).not.toBeNull()
     await user.click(within(v2Row as HTMLElement).getByRole('radio'))
-    await user.click(screen.getByRole('button', { name: '保存' }))
+    // instant-apply：选 variant 即时提交，无显式保存按钮
 
     await waitFor(() => {
       const putCall = fetchMock.mock.calls.find(

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -91,7 +91,7 @@ export default function SettingsPage() {
   const [llmModelsBusy, setLlmModelsBusy] = useState(false)
   const [llmTestBusy, setLlmTestBusy] = useState(false)
   const { toast } = useToast()
-  const { prompt } = useDialog()
+  const { prompt, confirm } = useDialog()
   const drawer = useSettingsDrawer()
   // 右侧 section index 用：sticky nav 的 IntersectionObserver root + 滚动平移容器
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -182,16 +182,18 @@ export default function SettingsPage() {
     update('llm_tagger', 'current_preset', id)
   }
 
-  const deleteCurrentPreset = () => {
+  const deleteCurrentPreset = async () => {
     if (currentPreset.builtin || draft.llm_tagger.presets.length <= 1) return
+    if (!(await confirm(t('settings.confirmDeletePreset', { label: currentPreset.label }), { tone: 'danger' }))) return
     const next = draft.llm_tagger.presets.filter((p) => p.id !== currentPreset.id)
     update('llm_tagger', 'presets', next)
     update('llm_tagger', 'current_preset', next[0]?.id ?? 'style_json')
   }
 
-  const resetCurrentPresetToBuiltin = () => {
+  const resetCurrentPresetToBuiltin = async () => {
     // 删除当前 builtin preset，让 backend validator 在 PUT 后从 defaults 补回
     if (!currentPreset.builtin) return
+    if (!(await confirm(t('settings.confirmResetPreset', { label: currentPreset.label }), { tone: 'danger' }))) return
     const next = draft.llm_tagger.presets.filter((p) => p.id !== currentPreset.id)
     update('llm_tagger', 'presets', next)
     // current_preset 不变；validator 会重建 preset

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -408,6 +408,7 @@ export default function SettingsPage() {
             onChange={(tags) => update('reg', 'default_excluded_tags', tags)}
             placeholder={t('settings.reg.defaultExcludedPlaceholder')}
             className={textInputClass}
+            commitOnBlur
           />
         </SettingsField>
       </SettingsSection>
@@ -540,6 +541,7 @@ export default function SettingsPage() {
             value={draft.wd14.blacklist_tags}
             onChange={(tags) => update('wd14', 'blacklist_tags', tags)}
             className={textInputClass}
+            commitOnBlur
           />
         </SettingsField>
         <SettingsField label={t('settings.fieldBatchSize')} desc={t('settings.batchSizeHint')}>
@@ -608,6 +610,7 @@ export default function SettingsPage() {
             value={draft.cltagger.blacklist_tags}
             onChange={(tags) => update('cltagger', 'blacklist_tags', tags)}
             className={textInputClass}
+            commitOnBlur
           />
         </SettingsField>
         <SettingsField label={t('settings.fieldBatchSize')} desc={t('settings.batchSizeHint')}>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -55,8 +55,16 @@ function SaveIndicator({ status }: { status: SaveStatus }) {
     return <span className="text-xs text-fg-tertiary">{t('settings.saveStatus.saving')}</span>
   }
   if (status.state === 'saved') {
-    const time = new Date(status.at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
-    return <span className="text-xs text-fg-tertiary">{t('settings.saveStatus.saved', { time })}</span>
+    const time = new Date(status.at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+    // key={status.at}：每次保存重挂载 → 重播 flash 动画，连续保存也能一眼看出"又存了"。
+    return (
+      <span key={status.at} className="settings-saved-flash text-xs inline-flex items-center gap-1">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M20 6L9 17l-5-5" />
+        </svg>
+        {t('settings.saveStatus.saved', { time })}
+      </span>
+    )
   }
   if (status.state === 'error') {
     return <span className="text-xs text-err">{t('settings.saveStatus.error')}</span>

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import {
   api,
   type CLTaggerVariantInfo,
   type LLMPreset,
   type Secrets,
+  type SecretsPatch,
   type WandBConfig,
 } from '../../api/client'
 import { useDialog } from '../../components/Dialog'
@@ -12,14 +13,14 @@ import LLMTaggerWorkspace from '../../components/LLMTaggerWorkspace'
 import { TagListInput } from '../../components/TagsInput'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
-import { useSettingsData } from '../../lib/SettingsData'
+import { useSettingsData, type SaveStatus } from '../../lib/SettingsData'
 import { useSettingsDrawer } from '../../lib/SettingsDrawer'
 import {
-  buildPatch,
   DEFAULT_LLM_PRESETS,
   EMPTY,
   getStoredTab,
   _makeFallbackPreset,
+  MASK,
   SECTION_TO_TAB,
   TAB_LIST,
   TAB_SECTIONS,
@@ -47,6 +48,22 @@ import {
 } from './settings/sections'
 import { SystemSection } from './settings/SystemSection'
 
+// 全局保存状态指示（instant-apply 取代旧的顶部保存按钮）。idle 不渲染。
+function SaveIndicator({ status }: { status: SaveStatus }) {
+  const { t } = useTranslation()
+  if (status.state === 'saving') {
+    return <span className="text-xs text-fg-tertiary">{t('settings.saveStatus.saving')}</span>
+  }
+  if (status.state === 'saved') {
+    const time = new Date(status.at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    return <span className="text-xs text-fg-tertiary">{t('settings.saveStatus.saved', { time })}</span>
+  }
+  if (status.state === 'error') {
+    return <span className="text-xs text-err">{t('settings.saveStatus.error')}</span>
+  }
+  return null
+}
+
 export default function SettingsPage() {
   const { t } = useTranslation()
   // 共享数据层（SettingsDataProvider）：secrets / catalog / SSE / downloadBusy 都在根级常驻，
@@ -56,6 +73,8 @@ export default function SettingsPage() {
     secrets: server,
     secretsError,
     setSecrets: setServer,
+    commitSecrets,
+    saveStatus,
     catalog,
     catalogError,
     reloadCatalog,
@@ -63,9 +82,11 @@ export default function SettingsPage() {
     startDownload,
     setDownloadSource,
   } = useSettingsData()
-  const [draft, setDraft] = useState<Secrets>(EMPTY)
+  // instant-apply：不再有本地 draft，控件直接读 server（未加载时 EMPTY 占位），
+  // 写一律走 commitSecrets 即时持久化。`draft` 别名保留是为了让下方大段表单
+  // 代码改动最小。
+  const draft = server ?? EMPTY
   const [error, setError] = useState<string | null>(null)
-  const [saving, setSaving] = useState(false)
   const [tab, setTab] = useState<Tab>(getStoredTab)
   const [llmModelsBusy, setLlmModelsBusy] = useState(false)
   const [llmTestBusy, setLlmTestBusy] = useState(false)
@@ -75,16 +96,7 @@ export default function SettingsPage() {
   // 右侧 section index 用：sticky nav 的 IntersectionObserver root + 滚动平移容器
   const scrollContainerRef = useRef<HTMLDivElement>(null)
 
-  // 第一次拿到 secrets 时把 draft 同步过来；之后 server 变化（save 后）不再
-  // 覆盖 draft，避免抹掉用户的未保存编辑（save 里会自己 setDraft(next)）。
-  const draftInitRef = useRef(false)
-  useEffect(() => {
-    if (server && !draftInitRef.current) {
-      setDraft(server)
-      draftInitRef.current = true
-    }
-  }, [server])
-  // 数据层 fetch secrets 失败时把错误透出到本组件 error 状态，复用底部错误条。
+  // 数据层 fetch secrets 失败时把错误透出到本组件 error 状态。
   useEffect(() => { if (secretsError) setError(secretsError) }, [secretsError])
 
   const switchTab = (next: Tab) => {
@@ -96,17 +108,9 @@ export default function SettingsPage() {
     }
   }
 
-  const dirty = useMemo(
-    () => server !== null && JSON.stringify(server) !== JSON.stringify(draft),
-    [server, draft]
-  )
-
-  // 抽屉关闭前用这个 ref 询问"是否 dirty"；ref 每次 render 刷新，
-  // 注册的函数只挂载一次，避免 effect churn。
-  const dirtyRef = useRef(false)
-  dirtyRef.current = dirty
+  // instant-apply：所有改动即时落盘，抽屉关闭无需 dirty 守卫。
   useEffect(() => {
-    drawer.registerDirtyGuard(() => dirtyRef.current)
+    drawer.registerDirtyGuard(null)
     return () => drawer.registerDirtyGuard(null)
   }, [drawer])
 
@@ -130,43 +134,20 @@ export default function SettingsPage() {
     key: K,
     value: Secrets[S][K]
   ) => {
-    setDraft((prev) => ({
-      ...prev,
-      [section]: { ...prev[section], [key]: value },
-    }))
+    // 敏感字段清空会回传 MASK 哨兵，语义是"未改"——跳过，保持现有契约。
+    if (value === MASK) return
+    commitSecrets({ [section]: { [key]: value } } as SecretsPatch)
   }
 
 
   const selectCLTaggerVariant = (variant: CLTaggerVariantInfo) => {
-    setDraft((prev) => ({
-      ...prev,
+    commitSecrets({
       cltagger: {
-        ...prev.cltagger,
         model_id: variant.model_id,
         model_path: variant.model_path,
         tag_mapping_path: variant.tag_mapping_path,
       },
-    }))
-  }
-
-  const save = async () => {
-    if (!server) return
-    const patch = buildPatch(draft, server)
-    setSaving(true)
-    setError(null)
-    try {
-      const next = await api.updateSecrets(patch)
-      setServer(next)
-      setDraft(next)
-      // 候选 model_ids 改了之后，catalog 里的 wd14 variants 需要刷新
-      void reloadCatalog()
-      toast(t('settings.saved'), 'success')
-    } catch (e) {
-      setError(String(e))
-      toast(t('settings.saveFailed'), 'error')
-    } finally {
-      setSaving(false)
-    }
+    } as SecretsPatch)
   }
 
   // 找到当前 active preset；如果 current_preset 指向不存在的 id（理论上 validator
@@ -249,15 +230,9 @@ export default function SettingsPage() {
     setLlmModelsBusy(true)
     setError(null)
     try {
-      let source = draft
-      if (dirty) {
-        const saved = await api.updateSecrets(buildPatch(draft, server))
-        setServer(saved)
-        setDraft(saved)
-        source = saved
-      }
-      const sourcePreset = source.llm_tagger.presets.find((p) => p.id === currentPreset.id)
-        ?? source.llm_tagger.presets[0]
+      // instant-apply：preset 字段已即时落盘，直接用 server 当前值刷新。
+      const sourcePreset = server.llm_tagger.presets.find((p) => p.id === currentPreset.id)
+        ?? server.llm_tagger.presets[0]
       const result = await api.refreshLLMModels({
         preset_id: sourcePreset.id,
         base_url: sourcePreset.base_url,
@@ -265,7 +240,6 @@ export default function SettingsPage() {
         timeout: sourcePreset.timeout,
       })
       setServer(result.secrets)
-      setDraft(result.secrets)
       toast(t('settings.modelsLoaded', { n: result.items.length }), 'success')
     } catch (e) {
       setError(String(e))
@@ -350,15 +324,7 @@ export default function SettingsPage() {
             </svg>
           </button>
         ) : undefined}
-        actions={
-          <button
-            onClick={save}
-            disabled={!dirty || saving}
-            className={dirty ? 'btn btn-primary btn-sm' : 'btn btn-secondary btn-sm'}
-          >
-            {saving ? t('common.saving') : t('common.save')}
-          </button>
-        }
+        actions={<SaveIndicator status={saveStatus} />}
       />
 
       <div ref={scrollContainerRef} className="p-6 pb-12 flex-1 overflow-y-auto">

--- a/studio/web/src/pages/tools/settings/constants.ts
+++ b/studio/web/src/pages/tools/settings/constants.ts
@@ -3,7 +3,6 @@ import {
   DEFAULT_WD14_MODELS,
   type LLMPreset,
   type Secrets,
-  type SecretsPatch,
 } from '../../../api/client'
 
 export const MASK = '***'
@@ -260,30 +259,6 @@ export const UPSCALER_DESCRIPTION_KEYS: Record<string, string> = {
 export function translatedCatalogText(keys: Record<string, string>, id: string, fallback: string | undefined, t: TFunction): string {
   const key = keys[id]
   return key ? t(key, { defaultValue: fallback ?? '' }) : (fallback ?? '')
-}
-
-// 顶层非 object 字段（string / number / bool），直接比较后塞入 patch。
-export const TOP_LEVEL_SCALARS: (keyof Secrets)[] = ['download_source']
-
-export function buildPatch(draft: Secrets, server: Secrets): SecretsPatch {
-  const out: Record<string, unknown> = {}
-  for (const key of Object.keys(draft) as (keyof Secrets)[]) {
-    if (TOP_LEVEL_SCALARS.includes(key)) {
-      if (draft[key] !== server[key]) out[key] = draft[key]
-      continue
-    }
-    const sub: Record<string, unknown> = {}
-    const d = draft[key] as unknown as Record<string, unknown>
-    const s = server[key] as unknown as Record<string, unknown>
-    for (const k of Object.keys(d)) {
-      const dv = d[k]
-      const sv = s[k]
-      if (dv === MASK) continue
-      if (JSON.stringify(dv) !== JSON.stringify(sv)) sub[k] = dv
-    }
-    if (Object.keys(sub).length) out[key] = sub
-  }
-  return out as SecretsPatch
 }
 
 // ── Models Section ─────────────────────────────────────────────────────────

--- a/studio/web/src/pages/tools/settings/fields.tsx
+++ b/studio/web/src/pages/tools/settings/fields.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type RefObject } from 'react'
+import { useEffect, useRef, useState, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { InfoButton } from '../../../components/InfoButton'
 import { MASK, textInputClass } from './constants'
@@ -193,15 +193,30 @@ export interface SettingsInputProps extends Omit<React.InputHTMLAttributes<HTMLI
 
 export function SettingsInput({ value, onChange, type = 'text', ...props }: SettingsInputProps) {
   const [localValue, setLocalValue] = useState(value)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(() => {
     setLocalValue(value)
   }, [value])
 
-  const handleBlur = () => {
-    if (String(localValue) !== String(value)) {
-      onChange(String(localValue))
-    }
+  // 卸载时清掉未触发的 debounce，避免对已卸载组件 setState / 提交。
+  useEffect(() => () => { if (timerRef.current) clearTimeout(timerRef.current) }, [])
+
+  const commit = (v: string) => {
+    if (timerRef.current) { clearTimeout(timerRef.current); timerRef.current = null }
+    if (String(v) !== String(value)) onChange(v)
+  }
+
+  // 数字框（spinner 点箭头 / 输入）停手 ~500ms 自动提交，不必主动失焦也有反馈；
+  // 文本框保持失焦 / Enter 提交（避免输入中途半截 PUT）。
+  const debounced = type === 'number'
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const v = e.target.value
+    setLocalValue(v)
+    if (!debounced) return
+    if (timerRef.current) clearTimeout(timerRef.current)
+    timerRef.current = setTimeout(() => commit(v), 500)
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -215,8 +230,8 @@ export function SettingsInput({ value, onChange, type = 'text', ...props }: Sett
       type={type}
       {...props}
       value={localValue}
-      onChange={(e) => setLocalValue(e.target.value)}
-      onBlur={handleBlur}
+      onChange={handleChange}
+      onBlur={() => commit(String(localValue))}
       onKeyDown={handleKeyDown}
     />
   )

--- a/studio/web/src/pages/tools/settings/modelCards.tsx
+++ b/studio/web/src/pages/tools/settings/modelCards.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../api/client'
 import { InfoButton } from '../../../components/InfoButton'
 import { fmtBytes, MODEL_DESCRIPTION_KEYS, textInputClass, translatedCatalogText } from './constants'
-import { SettingsField } from './fields'
+import { SettingsField, SettingsInput } from './fields'
 
 // ── HFEndpointSelect ────────────────────────────────────────────────────────
 //
@@ -56,11 +56,11 @@ export function HFEndpointSelect({ value, onChange }: {
         ))}
       </select>
       {mode === 'custom' && (
-        <input
+        <SettingsInput
           type="text"
           value={value && !isPreset ? value : ''}
           placeholder="https://your-mirror.example.com"
-          onChange={(e) => onChange(e.target.value.trim())}
+          onChange={(v) => onChange(v.trim())}
           className={textInputClass}
         />
       )}
@@ -268,10 +268,10 @@ export function EvalMetricModelCard({
       </button>
       {advOpen && (
         <SettingsField label={t('settings.fieldModelId')}>
-          <input
+          <SettingsInput
             type="text"
             value={modelId}
-            onChange={(e) => onModelIdChange(e.target.value)}
+            onChange={onModelIdChange}
             className={textInputClass}
             placeholder={t('settings.addHfModelId')}
           />
@@ -354,10 +354,10 @@ export function CLTaggerModelCard({
       </button>
       {advOpen && (
         <SettingsField label={t('settings.fieldModelId')}>
-          <input
+          <SettingsInput
             type="text"
             value={modelId}
-            onChange={(e) => onModelIdChange(e.target.value)}
+            onChange={onModelIdChange}
             className={textInputClass}
             placeholder="cella110n/cl_tagger"
           />

--- a/studio/web/src/pages/tools/settings/sections.tsx
+++ b/studio/web/src/pages/tools/settings/sections.tsx
@@ -20,7 +20,7 @@ import { useToast } from '../../../components/Toast'
 import { applyDensity, applyTheme, getStoredDensity, getStoredTheme, setStoredDensity, setStoredTheme, type Density, type Theme } from '../../../lib/theme'
 import i18n, { getStoredLangWithDefault, setStoredLang } from '../../../i18n'
 import { MODEL_DESCRIPTION_KEYS, textInputClass, translatedCatalogText, UPSCALER_DESCRIPTION_KEYS, type Section } from './constants'
-import { Bool, SettingsField, SettingsSection } from './fields'
+import { Bool, SettingsField, SettingsInput, SettingsSection } from './fields'
 import { DownloadButton, ModelGroupCard, ModelStatusBadge, SourceSelect, StatusLabel } from './modelCards'
 
 // ── 训练参数 Section ─────────────────────────────────────────────────
@@ -1296,12 +1296,12 @@ export function IdleTimeoutSection({
         helpTooltip={<p>{t('settings.idleTimeout.help')}</p>}
       >
         <div className="flex items-center gap-2">
-          <input
+          <SettingsInput
             type="number"
             min={0}
             max={240}
             value={minutes}
-            onChange={(e) => update('generate', 'idle_timeout_minutes', Math.max(0, Number(e.target.value) || 0))}
+            onChange={(v) => update('generate', 'idle_timeout_minutes', Math.max(0, Number(v) || 0))}
             className={`${textInputClass} max-w-32`}
           />
           <span className="text-xs text-fg-tertiary">
@@ -1365,12 +1365,12 @@ export function TaeFluxSection({
           <p>{t('settings.taeFluxHelp')}</p>
         }
       >
-        <input
+        <SettingsInput
           type="number"
           min={0}
           max={50}
           value={n}
-          onChange={(e) => update('generate', 'preview_every_n_steps', Number(e.target.value) || 0)}
+          onChange={(v) => update('generate', 'preview_every_n_steps', Number(v) || 0)}
           className={`${textInputClass} max-w-32`}
         />
       </SettingsField>

--- a/studio/web/src/pages/tools/settings/sections.tsx
+++ b/studio/web/src/pages/tools/settings/sections.tsx
@@ -76,6 +76,7 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
   t: TFunction
 }) {
   const { toast } = useToast()
+  const dialog = useDialog()
   const [selectedAnima, setSelectedAnima] = useState<string>('1.0')
   const [showPicker, setShowPicker] = useState(false)
   const [addingCustom, setAddingCustom] = useState(false)
@@ -124,6 +125,8 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
   }
 
   const removeCustom = async (p: string) => {
+    const name = p.split(/[\\/]/).pop() || p
+    if (!(await dialog.confirm(t('settings.confirmRemoveLocalModel', { name }), { tone: 'danger' }))) return
     try {
       await api.removeCustomAnima(p)
       if (p === selectedAnima) setSelectedAnima('1.0')
@@ -486,6 +489,7 @@ export function UpscalerSection({
 export function TagDictionarySection() {
   const { t } = useTranslation()
   const { toast } = useToast()
+  const dialog = useDialog()
   const dict = useTagDict()
   const [show, setShow] = useShowTagTranslation()
   const [busy, setBusy] = useState<null | 'reset' | 'upload'>(null)
@@ -504,6 +508,7 @@ export function TagDictionarySection() {
 
   const reset = async () => {
     if (busy) return
+    if (!(await dialog.confirm(t('settings.tagDictionary.confirmReset'), { tone: 'danger' }))) return
     setBusy('reset')
     try {
       await api.resetTagDictionary()

--- a/studio/web/src/pages/tools/settings/sections.tsx
+++ b/studio/web/src/pages/tools/settings/sections.tsx
@@ -17,6 +17,7 @@ import PathPicker from '../../../components/PathPicker'
 import { useShowTagTranslation } from '../../../tagDict/showToggle'
 import { useTagDict, reloadDict } from '../../../tagDict/store'
 import { useToast } from '../../../components/Toast'
+import { useSettingsData } from '../../../lib/SettingsData'
 import { applyDensity, applyTheme, getStoredDensity, getStoredTheme, setStoredDensity, setStoredTheme, type Density, type Theme } from '../../../lib/theme'
 import i18n, { getStoredLangWithDefault, setStoredLang } from '../../../i18n'
 import { MODEL_DESCRIPTION_KEYS, textInputClass, translatedCatalogText, UPSCALER_DESCRIPTION_KEYS, type Section } from './constants'
@@ -30,6 +31,7 @@ import { DownloadButton, ModelGroupCard, ModelStatusBadge, SourceSelect, StatusL
 export function TrainingParamsSection() {
   const { t } = useTranslation()
   const { toast } = useToast()
+  const { runSave } = useSettingsData()
   const [autoSyncPaths, setAutoSyncPaths] = useState<boolean>(true)
   const [savingAutoSync, setSavingAutoSync] = useState(false)
 
@@ -44,7 +46,7 @@ export function TrainingParamsSection() {
     const prev = autoSyncPaths
     setAutoSyncPaths(next)
     try {
-      await api.updateSecrets({ models: { auto_sync_paths: next } })
+      await runSave(() => api.updateSecrets({ models: { auto_sync_paths: next } }))
       toast(next ? t('settings.autoSyncPathsOn') : t('settings.autoSyncPathsOff'), 'success')
     } catch (e) {
       setAutoSyncPaths(prev)
@@ -77,6 +79,7 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
 }) {
   const { toast } = useToast()
   const dialog = useDialog()
+  const { runSave } = useSettingsData()
   const [selectedAnima, setSelectedAnima] = useState<string>('1.0')
   const [showPicker, setShowPicker] = useState(false)
   const [addingCustom, setAddingCustom] = useState(false)
@@ -93,7 +96,7 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
     if (variant === selectedAnima) return
     setSelectedAnima(variant)
     try {
-      await api.updateSecrets({ models: { selected_anima: variant } })
+      await runSave(() => api.updateSecrets({ models: { selected_anima: variant } }))
       toast(t('settings.mainModelSelected', { name: variant }), 'success')
       await reloadCatalog()
     } catch (e) {
@@ -114,7 +117,7 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
     }
     setAddingCustom(true)
     try {
-      await api.addCustomAnima(p)
+      await runSave(() => api.addCustomAnima(p))
       toast(t('settings.localModelAdded', { name: p.split(/[\\/]/).pop() }), 'success')
       await reloadCatalog()
     } catch (e) {
@@ -128,7 +131,7 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
     const name = p.split(/[\\/]/).pop() || p
     if (!(await dialog.confirm(t('settings.confirmRemoveLocalModel', { name }), { tone: 'danger' }))) return
     try {
-      await api.removeCustomAnima(p)
+      await runSave(() => api.removeCustomAnima(p))
       if (p === selectedAnima) setSelectedAnima('1.0')
       toast(t('settings.localModelRemoved'), 'success')
       await reloadCatalog()
@@ -295,6 +298,7 @@ export function UpscalerSection({
   t: TFunction
 }) {
   const { toast } = useToast()
+  const { runSave } = useSettingsData()
   const [customSource, setCustomSource] = useState<'hf' | 'ms'>('hf')
   const [customRepo, setCustomRepo] = useState('')
   const [customFile, setCustomFile] = useState('')
@@ -302,7 +306,7 @@ export function UpscalerSection({
 
   const pickUpscaler = async (label: string) => {
     try {
-      await api.selectUpscaler(label)
+      await runSave(() => api.selectUpscaler(label))
       toast(t('settings.defaultUpscaler', { name: label }), 'success')
       await reloadCatalog()
     } catch (e) {


### PR DESCRIPTION
## 背景

承接已合并的 #331（仅做了 `Settings.tsx` → `settings/` 子模块的机械拆分）。本 PR 在其之上，把全局设置页的保存语义从「页面级 draft + 底部悬浮保存条」改为 **instant-apply**（即时生效）。

> 方向决策见 `docs/todo/settings-instant-apply.md`：本地单机工具 + 配置即文件，设置页按控件类型即时生效（对齐 Apple HIG / GNOME HIG / Fluent2 / Material3 / NN-g），而不套页面级 dirty / Save 条。

## 改动

**三类控件保存策略**
- A 即时类（开关 / select / radio）：改动即提交
- B 失焦类（文本框 / 数字框）：onBlur / Enter 提交，不再逐字写盘；数字框 spinner 停手自动提交
- C 按钮类（runtime + 专用端点）：点击触发

**核心机制**
- `SettingsData.commitSecrets`：乐观更新 + 串行队列 PUT 单 leaf + drain 回写权威 + 失败重拉（原型为既有的 `setDownloadSource`）
- 删除 draft / dirty / 全局保存按钮，换成角落 `SaveIndicator`（保存中 / 已保存 HH:MM:SS，每次保存 flash）；删死代码 `buildPatch`
- 逐字文本框失焦缓冲（`settings/fields` 的 Input / SensitiveInput；`LLMTaggerWorkspace` 内置 BufferedInput，因 components 不能依赖 pages）；`TagsInput` 加 `commitOnBlur`（设置页传 true，打标页默认 false 不变）

**破坏性操作前置 confirm**
- 删 preset / 重置 builtin preset / 恢复词典默认 / 移除 custom 本地模型 4 项弹确认
- 下载源 / 主模型 / 通道改回即可，不 confirm

## 测试
- tsc / vitest / lint / build 全绿
- 手动验证各控件即时保存 + 保存指示 + confirm 弹窗

🤖 Generated with [Claude Code](https://claude.com/claude-code)
