### PR TITLE
fix(projects): 项目页 header 固定顶部（与队列页一致）

### DIFF
--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -241,6 +241,7 @@ export default function ProjectsPage() {
       <PageHeader
         title={t('projects.title')}
         subtitle={t('projects.description')}
+        sticky
         actions={
           <>
             {/* btn 词汇与 Queue / Generate 页 header 统一：轻操作 ghost、


### PR DESCRIPTION
## 背景 / 动机

队列页（StepShell）的 header 是钉在顶部的，滚动内容时 header 不动；但项目页直接用
`PageHeader` 且没传 `sticky`，页面级滚动时 header 会随内容一起滚走，两页行为不一致。

## 改动概要

给 Projects 的 `PageHeader` 传 `sticky`（= `sticky top-0 z-[5]`，相对 `RootLayout` 的
`<main overflow:auto>` 滚动容器粘顶）。PageHeader 本身已支持该 prop（StepShell 一直在用），
零新增逻辑。

## 测试方式

- `npm run build`（eslint + tsc + vite）绿。
- `Projects.test.tsx` 6/6 通过。
- 手测：项目列表向下滚动，header 固定在顶部。

## 截图

_（滚动时 header 固定，待补）_