### PR TITLE
test(announcements): 修 AnnouncementCenter 正文切换 flake（补 waitFor）

### DIFF
--- a/studio/web/src/components/AnnouncementCenter.test.tsx
+++ b/studio/web/src/components/AnnouncementCenter.test.tsx
@@ -66,7 +66,10 @@ describe('AnnouncementCenter', () => {
     fireEvent.click(screen.getByTestId('announcement-item-p-notice'))
     await waitFor(() =>
       expect(screen.queryByTestId('announcement-dot-p-notice')).toBeNull())
-    expect(screen.getByText('公告正文')).toBeInTheDocument()
+    // 正文切换是点击后异步渲染（markdown），跟红点消失不同 tick；CI 慢机上同步
+    // getByText 会 flake（红点已消失但正文未渲染）→ 用 waitFor 等正文到位。
+    await waitFor(() =>
+      expect(screen.getByText('公告正文')).toBeInTheDocument())
   })
 
   it('tag 过滤只显示该类', async () => {


### PR DESCRIPTION
## 背景 / 动机

`AnnouncementCenter.test.tsx > 点另一篇 → 标记已读，红点消失，正文切换` 在 CI 上偶发红
（本地稳过）。#347、#348 的 frontend job 都撞到过。根因是测试卫生问题，非产品代码 bug。

## 改动概要

点击切换公告后，红点消失（mark-as-read effect）和正文（markdown）渲染是不同 tick。原用例
`waitFor` 等红点消失后**同步** `getByText('公告正文')`，CI 慢机上红点已消失但正文尚未渲染
就断言 → flake。把正文断言也包进 `waitFor`。纯测试改动，不动产品代码。

## 测试方式

- `AnnouncementCenter.test.tsx` 6/6 本地通过（改前后本地都过，改的是 CI 慢机路径的稳健性）。

## 备注

修 dev 上既有 flake。合入后 #347 / #348 rebase 或 CI 重跑即稳。