### PR TITLE
fix(training): 训练端认不出本地打标写出的扁平 JSON caption（#345）

### DIFF
--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -170,6 +170,7 @@ class ImageDataset(Dataset):
         txt_count = len(self.samples) - json_count
         unique_count = len(set(id(s) for s in self.samples))
         logger.info(f"数据集: {unique_count} 张图 → {len(self.samples)} 样本（含 repeat）(JSON: {json_count}, TXT: {txt_count})")
+        self._preflight_json_captions()
         self.bucket_for_index = self._build_bucket_for_index()
 
     def _build_bucket_for_index(self):
@@ -341,6 +342,52 @@ class ImageDataset(Dataset):
 
         return samples
 
+    def _preflight_json_captions(self):
+        """开训前预检所有 JSON caption，构建失败直接拒绝开训（fail-fast）。
+
+        JSON 样本没有 .txt 兜底（``_make_sample`` 里 prefer_json 命中时
+        txt_path=None），caption 构建失败会在 ``__getitem__`` 静默退成空
+        caption——连触发词都不剩，整炉 LoRA 白炼且训练照常跑完（#345）。
+        与其训练中逐样本 warning 刷屏，不如开训前一次性报清楚并中止。
+
+        shuffle=False + dropout=0 保证预检确定性且不消耗随机数状态。
+        caption_override 全局覆盖时不读 caption 文件，跳过。
+        """
+        if self.caption_override is not None:
+            return
+        json_paths = []
+        seen = set()
+        for s in self.samples:
+            jp = s.get("json_path")
+            if jp and jp not in seen:
+                seen.add(jp)
+                json_paths.append(jp)
+        if not json_paths:
+            return
+        if self.caption_utils is None:
+            raise ValueError(
+                f"数据集含 {len(json_paths)} 个 JSON caption，但 caption_utils 加载失败"
+                f"（见上方 warning），这些图将以空 caption 训练，已拒绝开训。"
+            )
+        bad = []
+        for jp in json_paths:
+            try:
+                caption = self.caption_utils["load_and_build"](
+                    jp, shuffle=False, tag_dropout=0.0
+                )
+            except Exception:
+                caption = None
+            if caption is None:
+                bad.append(jp)
+        if bad:
+            preview = "\n".join(f"  - {p}" for p in bad[:5])
+            more = f"\n  ...等共 {len(bad)} 个" if len(bad) > 5 else ""
+            raise ValueError(
+                f"{len(bad)} 个 JSON caption 解析失败，对应图片将以空 caption"
+                f"（连触发词都没有）参与训练，已拒绝开训。"
+                f"请在打标页检查或重新打标这些文件：\n{preview}{more}"
+            )
+
     def _process_caption_txt(self, caption):
         """处理 TXT caption: 传统 tag 打乱 + keep_tokens"""
         if not caption:
@@ -365,24 +412,17 @@ class ImageDataset(Dataset):
         """处理 JSON caption: 分类 shuffle"""
         if self.caption_utils is None:
             return None
-        
+
         try:
-            raw_json = self.caption_utils["load_json"](json_path)
-            if raw_json is None:
-                return None
-            
-            # 检查是否已经是标准格式
-            if "tags" in raw_json and "meta" in raw_json:
-                normalized = raw_json
-            else:
-                normalized = self.caption_utils["normalize"](raw_json)
-            
-            # 构建 caption（分类 shuffle）
-            return self.caption_utils["build"](
-                normalized,
-                shuffle_appearance=self.shuffle_caption,
-                shuffle_tags=self.shuffle_caption,
-                shuffle_environment=self.shuffle_caption,
+            # 走 caption_utils 的权威编排（load → 判断标准格式 → normalize → build）。
+            # 早期这里 copy 了一份判断，用 `"tags" in raw_json` 只查 key 是否存在，会把
+            # Studio 打标写出的简化形式 {"tags": [list], "meta": {trigger}} 误判为标准
+            # 格式直接喂给 build，导致 build 对 list 调 .get() 崩（#345）。load_and_build
+            # 用 isinstance(tags, dict) 正确判断：list 形式走 normalize 搬到 tags.tags，
+            # 复用单一源避免逻辑再次漂移。
+            return self.caption_utils["load_and_build"](
+                json_path,
+                shuffle=self.shuffle_caption,
                 tag_dropout=self.tag_dropout,
             )
         except Exception as e:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -435,6 +435,61 @@ def test_image_dataset_loads_caption_utils_when_prefer_json(tmp_path: Path) -> N
         assert key in dataset.caption_utils
 
 
+def test_json_caption_list_shape_does_not_crash_issue_345(tmp_path: Path) -> None:
+    """#345: Studio 打标写出的简化 JSON（tags 为扁平 list、非分类 dict）以前被
+    误判为标准格式直接喂给 build，触发 'list' object has no attribute 'get'。
+    现在应正常构建 caption：trigger 在首位、tags 全部保留、trigger 去重。"""
+    pytest.importorskip("torch")
+    import json
+
+    from runtime.training.dataset import ImageDataset
+
+    payload = {
+        "tags": ["mika_pikazo", "1girl", "solo", "blue hair"],
+        "meta": {"trigger": "mika_pikazo"},
+    }
+    jp = tmp_path / "10032281.json"
+    jp.write_text(json.dumps(payload, ensure_ascii=False), encoding="utf-8")
+
+    dataset = ImageDataset(tmp_path, prefer_json=True)
+    caption = dataset._process_caption_json(jp)
+
+    assert caption is not None, "list 形式 caption 不应崩溃 / 静默返回 None"
+    assert caption.startswith("mika_pikazo"), "trigger 应在首位（keep_tokens 保护）"
+    assert "1girl" in caption and "blue hair" in caption
+    assert caption.count("mika_pikazo") == 1, "trigger 与 tags 内重复项应去重"
+
+
+def test_json_caption_preflight_rejects_broken_json(tmp_path: Path) -> None:
+    """#345 follow-up: JSON 样本没有 txt 兜底（_make_sample 置 txt_path=None），
+    caption 解析失败会静默以空 caption 训练。预检应在开训前直接报错拒绝。"""
+    pytest.importorskip("torch")
+    from runtime.training.dataset import ImageDataset
+
+    img = _touch_image(tmp_path, "a.png")
+    img.with_suffix(".json").write_text("{ not valid json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="拒绝开训"):
+        ImageDataset(tmp_path, prefer_json=True)
+
+
+def test_json_caption_preflight_passes_healthy_flat_json(tmp_path: Path) -> None:
+    """健康的扁平 list caption（#345 场景修复后）应通过预检正常建数据集。"""
+    pytest.importorskip("torch")
+    import json
+
+    from runtime.training.dataset import ImageDataset
+
+    img = _touch_image(tmp_path, "a.png")
+    img.with_suffix(".json").write_text(
+        json.dumps({"tags": ["mika_pikazo", "1girl"], "meta": {"trigger": "mika_pikazo"}}),
+        encoding="utf-8",
+    )
+
+    dataset = ImageDataset(tmp_path, prefer_json=True)
+    assert len(dataset.samples) == 1
+
+
 def test_parse_repeat_kohya_prefix() -> None:
     assert datasets.parse_repeat("5_concept") == (5, "concept")
     assert datasets.parse_repeat("12_a_long_name") == (12, "a_long_name")

--- a/utils/caption_utils.py
+++ b/utils/caption_utils.py
@@ -244,8 +244,12 @@ def batch_convert_json(
             if raw_json is None:
                 continue
             
-            # 跳过已经是标准格式的
-            if "tags" in raw_json and "meta" in raw_json:
+            # 跳过已经是标准格式的——tags 必须是分类 dict（与 load_and_build_caption
+            # 同款判断，#345）；扁平 {"tags": [...]} 需要转换，不能误判为已标准。
+            if (
+                isinstance(raw_json.get("tags"), dict)
+                and isinstance(raw_json.get("meta"), dict)
+            ):
                 continue
             
             normalized = normalize_caption_json(raw_json)


### PR DESCRIPTION
Fixes #345

## 根因

issue 里的 caption 文件形状 `{"tags": [扁平list], "meta": {"trigger": ...}}` **是 Studio 自己写出的规范格式**（`tag_worker.py` 本地打标器 + JSON 格式 + 触发词路径，`docs/user-guide/caption-format.md` 亦文档化），不是用户数据不合规。

训练端 `dataset.py:_process_caption_json` 里有一份 copy 出来的格式探测：`if "tags" in raw_json and "meta" in raw_json` 只查 key 存在、不查类型，把扁平 list 误判为"已是标准分类格式"，**跳过 normalize 适配器**直接喂给只认分类 dict 的 `build_caption_from_json` → `'list' object has no attribute 'get'`。权威实现 `caption_utils.load_and_build_caption` 早已用 `isinstance(tags, dict)` 修正了同一判断，dataset.py 那份漂移了没跟上。

**受影响组合**：本地打标（wd14/cltagger）+ JSON 输出。LLM 打标（分类形状）和 TXT 用户不受影响——这也是 bug 存活至今的原因。

## 更糟的部分：失败是静默的

JSON 样本没有 txt 兜底（`_make_sample` 里 prefer_json 命中时显式置 `txt_path=None`），解析失败被吞成逐样本 warning 后 `caption=""`——**这些图以空 caption（连触发词都没有）参与训练，训练照常跑完**。issue 用户那一炉的报错图就是这么训的。

## 改动

1. **根因修**：`_process_caption_json` 删掉漂移的格式探测，整段委托 `load_and_build_caption` 单一源，杜绝再次漂移
2. **静默降级治理**：新增开训预检 `_preflight_json_captions`——任何 JSON caption 构建失败，开训前集中列出文件并直接报错拒绝开训（fail-fast），不再空 caption 白炼；`shuffle=False + dropout=0` 保证预检确定性、不消耗随机数状态；`caption_override` 场景跳过
3. **同款漂移顺手治**：`batch_convert_json` CLI 的"已标准就跳过"判断对齐为 `isinstance(tags, dict)`，扁平 list 文件不再被误判跳过转换

## 测试

- 新增 `test_json_caption_list_shape_does_not_crash_issue_345`：issue 原始 payload 回归（不崩、trigger 首位、去重）
- 新增 `test_json_caption_preflight_rejects_broken_json` / `test_json_caption_preflight_passes_healthy_flat_json`
- `tests/test_datasets.py` 27 passed；`test_caption_snapshot.py` + `test_anima_reg_caption.py` + `test_tagedit.py` 35 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)