### PR TITLE
feat(tagging): 落盘格式跟着产物走 + TXT 路径补 tag_dropout

### DIFF
--- a/docs/user-guide/caption-format.md
+++ b/docs/user-guide/caption-format.md
@@ -121,12 +121,22 @@ tags: ["looking at viewer", "smile", "standing"]
 
 ## 如何生成
 
-在 Studio 的打标页用 **LLM 打标器**、选 JSON 输出预设（如 `general_json` / `style_json`）即可自动生成符合此格式的 JSON 文件。
+落盘格式跟着打标产物走，不再单独选择输出格式：
+
+- **LLM 打标器 + JSON 输出预设**（如 `general_json` / `style_json`）→ 生成符合此格式的 `.json` 文件
+- **本地打标器**（wd14 / CLTagger）与 **LLM 文本预设** → 生成 `.txt` 文件（触发词 prepend 在第一位）
+- 图片已有 `.json` 时，重新打标会更新其中的 `tags` 数组并保留其余字段（含 `meta.trigger`），不改变文件格式
 
 生成的 JSON 包含：
 - 从目录结构提取的 character/variant
 - LLM 打标的 count/appearance/tags/environment/nl
 - 配置中的 fixed 字段
+
+### Legacy 扁平格式
+
+早期版本的本地打标器可选输出 `{"tags": ["tag1", "tag2", ...], "meta": {"trigger": "..."}}`
+形式的扁平 JSON（tags 为列表而非分类对象）。该格式**读取永久兼容**——训练时
+`meta.trigger` 在第一位、其余 tags 作为可打乱区处理——但不再新生成。
 
 ## 配置示例
 
@@ -142,11 +152,17 @@ tag_dropout: 0.05        # 可选：5% 标签随机丢弃
 
 ## 回退机制
 
-如果 JSON 文件不存在或解析失败，会自动回退到同名 TXT 文件：
+同名 caption 文件按扩展名取优先级（文件级，扫描时决定）：
 
 ```
 优先级: image001.json > image001.txt
 ```
+
+注意：优先级是文件级的（扫描时按扩展名决定）——选中 `.json` 后不会再逐样本
+回退同名 `.txt`。
+
+TXT 模式下 `tag_dropout` 同样生效：`keep_tokens` 前缀不参与打乱与 dropout，
+其余 tag 逐个独立丢弃（与 kohya 语义一致）。
 
 ## 迁移指南
 

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -342,7 +342,12 @@ class ImageDataset(Dataset):
         return samples
 
     def _process_caption_txt(self, caption):
-        """处理 TXT caption: 传统 tag 打乱 + keep_tokens"""
+        """处理 TXT caption：kohya 语义的 keep_tokens + shuffle + tag_dropout。
+
+        keep_tokens 前缀既不参与打乱也不参与 dropout（kohya 同款语义——dropout
+        可能丢掉触发词是生态已知行为，保护靠用户显式配 keep_tokens，不做隐式
+        按值保护）；其余 tag 先 shuffle 再逐个独立 dropout，无保底。
+        """
         if not caption:
             return ""
         if "," in caption:
@@ -350,16 +355,14 @@ class ImageDataset(Dataset):
         else:
             tags = caption.split()
 
-        if self.keep_tokens > 0:
-            kept = tags[:self.keep_tokens]
-            rest = tags[self.keep_tokens:]
-            if self.shuffle_caption:
-                random.shuffle(rest)
-            tags = kept + rest
-        elif self.shuffle_caption:
-            random.shuffle(tags)
+        kept = tags[:self.keep_tokens]
+        rest = tags[self.keep_tokens:]
+        if self.shuffle_caption:
+            random.shuffle(rest)
+        if self.tag_dropout > 0:
+            rest = [t for t in rest if random.random() > self.tag_dropout]
 
-        return ", ".join(tags)
+        return ", ".join(kept + rest)
 
     def _process_caption_json(self, json_path):
         """处理 JSON caption: 分类 shuffle"""

--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -104,11 +104,6 @@ def start_tag(pid: int, vid: int, body: TagJobRequest) -> dict[str, Any]:
             code="tag.tagger_invalid", details={"name": body.tagger},
             http_status=400,
         )
-    if body.output_format not in {"txt", "json"}:
-        raise ValidationError(
-            "Output format must be txt or json",
-            code="tag.output_format_invalid", http_status=400,
-        )
     if body.on_existing not in {"overwrite", "skip", "append"}:
         raise ValidationError(
             "On-existing mode must be overwrite, skip, or append",
@@ -131,7 +126,6 @@ def start_tag(pid: int, vid: int, body: TagJobRequest) -> dict[str, Any]:
     params: dict[str, Any] = {
         "tagger": body.tagger,
         "version_id": vid,
-        "output_format": body.output_format,
     }
     # 默认值 "overwrite" 不写入 params（worker 端默认就是 overwrite），减小 payload。
     if body.on_existing != "overwrite":

--- a/studio/api/schemas/training.py
+++ b/studio/api/schemas/training.py
@@ -57,7 +57,9 @@ class LLMTaggerOverrides(BaseModel):
 
 class TagJobRequest(BaseModel):
     tagger: str = "wd14"
-    output_format: str = "txt"                # "txt" | "json"
+    # 落盘格式跟着产物走，不再由请求指定（老客户端传 output_format 会被忽略）：
+    # LLM json preset 产出结构化 caption_json → .json；其余（本地打标 tag list /
+    # LLM text preset）→ .txt。已存在的 .json 仍按 .json 更新。
     # 已有 caption 文件时的策略："overwrite"（默认，覆盖）| "skip"（保留原文件）
     # | "append"（tag 级 merge + dedupe，写回原格式）。
     on_existing: str = "overwrite"

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -96,7 +96,8 @@ class TrainingConfig(BaseModel):
     )
     keep_tokens: int = Field(
         0, ge=0,
-        description="保护前 N 个标签不打乱（仅 TXT 模式）",
+        description="保护前 N 个标签不参与打乱与 dropout（仅 TXT 模式；JSON 模式由"
+                    " meta.trigger 与固定字段承担同类角色）",
         json_schema_extra=_meta("caption"),
     )
     flip_augment: bool = Field(

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -2303,10 +2303,10 @@ export const api = {
     vid: number,
     body: {
       tagger: TaggerName
-      output_format?: 'txt' | 'json'
       /**
        * 已有 caption 文件时的策略：overwrite（默认覆盖）/ skip（保留原文件）
        * / append（tag 级 merge + dedupe 后写回原格式）。
+       * 落盘格式跟着产物走（LLM json preset → .json，其余 → .txt），不再由请求指定。
        */
       on_existing?: 'overwrite' | 'skip' | 'append'
       /**

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -126,7 +126,7 @@ export default function TaggingPage() {
 
   const [tagger, setTagger] = useState<TaggerName>('wd14')
   const [taggerStatus, setTaggerStatus] = useState<TaggerStatus | null>(null)
-  const [outputFormat, setOutputFormat] = useState<'txt' | 'json'>('txt')
+  // 落盘格式跟着产物走（LLM json preset → .json，其余 → .txt），不再由请求指定。
   const [onExisting, setOnExisting] = useState<'overwrite' | 'skip' | 'append'>('overwrite')
   // 触发词：初值从 activeVersion 取（持久化在 version 表）；启动打标时一并提交，
   // 后端会同步落库 + 传给 worker prepend 到每张 caption。
@@ -293,7 +293,7 @@ export default function TaggingPage() {
       const overrides = wd14_overrides ?? cltagger_overrides ?? llm_overrides
       const trigger = triggerWord.trim()
       const j = await api.startTag(project.id, activeVersion.id, {
-        tagger, output_format: outputFormat, on_existing: onExisting,
+        tagger, on_existing: onExisting,
         scope,
         wd14_overrides, cltagger_overrides, llm_overrides,
         // 传 trigger 永远，让 server 决定是否落库（与现有值比较），空串显式清空
@@ -411,18 +411,6 @@ export default function TaggingPage() {
                 <option key={f} value={f}>{f}</option>
               ))}
               <option value="validation">{t('tag.scopeValidation')}</option>
-            </select>
-
-            <span className="text-dim">|</span>
-            <span className="text-fg-tertiary">format</span>
-            <select
-              value={outputFormat}
-              onChange={(e) => setOutputFormat(e.target.value as 'txt' | 'json')}
-              className="input text-sm"
-              style={{ padding: '3px 8px' }}
-            >
-              <option value="txt">.txt</option>
-              <option value="json">.json</option>
             </select>
 
             <span className="text-dim">|</span>

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -4,10 +4,14 @@
     {
       "tagger": "wd14" | "cltagger" | "joycaption",
       "version_id": int,
-      "output_format": "txt"|"json",  # 默认 "txt"，已存在的 .json 仍按 .json 写
       "on_existing": "overwrite"|"skip"|"append",  # 默认 "overwrite"
       "<tagger>_overrides": {...}     # 可选；本次任务对全局 settings 的覆盖
     }
+
+落盘格式跟着产物走：LLM json preset 产出结构化 caption_json → .json；其余
+（本地打标 tag list / LLM text preset）→ .txt。已存在的 .json 仍按 .json 更新
+（格式决策唯一入口是 LLM preset 的 output_format；请求级 output_format 已删，
+老客户端传了会被忽略）。
 
 打标永远覆盖 train/ 下全部 repeat 子目录（不再支持按 folder 划分）。
 
@@ -115,7 +119,6 @@ def run(job_id: int) -> int:
     try:
         tagger_name = params.get("tagger", "wd14")
         version_id = int(params["version_id"])
-        fmt = str(params.get("output_format", "txt"))
         # 触发词：worker 端 prepend 到 caption 第一位。空串 / 缺省 = 不启用。
         trigger_word = str(params.get("trigger_word") or "").strip()
         on_existing = str(params.get("on_existing") or "overwrite")
@@ -143,7 +146,7 @@ def run(job_id: int) -> int:
 
         progress(
             f"[start] tagger={tagger_name} version={v['label']} "
-            f"images={total_images} format={fmt} on_existing={on_existing}"
+            f"images={total_images} on_existing={on_existing}"
         )
         if trigger_word:
             progress(f"[trigger] '{trigger_word}' 将作为第一个 tag prepend 到每张图")
@@ -180,7 +183,6 @@ def run(job_id: int) -> int:
             action = _write_caption(
                 r["image"],
                 r.get("tags") or [],
-                fmt,
                 caption_text=r.get("caption"),
                 caption_json=r.get("caption_json"),
                 trigger_word=trigger_word,
@@ -229,14 +231,15 @@ def _prepend_trigger_to_text(text: str, trigger_word: str) -> str:
 def _write_caption(
     image: Path,
     tags: list[str],
-    fmt: str,
     *,
     caption_text: str | None = None,
     caption_json: dict[str, Any] | None = None,
     trigger_word: str = "",
     on_existing: str = "overwrite",
 ) -> str:
-    """fmt 仅决定「不存在 caption 时」用什么格式；已存在的 .json 仍走 .json。
+    """落盘格式跟着产物走：caption_json（LLM json preset）→ .json；
+    其余（本地打标 tag list / LLM text preset）→ .txt；已存在的 .json 仍走
+    .json 更新（tagedit 路径）。请求级 output_format 已删。
 
     on_existing：已有 caption 文件（.txt 或 .json）时的策略
       - "overwrite"（默认）：覆盖（原行为）
@@ -247,9 +250,8 @@ def _write_caption(
 
     trigger_word 非空时（仅 overwrite 路径需特殊 prepend；append 走 merge 顺序自然处理）：
       - 标签列表：作为第 0 项 prepend（去重）
-      - 字符串 caption：prepend 到最前
       - JSON：写入 ``meta.trigger`` 字段；caption_utils.build_caption_from_json
-        会把它作为输出的第一个 token，不参与 shuffle —— 与 .txt 路径行为一致。
+        会把它作为输出的第一个 token，不参与 shuffle / dropout。
     """
     existing_path = tagedit.caption_path(image)
     if existing_path is not None:
@@ -266,36 +268,22 @@ def _write_caption(
             )
             return "appended"
     if caption_json is not None:
-        if fmt == "json":
-            doc = standard_to_documented_full(caption_json)
-            if trigger_word:
-                meta = doc.get("meta")
-                if not isinstance(meta, dict):
-                    meta = {}
-                meta["trigger"] = trigger_word
-                doc["meta"] = meta
-            image.with_suffix(".json").write_text(
-                json.dumps(doc, ensure_ascii=False, indent=2),
-                encoding="utf-8",
-            )
-            image.with_suffix(".txt").unlink(missing_ok=True)
-            return "wrote"
-        text = caption_text if caption_text is not None else caption_json_to_text(caption_json)
-        text = _prepend_trigger_to_text(text, trigger_word)
-        image.with_suffix(".txt").write_text(text, encoding="utf-8")
-        image.with_suffix(".json").unlink(missing_ok=True)
-        return "wrote"
-    if fmt == "json" and not image.with_suffix(".txt").exists():
-        # 强制写 json（即使没有现成 json 文件）
-        data: dict[str, Any] = {"tags": _prepend_trigger_to_tags(tags, trigger_word)}
+        # LLM 结构化产物 → 落 .json（documented full 形状）
+        doc = standard_to_documented_full(caption_json)
         if trigger_word:
-            data["meta"] = {"trigger": trigger_word}
+            meta = doc.get("meta")
+            if not isinstance(meta, dict):
+                meta = {}
+            meta["trigger"] = trigger_word
+            doc["meta"] = meta
         image.with_suffix(".json").write_text(
-            json.dumps(data, ensure_ascii=False, indent=2),
+            json.dumps(doc, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
+        image.with_suffix(".txt").unlink(missing_ok=True)
         return "wrote"
-    # 否则交给 tagedit 决定（已有 .json 就写 .json，否则 .txt）。
+    # 非结构化产物（本地打标 tag list / LLM text preset）交给 tagedit 决定
+    # （已有 .json 就写 .json，否则 .txt）。
     # 已有 .json 时 tagedit 保留其他字段（包括 meta.trigger 如有），只覆盖 tags 数组；
     # 这里我们把 trigger prepend 进 tags list，并保证 .json 走 tagedit 的同时也补 meta.trigger。
     new_tags = _prepend_trigger_to_tags(tags, trigger_word)

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -442,6 +442,26 @@ def test_parse_repeat_kohya_prefix() -> None:
     assert datasets.parse_repeat("0_zero") == (0, "zero")
 
 
+def test_txt_caption_tag_dropout_kohya_semantics(tmp_path: Path) -> None:
+    """TXT 路径 tag_dropout（kohya 语义）：keep_tokens 前缀免 shuffle 免 dropout，
+    其余 tag 逐个独立 dropout、无保底。dropout 丢触发词是生态已知行为，保护靠
+    用户显式配 keep_tokens。"""
+    pytest.importorskip("torch")
+    from runtime.training.dataset import ImageDataset
+
+    # dropout=1.0 → 非保护区全部丢弃（确定性）；keep_tokens 前缀原序保留
+    ds = ImageDataset(tmp_path, shuffle_caption=True, keep_tokens=2, tag_dropout=1.0)
+    assert ds._process_caption_txt("trigger, quality, a, b, c") == "trigger, quality"
+
+    # keep_tokens=0 + dropout=1.0 → 全丢、无保底（kohya 同款）
+    ds_all = ImageDataset(tmp_path, shuffle_caption=False, keep_tokens=0, tag_dropout=1.0)
+    assert ds_all._process_caption_txt("a, b, c") == ""
+
+    # dropout=0 → 原样（不 shuffle 时顺序不变）
+    ds_off = ImageDataset(tmp_path, shuffle_caption=False, keep_tokens=0, tag_dropout=0.0)
+    assert ds_off._process_caption_txt("a, b, c") == "a, b, c"
+
+
 def test_caption_kind_priority(tmp_path: Path) -> None:
     img = _touch_image(tmp_path, "a.png")
     assert datasets.caption_kind(img) == "none"

--- a/tests/test_tag_endpoints.py
+++ b/tests/test_tag_endpoints.py
@@ -81,13 +81,13 @@ def test_start_tag_creates_job(client: TestClient) -> None:
     pid, vid = _make(client)
     r = client.post(
         f"/api/projects/{pid}/versions/{vid}/tag",
-        json={"tagger": "wd14", "output_format": "txt"},
+        json={"tagger": "wd14"},
     )
     assert r.status_code == 200, r.text
     job = r.json()
     assert job["kind"] == "tag"
     assert job["status"] == "pending"
-    # 不再有 folders 入参；params 只剩 tagger / version_id / output_format
+    # 不再有 folders 入参；params 只剩 tagger / version_id
     import json as _json
     p_dict = _json.loads(job["params"])
     assert "folders" not in p_dict
@@ -103,13 +103,17 @@ def test_start_tag_unknown_tagger_400(client: TestClient) -> None:
     assert r.status_code == 400
 
 
-def test_start_tag_bad_format_400(client: TestClient) -> None:
+def test_start_tag_legacy_output_format_ignored(client: TestClient) -> None:
+    """请求级 output_format 已删（格式跟着产物走）；老客户端传了任意值 → 忽略、
+    不进 params、不报错。"""
+    import json as _json
     pid, vid = _make(client)
     r = client.post(
         f"/api/projects/{pid}/versions/{vid}/tag",
         json={"tagger": "wd14", "output_format": "yaml"},
     )
-    assert r.status_code == 400
+    assert r.status_code == 200, r.text
+    assert "output_format" not in _json.loads(r.json()["params"])
 
 
 def test_start_tag_scope_validation_into_params(client: TestClient) -> None:
@@ -152,7 +156,6 @@ def test_start_tag_with_wd14_overrides(client: TestClient) -> None:
         f"/api/projects/{pid}/versions/{vid}/tag",
         json={
             "tagger": "wd14",
-            "output_format": "txt",
             "wd14_overrides": {
                 "threshold_general": 0.2,
                 "blacklist_tags": ["solo"],
@@ -175,7 +178,6 @@ def test_start_tag_with_cltagger_overrides(client: TestClient) -> None:
         f"/api/projects/{pid}/versions/{vid}/tag",
         json={
             "tagger": "cltagger",
-            "output_format": "txt",
             "cltagger_overrides": {
                 "threshold_general": 0.25,
                 "threshold_character": 0.55,
@@ -202,7 +204,6 @@ def test_start_tag_with_llm_overrides(client: TestClient) -> None:
         f"/api/projects/{pid}/versions/{vid}/tag",
         json={
             "tagger": "llm",
-            "output_format": "json",
             "llm_overrides": {
                 "current_preset": "joycaption",
                 "endpoint": "responses",
@@ -335,7 +336,6 @@ def test_start_tag_drops_empty_wd14_overrides(client: TestClient) -> None:
         f"/api/projects/{pid}/versions/{vid}/tag",
         json={
             "tagger": "wd14",
-            "output_format": "txt",
             "wd14_overrides": {
                 "threshold_general": None,
                 "threshold_character": None,
@@ -352,7 +352,7 @@ def test_start_tag_on_existing_skip(client: TestClient) -> None:
     pid, vid = _make(client)
     r = client.post(
         f"/api/projects/{pid}/versions/{vid}/tag",
-        json={"tagger": "wd14", "output_format": "txt", "on_existing": "skip"},
+        json={"tagger": "wd14", "on_existing": "skip"},
     )
     assert r.status_code == 200, r.text
     params = _json.loads(r.json()["params"])
@@ -364,7 +364,7 @@ def test_start_tag_on_existing_append(client: TestClient) -> None:
     pid, vid = _make(client)
     r = client.post(
         f"/api/projects/{pid}/versions/{vid}/tag",
-        json={"tagger": "wd14", "output_format": "txt", "on_existing": "append"},
+        json={"tagger": "wd14", "on_existing": "append"},
     )
     assert r.status_code == 200, r.text
     params = _json.loads(r.json()["params"])
@@ -377,7 +377,7 @@ def test_start_tag_on_existing_overwrite_not_persisted(client: TestClient) -> No
     pid, vid = _make(client)
     r = client.post(
         f"/api/projects/{pid}/versions/{vid}/tag",
-        json={"tagger": "wd14", "output_format": "txt", "on_existing": "overwrite"},
+        json={"tagger": "wd14", "on_existing": "overwrite"},
     )
     assert r.status_code == 200, r.text
     params = _json.loads(r.json()["params"])
@@ -388,7 +388,7 @@ def test_start_tag_on_existing_bad_value_400(client: TestClient) -> None:
     pid, vid = _make(client)
     r = client.post(
         f"/api/projects/{pid}/versions/{vid}/tag",
-        json={"tagger": "wd14", "output_format": "txt", "on_existing": "bogus"},
+        json={"tagger": "wd14", "on_existing": "bogus"},
     )
     assert r.status_code == 400
 

--- a/tests/test_tag_worker.py
+++ b/tests/test_tag_worker.py
@@ -93,7 +93,6 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
             params={
                 "tagger": "wd14",
                 "version_id": v["id"],
-                "output_format": "txt",
             },
         )
     return {"db": dbfile, "p": p, "v": v, "job_id": job["id"], "train": train}
@@ -106,8 +105,9 @@ def test_run_creates_txt_captions(env) -> None:
     assert (env["train"] / "b.txt").read_text(encoding="utf-8") == "tag_b, common"
 
 
-def test_run_with_json_format(env, monkeypatch: pytest.MonkeyPatch) -> None:
-    # 改 job 的 output_format 为 json
+def test_legacy_output_format_param_is_ignored(env, monkeypatch: pytest.MonkeyPatch) -> None:
+    """老客户端仍可能传 output_format=json —— 请求级格式已删，worker 应忽略：
+    本地打标（无 caption_json）新 caption 一律落 .txt。"""
     with db.connection_for(env["db"]) as conn:
         conn.execute(
             "UPDATE project_jobs SET params = json_set(params, '$.output_format', 'json') "
@@ -117,8 +117,8 @@ def test_run_with_json_format(env, monkeypatch: pytest.MonkeyPatch) -> None:
         conn.commit()
     rc = tag_worker.run(env["job_id"])
     assert rc == 0
-    data = json.loads((env["train"] / "a.json").read_text(encoding="utf-8"))
-    assert data["tags"] == ["tag_a", "common"]
+    assert (env["train"] / "a.txt").read_text(encoding="utf-8") == "tag_a, common"
+    assert not (env["train"] / "a.json").exists()
 
 
 def test_run_passes_wd14_overrides_through(env, monkeypatch) -> None:
@@ -173,29 +173,7 @@ def test_run_passes_cltagger_overrides_through(env, monkeypatch) -> None:
 
 
 def test_run_writes_llm_json_caption(env, monkeypatch) -> None:
-    monkeypatch.setattr(
-        "studio.workers.tag_worker.get_tagger",
-        lambda name, overrides=None: _FakeLLMTagger(),
-    )
-    with db.connection_for(env["db"]) as conn:
-        conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, "
-            "'$.tagger', 'llm', '$.output_format', 'json') WHERE id = ?",
-            (env["job_id"],),
-        )
-        conn.commit()
-
-    rc = tag_worker.run(env["job_id"])
-    assert rc == 0
-    data = json.loads((env["train"] / "a.json").read_text(encoding="utf-8"))
-    assert data["ai_output"]["count"] == "1girl"
-    assert data["ai_output"]["appearance"] == ["watercolor"]
-    assert data["ai_output"]["environment"] == ["blue background"]
-    assert data["ai_output"]["nl"] == "Soft watercolor style."
-    assert not (env["train"] / "a.txt").exists()
-
-
-def test_run_writes_llm_txt_caption(env, monkeypatch) -> None:
+    """LLM json preset 产出 caption_json → 落 .json（格式跟着产物走，无需请求级 fmt）。"""
     monkeypatch.setattr(
         "studio.workers.tag_worker.get_tagger",
         lambda name, overrides=None: _FakeLLMTagger(),
@@ -210,9 +188,52 @@ def test_run_writes_llm_txt_caption(env, monkeypatch) -> None:
 
     rc = tag_worker.run(env["job_id"])
     assert rc == 0
+    data = json.loads((env["train"] / "a.json").read_text(encoding="utf-8"))
+    assert data["ai_output"]["count"] == "1girl"
+    assert data["ai_output"]["appearance"] == ["watercolor"]
+    assert data["ai_output"]["environment"] == ["blue background"]
+    assert data["ai_output"]["nl"] == "Soft watercolor style."
+    assert not (env["train"] / "a.txt").exists()
+
+
+class _FakeLLMTextTagger:
+    """LLM text preset：只有 caption 文本，无 caption_json（对齐 llm.py 真实返回）。"""
+    name = "llm"
+    requires_service = True
+
+    def is_available(self):
+        return True, "ok"
+
+    def prepare(self):
+        pass
+
+    def tag(self, paths, on_progress=lambda d, t: None):
+        text = "1girl, watercolor, blue background. Soft watercolor style."
+        for i, p in enumerate(paths):
+            on_progress(i + 1, len(paths))
+            yield {"image": p, "tags": [text], "caption": text}
+
+
+def test_run_writes_llm_txt_caption(env, monkeypatch) -> None:
+    """LLM text preset 无 caption_json → 落 .txt（格式跟着产物走）。"""
+    monkeypatch.setattr(
+        "studio.workers.tag_worker.get_tagger",
+        lambda name, overrides=None: _FakeLLMTextTagger(),
+    )
+    with db.connection_for(env["db"]) as conn:
+        conn.execute(
+            "UPDATE project_jobs SET params = json_set(params, '$.tagger', 'llm') "
+            "WHERE id = ?",
+            (env["job_id"],),
+        )
+        conn.commit()
+
+    rc = tag_worker.run(env["job_id"])
+    assert rc == 0
     assert (env["train"] / "a.txt").read_text(encoding="utf-8") == (
         "1girl, watercolor, blue background. Soft watercolor style."
     )
+    assert not (env["train"] / "a.json").exists()
 
 
 def test_run_unknown_job(env) -> None:
@@ -243,25 +264,25 @@ def test_trigger_word_prepended_to_txt(env) -> None:
     assert (env["train"] / "b.txt").read_text(encoding="utf-8") == "ohwx, tag_b, common"
 
 
-def test_trigger_word_writes_meta_in_simple_json(env) -> None:
-    """fmt=json + tagger 只给 tags list（无 caption_json）→ meta.trigger 写入。"""
+def test_trigger_word_writes_meta_when_updating_existing_json(env) -> None:
+    """已有 .json（legacy 扁平格式）+ 本地打标 → tagedit 更新 tags 并补 meta.trigger；
+    没有 caption 的图落 .txt（不再新写扁平 json）。"""
     _set_trigger(env, "ohwx")
-    with db.connection_for(env["db"]) as conn:
-        conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.output_format', 'json') "
-            "WHERE id = ?",
-            (env["job_id"],),
-        )
-        conn.commit()
+    (env["train"] / "a.json").write_text(
+        json.dumps({"tags": ["old"]}), encoding="utf-8"
+    )
     rc = tag_worker.run(env["job_id"])
     assert rc == 0
     data = json.loads((env["train"] / "a.json").read_text(encoding="utf-8"))
     assert data["tags"] == ["ohwx", "tag_a", "common"]
     assert data["meta"]["trigger"] == "ohwx"
+    # b 没有现成 caption → 新写 .txt（trigger prepend），不产生 .json
+    assert (env["train"] / "b.txt").read_text(encoding="utf-8") == "ohwx, tag_b, common"
+    assert not (env["train"] / "b.json").exists()
 
 
 def test_trigger_word_writes_meta_in_llm_json(env, monkeypatch) -> None:
-    """LLM tagger + fmt=json → documented_full 增加顶层 meta.trigger。"""
+    """LLM json preset（caption_json）→ documented_full 增加顶层 meta.trigger。"""
     _set_trigger(env, "ohwx")
     monkeypatch.setattr(
         "studio.workers.tag_worker.get_tagger",
@@ -269,8 +290,8 @@ def test_trigger_word_writes_meta_in_llm_json(env, monkeypatch) -> None:
     )
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, "
-            "'$.tagger', 'llm', '$.output_format', 'json') WHERE id = ?",
+            "UPDATE project_jobs SET params = json_set(params, '$.tagger', 'llm') "
+            "WHERE id = ?",
             (env["job_id"],),
         )
         conn.commit()
@@ -284,11 +305,11 @@ def test_trigger_word_writes_meta_in_llm_json(env, monkeypatch) -> None:
 
 
 def test_trigger_word_prepended_to_llm_txt(env, monkeypatch) -> None:
-    """LLM tagger + fmt=txt → caption_text 前 prepend trigger。"""
+    """LLM text preset（无 caption_json）→ .txt 前 prepend trigger。"""
     _set_trigger(env, "ohwx")
     monkeypatch.setattr(
         "studio.workers.tag_worker.get_tagger",
-        lambda name, overrides=None: _FakeLLMTagger(),
+        lambda name, overrides=None: _FakeLLMTextTagger(),
     )
     with db.connection_for(env["db"]) as conn:
         conn.execute(
@@ -343,8 +364,9 @@ def test_trigger_word_empty_string_no_op(env) -> None:
 
 
 def test_trigger_word_dataset_loader_sees_meta(env, tmp_path: Path) -> None:
-    """端到端：worker 写 meta.trigger → utils.caption_utils.build_caption_from_json
-    把 trigger 输出在第一位。验证 dataset 训练时确实拿到 trigger。"""
+    """端到端：worker 更新已有 .json 写 meta.trigger →
+    utils.caption_utils.load_and_build_caption 把 trigger 输出在第一位。
+    验证 dataset 训练时确实拿到 trigger。"""
     import sys
 
     # 把仓库根加进 sys.path 让 `import utils.caption_utils` 工作
@@ -354,13 +376,9 @@ def test_trigger_word_dataset_loader_sees_meta(env, tmp_path: Path) -> None:
     from utils.caption_utils import load_and_build_caption
 
     _set_trigger(env, "ohwx")
-    with db.connection_for(env["db"]) as conn:
-        conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.output_format', 'json') "
-            "WHERE id = ?",
-            (env["job_id"],),
-        )
-        conn.commit()
+    (env["train"] / "a.json").write_text(
+        json.dumps({"tags": ["old"]}), encoding="utf-8"
+    )
     rc = tag_worker.run(env["job_id"])
     assert rc == 0
     caption = load_and_build_caption(env["train"] / "a.json", shuffle=False)


### PR DESCRIPTION
关联 #345 的产品层收口（bug 修复本体在 #352）。

## 动机

#345 排查暴露的产品问题：本地打标器（wd14/cltagger）+ JSON 输出组合产出的扁平 JSON（tags 为 list、无分类），相对 .txt 的独有价值只有两点——meta.trigger 自动保护、tag_dropout 生效（TXT 路径此前根本没实现 dropout）。与其维护一个"json 格式的 txt"，不如把这两点价值归位，格式选项收敛。

## 改动

**1. 落盘格式跟着产物走（删请求级 output_format）**

| 打标产物 | 落盘 |
|---|---|
| LLM json preset（caption_json） | `.json`（documented full） |
| 本地打标 tag list / LLM text preset | `.txt`（触发词 prepend 首位） |
| 图片已有 `.json` | 仍按 `.json` 更新（tags + meta.trigger），格式不变 |

格式决策唯一入口 = LLM preset 的 `output_format`。打标页的 format 选择器删除；老客户端传 `output_format` 被 pydantic 忽略，不报错（有回归测试）。

**2. TXT 路径补 tag_dropout（kohya 语义）**

`_process_caption_txt`：`keep_tokens` 前缀免 shuffle 免 dropout，其余 tag 逐个独立 dropout、无保底。**不做触发词按值隐式保护**——dropout 可能丢触发词是生态已知行为，保护靠用户显式配 keep_tokens（隐式保护会和显式配置语义打架，比如 keep_tokens=1 实际保护到非触发词）。`keep_tokens` schema 描述同步更新。

**3. 兼容性**

- 存量扁平 JSON 数据集：训练端读取兼容**永久保留**（#352 修复的路径），重新打标走 tagedit 保留 json 格式与 meta.trigger —— 老用户零影响
- 新数据集：本地打标一律 .txt，不再产生新的扁平 json

**4. 文档**：caption-format.md 更新生成方式、补 legacy 扁平格式说明、修正"回退机制"错误描述（json 选中后并无逐样本 txt 回退——`_make_sample` 置 `txt_path=None`）。

## 测试

- `test_tag_worker.py`：格式跟着产物走全路径（本地→txt / LLM json→json / LLM text→txt / legacy 参数忽略 / 已有 json 更新+meta.trigger）
- `test_tag_endpoints.py`：legacy output_format 忽略不进 params
- `test_datasets.py`：txt dropout kohya 语义（keep_tokens 保护 / 无保底 / dropout=0 原样）
- 后端 108 passed（datasets/tag_worker/tag_endpoints/tagedit/caption_snapshot）；前端 `npm run build` + vitest 全绿

与 #352（读取端修复 + 预检）分支独立、无重叠 hunk，合并顺序任意。

🤖 Generated with [Claude Code](https://claude.com/claude-code)