### PR TITLE
fix(announcements): 默认选中 effect stale closure 覆盖用户点击（正文切换 flake 真因）

### DIFF
--- a/studio/web/src/components/AnnouncementCenter.test.tsx
+++ b/studio/web/src/components/AnnouncementCenter.test.tsx
@@ -66,14 +66,11 @@ describe('AnnouncementCenter', () => {
     fireEvent.click(screen.getByTestId('announcement-item-p-notice'))
     await waitFor(() =>
       expect(screen.queryByTestId('announcement-dot-p-notice')).toBeNull())
-    // 正文切换是点击后异步渲染（markdown），跟红点消失不同 tick；CI 慢机上同步
-    // getByText 会 flake（红点已消失但正文未渲染）→ 用 waitFor 等正文到位。
-    // waitFor 默认 1s 超时在 CI 慢机上仍不够（#349 后再次发作，实测 1047ms
-    // 耗尽默认窗口）→ 显式放宽到 5s；本地正常毫秒级完成，不拖慢绿色路径。
-    await waitFor(
-      () => expect(screen.getByText('公告正文')).toBeInTheDocument(),
-      { timeout: 5000 },
-    )
+    // 正文切换与红点消失不同 tick → waitFor 等正文到位。曾两次 CI flake
+    // （#349 补 waitFor、后又超时）：真因是组件默认选中 effect 的 stale closure
+    // 会覆盖点击选中（已在 AnnouncementCenter 内改函数式更新修复），非等待不够长。
+    await waitFor(() =>
+      expect(screen.getByText('公告正文')).toBeInTheDocument())
   })
 
   it('tag 过滤只显示该类', async () => {

--- a/studio/web/src/components/AnnouncementCenter.test.tsx
+++ b/studio/web/src/components/AnnouncementCenter.test.tsx
@@ -68,8 +68,12 @@ describe('AnnouncementCenter', () => {
       expect(screen.queryByTestId('announcement-dot-p-notice')).toBeNull())
     // 正文切换是点击后异步渲染（markdown），跟红点消失不同 tick；CI 慢机上同步
     // getByText 会 flake（红点已消失但正文未渲染）→ 用 waitFor 等正文到位。
-    await waitFor(() =>
-      expect(screen.getByText('公告正文')).toBeInTheDocument())
+    // waitFor 默认 1s 超时在 CI 慢机上仍不够（#349 后再次发作，实测 1047ms
+    // 耗尽默认窗口）→ 显式放宽到 5s；本地正常毫秒级完成，不拖慢绿色路径。
+    await waitFor(
+      () => expect(screen.getByText('公告正文')).toBeInTheDocument(),
+      { timeout: 5000 },
+    )
   })
 
   it('tag 过滤只显示该类', async () => {

--- a/studio/web/src/components/AnnouncementCenter.tsx
+++ b/studio/web/src/components/AnnouncementCenter.tsx
@@ -61,20 +61,27 @@ export function AnnouncementCenter() {
     [posts],
   )
 
-  // 打开 / 切换过滤后，默认选中第一篇并标记已读。
+  // 打开 / 切换过滤后，默认选中第一篇。必须用函数式更新读「当前」选中值：
+  // 旧实现直接读闭包里的 selectedId，慢机上用户点击（setSelectedId）可能发生在
+  // 本 effect 的 passive flush 之前，effect 随后带着 stale 的 selectedId=null 跑，
+  // 把用户刚点的选中覆盖回第一篇——红点已消（markRead 生效）但正文永远不切换
+  // （#349 / #354 两次 CI flake 的真因，测试侧加 waitFor 等不来）。
   useEffect(() => {
     if (!open) return
     if (filtered.length === 0) { setSelectedId(null); return }
-    if (selectedId === null || !filtered.some((p) => p.id === selectedId)) {
-      setSelectedId(filtered[0].id)
-      markRead(filtered[0].id)
-    }
-  }, [open, filtered, selectedId, markRead])
+    setSelectedId((cur) =>
+      cur !== null && filtered.some((p) => p.id === cur) ? cur : filtered[0].id)
+  }, [open, filtered])
+
+  // 选中即已读——默认选中和点击选中共用这一条路径。
+  useEffect(() => {
+    if (selectedId !== null) markRead(selectedId)
+  }, [selectedId, markRead])
 
   if (!open) return null
 
   const selected = posts.find((p) => p.id === selectedId) ?? null
-  const select = (p: AnnouncementPost) => { setSelectedId(p.id); markRead(p.id) }
+  const select = (p: AnnouncementPost) => setSelectedId(p.id)
   const tagLabel = (tg: 'all' | AnnouncementPost['tag']) => t(`announcements.tags.${tg}`)
 
   return (


### PR DESCRIPTION
`AnnouncementCenter` 「点另一篇 → 正文切换」测试两次 CI flake（#349 修过一次、本 PR CI 又发作）的**真因不是等待不够长**，是组件里一个真实竞态：

## 竞态

「打开后默认选中第一篇」的 effect 直接读闭包里的 `selectedId`：

```
提交渲染（selectedId=null，effect 尚未 flush）
  → 用户点击 p-notice：setSelectedId('p-notice') + markRead('p-notice')
  → 旧 effect 这时才跑，闭包里 selectedId===null 成立
  → 选中被覆盖回 filtered[0]（p-migration）
```

最终状态**稳定在错误值**：p-notice 红点消失（markRead 生效）、正文永远停在第一篇。与两次 CI 失败逐字吻合——首次 waitFor 默认 1s 耗尽（1047ms），本 PR 首个 commit 放宽到 5s 后仍在 5008ms 吃满测试超时。bimodal（要么秒过要么永不出现）说明不是慢机，是死状态。

用户可复现同款 bug：打开公告栏的瞬间快速点击另一篇，选中会被跳回第一篇。

## 修复

- 选中兜底改**函数式更新**读当前值——任何 effect/点击交错顺序下，用户选择都不会被 stale closure 覆盖
- 「选中即已读」拆成独立 effect，默认选中与点击选中共用一条路径
- 回退首个 commit 的 5s 超时创可贴，测试恢复 #349 的普通 waitFor（注释记录真因）

## 验证

- `AnnouncementCenter.test.tsx` 本地连跑 10 次 6/6 全过
- 全量 vitest 434/434、`npm run build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)