### PR TITLE
feat(queue): R-2 台账合并 schema —— tasks 承接数据作业字段（零行为变化）

### DIFF
--- a/studio/infrastructure/db.py
+++ b/studio/infrastructure/db.py
@@ -42,8 +42,15 @@ TERMINAL_STATUSES = {"done", "failed", "canceled"}
 # pending，到点由 supervisor tick 提升（promote_due_scheduled）。
 LIVE_STATUSES = ("running", "paused", "pending", "scheduled")
 HISTORY_STATUSES = ("done", "failed", "canceled")
-# tasks.task_type 的合法值（_v5 migration）；0.17 P-F 类型过滤校验用。
-VALID_TASK_TYPES = ("train", "reg_ai", "generate")
+# tasks.task_type 的合法值。R-2 台账合并起扩容纳九类数据作业 kind——tasks 表
+# 是全部工作项的统一台账（写路径切换在 R-3）。档位归属的权威在
+# supervisor/resources.py（infrastructure 不反向依赖 supervisor，此处平铺
+# 列出，tests/test_resource_admission.py 有同步断言防漂移）。
+VALID_TASK_TYPES = (
+    "train", "reg_ai", "generate",
+    "download", "preprocess", "tag", "reg_build",
+    "eval_samples", "eval_clip", "eval_dino", "eval_tag", "eval_ccip",
+)
 
 
 def connect(path: Optional[Path] = None) -> sqlite3.Connection:
@@ -82,7 +89,18 @@ def init_db(path: Optional[Path] = None) -> None:
 
 
 def _row_to_dict(row: Optional[sqlite3.Row]) -> Optional[dict[str, Any]]:
-    return dict(row) if row else None
+    if not row:
+        return None
+    out = dict(row)
+    # R-2：params（kind 专属参数 JSON，_v17）附带解码，消费端免二次 parse
+    # （同 project_jobs DAO 的 params_decoded 约定）。
+    if isinstance(out.get("params"), str):
+        try:
+            import json as _json
+            out["params_decoded"] = _json.loads(out["params"])
+        except Exception:
+            out["params_decoded"] = None
+    return out
 
 
 def create_task(
@@ -92,7 +110,20 @@ def create_task(
     config_name: str,
     priority: int = 0,
     scheduled_at: Optional[float] = None,
+    task_type: Optional[str] = None,
+    params: Optional[dict[str, Any]] = None,
+    project_id: Optional[int] = None,
+    version_id: Optional[int] = None,
 ) -> int:
+    """建 pending（或 scheduled）task。
+
+    R-2 台账合并：tasks 表承接全部工作项。`task_type` 缺省 'train'（老调用方
+    兼容）；数据作业类（download/tag/…）带 `params`（kind 专属参数 JSON）+
+    project_id/version_id 入库。写路径切换（services 从 create_job 改到这里）
+    在 R-3。
+    """
+    if task_type is not None and task_type not in VALID_TASK_TYPES:
+        raise ValueError(f"invalid task_type: {task_type!r}")
     # ADR-0009 PR-1 C6: 入 task 时存当前 ContextVar trace_id（HTTP 请求那一刻
     # 由 TraceIdMiddleware 已 bind）。无则用 bg-{uuid} 标后台触发（CLI / 测试 /
     # supervisor 直接拉起）。supervisor dispatcher 后续读这个列 → env 注入
@@ -102,11 +133,15 @@ def create_task(
     # 0.17 P-B：带 scheduled_at → 建成 scheduled，supervisor tick 到点提升为
     # pending。过去的时间也照建 —— 下一个 tick（≤1s）自然提升，无需特判。
     status = "scheduled" if scheduled_at is not None else "pending"
+    import json as _json
     cur = conn.execute(
         "INSERT INTO tasks(name, config_name, status, priority, created_at, "
-        "request_trace_id, scheduled_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        "request_trace_id, scheduled_at, task_type, params, project_id, version_id) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, COALESCE(?, 'train'), ?, ?, ?)",
         (name, config_name, status, priority, time.time(), request_trace_id,
-         scheduled_at),
+         scheduled_at, task_type,
+         _json.dumps(params) if params is not None else None,
+         project_id, version_id),
     )
     conn.commit()
     return int(cur.lastrowid)
@@ -139,7 +174,7 @@ def list_tasks(
     else:
         sql = "SELECT * FROM tasks ORDER BY priority DESC, created_at ASC"
         params = ()
-    return [dict(r) for r in conn.execute(sql, params)]
+    return [_row_to_dict(r) or {} for r in conn.execute(sql, params)]
 
 
 def _escape_like(s: str) -> str:
@@ -222,7 +257,7 @@ def list_tasks_page(
     if limit is not None:
         sql += " LIMIT ? OFFSET ?"
         params = [*params, int(limit), int(offset)]
-    return [dict(r) for r in conn.execute(sql, params)]
+    return [_row_to_dict(r) or {} for r in conn.execute(sql, params)]
 
 
 def promote_due_scheduled(

--- a/studio/infrastructure/migrations/__init__.py
+++ b/studio/infrastructure/migrations/__init__.py
@@ -31,6 +31,7 @@ from ._v13_last_state import migrate as _migrate_v13
 from ._v14_generate_meta import migrate as _migrate_v14
 from ._v15_scheduled_at import migrate as _migrate_v15
 from ._v16_job_created_at import migrate as _migrate_v16
+from ._v17_unified_ledger import migrate as _migrate_v17
 
 Migration = Callable[[sqlite3.Connection], None]
 
@@ -51,6 +52,7 @@ MIGRATIONS: list[Migration] = [
     _migrate_v14, # v14: tasks.generate_params / generate_cover（0.17 P-I forward-write，前端暂不读）
     _migrate_v15, # v15: tasks.scheduled_at（0.17 P-B 计划任务，配套新 scheduled 状态）
     _migrate_v16, # v16: project_jobs.created_at（0.17 P-G 数据作业详情页入队时间）
+    _migrate_v17, # v17: tasks.params（R-2 台账合并——tasks 承接数据作业 kind 参数）
 ]
 
 

--- a/studio/infrastructure/migrations/_v17_unified_ledger.py
+++ b/studio/infrastructure/migrations/_v17_unified_ledger.py
@@ -1,0 +1,21 @@
+"""v16 → v17: tasks 加 params（0.17 R-2 台账合并第一步）。
+
+资源档位模型（docs/design/queue-resource-model-0.17.md §5 R-2）：project_jobs
+的九类数据作业将统一写入 tasks 表（写路径切换在 R-3），tasks 需要承接 job 的
+params JSON（kind 专属参数：打标器配置 / 下载标签词 / 正则构建选项……）。
+
+- params：kind 专属参数 JSON（同 project_jobs.params 语义）。train/reg_ai 恒
+  NULL（它们的配置在 config_path yaml）；generate 的参数快照另有 _v14 的
+  generate_params（时间线 forward-write，不混用）。
+
+NULLABLE，不 backfill。旧 project_jobs 表保留只读（Q-R2：不迁移旧行、不展示）。
+"""
+from __future__ import annotations
+
+import sqlite3
+
+from ._v2_projects import _add_column_if_missing
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    _add_column_if_missing(conn, "tasks", "params", "params TEXT")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -104,6 +104,15 @@ def test_v16_adds_job_created_at_column(tmp_path: Path) -> None:
         assert "created_at" in cols
 
 
+def test_v17_adds_tasks_params_column(tmp_path: Path) -> None:
+    """v17: tasks 加 params（R-2 台账合并），nullable 不 backfill。"""
+    dbfile = tmp_path / "fresh.db"
+    db.init_db(dbfile)
+    with _open(dbfile) as c:
+        cols = {r["name"] for r in c.execute("PRAGMA table_info(tasks)")}
+        assert "params" in cols
+
+
 def test_v1_db_upgrades_in_place_preserving_tasks(tmp_path: Path) -> None:
     """模拟 PP0 之前留下来的 v1 库（只有 tasks 表）：执行 init_db 应升到 v2 且数据不丢。"""
     dbfile = tmp_path / "legacy.db"

--- a/tests/test_unified_ledger.py
+++ b/tests/test_unified_ledger.py
@@ -1,0 +1,77 @@
+"""R-2 台账合并（schema 层）：tasks 承接数据作业字段（写路径切换在 R-3）。
+
+docs/design/queue-resource-model-0.17.md §5 R-2。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from studio import db
+
+
+@pytest.fixture
+def dbfile(tmp_path: Path) -> Path:
+    path = tmp_path / "studio.db"
+    db.init_db(path)
+    return path
+
+
+def test_valid_task_types_covers_all_resource_kinds() -> None:
+    """db.VALID_TASK_TYPES 与 supervisor/resources.py 档位映射保持同步。
+
+    档位归属权威在 resources.py；db 层平铺列出（infrastructure 不反向依赖
+    supervisor）。本断言防两边漂移。
+    """
+    from studio.supervisor.resources import (
+        JOB_KIND_RESOURCE_CLASS,
+        TASK_TYPE_RESOURCE_CLASS,
+    )
+    expected = set(TASK_TYPE_RESOURCE_CLASS) | set(JOB_KIND_RESOURCE_CLASS)
+    assert set(db.VALID_TASK_TYPES) == expected
+
+
+def test_create_task_accepts_job_kind_with_params(dbfile: Path) -> None:
+    """数据作业类 task：task_type + params + project/version 全字段落库回读。"""
+    with db.connection_for(dbfile) as conn:
+        tid = db.create_task(
+            conn, name="tag v1", config_name="tag",
+            task_type="tag",
+            params={"tagger": "wd14", "threshold": 0.35},
+            project_id=1, version_id=2,
+        )
+        task = db.get_task(conn, tid)
+    assert task["task_type"] == "tag"
+    assert task["params_decoded"] == {"tagger": "wd14", "threshold": 0.35}
+    assert task["project_id"] == 1 and task["version_id"] == 2
+    assert task["status"] == "pending"
+
+
+def test_create_task_defaults_unchanged(dbfile: Path) -> None:
+    """老调用方（不带新参数）行为不变：task_type=train、params NULL。"""
+    with db.connection_for(dbfile) as conn:
+        tid = db.create_task(conn, name="t", config_name="c")
+        task = db.get_task(conn, tid)
+    assert task["task_type"] == "train"
+    assert task["params"] is None
+    assert "params_decoded" not in task
+
+
+def test_create_task_rejects_unknown_type(dbfile: Path) -> None:
+    with db.connection_for(dbfile) as conn:
+        with pytest.raises(ValueError):
+            db.create_task(conn, name="x", config_name="c", task_type="banana")
+
+
+def test_params_decoded_in_list_paths(dbfile: Path) -> None:
+    """list_tasks / list_tasks_page 与 get_task 同样带 params_decoded。"""
+    with db.connection_for(dbfile) as conn:
+        db.create_task(
+            conn, name="dl", config_name="dl",
+            task_type="download", params={"tag": "usa", "count": 5},
+        )
+        via_list = db.list_tasks(conn, status="pending")[0]
+        via_page = db.list_tasks_page(conn, statuses=("pending",))[0]
+    assert via_list["params_decoded"] == {"tag": "usa", "count": 5}
+    assert via_page["params_decoded"] == {"tag": "usa", "count": 5}


### PR DESCRIPTION
## 概要

资源档位模型第二步（`docs/design/queue-resource-model-0.17.md` §5 R-2）。**纯 schema/承接层，零行为变化**——为 R-3 把九类数据作业的写路径从 project_jobs 切到 tasks 做好台账准备。

## 改动

- **`_v17` 迁移**：tasks 加 `params` 列（kind 专属参数 JSON）。train/reg_ai 恒 NULL（配置在 config_path yaml）；与 `_v14` 的 `generate_params`（时间线 forward-write）语义分开不混用。
- **`VALID_TASK_TYPES` 扩容 12 类**（train/reg_ai/generate + 9 个数据作业 kind）。档位归属权威在 `supervisor/resources.py`；db 层平铺列出（infrastructure 不反向依赖 supervisor），`test_unified_ledger.py` 有同步断言防两边漂移。
- **`create_task` 承接** `task_type` / `params` / `project_id` / `version_id`（keyword-only，全部老调用方零改动）；非法 task_type 拒绝（ValueError）。
- **tasks 读路径统一带 `params_decoded`**：`get_task` / `list_tasks` / `list_tasks_page` 三处经同一 `_row_to_dict`（同 project_jobs DAO 的约定）。

## 测试

新增 `tests/test_unified_ledger.py` ×5（类型同步断言 / job-kind task 全字段回读 / 老调用方默认不变 / 非法类型拒绝 / 三条读路径 params_decoded 一致）+ `_v17` 迁移用例。后端全量 2649 passed（1 fail 为已知本机 flaky `test_cancel_running_returns_immediately`）。前端无改动。

## 后续

R-3（下一个 PR，行为翻转）：services `create_job`→`create_task`、worker `--job-id` 读 tasks 行、DATA 槽从 tasks 按档位取活、`dispatch_order` 转默认 priority 种子、事件统一（R-4）与前端数据源合流（R-5）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)