### PR TITLE
feat(queue): R-3 写路径翻转 —— 数据作业统一进 tasks 台账（DAO 换底）

### DIFF
--- a/studio/api/routers/queue/lifecycle.py
+++ b/studio/api/routers/queue/lifecycle.py
@@ -130,19 +130,25 @@ def list_queue(
                 http_status=400,
             )
 
+    # R-3 台账合并：数据作业进了 tasks 表。GPU 视图（本端点）在 R-5 档位化前
+    # 默认排除 JOB_TASK_TYPES——显式 types 过滤时不排（调用方自己指定）。
     if group is None:
-        # 兼容旧行为：全量 + 隐藏 generate/reg_ai（无 group 调用方依赖此默认）。
+        # 兼容旧行为：全量 + 隐藏 generate/reg_ai（无 group 调用方依赖此默认）
+        # + 隐藏数据作业（保护 Topbar/Overview/Monitor 不把它们当训练任务）。
         with db.connection_for() as conn:
             items = db.list_tasks(conn, status=status)
+        items = db.filter_out_task_types(items, db.JOB_TASK_TYPES)
         if not include_generate:
             items = db.filter_out_task_types(items, ("generate", "reg_ai"))
         _enrich_tasks(items)
         return {"items": items}
 
+    exclude = () if type_tuple else db.JOB_TASK_TYPES
     if group == "live":
         with db.connection_for() as conn:
             items = db.list_tasks_page(
                 conn, statuses=db.LIVE_STATUSES, q=q, types=type_tuple,
+                exclude_types=exclude,
             )
         _enrich_tasks(items)
         return {"items": items}
@@ -156,10 +162,10 @@ def list_queue(
     offset = (page - 1) * page_size
     with db.connection_for() as conn:
         total = db.count_tasks(
-            conn, statuses=statuses, q=q, types=type_tuple,
+            conn, statuses=statuses, q=q, types=type_tuple, exclude_types=exclude,
         )
         items = db.list_tasks_page(
-            conn, statuses=statuses, q=q, types=type_tuple,
+            conn, statuses=statuses, q=q, types=type_tuple, exclude_types=exclude,
             limit=page_size, offset=offset,
         )
     _enrich_tasks(items)
@@ -415,7 +421,9 @@ def retry_task(task_id: int) -> dict[str, Any]:
             priority=original["priority"],
         )
         copy_fields: dict[str, Any] = {}
-        for k in ("config_path", "project_id", "version_id"):
+        # R-3：task_type / params 必须一并复制——数据作业类 task 重跑靠它们
+        # 路由 worker 与还原参数（漏了会退化成 train 跑错脚本）。
+        for k in ("config_path", "project_id", "version_id", "task_type", "params"):
             if original.get(k) is not None:
                 copy_fields[k] = original[k]
         if copy_fields:

--- a/studio/infrastructure/db.py
+++ b/studio/infrastructure/db.py
@@ -42,15 +42,18 @@ TERMINAL_STATUSES = {"done", "failed", "canceled"}
 # pending，到点由 supervisor tick 提升（promote_due_scheduled）。
 LIVE_STATUSES = ("running", "paused", "pending", "scheduled")
 HISTORY_STATUSES = ("done", "failed", "canceled")
-# tasks.task_type 的合法值。R-2 台账合并起扩容纳九类数据作业 kind——tasks 表
-# 是全部工作项的统一台账（写路径切换在 R-3）。档位归属的权威在
-# supervisor/resources.py（infrastructure 不反向依赖 supervisor，此处平铺
-# 列出，tests/test_resource_admission.py 有同步断言防漂移）。
-VALID_TASK_TYPES = (
-    "train", "reg_ai", "generate",
+# tasks.task_type 的合法值。R-2/R-3 台账合并：tasks 表是全部工作项的统一台账。
+# 档位归属的权威在 supervisor/resources.py（infrastructure 不反向依赖
+# supervisor，此处平铺列出，tests 有同步断言防漂移）。
+GPU_TASK_TYPES = ("train", "reg_ai", "generate")
+# 数据作业 kind（R-3 起写入 tasks）。/api/queue 的 GPU 视图在 R-5 档位化前
+# 默认排除它们（含 no-group 兼容路径，保护 Topbar/Overview/Monitor 不把
+# 数据作业当训练任务）。
+JOB_TASK_TYPES = (
     "download", "preprocess", "tag", "reg_build",
     "eval_samples", "eval_clip", "eval_dino", "eval_tag", "eval_ccip",
 )
+VALID_TASK_TYPES = GPU_TASK_TYPES + JOB_TASK_TYPES
 
 
 def connect(path: Optional[Path] = None) -> sqlite3.Connection:

--- a/studio/infrastructure/migrations/__init__.py
+++ b/studio/infrastructure/migrations/__init__.py
@@ -32,6 +32,7 @@ from ._v14_generate_meta import migrate as _migrate_v14
 from ._v15_scheduled_at import migrate as _migrate_v15
 from ._v16_job_created_at import migrate as _migrate_v16
 from ._v17_unified_ledger import migrate as _migrate_v17
+from ._v18_legacy_jobs_freeze import migrate as _migrate_v18
 
 Migration = Callable[[sqlite3.Connection], None]
 
@@ -53,6 +54,7 @@ MIGRATIONS: list[Migration] = [
     _migrate_v15, # v15: tasks.scheduled_at（0.17 P-B 计划任务，配套新 scheduled 状态）
     _migrate_v16, # v16: project_jobs.created_at（0.17 P-G 数据作业详情页入队时间）
     _migrate_v17, # v17: tasks.params（R-2 台账合并——tasks 承接数据作业 kind 参数）
+    _migrate_v18, # v18: 冻结旧 project_jobs（R-3 写路径翻转，残留 pending/running→canceled）
 ]
 
 

--- a/studio/infrastructure/migrations/_v18_legacy_jobs_freeze.py
+++ b/studio/infrastructure/migrations/_v18_legacy_jobs_freeze.py
@@ -1,0 +1,22 @@
+"""v17 → v18: 冻结旧 project_jobs 表（R-3 写路径翻转配套）。
+
+R-3 起数据作业统一写入 tasks（task_type = kind），supervisor 不再从
+project_jobs 派发。升级瞬间残留的 pending / running 旧行如果不处理会永远
+停在原状态（没人再调度它们）——一次性标 canceled 并注明原因。
+
+旧表其余行保留只读遗留（Q-R2：不迁移不展示，避免 ID 重映射污染 eval run
+引用与旧日志路径）。
+"""
+from __future__ import annotations
+
+import sqlite3
+import time
+
+
+def migrate(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        "UPDATE project_jobs SET status = 'canceled', finished_at = ?, "
+        "error_msg = 'superseded by unified ledger (0.17 R-3)' "
+        "WHERE status IN ('pending', 'running')",
+        (time.time(),),
+    )

--- a/studio/services/projects/jobs.py
+++ b/studio/services/projects/jobs.py
@@ -1,35 +1,34 @@
-"""project_jobs DAO（pp2 起）。
+"""数据作业 DAO —— R-3 起换底到 tasks 统一台账。
 
-`project_jobs` 是非训练异步任务（download / tag / reg_build）的统一调度
-台账。supervisor 像调度 `tasks` 一样调度它们；前端通过 SSE 看进度。
+接口保持 pp2 以来的形状（create_job / get_job / list_jobs / mark_* / …），
+调用方（workers / eval 服务 / API 路由 / supervisor）零改动；底下全部读写
+tasks 表（`task_type` = job kind，`params` JSON 为 _v17 列）。
 
-字段（参见 migrations/_v2_projects.py）：
-    id, project_id, version_id?, kind, params(JSON), status,
-    started_at, finished_at, pid, log_path, error_msg
+旧 `project_jobs` 表冻结为只读遗留：_v18 把残留 pending/running 标 canceled；
+Q-R2 拍板不展示、不迁移旧行（ID 重映射会污染 eval run 引用与 log 路径）。
+
+行形状兼容：返回 dict 在 tasks 行基础上注入
+    kind     = task_type
+    log_path = tasks/<id>/run.log（paths.task_log_path，worker stdout 落点）
+params_decoded 由 db._row_to_dict 统一提供（同旧 DAO 约定）。
 """
 from __future__ import annotations
 
-import json
 import sqlite3
 import time
 from pathlib import Path
 from typing import Any, Optional
 
-from ...paths import STUDIO_DATA
+from ...infrastructure import db
+from ...infrastructure.paths import STUDIO_DATA, task_log_path
 
+# 旧 project_jobs 独立日志目录（studio_data/jobs/<id>.log）。R-3 起新作业日志
+# 走 tasks/<id>/run.log；此常量仅供遗留只读与老测试 fixture 引用。
 JOB_LOGS_DIR = STUDIO_DATA / "jobs"
 
-VALID_KINDS: frozenset[str] = frozenset({
-    "download",
-    "preprocess",
-    "tag",
-    "reg_build",
-    "eval_samples",
-    "eval_clip",
-    "eval_dino",
-    "eval_tag",
-    "eval_ccip",
-})
+# kind 全集（权威在 db.JOB_TASK_TYPES，保序 tuple 供 SQL IN；frozenset 供校验）。
+JOB_TASK_TYPES: tuple[str, ...] = db.JOB_TASK_TYPES
+VALID_KINDS: frozenset[str] = frozenset(JOB_TASK_TYPES)
 VALID_STATUSES: frozenset[str] = frozenset({
     "pending", "running", "done", "failed", "canceled"
 })
@@ -43,7 +42,7 @@ from studio.domain.errors import DomainError
 
 
 class JobError(DomainError):
-    """project_jobs 业务错误。
+    """数据作业业务错误。
 
     PR-2 C3 加 DomainError base — handler 自动翻 dual-write envelope。
     """
@@ -51,20 +50,17 @@ class JobError(DomainError):
 
 
 def log_path_for(job_id: int) -> Path:
-    JOB_LOGS_DIR.mkdir(parents=True, exist_ok=True)
-    return JOB_LOGS_DIR / f"{job_id}.log"
+    """作业日志路径。R-3 起 = tasks/<id>/run.log（与 GPU 任务同款布局）。"""
+    return task_log_path(job_id)
 
 
-def _row_to_dict(row: Optional[sqlite3.Row]) -> Optional[dict[str, Any]]:
-    if not row:
+def as_job(task: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+    """tasks 行 → 作业 dict（注入 kind / log_path 兼容字段），就地改并返回。"""
+    if not task:
         return None
-    out = dict(row)
-    if isinstance(out.get("params"), str):
-        try:
-            out["params_decoded"] = json.loads(out["params"])
-        except Exception:
-            out["params_decoded"] = None
-    return out
+    task["kind"] = task.get("task_type") or "train"
+    task["log_path"] = str(task_log_path(int(task["id"])))
+    return task
 
 
 def create_job(
@@ -77,30 +73,23 @@ def create_job(
 ) -> dict[str, Any]:
     if kind not in VALID_KINDS:
         raise JobError(f"非法 kind: {kind!r}")
-    cur = conn.execute(
-        "INSERT INTO project_jobs(project_id, version_id, kind, params, status, created_at) "
-        "VALUES (?, ?, ?, ?, 'pending', ?)",
-        (project_id, version_id, kind, json.dumps(params), time.time()),
+    jid = db.create_task(
+        conn,
+        name=kind,
+        config_name=kind,
+        task_type=kind,
+        params=params,
+        project_id=project_id,
+        version_id=version_id,
     )
-    conn.commit()
-    jid = int(cur.lastrowid)
-    log = log_path_for(jid)
-    conn.execute(
-        "UPDATE project_jobs SET log_path = ? WHERE id = ?",
-        (str(log), jid),
-    )
-    conn.commit()
-    return _row_to_dict(_row(conn, jid)) or {}
+    return as_job(db.get_task(conn, jid)) or {}
 
 
 def get_job(conn: sqlite3.Connection, jid: int) -> Optional[dict[str, Any]]:
-    return _row_to_dict(_row(conn, jid))
-
-
-def _row(conn: sqlite3.Connection, jid: int) -> Optional[sqlite3.Row]:
-    return conn.execute(
-        "SELECT * FROM project_jobs WHERE id = ?", (jid,)
-    ).fetchone()
+    task = db.get_task(conn, jid)
+    if not task or (task.get("task_type") or "train") not in VALID_KINDS:
+        return None
+    return as_job(task)
 
 
 def list_jobs(
@@ -111,22 +100,37 @@ def list_jobs(
     kind: Optional[str] = None,
     status: Optional[str] = None,
 ) -> list[dict[str, Any]]:
-    sql = "SELECT * FROM project_jobs WHERE 1=1"
-    params: list[Any] = []
+    if kind is not None:
+        type_clause = "task_type = ?"
+        params: list[Any] = [kind]
+    else:
+        type_clause = f"task_type IN ({','.join('?' for _ in JOB_TASK_TYPES)})"
+        params = list(JOB_TASK_TYPES)
+    sql = f"SELECT * FROM tasks WHERE {type_clause}"
     if project_id is not None:
         sql += " AND project_id = ?"
         params.append(project_id)
     if version_id is not None:
         sql += " AND version_id = ?"
         params.append(version_id)
-    if kind is not None:
-        sql += " AND kind = ?"
-        params.append(kind)
     if status is not None:
         sql += " AND status = ?"
         params.append(status)
     sql += " ORDER BY id DESC"
-    return [_row_to_dict(r) or {} for r in conn.execute(sql, params)]
+    return [as_job(db._row_to_dict(r)) or {} for r in conn.execute(sql, params)]
+
+
+def list_pending_fifo(conn: sqlite3.Connection) -> list[dict[str, Any]]:
+    """supervisor 派发用：pending 数据作业按 `priority DESC, created_at ASC`
+    （与 GPU 任务同一 FIFO 语义，D-R3 平级；dispatch_order 硬编码已删）。"""
+    placeholders = ",".join("?" for _ in JOB_TASK_TYPES)
+    rows = conn.execute(
+        f"SELECT * FROM tasks WHERE status = 'pending' "
+        f"AND task_type IN ({placeholders}) "
+        "ORDER BY priority DESC, created_at ASC",
+        JOB_TASK_TYPES,
+    )
+    return [as_job(db._row_to_dict(r)) or {} for r in rows]
 
 
 def _escape_like(q: str) -> str:
@@ -141,8 +145,11 @@ def _jobs_filter(
     where = f" WHERE status IN ({placeholders})"
     params: list[Any] = list(statuses)
     if kind:
-        where += " AND kind = ?"
+        where += " AND task_type = ?"
         params.append(kind)
+    else:
+        where += f" AND task_type IN ({','.join('?' for _ in JOB_TASK_TYPES)})"
+        params.extend(JOB_TASK_TYPES)
     if q:
         # jobs 自身没有 name —— 按所属项目的 title / slug 搜（下沉 SQL 保 total 准）。
         like = f"%{_escape_like(q)}%"
@@ -163,7 +170,7 @@ def count_jobs(
 ) -> int:
     """0.17 P-G — 按状态组（+ 可选 kind / 项目名搜索）计数，供 history 分页 total。"""
     where, params = _jobs_filter(statuses, kind, q)
-    row = conn.execute(f"SELECT COUNT(*) FROM project_jobs{where}", params).fetchone()
+    row = conn.execute(f"SELECT COUNT(*) FROM tasks{where}", params).fetchone()
     return int(row[0])
 
 
@@ -178,33 +185,23 @@ def list_jobs_page(
 ) -> list[dict[str, Any]]:
     """0.17 P-G — 按状态组取 job，`id DESC`；limit=None 不分页（live 组全量）。"""
     where, params = _jobs_filter(statuses, kind, q)
-    sql = f"SELECT * FROM project_jobs{where} ORDER BY id DESC"
+    sql = f"SELECT * FROM tasks{where} ORDER BY id DESC"
     if limit is not None:
         sql += " LIMIT ? OFFSET ?"
         params = [*params, int(limit), int(offset)]
-    return [_row_to_dict(r) or {} for r in conn.execute(sql, params)]
+    return [as_job(db._row_to_dict(r)) or {} for r in conn.execute(sql, params)]
 
 
-def dispatch_order(job: dict[str, Any]) -> tuple[int, int]:
-    """Return supervisor dispatch priority for pending project jobs.
-
-    Eval metric jobs should not sit behind a long tail of newly queued
-    eval_samples. Once a sample exists, users need the lightweight metric jobs
-    to finish before spending more GPU time generating more checkpoint samples.
-    """
-    kind = str(job.get("kind") or "")
-    priority = {
-        "eval_clip": 0,
-        "eval_dino": 0,
-        "eval_tag": 0,
-        "eval_ccip": 0,
-        "download": 1,
-        "preprocess": 1,
-        "tag": 1,
-        "reg_build": 1,
-        "eval_samples": 2,
-    }.get(kind, 1)
-    return priority, int(job.get("id") or 0)
+def count_active(
+    conn: sqlite3.Connection, *, version_id: int, kind: str
+) -> int:
+    """该 version 下指定 kind 的 pending/running 数（phase 门禁用）。"""
+    row = conn.execute(
+        "SELECT COUNT(*) FROM tasks "
+        "WHERE version_id = ? AND task_type = ? AND status IN ('pending', 'running')",
+        (version_id, kind),
+    ).fetchone()
+    return int(row[0])
 
 
 def latest_for(
@@ -214,62 +211,35 @@ def latest_for(
     kind: str,
     version_id: Optional[int] = None,
 ) -> Optional[dict[str, Any]]:
-    """取该项目（+ 可选 version）下最近一条指定 kind 的 job。"""
-    sql = (
-        "SELECT * FROM project_jobs WHERE project_id = ? AND kind = ?"
-    )
+    """取该项目（+ 可选 version）下最近一条指定 kind 的作业。"""
+    sql = "SELECT * FROM tasks WHERE project_id = ? AND task_type = ?"
     params: list[Any] = [project_id, kind]
     if version_id is not None:
         sql += " AND version_id = ?"
         params.append(version_id)
     sql += " ORDER BY id DESC LIMIT 1"
     row = conn.execute(sql, params).fetchone()
-    return _row_to_dict(row)
-
-
-def next_pending(conn: sqlite3.Connection) -> Optional[dict[str, Any]]:
-    row = conn.execute(
-        "SELECT * FROM project_jobs WHERE status = 'pending' "
-        "ORDER BY id ASC LIMIT 1"
-    ).fetchone()
-    return _row_to_dict(row)
+    return as_job(db._row_to_dict(row))
 
 
 def mark_running(
     conn: sqlite3.Connection, jid: int, *, pid: Optional[int] = None
 ) -> None:
-    conn.execute(
-        "UPDATE project_jobs SET status = 'running', started_at = ?, pid = ? "
-        "WHERE id = ?",
-        (time.time(), pid, jid),
-    )
-    conn.commit()
+    db.update_task(conn, jid, status="running", started_at=time.time(), pid=pid)
 
 
 def mark_done(conn: sqlite3.Connection, jid: int) -> None:
-    conn.execute(
-        "UPDATE project_jobs SET status = 'done', finished_at = ? WHERE id = ?",
-        (time.time(), jid),
-    )
-    conn.commit()
+    db.update_task(conn, jid, status="done", finished_at=time.time())
 
 
 def mark_failed(conn: sqlite3.Connection, jid: int, error_msg: str) -> None:
-    conn.execute(
-        "UPDATE project_jobs SET status = 'failed', finished_at = ?, "
-        "error_msg = ? WHERE id = ?",
-        (time.time(), error_msg, jid),
+    db.update_task(
+        conn, jid, status="failed", finished_at=time.time(), error_msg=error_msg
     )
-    conn.commit()
 
 
 def mark_canceled(conn: sqlite3.Connection, jid: int) -> None:
-    conn.execute(
-        "UPDATE project_jobs SET status = 'canceled', finished_at = ? "
-        "WHERE id = ?",
-        (time.time(), jid),
-    )
-    conn.commit()
+    db.update_task(conn, jid, status="canceled", finished_at=time.time())
 
 
 def update_status(
@@ -290,17 +260,15 @@ def update_status(
     elif status == "canceled":
         mark_canceled(conn, jid)
     elif status == "pending":
-        conn.execute(
-            "UPDATE project_jobs SET status = 'pending', "
-            "started_at = NULL, finished_at = NULL, pid = NULL, error_msg = NULL "
-            "WHERE id = ?",
-            (jid,),
+        db.update_task(
+            conn, jid, status="pending",
+            started_at=None, finished_at=None, pid=None, error_msg=None,
         )
-        conn.commit()
 
 
 def cleanup_orphan_running(conn: sqlite3.Connection) -> int:
-    """启动时把残留的 running 状态 job 标 failed（孤儿子进程已死）。"""
+    """启动清孤儿。作业已并入 tasks，由 supervisor 的 task 孤儿收割统一处理；
+    这里只兜旧 project_jobs 遗留表（_v18 已冻结，此处幂等再保险）。"""
     cur = conn.execute(
         "UPDATE project_jobs SET status = 'failed', finished_at = ?, "
         "error_msg = 'supervisor restart; orphan job' "

--- a/studio/services/projects/phase.py
+++ b/studio/services/projects/phase.py
@@ -67,15 +67,9 @@ def check_editing(stats: dict[str, Any]) -> CheckResult:
 def check_regularizing(
     conn: sqlite3.Connection, version_id: int
 ) -> CheckResult:
-    """无 reg_build job 处于 pending/running（§11.5-B；可跳过 = 不强求正则集非空）。"""
-    row = conn.execute(
-        "SELECT COUNT(*) FROM project_jobs "
-        "WHERE version_id = ? "
-        "  AND kind = 'reg_build' "
-        "  AND status IN ('pending', 'running')",
-        (version_id,),
-    ).fetchone()
-    if int(row[0]) > 0:
+    """无 reg_build 作业处于 pending/running（§11.5-B；可跳过 = 不强求正则集非空）。"""
+    from . import jobs as project_jobs
+    if project_jobs.count_active(conn, version_id=version_id, kind="reg_build") > 0:
         return CheckResult(False, "正则任务进行中，请等待完成")
     return CheckResult(True)
 
@@ -88,14 +82,8 @@ def check_preprocessing(
     跟 `check_regularizing` 同 pattern——预处理是可选 phase（upscale / crop /
     去重等都可跳过，接受训练时默认放大算法）；校验仅防 concurrent job 撞车。
     """
-    row = conn.execute(
-        "SELECT COUNT(*) FROM project_jobs "
-        "WHERE version_id = ? "
-        "  AND kind = 'preprocess' "
-        "  AND status IN ('pending', 'running')",
-        (version_id,),
-    ).fetchone()
-    if int(row[0]) > 0:
+    from . import jobs as project_jobs
+    if project_jobs.count_active(conn, version_id=version_id, kind="preprocess") > 0:
         return CheckResult(False, "预处理任务进行中，请等待完成")
     return CheckResult(True)
 

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -464,10 +464,13 @@ class Supervisor:
             return
         if self._exclusive_busy():
             return
-        task = self._next_pending_task_in(("train", "reg_ai", "generate"))
+        task = self._next_pending_task_in(
+            ("train", "reg_ai", "generate", "eval_samples")
+        )
         if task is None:
             return
-        if (task.get("task_type") or "train") == "generate":
+        ttype = task.get("task_type") or "train"
+        if ttype == "generate":
             # enqueue_generate 先 create_task(pending) 再写 config.json 落
             # config_path —— 两步之间这条 task 已 pending 但 config_path 还是
             # NULL。此时别提交（daemon 会报 "config not found"），等下个 tick。
@@ -475,6 +478,19 @@ class Supervisor:
             if not task.get("config_path"):
                 return
             self._submit_to_daemon(task)
+            return
+        if ttype == "eval_samples":
+            # R-3：exclusive 档数据作业。排队语义与 train/generate 同一 FIFO
+            # （D-R3 跨类型平级），执行位在 DATA 槽（worker 子进程）。DATA 槽
+            # 被 light 作业占着时等它结束（light 都是短任务），不越队。
+            data_slot = next(
+                (s for s in self._slots if s.name == SLOT_DATA), None
+            )
+            if data_slot is None or data_slot.busy:
+                return
+            if self._maybe_yield_daemon():
+                return
+            self._spawn_job(data_slot, project_jobs.as_job(dict(task)) or task)
             return
         # train / reg_ai：daemon 常驻模型是 exclusive 租约，spawn 前必须吊销
         # （unload 释放 VRAM）。daemon 在跑 generate 的情况已被 _exclusive_busy
@@ -537,16 +553,14 @@ class Supervisor:
         exclusive_busy = self._exclusive_busy()
         light_parallel = self._light_tasks_during_train()
         with db.connection_for(self._db_path) as conn:
-            pending = project_jobs.list_jobs(conn, status="pending")
-        pending.sort(key=project_jobs.dispatch_order)
+            pending = project_jobs.list_pending_fifo(conn)
         for job in pending:
             cls = job_resource_class(job["kind"])
             if cls == RESOURCE_EXCLUSIVE:
-                if exclusive_busy:
-                    continue
-                if self._maybe_yield_daemon():
-                    continue  # 吊销 daemon 租约，等下次 tick
-            elif cls == RESOURCE_LIGHT:
+                # eval_samples 走 exclusive 统一 FIFO（_dispatch_exclusive_tasks
+                # 与 train/generate 平级排队），本函数只管 light + io。
+                continue
+            if cls == RESOURCE_LIGHT:
                 if exclusive_busy and not light_parallel:
                     continue
                 if not light_parallel and self._maybe_yield_daemon():
@@ -1402,8 +1416,9 @@ class Supervisor:
                 elif status == "canceled":
                     project_jobs.mark_canceled(conn, cid)
                 else:
-                    # B-1.6: 同 task — tail jobs log 拼 error_msg
-                    tail = _tail_log_for_error_msg(self._logs_dir / f"{cid}.log")
+                    # B-1.6: 同 task — tail 作业 log 拼 error_msg。
+                    # R-3：作业日志已随台账合并搬到 tasks/<id>/run.log。
+                    tail = _tail_log_for_error_msg(project_jobs.log_path_for(cid))
                     err_msg = f"exit code {rc}\n{tail}" if tail else f"exit code {rc}"
                     project_jobs.mark_failed(conn, cid, err_msg)
                 job = project_jobs.get_job(conn, cid)

--- a/tests/test_jobs_list_endpoint.py
+++ b/tests/test_jobs_list_endpoint.py
@@ -33,7 +33,7 @@ def _seed_job(pid: int, kind: str, status: str) -> int:
             conn, project_id=pid, kind=kind, params={"n": 1}
         )
         conn.execute(
-            "UPDATE project_jobs SET status = ? WHERE id = ?", (status, job["id"])
+            "UPDATE tasks SET status = ? WHERE id = ?", (status, job["id"])
         )
         conn.commit()
     return int(job["id"])

--- a/tests/test_phase_endpoints.py
+++ b/tests/test_phase_endpoints.py
@@ -135,12 +135,11 @@ def test_skip_regularizing_blocked_by_running_job(client: TestClient) -> None:
     p, v = _make_pv(client)
     with db.connection_for() as conn:
         versions.update_version(conn, v["id"], phase="regularizing")
-        conn.execute(
-            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
-            "VALUES (?, ?, 'reg_build', '{}', 'running')",
-            (p["id"], v["id"]),
+        job = project_jobs.create_job(
+            conn, project_id=p["id"], version_id=v["id"],
+            kind="reg_build", params={},
         )
-        conn.commit()
+        project_jobs.update_status(conn, job["id"], "running")
     resp = client.post(f"/api/projects/{p['id']}/versions/{v['id']}/skip-phase")
     body = resp.json()
     assert body["advanced"] is False

--- a/tests/test_project_jobs.py
+++ b/tests/test_project_jobs.py
@@ -31,7 +31,8 @@ def test_create_job_assigns_log_path(isolated) -> None:
             params={"tag": "x", "count": 5},
         )
     assert job["status"] == "pending"
-    assert job["log_path"].endswith(f"{job['id']}.log")
+    # R-3 台账合并：作业日志与 GPU 任务同款布局 tasks/<id>/run.log
+    assert job["log_path"].replace("\\", "/").endswith(f"{job['id']}/run.log")
     assert job["params_decoded"] == {"tag": "x", "count": 5}
 
 
@@ -83,13 +84,15 @@ def test_mark_failed_sets_error_msg(isolated) -> None:
     assert got["error_msg"] == "boom"
 
 
-def test_next_pending_picks_oldest(isolated) -> None:
+def test_list_pending_fifo_picks_oldest_first(isolated) -> None:
+    """R-3：派发顺序 = priority DESC, created_at ASC（与 GPU 任务同 FIFO 语义）。"""
     with db.connection_for(isolated["db"]) as conn:
         a = project_jobs.create_job(conn, project_id=isolated['project_id'], kind="download", params={})
         b = project_jobs.create_job(conn, project_id=isolated['project_id'], kind="download", params={})
-        project_jobs.mark_running(conn, b["id"])
-        nxt = project_jobs.next_pending(conn)
-    assert nxt and nxt["id"] == a["id"]
+        db.update_task(conn, a["id"], created_at=100.0)
+        db.update_task(conn, b["id"], created_at=200.0)
+        pending = project_jobs.list_pending_fifo(conn)
+    assert [j["id"] for j in pending] == [a["id"], b["id"]]
 
 
 def test_latest_for_returns_most_recent(isolated) -> None:
@@ -100,17 +103,26 @@ def test_latest_for_returns_most_recent(isolated) -> None:
     assert latest and latest["id"] == b["id"]
 
 
-def test_cleanup_orphan_running(isolated) -> None:
+def test_cleanup_orphan_running_only_touches_legacy_table(isolated) -> None:
+    """R-3：作业已并入 tasks（孤儿由 supervisor task 收割统一处理）；
+    cleanup_orphan_running 只兜旧 project_jobs 遗留表。"""
     with db.connection_for(isolated["db"]) as conn:
+        # 新作业（tasks 表）running —— cleanup 不碰它
         job = project_jobs.create_job(
             conn, project_id=isolated['project_id'], kind="download", params={}
         )
         project_jobs.mark_running(conn, job["id"])
+        # 旧表遗留 running 行 —— cleanup 标 failed
+        conn.execute(
+            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
+            "VALUES (?, NULL, 'download', '{}', 'running')",
+            (isolated["project_id"],),
+        )
+        conn.commit()
         n = project_jobs.cleanup_orphan_running(conn)
         got = project_jobs.get_job(conn, job["id"])
     assert n == 1
-    assert got["status"] == "failed"
-    assert "orphan" in (got["error_msg"] or "")
+    assert got["status"] == "running", "tasks 表的新作业不该被 legacy cleanup 碰"
 
 
 def test_list_jobs_filters(isolated) -> None:

--- a/tests/test_reg_build_worker.py
+++ b/tests/test_reg_build_worker.py
@@ -137,7 +137,7 @@ def test_worker_full_mode_clears_existing_reg(env) -> None:
     # set incremental=False
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs "
+            "UPDATE tasks "
             "SET params = json_set(params, '$.incremental', 0, "
             "                      '$.auto_dedup', 0) "
             "WHERE id = ?",
@@ -208,7 +208,7 @@ def test_worker_auto_dedup_disabled_skips_scan(env, monkeypatch) -> None:
     monkeypatch.setattr("studio.services.reg.dedup.scan_for_dedup", fake_scan)
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = "
+            "UPDATE tasks SET params = "
             "json_set(params, '$.auto_dedup', 0) WHERE id = ?",
             (env["job_id"],),
         )
@@ -232,7 +232,7 @@ def test_worker_routes_to_cltagger_when_kind_set(env, monkeypatch) -> None:
     )
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs "
+            "UPDATE tasks "
             "SET params = json_set(params, '$.auto_tag_kind', 'cltagger') "
             "WHERE id = ?",
             (env["job_id"],),
@@ -269,7 +269,7 @@ def test_worker_skips_auto_tag_when_disabled(env) -> None:
     # 改 job 的 auto_tag 为 False
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.auto_tag', 0) "
+            "UPDATE tasks SET params = json_set(params, '$.auto_tag', 0) "
             "WHERE id = ?",
             (env["job_id"],),
         )

--- a/tests/test_resource_admission.py
+++ b/tests/test_resource_admission.py
@@ -224,7 +224,11 @@ def test_light_deferred_when_switch_off_but_io_still_runs(
 
 
 def test_eval_samples_requires_daemon_lease_release(env, fake_daemon, fake_secrets):
-    """eval_samples 与 train 同规格：daemon idle 常驻模型 → 先吊销租约再派。"""
+    """eval_samples 与 train 同规格：daemon idle 常驻模型 → 先吊销租约再派。
+
+    R-3 起 eval_samples 走 exclusive 统一 FIFO（_dispatch_exclusive_tasks），
+    执行位仍是 DATA 槽。
+    """
     fake_daemon.is_model_loaded = True
     fake_daemon.is_busy = False
     sup = _make_sup(env)
@@ -232,13 +236,36 @@ def test_eval_samples_requires_daemon_lease_release(env, fake_daemon, fake_secre
     sup._spawn_job = lambda slot, job: spawned_jobs.append(job)  # type: ignore
     _make_job(env, kind="eval_samples")
 
-    sup._dispatch_data(_slot(sup, "data"))
+    sup._dispatch_exclusive_tasks(_slot(sup, "train"))
     assert spawned_jobs == []
     fake_daemon.request_unload.assert_called_once()
 
     fake_daemon.is_model_loaded = False
-    sup._dispatch_data(_slot(sup, "data"))
+    sup._dispatch_exclusive_tasks(_slot(sup, "train"))
     assert len(spawned_jobs) == 1
+    assert spawned_jobs[0]["kind"] == "eval_samples"
+
+
+def test_exclusive_fifo_eval_samples_before_train(env, fake_daemon, fake_secrets):
+    """D-R3 跨类型平级：先入队的 eval_samples 先跑，后入队的 train 排队等。"""
+    sup = _make_sup(env)
+    spawned_jobs: list[Any] = []
+    spawned_tasks: list[Any] = []
+    sup._spawn_job = lambda slot, job: spawned_jobs.append(job)  # type: ignore
+    sup._spawn_task = lambda slot, task: spawned_tasks.append(task)  # type: ignore
+    ev = _make_job(env, kind="eval_samples")
+    with db.connection_for(env["db"]) as conn:
+        db.update_task(conn, ev, created_at=100.0)
+    _make_task(env, task_type="train", created_at=200.0)
+
+    sup._dispatch_exclusive_tasks(_slot(sup, "train"))
+    assert [j["id"] for j in spawned_jobs] == [ev] and spawned_tasks == []
+
+    # eval_samples 结束 → train 轮到
+    with db.connection_for(env["db"]) as conn:
+        db.update_task(conn, ev, status="done")
+    sup._dispatch_exclusive_tasks(_slot(sup, "train"))
+    assert len(spawned_tasks) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_supervisor_jobs.py
+++ b/tests/test_supervisor_jobs.py
@@ -39,33 +39,39 @@ def _setup_project(isolated) -> dict:
         return projects.create_project(conn, title="P")
 
 
-def test_eval_metric_jobs_dispatch_before_later_eval_samples(isolated) -> None:
-    """Completed samples should get metrics before spending GPU on more samples."""
+def test_eval_metrics_not_blocked_by_earlier_eval_samples(isolated) -> None:
+    """R-3：指标（light 档）与出图（exclusive 档）分档准入 —— 老 dispatch_order
+    的「指标插队」硬编码删除后，_dispatch_data 天然跳过 exclusive 档的
+    eval_samples（它走 exclusive 统一 FIFO），先入队的 sample 不再堵住指标。"""
+    from unittest.mock import MagicMock
     p = _setup_project(isolated)
     with db.connection_for(isolated["db"]) as conn:
-        sample = project_jobs.create_job(
-            conn,
-            project_id=p["id"],
-            kind="eval_samples",
+        project_jobs.create_job(
+            conn, project_id=p["id"], kind="eval_samples",
             params={"run_id": "run-later"},
         )
         clip = project_jobs.create_job(
-            conn,
-            project_id=p["id"],
-            kind="eval_clip",
+            conn, project_id=p["id"], kind="eval_clip",
             params={"run_id": "run-ready"},
         )
-        dino = project_jobs.create_job(
-            conn,
-            project_id=p["id"],
-            kind="eval_dino",
-            params={"run_id": "run-ready"},
+
+    from studio.services.inference import daemon as _daemon_mod
+    fake = MagicMock(); fake.is_model_loaded = False; fake.is_busy = False
+    _daemon_mod._INSTANCE = fake  # type: ignore[attr-defined]
+    try:
+        sup = Supervisor(
+            on_event=lambda _e: None,
+            db_path=isolated["db"], logs_dir=isolated["logs"],
         )
-        pending = project_jobs.list_jobs(conn, status="pending")
+        spawned: list = []
+        sup._spawn_job = lambda slot, job: spawned.append(job)  # type: ignore
+        data_slot = next(s for s in sup._slots if s.name == "data")
+        sup._dispatch_data(data_slot)
+    finally:
+        _daemon_mod._INSTANCE = None  # type: ignore[attr-defined]
 
-    pending.sort(key=project_jobs.dispatch_order)
-
-    assert [job["id"] for job in pending[:3]] == [clip["id"], dino["id"], sample["id"]]
+    assert [j["id"] for j in spawned] == [clip["id"]], \
+        "light 档指标不被更早入队的 exclusive 档 eval_samples 堵住"
 
 
 def test_download_job_runs_in_parallel_with_training_task(isolated, tmp_path) -> None:

--- a/tests/test_tag_worker.py
+++ b/tests/test_tag_worker.py
@@ -110,7 +110,7 @@ def test_legacy_output_format_param_is_ignored(env, monkeypatch: pytest.MonkeyPa
     本地打标（无 caption_json）新 caption 一律落 .txt。"""
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.output_format', 'json') "
+            "UPDATE tasks SET params = json_set(params, '$.output_format', 'json') "
             "WHERE id = ?",
             (env["job_id"],),
         )
@@ -134,7 +134,7 @@ def test_run_passes_wd14_overrides_through(env, monkeypatch) -> None:
 
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, "
+            "UPDATE tasks SET params = json_set(params, "
             "'$.wd14_overrides', json(?)) WHERE id = ?",
             (json.dumps({"threshold_general": 0.2}), env["job_id"]),
         )
@@ -159,7 +159,7 @@ def test_run_passes_cltagger_overrides_through(env, monkeypatch) -> None:
 
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, "
+            "UPDATE tasks SET params = json_set(params, "
             "'$.tagger', 'cltagger', "
             "'$.cltagger_overrides', json(?)) WHERE id = ?",
             (json.dumps({"threshold_character": 0.55}), env["job_id"]),
@@ -180,7 +180,7 @@ def test_run_writes_llm_json_caption(env, monkeypatch) -> None:
     )
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.tagger', 'llm') "
+            "UPDATE tasks SET params = json_set(params, '$.tagger', 'llm') "
             "WHERE id = ?",
             (env["job_id"],),
         )
@@ -222,7 +222,7 @@ def test_run_writes_llm_txt_caption(env, monkeypatch) -> None:
     )
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.tagger', 'llm') "
+            "UPDATE tasks SET params = json_set(params, '$.tagger', 'llm') "
             "WHERE id = ?",
             (env["job_id"],),
         )
@@ -248,7 +248,7 @@ def test_run_unknown_job(env) -> None:
 def _set_trigger(env, trigger: str) -> None:
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.trigger_word', ?) "
+            "UPDATE tasks SET params = json_set(params, '$.trigger_word', ?) "
             "WHERE id = ?",
             (trigger, env["job_id"]),
         )
@@ -290,7 +290,7 @@ def test_trigger_word_writes_meta_in_llm_json(env, monkeypatch) -> None:
     )
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.tagger', 'llm') "
+            "UPDATE tasks SET params = json_set(params, '$.tagger', 'llm') "
             "WHERE id = ?",
             (env["job_id"],),
         )
@@ -313,7 +313,7 @@ def test_trigger_word_prepended_to_llm_txt(env, monkeypatch) -> None:
     )
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.tagger', 'llm') "
+            "UPDATE tasks SET params = json_set(params, '$.tagger', 'llm') "
             "WHERE id = ?",
             (env["job_id"],),
         )
@@ -395,7 +395,7 @@ def test_trigger_word_dataset_loader_sees_meta(env, tmp_path: Path) -> None:
 def _set_on_existing(env, mode: str) -> None:
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.on_existing', ?) "
+            "UPDATE tasks SET params = json_set(params, '$.on_existing', ?) "
             "WHERE id = ?",
             (mode, env["job_id"]),
         )
@@ -540,7 +540,7 @@ def _val_dir(env, folder: str = "1_data") -> Path:
 def _set_scope(env, scope: str) -> None:
     with db.connection_for(env["db"]) as conn:
         conn.execute(
-            "UPDATE project_jobs SET params = json_set(params, '$.scope', ?) "
+            "UPDATE tasks SET params = json_set(params, '$.scope', ?) "
             "WHERE id = ?",
             (scope, env["job_id"]),
         )

--- a/tests/test_versions_phase.py
+++ b/tests/test_versions_phase.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from studio import db
-from studio.services.projects import projects, versions, phase as versions_phase
+from studio.services.projects import jobs as project_jobs, projects, versions, phase as versions_phase
 from studio.services.projects.phase import CheckResult
 
 
@@ -96,12 +96,11 @@ def test_check_regularizing_no_jobs(isolated) -> None:
 def test_check_regularizing_blocks_when_job_running(isolated) -> None:
     v = _make_version(isolated)
     with db.connection_for(isolated["db"]) as conn:
-        conn.execute(
-            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
-            "VALUES (?, ?, 'reg_build', '{}', 'running')",
-            (v["project_id"], v["id"]),
+        _job = project_jobs.create_job(
+            conn, project_id=v["project_id"], version_id=v["id"],
+            kind="reg_build", params={},
         )
-        conn.commit()
+        project_jobs.update_status(conn, _job["id"], "running")
         result = versions_phase.check_regularizing(conn, v["id"])
     assert not result.ok
     assert "正则" in result.reason
@@ -110,12 +109,10 @@ def test_check_regularizing_blocks_when_job_running(isolated) -> None:
 def test_check_regularizing_blocks_when_job_pending(isolated) -> None:
     v = _make_version(isolated)
     with db.connection_for(isolated["db"]) as conn:
-        conn.execute(
-            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
-            "VALUES (?, ?, 'reg_build', '{}', 'pending')",
-            (v["project_id"], v["id"]),
+        _job = project_jobs.create_job(
+            conn, project_id=v["project_id"], version_id=v["id"],
+            kind="reg_build", params={},
         )
-        conn.commit()
         result = versions_phase.check_regularizing(conn, v["id"])
     assert not result.ok
 
@@ -124,12 +121,11 @@ def test_check_regularizing_done_job_doesnt_block(isolated) -> None:
     """已完成的 reg job 不阻塞 cursor 前进。"""
     v = _make_version(isolated)
     with db.connection_for(isolated["db"]) as conn:
-        conn.execute(
-            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
-            "VALUES (?, ?, 'reg_build', '{}', 'done')",
-            (v["project_id"], v["id"]),
+        _job = project_jobs.create_job(
+            conn, project_id=v["project_id"], version_id=v["id"],
+            kind="reg_build", params={},
         )
-        conn.commit()
+        project_jobs.update_status(conn, _job["id"], "done")
         result = versions_phase.check_regularizing(conn, v["id"])
     assert result.ok
 
@@ -227,12 +223,11 @@ def test_skip_phase_preprocessing_blocked_by_running_job(isolated) -> None:
     v = _make_version(isolated)
     with db.connection_for(isolated["db"]) as conn:
         versions.update_version(conn, v["id"], phase="preprocessing")
-        conn.execute(
-            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
-            "VALUES (?, ?, 'preprocess', '{}', 'running')",
-            (v["project_id"], v["id"]),
+        _job = project_jobs.create_job(
+            conn, project_id=v["project_id"], version_id=v["id"],
+            kind="preprocess", params={},
         )
-        conn.commit()
+        project_jobs.update_status(conn, _job["id"], "running")
         advanced, result, _ = versions_phase.skip_phase(conn, v["id"])
     assert not advanced
     assert "预处理" in result.reason
@@ -262,12 +257,11 @@ def test_skip_phase_regularizing_blocked_by_running_job(isolated) -> None:
     v = _make_version(isolated)
     with db.connection_for(isolated["db"]) as conn:
         versions.update_version(conn, v["id"], phase="regularizing")
-        conn.execute(
-            "INSERT INTO project_jobs(project_id, version_id, kind, params, status) "
-            "VALUES (?, ?, 'reg_build', '{}', 'running')",
-            (v["project_id"], v["id"]),
+        _job = project_jobs.create_job(
+            conn, project_id=v["project_id"], version_id=v["id"],
+            kind="reg_build", params={},
         )
-        conn.commit()
+        project_jobs.update_status(conn, _job["id"], "running")
         advanced, result, _ = versions_phase.skip_phase(conn, v["id"])
     assert not advanced
     assert "正则" in result.reason


### PR DESCRIPTION
## 概要

资源档位模型第三步（`docs/design/queue-resource-model-0.17.md` §5 R-3）：九类数据作业的写路径从 project_jobs 翻转到 tasks 统一台账。

**翻转策略 = DAO 换底**：`services/projects/jobs.py` 的接口一个不动（create_job / get_job / list_jobs / mark_* / latest_for / P-G 分页…），底下全部读写 tasks 表（`task_type` = kind，`params` = _v17 列）。收益：workers、5 个 eval 服务、API 路由、SSE 事件、**前端**全部零改动——行为翻转集中在一个模块，R-5 再删兼容层。

## 关键点

- **_v18 迁移**：冻结旧 project_jobs——升级瞬间残留的 pending/running 标 canceled（否则没人再调度它们，永远卡住）；其余行只读遗留（Q-R2：不迁移不展示，避免 ID 重映射污染 eval run 引用）。
- **单一 ID 空间达成**（增量方向）：新作业与 GPU 任务同表自增，撞号问题就此终结。
- **D-R3 跨类型平级 FIFO 完全落地**：eval_samples 进 exclusive 统一队列——`_dispatch_exclusive_tasks` 四类（train/reg_ai/generate/eval_samples）同表按 `priority DESC, created_at ASC` 取队首，执行位仍是 DATA 槽 worker 子进程；`dispatch_order` 的「指标插队在出图前」硬编码删除——指标是 light 档、出图是 exclusive 档，分档准入天然不互堵，不再需要插队规则。
- **作业日志统一** `tasks/<id>/run.log`（与 GPU 任务同款布局）；失败 error_msg 的日志August tail 路径跟随。
- **/api/queue GPU 视图默认排除数据作业**（含 no-group 兼容路径，保护 Topbar/Overview/Monitor 不把数据作业当训练任务）——R-5 档位化时替换为 class 过滤。
- **retry 修复**：复制 task_type/params——此前数据作业类 task 重跑会退化成 train 跑错脚本。
- 作业白得 tasks 的基建：priority/reorder、scheduled、统一孤儿收割。

## 测试

后端全量 **2651 passed**（1 fail 为已知本机 flaky）；前端 447 passed + build 绿（零前端改动，验证 DAO 形状兼容）。测试适配：FIFO/租约/「指标不被更早的出图堵住」等语义更新；所有裸 project_jobs SQL 的测试改走 DAO 或 tasks 表。

## 后续

R-5（最后一步）：前端数据源合流——/api/jobs* 删除、DataJobsPanel 改读 /api/queue 档位过滤、QueueJobDetail 并入 QueueDetail、eval_samples 归位 GPU 视图、generate 训练时提交解禁（改提示文案）。（R-4 事件统一已被本 PR 的 DAO 策略吸收——事件形状未变，R-5 一并切换。）

🤖 Generated with [Claude Code](https://claude.com/claude-code)