### PR TITLE
fix(ui): sample prompts 换行输入被受控回显吃掉 + 采样 prompt textarea 自适应高度

### DIFF
--- a/studio/web/src/components/Field.test.tsx
+++ b/studio/web/src/components/Field.test.tsx
@@ -209,6 +209,95 @@ describe('Field number input (PP10.3)', () => {
   })
 })
 
+const stringListProp: SchemaProperty = {
+  type: 'array',
+  items: { type: 'string' },
+  default: [],
+  group: 'sample',
+  control: 'string-list',
+  description: '',
+}
+
+describe('Field string-list input (sample_prompts 换行)', () => {
+  it('preserves the newline while typing a second line', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Field
+        name="sample_prompts"
+        prop={stringListProp}
+        value={['first prompt']}
+        onChange={onChange}
+      />,
+    )
+
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement
+    // 敲回车的瞬间（尾部空行还没内容）换行不能被 split+filter 吃掉
+    await user.type(input, '{Enter}')
+    expect(input.value).toBe('first prompt\n')
+    await user.type(input, 'second prompt')
+    expect(input.value).toBe('first prompt\nsecond prompt')
+    expect(onChange).toHaveBeenLastCalledWith(['first prompt', 'second prompt'])
+  })
+
+  it('does not commit empty lines, and blur normalizes the raw text', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <Field
+        name="sample_prompts"
+        prop={stringListProp}
+        value={['first prompt']}
+        onChange={onChange}
+      />,
+    )
+
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement
+    await user.type(input, '{Enter}{Enter}  second prompt  ')
+    expect(onChange).toHaveBeenLastCalledWith(['first prompt', 'second prompt'])
+    fireEvent.blur(input)
+    expect(input.value).toBe('first prompt\nsecond prompt')
+  })
+
+  it('external value change syncs display only when not focused', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <Field
+        name="sample_prompts"
+        prop={stringListProp}
+        value={['a']}
+        onChange={onChange}
+      />,
+    )
+    const input = screen.getByRole('textbox') as HTMLTextAreaElement
+
+    // focus 中外部 value 变化不覆盖用户半截输入
+    await user.type(input, '{Enter}b')
+    rerender(
+      <Field
+        name="sample_prompts"
+        prop={stringListProp}
+        value={['reset']}
+        onChange={onChange}
+      />,
+    )
+    expect(input.value).toBe('a\nb')
+
+    // blur 后外部变化才同步
+    await user.tab()
+    rerender(
+      <Field
+        name="sample_prompts"
+        prop={stringListProp}
+        value={['x', 'y']}
+        onChange={onChange}
+      />,
+    )
+    expect(input.value).toBe('x\ny')
+  })
+})
+
 describe('Field code input', () => {
   it('renders object values as formatted JSON and commits parsed objects on blur', () => {
     const onChange = vi.fn()

--- a/studio/web/src/components/Field.tsx
+++ b/studio/web/src/components/Field.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import type { SchemaProperty } from '../api/client'
 import { useProjectCtx } from '../context/ProjectContext'
 import { controlKind, fieldLabel, schemaEnumLabel } from '../lib/schema'
+import { useAutoGrowTextarea } from '../lib/useAutoGrowTextarea'
 import PathPicker from './PathPicker'
 import ResumeFieldPicker from './ResumeFieldPicker'
 
@@ -124,46 +125,28 @@ export default function Field({
   // textarea ------------------------------------------------------------
   if (kind === 'textarea') {
     return (
-      <div className="py-1.5">
-        <div className="text-sm font-medium text-fg-secondary mb-1">
-          {label}{hintNode}
-        </div>
-        <textarea
-          rows={3}
-          value={String(value ?? '')}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={disabled}
-          className="input input-mono" style={inputStyle}
-        />
-        {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
-      </div>
+      <TextareaField
+        label={label}
+        help={help}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        hintNode={hintNode}
+      />
     )
   }
 
   // string-list ---------------------------------------------------------
   if (kind === 'string-list') {
-    const list = Array.isArray(value) ? (value as string[]) : []
-    const text = list.join('\n')
     return (
-      <div className="py-1.5">
-        <div className="text-sm font-medium text-fg-secondary mb-1">
-          {label}{t('field.multilineHint')}{hintNode}
-        </div>
-        <textarea
-          rows={Math.max(3, list.length + 1)}
-          value={text}
-          onChange={(e) => {
-            const arr = e.target.value
-              .split('\n')
-              .map((s) => s.trim())
-              .filter((s) => s.length > 0)
-            onChange(arr)
-          }}
-          disabled={disabled}
-          className="input input-mono" style={inputStyle}
-        />
-        {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
-      </div>
+      <StringListField
+        label={`${label}${t('field.multilineHint')}`}
+        help={help}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        hintNode={hintNode}
+      />
     )
   }
 
@@ -227,6 +210,80 @@ export default function Field({
       hintNode={hintNode}
       suffix={suffix}
     />
+  )
+}
+
+interface TextareaFieldProps {
+  label: string
+  help: string | undefined
+  value: unknown
+  onChange: (v: unknown) => void
+  disabled?: boolean
+  hintNode?: React.ReactNode
+}
+
+function TextareaField({
+  label, help, value, onChange, disabled = false, hintNode,
+}: TextareaFieldProps) {
+  const taRef = useRef<HTMLTextAreaElement>(null)
+  const text = String(value ?? '')
+  useAutoGrowTextarea(taRef, text)
+  return (
+    <div className="py-1.5">
+      <div className="text-sm font-medium text-fg-secondary mb-1">
+        {label}{hintNode}
+      </div>
+      <textarea
+        ref={taRef}
+        rows={5}
+        value={text}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        className="input input-mono resize-none overflow-hidden" style={inputStyle}
+      />
+      {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+    </div>
+  )
+}
+
+/** 字符串列表输入（每行一条）。textarea 显示走本地 raw 缓冲：受控值若直接用
+ *  join('\n') 回显，刚敲的换行（尾部空行）会被 split+filter 吃掉、光标换不了
+ *  行。raw 保留用户原始输入，解析后的数组仍每次击键同步给父级，blur 时把
+ *  raw 归一化（去空行 / 首尾空白）。 */
+function StringListField({
+  label, help, value, onChange, disabled = false, hintNode,
+}: TextareaFieldProps) {
+  const joined = Array.isArray(value) ? (value as string[]).join('\n') : ''
+  const [raw, setRaw] = useState<string>(joined)
+  const taRef = useRef<HTMLTextAreaElement>(null)
+  useAutoGrowTextarea(taRef, raw)
+
+  useEffect(() => {
+    if (document.activeElement !== taRef.current) setRaw(joined)
+  }, [joined])
+
+  const parse = (text: string) =>
+    text.split('\n').map((s) => s.trim()).filter((s) => s.length > 0)
+
+  return (
+    <div className="py-1.5">
+      <div className="text-sm font-medium text-fg-secondary mb-1">
+        {label}{hintNode}
+      </div>
+      <textarea
+        ref={taRef}
+        rows={5}
+        value={raw}
+        onChange={(e) => {
+          setRaw(e.target.value)
+          onChange(parse(e.target.value))
+        }}
+        onBlur={() => setRaw(parse(raw).join('\n'))}
+        disabled={disabled}
+        className="input input-mono resize-none overflow-hidden" style={inputStyle}
+      />
+      {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+    </div>
   )
 }
 


### PR DESCRIPTION
## 背景

训练配置页的 `sample_prompts`（多 prompt 轮换，每行一条）在前端敲不了回车：字段是受控 textarea，`onChange` 立即 `split('\n') + trim + filter(空行)`，再由 `list.join('\n')` 回显。刚敲的换行产生的尾部空行被 filter 掉，受控回显后换行符直接消失，多 prompt 功能实际不可用。

## 改动

- **修复换行**（`Field.tsx` string-list 控件，抽成 `StringListField`）：textarea 显示改走本地 raw 缓冲，用户输入原样保留；解析后的数组仍每次击键同步父级（配置页 debounce 自动落盘语义不变）；blur 时归一化（去空行 / trim 首尾空白）；外部 value 变化只在非 focus 时同步回显（沿用本文件 NumberField / IntListField 既有范式）。
- **textarea 自适应高度**（同页 3 个采样 prompt 字段：`sample_negative_prompt` / `sample_prompt` / `sample_prompts`）：接入现有 `useAutoGrowTextarea`，最小高度统一 `rows=5`，随内容自动撑高，与测试页提示词输入一致。textarea 控件同步抽成 `TextareaField`。

`textarea` / `string-list` 两个控件 kind 在训练 schema 里只有这 3 个字段使用，无其他字段受影响。

## 测试方式

- `Field.test.tsx` 新增 3 条回归测试：敲 Enter 换行保留 + 数组不含空行、blur 归一化、外部 value 仅非 focus 时同步。
- 前端全量 vitest 449 项全绿；`npm run lint` + `tsc --noEmit` 干净。
- 端到端手测（Playwright + Edge 驱动 serve-dist 实例，一次性项目）：三个 textarea 最小高度 5 行；`sample_prompts` 连敲 10 行完整保留；超过 5 行后自动撑高（115px → 199px）；blur 后空行/首尾空白归一化；debounce 自动落盘后后端 config 收到 10 条干净数组；刷新页面回显 10 行且初始渲染即按内容撑高。

🤖 Generated with [Claude Code](https://claude.com/claude-code)