### PR TITLE
feat(settings): 模型根目录迁移支持目标已有数据时跳过/覆盖合并

### DIFF
--- a/studio/api/routers/models_storage.py
+++ b/studio/api/routers/models_storage.py
@@ -41,10 +41,21 @@ def models_root_info(scan: bool = True) -> dict[str, Any]:
 
 @router.post("/api/models-root/migrate")
 def models_root_migrate(body: ModelsRootMigrateRequest) -> dict[str, Any]:
-    """起迁移。约束：无 running task（复制期间训练继续读权重 / move 语义不安全）。"""
+    """起迁移。约束：无 running task（复制期间训练继续读权重 / move 语义不安全）。
+
+    目标已有非空 models/ 且未传 on_conflict → 409 `target_conflict`（details 带
+    目标现有文件统计 + 同名文件数），前端弹「跳过/覆盖/取消」后带 on_conflict 重发。
+    """
     _check_no_running_tasks()
     try:
-        svc.start_migration(Path(body.target))
+        svc.start_migration(Path(body.target), on_conflict=body.on_conflict)
+    except svc.TargetConflictError as exc:
+        # 注意放 except ValueError 前（它是 ValueError 子类）
+        raise ConflictError(
+            "Target already contains a non-empty models directory",
+            code="models_root.target_conflict",
+            details=exc.details,
+        ) from exc
     except ValueError as exc:
         raise ValidationError(
             f"Invalid target location: {exc}",

--- a/studio/api/schemas/models_storage.py
+++ b/studio/api/schemas/models_storage.py
@@ -1,9 +1,17 @@
 """模型根目录迁移请求模型。"""
 from __future__ import annotations
 
+from typing import Literal, Optional
+
 from pydantic import BaseModel
 
 
 class ModelsRootMigrateRequest(BaseModel):
-    """迁移目标父目录（绝对路径；数据落 `target/models/`，目标不要求为空）。"""
+    """迁移目标父目录（绝对路径；数据落 `target/models/`，目标不要求为空）。
+
+    on_conflict：`target/models` 已有数据时的合并策略。不传 → 后端返回 409
+    `models_root.target_conflict`（前端据此弹「跳过/覆盖/取消」三选后重发）；
+    "skip" → 只复制目标缺少的文件；"overwrite" → 同名文件以当前根的副本覆盖。
+    """
     target: str
+    on_conflict: Optional[Literal["skip", "overwrite"]] = None

--- a/studio/services/models_storage.py
+++ b/studio/services/models_storage.py
@@ -7,16 +7,22 @@
    secret，无需重启；区别于 studio_data 的指针文件 + 重启）
 
 设计要点（与 `studio_data.py` 一致）：
-- **目标是父目录**：用户选任意目录，数据落 `目标/models/`；目标本身不要求为空，只
-  要求落地子目录不存在或为空（不 merge 进已有数据）。
+- **目标是父目录**：用户选任意目录，数据落 `目标/models/`；目标本身不要求为空。
 - **只复制不删除**：旧目录原样保留（用户决策；已有 version 的 yaml 里烤死的旧绝对
-  路径仍可解析）。失败时清掉复制了一半的落地目录，secret 不动，等于什么都没发生。
+  路径仍可解析）。
 - **单飞**：模块级 lock + 状态单例。
-- 模型权重无 sqlite/wal，直接 `shutil.copy2`，无 `.db` backup 分支。
+- 模型权重无 sqlite/wal，无 `.db` backup 分支。
+
+与 studio_data 的分歧（issue #351）：落地目录已有数据时不再一律拒绝，而是抛
+`TargetConflictError` 让前端弹「跳过 / 覆盖 / 取消」——模型目录常与跑图工具共用，
+「跳过已有文件」的合并迁移终态等于把路径指过去 + 补齐缺失文件。合并模式下失败
+回滚**不能** rmtree（会删掉用户既有数据），改为逐文件 `.part` 原子落盘 + 失败留下
+已复制完成的有效副本（skip 幂等，重跑即续传）；secret 仍只在全部复制完后才切换。
 """
 from __future__ import annotations
 
 import logging
+import os
 import shutil
 import threading
 import time
@@ -126,13 +132,55 @@ def _set_status(**kw: Any) -> None:
 # 校验 + 启动
 # ---------------------------------------------------------------------------
 
-def validate_target(target: Path, *, source: Path | None = None) -> Path:
+class TargetConflictError(ValueError):
+    """落地目录已有数据且未指定合并策略 —— 需要用户显式三选（跳过/覆盖/取消）。
+
+    子类化 ValueError 让旧的 `except ValueError` 兜底仍成立；router 捕获本类转
+    409 + code `models_root.target_conflict`，`details` 给前端冲突对话框展示。
+    """
+
+    def __init__(self, message: str, details: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.details = details
+
+
+def _conflict_details(src: Path, dst: Path) -> dict[str, Any]:
+    """冲突对话框的统计：目标已有文件数/字节数 + 与当前根同名（会被覆盖）的文件数。"""
+    existing_files = 0
+    existing_bytes = 0
+    for f in dst.rglob("*"):
+        if not f.is_file():
+            continue
+        existing_files += 1
+        try:
+            existing_bytes += f.stat().st_size
+        except OSError:
+            pass
+    same_name_files = 0
+    if src.is_dir():
+        for f in src.rglob("*"):
+            if f.is_file() and (dst / f.relative_to(src)).exists():
+                same_name_files += 1
+    return {
+        "target": str(dst),
+        "existing_files": existing_files,
+        "existing_bytes": existing_bytes,
+        "same_name_files": same_name_files,
+    }
+
+
+def validate_target(
+    target: Path, *, source: Path | None = None, on_conflict: str | None = None
+) -> Path:
     """迁移目标校验，不合法抛 ValueError（caller 转 422）；返回实际落地目录。
 
     target 是用户选的任意目录，数据落 `target/models/`，所以 target 本身不要求
     为空。规则：绝对路径；target 已存在时必须是目录；落地目录不等于当前位置；
-    落地目录与当前位置互不嵌套；落地目录不存在或为空。
+    落地目录与当前位置互不嵌套。落地目录已有数据时按 on_conflict：None → 抛
+    TargetConflictError（前端弹三选）；"skip" / "overwrite" → 放行合并。
     """
+    if on_conflict not in (None, "skip", "overwrite"):
+        raise ValueError(f"未知的冲突策略 {on_conflict!r}")
     src = (source if source is not None else models_root()).resolve()
     if not target.is_absolute():
         raise ValueError("目标必须是绝对路径")
@@ -150,8 +198,11 @@ def validate_target(target: Path, *, source: Path | None = None) -> Path:
     if dst.exists():
         if not dst.is_dir():
             raise ValueError(f"目标下已存在同名文件 {DATA_DIR_NAME}")
-        if any(dst.iterdir()):
-            raise ValueError(f"目标下已存在非空 {DATA_DIR_NAME} 目录")
+        if any(dst.iterdir()) and on_conflict is None:
+            raise TargetConflictError(
+                f"目标下已存在非空 {DATA_DIR_NAME} 目录",
+                _conflict_details(src, dst),
+            )
     return dst
 
 
@@ -160,13 +211,16 @@ def start_migration(
     *,
     source: Path | None = None,
     publish: Publish = bus.publish,
+    on_conflict: str | None = None,
 ) -> None:
     """校验 + 起后台复制线程。已有迁移在跑时抛 RuntimeError（caller 转 409）。
 
-    source 参数仅测试注入用；生产走默认（当前 `models_root()`）。
+    on_conflict：落地目录已有数据时的合并策略（"skip" / "overwrite"），None 且
+    有冲突时 validate_target 抛 TargetConflictError。source 参数仅测试注入用；
+    生产走默认（当前 `models_root()`）。
     """
     src = (source if source is not None else models_root()).resolve()
-    dst = validate_target(target, source=src)
+    dst = validate_target(target, source=src, on_conflict=on_conflict)
     with _status_lock:
         if _status.state == "running":
             raise RuntimeError("已有迁移正在进行")
@@ -180,7 +234,7 @@ def start_migration(
         _status.error = ""
     t = threading.Thread(
         target=_run_migration,
-        args=(src, dst, publish),
+        args=(src, dst, publish, on_conflict),
         name="models-root-migration",
         daemon=True,
     )
@@ -198,9 +252,32 @@ def _update_models_root_secret(new_root: Path) -> None:
 # 复制线程
 # ---------------------------------------------------------------------------
 
-def _run_migration(src: Path, dst: Path, publish: Publish) -> None:
+def _copy_atomic(src_file: Path, out: Path) -> None:
+    """copy2 到同目录临时名再 os.replace —— 目标位置永远只有完整文件。
+
+    合并/覆盖模式下直接 copy2 覆盖，失败会把目标原有的完整权重砸成半截；先写
+    临时名再原子替换，目标要么保持旧文件要么换成新文件。临时文件失败即清。
+    """
+    part = out.with_name(out.name + ".studio-migrate.part")
+    try:
+        shutil.copy2(src_file, part)
+    except BaseException:
+        part.unlink(missing_ok=True)
+        raise
+    os.replace(part, out)
+
+
+def _run_migration(
+    src: Path, dst: Path, publish: Publish, on_conflict: str | None = None
+) -> None:
+    # 开跑前记住 dst 是否已有数据：合并模式下 dst 的既有内容是用户的（可能与
+    # 跑图工具共用目录），失败回滚绝不能整树 rmtree —— 据此选回滚策略。
+    dst_preexisted = dst.is_dir() and any(dst.iterdir())
     try:
         files = [f for f in sorted(src.rglob("*")) if f.is_file()]
+        if on_conflict == "skip":
+            # 目标已有同名文件的不复制；进度总量只算真要复制的
+            files = [f for f in files if not (dst / f.relative_to(src)).exists()]
         total_bytes = 0
         for f in files:
             try:
@@ -219,7 +296,7 @@ def _run_migration(src: Path, dst: Path, publish: Publish) -> None:
             out.parent.mkdir(parents=True, exist_ok=True)
             try:
                 size = f.stat().st_size
-                shutil.copy2(f, out)
+                _copy_atomic(f, out)
             except FileNotFoundError:
                 # 扫描后被删（如临时文件）—— 跳过，进度可能停在 <100%，无碍
                 logger.info("迁移期间文件消失，跳过: %s", rel)
@@ -255,8 +332,13 @@ def _run_migration(src: Path, dst: Path, publish: Publish) -> None:
         )
     except Exception as exc:
         logger.exception("模型根目录迁移失败: %s → %s", src, dst)
-        # dst 开始前为空 / 不存在（validate_target 保证），整树清掉等于回到迁移前；
-        # secret 未动；用户的 target 父目录不受影响。
-        shutil.rmtree(dst, ignore_errors=True)
+        if dst_preexisted:
+            # 合并模式：dst 的既有数据是用户的，绝不能整树删。已复制完成的文件
+            # 都是完整有效副本（_copy_atomic 保证），留下无害；skip 幂等，重跑即续传。
+            logger.info("目标目录原有数据，保留已复制文件，不回滚: %s", dst)
+        else:
+            # dst 开始前为空 / 不存在，整树清掉等于回到迁移前；
+            # secret 未动；用户的 target 父目录不受影响。
+            shutil.rmtree(dst, ignore_errors=True)
         _set_status(state="error", error=str(exc))
         publish({"type": "models_root_migrate_done", "ok": False, "error": str(exc)})

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -2995,11 +2995,14 @@ export const api = {
   // 模型根目录存储位置（镜像 studio_data，但迁移完无需重启，立即生效）----------
   getModelsRootInfo: (withScan = true) =>
     req<ModelsRootInfo>(`/api/models-root/info?scan=${withScan}`),
-  // 422 = 目标不合法 / 有 running task；409 = 已有迁移在跑。
-  startModelsRootMigrate: (target: string) =>
+  // 422 = 目标不合法 / 有 running task；409 code models_root.migration_busy = 已有
+  // 迁移在跑；409 code models_root.target_conflict = 目标已有 models 数据（detail 带
+  // existing_files/existing_bytes/same_name_files，modal 弹「跳过/覆盖/取消」后带
+  // onConflict 重发）。
+  startModelsRootMigrate: (target: string, onConflict?: 'skip' | 'overwrite') =>
     req<{ ok: boolean }>('/api/models-root/migrate', {
       method: 'POST',
-      body: JSON.stringify({ target }),
+      body: JSON.stringify({ target, on_conflict: onConflict ?? null }),
     }),
   getModelsRootMigrateStatus: () =>
     req<ModelsRootMigrateStatus>('/api/models-root/migrate_status'),

--- a/studio/web/src/components/ModelsRootMigrateModal.test.tsx
+++ b/studio/web/src/components/ModelsRootMigrateModal.test.tsx
@@ -1,0 +1,118 @@
+/** ModelsRootMigrateModal：confirm 启动 / 409 target_conflict 三选流程（issue #351）。
+ *  SSE 在 jsdom 下不连（useEventStream 内部 EventSource guard），相位推进
+ *  只测到 running —— done/error 由 SSE 事件驱动，后端测试覆盖事件发布。 */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+import ModelsRootMigrateModal from './ModelsRootMigrateModal'
+
+const mockApi = {
+  getModelsRootInfo: vi.fn(),
+  startModelsRootMigrate: vi.fn(),
+  getModelsRootMigrateStatus: vi.fn(),
+}
+vi.mock('../api/client', () => ({
+  get api() { return mockApi },
+}))
+
+const INFO = {
+  current: 'G:\\AnimaLoraStudio\\models',
+  default: 'G:\\AnimaLoraStudio\\models',
+  is_custom: false,
+  scan: {
+    total_files: 7,
+    total_bytes: 3 * 1024 * 1024,
+    entries: [
+      { name: 'diffusion_models', is_dir: true, files: 2, bytes: 2 * 1024 * 1024 },
+      { name: 'vae', is_dir: true, files: 5, bytes: 1024 * 1024 },
+    ],
+  },
+}
+
+/** 后端 409 models_root.target_conflict 的 ApiError 形状（makeApiError 产物）。 */
+const conflictError = () =>
+  Object.assign(new Error('Target already contains a non-empty models directory'), {
+    status: 409,
+    code: 'models_root.target_conflict',
+    detail: {
+      target: 'D:\\newroot\\models',
+      existing_files: 12,
+      existing_bytes: 2 * 1024 * 1024,
+      same_name_files: 3,
+    },
+  })
+
+describe('ModelsRootMigrateModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockApi.getModelsRootInfo.mockResolvedValue(INFO)
+    mockApi.startModelsRootMigrate.mockResolvedValue({ ok: true })
+  })
+
+  it('confirm 态点开始迁移 → 调 startModelsRootMigrate(target, undefined) 并进入 running', async () => {
+    render(<ModelsRootMigrateModal target="D:\newroot" onClose={() => {}} onDone={() => {}} />)
+    await screen.findByText('开始迁移')
+    await userEvent.click(screen.getByText('开始迁移'))
+    expect(mockApi.startModelsRootMigrate).toHaveBeenCalledWith('D:\\newroot', undefined)
+    await screen.findByText('正在复制…')
+  })
+
+  it('409 target_conflict → conflict 态展示统计，跳过已有文件 → 带 skip 重发进 running', async () => {
+    mockApi.startModelsRootMigrate
+      .mockRejectedValueOnce(conflictError())
+      .mockResolvedValueOnce({ ok: true })
+    render(<ModelsRootMigrateModal target="D:\newroot" onClose={() => {}} onDone={() => {}} />)
+    await screen.findByText('开始迁移')
+    await userEvent.click(screen.getByText('开始迁移'))
+
+    await screen.findByText('目标目录已包含 models 数据')
+    // 统计插值：目标路径 + 已有文件数/大小 + 同名数
+    expect(screen.getByText(/已有 12 个文件（2\.0 MB），其中 3 个/)).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText('跳过已有文件'))
+    await waitFor(() => {
+      expect(mockApi.startModelsRootMigrate).toHaveBeenLastCalledWith('D:\\newroot', 'skip')
+    })
+    await screen.findByText('正在复制…')
+  })
+
+  it('conflict 态覆盖已有文件 → 带 overwrite 重发', async () => {
+    mockApi.startModelsRootMigrate
+      .mockRejectedValueOnce(conflictError())
+      .mockResolvedValueOnce({ ok: true })
+    render(<ModelsRootMigrateModal target="D:\newroot" onClose={() => {}} onDone={() => {}} />)
+    await screen.findByText('开始迁移')
+    await userEvent.click(screen.getByText('开始迁移'))
+    await screen.findByText('覆盖已有文件')
+
+    await userEvent.click(screen.getByText('覆盖已有文件'))
+    await waitFor(() => {
+      expect(mockApi.startModelsRootMigrate).toHaveBeenLastCalledWith('D:\\newroot', 'overwrite')
+    })
+  })
+
+  it('conflict 态取消 → 回到 confirm（不关 modal，不再发请求）', async () => {
+    mockApi.startModelsRootMigrate.mockRejectedValueOnce(conflictError())
+    const onClose = vi.fn()
+    render(<ModelsRootMigrateModal target="D:\newroot" onClose={onClose} onDone={() => {}} />)
+    await screen.findByText('开始迁移')
+    await userEvent.click(screen.getByText('开始迁移'))
+    await screen.findByText('取消')
+
+    await userEvent.click(screen.getByText('取消'))
+    await screen.findByText('开始迁移')
+    expect(onClose).not.toHaveBeenCalled()
+    expect(mockApi.startModelsRootMigrate).toHaveBeenCalledTimes(1)
+  })
+
+  it('非 conflict 错误 → error 态展示原因', async () => {
+    mockApi.startModelsRootMigrate.mockRejectedValue(
+      Object.assign(new Error('目标位置无效'), { status: 422, code: 'models_root.target_invalid' }),
+    )
+    render(<ModelsRootMigrateModal target="D:\newroot" onClose={() => {}} onDone={() => {}} />)
+    await screen.findByText('开始迁移')
+    await userEvent.click(screen.getByText('开始迁移'))
+    await screen.findByText(/目标位置无效/)
+  })
+})

--- a/studio/web/src/components/ModelsRootMigrateModal.tsx
+++ b/studio/web/src/components/ModelsRootMigrateModal.tsx
@@ -4,17 +4,25 @@
  * 现读 secrets.models.root）。所以 done 态不给「立即重启」，只给「完成」+ 关闭，
  * 并回调 onDone 让父级刷新当前路径显示。
  *
- * 四态：loading（拉 info 扫描）→ confirm（文件数/大小/顶层明细 + 确认）→
+ * 相位：loading（拉 info 扫描）→ confirm（文件数/大小/顶层明细 + 确认）→
  * running（进度条，SSE 驱动）→ done / error。running 期间 modal 不可关。
+ * 目标已有 models 数据时后端回 409 target_conflict → conflict 相位（issue #351）：
+ * 「跳过已有文件」（合并补齐，同名保留目标现有版本）/「覆盖已有文件」/ 取消。
  */
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { api, type ModelsRootInfo } from '../api/client'
+import { api, type ApiError, type ModelsRootInfo } from '../api/client'
 import { formatBytes } from '../lib/useUploadProgress'
 import { useEventStream } from '../lib/useEventStream'
 
-type Phase = 'loading' | 'confirm' | 'running' | 'done' | 'error'
+type Phase = 'loading' | 'confirm' | 'conflict' | 'running' | 'done' | 'error'
+
+interface ConflictInfo {
+  existingFiles: number
+  existingBytes: number
+  sameNameFiles: number
+}
 
 interface Progress {
   doneFiles: number
@@ -42,6 +50,7 @@ export default function ModelsRootMigrateModal({ target, onClose, onDone }: {
   const [phase, setPhase] = useState<Phase>('loading')
   const [info, setInfo] = useState<ModelsRootInfo | null>(null)
   const [progress, setProgress] = useState<Progress>(EMPTY_PROGRESS)
+  const [conflict, setConflict] = useState<ConflictInfo | null>(null)
   const [error, setError] = useState('')
 
   useEffect(() => {
@@ -91,12 +100,23 @@ export default function ModelsRootMigrateModal({ target, onClose, onDone }: {
     },
   })
 
-  const handleStart = async () => {
+  const handleStart = async (onConflict?: 'skip' | 'overwrite') => {
     setPhase('running')
     setProgress(EMPTY_PROGRESS)
     try {
-      await api.startModelsRootMigrate(target)
+      await api.startModelsRootMigrate(target, onConflict)
     } catch (e) {
+      const err = e as ApiError
+      if (err.code === 'models_root.target_conflict') {
+        const d = (err.detail ?? {}) as Record<string, unknown>
+        setConflict({
+          existingFiles: Number(d.existing_files) || 0,
+          existingBytes: Number(d.existing_bytes) || 0,
+          sameNameFiles: Number(d.same_name_files) || 0,
+        })
+        setPhase('conflict')
+        return
+      }
       setError(String(e))
       setPhase('error')
     }
@@ -169,6 +189,25 @@ export default function ModelsRootMigrateModal({ target, onClose, onDone }: {
             </>
           )}
 
+          {phase === 'conflict' && conflict && (
+            <>
+              <div className="text-sm font-semibold">
+                {t('settings.storage.conflictTitle')}
+              </div>
+              <div className="text-xs text-fg-secondary">
+                {t('settings.storage.conflictSummary', {
+                  path: destination,
+                  files: conflict.existingFiles,
+                  size: formatBytes(conflict.existingBytes),
+                  same: conflict.sameNameFiles,
+                })}
+              </div>
+              <div className="text-xs text-fg-tertiary">
+                {t('settings.storage.conflictHint')}
+              </div>
+            </>
+          )}
+
           {phase === 'running' && (
             <>
               <div className="text-sm">{t('settings.storage.migrating')}</div>
@@ -213,6 +252,19 @@ export default function ModelsRootMigrateModal({ target, onClose, onDone }: {
               <button className="btn btn-ghost" onClick={onClose}>{t('common.cancel')}</button>
               <button className="btn btn-primary" onClick={() => void handleStart()}>
                 {t('settings.storage.startMigrate')}
+              </button>
+            </>
+          )}
+          {phase === 'conflict' && (
+            <>
+              <button className="btn btn-ghost" onClick={() => setPhase('confirm')}>
+                {t('common.cancel')}
+              </button>
+              <button className="btn btn-danger" onClick={() => void handleStart('overwrite')}>
+                {t('settings.storage.conflictOverwrite')}
+              </button>
+              <button className="btn btn-primary" onClick={() => void handleStart('skip')}>
+                {t('settings.storage.conflictSkip')}
               </button>
             </>
           )}

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -972,7 +972,12 @@
       "modelsRootHelp": "Holds downloaded model weights (Anima / VAE / text encoder / tokenizer / WD14, etc.); defaults to models/ in the app root. Changing the location copies existing weights into a models subdirectory of the chosen directory and takes effect immediately (no restart); the original is kept.",
       "modelsMigrateTitle": "Migrate models root",
       "modelsKeepOriginalNote": "Data at the original location is kept, not deleted. Takes effect immediately after copying — no restart needed.",
-      "modelsDoneNote": "Switched to the new models root, effective immediately (no restart). The original data is kept; delete it yourself once verified."
+      "modelsDoneNote": "Switched to the new models root, effective immediately (no restart). The original data is kept; delete it yourself once verified.",
+      "conflictTitle": "Target already contains models data",
+      "conflictSummary": "{{path}} already has {{files}} files ({{size}}), {{same}} of which have the same names as files in the current root.",
+      "conflictHint": "\"Skip existing files\" copies only files missing at the target and keeps the target's version of same-name files. \"Overwrite existing files\" replaces all same-name files with copies from the current root. Either way, the new location takes effect after copying and the original data is kept.",
+      "conflictSkip": "Skip existing files",
+      "conflictOverwrite": "Overwrite existing files"
     },
     "gelbooru": "Gelbooru",
     "danbooru": "Danbooru",
@@ -2748,6 +2753,11 @@
     "studio_data": {
       "target_invalid": "Invalid target location: {{reason}}",
       "migration_busy": "A data migration is already in progress"
+    },
+    "models_root": {
+      "target_invalid": "Invalid target location: {{reason}}",
+      "migration_busy": "A models-root migration is already in progress",
+      "target_conflict": "Target already contains models data"
     },
     "export": {
       "name_conflict": "Too many files named \"{{name}}\"; rename and try again"

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -972,7 +972,12 @@
       "modelsRootHelp": "存放下载的 Anima / VAE / 文本编码器 / tokenizer / WD14 等模型权重，默认在程序根目录的 models/。更改位置会把现有权重复制到所选目录的 models 子目录并立即生效（无需重启），原数据保留不删除。",
       "modelsMigrateTitle": "迁移模型根目录",
       "modelsKeepOriginalNote": "原位置数据不会被删除。复制完成后立即生效，无需重启。",
-      "modelsDoneNote": "已切换到新模型根目录，立即生效（无需重启）；原位置数据已保留，确认无误后可自行删除。"
+      "modelsDoneNote": "已切换到新模型根目录，立即生效（无需重启）；原位置数据已保留，确认无误后可自行删除。",
+      "conflictTitle": "目标目录已包含 models 数据",
+      "conflictSummary": "{{path}} 已有 {{files}} 个文件（{{size}}），其中 {{same}} 个与当前目录中的文件同名。",
+      "conflictHint": "「跳过已有文件」只复制目标缺少的文件，同名文件保留目标现有版本；「覆盖已有文件」用当前目录的副本替换全部同名文件。两种方式完成后都会切换到新位置，原位置数据保留不删除。",
+      "conflictSkip": "跳过已有文件",
+      "conflictOverwrite": "覆盖已有文件"
     },
     "gelbooru": "Gelbooru",
     "danbooru": "Danbooru",
@@ -2748,6 +2753,11 @@
     "studio_data": {
       "target_invalid": "目标位置无效：{{reason}}",
       "migration_busy": "数据迁移已在进行中"
+    },
+    "models_root": {
+      "target_invalid": "目标位置无效：{{reason}}",
+      "migration_busy": "模型根目录迁移已在进行中",
+      "target_conflict": "目标目录已包含 models 数据"
     },
     "export": {
       "name_conflict": "导出文件名「{{name}}」冲突过多，请重命名后重试"

--- a/tests/test_models_storage.py
+++ b/tests/test_models_storage.py
@@ -1,7 +1,8 @@
 """模型根目录迁移服务（studio.services.models_storage）单测。
 
 只测纯函数（scan / validate_target / _run_migration 直调，避免线程 flaky）：
-复制 + 更新 secrets.models.root + 失败回滚 + 校验规则 + 单飞。
+复制 + 更新 secrets.models.root + 失败回滚 + 校验规则 + 单飞 + 合并模式
+（issue #351：目标非空冲突三选，skip/overwrite 及其失败不回滚语义）。
 """
 from __future__ import annotations
 
@@ -102,6 +103,41 @@ def test_validate_rejects_nonempty_dst(tmp_path: Path) -> None:
         ms.validate_target(target, source=src)
 
 
+def test_validate_conflict_error_with_details(tmp_path: Path) -> None:
+    """非空落地目录 + 未指定策略 → TargetConflictError，details 带三项统计。"""
+    src = _make_src(tmp_path / "cur")
+    target = tmp_path / "newroot"
+    dst = target / "models"
+    (dst / "diffusion_models").mkdir(parents=True)
+    # 与 src 同名（会被 overwrite 覆盖）
+    (dst / "diffusion_models" / "anima.safetensors").write_bytes(b"other" * 4)
+    # 目标独有
+    (dst / "extra.bin").write_bytes(b"e" * 10)
+    with pytest.raises(ms.TargetConflictError) as ei:
+        ms.validate_target(target, source=src)
+    d = ei.value.details
+    assert d["target"] == str(target.resolve() / "models")
+    assert d["existing_files"] == 2
+    assert d["existing_bytes"] == 20 + 10
+    assert d["same_name_files"] == 1
+
+
+def test_validate_allows_nonempty_dst_with_on_conflict(tmp_path: Path) -> None:
+    src = tmp_path / "cur"
+    src.mkdir()
+    target = tmp_path / "newroot"
+    dst = target / "models"
+    dst.mkdir(parents=True)
+    (dst / "existing.bin").write_bytes(b"z")
+    for mode in ("skip", "overwrite"):
+        assert ms.validate_target(target, source=src, on_conflict=mode) == dst.resolve()
+
+
+def test_validate_rejects_unknown_on_conflict(tmp_path: Path) -> None:
+    with pytest.raises(ValueError):
+        ms.validate_target(tmp_path / "newroot", source=tmp_path / "cur", on_conflict="merge")
+
+
 # ---------------------------------------------------------------------------
 # _run_migration（直调，同步）
 # ---------------------------------------------------------------------------
@@ -143,6 +179,82 @@ def test_run_migration_rollback_on_failure(
     # dst 整树清掉（回滚），secret 未动
     assert not dst.exists()
     assert state["s"].models.root == orig_root
+    assert any(e["type"] == "models_root_migrate_done" and not e["ok"] for e in events)
+    assert ms.migration_status()["state"] == "error"
+
+
+def test_run_migration_skip_keeps_existing_and_fills_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reset_status
+) -> None:
+    """skip：目标同名文件保留原内容，缺的补齐；进度总量只算真复制的。"""
+    src = _make_src(tmp_path / "old" / "models")
+    dst = tmp_path / "new" / "models"
+    (dst / "diffusion_models").mkdir(parents=True)
+    (dst / "diffusion_models" / "anima.safetensors").write_bytes(b"theirs")
+    state = _fake_secrets_store(monkeypatch, tmp_path / "old" / "models")
+    events: list[dict] = []
+
+    ms._run_migration(src, dst, publish=events.append, on_conflict="skip")
+
+    # 同名文件保留目标原有版本
+    assert (dst / "diffusion_models" / "anima.safetensors").read_bytes() == b"theirs"
+    # 缺失文件补齐
+    assert (dst / "vae" / "vae.safetensors").read_bytes() == b"y" * 50
+    assert (dst / "top.txt").exists()
+    # secret 切换 + 完成事件
+    assert state["s"].models.root == str(dst)
+    assert any(e["type"] == "models_root_migrate_done" and e["ok"] for e in events)
+    status = ms.migration_status()
+    assert status["state"] == "done"
+    # src 共 3 个文件，1 个被跳过 → 只复制 2 个
+    assert status["total_files"] == 2
+    # 无临时文件残留
+    assert not list(dst.rglob("*.part"))
+
+
+def test_run_migration_overwrite_replaces_same_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reset_status
+) -> None:
+    """overwrite：同名文件换成当前根的副本，目标独有文件不动。"""
+    src = _make_src(tmp_path / "old" / "models")
+    dst = tmp_path / "new" / "models"
+    (dst / "diffusion_models").mkdir(parents=True)
+    (dst / "diffusion_models" / "anima.safetensors").write_bytes(b"theirs")
+    (dst / "their-extra.bin").write_bytes(b"keep me")
+    state = _fake_secrets_store(monkeypatch, tmp_path / "old" / "models")
+    events: list[dict] = []
+
+    ms._run_migration(src, dst, publish=events.append, on_conflict="overwrite")
+
+    assert (dst / "diffusion_models" / "anima.safetensors").read_bytes() == b"x" * 100
+    assert (dst / "their-extra.bin").read_bytes() == b"keep me"
+    assert state["s"].models.root == str(dst)
+    assert ms.migration_status()["state"] == "done"
+    assert not list(dst.rglob("*.part"))
+
+
+def test_run_migration_merge_failure_keeps_preexisting(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, reset_status
+) -> None:
+    """合并模式失败：目标既有数据绝不 rmtree，secret 不动，无 .part 残留。"""
+    src = _make_src(tmp_path / "old" / "models")
+    dst = tmp_path / "new" / "models"
+    dst.mkdir(parents=True)
+    (dst / "their-extra.bin").write_bytes(b"keep me")
+    state = _fake_secrets_store(monkeypatch, tmp_path / "old" / "models")
+    orig_root = state["s"].models.root
+
+    def boom(*a, **k):
+        raise OSError("disk full")
+    monkeypatch.setattr(ms.shutil, "copy2", boom)
+
+    events: list[dict] = []
+    ms._run_migration(src, dst, publish=events.append, on_conflict="skip")
+
+    # 目标目录和既有文件原样保留
+    assert (dst / "their-extra.bin").read_bytes() == b"keep me"
+    assert state["s"].models.root == orig_root
+    assert not list(dst.rglob("*.part"))
     assert any(e["type"] == "models_root_migrate_done" and not e["ok"] for e in events)
     assert ms.migration_status()["state"] == "error"
 


### PR DESCRIPTION
Closes #351

## 背景

设置页迁移模型根目录时，目标 `target/models` 已有数据会被直接拒绝（「目标下已存在非空 models 目录」），导致无法把模型目录指向与跑图工具共用的路径，云端「临时工作区 / 永久存储区分离」场景同样被挡住。

## 方案

不做独立的 adopt（只指路不复制）入口，而是把 migrate 升级为文件复制式的冲突三选：目标已有数据时后端回 `409 models_root.target_conflict`（details 带目标现有文件数/字节数 + 与当前根同名的文件数），前端在迁移 modal 内弹「跳过已有文件 / 覆盖已有文件 / 取消」，选择后带 `on_conflict` 重发。

选「跳过」的终态 = 把路径指向共用目录 + 顺带补齐缺失文件；目标已齐全时几乎瞬时完成，退化为纯指路。相比独立 adopt 入口：单一入口、心智模型就是文件管理器冲突对话框、不新增路由。

## 语义

- **skip**：只复制目标缺少的文件，同名文件保留目标现有版本；进度总量只按真要复制的文件计算
- **overwrite**：同名文件以当前根的副本覆盖，目标独有文件不动
- 两种模式复制均改为逐文件写 `.part` 临时名 + `os.replace` 原子替换——目标位置任何时刻只有完整文件，覆盖失败不会把既有完整权重砸成半截
- **失败回滚分支**：目标开跑前为空/不存在 → 保持原有 `rmtree` 整树回滚；目标原本非空（合并模式）→ 绝不 rmtree（既有数据可能与其他工具共用），留下的已复制文件均为完整副本，skip 幂等重跑即续传。`secrets.models.root` 仍只在全部复制完成后切换
- `errors.*` 补齐 `models_root` 词条（`target_invalid` / `migration_busy` 此前缺失，回退英文）
- studio_data 迁移不动（结构强耦合、无此需求），仅 models root

## 测试

- 后端：`tests/test_models_storage.py` 新增冲突 details 统计 / on_conflict 放行 / skip 保留既有文件并补缺 / overwrite 覆盖同名保留独有 / 合并失败不回滚不残留 `.part`，共 16 过
- 前端：新增 `ModelsRootMigrateModal.test.tsx` 覆盖冲突三选流程（skip / overwrite 重发、取消回 confirm、非冲突错误进 error 态），全量 vitest 52 文件 463 过
- 无新路由，route snapshot 不变；`npm run build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)