### PR TITLE
fix(ui): 队列行继续训练/暂停操作移入 action 列并 icon 化

### DIFF
--- a/studio/web/src/pages/Queue.test.tsx
+++ b/studio/web/src/pages/Queue.test.tsx
@@ -217,6 +217,63 @@ describe('QueuePage 分区 + 分页', () => {
     await waitFor(() => expect(startSpy).toHaveBeenCalledWith(21))
   })
 
+  it('paused 行：恢复/取消操作在 action 列，恢复走 confirm 后调 resumeTask', async () => {
+    vi.spyOn(api, 'getQueueHold').mockResolvedValue({ held: false } as never)
+    vi.spyOn(api, 'listQueueLive').mockResolvedValue([
+      makeTask({
+        id: 40, name: 'paused-task', status: 'paused', pid: null,
+        paused_step: 120, paused_at: 1200, is_resumable: true,
+      }),
+    ])
+    vi.spyOn(api, 'listQueueHistory').mockResolvedValue({
+      items: [], total: 0, page: 1, page_size: 20,
+    })
+    const resumeSpy = vi.spyOn(api, 'resumeTask').mockResolvedValue({
+      task_id: 40, status: 'pending',
+    })
+
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('resume-btn-40')).toBeInTheDocument())
+    expect(screen.getByTestId('cancel-paused-btn-40')).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('resume-btn-40'))
+    // 状态转移走 confirm（行按钮已 icon 化，「恢复」文案只在 dialog 确认键上）
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    expect(resumeSpy).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByText('恢复'))
+    await waitFor(() => expect(resumeSpy).toHaveBeenCalledWith(40))
+  })
+
+  it('失败/取消且恢复点在盘的历史行：继续训练在 action 列，confirm 后调 resumeTask', async () => {
+    vi.spyOn(api, 'getQueueHold').mockResolvedValue({ held: false } as never)
+    vi.spyOn(api, 'listQueueLive').mockResolvedValue([])
+    vi.spyOn(api, 'listQueueHistory').mockResolvedValue({
+      items: [
+        makeTask({
+          id: 30, name: 'dead', status: 'canceled', pid: null,
+          finished_at: 900, is_resumable: true,
+        }),
+        makeTask({
+          id: 31, name: 'dead-no-backup', status: 'canceled', pid: null,
+          finished_at: 800,
+        }),
+      ],
+      total: 2, page: 1, page_size: 20,
+    })
+    const resumeSpy = vi.spyOn(api, 'resumeTask').mockResolvedValue({
+      task_id: 30, status: 'pending',
+    })
+
+    renderQueue()
+    await waitFor(() => expect(screen.getByTestId('resume-btn-30')).toBeInTheDocument())
+    // 无恢复点的终态行没有继续训练按钮
+    expect(screen.queryByTestId('resume-btn-31')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('resume-btn-30'))
+    await waitFor(() => expect(screen.getByRole('dialog')).toBeInTheDocument())
+    expect(resumeSpy).not.toHaveBeenCalled()
+    fireEvent.click(screen.getByText('继续训练'))
+    await waitFor(() => expect(resumeSpy).toHaveBeenCalledWith(30))
+  })
+
   it('右上角「数据作业」toggle → 切换只读区，漏斗变 kind 过滤（P-G）', async () => {
     vi.spyOn(api, 'getQueueHold').mockResolvedValue({ held: false } as never)
     vi.spyOn(api, 'listQueueLive').mockResolvedValue([

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -306,30 +306,12 @@ function QueueTaskRow({
               <span className="text-xs">{fmtAgo(task.started_at!)} 开始</span>
             </>
           ) : isPaused ? (
-            <span className="flex flex-col items-end gap-1">
-              <span className="flex gap-1.5">
-                <button
-                  onClick={(e) => { e.stopPropagation(); void onResume(task) }}
-                  className="btn btn-secondary btn-xs"
-                  title={t('queue.resumeHint')}
-                  data-testid={`resume-btn-${task.id}`}
-                >
-                  {t('queue.resume')}
-                </button>
-                <button
-                  onClick={(e) => { e.stopPropagation(); void onCancelPaused(task) }}
-                  className="btn btn-ghost btn-xs text-err"
-                  title={t('queue.cancelPausedHint')}
-                >
-                  {t('queue.cancelPaused')}
-                </button>
-              </span>
-              {isWaitingForRelease && (
-                <span className="text-xs text-fg-tertiary">
-                  {t('queue.waitingForRelease')}
-                </span>
-              )}
-            </span>
+            /* 暂停时间在左侧 duration 列（pausedAtStep），操作在右侧 action 列 */
+            isWaitingForRelease ? (
+              <span className="text-xs font-normal">{t('queue.waitingForRelease')}</span>
+            ) : (
+              <span>—</span>
+            )
           ) : isScheduled ? (
             /* 0.17 P-B — 计划任务：计划时间 + 倒计时（操作在右侧 action 列） */
             <span className="flex flex-col items-end gap-0.5">
@@ -345,23 +327,10 @@ function QueueTaskRow({
               )}
             </span>
           ) : task.finished_at ? (
-            <span className="flex flex-col items-end gap-1">
-              {/* ADR 0006 Addendum 2 — failed/canceled 且恢复点在盘 → 继续训练。 */}
-              {task.is_resumable && (
-                <button
-                  onClick={(e) => { e.stopPropagation(); void onResume(task) }}
-                  className="btn btn-secondary btn-xs"
-                  title={t('queue.resumeTerminalHint')}
-                  data-testid={`resume-btn-${task.id}`}
-                >
-                  {t('queue.resumeTerminal')}
-                </button>
-              )}
-              <span>
-                <span>{fmtAgo(task.finished_at)}</span>
-                <br />
-                <span className="text-xs text-fg-tertiary">{t('status.done')}</span>
-              </span>
+            <span>
+              <span>{fmtAgo(task.finished_at)}</span>
+              <br />
+              <span className="text-xs text-fg-tertiary">{t('status.done')}</span>
             </span>
           ) : (
             <span className="flex flex-col items-end gap-0.5">
@@ -375,9 +344,49 @@ function QueueTaskRow({
           )}
         </span>
 
-        {/* 0.17 action 列：跳转 + scheduled 的立即开始/取消计划，全 icon 化
-            （hover title 显示文字）。 */}
+        {/* 0.17 action 列：跳转 + scheduled 的立即开始/取消计划 + paused 的恢复/取消
+            + 终态可恢复的继续训练，全 icon 化（hover title 显示文字）。 */}
         <div className="flex items-center justify-end gap-1.5">
+          {isPaused && (
+            <>
+              <button
+                onClick={(e) => { e.stopPropagation(); void onResume(task) }}
+                className="btn btn-ghost btn-sm px-2"
+                title={`${t('queue.resume')} — ${t('queue.resumeHint')}`}
+                aria-label={t('queue.resume')}
+                data-testid={`resume-btn-${task.id}`}
+              >
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="M8 5v14l11-7z" />
+                </svg>
+              </button>
+              <button
+                onClick={(e) => { e.stopPropagation(); void onCancelPaused(task) }}
+                className="btn btn-ghost btn-sm px-2 text-err"
+                title={`${t('queue.cancelPaused')} — ${t('queue.cancelPausedHint')}`}
+                aria-label={t('queue.cancelPaused')}
+                data-testid={`cancel-paused-btn-${task.id}`}
+              >
+                <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                  <path d="M18 6L6 18M6 6l12 12" />
+                </svg>
+              </button>
+            </>
+          )}
+          {/* ADR 0006 Addendum 2 — failed/canceled 且恢复点在盘 → 继续训练。 */}
+          {isTerminal && task.is_resumable && (
+            <button
+              onClick={(e) => { e.stopPropagation(); void onResume(task) }}
+              className="btn btn-ghost btn-sm px-2"
+              title={`${t('queue.resumeTerminal')} — ${t('queue.resumeTerminalHint')}`}
+              aria-label={t('queue.resumeTerminal')}
+              data-testid={`resume-btn-${task.id}`}
+            >
+              <svg width="22" height="22" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M8 5v14l11-7z" />
+              </svg>
+            </button>
+          )}
           {isScheduled && (
             <>
               <button
@@ -638,6 +647,10 @@ export default function QueuePage() {
   }
 
   const resumeTask = async (task: Task) => {
+    const label = task.status === 'paused' ? t('queue.resume') : t('queue.resumeTerminal')
+    const hint = task.status === 'paused' ? t('queue.resumeHint') : t('queue.resumeTerminalHint')
+    const ok = await confirm(`${label} #${task.id}？${hint}`, { okText: label })
+    if (!ok) return
     try {
       await api.resumeTask(task.id)
       toast(t('queue.resumeSent', { id: task.id }), 'success')


### PR DESCRIPTION
## 背景 / 动机

队列页历史区里，failed/canceled 且恢复点在盘的行的「继续训练」按钮渲染在时间列（「Nd 前 / 完成」）里，和时间信息挤在一起，不在行尾的 action icon 列。paused 行的「恢复 / 取消任务」是同样的问题。

## 改动概要

- 「继续训练」（终态可恢复行）和「恢复 / 取消任务」（paused 行）统一挪到行尾 action 列，icon 化（play / ×），hover title 显示完整文案 + 说明，与 scheduled 行「立即开始 / 取消计划」同范式
- 时间列恢复纯时间信息：终态行只显示「Nd 前 / 完成」；paused 行显示「等待恢复调度」或「—」（暂停 step / 时间本就在左侧用时列的「在 step X 暂停于 …」里）
- `resumeTask` 补 confirm 弹窗：`startNow` / `cancelPaused` / `cancelScheduled` 都有 confirm，唯独 resume 没有；icon 化后误点会直接把训练拉起来，按列表行状态转移走 confirm 的既有范式补齐（复用现有 i18n 文案，无新增 key）

## 测试方式

- 新增 2 个 regression 测试：paused 行、终态可恢复行各一，覆盖按钮存在性（无恢复点的行不渲染）+ confirm 后才调 `api.resumeTask`
- `npx vitest run` 全量 467 全绿；`npm run lint` + `npx tsc --noEmit` 通过

## 截图

改前（按钮挤在时间列）见 issue 描述位置；改后截图待补。

🤖 Generated with [Claude Code](https://claude.com/claude-code)