### PR TITLE
feat(ui): 提示词选择器数据集图片预览支持点击放大

### DIFF
--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1530,6 +1530,7 @@
     "selectedDatasetTagsAria": "Selected caption tags (read-only)",
     "datasetPreviewAlt": "Training image preview",
     "datasetPreviewEmpty": "Hover or select a row to preview",
+    "datasetPreviewZoomTitle": "Click to enlarge",
     "replaceCurrentPrompt": "Replace current prompt",
     "appendToCurrentPrompt": "Append to current prompt",
     "weight": "Weight",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1530,6 +1530,7 @@
     "selectedDatasetTagsAria": "已选 caption 的 tags（只读）",
     "datasetPreviewAlt": "训练集图片预览",
     "datasetPreviewEmpty": "悬停或选中一行看大图",
+    "datasetPreviewZoomTitle": "点击放大",
     "replaceCurrentPrompt": "替换当前提示词",
     "appendToCurrentPrompt": "追加到当前提示词",
     "weight": "权重",

--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.test.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { api, type CaptionEntry, type ProjectDetail, type ProjectSummary } from '../../../api/client'
@@ -122,5 +122,34 @@ describe('PromptFromDatasetPicker — thumbnail / pid·vid 同步', () => {
     const src = rowThumb().getAttribute('src') ?? ''
     expect(src).toContain('/versions/11/thumb')
     expect(src).not.toContain('/versions/12/thumb')
+  })
+
+  it('点击底部大图预览放大成全屏 modal（复用 ImagePreviewModal，请求 1600 大图）', async () => {
+    vi.spyOn(api, 'listProjects').mockResolvedValue(projects)
+    vi.spyOn(api, 'getProject').mockResolvedValue(projectDetail)
+    vi.spyOn(api, 'listCaptionsFull').mockResolvedValue({ folder: null, items: [cap('shot.png', 'x')] })
+
+    const user = await selectProjectAndV1()
+    await waitFor(() => expect(screen.getByText('shot.png')).toBeInTheDocument())
+
+    // 悬停一行 → 底部大图预览出现，其可点击放大按钮 aria-label="点击放大"
+    await user.hover(screen.getByText('shot.png'))
+    const zoomBtn = await screen.findByRole('button', { name: '点击放大' })
+
+    // 点击放大按钮 → 全屏 ImagePreviewModal，主图 alt=文件名、URL 请求 1600 大图 + 当前 (pid,vid)。
+    // 用 fireEvent.click 而非 user.click：userEvent 点击前会把指针移出再移入目标，途中触发 picker
+    // 根节点 onMouseLeave 清掉 hoveredKey，使放大按钮在点击前卸载（真实浏览器里指针从列表行到大图
+    // 连续移动、始终在 picker 内，根节点 mouseleave 不会触发，故属模拟 artifact）。这里只验证
+    // 「点击放大按钮」本身，直接派发 click 更贴切。
+    fireEvent.click(zoomBtn)
+    const modalImg = await screen.findByAltText('shot.png')
+    const src = modalImg.getAttribute('src') ?? ''
+    expect(src).toContain('/projects/1/versions/11/thumb')
+    expect(src).toContain('name=shot.png')
+    expect(src).toContain('size=1600')
+
+    // Esc 关闭（ImagePreviewModal 的键盘监听；picker 自身不监听 Esc，不冲突）
+    await user.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByAltText('shot.png')).not.toBeInTheDocument())
   })
 })

--- a/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
+++ b/studio/web/src/pages/tools/generate/PromptFromDatasetPicker.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, type CaptionEntry, type ProjectSummary } from '../../../api/client'
 import { useLocalStorageState } from '../../../lib/useLocalStorageState'
+import ImagePreviewModal from '../../../components/ImagePreviewModal'
 
 // 命名前缀对齐 useAdvancedMode 的 `studio:` 约定（PR #66 P1-4）。旧的
 // `anima.generate.promptDataset.*` key 在 mount 时 migrate 一次后丢弃。
@@ -89,6 +90,12 @@ export default function PromptFromDatasetPicker({
   const [search, setSearch] = useState('')
   // 鼠标悬停的 caption key，驱动底部大图预览（移开 → 回落到已选 value 的图）
   const [hoveredKey, setHoveredKey] = useState<string | null>(null)
+  // 点击底部大图放大成全屏 modal。存的是点击那一刻预览图的定位快照，而非实时
+  // previewMeta —— 鼠标移进覆盖全屏的 modal 会离开 picker、触发根节点 onMouseLeave 清空
+  // hoveredKey，若跟随实时值放大的图会瞬间消失。快照后与 hover 解耦，稳定显示到手动关闭。
+  const [zoomMeta, setZoomMeta] = useState<
+    { pid: number; vid: number; name: string; folder?: string } | null
+  >(null)
 
   // 1. 拉项目列表；若上次记的 pid 在新项目列表中不存在则清掉避免幽灵选择
   useEffect(() => {
@@ -173,12 +180,16 @@ export default function PromptFromDatasetPicker({
   const hoveredCaption = hoveredKey
     ? captions.find((c) => `${c.folder}/${c.name}` === hoveredKey) ?? null
     : null
-  const previewSrc =
+  // 当前预览图的定位信息，缩览图（512）和点击放大（1600）共用；null = 无图可显示。
+  const previewMeta =
     hoveredCaption && loaded
-      ? api.versionThumbUrl(loaded.pid, loaded.vid, 'train', hoveredCaption.name, hoveredCaption.folder, 512)
+      ? { pid: loaded.pid, vid: loaded.vid, name: hoveredCaption.name, folder: hoveredCaption.folder }
       : value && value.folder
-        ? api.versionThumbUrl(value.projectId, value.versionId, 'train', value.name, value.folder, 512)
-        : ''
+        ? { pid: value.projectId, vid: value.versionId, name: value.name, folder: value.folder }
+        : null
+  const previewSrc = previewMeta
+    ? api.versionThumbUrl(previewMeta.pid, previewMeta.vid, 'train', previewMeta.name, previewMeta.folder, 512)
+    : ''
 
   const handleRowClick = (c: CaptionEntry) => {
     // 行属于 loaded 这一组 captions，选中也要落到 loaded 的 (pid, vid)，不能用
@@ -204,9 +215,14 @@ export default function PromptFromDatasetPicker({
   }
 
   return (
+    <>
+    {/* onMouseLeave 绑在整个 picker（而非仅列表）：从列表行移到底部大图想点击放大时
+        不能丢 hover —— 否则未选中场景下大图与放大按钮会随 hoveredKey 清空而消失、点不到，
+        已选场景下则会回落成放大 value 的另一张图。移出整个 picker 才清空、回落到 value。 */}
     <div
       className="rounded-md border border-subtle bg-overlay p-2.5 flex flex-col gap-2"
       data-testid="prompt-dataset-picker"
+      onMouseLeave={() => setHoveredKey(null)}
     >
       {/* header */}
       <div className="flex items-center gap-2">
@@ -274,7 +290,6 @@ export default function PromptFromDatasetPicker({
       <div
         className="flex flex-col gap-px overflow-y-auto"
         style={{ maxHeight: 320 }}
-        onMouseLeave={() => setHoveredKey(null)}
       >
         {loading && <div className="text-2xs text-fg-tertiary">{t('common.loading')}</div>}
         {!loading && pid && vid && captions.length === 0 && !error && (
@@ -332,13 +347,21 @@ export default function PromptFromDatasetPicker({
           style={{ height: 240 }}
         >
           {previewSrc ? (
-            <img
-              src={previewSrc}
-              alt={t('generate.datasetPreviewAlt')}
-              loading="lazy"
-              className="w-full h-full object-contain"
-              onError={(e) => { e.currentTarget.style.visibility = 'hidden' }}
-            />
+            <button
+              type="button"
+              onClick={() => previewMeta && setZoomMeta(previewMeta)}
+              className="w-full h-full flex items-center justify-center border-none bg-transparent p-0 cursor-zoom-in"
+              title={t('generate.datasetPreviewZoomTitle')}
+              aria-label={t('generate.datasetPreviewZoomTitle')}
+            >
+              <img
+                src={previewSrc}
+                alt={t('generate.datasetPreviewAlt')}
+                loading="lazy"
+                className="w-full h-full object-contain"
+                onError={(e) => { e.currentTarget.style.visibility = 'hidden' }}
+              />
+            </button>
           ) : (
             <span className="text-2xs text-fg-tertiary px-1.5 text-center leading-snug">
               {t('generate.datasetPreviewEmpty')}
@@ -356,5 +379,13 @@ export default function PromptFromDatasetPicker({
         />
       </div>
     </div>
+    {zoomMeta && (
+      <ImagePreviewModal
+        src={api.versionThumbUrl(zoomMeta.pid, zoomMeta.vid, 'train', zoomMeta.name, zoomMeta.folder, 1600)}
+        caption={zoomMeta.name}
+        onClose={() => setZoomMeta(null)}
+      />
+    )}
+    </>
   )
 }


### PR DESCRIPTION
## 背景 / 动机

测试页「从训练集选 prompt」选择器底部有一张训练集图片大预览，用来跟生成结果肉眼比对。此前只能看缩览尺寸（512），细节看不清。

## 改动概要

- **点击放大**：点击底部大图预览 → 放大成全屏 modal，复用 `ImagePreviewModal`（与流水线筛选页 `Curation` 同一组件），请求 1600 大图；`Esc` / 点空白关闭。仅传 `src / caption / onClose` 三个必要 prop（不需要筛选页那套翻页 / 删除）。
- **抽 `previewMeta`**：把原先直接算 `previewSrc` 的逻辑抽成 `{pid, vid, name, folder}` 定位对象，缩览（512）与放大（1600）共用同一来源；`zoomMeta` 存点击瞬间快照、与 hover 解耦，避免 modal 覆盖全屏后 hover 清空导致放大图消失。
- **顺带修交互 bug**：`onMouseLeave={() => setHoveredKey(null)}` 原绑在**列表容器**上——鼠标从列表行移向底部大图去点放大时会离开列表、清空 `hoveredKey`，导致大图与放大按钮在点击前消失（未选中场景）或放大成 `value` 的另一张图（已选中场景）。改为绑在 **picker 根节点**（真实浏览器里从列表到大图连续移动始终在 picker 内，移出整个 picker 才回落 `value`）。此 bug 本就让新增测试红。

## 测试方式

- 新增单测：hover 行 → 点放大按钮 → 全屏 modal 主图 `alt=文件名`、URL 请求 `size=1600` + 当前 `(pid, vid)` → `Esc` 关闭。
  - 该用例用 `fireEvent.click` 而非 `user.click`：userEvent 点击前会把指针漂移出容器再移入，误触发根节点 `onMouseLeave`（真实浏览器连续移动不会），属模拟 artifact。
- 前端全量 `vitest run` **469/469** 绿；`npm run lint` / `tsc --noEmit` 干净。

## 截图

纯前端交互，此环境无法附截图：本地 `npm run build` 后在测试页「从训练集选 prompt」底部大图点击即放大，`Esc` 关闭。

🤖 Generated with [Claude Code](https://claude.com/claude-code)