### PR TITLE
fix(generate): 点开始生成清掉历史回看，结果区回到实时任务

### DIFF
--- a/studio/web/src/pages/tools/Generate.test.tsx
+++ b/studio/web/src/pages/tools/Generate.test.tsx
@@ -488,4 +488,67 @@ describe('GeneratePage 端到端 smoke', () => {
     // ……但右侧已出结果网格冻结：仍含 "30" 表头，未被 live 编辑串改
     expect(screen.getByText('30')).toBeInTheDocument()
   })
+
+  // ---- 回看历史 XY 时点「开始生成」→ 回到实时视图（P-I 回归修复）----
+  it('回看 XY 历史时点开始生成：清掉历史 override，结果区回到实时新任务', async () => {
+    // 修前（P-I 删了「currentTask.id 变自动清 override」的 effect）：点开始生成不清
+    // override，结果区停留在正回看的老 XY 图，看不到新入队/正在跑的这次。
+    // 修后：提交即清 override，回到实时视图。
+    vi.mocked(useMonitorProgress).mockReturnValue({
+      state: {
+        samples: [{ path: 'cell x0 y0.png', xy: { xi: 0, yi: 0, xv: 20, yv: null } }],
+      },
+    } as never)
+    seedPrefs({ mode: 'xy' })  // 默认 X=steps raw "20, 25, 30"
+    const xySnapshotParams = {
+      schema_version: 1, mode: 'xy',
+      prompts: ['recall'], negative_prompt: '',
+      width: 1024, height: 1024, steps: 25, cfg_scale: 4, count: 1, seed: 0,
+      loras: [],
+      // 用 steps 轴（非 lora_ckpt）→ 回填后按钮仍是「· 3 张」，不引入 picker 异步
+      xy_draft: { x: { axis: 'steps', raw: '20, 25, 30', loraIndex: null }, y: null },
+      dataset_pick: null,
+    }
+    const diskEntry = {
+      id: 'disk:xy1', date: '2026-06-09', mode: 'xy', folder: 'xy plot 1',
+      path: '/tmp/test/2026-06-09/xy/xy plot 1',
+      image_url: '/api/generate/disk/image/2026-06-09/xy/xy%20plot%201/xy%20plot.png',
+      thumb_url: '/api/generate/disk/thumb/2026-06-09/xy/xy%20plot%201/xy%20plot.png?w=128',
+      created_at: 1717900000, schema_version: 2,
+      params: xySnapshotParams,
+      xy_meta: {
+        x_axis: 'steps', y_axis: null,
+        x_values: ['20', '25', '30'], y_values: [null], samples: [],
+      },
+    }
+    const previousImpl = fetchMock.getMockImplementation()
+    fetchMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.endsWith('/api/generate/disk/history') && (init?.method ?? 'GET') === 'GET') {
+        return Promise.resolve({
+          ok: true, status: 200,
+          json: async () => ({ entries: [diskEntry] }),
+          text: async () => JSON.stringify({ entries: [diskEntry] }),
+          headers: new Headers({ 'content-type': 'application/json' }),
+        } as Response)
+      }
+      return previousImpl ? previousImpl(url, init) : Promise.resolve({
+        ok: false, status: 404, json: async () => null, text: async () => '',
+        headers: new Headers(),
+      } as Response)
+    })
+
+    const user = userEvent.setup()
+    setup()
+    await waitForInitialLorasLoad()
+
+    // 点历史缩略图进入回看：结果区底部显示文件夹名 "xy plot 1"（override 生效标志）
+    const thumb = await screen.findByTitle(/xy plot 1 ·/)
+    await user.click(thumb)
+    await waitFor(() => expect(screen.getByText('xy plot 1')).toBeInTheDocument())
+
+    // 点开始生成 → 清掉 override，结果区回到实时任务：底部 "xy plot 1" 文本消失
+    await user.click(screen.getByRole('button', { name: /开始生成 · 3 张/ }))
+    await waitFor(() => expect(lastEnqueueBody).not.toBeNull())
+    await waitFor(() => expect(screen.queryByText('xy plot 1')).not.toBeInTheDocument())
+  })
 })

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -659,6 +659,12 @@ export default function GeneratePage() {
         })
         if (firstId === null) {
           firstId = task.id
+          // 点「开始生成」= 明确要看这次出图 → 回到实时视图：清掉正在回看的历史
+          // override（否则结果区停留在老图，看不到新入队/正在跑的这次，XY 尤甚 ——
+          // 出图慢，用户常停在回看态点生成）。P-I 删掉了「currentTask.id 变自动清
+          // override」的 effect（多任务下会把回看中的 done 项踢回实时），这里改成只在
+          // 用户显式提交时清，兼顾两者。
+          setHistoryOverride(null)
           // 首次生成（当前无显示）乐观置为第一个 task，立刻看到「排队/开始」而非空屏。
           if (!currentTaskRef.current || TERMINAL_TASK_STATUSES.includes(currentTaskRef.current.status)) {
             setCurrentTask(task)


### PR DESCRIPTION
## 背景 / 动机

回看历史或已完成的 XY 图时（结果区处于 `historyOverride` 回看态），点「开始生成」后结果区**停留在那张老图**，看不到新入队 / 正在跑的这次出图。XY 尤其明显 —— 出图慢，用户常停在回看态再点生成；单图出得快，很少撞上，所以「看起来只有 XY 坏」。

期望（也是 P-I 之前的行为）：点开始生成 → 结果区回到实时视图，能看到正在生成的 XY 网格，**已出的格子显示图、未出的显示占位**。

## 根因

PR #355（P-I 多任务排队）为支持「显示跟着正在跑的那张走」，删掉了 `currentTask.id` 变化时自动清 `historyOverride` 的 `useEffect`。副作用是提交出图不再清 override，于是结果区卡在回看的老图上。

## 改动

`handleGenerate` 里在成功入队第一个 task 时 `setHistoryOverride(null)`：

- 只在用户**显式提交**时清 override → 回到实时视图；
- 不像被删的旧 effect 那样在每次 `currentTask.id` 变时清 → 多任务下不会把用户正在回看的 done 项踢回实时；
- 放在 `enqueue` 成功之后，入队失败时不误清用户正在看的图。

XY 生成中网格（`PreviewXYGrid` / `GridCell`）本身已支持「已出格子显图、未出格子显示 `…` 占位」，回到实时视图即可看到进度，无需改渲染层。

## 测试

- 新增回归测试：回看 XY 落盘历史 → 点「开始生成」→ 断言 override 被清（结果区离开历史回看）。已验证**移除修复时该测试失败**（复现 bug）、**有修复时通过**。
- `npx vitest run`（generate 相关 106 个用例）全绿；`npm run lint`、`npx tsc --noEmit` 通过。

## 截图

纯状态逻辑修复（清一处 UI state），无新增视觉元素，未附截图。