### PR TITLE
fix(generate): 中间步预览改用 Wan2.1 latent2rgb，修复反色 + 铺满结果区

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -51,6 +51,11 @@
     `runtime/anima_daemon.py`、`runtime/training/sample_runner.py`、
     `studio/api/routers/generate.py` — 将测试出图与训练 sample 接到 Comfy-style
     parity runtime 的本项目 glue/config 代码
+  - `runtime/anima_daemon.py` — 中间步预览的 `_WAN21_LATENT_RGB_FACTORS` /
+    `_WAN21_LATENT_RGB_BIAS` 常量取自 ComfyUI `comfy/latent_formats.py` 的 `Wan21`
+    （Qwen-Image VAE 复用 Wan2.1 latent 空间：`comfy/supported_models.py`
+    `QwenImage.latent_format = Wan21`）；`_decode_latent2rgb_preview` 的投影 + 范围
+    映射对齐 ComfyUI `latent_preview.py` `Latent2RGBPreviewer`
 
 > 由于包含/派生自 GPL-3.0 代码，本项目整体以 GPL-3.0 发布（见 `LICENSE`）。
 

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -195,8 +195,6 @@ class ModelCache:
     第一次 task 进来 load_model_paths()；之后路径不变则复用；adapters
     在 lora_configs 改变时才重 inject（commit 9 简化：每次都重 inject，
     成本 ~1-2s/LoRA，相比 30s+ model load 可忽略；后续 commit 优化）。
-
-    commit 14：lazy 加载 TAEFlux（中间步预览用），失败不阻塞主流程。
     """
 
     def __init__(self) -> None:
@@ -221,40 +219,8 @@ class ModelCache:
         self.adapters: list[Any] = []
         self.last_lora_specs: list[LoRASpec] = []
         self.last_lora_metas: list[LoRAMeta] = []
-        # commit 14：TAEFlux for preview
-        self.taeflux: Any = None
-        self.taeflux_attempted: bool = False  # 失败后不再重试
-
-    def ensure_taeflux(self) -> Any:
-        """lazy 加载 TAEFlux。已加载或上次失败 → 返回缓存（可能是 None）。
-
-        缺失时**自动后台下载**（1.6MB ~1-2s）：用户开启预览后第一次跑生成
-        会触发；下载期间该次生成跳过预览，下次正常。失败标 attempted=True
-        不再重试，避免反复尝试（用户排查后手动重启或 settings 重新触发）。
-        """
-        if self.taeflux is not None or self.taeflux_attempted:
-            return self.taeflux
-        self.taeflux_attempted = True
-        try:
-            from studio.services import models as _md
-            if not _md.taeflux_available():
-                # 自动下载（1.6MB；用户配置的 HF mirror 自动生效）
-                logger.info("taeflux missing → auto-downloading (~1.6MB)…")
-                ok = _md.download_taeflux(on_log=lambda m: logger.info("[taeflux] %s", m))
-                if not ok:
-                    logger.warning("taeflux auto-download failed; preview disabled")
-                    return None
-            from diffusers import AutoencoderTiny
-            tae = AutoencoderTiny.from_pretrained(
-                str(_md.taeflux_dir()), torch_dtype=self.dtype,
-            ).to(self.device)
-            tae.eval()
-            self.taeflux = tae
-            logger.info("taeflux loaded")
-        except Exception as e:
-            logger.warning("taeflux load failed: %s; preview disabled", e)
-            self.taeflux = None
-        return self.taeflux
+        # 中间步预览用 latent2rgb 线性投影（见 _decode_latent2rgb_preview）——
+        # 无外部模型 / 无下载，故 CACHE 不再持任何 preview decoder 状态。
 
     @property
     def loaded(self) -> bool:
@@ -481,9 +447,6 @@ class ModelCache:
         self.adapters = []
         self.last_lora_specs = []
         self.last_lora_metas = []
-        # taeflux 也卸（占很小但保持一致）
-        self.taeflux = None
-        self.taeflux_attempted = False
         try:
             import gc
             gc.collect()
@@ -588,30 +551,28 @@ def _build_preview_callback(
     every_n: int,
     cancel_event: threading.Event | None = None,
 ) -> Any:
-    """每步推 preview_step 事件；TAEFlux 可用 + 节流命中时附 image_b64。
+    """每步推 preview_step 事件；节流命中时附 latent2rgb 预览图 image_b64。
 
     用户反馈：进度条始终要可见（"当前在做什么，第几步"），预览图按需。
     本 callback 拆成两路：
       - 永远 emit preview_step { step, total } —— 前端进度条
-      - every_n>0 且步命中（含末步）+ TAEFlux 加载 OK → 附 image_b64
-    callback 在 daemon 主线程同步执行；空逻辑 ~微秒级，TAEFlux decode +
-    JPEG 编码 ~10-20ms。
+      - every_n>0 且步命中（含末步）→ latent2rgb decode + 附 image_b64
+    callback 在 daemon 主线程同步执行；空逻辑 ~微秒级，latent2rgb（纯线性
+    投影，无 NN forward）+ JPEG 编码 ~1-2ms。
 
     cancel_event 注入后每步检查，取消延迟从"整张图"降到"一步"。
     """
     def _cb(step: int, total: int, latent: Any) -> None:
         _raise_if_canceled(cancel_event)
-        # 是否带预览图：preview_every_n_steps>0 + 节流命中 + TAEFlux 可用
+        # 是否带预览图：preview_every_n_steps>0 + 节流命中（含末步）。
         with_image = False
         b64: Optional[str] = None
         byte_size = 0
         if every_n > 0 and (step % every_n == 0 or step == total - 1):
-            tae = CACHE.ensure_taeflux()
-            if tae is not None:
-                img = _decode_taeflux_preview(tae, latent, CACHE.dtype)
-                if img is not None:
-                    b64, byte_size = _encode_jpeg(img, quality=80)
-                    with_image = True
+            img = _decode_latent2rgb_preview(latent)
+            if img is not None:
+                b64, byte_size = _encode_jpeg(img, quality=80)
+                with_image = True
         payload: dict[str, Any] = {"step": step + 1, "total": total}
         if with_image:
             payload["image_b64"] = b64
@@ -620,32 +581,72 @@ def _build_preview_callback(
     return _cb
 
 
-def _decode_taeflux_preview(taeflux: Any, latent: Any, dtype: Any) -> Optional[Any]:
-    """latent → TAEFlux decode → PIL.Image (256px)。失败返 None（preview 不阻塞）。
+# Wan2.1 VAE 的 latent→RGB 线性投影系数（16 通道 → RGB）。
+# Anima 的 VAE 是 Qwen-Image VAE（models/vae/qwen_image_vae.safetensors），其 latent
+# 空间就是 Wan2.1 的 16-ch 空间——ComfyUI supported_models.py 里
+# `QwenImage.latent_format = latent_formats.Wan21`，且本仓库 models.py 的 VAE
+# 归一化 mean/std 与 ComfyUI Wan21.latents_mean/std 逐位一致。系数与 bias 取自
+# ComfyUI comfy/latent_formats.py 的 `Wan21.latent_rgb_factors[_bias]`（latent2rgb
+# 快速预览，即"模糊但能看出图"）。之前误用 TAEFlux（Flux VAE 的 tiny decoder）解码
+# 这个 WAN latent，空间不匹配 → 颜色反相/错乱，已废弃。
+_WAN21_LATENT_RGB_FACTORS = [
+    [-0.1299, -0.1692, 0.2932],
+    [0.0671, 0.0406, 0.0442],
+    [0.3568, 0.2548, 0.1747],
+    [0.0372, 0.2344, 0.1420],
+    [0.0313, 0.0189, -0.0328],
+    [0.0296, -0.0956, -0.0665],
+    [-0.3477, -0.4059, -0.2925],
+    [0.0166, 0.1902, 0.1975],
+    [-0.0412, 0.0267, -0.1364],
+    [-0.1293, 0.0740, 0.1636],
+    [0.0680, 0.3019, 0.1128],
+    [0.0032, 0.0581, 0.0639],
+    [-0.1251, 0.0927, 0.1699],
+    [0.0060, -0.0633, 0.0005],
+    [0.3477, 0.2275, 0.2950],
+    [0.1984, 0.0913, 0.1861],
+]
+_WAN21_LATENT_RGB_BIAS = [-0.1835, -0.0868, -0.3360]
+# 预览放大目标（最长边像素）。latent 是 1/8 分辨率（1024²→128²），latent2rgb 直出
+# 128²；放大到 512 让前端铺满时不至于过糊，JPEG 仍很小。
+_PREVIEW_TARGET_PX = 512
 
-    Anima latent shape：[B, 16, F=1, H, W]；TAEFlux 期望 [B, 16, H, W]。
+
+def _decode_latent2rgb_preview(latent: Any) -> Optional[Any]:
+    """latent → Wan2.1 latent2rgb 线性投影 → PIL.Image。失败返 None（preview 不阻塞）。
+
+    Anima latent shape：[B, 16, F=1, H, W]。对齐 ComfyUI Latent2RGBPreviewer：
+      x0 = latent[0, :, 0]                          # [16, H, W]
+      rgb[h,w,r] = Σ_c x0[c,h,w]·factors[c,r] + bias[r]
+      img = ((rgb + 1) / 2).clamp(0,1) · 255        # [-1,1] → [0,255]
     """
     try:
         import numpy as np
         from PIL import Image
         with torch.no_grad():
-            # 去掉 frame 维 (F=1)，转 dtype
-            x = latent[:, :, 0].to(dtype=dtype)
-            decoded = taeflux.decode(x).sample  # [B, 3, H, W] in [-1, 1]
-            decoded = (decoded.clamp(-1, 1) + 1) / 2
-            arr = decoded[0].permute(1, 2, 0).cpu().float().numpy()
-            arr = (arr * 255).clip(0, 255).astype(np.uint8)
+            x = latent[0, :, 0].float()  # [16, H, W]
+            factors = torch.tensor(
+                _WAN21_LATENT_RGB_FACTORS, device=x.device, dtype=x.dtype,
+            )  # [16, 3]
+            bias = torch.tensor(
+                _WAN21_LATENT_RGB_BIAS, device=x.device, dtype=x.dtype,
+            )  # [3]
+            rgb = torch.einsum("chw,cr->hwr", x, factors) + bias  # [H, W, 3]
+            rgb = ((rgb + 1.0) / 2.0).clamp(0.0, 1.0)
+            arr = (rgb.cpu().numpy() * 255).astype(np.uint8)  # [H, W, 3]
             img = Image.fromarray(arr)
-            # 缩到 256px（保持比例）
+            # 放大到 _PREVIEW_TARGET_PX 最长边（保持比例），前端再铺满结果区
             w, h = img.size
-            scale = 256.0 / max(w, h)
-            img = img.resize(
-                (max(1, int(w * scale)), max(1, int(h * scale))),
-                Image.BILINEAR,
-            )
+            scale = _PREVIEW_TARGET_PX / max(w, h)
+            if scale > 1.0:
+                img = img.resize(
+                    (max(1, round(w * scale)), max(1, round(h * scale))),
+                    Image.BILINEAR,
+                )
             return img
     except Exception:
-        logger.exception("taeflux decode failed")
+        logger.exception("latent2rgb preview decode failed")
         return None
 
 

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -1100,11 +1100,14 @@ export default function GeneratePage() {
               ) : samples.length === 0 && previewStep ? (
                 <div className="flex-1 min-h-0 flex flex-col items-center gap-2">
                   <div className="flex-1 min-h-0 w-full flex items-center justify-center">
+                    {/* 中间步预览是低分辨率 latent2rgb 图（模糊但能看出大致图）：铺满结果区
+                        —— width/height:100% + object-contain 会放大小图并保持比例；旧的
+                        maxWidth/maxHeight 只限上限，小图不放大 → 显示成中间一小块。 */}
                     <img
                       src={previewStep.dataUrl}
                       alt={`step ${previewStep.step}/${previewStep.total}`}
-                      className="rounded-md object-contain"
-                      style={{ maxWidth: '100%', maxHeight: '100%' }}
+                      className="rounded-md"
+                      style={{ width: '100%', height: '100%', objectFit: 'contain' }}
                     />
                   </div>
                   <div className="text-xs text-fg-tertiary shrink-0">

--- a/tests/test_generate_preview_latent2rgb.py
+++ b/tests/test_generate_preview_latent2rgb.py
@@ -1,0 +1,62 @@
+"""latent2rgb 中间步预览 decode 的回归测试（CPU，无需 GPU / 模型 / 下载）。
+
+背景：Anima 的 VAE 是 Qwen-Image VAE（models/vae/qwen_image_vae.safetensors），其
+latent 空间就是 Wan2.1 的 16-ch 空间（ComfyUI `QwenImage.latent_format = Wan21`，
+且本仓库 VAE 归一化 mean/std 与 ComfyUI `Wan21.latents_mean/std` 逐位一致）。之前
+预览误用 TAEFlux（Flux VAE 的 tiny decoder）解码这个 WAN latent → 颜色反相/错乱。
+改用 Wan2.1 `latent_rgb_factors` 线性投影（latent2rgb，即 ComfyUI 快速预览）。
+
+本测试锁定：投影公式与 ComfyUI Latent2RGBPreviewer 逐像素一致 + 输出为放大后的
+RGB 图，防止再次回归到错误 decoder / 错误范围映射。
+"""
+from __future__ import annotations
+
+import numpy as np
+import torch
+from PIL import Image
+
+from runtime.anima_daemon import (
+    _PREVIEW_TARGET_PX,
+    _WAN21_LATENT_RGB_BIAS,
+    _WAN21_LATENT_RGB_FACTORS,
+    _decode_latent2rgb_preview,
+)
+
+
+def test_wan21_factors_shape() -> None:
+    # 16 通道 → RGB：16 行 × 3 列 + 3 个 bias。
+    assert len(_WAN21_LATENT_RGB_FACTORS) == 16
+    assert all(len(row) == 3 for row in _WAN21_LATENT_RGB_FACTORS)
+    assert len(_WAN21_LATENT_RGB_BIAS) == 3
+
+
+def test_decode_returns_upscaled_rgb_image() -> None:
+    # Anima latent shape [B, 16, F=1, H, W]；小 latent → 放大到 target 最长边、保持比例。
+    latent = torch.randn(1, 16, 1, 16, 16)
+    img = _decode_latent2rgb_preview(latent)
+    assert isinstance(img, Image.Image)
+    assert img.mode == "RGB"
+    assert max(img.size) == _PREVIEW_TARGET_PX  # 16px < target → 放大到 target
+    assert img.size[0] == img.size[1]  # 1:1 latent → 1:1 图
+
+
+def test_decode_matches_comfy_latent2rgb_math() -> None:
+    # 用「最长边 ≥ target」的 latent 跳过放大（scale ≤ 1 不 resize），直接核对原始投影
+    # 与 ComfyUI Latent2RGBPreviewer 公式逐像素一致。
+    h, w = _PREVIEW_TARGET_PX, _PREVIEW_TARGET_PX // 3
+    latent = torch.randn(1, 16, 1, h, w)
+    img = _decode_latent2rgb_preview(latent)
+    assert img.size == (w, h)  # PIL size 是 (W, H)，未放大
+
+    x0 = latent[0, :, 0].float()  # [16, H, W]
+    factors = torch.tensor(_WAN21_LATENT_RGB_FACTORS)
+    bias = torch.tensor(_WAN21_LATENT_RGB_BIAS)
+    rgb = torch.einsum("chw,cr->hwr", x0, factors) + bias  # [H, W, 3]
+    rgb = ((rgb + 1.0) / 2.0).clamp(0.0, 1.0)  # [-1,1] → [0,1]，同 ComfyUI preview_to_image
+    expected = (rgb.numpy() * 255).astype(np.uint8)
+    assert np.array_equal(np.asarray(img), expected)
+
+
+def test_decode_never_crashes_on_bad_input() -> None:
+    # preview 不阻塞主流程：形状不对时返 None 而非抛。
+    assert _decode_latent2rgb_preview(torch.randn(3, 3)) is None


### PR DESCRIPTION
## 背景 / 动机

single 生成过程中的中间步预览有三个问题：**颜色反相/错乱**、**非常小**、**不拉伸**。ComfyUI 的预览虽然模糊但至少能看出大致图片。

**根因（颜色）**：`commit 14` 给预览用的是 **TAEFlux（Flux VAE 的 tiny decoder）**。但 Anima 实际用的 VAE 是 **Qwen-Image VAE**（`models/vae/qwen_image_vae.safetensors`，`studio/domain/generate.py:29` + `paths.py:33`），其 latent 是 **Wan2.1 的 16 通道空间**。两个 VAE 的 latent 空间完全不同——把 WAN latent 喂进 Flux 解码器，输出必然反相/错乱。这是"用错了解码器"，不是范围/通道顺序的小 bug。

## 上游核对（不靠记忆）

- ComfyUI `comfy/supported_models.py`：`QwenImage.latent_format = latent_formats.Wan21` —— Qwen-Image 复用 Wan2.1 的 latent 空间。
- 本仓库 `runtime/training/models.py` 的 VAE 归一化 `mean`/`std` 与 ComfyUI `comfy/latent_formats.py` 里 `Wan21.latents_mean`/`latents_std` **逐位一致** —— 坐实是 **2.1** 不是 2.2（2.2 TI2V 是 48 通道 VAE）。
- 预览系数 `latent_rgb_factors` / `latent_rgb_factors_bias` 取自 `Wan21`；投影 + `(x+1)/2` 范围映射对齐 `latent_preview.py` 的 `Latent2RGBPreviewer`。

## 改动

**后端**（`runtime/anima_daemon.py`）：中间步预览改用 **Wan2.1 latent2rgb 线性投影**（ComfyUI 对 Qwen-Image/WAN 的快速预览做法）。颜色正确、模糊但能看出大致图，且**无需任何模型下载**——删掉 daemon 里的 TAEFlux lazy-load + `diffusers.AutoencoderTiny` 依赖。latent2rgb 是纯线性投影（无 NN forward），每步 decode + JPEG ~1-2ms。

**前端**（`Generate.tsx`）：预览 `<img>` 从 `maxWidth/maxHeight:100%`（只限上限、小图不放大 → 显示成中间一小块）改为 `width/height:100% + object-contain`，铺满结果区并保持比例。

## 测试

- 新增 CPU 回归测试 `tests/test_generate_preview_latent2rgb.py`：latent2rgb 投影与 ComfyUI `Latent2RGBPreviewer` 公式**逐像素一致** + 输出为放大后 RGB 图 + 坏输入返 `None` 不崩。
- `pytest`：新测试 + `test_anima_daemon_comfy_parity_runtime` / `test_inference_sampler_cancel`（daemon 导入不因删 TAEFlux 而挂）+ `test_route_snapshot` 全绿。
- 前端：`vitest`（Generate 14 用例）、`npm run lint`、`tsc --noEmit` 通过。
- ⚠️ 颜色正确性与铺满效果需在**有 GPU 的机器上肉眼验证**（本机无 GPU，无法真出图）。

## 归属

系数与投影来源已补进 `THIRD_PARTY_NOTICES.md`（ComfyUI GPL-3.0，与本仓库同许可，兼容）。

## Follow-up（不在本 PR）

TAEFlux 的下载注册（`studio/services/models/*`）、Settings 卡片（`settings/sections.tsx` `TaeFluxSection`）、API 路由（`/api/generate/taeflux/*`）、启动时自动下载现已无用，留作单独的死代码清理 PR（避免本 PR 横扫 ~15 个文件、难 review）。