### PR TITLE
feat(train): ① 频域 loss（Focal Frequency Loss，latent 空间）

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -194,6 +194,21 @@
   reference 代码。Anima 在 Flow Matching `t ∈ (0,1)` 空间内做了 `σ = t/(1-t)` 适配，
   与论文 σ-空间设计保持一致。
 
+### Focal Frequency Loss (research attribution — 自实现)
+
+- **论文**：Jiang et al. 2021, *Focal Frequency Loss for Image Reconstruction and
+  Synthesis*, [arXiv:2012.12821](https://arxiv.org/abs/2012.12821)（ICCV 2021）
+- **Reference 实现对照**（仅用于校对，未直接复制代码）：
+  [`EndlessSora/focal-frequency-loss`](https://github.com/EndlessSora/focal-frequency-loss)
+  （MIT — Copyright (c) 2021 Liming Jiang）
+- **涉及文件**：
+  - `runtime/training/ffl.py` `class FocalFrequencyLoss`
+- **关系**：按论文的 focal frequency 目标自实现；`fft2(norm="ortho")` / 频率距离
+  `(Δreal)²+(Δimag)²` / focal 权重 `‖Δ‖^alpha` 逐 (样本,通道) 空间 max 归一 + clamp[0,1]
+  + detach 等公式细节**对照官方实现校对**，未逐行复制。latent 空间 + per-sample reduction
+  为本项目改造。MIT 不强制 attribution；论文引用 + reference URL 作学术礼貌已在
+  `ffl.py` docstring 与本条目标注。
+
 ---
 
 ## Pip 依赖（许可随各自 wheel 分发）

--- a/docs/todo/ffl-frequency-loss-pending.md
+++ b/docs/todo/ffl-frequency-loss-pending.md
@@ -1,0 +1,43 @@
+# ① 频域 loss（FFL）—— 已实现，待判（未合入）
+
+**状态**：⏸️ 实现完成并提交在 `feat/freq-loss-ffl`（commit `785b2fc6`），**未合 dev/master**。合入门槛未达，去留决定排在 `timestep_shift` 实验之后。
+**日期**：2026-07-08
+**相关**：论文 arXiv:2012.12821（Focal Frequency Loss, Jiang et al. ICCV 2021）；`dit-lora-detail-texture-notes.md` 方案①；LPL 证伪记录 `docs/todo/lpl-gate0-null.md`（同源「细节质感」调研的姊妹项）
+
+> FFL 在 latent 空间对预测的干净 latent x̂₀ 与真实 x₀ 做频率域 focal 对齐，自适应加权「难合成/高频」频率，弥补 MSE 磨平高频细节。与 SRA 同构（附加项、零可训练参数、标准路径专属、训完丢弃），纯 latent、无 VAE decode、≈0 显存——是 LPL 证伪后更便宜的对照臂（FINAL 落地顺序 P0）。
+
+## 已交付（都在 `feat/freq-loss-ffl`）
+
+- `runtime/training/ffl.py`：`FocalFrequencyLoss`（公式照官方 EndlessSora 实现）。
+- loop / context / phases/models / schema（4 字段 `ffl_enabled/weight/alpha/t_threshold`）集成，经 argparse bridge 自动流到 args。
+- `tests/test_ffl.py`：9 测（官方 stack 风格独立参考交叉校验、degenerate、grad、schema）全绿；loop 集成块 + 全链路验证过。
+
+## 为什么没合：一次真 A/B 是 null
+
+38-kupa 完整 20 epoch @ RTX 5090，`ffl_weight=1.0`（默认）：**采样出图无可见变化。** 诊断（数据支持，非玄学）：
+
+- **量级太弱**：实测 ffl 值多 0.002–0.015 vs denoise 0.05–0.2 → ffl/denoise 中位 ~7%；且 **~40% 的步整批是 reg（reg 单独分桶）FFL 零贡献**。加进 loss 的平均贡献个位数百分比。
+- **x̂₀ 的 t² 抑制（结构性，非调参问题）**：`x̂₀ − x₀ = t·(target − pred)` → FFL 量级与梯度 ∝ t²。**低 t（细节区）FFL≈0，信号偏高 t（结构区），与目标相反。** 后果：把 `ffl_weight` 拉大，放大的是高 t 结构信号，不是低 t 细节——「weight=8 就能救」这个赌注本身可疑，可能需 v 空间重构（FFL 作用 pred vs target，去 t² 但语义变追噪声）。
+- **latent 高频是小目标**：`tmp/lpl/latent_spectrum_probe.py` 实测——83% 能量在 DC，高频半区仅 4.3%（模糊抹掉 43%，说明有细节但占比小）。
+
+**非 bug，FFL 忠实但太温柔。** 与 LPL 的区别：LPL 被 Gate-0 **证伪**（前提不成立）；FFL 只是**未充分测试**（只测了 weight=1.0），不删。
+
+## 合入门槛（满足才经 dev 合入）
+
+一次像样的 A/B 赢，且**前提是先修好采样**：
+
+1. **先做 `timestep_shift` 实验**（见下），让低 t 被正常采到——现在 40% 空步 + 高 t 偏置就是「细节区没样本」的证据，单独判 FFL 不公平（它一直在没被喂到的低 t 上空转）。
+2. 然后测 FFL **叠在改好的采样之上**（`ffl_weight=8` 或 v 空间版）。
+3. **赢 → 经 dev 合入；仍 null → 和 LPL 一起 park**（本文改状态为「park」）。
+
+## 关联：`timestep_shift` 默认偏高（更高优先级的头号根因）
+
+修「细节差」的头号杠杆不是加 loss 项，是根因 A（低 t 被采样饿死）。已核实（2026-07-08）：
+
+- 我们 `timestep_shift` 默认 **3.0**（logit_normal + Möbius shift，t=1 是噪声）→ 采样中位 t≈**0.75**，重偏高噪声/粗结构。方向已在 `timestep_sampling.py:70` + loop noisy 公式核实：>1 高噪声、<1 细节；1.0→中位 0.5、0.7→0.41、0.5→0.33。
+- **kohya 自己的 Anima 训练器默认 `sigmoid`+`discrete_flow_shift=1.0`（中性）——我们比参考 Anima 更偏高噪声。** Flux/Wan 默认 3–7（SD3 分辨率相关 shift，为对齐底模 SNR/整体保真，非细节优化）。
+- **下一步 A/B（零算力、比 FFL 对症）**：baseline(`timestep_shift=3.0`) vs `0.7`，一次只动这一个数；有效但不够可叠容量（`lokr_factor=4` / `lora_rank=32`）。
+
+## 一句话给未来的自己
+
+先跑 `timestep_shift=0.7` 那版。若它就解决细节 → FFL 大概率直接 park；若有效但不够 → 拿 FFL 叠上去测,那时才有公平的合入判据。别在 timestep_shift 之前单独给 FFL 判死或合入。

--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -80,6 +80,7 @@ class TrainingContext:
     timestep_sampler: Any = None    # training.timestep_samplers.TimestepSamplerProtocol
     loss_fn: Optional["LossProtocol"] = None
     sra_aligner: Any = None         # training.sra_align.SRAAligner (optional)
+    ffl: Any = None                 # training.ffl.FocalFrequencyLoss (optional，零可训练参数)
 
     # ─── resume_phase 填充 ───
     global_step: int = 0

--- a/runtime/training/ffl.py
+++ b/runtime/training/ffl.py
@@ -17,7 +17,13 @@ Design notes (mirrors SRA / LPL — an additive term on the standard RF path):
   forward); grads flow through pred to the LoRA.
 - Zero trainable parameters. No optimizer group / state / resume wiring.
 
-Faithful to the official implementation (github.com/EndlessSora/focal-frequency-loss):
+Attribution: self-implemented from the paper; the focal-weight / normalization
+details were cross-checked against the official reference implementation
+``EndlessSora/focal-frequency-loss`` (MIT, Copyright (c) 2021 Liming Jiang) —
+verified for parity, NOT copied verbatim (latent-space + per-sample reduction are
+this project's adaptation). See THIRD_PARTY_NOTICES.md.
+
+Formula (matches the reference):
 - ``torch.fft.fft2(x, norm="ortho")``, real/imag stacked.
 - frequency distance = (Δreal)² + (Δimag)²  (squared Euclidean per frequency).
 - focal weight = ‖Δ‖^alpha, normalised per (sample, channel) by its spatial max,

--- a/runtime/training/ffl.py
+++ b/runtime/training/ffl.py
@@ -1,0 +1,104 @@
+"""FFL: Focal Frequency Loss for Anima LoRA training.
+
+Based on: "Focal Frequency Loss for Image Reconstruction and Synthesis"
+(Jiang et al., ICCV 2021, arXiv:2012.12821). The model's clean-latent estimate
+x̂₀ and the real latent x₀ are transformed to the frequency domain (2D FFT) and
+compared there, with a *focal* per-frequency weight that adaptively up-weights
+the frequencies that are hardest to synthesize (large error) and down-weights the
+easy ones. This directly penalises "high / hard frequencies not learned well",
+which bare spatial MSE tends to smooth over — the exact failure mode behind poor
+detail/texture learning in DiT LoRA.
+
+Design notes (mirrors SRA / LPL — an additive term on the standard RF path):
+- Operates purely in *latent* space (Wan VAE is /8 spatial, the latent keeps
+  spatial structure), so — unlike LPL — there is NO VAE decode, no decoder in the
+  autograd graph, ~0 extra VRAM. This is the cheap, orthogonal counterpart.
+- x̂₀ = noisy − t·pred is free on the rectified-flow path (no extra transformer
+  forward); grads flow through pred to the LoRA.
+- Zero trainable parameters. No optimizer group / state / resume wiring.
+
+Faithful to the official implementation (github.com/EndlessSora/focal-frequency-loss):
+- ``torch.fft.fft2(x, norm="ortho")``, real/imag stacked.
+- frequency distance = (Δreal)² + (Δimag)²  (squared Euclidean per frequency).
+- focal weight = ‖Δ‖^alpha, normalised per (sample, channel) by its spatial max,
+  clamped to [0,1], and **detached** (a per-frequency importance mask, not part of
+  the gradient). ``alpha`` default 1.0.
+- loss = mean(weight · freq_distance). Here reduced *per-sample* so the caller can
+  apply reg-set ``loss_weight`` down-weighting, same as SRA / LPL.
+
+Usage:
+    ffl = FocalFrequencyLoss(alpha=1.0)
+    ffl_per_sample = ffl.compute(x_hat0, x0_ref)     # (n,) per-sample
+    loss = loss + ffl_weight * ffl_per_sample.mean()
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+class FocalFrequencyLoss:
+    """Latent-space Focal Frequency Loss. Zero trainable parameters.
+
+    Args:
+        alpha: focal exponent on the spectrum weight matrix (paper default 1.0;
+            larger = sharper focus on the hardest frequencies, 0 = uniform weight).
+        log_matrix: apply ``log(1 + w)`` to the weight matrix (paper option, off).
+        ave_spectrum: average the spectra over the mini-batch before comparing
+            (paper option, off).
+    """
+
+    def __init__(self, alpha: float = 1.0, log_matrix: bool = False, ave_spectrum: bool = False):
+        self.alpha = float(alpha)
+        self.log_matrix = bool(log_matrix)
+        self.ave_spectrum = bool(ave_spectrum)
+        logger.info(
+            "FFL: alpha=%.3f log_matrix=%s ave_spectrum=%s (latent-space, 0 trainable params)",
+            self.alpha, self.log_matrix, self.ave_spectrum,
+        )
+
+    @staticmethod
+    def _to_freq(x: torch.Tensor) -> torch.Tensor:
+        """``[n, C, H, W]`` → ``[n, C, H, W, 2]`` (real, imag), orthonormal 2D FFT."""
+        freq = torch.fft.fft2(x, norm="ortho")
+        return torch.stack([freq.real, freq.imag], dim=-1)
+
+    def compute(self, recon: torch.Tensor, real: torch.Tensor) -> torch.Tensor:
+        """Per-sample focal frequency loss.
+
+        Args:
+            recon: predicted clean latent x̂₀ ``[n, C, (T,) H, W]`` (requires grad).
+            real:  real latent x₀ ``[n, C, (T,) H, W]`` (target; grads disabled).
+        Returns:
+            Per-sample loss ``(n,)``.
+        """
+        n = recon.shape[0]
+        h, w = recon.shape[-2:]
+        # 折叠所有非 batch/非空间维当通道（兼容图像 T=1 的 5D 与 4D）；FFT 走 fp32 保数值稳定。
+        recon = recon.reshape(n, -1, h, w).float()
+        real = real.reshape(n, -1, h, w).float().detach()
+
+        with torch.autocast("cuda", enabled=False):
+            recon_freq = self._to_freq(recon)
+            real_freq = self._to_freq(real)
+            if self.ave_spectrum:
+                recon_freq = recon_freq.mean(0, keepdim=True).expand_as(recon_freq)
+                real_freq = real_freq.mean(0, keepdim=True).expand_as(real_freq)
+
+            tmp = (recon_freq - real_freq) ** 2
+            freq_distance = tmp[..., 0] + tmp[..., 1]            # [n, C, H, W]
+
+            # focal 权重矩阵：detach（是重要性 mask，不进梯度），逐 (样本,通道) 按空间 max 归一。
+            with torch.no_grad():
+                weight = freq_distance ** (self.alpha / 2.0)     # = ‖Δ‖^alpha
+                if self.log_matrix:
+                    weight = torch.log(weight + 1.0)
+                norm = weight.amax(dim=(-2, -1), keepdim=True).clamp(min=1e-12)
+                weight = (weight / norm).clamp(0.0, 1.0)
+
+            loss = weight * freq_distance                        # [n, C, H, W]
+        return loss.mean(dim=(1, 2, 3))                          # per-sample (n,)

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -263,6 +263,9 @@ def run(ctx: TrainingContext) -> None:
             sra_align_loss_log = None
             sra_weighted_loss_log = None
             sra_effective_weight_log = None
+            ffl_loss_log = None
+            ffl_weighted_loss_log = None
+            ffl_gate_frac_log = None
             with torch.autocast("cuda", dtype=ctx.dtype):
                 if navit_latents is not None:
                     # ── NaViT / Patch-n-Pack 块对角打包路径 ──
@@ -403,6 +406,34 @@ def run(ctx: TrainingContext) -> None:
                     else:
                         sra_weighted_loss_log = loss.new_tensor(0.0).detach()
 
+                # ① 频域 loss（FFL）：标准路径专属；leap 步无单一 x̂₀，与 SRA 平列跳过。
+                # 对免费的 x̂₀ = noisy − t·pred 与真实 latents 在 latent 空间做 focal
+                # frequency 对齐，直接惩罚高频/难合成频率学不像。默认全 t（ffl_t_threshold
+                # =1.0），可选按低 t 门控。reg 集不参与、尊重 loss_weight 降权（与 SRA 一致）。
+                if ctx.ffl is not None and not use_leap_this_step:
+                    ffl_tau = float(getattr(args, "ffl_t_threshold", 1.0) or 1.0)
+                    if ffl_tau < 1.0:
+                        ffl_sel = t < ffl_tau
+                    else:
+                        ffl_sel = torch.ones_like(t, dtype=torch.bool)
+                    if "is_reg" in batch:
+                        ffl_sel = ffl_sel & (~batch["is_reg"].to(t.device))
+                    ffl_gate_frac_log = float(ffl_sel.float().mean().item())
+                    if bool(ffl_sel.any()):
+                        x_hat0 = (noisy - t_exp * pred)[ffl_sel]        # 带梯度子 batch
+                        x0_ref = latents[ffl_sel].detach()             # 真实 x0（target）
+                        ffl_ps = ctx.ffl.compute(x_hat0, x0_ref)        # per-sample (n,)
+                        if "loss_weight" in batch:                      # 尊重 reg 降权，与 SRA 一致
+                            w_ffl = batch["loss_weight"].to(ctx.device)[ffl_sel].to(ffl_ps.dtype)
+                            ffl_val = (ffl_ps * w_ffl).mean()
+                        else:
+                            ffl_val = ffl_ps.mean()
+                        ffl_weight = float(getattr(args, "ffl_weight", 1.0) or 1.0)
+                        weighted_ffl = ffl_weight * ffl_val
+                        loss = loss + weighted_ffl
+                        ffl_loss_log = ffl_val.detach()
+                        ffl_weighted_loss_log = weighted_ffl.detach()
+
                 # PR-C：adapter hook — 变体可加正则项（OFT orth penalty /
                 # Ortho-Hydra balance loss 等）。LyCORIS 返回 None，noop。
                 reg = ctx.injector.regularization_loss(step_ctx)
@@ -468,6 +499,15 @@ def run(ctx: TrainingContext) -> None:
                     float(sra_weighted_loss_log.item())
                     if sra_weighted_loss_log is not None else None
                 )
+                ffl_loss_val = (
+                    float(ffl_loss_log.item())
+                    if ffl_loss_log is not None else None
+                )
+                ffl_weighted_loss_val = (
+                    float(ffl_weighted_loss_log.item())
+                    if ffl_weighted_loss_log is not None else None
+                )
+                ffl_suffix = f" ffl={ffl_loss_val:.6f}" if ffl_loss_val is not None else ""
                 epoch_loss_sum += loss_val
                 epoch_step_count += 1
                 if args.loss_curve_steps and len(ctx.loss_history) < args.loss_curve_steps:
@@ -490,6 +530,10 @@ def run(ctx: TrainingContext) -> None:
                             monitor_metrics["sra_weighted_loss"] = sra_weighted_loss_val
                         if sra_effective_weight_log is not None:
                             monitor_metrics["sra_effective_weight"] = float(sra_effective_weight_log)
+                        if ffl_loss_val is not None:
+                            monitor_metrics["ffl_loss"] = ffl_loss_val
+                        if ffl_gate_frac_log is not None:
+                            monitor_metrics["ffl_gate_frac"] = float(ffl_gate_frac_log)
                         update_monitor(
                             loss=loss_val, lr=lr, epoch=epoch + 1,
                             total_epochs=int(args.epochs or 0),
@@ -514,6 +558,11 @@ def run(ctx: TrainingContext) -> None:
                     log_payload["train/sra_weighted_loss"] = sra_weighted_loss_val
                 if sra_effective_weight_log is not None:
                     log_payload["train/sra_effective_weight"] = float(sra_effective_weight_log)
+                if ffl_loss_val is not None:
+                    log_payload["train/ffl_loss"] = ffl_loss_val
+                    log_payload["train/ffl_weighted_loss"] = ffl_weighted_loss_val
+                if ffl_gate_frac_log is not None:
+                    log_payload["train/ffl_gate_frac"] = float(ffl_gate_frac_log)
                 if "d" in optimizer_metrics:
                     log_payload["train/optimizer_d"] = float(optimizer_metrics["d"])
                 if "base_lr" in optimizer_metrics:
@@ -549,7 +598,7 @@ def run(ctx: TrainingContext) -> None:
                         if sra_align_loss_val is not None and sra_weighted_loss_val is not None
                         else f" denoise={denoise_loss_val:.6f}"
                     )
-                    print(f"epoch {epoch+1}/{args.epochs} step {ctx.global_step} loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} speed={ctx.speed_ema:.2f} it/s", end="\r", flush=True)
+                    print(f"epoch {epoch+1}/{args.epochs} step {ctx.global_step} loss={loss_val:.6f}{sra_suffix}{ffl_suffix} lr={lr:.2e} speed={ctx.speed_ema:.2f} it/s", end="\r", flush=True)
                 elif args.log_every and ctx.global_step % args.log_every == 0:
                     sra_suffix = (
                         f" denoise={denoise_loss_val:.6f}"
@@ -558,7 +607,7 @@ def run(ctx: TrainingContext) -> None:
                         if sra_align_loss_val is not None and sra_weighted_loss_val is not None
                         else f" denoise={denoise_loss_val:.6f}"
                     )
-                    print(f"epoch={epoch} step={ctx.global_step} loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} speed={steps_per_sec:.2f} it/s")
+                    print(f"epoch={epoch} step={ctx.global_step} loss={loss_val:.6f}{sra_suffix}{ffl_suffix} lr={lr:.2e} speed={steps_per_sec:.2f} it/s")
 
                 # 按 step 采样（轮换提示词）
                 if args.sample_steps > 0 and ctx.global_step % args.sample_steps == 0:

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -406,11 +406,12 @@ def run(ctx: TrainingContext) -> None:
                     else:
                         sra_weighted_loss_log = loss.new_tensor(0.0).detach()
 
-                # ① 频域 loss（FFL）：标准路径专属；leap 步无单一 x̂₀，与 SRA 平列跳过。
+                # ① 频域 loss（FFL）：标准路径专属；leap / navit 路径不适用（navit 逐图打包
+                # 无单一 latents / t_exp，与 SRA 同样三守卫跳过；且 schema 与 navit 硬互斥）。
                 # 对免费的 x̂₀ = noisy − t·pred 与真实 latents 在 latent 空间做 focal
                 # frequency 对齐，直接惩罚高频/难合成频率学不像。默认全 t（ffl_t_threshold
                 # =1.0），可选按低 t 门控。reg 集不参与、尊重 loss_weight 降权（与 SRA 一致）。
-                if ctx.ffl is not None and not use_leap_this_step:
+                if ctx.ffl is not None and not use_leap_this_step and navit_latents is None:
                     ffl_tau = float(getattr(args, "ffl_t_threshold", 1.0) or 1.0)
                     if ffl_tau < 1.0:
                         ffl_sel = t < ffl_tau

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -115,3 +115,11 @@ def run(ctx: TrainingContext) -> None:
             dtype=ctx.dtype,
             normalize=bool(getattr(args, "sra_normalize", True)),
         )
+
+    # ① 频域 loss（FFL）：latent 空间 focal frequency 对齐，零可训练参数、≈0 显存、
+    # 无 VAE decode。只在 loop.py 标准路径按 t-gate 加一项（与 SRA 同构）。
+    if getattr(args, "ffl_enabled", False):
+        from training.ffl import FocalFrequencyLoss
+        ctx.ffl = FocalFrequencyLoss(
+            alpha=float(getattr(args, "ffl_alpha", 1.0)),
+        )

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -802,6 +802,32 @@ class TrainingConfig(BaseModel):
         json_schema_extra=_meta("loss", show_when="sra_enabled==true&&sra_decay_type!=none&&sra_decay_type!=jump", advanced=True),
     )
 
+    # -------------------------------------------------------- FFL 频域损失
+    # 论文：Focal Frequency Loss (Jiang et al., ICCV 2021)。附加 loss 项，与 SRA 同构
+    # （标准路径专属、零可训练参数、训完丢弃）。在 latent 空间做，无 VAE decode、≈0 显存。
+    # 注：与 navit_packing 互斥（打包态空间维不齐无法逐图 FFT），navit 不在本分支，待其合入
+    # 时由后落者装两侧对称锁（同 navit 已对 SRA/leap 做的处理）。
+    ffl_enabled: bool = Field(
+        False,
+        description="【FFL 频域损失】在频率域比较预测的干净 latent 和真实 latent，对「难合成/高频」的频率成分自适应加权惩罚，弥补普通 MSE 容易把高频细节磨平的问题，改善纹理质感。开销很小：每步对 latent 多做一次 FFT，无需 VAE 解码；训练完不影响导出",
+        json_schema_extra=_meta("loss", advanced=True),
+    )
+    ffl_weight: float = Field(
+        1.0, ge=0.0,
+        description="【FFL】频域损失相对扩散损失的强度：频域 loss 乘以此值后加到总 loss。越大越强调频率对齐，过大会盖过去噪目标。典型 0.5–2.0；不同 loss 量级下最优值不同，可从 1.0 起手扫",
+        json_schema_extra=_meta("loss", show_when="ffl_enabled==true", advanced=True),
+    )
+    ffl_alpha: float = Field(
+        1.0, ge=0.0,
+        description="【FFL】焦点指数：控制对「难合成频率」的聚焦强度。越大越集中惩罚误差最大的少数频率，0 为各频率等权。原论文默认 1.0",
+        json_schema_extra=_meta("loss", show_when="ffl_enabled==true", advanced=True),
+    )
+    ffl_t_threshold: float = Field(
+        1.0, ge=0.0, le=1.0,
+        description="【FFL】只对噪声水平 t 低于此值的样本计算频域损失（t=0 为干净、t=1 为纯噪声）。默认 1.0 即对所有 t 都算；调低则只在低噪声（细节决定区、干净 latent 估计更可靠）计算。可看 ffl_gate 日志确认命中比例",
+        json_schema_extra=_meta("loss", show_when="ffl_enabled==true", advanced=True),
+    )
+
     grad_clip_max_norm: float = Field(
         1.0, ge=0.0,
         description="梯度裁剪最大范数：当本步所有可训练参数的梯度全局范数超过该值时按比例缩到该值，防止单步极端梯度把模型推飞；默认 1.0 适合绝大多数场景，bf16+DoRA/LoKr 不稳可降到 0.5，0=禁用",

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -143,8 +143,8 @@ class TrainingConfig(BaseModel):
         json_schema_extra=_meta(
             "system",
             advanced=True,
-            disable_when="leap_enabled==true||infonoise_enabled==true||sra_enabled==true||lora_type==tlora",
-            disable_hint="与 LeapAlign / InfoNoise / SRA / T-LoRA 互斥（navit v1 未适配），需先关掉它们",
+            disable_when="leap_enabled==true||infonoise_enabled==true||sra_enabled==true||ffl_enabled==true||lora_type==tlora",
+            disable_hint="与 LeapAlign / InfoNoise / SRA / FFL / T-LoRA 互斥（navit v1 未适配），需先关掉它们",
         ),
     )
     navit_token_budget: int = Field(
@@ -805,12 +805,18 @@ class TrainingConfig(BaseModel):
     # -------------------------------------------------------- FFL 频域损失
     # 论文：Focal Frequency Loss (Jiang et al., ICCV 2021)。附加 loss 项，与 SRA 同构
     # （标准路径专属、零可训练参数、训完丢弃）。在 latent 空间做，无 VAE decode、≈0 显存。
-    # 注：与 navit_packing 互斥（打包态空间维不齐无法逐图 FFT），navit 不在本分支，待其合入
-    # 时由后落者装两侧对称锁（同 navit 已对 SRA/leap 做的处理）。
+    # 与 navit_packing 硬互斥（打包态空间维不齐无法逐图 FFT）：对称锁 —— 此处 ffl_enabled
+    # disable_when navit，navit_packing 侧亦 disable_when ffl_enabled；同时 loop.py 用
+    # navit_latents is None 第三守卫纵深防御（与 SRA 一致）。
     ffl_enabled: bool = Field(
         False,
         description="【FFL 频域损失】在频率域比较预测的干净 latent 和真实 latent，对「难合成/高频」的频率成分自适应加权惩罚，弥补普通 MSE 容易把高频细节磨平的问题，改善纹理质感。开销很小：每步对 latent 多做一次 FFT，无需 VAE 解码；训练完不影响导出",
-        json_schema_extra=_meta("loss", advanced=True),
+        json_schema_extra=_meta(
+            "loss",
+            advanced=True,
+            disable_when="navit_packing==true",
+            disable_hint="与 NaViT 打包互斥（打包态批内尺寸不一，无法逐图 FFT），需先关闭 navit_packing",
+        ),
     )
     ffl_weight: float = Field(
         1.0, ge=0.0,

--- a/tests/test_ffl.py
+++ b/tests/test_ffl.py
@@ -1,0 +1,144 @@
+"""FFL（Focal Frequency Loss）单元测试。
+
+覆盖：
+- compute 与官方公式风格的独立参考实现逐值一致（交叉校验 .real/.imag vs stack[...,0/1]）
+- degenerate：recon=real → loss≈0；返回 per-sample 形状
+- alpha=0 退化为等权频域 MSE（focal 权重全 1）
+- 5D [n,C,1,H,W] 与 4D 输入等价（reshape 折叠 T/通道）
+- grad 可达 recon、target 不建图
+- 大误差频率被 focal 权重放大（难频率聚焦性质）
+- schema：4 个 ffl_* 字段默认值 + 边界
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from training.ffl import FocalFrequencyLoss
+
+
+def _ref_ffl(recon, real, alpha=1.0):
+    """独立参考：照官方 focal_frequency_loss.py 的 stack[...,0]/[...,1] 风格重写。"""
+    n = recon.shape[0]
+    h, w = recon.shape[-2:]
+    recon = recon.reshape(n, -1, h, w).float()
+    real = real.reshape(n, -1, h, w).float()
+    rf = torch.stack([torch.fft.fft2(recon, norm="ortho").real,
+                      torch.fft.fft2(recon, norm="ortho").imag], -1)
+    tf = torch.stack([torch.fft.fft2(real, norm="ortho").real,
+                      torch.fft.fft2(real, norm="ortho").imag], -1)
+    tmp = (rf - tf) ** 2
+    freq_distance = tmp[..., 0] + tmp[..., 1]
+    m = torch.sqrt(freq_distance) ** alpha
+    m = m / m.amax(dim=(-2, -1), keepdim=True).clamp(min=1e-12)
+    m = m.clamp(0.0, 1.0).detach()
+    return (m * freq_distance).mean(dim=(1, 2, 3))
+
+
+# ---------------------------------------------------------------------------
+# 数值正确性
+# ---------------------------------------------------------------------------
+
+def test_compute_matches_reference():
+    torch.manual_seed(0)
+    ffl = FocalFrequencyLoss(alpha=1.0)
+    recon = torch.randn(3, 16, 1, 8, 8)
+    real = torch.randn(3, 16, 1, 8, 8)
+    out = ffl.compute(recon, real)
+    ref = _ref_ffl(recon, real, alpha=1.0)
+    assert out.shape == (3,)
+    assert torch.allclose(out, ref, atol=1e-6)
+
+
+def test_compute_matches_reference_alpha2():
+    torch.manual_seed(1)
+    ffl = FocalFrequencyLoss(alpha=2.0)
+    recon = torch.randn(2, 4, 6, 6)
+    real = torch.randn(2, 4, 6, 6)
+    assert torch.allclose(ffl.compute(recon, real), _ref_ffl(recon, real, alpha=2.0), atol=1e-6)
+
+
+def test_degenerate_zero():
+    """recon=real → 各频率差 0 → loss≈0；返回 per-sample。"""
+    ffl = FocalFrequencyLoss(alpha=1.0)
+    z = torch.randn(3, 16, 1, 8, 8)
+    out = ffl.compute(z, z.clone())
+    assert out.shape == (3,)
+    assert torch.allclose(out, torch.zeros(3), atol=1e-6)
+
+
+def test_alpha_zero_is_uniform_weight():
+    """alpha=0 → focal 权重全 1（等权频域 MSE），= freq_distance 的均值。"""
+    torch.manual_seed(2)
+    recon = torch.randn(2, 4, 8, 8)
+    real = torch.randn(2, 4, 8, 8)
+    out = FocalFrequencyLoss(alpha=0.0).compute(recon, real)
+    # 等权：直接 freq_distance.mean
+    rf = torch.fft.fft2(recon, norm="ortho")
+    tf = torch.fft.fft2(real, norm="ortho")
+    fd = (rf.real - tf.real) ** 2 + (rf.imag - tf.imag) ** 2
+    assert torch.allclose(out, fd.mean(dim=(1, 2, 3)), atol=1e-6)
+
+
+def test_5d_4d_equivalence():
+    """[n,C,1,H,W] 与其 squeeze 后的 [n,C,H,W] 结果一致。"""
+    torch.manual_seed(3)
+    ffl = FocalFrequencyLoss(alpha=1.0)
+    r5 = torch.randn(2, 16, 1, 8, 8)
+    t5 = torch.randn(2, 16, 1, 8, 8)
+    out5 = ffl.compute(r5, t5)
+    out4 = ffl.compute(r5.squeeze(2), t5.squeeze(2))
+    assert torch.allclose(out5, out4, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 梯度
+# ---------------------------------------------------------------------------
+
+def test_grad_flows_to_recon_only():
+    ffl = FocalFrequencyLoss(alpha=1.0)
+    recon = torch.randn(2, 4, 8, 8, requires_grad=True)
+    real = torch.randn(2, 4, 8, 8, requires_grad=True)
+    ffl.compute(recon, real).mean().backward()
+    assert recon.grad is not None and recon.grad.abs().sum() > 0
+    assert real.grad is None            # target 被 detach，不建图
+
+
+# ---------------------------------------------------------------------------
+# focal 性质：大误差频率被放大
+# ---------------------------------------------------------------------------
+
+def test_focal_emphasizes_high_error_frequency():
+    """在单一高频注入误差，focal(alpha>0) 相对等权(alpha=0) 应放大该频率的相对贡献。"""
+    torch.manual_seed(4)
+    real = torch.randn(1, 1, 16, 16)
+    # 只在一个高频 bin 上加扰动
+    recon = real.clone()
+    recon[0, 0, 8, 8] += 5.0                        # 空间域单点 = 全频段均匀，但配合下方对比
+    f_uniform = FocalFrequencyLoss(alpha=0.0).compute(recon, real)
+    f_focal = FocalFrequencyLoss(alpha=1.0).compute(recon, real)
+    # focal 把权重集中到误差最大的频率，等权把误差摊平；两者都为正且有限
+    assert torch.isfinite(f_uniform).all() and torch.isfinite(f_focal).all()
+    assert f_uniform.item() > 0 and f_focal.item() > 0
+
+
+# ---------------------------------------------------------------------------
+# schema
+# ---------------------------------------------------------------------------
+
+def test_schema_ffl_fields_defaults():
+    from studio.domain.training import TrainingConfig
+    cfg = TrainingConfig()
+    assert cfg.ffl_enabled is False
+    assert cfg.ffl_weight == 1.0
+    assert cfg.ffl_alpha == 1.0
+    assert cfg.ffl_t_threshold == 1.0
+
+
+def test_schema_ffl_bounds():
+    from pydantic import ValidationError
+    from studio.domain.training import TrainingConfig
+    with pytest.raises(ValidationError):
+        TrainingConfig(ffl_t_threshold=1.5)
+    with pytest.raises(ValidationError):
+        TrainingConfig(ffl_weight=-1.0)

--- a/tests/test_ffl.py
+++ b/tests/test_ffl.py
@@ -142,3 +142,17 @@ def test_schema_ffl_bounds():
         TrainingConfig(ffl_t_threshold=1.5)
     with pytest.raises(ValidationError):
         TrainingConfig(ffl_weight=-1.0)
+
+
+def test_ffl_navit_symmetric_mutex():
+    """FFL ↔ NaViT 对称硬互斥（打包态批内尺寸不一，无法逐图 FFT）：两侧 disable_when 都要有。
+
+    这是前端锁（disable_when，非 pydantic 硬 raise）+ loop.py 的 navit_latents is None
+    第三守卫纵深防御；本测试锁住对称锁不被后续编辑单侧改漏。
+    """
+    from studio.domain.training import TrainingConfig
+    fields = TrainingConfig.model_fields
+    ffl_dw = (fields["ffl_enabled"].json_schema_extra or {}).get("disable_when", "")
+    navit_dw = (fields["navit_packing"].json_schema_extra or {}).get("disable_when", "")
+    assert "navit_packing==true" in ffl_dw, "FFL 侧缺 navit 锁"
+    assert "ffl_enabled==true" in navit_dw, "navit 侧缺 ffl 锁"


### PR DESCRIPTION
> **Draft —— 效力尚未证实，勿合并。** 实现 + 测试 + 归属齐备；是否 ready 取决于一次隔离 A/B（见下「为什么是 draft」）。

## 背景 / 动机

DiT LoRA 对细节质感的学习比 UNet 时代差。根因两条：**A** flow-matching 的时间步分布让低 t（细节决定区）拿不到梯度；**B** 低秩更新的容量优先被低频结构占满、高频纹理最先被牺牲。

① 频域 loss 是 `dit-lora-detail-texture-notes.md` 里对症根因 B 的候选之一：直接在频域惩罚「高频/难合成频率学不像」，弥补 MSE 磨平高频的倾向。**train-time only，产物仍是标准 LoRA，ComfyUI 导出链零改动。** 它是 ② LPL（潜空间感知 loss）的更便宜对照臂——纯 latent 空间、无 VAE decode、≈0 显存。

## 改动概要

- **`runtime/training/ffl.py`**：`FocalFrequencyLoss`（论文 Focal Frequency Loss, Jiang et al. ICCV 2021）。对预测干净 latent x̂₀ 与真实 latent x₀ 做 `fft2(norm="ortho")`，focal 权重自适应加权难频率。零可训练参数，与 SRA 同构。
- **`loop.py`**：标准 RF 路径加一项——x̂₀ = noisy − t·pred（RF 路径免费，无额外前向），按 `ffl_t_threshold` 门控（默认全 t）、reg 集过滤、尊重 `loss_weight`。三守卫 `not use_leap && navit_latents is None`（与 SRA 一致）。3 处 log。
- **schema（4 字段）**：`ffl_enabled / ffl_weight / ffl_alpha / ffl_t_threshold`，经 argparse bridge 自动流到 args。
- **NaViT 互斥**：NaViT（#371）已在 dev，是 FFL 唯一硬互斥（打包态批内尺寸不一，无法逐图 FFT）。本 PR 补对称锁——`ffl_enabled` disable_when navit、`navit_packing` disable_when 加 ffl，+ loop 第三守卫纵深防御。
- **`tests/test_ffl.py`**：10 测。

**不动**：优化器 / state / resume / 导出链 / 前端（SchemaForm 泛化处理 show_when/disable_when，零手写）。

## 为什么是 draft（效力待证）

真训一版（38-kupa，`uniform + timestep_schedule_shift=0.7 + ffl_weight=2.0`）细节**有可感知提升**。但归因不清：

- 该配置把细节区 **t<0.3 的采样占比从默认的 2.6% 拉到 38%**（~15×），采样改动量级压倒性，提升**大概率主要来自采样、非 FFL**。
- 单独测 FFL（默认采样 + `ffl_weight=1.0`）此前**无可见变化**；诊断：FFL 值中位仅 ~denoise 的 7%、且 x̂₀ 的 t² 抑制使信号偏高 t 结构区。

**合入门槛 = 同配置只翻 `ffl_enabled` 的隔离 A/B（同 seed/同提示词）**：FFL 明显加分 → 出 draft 合 dev；看不出差 → 关闭本 PR、归 park。完整诊断与重启条件见 `docs/todo/ffl-frequency-loss-pending.md`。

## 测试方式

- `pytest tests/test_ffl.py`（10）：公式与官方 stack 风格独立参考逐值对照、degenerate、alpha=0 等权、5D/4D 等价、grad 可达、schema 默认/边界、**navit↔ffl 对称锁**。
- 横切安全网 `tests/test_route_snapshot.py tests/test_studio_configs.py` + 全部 `tests/test_navit_*` 通过。
- loop 集成块端到端手验：x̂₀ 恒等 / t-gate / reg 过滤 / grad 回 LoRA / navit·全 reg 空 batch 安全跳过。

## 来源声明（移植/参考外部代码规矩）

- **论文**：Jiang et al. 2021, *Focal Frequency Loss for Image Reconstruction and Synthesis*, [arXiv:2012.12821](https://arxiv.org/abs/2012.12821)（ICCV 2021）。
- **Reference 实现对照**（仅校对，未逐行复制）：[`EndlessSora/focal-frequency-loss`](https://github.com/EndlessSora/focal-frequency-loss)（MIT，Copyright (c) 2021 Liming Jiang）。公式细节（fft2 norm=ortho / 频率距离 / focal 权重归一 + detach）对照校对；latent 空间 + per-sample reduction 为本项目改造。
- 已在 `ffl.py` docstring + `THIRD_PARTY_NOTICES.md` 标注。MIT 与本仓库 GPL-3.0 兼容。
