### PR TITLE
feat(train): timestep shift 分辨率修正 —— per-image sqrt(n/n_base) Möbius 偏移（opt-in）

### DIFF
--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -45,6 +45,7 @@ from training.text_encoding import (
     tokenize_t5_comfy_literal,
     tokenize_t5_weighted,
 )
+from training.timestep_sampling import apply_resolution_shift, latent_token_counts
 from utils.optimizer_utils import get_optimizer_monitor_metrics, optimizer_eval_mode
 
 
@@ -144,6 +145,21 @@ def run(ctx: TrainingContext) -> None:
         dl_len = None
         _has_len = False
 
+    # timestep shift 分辨率修正（timestep_shift_resolution_aware，opt-in）：多分辨率 /
+    # NaViT 原生分辨率下按每图 token 数把 t 推到与基准档等效的噪声水平（SD3 §5.3.2，
+    # s_i = sqrt(n_i/n_base)）。基准档 = resolution 首档：该档 s=1 恒等，全局
+    # timestep_shift 仍是"基准档的校准值"；单分辨率训练下本开关是 no-op。
+    res_shift_base_tokens = 0
+    if bool(getattr(args, "timestep_shift_resolution_aware", False)):
+        _r = getattr(args, "resolution", 1024)
+        _base_reso = int(_r[0] if isinstance(_r, (list, tuple)) else _r)
+        res_shift_base_tokens = max(1, (_base_reso // 16) ** 2)
+        logger.info(
+            "[res-shift] timestep shift 分辨率修正已启用：s_i=sqrt(token_i/%d)"
+            "（基准档 %dpx），作用于采样后的 t。",
+            res_shift_base_tokens, _base_reso,
+        )
+
     for epoch in range(ctx.start_epoch, args.epochs):
         ctx.current_epoch = epoch
         epoch_loss_sum = 0.0
@@ -219,6 +235,18 @@ def run(ctx: TrainingContext) -> None:
             # Flow Matching：统一通过 timestep_sampler plugin 接口采样
             # （baseline = 4 种 mode；adaptive = InfoNoise 等；接口在 ADR 0003 plugin registry）
             t = ctx.timestep_sampler.sample(bs, ctx.device)
+
+            # 分辨率相关 shift 修正（见 run() 顶部 setup）：navit 逐图 latent 各算各的
+            # token 数；批量网格 batch 内同尺寸 → 等值向量。后续 record / sigma_t /
+            # 加噪全部看到修正后的 t（记录的是实际训练到的噪声水平）。
+            if res_shift_base_tokens:
+                t = apply_resolution_shift(
+                    t,
+                    latent_token_counts(
+                        navit_latents if navit_latents is not None else latents
+                    ),
+                    res_shift_base_tokens,
+                )
 
             # PR-C：adapter hook — 允许变体按 sigma_t / step 调整运行时结构
             # （T-LoRA / AdaLoRA / B-LoRA 等）。LyCORIS 走默认 no-op。

--- a/runtime/training/timestep_sampling.py
+++ b/runtime/training/timestep_sampling.py
@@ -82,3 +82,42 @@ def _apply_timestep_schedule_shift(t: torch.Tensor, timestep_schedule_shift: flo
     if s == 1.0:
         return t
     return ((t * s) / (1 + (s - 1) * t)).clamp(1e-4, 1 - 1e-4)
+
+
+def latent_token_counts(latents, patch_spatial: int = 2) -> list[int]:
+    """每样本的 patch-token 数（``timestep_shift_resolution_aware`` 用）。
+
+    - list/tuple（NaViT 逐图 latent，各 ``[.,C,T,h_i,w_i]``，形状可异构）→ 逐图计数；
+    - 批量网格 tensor ``[B,C,T,H,W]``（ARB / 多分辨率，batch 内同尺寸）→ B 个等值计数。
+
+    ``patch_spatial=2`` 与 ``CachedLatentDataset._fill_bucket_for_index`` 的
+    token 口径一致（1 token = 16×16px）。
+    """
+    if isinstance(latents, (list, tuple)):
+        return [
+            int(l.shape[-2] // patch_spatial) * int(l.shape[-1] // patch_spatial)
+            for l in latents
+        ]
+    n = int(latents.shape[-2] // patch_spatial) * int(latents.shape[-1] // patch_spatial)
+    return [n] * int(latents.shape[0])
+
+
+def apply_resolution_shift(t: torch.Tensor, token_counts, base_tokens: int) -> torch.Tensor:
+    """SD3（arXiv 2403.03206 §5.3.2）分辨率相关 timestep shift 修正。
+
+    对每样本施加 Möbius 偏移 t' = (t·s)/(1+(s−1)·t)，s_i = sqrt(n_i / n_base)。
+    同一 t 下分辨率越高的图相邻像素相关性越强、等效 SNR 越高，需要更高的 t 才达到
+    与基准档等效的破坏程度——所以大图（n_i > n_base）推向高噪声端、小图反之，
+    n_i == n_base 恒等。
+
+    Möbius 偏移按 s 乘法复合（shift(s1) ∘ shift(s2) == shift(s1·s2)），因此本修正
+    与全局 timestep_shift / timestep_schedule_shift 正交：全局值仍是"基准档的校准值"，
+    本函数只补分辨率相对基准档的差。
+    """
+    s = (
+        torch.as_tensor(token_counts, dtype=t.dtype, device=t.device)
+        .clamp_min(1)
+        .div(float(max(1, int(base_tokens))))
+        .sqrt()
+    )
+    return ((t * s) / (1 + (s - 1) * t)).clamp(1e-4, 1 - 1e-4)

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -625,6 +625,18 @@ class TrainingConfig(BaseModel):
             disable_hint="InfoNoise 启用时禁用 schedule shift（schema 互斥，仅 1.0 兼容）",
         ),
     )
+    timestep_shift_resolution_aware: bool = Field(
+        False,
+        description="按每图 token 数对采样后的 t 做分辨率修正（SD3 式 s=sqrt(该图 token 数/基准档 token 数)，"
+                    "基准档取 resolution 首档）：基准档尺寸的图不变，更大的图偏向高噪声端、更小的偏向低噪声端。"
+                    "多分辨率与 NaViT 原生分辨率训练下，各尺寸的图落在与基准档等效的噪声水平；单分辨率训练下无效果",
+        json_schema_extra=_meta(
+            "timestep_sampling",
+            alt_description="Leap 启用时 leap 路径的 t_k/t_j 不做本修正，仅作用于 (1-leap_ratio) 比例的标准 step",
+            alt_description_when="leap_enabled==true",
+            advanced=True,
+        ),
+    )
     infonoise_enabled: bool = Field(
         False,
         description="【InfoNoise】启用自适应时间步采样：训练中根据信息量自动调整 t 分布，聚焦更有效的训练区间",

--- a/tests/test_timestep_resolution_shift.py
+++ b/tests/test_timestep_resolution_shift.py
@@ -1,0 +1,93 @@
+"""timestep shift 分辨率修正（timestep_shift_resolution_aware）单测。
+
+覆盖：
+  1) apply_resolution_shift：基准档恒等 / 大图升 t、小图降 t / 公式数值点。
+  2) Möbius 乘法复合律：先全局 shift 再分辨率修正 == 一次乘积 shift（正交性依据）。
+  3) per-sample 向量：一个 batch 内不同 token 数各得各的修正。
+  4) 端点 clamp：极端 token 比不越出 (1e-4, 1-1e-4)。
+  5) latent_token_counts：批量网格 tensor 与 NaViT 异构 latent 列表两种输入。
+  6) config：默认 off、可开。
+
+CPU-only、无 GPU：CI（Linux 无 GPU）可跑。
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from training.timestep_sampling import (
+    apply_resolution_shift,
+    latent_token_counts,
+)
+
+
+# --------------------------------------------------------- 公式性质
+def test_identity_at_base_tokens():
+    t = torch.linspace(0.05, 0.95, 10)
+    out = apply_resolution_shift(t, [4096] * 10, 4096)
+    assert torch.allclose(out, t, atol=1e-6)
+
+
+def test_direction_and_known_values():
+    # 4× token → s=2；1/4 token → s=0.5。t=0.5 处解析值 2/3 与 1/3。
+    t = torch.full((4,), 0.5)
+    up = apply_resolution_shift(t, [4096 * 4] * 4, 4096)
+    down = apply_resolution_shift(t, [4096 // 4] * 4, 4096)
+    assert torch.all(up > t) and torch.all(down < t)
+    assert torch.allclose(up, torch.full((4,), 2.0 / 3.0), atol=1e-5)
+    assert torch.allclose(down, torch.full((4,), 1.0 / 3.0), atol=1e-5)
+
+
+def test_composes_multiplicatively_with_global_shift():
+    """Möbius 偏移按 s 乘法复合：全局 shift(s1) 后再分辨率修正(s2) == shift(s1·s2)。
+
+    这是"全局 timestep_shift 仍是基准档校准值、本修正只补分辨率差"的数学依据。
+    """
+    t = torch.linspace(0.05, 0.95, 17)
+    s1, n, base = 3.0, 16384, 4096  # s2 = sqrt(16384/4096) = 2
+    a = (t * s1) / (1 + (s1 - 1) * t)
+    a = apply_resolution_shift(a, [n] * len(t), base)
+    s12 = s1 * math.sqrt(n / base)
+    b = ((t * s12) / (1 + (s12 - 1) * t)).clamp(1e-4, 1 - 1e-4)
+    assert torch.allclose(a, b, atol=1e-5)
+
+
+def test_per_sample_vector():
+    t = torch.tensor([0.5, 0.5, 0.5])
+    out = apply_resolution_shift(t, [4096, 16384, 1024], 4096)
+    assert out[0] == pytest.approx(0.5, abs=1e-6)
+    assert out[1] > 0.5 > out[2]
+
+
+def test_bounds_clamped():
+    t = torch.tensor([1e-4, 1 - 1e-4])
+    out = apply_resolution_shift(t, [1_000_000, 1], 4096)
+    assert torch.all(out >= 1e-4) and torch.all(out <= 1 - 1e-4)
+
+
+# --------------------------------------------------------- token 计数口径
+def test_latent_token_counts_batched_tensor():
+    # 1024px → latent 128×128 → 64×64 token = 4096（与 CachedLatentDataset 口径一致）
+    lat = torch.zeros(3, 16, 1, 128, 128)
+    assert latent_token_counts(lat) == [4096, 4096, 4096]
+
+
+def test_latent_token_counts_navit_list():
+    # NaViT 异构列表：5D [1,C,T,h,w] 与 4D [C,T,h,w] 都按最后两维算
+    lst = [torch.zeros(1, 16, 1, 62, 93), torch.zeros(16, 1, 48, 48)]
+    assert latent_token_counts(lst) == [31 * 46, 24 * 24]
+
+
+# --------------------------------------------------------- config switch
+def test_config_default_off():
+    from studio.domain import TrainingConfig
+    cfg = TrainingConfig()
+    assert cfg.timestep_shift_resolution_aware is False
+
+
+def test_config_can_enable():
+    from studio.domain import TrainingConfig
+    cfg = TrainingConfig(timestep_shift_resolution_aware=True)
+    assert cfg.timestep_shift_resolution_aware is True


### PR DESCRIPTION
## 背景 / 动机

最优 timestep shift 是**分辨率的函数**（SD3 arXiv 2403.03206 §5.3.2：同一 t 下分辨率越高的图相邻像素相关性越强、等效 SNR 越高，shift 应按 `sqrt(token数之比)` 缩放）。而现有 `timestep_shift` / `timestep_schedule_shift` 都是全局标量，对 batch 内每个样本一视同仁：

- **多分辨率 fan-out**（已有 feature）：`resolution: [1024, 512]` 时同一 run 里 token 数差 4×、最优 shift 差 2×，全局单值必有一头失配——问题从多分辨率落地起就存在。
- **NaViT 原生分辨率**（#372）：数据集内 token 数连续分布、可差 10×+，把离散失配放大成连续 per-image 方差。**不做本修正，native 的 A/B 结果会被 shift 失配污染。**

## 改动概要

- **`runtime/training/timestep_sampling.py`**：`apply_resolution_shift`（per-sample Möbius 偏移 `t' = s·t/(1+(s−1)·t)`，`s_i = sqrt(n_i/n_base)`）+ `latent_token_counts`（批量网格 tensor 与 navit 异构 latent 列表统一 token 口径，`patch_spatial=2` 与 `CachedLatentDataset` 一致）。
- **`runtime/training/loop.py`**：`ctx.timestep_sampler.sample()` 之后统一施加——批量网格路径 batch 内同尺寸（等值向量）、navit 路径逐图各算各的。后续 `record` / `sigma_t` / 加噪全部看到修正后的 t。
- **`studio/domain/training.py`**：`timestep_shift_resolution_aware`（默认 false，timestep_sampling 组 advanced）。

## 正交性（为什么不动全局 shift 的语义）

Möbius 偏移按 s **乘法复合**（`shift(s1) ∘ shift(s2) == shift(s1·s2)`，有单测钉住）。基准档取 `resolution` 首档，该档 `s=1` 恒等——已校准的全局 `timestep_shift` 仍是「基准档的值」，本修正只补各图相对基准档的差。因此：

- 默认关 → 零行为变化；
- 开了但单分辨率训练 → no-op（所有图都在基准档）；
- 与 InfoNoise 兼容（作用于其返回的 t 之后，自适应 CDF 记录到的是实际训练分布）；LEAP 路径的 `t_k/t_j` 不修正（字段 alt_description 注明）。

## 与 #372 的关系

为 NaViT 原生分辨率真训 A/B 的**前置项**（先定住噪声调度再判特性价值），设计为与 #372 分支合并测试时零文件冲突（`training.py` 改动在 timestep 字段区，远离 navit 字段区）。对多分辨率训练独立有效，不依赖 #372。

## 测试

新增 `tests/test_timestep_resolution_shift.py`（CPU-only，CI 可跑）：基准档恒等 / 方向与解析值（t=0.5、s=2 → 2/3）/ **乘法复合律** / per-sample 向量 / 端点 clamp / 两种 latent 输入的 token 口径 / config 开关。本地 `test_timestep_sampling` + `test_timestep_sampler_resume` + `test_navit_packed_objective` + `test_studio_configs` + `test_route_snapshot` 回归全绿。

**诚实标注**：数值效果（loss 曲线 / 出图）待真训验证——与 #372 一起上卡 A/B。

🤖 Generated with [Claude Code](https://claude.com/claude-code)