### PR TITLE
fix(train): T5 tokenizer 在线 fallback 补缺失提示与下载失败错误信息

### DIFF
--- a/runtime/training/models.py
+++ b/runtime/training/models.py
@@ -506,7 +506,19 @@ def load_text_encoders(
     if t5_tokenizer_path and Path(t5_tokenizer_path).exists():
         t5_tokenizer = t5_cls.from_pretrained(t5_tokenizer_path)
     else:
-        t5_tokenizer = t5_cls.from_pretrained("google/t5-v1_1-xxl")
+        logger.warning(
+            "T5 tokenizer 本地目录缺失（t5_tokenizer_path=%s），"
+            "开始从 Hugging Face 下载 google/t5-v1_1-xxl",
+            t5_tokenizer_path or "未配置",
+        )
+        try:
+            t5_tokenizer = t5_cls.from_pretrained("google/t5-v1_1-xxl")
+        except Exception as e:
+            raise RuntimeError(
+                f"T5 tokenizer 下载失败（google/t5-v1_1-xxl）：{type(e).__name__}: {e}\n"
+                f"请检查网络后重试；或在 Studio 设置页下载 t5_tokenizer 模型，"
+                f"并确认 t5_tokenizer_path（当前值：{t5_tokenizer_path or '未配置'}）指向该目录。"
+            ) from e
 
     logger.info("文本编码器加载完成")
     return qwen_model, qwen_tokenizer, t5_tokenizer

--- a/tests/test_training_models_t5_fallback.py
+++ b/tests/test_training_models_t5_fallback.py
@@ -1,0 +1,125 @@
+"""load_text_encoders 的 T5 tokenizer 在线 fallback 错误信息回归测试。
+
+背景（任务 #363 截图）：t5_tokenizer_path 本地目录缺失时会静默从 Hugging Face
+在线拉 google/t5-v1_1-xxl，网络超时曾以裸 httpx.ConnectTimeout 堆栈崩训练，
+用户完全看不出是缺模型。现在要求：
+    - fallback 前打「本地目录缺失 → 开始下载」的 warning
+    - 下载失败必须 raise RuntimeError：含「下载失败」+ 原始原因 + 怎么办
+      （任务详情的错误字段只显示 stderr 尾部，原因必须进 message 而不能只在
+      异常链的上游 traceback 里）
+
+transformers 用假模块顶替（sys.modules），不真加载权重、不联网。
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import types
+
+import pytest
+
+
+class _SelfReturningModel:
+    """顶替 AutoModelForCausalLM 实例，兼容 .to(...).eval().requires_grad_(False) 链。"""
+
+    def to(self, *args, **kwargs):
+        return self
+
+    def eval(self):
+        return self
+
+    def requires_grad_(self, *args, **kwargs):
+        return self
+
+
+def _make_fake_transformers(t5_from_pretrained):
+    """返回 (假 transformers 模块, T5 from_pretrained 收到的 path 列表)。"""
+    mod = types.ModuleType("transformers")
+    t5_calls: list[str] = []
+
+    class AutoTokenizer:
+        @staticmethod
+        def from_pretrained(path, **kwargs):
+            return object()
+
+    class AutoModelForCausalLM:
+        @staticmethod
+        def from_pretrained(path, **kwargs):
+            return _SelfReturningModel()
+
+    class T5Tokenizer:
+        @staticmethod
+        def from_pretrained(path, **kwargs):
+            t5_calls.append(str(path))
+            return t5_from_pretrained(str(path))
+
+    class T5TokenizerFast(T5Tokenizer):
+        pass
+
+    mod.AutoTokenizer = AutoTokenizer
+    mod.AutoModelForCausalLM = AutoModelForCausalLM
+    mod.T5Tokenizer = T5Tokenizer
+    mod.T5TokenizerFast = T5TokenizerFast
+    return mod, t5_calls
+
+
+@pytest.fixture()
+def tm():
+    from training import models  # noqa: PLC0415  (conftest 已把 runtime/ 注入 sys.path)
+
+    return models
+
+
+def test_missing_t5_dir_download_error_is_wrapped(tm, monkeypatch, tmp_path, caplog):
+    """目录缺失 + 下载抛网络错 → RuntimeError 带下载失败原因与修复指引。"""
+
+    def _boom(path):
+        raise ConnectionError("[WinError 10060] 由于连接方在一段时间后没有正确答复")
+
+    fake, t5_calls = _make_fake_transformers(_boom)
+    monkeypatch.setitem(sys.modules, "transformers", fake)
+
+    missing = tmp_path / "no_such_dir"
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(RuntimeError) as excinfo:
+            tm.load_text_encoders(str(tmp_path), str(missing), "cpu", None)
+
+    msg = str(excinfo.value)
+    assert "T5 tokenizer 下载失败" in msg
+    assert "google/t5-v1_1-xxl" in msg
+    assert "10060" in msg  # 原始原因必须进 message（错误字段只显示 stderr 尾部）
+    assert "t5_tokenizer_path" in msg  # 指引用户检查配置
+    assert isinstance(excinfo.value.__cause__, ConnectionError)
+    assert t5_calls == ["google/t5-v1_1-xxl"]
+    assert any("本地目录缺失" in r.getMessage() for r in caplog.records)
+
+
+def test_missing_t5_dir_fallback_success_logs_warning(tm, monkeypatch, tmp_path, caplog):
+    """目录缺失但下载成功 → 有「缺失 → 开始下载」warning，正常返回。"""
+    fake, t5_calls = _make_fake_transformers(lambda path: "tok")
+    monkeypatch.setitem(sys.modules, "transformers", fake)
+
+    with caplog.at_level(logging.WARNING):
+        _, _, t5_tokenizer = tm.load_text_encoders(
+            str(tmp_path), str(tmp_path / "no_such_dir"), "cpu", None
+        )
+
+    assert t5_tokenizer == "tok"
+    assert t5_calls == ["google/t5-v1_1-xxl"]
+    warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("本地目录缺失" in m and "google/t5-v1_1-xxl" in m for m in warnings)
+
+
+def test_local_t5_dir_never_falls_back(tm, monkeypatch, tmp_path, caplog):
+    """本地目录存在 → 只用本地路径，不联网、不打缺失 warning。"""
+    fake, t5_calls = _make_fake_transformers(lambda path: "tok")
+    monkeypatch.setitem(sys.modules, "transformers", fake)
+
+    local = tmp_path / "t5_tokenizer"
+    local.mkdir()
+    with caplog.at_level(logging.WARNING):
+        _, _, t5_tokenizer = tm.load_text_encoders(str(tmp_path), str(local), "cpu", None)
+
+    assert t5_tokenizer == "tok"
+    assert t5_calls == [str(local)]
+    assert not any("本地目录缺失" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
## 背景 / 动机

用户报告训练偶发失败（任务 #363 截图）：任务详情错误字段只有一段裸 `httpx.ConnectTimeout: [WinError 10060]` 堆栈尾巴，完全看不出根因。

排查结论：`load_text_encoders` 在 `t5_tokenizer_path` 本地目录缺失时**静默**走 `T5Tokenizer.from_pretrained(google/t5-v1_1-xxl)` 在线下载（huggingface_hub >= 1.0 底层已换 httpx，与堆栈吻合）。网络通畅时下载成功、没人察觉联了网；网络抖动时 ConnectTimeout 无人捕获直接崩训练——「偶发」由此而来。

## 改动概要

行为不变（缺失时仍自动下载），只改信息呈现，`runtime/training/models.py`：

- 进 fallback 前打 warning：`T5 tokenizer 本地目录缺失（t5_tokenizer_path=...），开始从 Hugging Face 下载 google/t5-v1_1-xxl`
- 下载失败时 `raise RuntimeError(...) from e`：message 内嵌原始原因（`ConnectTimeout: [WinError 10060] ...`）+ 修复指引（检查网络 / 在 Studio 设置页下载 t5_tokenizer / 核对 t5_tokenizer_path 当前值）。原因必须进 message——任务错误字段只截 stderr 尾部，只靠异常链的话用户仍然只看得到 httpx 那几帧

对 `load_text_encoders` 的所有调用方生效（train / generate / reg_ai / daemon）。

## 测试方式

- 新增 `tests/test_training_models_t5_fallback.py` 3 个回归测试（假 transformers 模块顶替，不联网不加载权重）：下载失败 message 含「下载失败 + 原始原因 + t5_tokenizer_path 指引」且 `__cause__` 保留；缺失但下载成功有 warning；本地目录存在绝不走 fallback
- 相关既有测试：`test_anima_train_migration.py` / `test_anima_daemon_comfy_parity_runtime.py` / `test_anima_reg_caption.py` 24 passed
- 横切安全网：`test_route_snapshot.py` + `test_studio_configs.py` 33 passed

## 后续（本 PR 不做）

- `qwen_path` 配置错误时会被 transformers 当 repo id 联网，症状类似，可与「训练子进程 HF 离线化」（按任务 kind 给 `HF_HUB_OFFLINE=1`，download worker 除外）一起做

🤖 Generated with [Claude Code](https://claude.com/claude-code)