### PR TITLE
fix(studio): 子进程短路 xformers triton 探测，消除无害 traceback 误报

### DIFF
--- a/studio/services/inference/daemon.py
+++ b/studio/services/inference/daemon.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from ...paths import REPO_ROOT
+from ..runtime import xformers as _xformers_svc
 from . import disk_cache as generate_cache
 
 logger = logging.getLogger(__name__)
@@ -230,6 +231,9 @@ class InferenceDaemon:
         env.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
         env.setdefault("TRANSFORMERS_VERBOSITY", "error")
         env.setdefault("DIFFUSERS_VERBOSITY", "error")
+        # xformers 的 triton 探测会把无害的 ImportError traceback 打进 daemon
+        # 日志抽屉；本 app 的 xformers 路径不用 triton kernel，无条件短路。
+        _xformers_svc.disable_triton_probe(env)
 
         creationflags = 0
         if os.name == "nt":

--- a/studio/services/runtime/xformers.py
+++ b/studio/services/runtime/xformers.py
@@ -51,6 +51,27 @@ def detect_attention_backend() -> str:
     return "none"
 
 
+def disable_triton_probe(env: dict[str, str]) -> None:
+    """替 xformers 短路 triton 探测（子进程 env 注入用）。
+
+    xformers 启用后其 `_is_triton_available()` 会 `import triton`。triton 官方
+    不发 Windows wheel，未安装时必然 ImportError，xformers 用
+    `logger.warning(..., exc_info=True)` 把完整 traceback 打进 task log ——
+    还会被失败摘要 `_tail_log_for_error_msg`（取最后一处 Traceback）误当
+    失败原因展示给用户。
+
+    无条件短路：xformers 里 triton 只服务 LLM 型 kernel（fmha triton_splitk /
+    rmsnorm / rope_padded / tiled_matmul），本 app 的 memory_efficient_attention
+    （含 NaViT varlen）走 cutlass/flash C++ kernel，triton 装没装、好没好都
+    零参与，探测结果与 warning 对用户均无价值。torch.compile 的 triton 使用
+    不读本变量，不受影响。`XFORMERS_FORCE_DISABLE_TRITON=1` 在 xformers 源码
+    里的检查位于 `import triton` 之前，设了就完全跳过探测；setdefault 保证
+    用户显式设过的值优先，且 xformers 侧 `XFORMERS_ENABLE_TRITON=1` 优先级
+    更高，仍是强开逃生口。
+    """
+    env.setdefault("XFORMERS_FORCE_DISABLE_TRITON", "1")
+
+
 def _torch_cuda_index() -> Optional[str]:
     """从 `torch.__version__` 的 `+cuXXX` 后缀推 PyTorch CUDA index URL。
 

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -33,6 +33,7 @@ from typing import Any, Callable, Optional
 
 from .. import db, secrets as _secrets
 from ..services import eval_auto, eval_validation
+from ..services.runtime import xformers as _xformers_svc
 from ..services.projects import jobs as project_jobs
 from ..infrastructure.log_tail import LogTailer, MonitorStatePoller
 from ..paths import (
@@ -1278,6 +1279,10 @@ class Supervisor:
         env.setdefault("TRANSFORMERS_VERBOSITY", "error")
         env.setdefault("DIFFUSERS_VERBOSITY", "error")
         env.setdefault("ACCELERATE_DISABLE_RICH", "1")
+        # xformers 的 triton 探测会把无害的 ImportError traceback 打进 task log
+        # （Windows 无官方 triton wheel），被失败摘要误当失败原因；本 app 的
+        # xformers 路径不用 triton kernel，无条件短路。
+        _xformers_svc.disable_triton_probe(env)
         try:
             wandb_cfg = _secrets.load().wandb
             if wandb_cfg.enabled:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -365,6 +365,32 @@ def test_popen_injects_wandb_env(env, tmp_path, monkeypatch: pytest.MonkeyPatch)
     assert captured["env"]["WANDB_UPLOAD_STATE_AUTO_POLICY"] == "last"
 
 
+def test_popen_disables_triton_probe(env, tmp_path, monkeypatch) -> None:
+    """子进程注入 XFORMERS_FORCE_DISABLE_TRITON=1，xformers 不再往 task log
+    打无害的 triton ImportError traceback（否则会被 _tail_log_for_error_msg
+    误当失败原因）。"""
+    # os.environ.copy() 起点：本机若设过该 var 会干扰断言
+    monkeypatch.delenv("XFORMERS_FORCE_DISABLE_TRITON", raising=False)
+    captured: dict[str, Any] = {}
+
+    class FakePopen:
+        pid = 123
+
+    def fake_popen(cmd, **kwargs):  # noqa: ANN001
+        captured["env"] = kwargs["env"]
+        return FakePopen()
+
+    monkeypatch.setattr("studio.supervisor.subprocess.Popen", fake_popen)
+    sup = Supervisor(
+        db_path=env["db"], logs_dir=env["logs"], configs_dir=env["configs"],
+    )
+    log_path = tmp_path / "x.log"
+    with log_path.open("wb") as fp:
+        sup._popen([sys.executable, "-c", "pass"], fp)
+
+    assert captured["env"]["XFORMERS_FORCE_DISABLE_TRITON"] == "1"
+
+
 def test_config_path_takes_priority(env, tmp_path) -> None:
     """PP6.3：task.config_path 设了就用它，不再读 _configs_dir。"""
     captured: dict[str, Any] = {}

--- a/tests/test_xformers_setup.py
+++ b/tests/test_xformers_setup.py
@@ -69,6 +69,25 @@ def test_torch_cuda_index_no_torch(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 # ---------------------------------------------------------------------------
+# disable_triton_probe — 子进程 env 注入的 triton 探测短路
+# ---------------------------------------------------------------------------
+
+
+def test_triton_probe_disabled() -> None:
+    """无条件设 XFORMERS_FORCE_DISABLE_TRITON=1（app 的 xformers 路径不用 triton）。"""
+    env: dict[str, str] = {}
+    xs.disable_triton_probe(env)
+    assert env == {"XFORMERS_FORCE_DISABLE_TRITON": "1"}
+
+
+def test_triton_probe_respects_explicit_value() -> None:
+    """用户显式设过（如 =0 强制探测）→ setdefault 不覆盖。"""
+    env = {"XFORMERS_FORCE_DISABLE_TRITON": "0"}
+    xs.disable_triton_probe(env)
+    assert env == {"XFORMERS_FORCE_DISABLE_TRITON": "0"}
+
+
+# ---------------------------------------------------------------------------
 # install
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 背景 / 动机

大量用户反馈某次更新后训练日志 / 失败信息里出现：

```
Traceback (most recent call last):
  File "...\xformers\__init__.py", line 57, in _is_triton_available
    import triton  # noqa
ModuleNotFoundError: No module named 'triton'
```

根因链：

- xformers 启用后其 `_is_triton_available()` 会 `import triton`，失败时用 `logger.warning(..., exc_info=True)` 把**完整 traceback** 打进日志。triton 官方不发 Windows wheel，所以 Windows 上装了 xformers 就必然出现。
- 它本身是无害 warning（xformers 的 C++/CUDA kernel 不受影响），但 `_tail_log_for_error_msg` 的失败摘要策略是「取日志里最后一处 Traceback」——当任务因**没有 Python traceback 的原因**失败（进程被杀 / 驱动层崩溃等）时，这段 warning 会被误当失败原因展示在 UI 上，用户据此以为训练失败是缺 triton。
- 触发面在 v0.13.0 后显著扩大：首启 checklist 一键装 xformers 让装机量大增；NaViT packing 又强制 `attention_backend=xformers`。

**为什么无条件压制而不是探测门控**：核对了 xformers 源码，triton 在 xformers 内只 gate LLM 型 kernel（`fmha/triton_splitk` / `rmsnorm` / `rope_padded` / `tiled_matmul`）；本项目的 `memory_efficient_attention`（含 NaViT varlen）走 cutlass/flash C++ kernel，triton 装没装、好没好都零参与，探测结果与 warning 对用户均无可行动价值。torch.compile 的 triton 使用由 inductor 直接 import，不读本变量，不受影响。

## 改动概要

- `studio/services/runtime/xformers.py` 新增 `disable_triton_probe(env)`：无条件 `setdefault("XFORMERS_FORCE_DISABLE_TRITON", "1")`。该检查在 xformers 源码里位于 `import triton` **之前**，设了就完全跳过探测、不打 traceback。
- 两个子进程 env 注入点统一接入：supervisor `_popen`（训练 / 打标 / reg 等全部任务）+ 生成 daemon `start()`。
- 逃生口保留：`setdefault` 不覆盖用户显式设置；xformers 侧 `XFORMERS_ENABLE_TRITON=1` 优先级更高，仍可强开。

## 测试方式

- 新增：`test_xformers_setup.py` 2 条（注入 / 不覆盖显式值）+ `test_supervisor.py` 1 条（`_popen` 子进程 env 断言，仿既有 `test_popen_injects_wandb_env` 模式）。
- 相关测试全绿：`test_xformers_setup.py` + `test_supervisor.py`（27 passed）、`test_inference_daemon*.py`（25 passed）。
- 横切安全网全绿：`test_route_snapshot.py` + `test_studio_configs.py`（33 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)