### PR TITLE
fix(web): 版本切换乐观更新，修切换后立即训练入队旧版本 (#386)

### DIFF
--- a/studio/api/routers/projects/crud.py
+++ b/studio/api/routers/projects/crud.py
@@ -269,11 +269,13 @@ def activate_version_endpoint(pid: int, vid: int) -> dict[str, Any]:
                 "Version not found", code="version.not_found",
                 details={"id": vid},
             )
-        v = versions.activate_version(conn, vid)
+        versions.activate_version(conn, vid)
         p = projects.get_project(conn, pid)
     assert p is not None
     _publish_project_state(p)
-    return _project_payload(p)
+    # 瘦响应：不回全量 _project_payload（逐版本文件系统 stats，多版本项目可达秒级）。
+    # 前端乐观更新已持有新值，全量数据由 project_state_changed → reload 收敛。
+    return {"active_version_id": vid}
 
 
 # ---------------------------------------------------------------------------

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -2110,7 +2110,7 @@ export const api = {
       method: 'DELETE',
     }),
   activateVersion: (pid: number, vid: number) =>
-    req<ProjectDetail>(
+    req<{ active_version_id: number }>(
       `/api/projects/${pid}/versions/${vid}/activate`,
       { method: 'POST' }
     ),

--- a/studio/web/src/pages/project/Layout.test.tsx
+++ b/studio/web/src/pages/project/Layout.test.tsx
@@ -100,7 +100,7 @@ describe('ProjectLayout 版本切换（#386）', () => {
   })
 
   it('activate 在途时 activeVersion 已乐观切到新版本', async () => {
-    const d = deferred<ProjectDetail>()
+    const d = deferred<{ active_version_id: number }>()
     activateVersionMock.mockReturnValue(d.promise)
     renderLayout()
     await screen.findByTestId('active-vid')
@@ -110,12 +110,12 @@ describe('ProjectLayout 版本切换（#386）', () => {
     // 后端未返回，本地已经是 v1 —— 此刻点「开始训练」入队的就是 v1。
     expect(screen.getByTestId('active-vid')).toHaveTextContent('1')
 
-    await act(async () => { d.resolve(makeProject(1, [V1, V2])) })
+    await act(async () => { d.resolve({ active_version_id: 1 }) })
     expect(screen.getByTestId('active-vid')).toHaveTextContent('1')
   })
 
   it('activate 失败回滚到原版本并 toast', async () => {
-    const d = deferred<ProjectDetail>()
+    const d = deferred<{ active_version_id: number }>()
     activateVersionMock.mockReturnValue(d.promise)
     renderLayout()
     await screen.findByTestId('active-vid')
@@ -130,8 +130,8 @@ describe('ProjectLayout 版本切换（#386）', () => {
 
   it('快速连切两次，第一次失败不覆盖第二次的选择', async () => {
     getProjectMock.mockResolvedValue(makeProject(2, [V1, V2, V3]))
-    const d1 = deferred<ProjectDetail>()
-    const d2 = deferred<ProjectDetail>()
+    const d1 = deferred<{ active_version_id: number }>()
+    const d2 = deferred<{ active_version_id: number }>()
     activateVersionMock.mockImplementation((_pid: number, vid: number) =>
       vid === 1 ? d1.promise : d2.promise)
     renderLayout()
@@ -146,7 +146,7 @@ describe('ProjectLayout 版本切换（#386）', () => {
     expect(screen.getByTestId('active-vid')).toHaveTextContent('3')
     expect(toastMock).not.toHaveBeenCalled()
 
-    await act(async () => { d2.resolve(makeProject(3, [V1, V2, V3])) })
+    await act(async () => { d2.resolve({ active_version_id: 3 }) })
     expect(screen.getByTestId('active-vid')).toHaveTextContent('3')
   })
 })

--- a/studio/web/src/pages/project/Layout.test.tsx
+++ b/studio/web/src/pages/project/Layout.test.tsx
@@ -90,6 +90,14 @@ function deferred<T>() {
   return { promise, resolve, reject }
 }
 
+/** 等 Layout 首载完成：Probe 已渲染**且** setCtx effect 已 flush。慢环境（CI）下
+ * getProject 可能在 findByTestId 首次同步检查前就 resolve，元素直接命中、没走
+ * act 包裹的轮询路径 → passive effect 未跑、lastCtx 还是 null，必须显式再等。 */
+async function ready() {
+  await screen.findByTestId('active-vid')
+  await waitFor(() => expect(lastCtx).not.toBeNull())
+}
+
 describe('ProjectLayout 版本切换（#386）', () => {
   beforeEach(() => {
     lastCtx = null
@@ -103,7 +111,7 @@ describe('ProjectLayout 版本切换（#386）', () => {
     const d = deferred<{ active_version_id: number }>()
     activateVersionMock.mockReturnValue(d.promise)
     renderLayout()
-    await screen.findByTestId('active-vid')
+    await ready()
     expect(screen.getByTestId('active-vid')).toHaveTextContent('2')
 
     act(() => { lastCtx!.onSelectVersion(1) })
@@ -118,7 +126,7 @@ describe('ProjectLayout 版本切换（#386）', () => {
     const d = deferred<{ active_version_id: number }>()
     activateVersionMock.mockReturnValue(d.promise)
     renderLayout()
-    await screen.findByTestId('active-vid')
+    await ready()
 
     act(() => { lastCtx!.onSelectVersion(1) })
     expect(screen.getByTestId('active-vid')).toHaveTextContent('1')
@@ -135,7 +143,7 @@ describe('ProjectLayout 版本切换（#386）', () => {
     activateVersionMock.mockImplementation((_pid: number, vid: number) =>
       vid === 1 ? d1.promise : d2.promise)
     renderLayout()
-    await screen.findByTestId('active-vid')
+    await ready()
 
     act(() => { lastCtx!.onSelectVersion(1) })
     act(() => { lastCtx!.onSelectVersion(3) })

--- a/studio/web/src/pages/project/Layout.test.tsx
+++ b/studio/web/src/pages/project/Layout.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * ProjectLayout 版本切换回归测试（issue #386）。
+ *
+ * 场景：切换版本后 activate 请求还在途时立即点「开始训练」，Train 页读到的
+ * activeVersion 必须已经是新版本（乐观更新），否则会把旧版本入队。
+ */
+import { act, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes, useOutletContext } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  ProjectSetterContext,
+  type ProjectCtxValue,
+} from '../../context/ProjectContext'
+import type { ProjectDetail, Version } from '../../api/client'
+import { DialogProvider } from '../../components/Dialog'
+
+const toastMock = vi.fn()
+vi.mock('../../components/Toast', () => ({
+  useToast: () => ({ toast: toastMock }),
+}))
+
+vi.mock('../../lib/useEventStream', () => ({
+  useEventStream: () => {},
+}))
+
+const getProjectMock = vi.fn()
+const activateVersionMock = vi.fn()
+vi.mock('../../api/client', () => ({
+  api: {
+    getProject: (pid: number) => getProjectMock(pid),
+    activateVersion: (pid: number, vid: number) => activateVersionMock(pid, vid),
+  },
+}))
+
+import ProjectLayout from './Layout'
+
+function makeVersion(id: number, label: string): Version {
+  return {
+    id, project_id: 3, label, config_name: null, status: 'preparing',
+    phase: 'curating', last_failure_reason: null, created_at: 0,
+    output_lora_path: null, note: null, trigger_word: '',
+  }
+}
+
+const V1 = makeVersion(1, 'v1')
+const V2 = makeVersion(2, 'v2')
+const V3 = makeVersion(3, 'v3')
+
+function makeProject(activeVid: number, versions: Version[]): ProjectDetail {
+  return {
+    id: 3, slug: 'ganyu', title: '甘雨', active_version_id: activeVid,
+    active_version_label: 'v2', active_version_status: 'preparing',
+    active_version_phase: 'curating', created_at: 0, updated_at: 0,
+    archived_at: null, note: null, versions,
+    download_image_count: 0, preprocess_image_count: 0,
+  }
+}
+
+/** 模拟 Train 等步骤页：从 Outlet context 读 activeVersion（Train.tsx 入队用的就是它）。 */
+function Probe() {
+  const { activeVersion } = useOutletContext<{ activeVersion: Version | null }>()
+  return <div data-testid="active-vid">{activeVersion ? String(activeVersion.id) : 'none'}</div>
+}
+
+let lastCtx: ProjectCtxValue | null = null
+
+function renderLayout() {
+  return render(
+    <MemoryRouter
+      initialEntries={['/projects/3']}
+      future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
+    >
+      <DialogProvider>
+        <ProjectSetterContext.Provider value={(v) => { lastCtx = v }}>
+          <Routes>
+            <Route path="/projects/:pid" element={<ProjectLayout />}>
+              <Route index element={<Probe />} />
+            </Route>
+          </Routes>
+        </ProjectSetterContext.Provider>
+      </DialogProvider>
+    </MemoryRouter>
+  )
+}
+
+function deferred<T>() {
+  let resolve!: (v: T) => void
+  let reject!: (e: unknown) => void
+  const promise = new Promise<T>((res, rej) => { resolve = res; reject = rej })
+  return { promise, resolve, reject }
+}
+
+describe('ProjectLayout 版本切换（#386）', () => {
+  beforeEach(() => {
+    lastCtx = null
+    toastMock.mockClear()
+    getProjectMock.mockReset()
+    activateVersionMock.mockReset()
+    getProjectMock.mockResolvedValue(makeProject(2, [V1, V2]))
+  })
+
+  it('activate 在途时 activeVersion 已乐观切到新版本', async () => {
+    const d = deferred<ProjectDetail>()
+    activateVersionMock.mockReturnValue(d.promise)
+    renderLayout()
+    await screen.findByTestId('active-vid')
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('2')
+
+    act(() => { lastCtx!.onSelectVersion(1) })
+    // 后端未返回，本地已经是 v1 —— 此刻点「开始训练」入队的就是 v1。
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('1')
+
+    await act(async () => { d.resolve(makeProject(1, [V1, V2])) })
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('1')
+  })
+
+  it('activate 失败回滚到原版本并 toast', async () => {
+    const d = deferred<ProjectDetail>()
+    activateVersionMock.mockReturnValue(d.promise)
+    renderLayout()
+    await screen.findByTestId('active-vid')
+
+    act(() => { lastCtx!.onSelectVersion(1) })
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('1')
+
+    await act(async () => { d.reject(new Error('boom')) })
+    await waitFor(() => expect(screen.getByTestId('active-vid')).toHaveTextContent('2'))
+    expect(toastMock).toHaveBeenCalled()
+  })
+
+  it('快速连切两次，第一次失败不覆盖第二次的选择', async () => {
+    getProjectMock.mockResolvedValue(makeProject(2, [V1, V2, V3]))
+    const d1 = deferred<ProjectDetail>()
+    const d2 = deferred<ProjectDetail>()
+    activateVersionMock.mockImplementation((_pid: number, vid: number) =>
+      vid === 1 ? d1.promise : d2.promise)
+    renderLayout()
+    await screen.findByTestId('active-vid')
+
+    act(() => { lastCtx!.onSelectVersion(1) })
+    act(() => { lastCtx!.onSelectVersion(3) })
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('3')
+
+    // 第一次切换的失败先落地：序号已过期，既不回滚也不 toast。
+    await act(async () => { d1.reject(new Error('stale boom')) })
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('3')
+    expect(toastMock).not.toHaveBeenCalled()
+
+    await act(async () => { d2.resolve(makeProject(3, [V1, V2, V3])) })
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('3')
+  })
+})

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -25,6 +25,8 @@ export default function ProjectLayout() {
   const [showExportDialog, setShowExportDialog] = useState(false)
   const projectRef = useRef<ProjectDetail | null>(null)
   projectRef.current = project
+  // 版本切换请求序号：快速连切时只认最后一次切换的结果，防止先发后至的响应/回滚覆盖新选择。
+  const switchSeqRef = useRef(0)
 
   const reload = useCallback(async () => {
     if (!Number.isFinite(projectId)) return
@@ -77,13 +79,22 @@ export default function ProjectLayout() {
   }, [project])
 
   const handleSelectVersion = useCallback(async (vid: number) => {
-    if (!projectRef.current) return
-    if (projectRef.current.active_version_id === vid) return
+    const prev = projectRef.current
+    if (!prev || prev.active_version_id === vid) return
+    const prevVid = prev.active_version_id
+    const seq = ++switchSeqRef.current
+    // 乐观更新：先本地切换再等后端。activate 往返期间 activeVersion 若停在旧值，
+    // 「切完版本马上点开始训练」会把旧版本入队（#386）。
+    setProject((cur) => (cur ? { ...cur, active_version_id: vid } : cur))
     try {
-      const updated = await api.activateVersion(projectRef.current.id, vid)
-      setProject(updated)
+      const updated = await api.activateVersion(prev.id, vid)
+      if (seq === switchSeqRef.current) setProject(updated)
     } catch (e) {
-      toast(String(e), 'error')
+      if (seq === switchSeqRef.current) {
+        // 只回滚 active_version_id 字段，不整包回退——避免吞掉在途 reload 带来的其他更新。
+        setProject((cur) => (cur ? { ...cur, active_version_id: prevVid } : cur))
+        toast(String(e), 'error')
+      }
     }
   }, [toast])
 

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -87,8 +87,9 @@ export default function ProjectLayout() {
     // 「切完版本马上点开始训练」会把旧版本入队（#386）。
     setProject((cur) => (cur ? { ...cur, active_version_id: vid } : cur))
     try {
-      const updated = await api.activateVersion(prev.id, vid)
-      if (seq === switchSeqRef.current) setProject(updated)
+      await api.activateVersion(prev.id, vid)
+      // 成功不应用响应（瘦响应）：乐观值即服务端新状态，全量数据由
+      // project_state_changed → reload 收敛。
     } catch (e) {
       if (seq === switchSeqRef.current) {
         // 只回滚 active_version_id 字段，不整包回退——避免吞掉在途 reload 带来的其他更新。

--- a/tests/test_project_endpoints.py
+++ b/tests/test_project_endpoints.py
@@ -176,6 +176,9 @@ def test_version_activate_updates_project(client: TestClient) -> None:
     )
     assert resp.status_code == 200
     assert resp.json()["active_version_id"] == v2["id"]
+    # 瘦响应只回 id，落库状态经 GET 验证。
+    got = client.get(f"/api/projects/{p['id']}").json()
+    assert got["active_version_id"] == v2["id"]
 
 
 def test_version_delete_endpoint(client: TestClient) -> None:


### PR DESCRIPTION
修 #386 第 1 条:多版本项目切到旧版本后**马上**点「开始训练」,入队的是切换前的版本。

## 根因

切换版本此前等 `POST /versions/{vid}/activate` 往返落地才更新本地 `active_version_id`(`Layout.tsx handleSelectVersion`),而 Train 页入队用的 `vid` 正是从它派生的 `activeVersion.id`。activate 响应要对**每个版本**跑 `stats_for_version`(train/reg/output 三目录文件系统遍历),多版本、素材多的项目往返可达数百 ms~秒级——在途窗口内点「开始训练」,读到的还是旧版本。后端入队端点忠实使用前端传的 `vid`,问题完全在前端。

## 改动

**commit 1 — 乐观更新(修复本体)**
- 点击切换即本地更新 `active_version_id`,再发 activate;失败按字段回滚 + toast(不整包回退,避免吞掉在途 reload 的其他更新)
- 加请求序号 `switchSeqRef`:快速连切时只认最后一次切换的结果,防先发后至的回滚覆盖新选择
- 顺带修复:侧边栏步骤链接的 `activeVid` 同样从 `activeVersion` 派生,切换在途时不再指向旧版本
- 回归测试 `Layout.test.tsx` 三条(在途乐观切换 / 失败回滚 / 连切乱序保护),旧代码下全红

**commit 2 — activate 端点瘦身(性能顺手改)**
- activate 只回 `{active_version_id}`,不再构造 `_project_payload`;端点本就发布 `project_state_changed`,前端 reload 会再拉一次全量 payload,此前同一次切换全量 stats 算了两遍
- 前端成功分支不再应用响应,全量数据由 SSE reload 收敛;`test_project_endpoints.py` 补 GET 落库断言

## 验证

- `pytest tests/test_project_endpoints.py tests/test_versions.py` 32 passed
- `vitest run src/pages/project/Layout.test.tsx` 3 passed(修复前 3 failed)
- `npm run build`(lint + tsc + vite)全过

#386 第 2 条(bundle.zip 打包 VAE npz 缓存)另开 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)