### PR TITLE
fix(web): 切版本重挂载版本作用域步骤页，消除旧版本数据残留

### DIFF
--- a/studio/web/src/pages/project/Layout.test.tsx
+++ b/studio/web/src/pages/project/Layout.test.tsx
@@ -4,6 +4,7 @@
  * 场景：切换版本后 activate 请求还在途时立即点「开始训练」，Train 页读到的
  * activeVersion 必须已经是新版本（乐观更新），否则会把旧版本入队。
  */
+import { useEffect } from 'react'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes, useOutletContext } from 'react-router-dom'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
@@ -56,18 +57,28 @@ function makeProject(activeVid: number, versions: Version[]): ProjectDetail {
   }
 }
 
+type OutletCtx = {
+  activeVersion: Version | null
+  setVersionSwitchGuard: (g: (() => Promise<boolean>) | null) => void
+}
+
+let lastOutletCtx: OutletCtx | null = null
+let probeMounts = 0
+
 /** 模拟 Train 等步骤页：从 Outlet context 读 activeVersion（Train.tsx 入队用的就是它）。 */
 function Probe() {
-  const { activeVersion } = useOutletContext<{ activeVersion: Version | null }>()
-  return <div data-testid="active-vid">{activeVersion ? String(activeVersion.id) : 'none'}</div>
+  const octx = useOutletContext<OutletCtx>()
+  lastOutletCtx = octx
+  useEffect(() => { probeMounts += 1 }, [])
+  return <div data-testid="active-vid">{octx.activeVersion ? String(octx.activeVersion.id) : 'none'}</div>
 }
 
 let lastCtx: ProjectCtxValue | null = null
 
-function renderLayout() {
+function renderLayout(path = '/projects/3') {
   return render(
     <MemoryRouter
-      initialEntries={['/projects/3']}
+      initialEntries={[path]}
       future={{ v7_relativeSplatPath: true, v7_startTransition: true }}
     >
       <DialogProvider>
@@ -75,6 +86,9 @@ function renderLayout() {
           <Routes>
             <Route path="/projects/:pid" element={<ProjectLayout />}>
               <Route index element={<Probe />} />
+              <Route path="v/:vid">
+                <Route path="train" element={<Probe />} />
+              </Route>
             </Route>
           </Routes>
         </ProjectSetterContext.Provider>
@@ -101,6 +115,8 @@ async function ready() {
 describe('ProjectLayout 版本切换（#386）', () => {
   beforeEach(() => {
     lastCtx = null
+    lastOutletCtx = null
+    probeMounts = 0
     toastMock.mockClear()
     getProjectMock.mockReset()
     activateVersionMock.mockReset()
@@ -156,5 +172,37 @@ describe('ProjectLayout 版本切换（#386）', () => {
 
     await act(async () => { d2.resolve({ active_version_id: 3 }) })
     expect(screen.getByTestId('active-vid')).toHaveTextContent('3')
+  })
+
+  it('版本作用域路由：切版本重挂载步骤页', async () => {
+    activateVersionMock.mockResolvedValue({ active_version_id: 1 })
+    renderLayout('/projects/3/v/2/train')
+    await ready()
+    expect(probeMounts).toBe(1)
+
+    await act(async () => { lastCtx!.onSelectVersion(1) })
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('1')
+    // 旧步骤页实例卸载、新实例重挂载 —— 本地缓存 / 选中态全部换代。
+    expect(probeMounts).toBe(2)
+  })
+
+  it('project 作用域路由（总览）：切版本不重挂载', async () => {
+    activateVersionMock.mockResolvedValue({ active_version_id: 1 })
+    renderLayout()
+    await ready()
+
+    await act(async () => { lastCtx!.onSelectVersion(1) })
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('1')
+    expect(probeMounts).toBe(1)
+  })
+
+  it('切换守卫返回 false 时取消切换', async () => {
+    renderLayout('/projects/3/v/2/train')
+    await ready()
+    act(() => { lastOutletCtx!.setVersionSwitchGuard(() => Promise.resolve(false)) })
+
+    await act(async () => { lastCtx!.onSelectVersion(1) })
+    expect(screen.getByTestId('active-vid')).toHaveTextContent('2')
+    expect(activateVersionMock).not.toHaveBeenCalled()
   })
 })

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Outlet, useNavigate, useParams } from 'react-router-dom'
+import { Outlet, useMatch, useNavigate, useParams } from 'react-router-dom'
 import { api, type ProjectDetail } from '../../api/client'
 import { useProjectCtxSetter, useSelectedProjectSetter } from '../../context/ProjectContext'
 import { useDialog } from '../../components/Dialog'
@@ -27,6 +27,19 @@ export default function ProjectLayout() {
   projectRef.current = project
   // 版本切换请求序号：快速连切时只认最后一次切换的结果，防止先发后至的响应/回滚覆盖新选择。
   const switchSeqRef = useRef(0)
+  // 版本切换守卫：步骤页有需确认才能丢弃的状态时（如 TagEdit 未保存编辑）注册，
+  // 返回 false 取消切换。切版本重挂载步骤页不走路由导航，useBlocker 拦不住，
+  // 需要这条独立通道。
+  const switchGuardRef = useRef<(() => Promise<boolean>) | null>(null)
+  const setVersionSwitchGuard = useCallback(
+    (g: (() => Promise<boolean>) | null) => { switchGuardRef.current = g },
+    [],
+  )
+  // 版本作用域路由（v/:vid/*）下 Outlet 以 activeVersion.id 为 key：切版本强制
+  // 步骤页重挂载，本地 state / 缓存全部换代，杜绝「挂着新版本显示旧数据」
+  //（如 Curation 的 view 缓存守卫不会因 vid 变化重拉）。Overview / Download 是
+  // project 作用域（Overview 另有自己的 selectedVid 本地态），不跟切。
+  const inVersionScope = useMatch('/projects/:pid/v/:vid/*') != null
 
   const reload = useCallback(async () => {
     if (!Number.isFinite(projectId)) return
@@ -81,6 +94,8 @@ export default function ProjectLayout() {
   const handleSelectVersion = useCallback(async (vid: number) => {
     const prev = projectRef.current
     if (!prev || prev.active_version_id === vid) return
+    const guard = switchGuardRef.current
+    if (guard && !(await guard())) return
     const prevVid = prev.active_version_id
     const seq = ++switchSeqRef.current
     // 乐观更新：先本地切换再等后端。activate 往返期间 activeVersion 若停在旧值，
@@ -157,6 +172,9 @@ export default function ProjectLayout() {
 
   const handleCreateVersion = useCallback(async (label: string, forkFromVersionId: number | null) => {
     if (!projectRef.current || creatingBusy) return
+    // 建新版本会激活它 → 步骤页重挂载，同样要过切换守卫（取消则对话框留在原地）。
+    const guard = switchGuardRef.current
+    if (guard && !(await guard())) return
     setCreatingBusy(true)
     try {
       const body: { label: string; fork_from_version_id?: number } = { label }
@@ -216,12 +234,13 @@ export default function ProjectLayout() {
 
   return (
     <div className="flex flex-col h-full">
-      <Outlet context={{
+      <Outlet key={inVersionScope ? activeVersion?.id ?? -1 : 'project'} context={{
         project,
         activeVersion,
         reload,
         onCreateVersion: (forkFromVid?: number) => setCreating({ forkFrom: forkFromVid ?? null }),
         creatingVersionBusy: creatingBusy,
+        setVersionSwitchGuard,
       }} />
       {creating && (
         <NewVersionDialog

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -21,6 +21,7 @@ interface Ctx {
   project: ProjectDetail
   activeVersion: Version | null
   reload: () => Promise<void>
+  setVersionSwitchGuard: (g: (() => Promise<boolean>) | null) => void
 }
 
 const keyOf = (folder: string, name: string) => `${folder}/${name}`
@@ -39,7 +40,7 @@ function arraysEqual(a: string[], b: string[]): boolean {
 
 export default function TagEditPage() {
   const { t } = useTranslation()
-  const { project, activeVersion, reload } = useOutletContext<Ctx>()
+  const { project, activeVersion, reload, setVersionSwitchGuard } = useOutletContext<Ctx>()
   const { toast } = useToast()
   const { confirm } = useDialog()
   const versionId = activeVersion?.id ?? null
@@ -131,6 +132,24 @@ export default function TagEditPage() {
     })
     return () => { cancelled = true }
   }, [blocker, confirm, t, dirtyKeys.length])
+
+  // 切版本会重挂载本页（Layout 的 Outlet key），不走路由导航、useBlocker 拦不住；
+  // dirty 时注册切换守卫，复用同一套 confirm 文案。
+  useEffect(() => {
+    if (!dirty) return
+    setVersionSwitchGuard(() =>
+      confirm(
+        t('tagEdit.unsavedConfirmMessage', { n: dirtyKeys.length }),
+        {
+          tone: 'danger',
+          title: t('tagEdit.unsavedConfirmTitle'),
+          okText: t('tagEdit.unsavedConfirmDiscard'),
+          cancelText: t('tagEdit.unsavedConfirmStay'),
+        },
+      )
+    )
+    return () => setVersionSwitchGuard(null)
+  }, [dirty, dirtyKeys.length, setVersionSwitchGuard, confirm, t])
 
   // folder 列表 + 每个 folder 的原始张数（不受 filterTag 影响，让 tab 数字稳定
   // 不抖动 — 同 Preprocess chip 风格）。单 folder 项目时 UI 不显示 tabs。


### PR DESCRIPTION

#389 修的是"切版本后立即操作用了旧 vid"(写路径);本 PR 修的是镜像问题:**切版本后步骤页正文还是旧版本的数据**(读路径)。

## 问题

步骤页的本地 state 不随 vid 换代,分两档:

- **多数页(TagEdit/Preprocess/Train 等)**:vid 变会自动重拉,但重拉在途时不清旧数据、无 loading,短暂出现"挂着 v2 的名,显示 v1 的图"。
- **Curation(图片筛选页)是真 bug**:拉取被 `view == null` 缓存守卫挡住(为 train/validation bucket 来回切不重拉设计),vid 变化没人清缓存,SSE 也救不了(它只听 `version_state_changed`,activate 发的是 `project_state_changed`)。站在筛选页切版本,右栏**永远**显示旧版本内容——而操作 API 全带新 vid,看着 v1 的图点"移入训练集"写的是 v2。该 bug 与 #389 无关,此前就存在。

## 修法

**`Layout.tsx` 给 `<Outlet>` 按 `activeVersion.id` 加 key,仅限版本作用域路由(`v/:vid/*`,用 `useMatch` 判定)。** 切版本 = 步骤页强制重挂载:本地 state/缓存全部换代,各页已有的首载 loading 态自然成为"切换中"的可见反馈;在途旧 fetch 的迟到响应落在已卸载实例上被丢弃,乱序覆盖问题一并消失。Overview/Download 是 project 作用域不跟切——Overview 有自己的 `selectedVid` 本地态和 seq 守卫,remount 反而会破坏它。

**TagEdit 未保存编辑保护:** 重挂载不走路由导航,现有 `useBlocker` 拦不住,dirty 编辑会被静默丢弃(现状更糟:dirty keys 挂着不清,保存会把旧版本的编辑写进新版本)。加了一条版本切换守卫通道:Layout 经 Outlet context 暴露 `setVersionSwitchGuard`,TagEdit dirty 时注册(复用 unsavedConfirm 同套文案);`handleSelectVersion` 和 `handleCreateVersion`(建新版本也会激活触发重挂载)在动手前过守卫,取消则不切换。

## 测试

`Layout.test.tsx` 新增 3 条:版本作用域切版本重挂载(mount 计数)/ project 作用域不重挂载 / 守卫返回 false 取消切换且不发 activate。

- `vitest run`(全量)53 files / 481 passed
- `npm run build`(lint + tsc + vite)全过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
