### PR TITLE
feat(studio): bundle 导出可选打包 VAE latent 缓存 (#386)

### DIFF
--- a/studio/api/routers/projects/exports.py
+++ b/studio/api/routers/projects/exports.py
@@ -110,7 +110,8 @@ def export_version_bundle(
     reg: bool = False,
     reg_captions: bool = False,
     include_config: bool = False,
-    latent_cache: bool = False,
+    train_latent_cache: bool = False,
+    reg_latent_cache: bool = False,
 ) -> FileResponse:
     """按选项临时打包 bundle.zip（schema_version 2）并交给浏览器下载。"""
     opts = train_io.BundleOptions(
@@ -119,7 +120,8 @@ def export_version_bundle(
         reg=reg,
         reg_captions=reg_captions,
         include_config=include_config,
-        latent_cache=latent_cache,
+        train_latent_cache=train_latent_cache,
+        reg_latent_cache=reg_latent_cache,
     )
 
     with db.connection_for() as conn:

--- a/studio/api/routers/projects/exports.py
+++ b/studio/api/routers/projects/exports.py
@@ -110,6 +110,7 @@ def export_version_bundle(
     reg: bool = False,
     reg_captions: bool = False,
     include_config: bool = False,
+    latent_cache: bool = False,
 ) -> FileResponse:
     """按选项临时打包 bundle.zip（schema_version 2）并交给浏览器下载。"""
     opts = train_io.BundleOptions(
@@ -118,6 +119,7 @@ def export_version_bundle(
         reg=reg,
         reg_captions=reg_captions,
         include_config=include_config,
+        latent_cache=latent_cache,
     )
 
     with db.connection_for() as conn:

--- a/studio/api/schemas/exports.py
+++ b/studio/api/schemas/exports.py
@@ -14,6 +14,7 @@ class BundleOptionsBody(BaseModel):
     reg: bool = False
     reg_captions: bool = False
     include_config: bool = False
+    latent_cache: bool = False
 
     def to_options(self) -> train_io.BundleOptions:
         return train_io.BundleOptions(
@@ -22,6 +23,7 @@ class BundleOptionsBody(BaseModel):
             reg=self.reg,
             reg_captions=self.reg_captions,
             include_config=self.include_config,
+            latent_cache=self.latent_cache,
         )
 
 

--- a/studio/api/schemas/exports.py
+++ b/studio/api/schemas/exports.py
@@ -14,7 +14,8 @@ class BundleOptionsBody(BaseModel):
     reg: bool = False
     reg_captions: bool = False
     include_config: bool = False
-    latent_cache: bool = False
+    train_latent_cache: bool = False
+    reg_latent_cache: bool = False
 
     def to_options(self) -> train_io.BundleOptions:
         return train_io.BundleOptions(
@@ -23,7 +24,8 @@ class BundleOptionsBody(BaseModel):
             reg=self.reg,
             reg_captions=self.reg_captions,
             include_config=self.include_config,
-            latent_cache=self.latent_cache,
+            train_latent_cache=self.train_latent_cache,
+            reg_latent_cache=self.reg_latent_cache,
         )
 
 

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -32,6 +32,7 @@ slug 冲突自动加 -imported-{ts}。
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import time
 import zipfile
@@ -50,6 +51,8 @@ TRAIN_PREFIX = "train/"
 REG_PREFIX = "reg/"
 PRESETS_PREFIX = "presets/"
 CAPTION_EXTS = {".txt"}
+# VAE latent 缓存（CachedLatentDataset 的 {名}.npz / {名}.r{reso}.npz，紧挨图片）
+LATENT_CACHE_EXT = ".npz"
 
 
 VERSION_CONFIG_ARC = "presets/config.yaml"
@@ -63,6 +66,8 @@ class BundleOptions:
     reg_captions: bool = False
     # True = 导出本 version 的私有 config.yaml（去掉路径字段后）作为可移植训练配置
     include_config: bool = False
+    # True = 一并打包 train/reg 里的 VAE latent 缓存（*.npz），导入后免重新 encode
+    latent_cache: bool = False
 
 
 from studio.domain.errors import DomainError, NotFoundError
@@ -343,16 +348,20 @@ def import_train(
 
 
 def _collect_train(
-    train_dir: Path, include_captions: bool
+    train_dir: Path, include_captions: bool, include_latent_cache: bool = False
 ) -> tuple[list[tuple[Path, str]], dict[str, Any]]:
     """扫 train/ 目录，返回 (payload, stats_dict)。"""
     payload: list[tuple[Path, str]] = []
     concepts: list[dict[str, Any]] = []
     image_count = 0
     tagged_count = 0
+    latent_cache_count = 0
 
     if not train_dir.exists():
-        return payload, {"image_count": 0, "tagged_count": 0, "concepts": []}
+        return payload, {
+            "image_count": 0, "tagged_count": 0, "concepts": [],
+            "latent_cache_count": 0,
+        }
 
     for sub in sorted(train_dir.iterdir()):
         if not sub.is_dir():
@@ -370,6 +379,9 @@ def _collect_train(
                     if include_captions:
                         txt = f.with_suffix(".txt")
                         payload.append((txt, f"{TRAIN_PREFIX}{sub.name}/{txt.name}"))
+            elif ext == LATENT_CACHE_EXT and include_latent_cache:
+                latent_cache_count += 1
+                payload.append((f, f"{TRAIN_PREFIX}{sub.name}/{f.name}"))
             elif ext in CAPTION_EXTS and include_captions:
                 # .txt 先由图片那侧 include，这里跳过避免重复
                 pass
@@ -381,18 +393,20 @@ def _collect_train(
         "image_count": image_count,
         "tagged_count": tagged_count,
         "concepts": concepts,
+        "latent_cache_count": latent_cache_count,
     }
 
 
 def _collect_reg(
-    reg_dir: Path, include_captions: bool
+    reg_dir: Path, include_captions: bool, include_latent_cache: bool = False
 ) -> tuple[list[tuple[Path, str]], dict[str, Any]]:
     """扫 reg/ 目录，返回 (payload, stats_dict)。"""
     payload: list[tuple[Path, str]] = []
     image_count = 0
+    latent_cache_count = 0
 
     if not reg_dir.exists():
-        return payload, {"image_count": 0}
+        return payload, {"image_count": 0, "latent_cache_count": 0}
 
     # meta.json
     meta = reg_dir / "meta.json"
@@ -413,14 +427,18 @@ def _collect_reg(
                     if include_captions and f.with_suffix(".txt").exists():
                         txt = f.with_suffix(".txt")
                         payload.append((txt, f"{REG_PREFIX}{item.name}/{txt.name}"))
+                elif ext == LATENT_CACHE_EXT and include_latent_cache:
+                    latent_cache_count += 1
+                    payload.append((f, f"{REG_PREFIX}{item.name}/{f.name}"))
                 elif ext in CAPTION_EXTS and include_captions:
                     pass  # 由图片侧 include
         elif item.is_file() and item.suffix.lower() in IMAGE_EXTS:
-            # reg/ 根目录直接放的图（非标准但兼容）
+            # reg/ 根目录直接放的图（非标准但兼容）。旁边的 npz 不收：
+            # 单层 reg/{file} 在 _safe_arc_bundle 里本就只放行 meta.json。
             image_count += 1
             payload.append((item, f"{REG_PREFIX}{item.name}"))
 
-    return payload, {"image_count": image_count}
+    return payload, {"image_count": image_count, "latent_cache_count": latent_cache_count}
 
 
 def export_bundle(
@@ -461,7 +479,9 @@ def export_bundle(
     # --- train section ---
     train_stats: dict[str, Any] = {}
     if opts.train:
-        tp, train_stats = _collect_train(vdir / "train", opts.train_captions)
+        tp, train_stats = _collect_train(
+            vdir / "train", opts.train_captions, opts.latent_cache
+        )
         if not tp:
             raise TrainIOError(
                 "No images to export", code="dataset.export_empty",
@@ -472,7 +492,9 @@ def export_bundle(
     # --- reg section ---
     reg_stats: dict[str, Any] = {}
     if opts.reg:
-        rp, reg_stats = _collect_reg(vdir / "reg", opts.reg_captions)
+        rp, reg_stats = _collect_reg(
+            vdir / "reg", opts.reg_captions, opts.latent_cache
+        )
         payload.extend(rp)
 
     # --- version 私有训练配置 ---
@@ -515,12 +537,17 @@ def export_bundle(
             "reg": opts.reg,
             "reg_captions": opts.reg_captions,
             "config": config_included,
+            "latent_cache": opts.latent_cache,
         },
         "stats": {
             "train_image_count": train_stats.get("image_count", 0),
             "train_tagged_count": train_stats.get("tagged_count", 0),
             "reg_image_count": reg_stats.get("image_count", 0),
             "config_included": config_included,
+            "latent_cache_count": (
+                train_stats.get("latent_cache_count", 0)
+                + reg_stats.get("latent_cache_count", 0)
+            ),
         },
     }
 
@@ -733,6 +760,7 @@ def import_bundle(
 
             # --- 写入 train ---
             seen_train: set[str] = set()
+            npz_targets: list[Path] = []
             if train_entries:
                 train_dir = vdir / "train"
                 for info, inner in train_entries:
@@ -747,6 +775,8 @@ def import_bundle(
                     seen_train.add(folder)
                     with zf.open(info) as src, target.open("wb") as dst:
                         _copy_chunks(src, dst)
+                    if target.suffix.lower() == LATENT_CACHE_EXT:
+                        npz_targets.append(target)
 
             # --- 写入 reg ---
             reg_image_count = 0
@@ -773,8 +803,16 @@ def import_bundle(
                         target.parent.mkdir(parents=True, exist_ok=True)
                         if target.suffix.lower() in IMAGE_EXTS:
                             reg_image_count += 1
+                        elif target.suffix.lower() == LATENT_CACHE_EXT:
+                            npz_targets.append(target)
                     with zf.open(info) as src, target.open("wb") as dst:
                         _copy_chunks(src, dst)
+
+            # latent 缓存 mtime 修正：训练侧 _is_cache_valid 要求 npz mtime ≥
+            # 图片 mtime，而逐条解包按字典序 npz 常先于同名图片落盘（.npz < .png）
+            # → 缓存会被判失效重 encode。解包完统一 touch 到当前时间。
+            for t in npz_targets:
+                os.utime(t, None)
 
             # --- 写入 version 训练配置 / 其他预设 ---
             # presets/config.yaml → 应用到新 version（force_project_overrides 自动填路径）

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -66,8 +66,9 @@ class BundleOptions:
     reg_captions: bool = False
     # True = 导出本 version 的私有 config.yaml（去掉路径字段后）作为可移植训练配置
     include_config: bool = False
-    # True = 一并打包 train/reg 里的 VAE latent 缓存（*.npz），导入后免重新 encode
-    latent_cache: bool = False
+    # True = 一并打包对应目录里的 VAE latent 缓存（*.npz），导入后免重新 encode
+    train_latent_cache: bool = False
+    reg_latent_cache: bool = False
 
 
 from studio.domain.errors import DomainError, NotFoundError
@@ -480,7 +481,7 @@ def export_bundle(
     train_stats: dict[str, Any] = {}
     if opts.train:
         tp, train_stats = _collect_train(
-            vdir / "train", opts.train_captions, opts.latent_cache
+            vdir / "train", opts.train_captions, opts.train_latent_cache
         )
         if not tp:
             raise TrainIOError(
@@ -493,7 +494,7 @@ def export_bundle(
     reg_stats: dict[str, Any] = {}
     if opts.reg:
         rp, reg_stats = _collect_reg(
-            vdir / "reg", opts.reg_captions, opts.latent_cache
+            vdir / "reg", opts.reg_captions, opts.reg_latent_cache
         )
         payload.extend(rp)
 
@@ -537,7 +538,8 @@ def export_bundle(
             "reg": opts.reg,
             "reg_captions": opts.reg_captions,
             "config": config_included,
-            "latent_cache": opts.latent_cache,
+            "train_latent_cache": opts.train_latent_cache,
+            "reg_latent_cache": opts.reg_latent_cache,
         },
         "stats": {
             "train_image_count": train_stats.get("image_count", 0),

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -2808,6 +2808,7 @@ export const api = {
       reg?: boolean
       regCaptions?: boolean
       includeConfig?: boolean
+      latentCache?: boolean
     },
   ): string => {
     const p = new URLSearchParams()
@@ -2816,6 +2817,7 @@ export const api = {
     p.set('reg', opts.reg ? '1' : '0')
     p.set('reg_captions', opts.regCaptions ? '1' : '0')
     p.set('include_config', opts.includeConfig ? '1' : '0')
+    p.set('latent_cache', opts.latentCache ? '1' : '0')
     return `/api/projects/${pid}/versions/${vid}/bundle.zip?${p.toString()}`
   },
   exportBundleToDataExports: (
@@ -2827,6 +2829,7 @@ export const api = {
       reg?: boolean
       regCaptions?: boolean
       includeConfig?: boolean
+      latentCache?: boolean
     },
   ) =>
     req<DataExportItem>(`/api/projects/${pid}/versions/${vid}/export-bundle`, {
@@ -2837,6 +2840,7 @@ export const api = {
         reg: opts.reg === true,
         reg_captions: opts.regCaptions === true,
         include_config: opts.includeConfig === true,
+        latent_cache: opts.latentCache === true,
       }),
     }),
   listDataExports: () => req<DataExportItem[]>('/api/data-exports'),

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -2808,7 +2808,8 @@ export const api = {
       reg?: boolean
       regCaptions?: boolean
       includeConfig?: boolean
-      latentCache?: boolean
+      trainLatentCache?: boolean
+      regLatentCache?: boolean
     },
   ): string => {
     const p = new URLSearchParams()
@@ -2817,7 +2818,8 @@ export const api = {
     p.set('reg', opts.reg ? '1' : '0')
     p.set('reg_captions', opts.regCaptions ? '1' : '0')
     p.set('include_config', opts.includeConfig ? '1' : '0')
-    p.set('latent_cache', opts.latentCache ? '1' : '0')
+    p.set('train_latent_cache', opts.trainLatentCache ? '1' : '0')
+    p.set('reg_latent_cache', opts.regLatentCache ? '1' : '0')
     return `/api/projects/${pid}/versions/${vid}/bundle.zip?${p.toString()}`
   },
   exportBundleToDataExports: (
@@ -2829,7 +2831,8 @@ export const api = {
       reg?: boolean
       regCaptions?: boolean
       includeConfig?: boolean
-      latentCache?: boolean
+      trainLatentCache?: boolean
+      regLatentCache?: boolean
     },
   ) =>
     req<DataExportItem>(`/api/projects/${pid}/versions/${vid}/export-bundle`, {
@@ -2840,7 +2843,8 @@ export const api = {
         reg: opts.reg === true,
         reg_captions: opts.regCaptions === true,
         include_config: opts.includeConfig === true,
-        latent_cache: opts.latentCache === true,
+        train_latent_cache: opts.trainLatentCache === true,
+        reg_latent_cache: opts.regLatentCache === true,
       }),
     }),
   listDataExports: () => req<DataExportItem[]>('/api/data-exports'),

--- a/studio/web/src/components/ExportBundleDialog.tsx
+++ b/studio/web/src/components/ExportBundleDialog.tsx
@@ -123,7 +123,6 @@ export default function ExportBundleDialog({ onConfirm, onCancel }: Props) {
                 <span className="text-sm text-fg-secondary">
                   {t('layout.exportBundleLatentCache')}
                 </span>
-                <span className="text-xs text-fg-tertiary">{t('layout.exportBundleLatentCacheHint')}</span>
               </label>
             </>
           )}
@@ -162,7 +161,6 @@ export default function ExportBundleDialog({ onConfirm, onCancel }: Props) {
                 <span className="text-sm text-fg-secondary">
                   {t('layout.exportBundleLatentCache')}
                 </span>
-                <span className="text-xs text-fg-tertiary">{t('layout.exportBundleLatentCacheHint')}</span>
               </label>
             </>
           )}

--- a/studio/web/src/components/ExportBundleDialog.tsx
+++ b/studio/web/src/components/ExportBundleDialog.tsx
@@ -10,6 +10,7 @@ export interface BundleExportOpts {
   reg: boolean
   regCaptions: boolean
   includeConfig: boolean
+  latentCache: boolean
   destination: BundleExportDestination
 }
 
@@ -25,6 +26,7 @@ export default function ExportBundleDialog({ onConfirm, onCancel }: Props) {
   const [reg, setReg] = useState(false)
   const [regCaptions, setRegCaptions] = useState(false)
   const [includeConfig, setIncludeConfig] = useState(false)
+  const [latentCache, setLatentCache] = useState(false)
   const [destination, setDestination] = useState<BundleExportDestination>('download')
 
   const nothingSelected = !train && !reg && !includeConfig
@@ -32,7 +34,7 @@ export default function ExportBundleDialog({ onConfirm, onCancel }: Props) {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (nothingSelected) return
-    onConfirm({ train, trainCaptions, reg, regCaptions, includeConfig, destination })
+    onConfirm({ train, trainCaptions, reg, regCaptions, includeConfig, latentCache, destination })
   }
 
   return (
@@ -134,6 +136,21 @@ export default function ExportBundleDialog({ onConfirm, onCancel }: Props) {
             </label>
           )}
         </div>
+
+        {/* VAE latent 缓存 — 跟着选中的 train/reg 素材走 */}
+        {(train || reg) && (
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={latentCache}
+              onChange={(e) => setLatentCache(e.target.checked)}
+            />
+            <span className="text-sm text-fg-primary font-medium">
+              {t('layout.exportBundleLatentCache')}
+            </span>
+            <span className="text-xs text-fg-tertiary">{t('layout.exportBundleLatentCacheHint')}</span>
+          </label>
+        )}
 
         {/* 训练配置 */}
         <label className="flex items-center gap-2 cursor-pointer">

--- a/studio/web/src/components/ExportBundleDialog.tsx
+++ b/studio/web/src/components/ExportBundleDialog.tsx
@@ -10,7 +10,8 @@ export interface BundleExportOpts {
   reg: boolean
   regCaptions: boolean
   includeConfig: boolean
-  latentCache: boolean
+  trainLatentCache: boolean
+  regLatentCache: boolean
   destination: BundleExportDestination
 }
 
@@ -26,7 +27,8 @@ export default function ExportBundleDialog({ onConfirm, onCancel }: Props) {
   const [reg, setReg] = useState(false)
   const [regCaptions, setRegCaptions] = useState(false)
   const [includeConfig, setIncludeConfig] = useState(false)
-  const [latentCache, setLatentCache] = useState(false)
+  const [trainLatentCache, setTrainLatentCache] = useState(false)
+  const [regLatentCache, setRegLatentCache] = useState(false)
   const [destination, setDestination] = useState<BundleExportDestination>('download')
 
   const nothingSelected = !train && !reg && !includeConfig
@@ -34,7 +36,10 @@ export default function ExportBundleDialog({ onConfirm, onCancel }: Props) {
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     if (nothingSelected) return
-    onConfirm({ train, trainCaptions, reg, regCaptions, includeConfig, latentCache, destination })
+    onConfirm({
+      train, trainCaptions, reg, regCaptions, includeConfig,
+      trainLatentCache, regLatentCache, destination,
+    })
   }
 
   return (
@@ -98,16 +103,29 @@ export default function ExportBundleDialog({ onConfirm, onCancel }: Props) {
             </span>
           </label>
           {train && (
-            <label className="flex items-center gap-2 cursor-pointer pl-5">
-              <input
-                type="checkbox"
-                checked={trainCaptions}
-                onChange={(e) => setTrainCaptions(e.target.checked)}
-              />
-              <span className="text-sm text-fg-secondary">
-                {t('layout.exportBundleCaptions')}
-              </span>
-            </label>
+            <>
+              <label className="flex items-center gap-2 cursor-pointer pl-5">
+                <input
+                  type="checkbox"
+                  checked={trainCaptions}
+                  onChange={(e) => setTrainCaptions(e.target.checked)}
+                />
+                <span className="text-sm text-fg-secondary">
+                  {t('layout.exportBundleCaptions')}
+                </span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer pl-5">
+                <input
+                  type="checkbox"
+                  checked={trainLatentCache}
+                  onChange={(e) => setTrainLatentCache(e.target.checked)}
+                />
+                <span className="text-sm text-fg-secondary">
+                  {t('layout.exportBundleLatentCache')}
+                </span>
+                <span className="text-xs text-fg-tertiary">{t('layout.exportBundleLatentCacheHint')}</span>
+              </label>
+            </>
           )}
         </div>
 
@@ -124,33 +142,31 @@ export default function ExportBundleDialog({ onConfirm, onCancel }: Props) {
             </span>
           </label>
           {reg && (
-            <label className="flex items-center gap-2 cursor-pointer pl-5">
-              <input
-                type="checkbox"
-                checked={regCaptions}
-                onChange={(e) => setRegCaptions(e.target.checked)}
-              />
-              <span className="text-sm text-fg-secondary">
-                {t('layout.exportBundleCaptions')}
-              </span>
-            </label>
+            <>
+              <label className="flex items-center gap-2 cursor-pointer pl-5">
+                <input
+                  type="checkbox"
+                  checked={regCaptions}
+                  onChange={(e) => setRegCaptions(e.target.checked)}
+                />
+                <span className="text-sm text-fg-secondary">
+                  {t('layout.exportBundleCaptions')}
+                </span>
+              </label>
+              <label className="flex items-center gap-2 cursor-pointer pl-5">
+                <input
+                  type="checkbox"
+                  checked={regLatentCache}
+                  onChange={(e) => setRegLatentCache(e.target.checked)}
+                />
+                <span className="text-sm text-fg-secondary">
+                  {t('layout.exportBundleLatentCache')}
+                </span>
+                <span className="text-xs text-fg-tertiary">{t('layout.exportBundleLatentCacheHint')}</span>
+              </label>
+            </>
           )}
         </div>
-
-        {/* VAE latent 缓存 — 跟着选中的 train/reg 素材走 */}
-        {(train || reg) && (
-          <label className="flex items-center gap-2 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={latentCache}
-              onChange={(e) => setLatentCache(e.target.checked)}
-            />
-            <span className="text-sm text-fg-primary font-medium">
-              {t('layout.exportBundleLatentCache')}
-            </span>
-            <span className="text-xs text-fg-tertiary">{t('layout.exportBundleLatentCacheHint')}</span>
-          </label>
-        )}
 
         {/* 训练配置 */}
         <label className="flex items-center gap-2 cursor-pointer">

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1792,6 +1792,8 @@
     "exportBundleCaptions": "Include caption files (.txt)",
     "exportBundleConfig": "Training config",
     "exportBundleConfigHint": "(hyperparams for this version, no path fields)",
+    "exportBundleLatentCache": "VAE latent cache (.npz)",
+    "exportBundleLatentCacheHint": "(skips re-encoding after import; bundle gets notably larger)",
     "exportBundleDestinationHint": "The bundle will be generated now, then downloaded by your browser or saved to data_exports/.",
     "exportBundleDestination": "Export destination",
     "exportBundleDownload": "Download to local",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1793,7 +1793,6 @@
     "exportBundleConfig": "Training config",
     "exportBundleConfigHint": "(hyperparams for this version, no path fields)",
     "exportBundleLatentCache": "Include VAE latent cache (.npz)",
-    "exportBundleLatentCacheHint": "(skips re-encoding after import; bundle gets notably larger)",
     "exportBundleDestinationHint": "The bundle will be generated now, then downloaded by your browser or saved to data_exports/.",
     "exportBundleDestination": "Export destination",
     "exportBundleDownload": "Download to local",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1792,7 +1792,7 @@
     "exportBundleCaptions": "Include caption files (.txt)",
     "exportBundleConfig": "Training config",
     "exportBundleConfigHint": "(hyperparams for this version, no path fields)",
-    "exportBundleLatentCache": "VAE latent cache (.npz)",
+    "exportBundleLatentCache": "Include VAE latent cache (.npz)",
     "exportBundleLatentCacheHint": "(skips re-encoding after import; bundle gets notably larger)",
     "exportBundleDestinationHint": "The bundle will be generated now, then downloaded by your browser or saved to data_exports/.",
     "exportBundleDestination": "Export destination",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1792,6 +1792,8 @@
     "exportBundleCaptions": "包含 caption 文件 (.txt)",
     "exportBundleConfig": "训练配置",
     "exportBundleConfigHint": "（当前版本超参数，路径字段不含）",
+    "exportBundleLatentCache": "VAE latent 缓存 (.npz)",
+    "exportBundleLatentCacheHint": "（导入后免重新 encode；包体积会明显变大）",
     "exportBundleDestinationHint": "导出的 bundle 会即时生成，可交给浏览器下载，也可保存到 data_exports/。",
     "exportBundleDestination": "导出目标",
     "exportBundleDownload": "下载到本地",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1792,7 +1792,7 @@
     "exportBundleCaptions": "包含 caption 文件 (.txt)",
     "exportBundleConfig": "训练配置",
     "exportBundleConfigHint": "（当前版本超参数，路径字段不含）",
-    "exportBundleLatentCache": "VAE latent 缓存 (.npz)",
+    "exportBundleLatentCache": "包含 VAE latent 缓存 (.npz)",
     "exportBundleLatentCacheHint": "（导入后免重新 encode；包体积会明显变大）",
     "exportBundleDestinationHint": "导出的 bundle 会即时生成，可交给浏览器下载，也可保存到 data_exports/。",
     "exportBundleDestination": "导出目标",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1793,7 +1793,6 @@
     "exportBundleConfig": "训练配置",
     "exportBundleConfigHint": "（当前版本超参数，路径字段不含）",
     "exportBundleLatentCache": "包含 VAE latent 缓存 (.npz)",
-    "exportBundleLatentCacheHint": "（导入后免重新 encode；包体积会明显变大）",
     "exportBundleDestinationHint": "导出的 bundle 会即时生成，可交给浏览器下载，也可保存到 data_exports/。",
     "exportBundleDestination": "导出目标",
     "exportBundleDownload": "下载到本地",

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -133,6 +133,7 @@ export default function ProjectLayout() {
       reg: opts.reg,
       regCaptions: opts.regCaptions,
       includeConfig: opts.includeConfig,
+      latentCache: opts.latentCache,
     }
     if (opts.destination === 'download') {
       const filename = `${projectRef.current.slug}-${av.label}.bundle.zip`

--- a/studio/web/src/pages/project/Layout.tsx
+++ b/studio/web/src/pages/project/Layout.tsx
@@ -133,7 +133,8 @@ export default function ProjectLayout() {
       reg: opts.reg,
       regCaptions: opts.regCaptions,
       includeConfig: opts.includeConfig,
-      latentCache: opts.latentCache,
+      trainLatentCache: opts.trainLatentCache,
+      regLatentCache: opts.regLatentCache,
     }
     if (opts.destination === 'download') {
       const filename = `${projectRef.current.slug}-${av.label}.bundle.zip`

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -294,10 +294,14 @@ def test_export_bundle_latent_cache_roundtrip(isolated, tmp_path: Path) -> None:
     with db.connection_for(isolated["db"]) as conn:
         result = train_io.export_bundle(
             conn, v["id"], dest,
-            train_io.BundleOptions(train=True, reg=True, latent_cache=True),
+            train_io.BundleOptions(
+                train=True, reg=True,
+                train_latent_cache=True, reg_latent_cache=True,
+            ),
         )
 
-    assert result["manifest"]["includes"]["latent_cache"] is True
+    assert result["manifest"]["includes"]["train_latent_cache"] is True
+    assert result["manifest"]["includes"]["reg_latent_cache"] is True
     assert result["manifest"]["stats"]["latent_cache_count"] == 3
     with zipfile.ZipFile(dest) as zf:
         names = set(zf.namelist())
@@ -336,7 +340,8 @@ def test_export_bundle_excludes_latent_cache_by_default(isolated, tmp_path: Path
             conn, v["id"], dest, train_io.BundleOptions(train=True),
         )
 
-    assert result["manifest"]["includes"]["latent_cache"] is False
+    assert result["manifest"]["includes"]["train_latent_cache"] is False
+    assert result["manifest"]["includes"]["reg_latent_cache"] is False
     assert result["manifest"]["stats"]["latent_cache_count"] == 0
     with zipfile.ZipFile(dest) as zf:
         assert not [n for n in zf.namelist() if n.endswith(".npz")]

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -277,6 +277,71 @@ def test_export_bundle_records_version_and_preset_names(isolated, tmp_path: Path
     assert manifest["source"]["preset_name"] == "style_preset"
 
 
+def test_export_bundle_latent_cache_roundtrip(isolated, tmp_path: Path) -> None:
+    """latent_cache=True：train/reg 的 npz 一并打包；导入后 npz mtime ≥ 图片
+    mtime（_is_cache_valid 的不变量，否则缓存白搬）。"""
+    p, v, train = _make_project_with_train(isolated)
+    (train / "1_data").mkdir(parents=True, exist_ok=True)
+    (train / "1_data" / "a.png").write_bytes(_png())
+    (train / "1_data" / "a.npz").write_bytes(b"fake-latent")
+    (train / "1_data" / "a.r512.npz").write_bytes(b"fake-latent-512")
+    reg = train.parent / "reg" / "girl"
+    reg.mkdir(parents=True)
+    (reg / "r.png").write_bytes(_png(b"r"))
+    (reg / "r.npz").write_bytes(b"fake-reg-latent")
+
+    dest = tmp_path / "cache.bundle.zip"
+    with db.connection_for(isolated["db"]) as conn:
+        result = train_io.export_bundle(
+            conn, v["id"], dest,
+            train_io.BundleOptions(train=True, reg=True, latent_cache=True),
+        )
+
+    assert result["manifest"]["includes"]["latent_cache"] is True
+    assert result["manifest"]["stats"]["latent_cache_count"] == 3
+    with zipfile.ZipFile(dest) as zf:
+        names = set(zf.namelist())
+    assert "train/1_data/a.npz" in names
+    assert "train/1_data/a.r512.npz" in names
+    assert "reg/girl/r.npz" in names
+
+    with db.connection_for(isolated["db"]) as conn:
+        imported = train_io.import_bundle(conn, dest, presets_base=tmp_path / "presets")
+
+    new_dir = versions.version_dir(
+        imported["project"]["id"],
+        imported["project"]["slug"],
+        imported["version"]["label"],
+    )
+    npz = new_dir / "train" / "1_data" / "a.npz"
+    img = new_dir / "train" / "1_data" / "a.png"
+    reg_npz = new_dir / "reg" / "girl" / "r.npz"
+    reg_img = new_dir / "reg" / "girl" / "r.png"
+    assert npz.exists() and (new_dir / "train" / "1_data" / "a.r512.npz").exists()
+    assert reg_npz.exists()
+    # zip 内 npz 按字典序先于图片落盘，没有 touch 修正会比图片旧
+    assert npz.stat().st_mtime >= img.stat().st_mtime
+    assert reg_npz.stat().st_mtime >= reg_img.stat().st_mtime
+
+
+def test_export_bundle_excludes_latent_cache_by_default(isolated, tmp_path: Path) -> None:
+    p, v, train = _make_project_with_train(isolated)
+    (train / "1_data").mkdir(parents=True, exist_ok=True)
+    (train / "1_data" / "a.png").write_bytes(_png())
+    (train / "1_data" / "a.npz").write_bytes(b"fake-latent")
+
+    dest = tmp_path / "nocache.bundle.zip"
+    with db.connection_for(isolated["db"]) as conn:
+        result = train_io.export_bundle(
+            conn, v["id"], dest, train_io.BundleOptions(train=True),
+        )
+
+    assert result["manifest"]["includes"]["latent_cache"] is False
+    assert result["manifest"]["stats"]["latent_cache_count"] == 0
+    with zipfile.ZipFile(dest) as zf:
+        assert not [n for n in zf.namelist() if n.endswith(".npz")]
+
+
 def _named_bundle(tmp_path: Path, *, with_preset: bool) -> Path:
     bundle = tmp_path / "named.bundle.zip"
     with zipfile.ZipFile(bundle, "w", compression=zipfile.ZIP_STORED) as zf:


### PR DESCRIPTION
实现 #386 第 2 条:导出 bundle.zip 时可选把 VAE encode 好的 latent 缓存(npz)一并打包,迁移到另一台机器导入后直接复用、免重新 encode(A 卡 encode 慢的场景收益最大)。

## 可移植性依据

npz 里只有纯数据:`latent`(fp32 numpy,VAE 确定性均值,`vae2_1.py` 的 encode 不采样)、可选 `latent_flipped`、`bucket_w/h`。无绝对路径/设备/CUDA 信息;训练时加载是纯 `np.load`,对 GPU/驱动零要求。缓存文件紧挨图片(`{名}.npz` / `{名}.r{reso}.npz`),跟着素材走即可。

## 改动

**后端(`train_io.py`)**
- `BundleOptions.train_latent_cache` / `reg_latent_cache`(默认 False,镜像 `train_captions`/`reg_captions` 的拆分);`_collect_train`/`_collect_reg` 按各自开关收集 `.npz`
- manifest 增加 `includes.train_latent_cache` + `includes.reg_latent_cache` + `stats.latent_cache_count`
- **导入侧关键修正**:解包后把所有 npz `os.utime` 到当前时间。训练侧 `_is_cache_valid` 要求 npz mtime ≥ 图片 mtime,而 zip 逐条解包按字典序 npz 常先于同名图片落盘(`.npz` < `.png`),不修正的话缓存到手即失效、静默重 encode——迁移就白做了

**API/前端**
- GET query 参数 + POST body 各加 `train_latent_cache`/`reg_latent_cache`;`ExportBundleDialog` 在训练集、正则集各自的 caption 勾选项下面加同级子选项,hint 注明"导入后免重新 encode;包体积会明显变大"(latent 为 fp32,1024² 一张约 1MB,开 flip 翻倍)

**兼容性**:schema_version 不变(仍为 2)。npz 的归档路径本就通过 `_safe_arc_bundle` 的两层校验,老版本 Studio 导入新 bundle 会把 npz 当普通文件落到位(缺 touch 修正,最坏情况是缓存失效重 encode,不会出错)。

## 已知边界(有意不做)

- 缓存有效性仍由训练侧现有校验兜底:目标机 bucket/分辨率配置不同、或开了源机没开的 flip_augment → 对应 npz 判失效重 encode(正确行为)
- 缓存不含 VAE 模型标识(现有设计如此,本项目 VAE 固定为 Qwen-Image VAE);换 VAE 需手动清缓存,属既有行为不在本 PR 扩展

## 测试

- 新增 `test_export_bundle_latent_cache_roundtrip`(train+reg npz 打包、manifest 计数、导入后 mtime 不变量)和 `test_export_bundle_excludes_latent_cache_by_default`
- `pytest tests/test_train_io.py` 21 passed;`tests/test_project_endpoints.py` 20 passed
- 前端全量 vitest 481 passed;`npm run build`(lint + tsc + vite)全过

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)
