### PR TITLE
feat(train): masked loss —— mask 区域零梯度（训练联动）

### DIFF
--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -282,7 +282,7 @@ class ImageDataset(Dataset):
         self.tag_dropout = tag_dropout
         self.prefer_json = prefer_json
         self.caption_override = caption_override  # 正则集：统一 caption，如 "1girl, solo"
-        # masked loss（B2）：加载 masks/ 保留目录下的 mask sidecar，随图走同一
+        # masked loss（B2）：加载与图同目录的 {stem}.mask sidecar，随图走同一
         # 几何变换后 area 下采样到 latent 分辨率，作为 loss 空间权重。
         self.load_masks = bool(load_masks)
         self._mask_warned: set = set()
@@ -611,17 +611,13 @@ class ImageDataset(Dataset):
         return len(self.samples)
 
     def _mask_path_for(self, img_path) -> Path:
-        """studio 训练 mask sidecar 路径：`{data_dir}/masks/{rel.parent}/{stem}.png`。
+        """studio 训练 mask sidecar 路径：与图同目录同 stem 的 `{stem}.mask`。
 
-        与 studio/services/preprocess/masks.py 的落盘约定镜像（恒 .png、stem
-        对应图片）。根目录散图 rel.parent="." 时落 masks/{stem}.png。
+        与 studio/services/preprocess/masks.py 的落盘约定镜像（后缀恒 .mask，
+        内容灰度 PNG 字节）——stem 不含扩展名，X.jpg 与 X.png 共享同一 mask。
         """
         img_path = Path(img_path)
-        try:
-            rel = img_path.relative_to(self.data_dir)
-        except ValueError:
-            return self.data_dir / "masks" / f"{img_path.stem}.png"
-        return self.data_dir / "masks" / rel.parent / f"{img_path.stem}.png"
+        return img_path.parent / f"{img_path.stem}.mask"
 
     def _load_mask_image(self, img_path, size):
         """加载并校验 mask（灰度 L，尺寸必须等于图片当前尺寸）。

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -248,7 +248,7 @@ class ImageDataset(Dataset):
                  resolutions=None, aspect_ratio_limit=2.0,
                  native_resolution=False, native_token_budget=0,
                  native_over_budget="downscale", native_max_side_tokens=0,
-                 native_align=16):
+                 native_align=16, load_masks=False):
         self.data_dir = Path(data_dir)
         self.resolution = resolution
         # 多分辨率：bucket_mgr 是 base 分辨率的 manager（向后兼容，单一 ARB 路径仍走它，
@@ -282,6 +282,10 @@ class ImageDataset(Dataset):
         self.tag_dropout = tag_dropout
         self.prefer_json = prefer_json
         self.caption_override = caption_override  # 正则集：统一 caption，如 "1girl, solo"
+        # masked loss（B2）：加载 masks/ 保留目录下的 mask sidecar，随图走同一
+        # 几何变换后 area 下采样到 latent 分辨率，作为 loss 空间权重。
+        self.load_masks = bool(load_masks)
+        self._mask_warned: set = set()
         
         # 尝试导入 caption_utils（直接导入避开 __init__.py）
         self.caption_utils = None
@@ -606,6 +610,49 @@ class ImageDataset(Dataset):
     def __len__(self):
         return len(self.samples)
 
+    def _mask_path_for(self, img_path) -> Path:
+        """studio 训练 mask sidecar 路径：`{data_dir}/masks/{rel.parent}/{stem}.png`。
+
+        与 studio/services/preprocess/masks.py 的落盘约定镜像（恒 .png、stem
+        对应图片）。根目录散图 rel.parent="." 时落 masks/{stem}.png。
+        """
+        img_path = Path(img_path)
+        try:
+            rel = img_path.relative_to(self.data_dir)
+        except ValueError:
+            return self.data_dir / "masks" / f"{img_path.stem}.png"
+        return self.data_dir / "masks" / rel.parent / f"{img_path.stem}.png"
+
+    def _load_mask_image(self, img_path, size):
+        """加载并校验 mask（灰度 L，尺寸必须等于图片当前尺寸）。
+
+        fail-safe（设计 §2）：缺文件 → None（全图正常学习）；尺寸不匹配 /
+        不可读 → warning 一次 + None，**不 crash 训练**。
+        """
+        from PIL import Image
+        mp = self._mask_path_for(img_path)
+        if not mp.is_file():
+            return None
+        try:
+            with Image.open(mp) as raw:
+                raw.load()
+                mask = raw.convert("L") if raw.mode != "L" else raw.copy()
+        except Exception as e:  # noqa: BLE001
+            if str(mp) not in self._mask_warned:
+                self._mask_warned.add(str(mp))
+                logger.warning(f"[masked-loss] mask 不可读，按无 mask 处理: {mp} ({e})")
+            return None
+        if mask.size != tuple(size):
+            if str(mp) not in self._mask_warned:
+                self._mask_warned.add(str(mp))
+                logger.warning(
+                    "[masked-loss] mask 尺寸 %sx%s 与图片 %sx%s 不匹配，按无 mask 处理"
+                    "（外部改图后请重画 mask）: %s",
+                    mask.size[0], mask.size[1], size[0], size[1], mp,
+                )
+            return None
+        return mask
+
     def __getitem__(self, idx):
         # 默认 path：DataLoader 不能传额外参数，所以由 flip_augment 决定是否随机翻转。
         # CachedLatentDataset 想显式控制 flip 时直接调 get_with_flip(idx, flip=...)，
@@ -648,6 +695,13 @@ class ImageDataset(Dataset):
         else:
             tw = th = target_reso or self.resolution
 
+        # masked loss：mask 在原始尺寸加载（校验 == 图片尺寸），下面随图走
+        # 完全相同的几何变换（NEAREST 防灰度插值污染），最后 area 下采样到
+        # latent /8（BOX = 块均值，§9 决策 4）。
+        mask_img = None
+        if self.load_masks:
+            mask_img = self._load_mask_image(sample["image"], (img.width, img.height))
+
         # 缩放裁剪
         scale = max(tw / img.width, th / img.height)
         nw, nh = int(img.width * scale), int(img.height * scale)
@@ -660,11 +714,23 @@ class ImageDataset(Dataset):
         if flip:
             img = img.transpose(Image.FLIP_LEFT_RIGHT)
 
+        mask_tensor = None
+        if mask_img is not None:
+            m = mask_img.resize((nw, nh), Image.NEAREST)
+            m = m.crop((left, top, left + tw, top + th))
+            if flip:
+                m = m.transpose(Image.FLIP_LEFT_RIGHT)
+            m = m.resize((max(1, tw // 8), max(1, th // 8)), Image.BOX)
+            # 灰度 255=学 / 0=不学 → [0,1] loss 空间权重
+            mask_tensor = torch.from_numpy(
+                np.array(m).astype(np.float32) / 255.0
+            )
+
         # 转 tensor [-1, 1]
         arr = np.array(img).astype(np.float32) / 127.5 - 1.0
         tensor = torch.from_numpy(arr).permute(2, 0, 1)
 
-        return {"pixel_values": tensor, "caption": caption}
+        return {"pixel_values": tensor, "caption": caption, "mask": mask_tensor}
 
 
 class RepeatDataset(Dataset):
@@ -856,6 +922,11 @@ class CachedLatentDataset(Dataset):
         self.flip_augment = bool(
             getattr(self.base_image_dataset, "flip_augment", False)
         )
+        # masked loss（B2）：底层 ImageDataset.load_masks 开启时，mask 随缓存
+        # 编码期一并下采样存进 npz（mask / mask_flipped 键，仿 latent_flipped）
+        self.load_masks = bool(
+            getattr(self.base_image_dataset, "load_masks", False)
+        )
         # cache_encode_tiled（opt-in）：超大图改走分块 encode + latent 羽化拼接，
         # 峰值显存 ∝ 单块像素。阈值内的图路径不变（逐字节等价）。
         self.encode_tiled = bool(encode_tiled)
@@ -924,11 +995,18 @@ class CachedLatentDataset(Dataset):
         - flip_augment=False 且 npz 有 `latent_flipped` → 仍视为有效（双份
           cache 是 flip 模式的超集，关 flip 后只读 latent 不浪费）
         - bucket 尺寸不匹配 → 失效
+        - masked loss 开启时 mask sidecar 与 npz 一致性三条（§9 决策 3，
+          漏一条就训到旧 mask）：mask 存在但 npz 无 `mask` 键（新画）；
+          mask mtime 新于 npz（重画）；mask 已删但 npz 有 `mask` 键（清除）。
+          load_masks 关闭时跳过这些校验（带 mask 键的缓存是超集，不浪费）。
         """
         if not npz_path.exists():
             return False
         if npz_path.stat().st_mtime < img_path.stat().st_mtime:
             return False
+        mask_path = None
+        if getattr(self, "load_masks", False) and self.base_image_dataset is not None:
+            mask_path = self.base_image_dataset._mask_path_for(img_path)
         try:
             with self.np.load(npz_path) as data:
                 if "latent" not in data.files:
@@ -942,6 +1020,19 @@ class CachedLatentDataset(Dataset):
                     if "bucket_w" not in data.files or "bucket_h" not in data.files:
                         return False
                     if (int(data["bucket_w"]), int(data["bucket_h"])) != expected_bucket:
+                        return False
+                if mask_path is not None:
+                    has_mask_file = mask_path.is_file()
+                    has_mask_key = "mask" in data.files
+                    if has_mask_file != has_mask_key:
+                        return False
+                    if has_mask_file and npz_path.stat().st_mtime < mask_path.stat().st_mtime:
+                        return False
+                    if (
+                        has_mask_key
+                        and getattr(self, "flip_augment", False)
+                        and "mask_flipped" not in data.files
+                    ):
                         return False
         except Exception:
             try:
@@ -1052,6 +1143,16 @@ class CachedLatentDataset(Dataset):
                 and h * w > self.encode_max_pixels
             )
 
+            def _mask_kwargs(entry):
+                """masked loss：mask 已在 get_with_flip 内下采样到 latent 分辨率，
+                直接存 npz（无 mask 图不写键 —— 键的有无是缓存失效判据）。"""
+                out = {}
+                if entry.get("mask") is not None:
+                    out["mask"] = entry["mask"].numpy()
+                if entry.get("mask_flipped") is not None:
+                    out["mask_flipped"] = entry["mask_flipped"].numpy()
+                return out
+
             if use_tiled:
                 logger.info(
                     "[cache-tiled] %dx%d 超像素预算，分块 encode（tile=%d overlap=%d）",
@@ -1063,6 +1164,7 @@ class CachedLatentDataset(Dataset):
                     npz_kwargs = {"latent": lat.numpy()}
                     if lat_f is not None:
                         npz_kwargs["latent_flipped"] = lat_f.numpy()
+                    npz_kwargs.update(_mask_kwargs(entry))
                     _entry_sample = self.samples[entry["index"]]
                     npz_path = self._get_npz_path(
                         _entry_sample["image"], _entry_sample.get("target_reso"))
@@ -1087,6 +1189,7 @@ class CachedLatentDataset(Dataset):
                 npz_kwargs = {"latent": latents[n].numpy()}
                 if want_flip:
                     npz_kwargs["latent_flipped"] = latents_flipped[n].numpy()
+                npz_kwargs.update(_mask_kwargs(entry))
 
                 _entry_sample = self.samples[entry["index"]]
                 npz_path = self._get_npz_path(
@@ -1113,15 +1216,19 @@ class CachedLatentDataset(Dataset):
             bucket_w, bucket_h = pw, ph
 
             pixels_flipped = None
+            mask_flipped = None
             if want_flip:
                 item_f = base_img.get_with_flip(i, flip=True)
                 pixels_flipped = item_f["pixel_values"]
+                mask_flipped = item_f.get("mask")
 
             bucket_key = (bucket_h, bucket_w)
             pending.setdefault(bucket_key, []).append({
                 "index": i,
                 "pixels": pixels,
                 "pixels_flipped": pixels_flipped,
+                "mask": item.get("mask"),
+                "mask_flipped": mask_flipped,
                 "bucket_w": bucket_w,
                 "bucket_h": bucket_h,
             })
@@ -1150,6 +1257,14 @@ class CachedLatentDataset(Dataset):
         latent_key = "latent_flipped" if use_flip else "latent"
         latent = torch.from_numpy(data[latent_key])
 
+        # masked loss：mask 与 latent 保持同一 flip 选择（错位会把权重贴到镜像
+        # 位置）。npz 无键 = 该图无 mask（collate 填全 1）。
+        mask = None
+        if getattr(self, "load_masks", False):
+            mask_key = "mask_flipped" if use_flip and "mask_flipped" in data.files else "mask"
+            if mask_key in data.files:
+                mask = torch.from_numpy(data[mask_key])
+
         # 获取 base_dataset 的引用（处理可能的嵌套）
         base = self.base_dataset
         while hasattr(base, "dataset"):
@@ -1173,9 +1288,23 @@ class CachedLatentDataset(Dataset):
         return {
             "latent": latent,
             "caption": caption,
+            "mask": mask,
             # navit collate 需要逐图 image 路径
             "image": str(sample["image"]),
         }
+
+
+def _stack_masks(batch, h, w):
+    """masked loss：批内任一样本有 mask 才输出（无 mask 时零开销）。
+
+    无 mask 的样本填全 1（正常学习）；同桶保证 mask 空间尺寸一致。
+    """
+    if not any(b.get("mask") is not None for b in batch):
+        return None
+    return torch.stack([
+        b["mask"] if b.get("mask") is not None else torch.ones(h, w)
+        for b in batch
+    ])
 
 
 def collate_fn(batch):
@@ -1183,6 +1312,9 @@ def collate_fn(batch):
     pixels = torch.stack([b["pixel_values"] for b in batch])
     captions = [b["caption"] for b in batch]
     result = {"pixel_values": pixels, "captions": captions}
+    masks = _stack_masks(batch, pixels.shape[-2] // 8, pixels.shape[-1] // 8)
+    if masks is not None:
+        result["masks"] = masks
     if "loss_weight" in batch[0]:
         result["loss_weight"] = torch.tensor([b["loss_weight"] for b in batch], dtype=torch.float32)
         result["is_reg"] = torch.tensor([b["is_reg"] for b in batch], dtype=torch.bool)
@@ -1194,6 +1326,9 @@ def collate_fn_cached(batch):
     latents = torch.stack([b["latent"] for b in batch])
     captions = [b["caption"] for b in batch]
     result = {"latents": latents, "captions": captions}
+    masks = _stack_masks(batch, latents.shape[-2], latents.shape[-1])
+    if masks is not None:
+        result["masks"] = masks
     if "loss_weight" in batch[0]:
         result["loss_weight"] = torch.tensor([b["loss_weight"] for b in batch], dtype=torch.float32)
         result["is_reg"] = torch.tensor([b["is_reg"] for b in batch], dtype=torch.bool)

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -108,6 +108,27 @@ def _compute_loss_weight_from_args(args, t, device):
     ).to(device=device, dtype=torch.float32)
 
 
+def _masked_mean(per_element, spatial_mask):
+    """masked loss 的加权均值 reduction：`(loss*mask).sum() / mask.sum()`。
+
+    分母是 mask 元素和而非元素总数 —— 不同 mask 面积的样本在 batch 内权重
+    一致，避免 kohya 朴素 `mean()` 里大 mask 图被隐性降权（设计文档 §8）。
+    per-sample 权重（reg / timestep weighting）已乘在 per_element 上，分母
+    不含它们（与无 mask 时 `mean()` 的分母不含权重对称）。
+    """
+    m = spatial_mask.expand_as(per_element)
+    return (per_element * m).sum() / m.sum().clamp_min(1e-6)
+
+
+def _masked_mean_per_sample(per_element, spatial_mask):
+    """per-sample 版 masked mean（InfoNoise `_raw_mse` 记录用）：对每个样本
+    在非 batch 维上做 mask 加权均值，返回 (B,)。mask 区域的误差不进 I-MMSE
+    统计，否则无监督区域的噪声会污染 CDF。"""
+    m = spatial_mask.expand_as(per_element)
+    dims = list(range(1, per_element.dim()))
+    return (per_element * m).sum(dim=dims) / m.sum(dim=dims).clamp_min(1e-6)
+
+
 def _accumulation_step(batch_idx, dl_len, grad_accum):
     """返回 (group_size, is_group_end)：该 micro-batch 所在梯度累积组的实际大小，
     以及它是否是该组最后一个（触发 optimizer.step / zero_grad）。
@@ -381,6 +402,13 @@ def run(ctx: TrainingContext) -> None:
                         ctx.model, noisy, t.view(-1, 1), cross, pad_mask,
                         use_checkpoint=args.grad_checkpoint,
                     )
+                    # masked loss（B2）：dataset 已把 mask 下采样到 latent 分辨率，
+                    # (B,h,w) → (B,1,1,h,w) 广播到 loss 的 (B,C,T,H,W)。
+                    # masked_loss 关闭或本 batch 全无 mask 时为 None（零开销）。
+                    spatial_mask = None
+                    if bool(getattr(args, "masked_loss", False)) and "masks" in batch:
+                        _m = batch["masks"].to(ctx.device, dtype=torch.float32)
+                        spatial_mask = _m.view(bs, 1, 1, *_m.shape[-2:])
                     # 训练 loss 通过 losses/ plugin registry 派发（mse / huber / ...）
                     loss_per_sample = ctx.loss_fn.compute(pred.float(), target.float(), t)
                     # 自适应采样器（如 InfoNoise）记录原始 per-sample MSE（不受 huber/loss_weighting 等
@@ -389,9 +417,13 @@ def run(ctx: TrainingContext) -> None:
                     # 用 no_grad 避免构造 autograd 元数据（比 .detach() 少一份 grad_fn 开销）。
                     with torch.no_grad():
                         _raw_mse_per_sample = F.mse_loss(pred.float(), target.float(), reduction="none")
-                        _raw_mse = _raw_mse_per_sample.mean(
-                            dim=list(range(1, _raw_mse_per_sample.dim()))
-                        )
+                        if spatial_mask is not None:
+                            # mask 区域无监督，其误差不进 I-MMSE 统计
+                            _raw_mse = _masked_mean_per_sample(_raw_mse_per_sample, spatial_mask)
+                        else:
+                            _raw_mse = _raw_mse_per_sample.mean(
+                                dim=list(range(1, _raw_mse_per_sample.dim()))
+                            )
                     # 仅 main 集样本进 InfoNoise schedule 学习：I-MMSE 假设单一数据分布，
                     # reg 集典型是通用图（booru）vs main 集是单一主题，混入 record 学到的是
                     # mixture MMSE 不是 mmse_main(t)。用 is_reg flag 而非 loss_weight 阈值
@@ -412,7 +444,10 @@ def run(ctx: TrainingContext) -> None:
                     lw = _compute_loss_weight_from_args(args, t, ctx.device)
                     if lw is not None:
                         loss_per_sample = loss_per_sample * lw.view(-1, *([1] * (loss_per_sample.dim() - 1)))
-                    loss = loss_per_sample.mean()
+                    if spatial_mask is not None:
+                        loss = _masked_mean(loss_per_sample, spatial_mask)
+                    else:
+                        loss = loss_per_sample.mean()
                     denoise_loss_log = loss.detach()
 
                 # SRA v2 表征对齐 loss（标准路径；leap / navit 路径不适用）

--- a/runtime/training/phases/dataset.py
+++ b/runtime/training/phases/dataset.py
@@ -94,7 +94,7 @@ def run(ctx: TrainingContext) -> None:
     # NaViT 原生定尺寸参数（navit_native_resolution）；关闭时为空 dict → 行为中立。
     native_kwargs = _native_dataset_kwargs(args, ctx)
 
-    # masked loss（B2）：开关开启时数据层加载 masks/ 保留目录下的 mask sidecar。
+    # masked loss（B2）：开关开启时数据层加载与图同目录的 {stem}.mask sidecar。
     # NaViT 打包路径第一版不支持（逐图打包 loss 无批量网格，§5 决策）——警告并
     # 关闭，避免 npz 白写 mask 键。
     load_masks = bool(getattr(args, "masked_loss", False))
@@ -134,7 +134,7 @@ def run(ctx: TrainingContext) -> None:
             )
         else:
             logger.info(
-                "[masked-loss] 开关已开但训练集没有任何 mask 文件（train/masks/ 为空）"
+                "[masked-loss] 开关已开但训练集没有任何 mask 文件（无 .mask sidecar）"
                 "——本次训练等效于未开启"
             )
 

--- a/runtime/training/phases/dataset.py
+++ b/runtime/training/phases/dataset.py
@@ -94,6 +94,17 @@ def run(ctx: TrainingContext) -> None:
     # NaViT 原生定尺寸参数（navit_native_resolution）；关闭时为空 dict → 行为中立。
     native_kwargs = _native_dataset_kwargs(args, ctx)
 
+    # masked loss（B2）：开关开启时数据层加载 masks/ 保留目录下的 mask sidecar。
+    # NaViT 打包路径第一版不支持（逐图打包 loss 无批量网格，§5 决策）——警告并
+    # 关闭，避免 npz 白写 mask 键。
+    load_masks = bool(getattr(args, "masked_loss", False))
+    if load_masks and bool(getattr(args, "navit_packing", False)):
+        logger.warning(
+            "[masked-loss] NaViT 打包路径暂不支持 masked loss：本次训练忽略 mask"
+        )
+        load_masks = False
+        args.masked_loss = False
+
     # 数据集
     ctx.bucket_mgr = BucketManager(base_reso, aspect_ratio_limit=ar_limit)
     ctx.base_dataset = ImageDataset(
@@ -105,9 +116,27 @@ def run(ctx: TrainingContext) -> None:
         prefer_json=args.prefer_json,
         resolutions=res_list,
         aspect_ratio_limit=ar_limit,
+        load_masks=load_masks,
         **native_kwargs,
     )
     ctx.dataset = ctx.base_dataset
+
+    if load_masks:
+        # 统计有 mask 的图数（决策 5：开关开但零 mask 只 log 不报错）
+        n_masked = sum(
+            1 for s in ctx.base_dataset.samples
+            if ctx.base_dataset._mask_path_for(s["image"]).is_file()
+        )
+        if n_masked > 0:
+            logger.info(
+                "[masked-loss] 已启用：%d/%d 张图带 mask（其余全图正常学习）",
+                n_masked, len(ctx.base_dataset.samples),
+            )
+        else:
+            logger.info(
+                "[masked-loss] 开关已开但训练集没有任何 mask 文件（train/masks/ 为空）"
+                "——本次训练等效于未开启"
+            )
 
     # 正则数据集（Kohya 风格，防过拟合）
     reg_data_dir = getattr(args, "reg_data_dir", "") or ""

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -723,6 +723,15 @@ class TrainingConfig(BaseModel):
             disable_hint="InfoNoise / Leap 启用时禁用 loss 加权（schema 互斥，仅 none 兼容）",
         ),
     )
+    masked_loss: bool = Field(
+        False,
+        description="按训练 mask 加权 loss：预处理涂抹页画的 mask 区域（灰度 0=不学、255=正常学习、中间值=部分权重）不产生梯度，该区域生成时由 base 模型先验决定；没有 mask 的图不受影响",
+        json_schema_extra=_meta(
+            "loss",
+            disable_when="leap_enabled==true||navit_packing==true",
+            disable_hint="Leap（per-sample loss 无空间维度）/ NaViT 打包路径不支持 mask（schema 互斥）",
+        ),
+    )
     min_snr_gamma: float = Field(
         5.0, ge=0.1, le=20.0,
         description="Min-SNR 阈值：高 SNR 简单步（低 t 端）的权重压制阈值。默认 5.0；越小压制越强",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -363,6 +363,7 @@
       "noise_enhancement_type": "Disabled while InfoNoise is enabled (schema mutex)",
       "loss_weighting": "Disabled while InfoNoise is enabled (schema mutex, only `none` compatible)",
       "loss_type": "Disabled while InfoNoise or Leap is enabled (schema mutex, only `mse` compatible)",
+      "masked_loss": "Not supported with Leap (per-sample loss has no spatial dims) or NaViT packing (schema mutex)",
       "timestep_schedule_shift": "Disabled while InfoNoise is enabled (schema mutex, only `1.0` compatible)",
       "infonoise_enabled": "Reset noise_enhancement / loss_weighting / loss_type / schedule_shift to defaults to enable (schema mutex)"
     },
@@ -457,6 +458,7 @@
       "loss_type": "Training loss type. mse classic; huber is robust to outliers (quadratic when |x|<δ, linear when |x|≥δ)",
       "huber_c": "[Huber loss] Delta coefficient (quadratic/linear transition point): larger = closer to MSE, smaller = more outlier-tolerant. Typical 0.1-0.3",
       "loss_weighting": "Loss weighting scheme: none = no weighting; min_snr suppresses weights on easy steps; detail_inv_t boosts low-t detail steps; cosmap uses SD3-style cosine mapping",
+      "masked_loss": "Weight the loss by training masks: regions masked on the inpaint page (grayscale 0 = don't learn, 255 = learn, in-between = partial weight) produce no gradient and are left to the base model's prior at generation time; images without a mask are unaffected",
       "min_snr_gamma": "Min-SNR threshold: caps the weight of high-SNR easy steps (low-t end). Default 5.0; smaller = stronger suppression",
       "weight_cap_ratio": "Batch max/min weight ratio cap: limits extreme weight contributions. 0 = disabled; recommended 5 for small batch + Prodigy",
       "detail_inv_t_min": "detail_inv_t weight lower bound. Default 1.0; raising to 1.5 lets high-t steps get a slight boost (<1.0 has no effect since 1/t≥1 always holds)",
@@ -2387,6 +2389,7 @@
     "folderTipReso": "{{name}}: {{repeat}} repeat × {{imgs}} imgs × {{resos}} resolutions = {{total}}",
     "bucketDistTitle": "Bucket distribution (actual)",
     "bucketDistHint": "Buckets group by resolution × aspect ratio; same bucket = same batch. Under-filled buckets emit a short batch — no images are dropped.",
+    "maskedLossHint": "{{n}} training image(s) have masks (Inpaint · Mask) but masked_loss is off — this run will not use them. Enable masked_loss in the loss group to apply.",
     "confirmReset": "Reset config to preset {{name}}? All customizations on the current version will be lost.",
     "resetOkText": "Reset",
     "resetSuccess": "Reset to preset {{name}} config",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -363,6 +363,7 @@
       "noise_enhancement_type": "InfoNoise 启用时禁用噪声增强（schema 互斥）",
       "loss_weighting": "InfoNoise 启用时禁用 loss 加权（schema 互斥，仅 none 兼容）",
       "loss_type": "InfoNoise / Leap 启用时禁用 loss 类型切换（schema 互斥，仅 mse 兼容）",
+      "masked_loss": "Leap（per-sample loss 无空间维度）/ NaViT 打包路径不支持 mask（schema 互斥）",
       "timestep_schedule_shift": "InfoNoise 启用时禁用 schedule shift（schema 互斥，仅 1.0 兼容）",
       "infonoise_enabled": "需先把 noise_enhancement / loss_weighting / loss_type / schedule_shift 全部置默认才能启用（schema 互斥）"
     },
@@ -457,6 +458,7 @@
       "loss_type": "训练 loss 类型。mse 经典；huber 对 outlier 鲁棒（在 |x|<δ 时用二次，|x|≥δ 时用线性）",
       "huber_c": "【Huber loss】delta 系数（控制二次/线性转折点）：越大越接近 MSE，越小越宽容 outlier。典型 0.1-0.3",
       "loss_weighting": "loss 加权方案：none 不加权；min_snr 抑制极端时步的权重；detail_inv_t 强化低 t 细节；cosmap 用 SD3 cosine 映射",
+      "masked_loss": "按训练 mask 加权 loss：预处理涂抹页画的 mask 区域（灰度 0=不学、255=正常学习、中间值=部分权重）不产生梯度，该区域生成时由 base 模型先验决定；没有 mask 的图不受影响",
       "min_snr_gamma": "Min-SNR 阈值：高 SNR 简单步（低 t 端）的权重压制阈值。默认 5.0；越小压制越强",
       "weight_cap_ratio": "Batch 内权重 max/min 比上限：限制极端权重影响。0 = 禁用；小 batch + Prodigy 建议 5",
       "detail_inv_t_min": "detail_inv_t 权重下限。默认 1.0；升至 1.5 让高 t 步也略微加权（<1.0 因 1/t≥1 恒成立故无效）",
@@ -2387,6 +2389,7 @@
     "folderTipReso": "{{name}}：{{repeat}} repeat × {{imgs}} 图 × {{resos}} 分辨率 = {{total}}",
     "bucketDistTitle": "桶分布（实际）",
     "bucketDistHint": "按分辨率 × 长宽比分桶，同桶进同一 batch；桶不满只出短 batch、不丢图。",
+    "maskedLossHint": "训练集有 {{n}} 张图带 mask（涂抹页 · 遮罩），但 masked_loss 未开启 —— 本次训练不会使用这些 mask。需要生效请在 loss 配置组开启 masked_loss。",
     "confirmReset": "重置为预设 {{name}} 的配置？当前 version 的所有自定义内容会丢失。",
     "resetOkText": "重置",
     "resetSuccess": "已重置为预设 {{name}} 的配置",

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -1012,6 +1012,44 @@ function DatasetStatsPanel({
           activeVersion?.stats?.train_folders,
         ])}
       />
+
+      <MaskedLossHint
+        projectId={projectId}
+        vid={activeVersion?.id ?? 0}
+        maskedLoss={config?.masked_loss === true}
+      />
+    </div>
+  )
+}
+
+/** 训练集有 mask 但 masked_loss 关闭时的提示（决策 D7：只提示不代开）。 */
+function MaskedLossHint({
+  projectId, vid, maskedLoss,
+}: {
+  projectId: number
+  vid: number
+  maskedLoss: boolean
+}) {
+  const { t } = useTranslation()
+  const [maskCount, setMaskCount] = useState(0)
+
+  useEffect(() => {
+    if (!projectId || !vid) return
+    let cancelled = false
+    api.listCropWorkspaceTrain(projectId, vid)
+      .then((r) => {
+        if (!cancelled) {
+          setMaskCount(r.images.filter((im) => im.mask_mtime != null).length)
+        }
+      })
+      .catch(() => { if (!cancelled) setMaskCount(0) })
+    return () => { cancelled = true }
+  }, [projectId, vid])
+
+  if (maskCount === 0 || maskedLoss) return null
+  return (
+    <div className="rounded-md border border-subtle bg-surface px-3 py-2.5 text-xs text-fg-secondary leading-relaxed">
+      {t('train.maskedLossHint', { n: maskCount })}
     </div>
   )
 }

--- a/tests/test_masked_loss.py
+++ b/tests/test_masked_loss.py
@@ -1,9 +1,9 @@
 """masked loss（PR-B B2）——dataset mask 管线 / npz 缓存失效 / collate / loss 数学。
 
-设计：docs/design/preprocess-inpaint-mask-design.md §5 / §9。
-mask sidecar 路径 = {data_dir}/masks/{rel.parent}/{stem}.png，灰度 255=学 0=不学；
-数据层随图同几何变换（NEAREST）后 area 下采样到 latent /8，loss 层加权均值
-reduction `(loss*mask).sum()/mask.sum()`。
+设计：docs/design/preprocess-inpaint-mask-design.md §5 / §9（D5 修订）。
+mask sidecar 路径 = 与图同目录的 {stem}.mask（内容灰度 PNG 字节），
+灰度 255=学 0=不学；数据层随图同几何变换（NEAREST）后 area 下采样到
+latent /8，loss 层加权均值 reduction `(loss*mask).sum()/mask.sum()`。
 """
 from __future__ import annotations
 
@@ -48,12 +48,13 @@ def _write_img(path: Path, size=(256, 256)) -> None:
     path.with_suffix(".txt").write_text("test", encoding="utf-8")
 
 
-def _write_mask(data_dir: Path, img_path: Path, builder) -> Path:
-    """builder(Image) 生成 mask 内容；路径按训练器约定落 masks/ 镜像。"""
-    rel = img_path.relative_to(data_dir)
-    mp = data_dir / "masks" / rel.parent / f"{img_path.stem}.png"
-    mp.parent.mkdir(parents=True, exist_ok=True)
-    builder().save(mp)
+def _write_mask(img_path: Path, builder) -> Path:
+    """builder(Image) 生成 mask 内容；路径按落盘约定 = 同目录 {stem}.mask。
+
+    .mask 后缀 PIL 推断不出格式，必须显式 format="PNG"。
+    """
+    mp = img_path.parent / f"{img_path.stem}.mask"
+    builder().save(mp, format="PNG")
     return mp
 
 
@@ -77,7 +78,7 @@ def _square_dataset(tmp_path: Path, **kwargs) -> ImageDataset:
 def test_mask_transforms_with_image(tmp_path: Path) -> None:
     img_path = tmp_path / "X.png"
     _write_img(img_path)
-    _write_mask(tmp_path, img_path, _half_mask)
+    _write_mask(img_path, _half_mask)
 
     ds = _square_dataset(tmp_path, load_masks=True)
     item = ds.get_with_flip(0, flip=False)
@@ -98,7 +99,7 @@ def test_mask_flips_with_image(tmp_path: Path) -> None:
         m.paste(0, (0, 0, 128, 256))  # 左半不学
         return m
 
-    _write_mask(tmp_path, img_path, left_mask)
+    _write_mask(img_path, left_mask)
     ds = _square_dataset(tmp_path, load_masks=True)
     m0 = ds.get_with_flip(0, flip=False)["mask"]
     m1 = ds.get_with_flip(0, flip=True)["mask"]
@@ -110,7 +111,7 @@ def test_mask_flips_with_image(tmp_path: Path) -> None:
 def test_mask_size_mismatch_degrades_to_none(tmp_path: Path) -> None:
     img_path = tmp_path / "X.png"
     _write_img(img_path)
-    _write_mask(tmp_path, img_path, lambda: Image.new("L", (128, 128), 0))
+    _write_mask(img_path, lambda: Image.new("L", (128, 128), 0))
 
     ds = _square_dataset(tmp_path, load_masks=True)
     assert ds.get_with_flip(0, flip=False)["mask"] is None
@@ -119,7 +120,7 @@ def test_mask_size_mismatch_degrades_to_none(tmp_path: Path) -> None:
 def test_mask_not_loaded_when_disabled(tmp_path: Path) -> None:
     img_path = tmp_path / "X.png"
     _write_img(img_path)
-    _write_mask(tmp_path, img_path, _half_mask)
+    _write_mask(img_path, _half_mask)
 
     ds = _square_dataset(tmp_path, load_masks=False)
     assert ds.get_with_flip(0, flip=False)["mask"] is None
@@ -136,7 +137,7 @@ def test_gray_mask_partial_weight(tmp_path: Path) -> None:
     """灰度中间值 = 部分权重（软边笔刷语义）。"""
     img_path = tmp_path / "X.png"
     _write_img(img_path)
-    _write_mask(tmp_path, img_path, lambda: Image.new("L", (256, 256), 128))
+    _write_mask(img_path, lambda: Image.new("L", (256, 256), 128))
 
     ds = _square_dataset(tmp_path, load_masks=True)
     mask = ds.get_with_flip(0, flip=False)["mask"]
@@ -151,7 +152,7 @@ def test_gray_mask_partial_weight(tmp_path: Path) -> None:
 def test_cache_stores_mask_keys(tmp_path: Path) -> None:
     img_path = tmp_path / "X.png"
     _write_img(img_path)
-    _write_mask(tmp_path, img_path, _half_mask)
+    _write_mask(img_path, _half_mask)
 
     ds = _square_dataset(tmp_path, load_masks=True, flip_augment=True)
     cached = CachedLatentDataset(ds, _FakeVAE(), device="cpu", dtype=torch.float32)
@@ -186,7 +187,7 @@ def test_cache_invalidation_three_rules(tmp_path: Path) -> None:
     assert cached._is_cache_valid(img_path, npz_path) is True
 
     # 1) 新画 mask（文件出现但 npz 无 mask 键）→ 失效
-    mp = _write_mask(tmp_path, img_path, _half_mask)
+    mp = _write_mask(img_path, _half_mask)
     assert cached._is_cache_valid(img_path, npz_path) is False
 
     # 重建缓存（含 mask）后有效
@@ -215,7 +216,7 @@ def test_cache_with_mask_keys_valid_when_masks_disabled(tmp_path: Path) -> None:
     """load_masks=False 时带 mask 键的缓存仍有效（超集语义，对齐 latent_flipped）。"""
     img_path = tmp_path / "X.png"
     _write_img(img_path)
-    _write_mask(tmp_path, img_path, _half_mask)
+    _write_mask(img_path, _half_mask)
     ds = _square_dataset(tmp_path, load_masks=True)
     CachedLatentDataset(ds, _FakeVAE(), device="cpu", dtype=torch.float32)
 

--- a/tests/test_masked_loss.py
+++ b/tests/test_masked_loss.py
@@ -1,0 +1,313 @@
+"""masked loss（PR-B B2）——dataset mask 管线 / npz 缓存失效 / collate / loss 数学。
+
+设计：docs/design/preprocess-inpaint-mask-design.md §5 / §9。
+mask sidecar 路径 = {data_dir}/masks/{rel.parent}/{stem}.png，灰度 255=学 0=不学；
+数据层随图同几何变换（NEAREST）后 area 下采样到 latent /8，loss 层加权均值
+reduction `(loss*mask).sum()/mask.sum()`。
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("torch")
+import numpy as np  # noqa: E402
+import torch  # noqa: E402
+from PIL import Image  # noqa: E402
+
+from runtime.training.dataset import (  # noqa: E402
+    BucketManager,
+    CachedLatentDataset,
+    ImageDataset,
+    collate_fn,
+    collate_fn_cached,
+)
+from runtime.training.loop import _masked_mean, _masked_mean_per_sample  # noqa: E402
+
+
+class _FakeVAEModel:
+    def encode(self, pixels_5d, scale):
+        b, c, t, h, w = pixels_5d.shape
+        return torch.zeros(b, 16, 1, h // 8, w // 8, dtype=pixels_5d.dtype)
+
+
+class _FakeVAE:
+    def __init__(self):
+        self.model = _FakeVAEModel()
+        self.scale = 1.0
+
+    def encode(self, pixels):
+        return self.model.encode(pixels, self.scale)
+
+
+def _write_img(path: Path, size=(256, 256)) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", size, color=(127, 127, 127)).save(path)
+    path.with_suffix(".txt").write_text("test", encoding="utf-8")
+
+
+def _write_mask(data_dir: Path, img_path: Path, builder) -> Path:
+    """builder(Image) 生成 mask 内容；路径按训练器约定落 masks/ 镜像。"""
+    rel = img_path.relative_to(data_dir)
+    mp = data_dir / "masks" / rel.parent / f"{img_path.stem}.png"
+    mp.parent.mkdir(parents=True, exist_ok=True)
+    builder().save(mp)
+    return mp
+
+
+def _half_mask(size=(256, 256)):
+    """上半 0（不学）下半 255（学）。"""
+    m = Image.new("L", size, 255)
+    m.paste(0, (0, 0, size[0], size[1] // 2))
+    return m
+
+
+def _square_dataset(tmp_path: Path, **kwargs) -> ImageDataset:
+    mgr = BucketManager(256, min_reso=256, max_reso=256, step=64)
+    return ImageDataset(tmp_path, 256, mgr, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# ImageDataset：mask 加载 + 几何变换 + latent 下采样
+# ---------------------------------------------------------------------------
+
+
+def test_mask_transforms_with_image(tmp_path: Path) -> None:
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+    _write_mask(tmp_path, img_path, _half_mask)
+
+    ds = _square_dataset(tmp_path, load_masks=True)
+    item = ds.get_with_flip(0, flip=False)
+    mask = item["mask"]
+    assert mask is not None
+    assert mask.shape == (32, 32)  # 256/8
+    # 上半不学（0）下半学（1）
+    assert float(mask[:16].max()) == 0.0
+    assert float(mask[16:].min()) == 1.0
+
+
+def test_mask_flips_with_image(tmp_path: Path) -> None:
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+
+    def left_mask():
+        m = Image.new("L", (256, 256), 255)
+        m.paste(0, (0, 0, 128, 256))  # 左半不学
+        return m
+
+    _write_mask(tmp_path, img_path, left_mask)
+    ds = _square_dataset(tmp_path, load_masks=True)
+    m0 = ds.get_with_flip(0, flip=False)["mask"]
+    m1 = ds.get_with_flip(0, flip=True)["mask"]
+    assert float(m0[:, :16].max()) == 0.0 and float(m0[:, 16:].min()) == 1.0
+    # flip 后左右对调
+    assert float(m1[:, 16:].max()) == 0.0 and float(m1[:, :16].min()) == 1.0
+
+
+def test_mask_size_mismatch_degrades_to_none(tmp_path: Path) -> None:
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+    _write_mask(tmp_path, img_path, lambda: Image.new("L", (128, 128), 0))
+
+    ds = _square_dataset(tmp_path, load_masks=True)
+    assert ds.get_with_flip(0, flip=False)["mask"] is None
+
+
+def test_mask_not_loaded_when_disabled(tmp_path: Path) -> None:
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+    _write_mask(tmp_path, img_path, _half_mask)
+
+    ds = _square_dataset(tmp_path, load_masks=False)
+    assert ds.get_with_flip(0, flip=False)["mask"] is None
+
+
+def test_mask_missing_is_none(tmp_path: Path) -> None:
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+    ds = _square_dataset(tmp_path, load_masks=True)
+    assert ds.get_with_flip(0, flip=False)["mask"] is None
+
+
+def test_gray_mask_partial_weight(tmp_path: Path) -> None:
+    """灰度中间值 = 部分权重（软边笔刷语义）。"""
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+    _write_mask(tmp_path, img_path, lambda: Image.new("L", (256, 256), 128))
+
+    ds = _square_dataset(tmp_path, load_masks=True)
+    mask = ds.get_with_flip(0, flip=False)["mask"]
+    assert abs(float(mask.mean()) - 128 / 255) < 0.01
+
+
+# ---------------------------------------------------------------------------
+# CachedLatentDataset：npz mask 键 + 缓存失效三条
+# ---------------------------------------------------------------------------
+
+
+def test_cache_stores_mask_keys(tmp_path: Path) -> None:
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+    _write_mask(tmp_path, img_path, _half_mask)
+
+    ds = _square_dataset(tmp_path, load_masks=True, flip_augment=True)
+    cached = CachedLatentDataset(ds, _FakeVAE(), device="cpu", dtype=torch.float32)
+
+    with np.load(img_path.with_suffix(".npz")) as data:
+        assert "mask" in data.files
+        assert "mask_flipped" in data.files
+        assert data["mask"].shape == (32, 32)
+
+    item = cached[0]
+    assert item["mask"] is not None
+    assert item["mask"].shape == (32, 32)
+
+
+def test_cache_no_mask_keys_without_mask(tmp_path: Path) -> None:
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+    ds = _square_dataset(tmp_path, load_masks=True)
+    CachedLatentDataset(ds, _FakeVAE(), device="cpu", dtype=torch.float32)
+    with np.load(img_path.with_suffix(".npz")) as data:
+        assert "mask" not in data.files
+
+
+def test_cache_invalidation_three_rules(tmp_path: Path) -> None:
+    """§9 决策 3：新画 / 重画 / 清除 三条都必须让缓存失效。"""
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+
+    ds = _square_dataset(tmp_path, load_masks=True)
+    cached = CachedLatentDataset(ds, _FakeVAE(), device="cpu", dtype=torch.float32)
+    npz_path = img_path.with_suffix(".npz")
+    assert cached._is_cache_valid(img_path, npz_path) is True
+
+    # 1) 新画 mask（文件出现但 npz 无 mask 键）→ 失效
+    mp = _write_mask(tmp_path, img_path, _half_mask)
+    assert cached._is_cache_valid(img_path, npz_path) is False
+
+    # 重建缓存（含 mask）后有效
+    ds2 = _square_dataset(tmp_path, load_masks=True)
+    cached2 = CachedLatentDataset(ds2, _FakeVAE(), device="cpu", dtype=torch.float32)
+    assert cached2._is_cache_valid(img_path, npz_path) is True
+
+    # 2) 重画 mask（mtime 新于 npz）→ 失效
+    future = npz_path.stat().st_mtime + 10
+    os.utime(mp, (future, future))
+    assert cached2._is_cache_valid(img_path, npz_path) is False
+
+    # 恢复 mask mtime 到当前（消掉人为的未来时间戳），否则第 3 步重建的
+    # npz 永远"旧于" mask
+    os.utime(mp, None)
+
+    # 3) 清除 mask（文件删了但 npz 还有 mask 键）→ 失效
+    ds3 = _square_dataset(tmp_path, load_masks=True)
+    cached3 = CachedLatentDataset(ds3, _FakeVAE(), device="cpu", dtype=torch.float32)
+    assert cached3._is_cache_valid(img_path, npz_path) is True
+    mp.unlink()
+    assert cached3._is_cache_valid(img_path, npz_path) is False
+
+
+def test_cache_with_mask_keys_valid_when_masks_disabled(tmp_path: Path) -> None:
+    """load_masks=False 时带 mask 键的缓存仍有效（超集语义，对齐 latent_flipped）。"""
+    img_path = tmp_path / "X.png"
+    _write_img(img_path)
+    _write_mask(tmp_path, img_path, _half_mask)
+    ds = _square_dataset(tmp_path, load_masks=True)
+    CachedLatentDataset(ds, _FakeVAE(), device="cpu", dtype=torch.float32)
+
+    ds_off = _square_dataset(tmp_path, load_masks=False)
+    cached_off = CachedLatentDataset(ds_off, _FakeVAE(), device="cpu", dtype=torch.float32)
+    assert cached_off._is_cache_valid(img_path, img_path.with_suffix(".npz")) is True
+    # 且不返回 mask
+    assert cached_off[0]["mask"] is None
+
+
+# ---------------------------------------------------------------------------
+# collate：混合有 / 无 mask
+# ---------------------------------------------------------------------------
+
+
+def test_collate_cached_fills_ones_for_unmasked() -> None:
+    latent = torch.zeros(16, 1, 32, 32)
+    half = torch.zeros(32, 32)
+    half[16:] = 1.0
+    batch = [
+        {"latent": latent, "caption": "a", "mask": half},
+        {"latent": latent, "caption": "b", "mask": None},
+    ]
+    out = collate_fn_cached(batch)
+    assert out["masks"].shape == (2, 32, 32)
+    assert float(out["masks"][1].min()) == 1.0  # 无 mask 图全 1
+    assert float(out["masks"][0][:16].max()) == 0.0
+
+
+def test_collate_omits_masks_when_all_none() -> None:
+    latent = torch.zeros(16, 1, 32, 32)
+    batch = [{"latent": latent, "caption": "a", "mask": None}]
+    assert "masks" not in collate_fn_cached(batch)
+
+    pixels = torch.zeros(3, 256, 256)
+    pbatch = [{"pixel_values": pixels, "caption": "a", "mask": None}]
+    assert "masks" not in collate_fn(pbatch)
+
+
+def test_collate_pixel_path_mask_shape() -> None:
+    pixels = torch.zeros(3, 256, 256)
+    mask = torch.ones(32, 32)
+    batch = [
+        {"pixel_values": pixels, "caption": "a", "mask": mask},
+        {"pixel_values": pixels, "caption": "b", "mask": None},
+    ]
+    out = collate_fn(batch)
+    assert out["masks"].shape == (2, 32, 32)
+
+
+# ---------------------------------------------------------------------------
+# loss 数学：加权均值 reduction（§8）
+# ---------------------------------------------------------------------------
+
+
+def test_masked_mean_ignores_masked_region() -> None:
+    """mask=0 区域的 loss 值完全不影响结果。"""
+    loss = torch.ones(2, 16, 1, 4, 4)
+    loss[:, :, :, :2, :] = 999.0  # 上半灌大值
+    mask = torch.zeros(2, 1, 1, 4, 4)
+    mask[:, :, :, 2:, :] = 1.0  # 只学下半
+    assert abs(float(_masked_mean(loss, mask)) - 1.0) < 1e-6
+
+
+def test_masked_mean_equals_mean_with_full_mask() -> None:
+    """全 1 mask 时与朴素 mean 等价（无 mask 图的行为不变性）。"""
+    torch.manual_seed(0)
+    loss = torch.rand(2, 16, 1, 4, 4)
+    mask = torch.ones(2, 1, 1, 4, 4)
+    assert abs(float(_masked_mean(loss, mask)) - float(loss.mean())) < 1e-6
+
+
+def test_masked_mean_area_normalization() -> None:
+    """不同 mask 面积的样本不被隐性降权：分母是 mask 元素和。
+
+    样本 0 学一半（loss=2）、样本 1 全学（loss=1）→
+    (2*8*16 + 1*16*16) / (8*16 + 16*16) = 512/384 = 4/3。
+    """
+    loss = torch.ones(2, 16, 1, 4, 4)
+    loss[0] = 2.0
+    mask = torch.ones(2, 1, 1, 4, 4)
+    mask[0, :, :, :2, :] = 0.0
+    expected = (2.0 * 8 * 16 + 1.0 * 16 * 16) / (8 * 16 + 16 * 16)
+    assert abs(float(_masked_mean(loss, mask)) - expected) < 1e-6
+
+
+def test_masked_mean_per_sample() -> None:
+    loss = torch.ones(2, 16, 1, 4, 4)
+    loss[0, :, :, :2, :] = 999.0
+    mask = torch.ones(2, 1, 1, 4, 4)
+    mask[0, :, :, :2, :] = 0.0
+    per = _masked_mean_per_sample(loss, mask)
+    assert per.shape == (2,)
+    assert abs(float(per[0]) - 1.0) < 1e-6
+    assert abs(float(per[1]) - 1.0) < 1e-6


### PR DESCRIPTION
## 概要

PR-B 第二期（B2，训练器侧，设计文档 §5/§9）。消费 #394 落盘的 mask 数据面（布局随 #400 的 D5 修订为与图**同目录**的 `{stem}.mask` sidecar，内容灰度 PNG 字节）：开启 `masked_loss` 后，涂抹页画的 mask 区域在训练时不产生梯度（灰度 0=不学 / 255=学 / 中间=部分权重），生成时该区域由 base 模型先验接管——手部等易崩坏部位的标准解法（对齐 kohya sd-scripts masked loss / diffusion-pipe 生态）。

**Draft 直到 A/B 验证达标**（§9 决策 6，见下）。

## 实现

- **dataset**（`runtime/training/dataset.py`）：mask 随图走同一几何变换（bucket resize-cover + center-crop + flip，NEAREST 防灰度插值污染）后 **area（BOX 块均值）下采样**到 latent /8。mask 路径 = `img_path` 同目录 `{stem}.mask`（`Image.open` 按内容嗅探格式，非图片后缀天然不被任何扫描点当训练图——#400 D5 修订）。缺文件 = 全图正常学习；尺寸不匹配 warning 一次 + 降级无 mask（fail-safe，训练不 crash）。
- **npz 缓存**：`mask` / `mask_flipped` 键与 latent 同 flip 选择（仿 `latent_flipped` 双份先例）；`_is_cache_valid` 新增三条失效——新画（有文件无键）/ 重画（mask mtime 新于 npz）/ 清除（无文件有键），漏一条就训到旧 mask。`load_masks` 关闭时带 mask 键的缓存按超集语义仍有效。
- **loss**（`runtime/training/loop.py`）：加权均值 reduction `(loss*mask).sum() / mask.sum()`——分母是 mask 元素和，不同 mask 面积的样本在 batch 内权重一致，避免 kohya 朴素 `mean()` 中大 mask 图被隐性降权。与 reg weight / timestep weighting 正交叠加（它们乘在分子、不进分母，与无 mask 时 `mean()` 语义对称）。
- **InfoNoise**：`_raw_mse` 记录同样 mask 加权（`_masked_mean_per_sample`），无监督区域的噪声不进 I-MMSE 统计。
- **路径边界**：NaViT 打包运行时闸掉（warning + 忽略 mask，不写 npz mask 键）；Leap schema 互斥（per-sample loss 无空间维度）。
- **config / UI**：`masked_loss: bool`（loss 组，默认 False，显式开关不因存在 mask 文件自动开启——D7）；Train 页检测到训练集有 mask 但开关关闭时渲染提示（不代开）；开关开但零 mask 只 log 一条。

## 测试

- 新增 `tests/test_masked_loss.py` 17 条（CPU + _FakeVAE，无 GPU 依赖）：mask 几何变换 / flip 对调 / 灰度部分权重 / 尺寸不匹配降级 / npz 双份键 / 缓存三条失效 / 超集语义 / collate 混合全 1 填充 / 加权均值数学（mask 区域不影响结果、全 1 mask 与 mean 等价、面积归一）。测试落盘用与 studio 一致的 `.mask` 同目录布局（PIL 存非标准后缀需显式 `format="PNG"`）。
- runtime.training 相关后端 216 条全绿；前端 vitest 488 条全绿。
- 数据链路可先用 `tools/mask_check.py`（#394，#400 已适配新布局）对真实数据集 dry-run。

## 合并门槛（§9 决策 6）

本地小 A/B（同数据集同 seed，手部 mask vs 无 mask）：
1. loss 曲线正常无 NaN；
2. 出图 mask 区域不带崩坏特征（base 先验接管）。

达标转 ready 合并；不达标挂待判（先例：FFL）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
