### PR TITLE
fix(server): 终端 Ctrl+C 关不掉 server —— graceful shutdown 加超时上限

### DIFF
--- a/studio/api/lifespan.py
+++ b/studio/api/lifespan.py
@@ -68,6 +68,36 @@ def _install_proactor_disconnect_filter(loop: asyncio.AbstractEventLoop) -> None
     loop.set_exception_handler(_filter)
 
 
+class _CancelledAsgiNoiseFilter(logging.Filter):
+    """吞 shutdown 收尾取消连接时 uvicorn 的 cosmetic CancelledError 噪声。
+
+    uvicorn 启动参数带 timeout_graceful_shutdown（见 api/main.py）：超时后
+    uvicorn cancel 剩余连接 task（/api/events 等 SSE 长连接），CancelledError
+    从 starlette 冒回 h11 的 run_asgi 时被 `except BaseException` 兜住、按
+    「Exception in ASGI application」打 ERROR + 完整 traceback —— 但这个取消
+    是关停流程主动要求的，不是应用错误，Ctrl+C 一次就刷两大坨假报错。
+
+    精确过滤：只吞 message 为该文案且异常类型是 CancelledError 的记录；
+    其它 ASGI 异常照常打。
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if not str(record.msg).startswith("Exception in ASGI application"):
+            return True
+        exc = record.exc_info[1] if record.exc_info else None
+        return not isinstance(exc, asyncio.CancelledError)
+
+
+_cancelled_asgi_filter = _CancelledAsgiNoiseFilter()
+
+
+def _install_uvicorn_cancelled_asgi_filter() -> None:
+    """幂等挂到 uvicorn.error logger（测试里 lifespan 会反复 startup）。"""
+    uvicorn_logger = logging.getLogger("uvicorn.error")
+    if _cancelled_asgi_filter not in uvicorn_logger.filters:
+        uvicorn_logger.addFilter(_cancelled_asgi_filter)
+
+
 @asynccontextmanager
 async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
     """启动绑定 event bus 到当前 loop 并起 supervisor；关闭时停 supervisor。"""
@@ -78,6 +108,8 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
 
     # 装 Windows ProactorEventLoop 的 ConnectionResetError 过滤器（详见 helper docstring）
     _install_proactor_disconnect_filter(asyncio.get_running_loop())
+    # 装 shutdown 取消 SSE 连接时的 CancelledError 日志过滤器（详见 class docstring）
+    _install_uvicorn_cancelled_asgi_filter()
 
     # PR-5：从 server.py 顶层搬来的 import-time 副作用 —— 现在跟随 app 启动
     # 才落盘，便于测试 / 工具 import 而不写文件系统。

--- a/studio/api/main.py
+++ b/studio/api/main.py
@@ -27,4 +27,11 @@ def main() -> None:
         port=args.port,
         reload=args.reload,
         log_level="info",
+        # 浏览器开着时 /api/events 的 SSE 长连接不会主动断，graceful shutdown
+        # 默认无限等 →「Waiting for connections to close」卡死；且 py3.12+ 的
+        # Server.wait_closed() 等全部活跃连接，二次 Ctrl+C 的 force_exit 也
+        # 解不开（transport 不被强关）。给 graceful 一个上限：超时后 uvicorn
+        # cancel 剩余连接 task → 连接关闭 → lifespan 正常收尾（supervisor /
+        # daemon 优雅停）。
+        timeout_graceful_shutdown=3,
     )

--- a/studio/api/routers/system.py
+++ b/studio/api/routers/system.py
@@ -41,7 +41,7 @@ from ...services.runtime import updater
 router = APIRouter()
 
 _RESTART_FLAG = REPO_ROOT / "tmp" / "restart"
-_SHUTDOWN_FORCE_EXIT_TIMEOUT = 5.0
+_SHUTDOWN_FORCE_EXIT_TIMEOUT = 15.0
 
 
 def _raise_sigint_after_response() -> None:
@@ -50,13 +50,13 @@ def _raise_sigint_after_response() -> None:
     BackgroundTask 在 starlette 路径上是 response 完成后调度的；这里再 sleep
     一点点保险（防止某些代理 / keep-alive 情况下还有数据没冲走）。
 
-    Force-exit 兜底（PR-D fix）：`/api/events` 是长 SSE，generator 内的
-    `asyncio.wait_for(queue.get(), 15)` 不响应 uvicorn 关停信号，graceful
-    shutdown 会等 client 主动断开 → 表现为「后端卡在 waiting for
-    connection to close」，用户必须刷页让浏览器关 SSE 才能继续。给 graceful
-    5 秒窗口后强退（正常 in-flight 1-2s 收尾够用）。BackgroundTask 跑在
-    threadpool，graceful 成功路径主进程退出会带走此线程，os._exit 不会
-    触达；只有 graceful 卡住时才真正强退。
+    Force-exit 兜底（PR-D fix）：`/api/events` 是长 SSE，不响应 uvicorn 关停
+    信号，graceful shutdown 会等 client 主动断开。现在 uvicorn 启动参数带
+    timeout_graceful_shutdown=3（见 api/main.py）——3s 后强制 cancel 剩余
+    连接再走 lifespan 收尾（supervisor / daemon 优雅停，可能再要数秒），
+    所以兜底窗口必须 > 3s + lifespan 用时，否则会把即将成功的 graceful
+    半路 os._exit 掉。15s 只在 graceful 真卡死时触达；正常路径主进程退出
+    会带走此 daemon 线程，os._exit 不会执行。
     """
     import signal
     time.sleep(0.3)

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -676,9 +676,16 @@ def cmd_run(args: argparse.Namespace) -> int:
         if not args.no_browser and not opened_browser:
             _spawn_browser_opener(url)
             opened_browser = True
-        rc = subprocess.call(
-            [find_python(), "-m", "studio.server", "--host", args.host, "--port", str(args.port)]
-        )
+        try:
+            rc = subprocess.call(
+                [find_python(), "-m", "studio.server", "--host", args.host, "--port", str(args.port)]
+            )
+        except KeyboardInterrupt:
+            # 终端 Ctrl+C：CTRL_C_EVENT 同时广播给 server 子进程（它自己走
+            # graceful shutdown）；父进程这边阻塞在 wait 的 KeyboardInterrupt
+            # 要等子进程退干净后才抛出来。用户主动停机，不打 traceback。
+            _say("已停止（Ctrl+C）")
+            return 130
 
         if not _RESTART_FLAG.exists():
             return rc

--- a/tests/test_studio_cli.py
+++ b/tests/test_studio_cli.py
@@ -587,6 +587,25 @@ def test_cmd_run_normal_restart_when_installer_unchanged(
     assert server_calls[0] == 2, "正常 restart 应当 loop 两次"
 
 
+def test_cmd_run_ctrl_c_returns_130_without_traceback(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    """终端 Ctrl+C：父进程在 subprocess.call 等 server 期间收到的
+    KeyboardInterrupt 会在子进程退出后才抛出 —— 应按用户主动停机处理
+    （return 130），不冒 traceback。"""
+    _stub_run_bootstrap(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli, "_RESTART_FLAG", tmp_path / "restart")
+
+    def fake(cmd, **_: Any) -> int:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(cli.subprocess, "call", fake)
+
+    rc = cli.main(["run", "--no-browser"])
+    assert rc == 130
+    assert "Ctrl+C" in capsys.readouterr().out
+
+
 def test_cmd_run_no_flag_no_dispatch(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -599,6 +599,28 @@ def test_system_restart_writes_flag_and_schedules_shutdown(
     assert called["ran"], "_raise_sigint_after_response BackgroundTask 应被调度"
 
 
+def test_uvicorn_run_bounds_graceful_shutdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """main() 必须给 uvicorn 传 timeout_graceful_shutdown 上限。
+
+    浏览器开着时 /api/events 的 SSE 长连接不主动断，graceful shutdown 默认
+    无限等 →「Waiting for connections to close」卡死；且 py3.12+ 的
+    asyncio.Server.wait_closed() 等全部活跃连接，二次 Ctrl+C 设 force_exit
+    也解不开。没有这个上限，终端 Ctrl+C 永远关不掉 server。
+    """
+    import uvicorn
+
+    from studio.api import main as main_mod
+
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(uvicorn, "run", lambda *a, **kw: captured.update(kw))
+    monkeypatch.setattr("sys.argv", ["anima-studio"])
+    main_mod.main()
+    timeout = captured.get("timeout_graceful_shutdown")
+    assert isinstance(timeout, (int, float)) and timeout > 0
+
+
 # ---------------------------------------------------------------------------
 # /api/system/version (ADR 0002 / PR-B)
 # ---------------------------------------------------------------------------

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 
 import pytest
@@ -619,6 +620,36 @@ def test_uvicorn_run_bounds_graceful_shutdown(
     main_mod.main()
     timeout = captured.get("timeout_graceful_shutdown")
     assert isinstance(timeout, (int, float)) and timeout > 0
+
+
+def test_cancelled_asgi_noise_filter_scope() -> None:
+    """shutdown 超时取消 SSE 连接时，uvicorn 把 CancelledError 按
+    「Exception in ASGI application」打 ERROR traceback —— 主动取消不是
+    应用错误，应被过滤；其它 ASGI 异常 / 其它 message 必须照常放行。"""
+    import asyncio
+
+    from studio.api.lifespan import _CancelledAsgiNoiseFilter
+
+    f = _CancelledAsgiNoiseFilter()
+
+    def record(msg: str, exc: BaseException | None) -> logging.LogRecord:
+        return logging.LogRecord(
+            name="uvicorn.error", level=logging.ERROR, pathname=__file__,
+            lineno=1, msg=msg, args=(),
+            exc_info=(type(exc), exc, None) if exc is not None else None,
+        )
+
+    # 目标噪声：吞
+    assert not f.filter(
+        record("Exception in ASGI application\n", asyncio.CancelledError())
+    )
+    # 真实应用异常：放行
+    assert f.filter(
+        record("Exception in ASGI application\n", RuntimeError("boom"))
+    )
+    # 无异常信息 / 其它 message：放行
+    assert f.filter(record("Exception in ASGI application\n", None))
+    assert f.filter(record("Cancel 2 running task(s)", asyncio.CancelledError()))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

用户报告：终端里 Ctrl+C 停 server，有时卡在

```
INFO uvicorn.error: Shutting down
INFO uvicorn.error: Waiting for connections to close. (CTRL+C to force quit)
```

再按 Ctrl+C 也无法强制退出，只能杀进程。

## 根因（最小复现已定位）

两层叠加，触发条件是「浏览器 tab 开着」：

1. **graceful 无限等 SSE**：`/api/events` 是无限长连接（浏览器 EventSource 不主动断），uvicorn 默认 `timeout_graceful_shutdown=None`，`_wait_tasks_to_complete` 里的连接等待循环永不结束。
2. **二次 Ctrl+C 的 force quit 在 py3.12+ 失效**：用最小 app（同 venv、uvicorn 0.46、复刻 events_sse.py 的 SSE 循环）+ `GenerateConsoleCtrlEvent` 模拟终端 Ctrl+C 复现：第二次 SIGINT 确实到达 `Server.handle_exit` 并设了 `force_exit=True`（monkeypatch 打点确认），但 `force_exit` 只是让等待循环退出，随后 `await server.wait_closed()` 在 Python 3.12+ 语义下要等**全部活跃连接结束**，而 SSE transport 没人强关 → 依然永久挂起。`(CTRL+C to force quit)` 这行提示在这个组合下是空头支票。

## 改动

**commit 1 — 能退出：**

- `api/main.py`：`uvicorn.run(..., timeout_graceful_shutdown=3)`。超时后 uvicorn 主动 cancel 剩余连接 task → transport 关闭 → `wait_closed` 返回 → lifespan 正常收尾（supervisor / generate daemon 优雅停）。最小复现实测：修复前两次 Ctrl+C 均无法退出；修复后一次 Ctrl+C 约 3 秒干净退出。
- `api/routers/system.py`：`/api/system/restart` 的 `os._exit` 兜底窗口 5s → 15s。graceful 现在需要 3s（等 SSE 超时）+ lifespan 收尾用时，原 5s 窗口会把即将成功的 graceful 半路强杀；15s 只在真卡死时触达，正常路径主进程退出带走兜底线程。

**commit 2 — 退得干净（用户实测反馈收尾刷两类假报错）：**

- `api/lifespan.py`：uvicorn 把「shutdown 超时主动 cancel SSE 连接」的 CancelledError 按 `Exception in ASGI application` 打 ERROR + 完整 traceback（每个 SSE 连接一坨）。加 `uvicorn.error` logger 过滤器，只吞该文案 + CancelledError 的记录，真实 ASGI 异常照常打（与既有 proactor ConnectionResetError 过滤器同款手法、同处安装）。
- `cli.py`：CLI 父进程在 `subprocess.call` 等 server 期间收到的 KeyboardInterrupt 在子进程退出后才抛出，无人接住 → traceback。按用户主动停机处理（`已停止（Ctrl+C）` + return 130）。以前 server 杀不掉根本走不到这步，commit 1 之后才暴露。

修完后 Ctrl+C 的完整输出（最小复现验证）：

```
INFO  uvicorn.error: Shutting down
INFO  uvicorn.error: Waiting for connections to close. (CTRL+C to force quit)
ERROR uvicorn.error: Cancel n running task(s), timeout graceful shutdown exceeded
INFO  uvicorn.error: Waiting for application shutdown.
INFO  uvicorn.error: Application shutdown complete.
INFO  uvicorn.error: Finished server process [...]
[studio] 已停止（Ctrl+C）
```

（保留 `Cancel n running task(s)` 一行——它解释了为什么等了 3 秒，且只有一行。）

## 测试

- 新增回归测试 ×3：`test_uvicorn_run_bounds_graceful_shutdown`（main() 必须传正数超时）、`test_cancelled_asgi_noise_filter_scope`（只吞目标噪声，真实异常放行）、`test_cmd_run_ctrl_c_returns_130_without_traceback`。
- `test_studio_cli.py` + `test_studio_server.py`（86 条）+ 横切安全网（`test_route_snapshot.py` / `test_studio_configs.py` 33 条）全绿。
- 既有问题（与本 PR 无关，干净 dev 同样复现）：单独跑 `tests/test_studio_server.py` 时 `test_generate_sample_response_is_not_browser_cached` 因 disk_cache 未 init 失败，疑似测试顺序依赖，CI 全量跑为绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)