### PR TITLE
fix(reg): AI 先验生成把 train/masks/ 的 mask 灰度图当训练图

### DIFF
--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -52,6 +52,7 @@ from studio.services.reg.builder import (  # noqa: E402
     read_meta,
     write_meta,
 )
+from studio.services.dataset.scan import TRAIN_RESERVED_DIRS  # noqa: E402
 from studio.services.tagging.caption_format import (  # noqa: E402
     caption_json_to_tags,
     caption_json_to_text,
@@ -291,6 +292,11 @@ def _scan_train(train_dir: Path) -> list[dict]:
                     "tags": _read_tags(f),
                 })
             elif f.is_dir():
+                # train/ 直下的保留目录（masks/ 训练 mask sidecar）不是 concept
+                # folder —— 递归扫描点必须排除，否则 mask 灰度图被当训练图、
+                # 生成总数虚高（见 services/preprocess/masks.py docstring）。
+                if not sub and f.name in TRAIN_RESERVED_DIRS:
+                    continue
                 child = f.name if not sub else f"{sub}/{f.name}"
                 _scan(f, child)
 

--- a/tests/test_anima_reg_caption.py
+++ b/tests/test_anima_reg_caption.py
@@ -229,3 +229,35 @@ def test_txt_caption_path_unchanged(reg_module, tmp_path: Path) -> None:
     assert "1girl" not in prompt
     on_disk = src.read_text(encoding="utf-8")
     assert on_disk == prompt
+
+
+# ---------------------------------------------------------------------------
+# _scan_train：train/ 直下保留目录（masks/）不算训练图
+# ---------------------------------------------------------------------------
+
+def test_scan_train_skips_reserved_masks_dir(reg_module, tmp_path: Path) -> None:
+    """mask sidecar（train/masks/{folder}/{stem}.png）不是训练图。
+
+    TRAIN_RESERVED_DIRS 在 trainer / booru builder / versions 统计三处都
+    排除了，reg_ai 的递归扫描漏掉会把 mask 灰度图计入生成清单——生成总数
+    虚高（用户报告：删图后重新生成数量不降）。"""
+    train = tmp_path / "train"
+    (train / "1_data").mkdir(parents=True)
+    (train / "1_data" / "a.png").write_bytes(b"png")
+    (train / "1_data" / "b.png").write_bytes(b"png")
+    (train / "masks" / "1_data").mkdir(parents=True)
+    (train / "masks" / "1_data" / "a.png").write_bytes(b"png")
+
+    entries = reg_module._scan_train(train)
+    imgs = sorted(str(e["img"].relative_to(train)).replace("\\", "/") for e in entries)
+    assert imgs == ["1_data/a.png", "1_data/b.png"]
+
+
+def test_scan_train_keeps_nested_concept_folders(reg_module, tmp_path: Path) -> None:
+    """排除只针对 train/ 直下的保留名；嵌套同名子目录仍是普通 concept 内容。"""
+    train = tmp_path / "train"
+    (train / "1_data" / "masks").mkdir(parents=True)
+    (train / "1_data" / "masks" / "c.png").write_bytes(b"png")
+
+    entries = reg_module._scan_train(train)
+    assert [e["subfolder"] for e in entries] == ["1_data/masks"]


### PR DESCRIPTION
## 背景

用户报告：训练集从 100 删到 75 张后，正则页清空重新生成，数量仍是 100。排查确认全链路**没有任何数量缓存**（reg_ai 每次启动实时扫 `vdir/train`、full 模式生成前 `clear_reg_dir`、「清空」真删），数量虚高来自扫描本身。

## 根因

`runtime/anima_reg_ai.py` 的 `_scan_train` 递归扫 `train/` 但没排除保留目录。涂抹功能（#393 / #394）把训练 mask 存在 `train/masks/{folder}/{stem}.png`——画过 mask 的训练集会把这些灰度 PNG 计入生成清单：

- 日志「train 共 N 张图」与 monitor 进度 total 虚高（训练图 + mask 数）；
- mask 无 caption，生成循环逐张打「无 tag 文件，跳过」warning。

`TRAIN_RESERVED_DIRS = {masks}`（`services/dataset/scan.py`）在 trainer（`RESERVED_SUBDIRS`）、booru builder（`rel.parts[0]` 过滤）、versions 统计三处都已排除，reg_ai 是漏改点——`services/preprocess/masks.py` 的 docstring 明确要求所有递归扫描点排除。

## 改动

- `_scan_train` 在 train/ 直下一层跳过 `TRAIN_RESERVED_DIRS`；嵌套同名子目录仍按 concept 内容扫（与 builder 的 `rel.parts[0]` 语义一致）。
- 常量直接 import 权威源 `studio.services.dataset.scan`（本文件已有 `studio.services.reg.builder` 的 import 先例，不再复刻副本）。

附带说明：报告场景的另一个可能来源是 Curation 训练集行数按 origin 去重（multi-crop fan-out 折叠显示）而生成按物理文件 1:1——这是设计语义，maintainer 确认不改。

## 测试

- 新增 2 条：`masks/` 下的图不计入扫描结果；嵌套同名目录不受影响。
- `tests/test_anima_reg_caption.py` 13 条 + 横切安全网（route_snapshot / studio_configs 33 条）全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)