### PR TITLE
feat(web): tag autocomplete 全局开关 + 候选只在输入变化后弹出

### DIFF
--- a/studio/web/src/components/TagEditor.tsx
+++ b/studio/web/src/components/TagEditor.tsx
@@ -195,6 +195,7 @@ export default function TagEditor({
                     e.preventDefault(); addTag(draft)
                   }
                 }}
+                onClick={() => draftSuggest.notifyClick()}
                 onFocus={() => draftSuggest.notifyFocus()}
                 onBlur={() => draftSuggest.notifyBlur()}
                 placeholder={t('tagEditor.addPlaceholder')}
@@ -231,7 +232,7 @@ export default function TagEditor({
               onChange={(e) => { setTextBuf(e.target.value); textSuggest.notifyChange() }}
               onKeyDown={(e) => { textSuggest.handleKeyDown(e) }}
               onKeyUp={() => textSuggest.notifySelect()}
-              onClick={() => textSuggest.notifySelect()}
+              onClick={() => textSuggest.notifyClick()}
               onFocus={() => textSuggest.notifyFocus()}
               onBlur={() => { textSuggest.notifyBlur(); commitText() }}
               placeholder={t('tagEditor.textPlaceholder')}

--- a/studio/web/src/components/TagStatsPanel.tsx
+++ b/studio/web/src/components/TagStatsPanel.tsx
@@ -264,6 +264,7 @@ function EditTagInput({ editInputRef, value, setValue, onCommit, onCancel }: {
           if (e.key === 'Enter') onCommit()
           else if (e.key === 'Escape') onCancel()
         }}
+        onClick={() => suggest.notifyClick()}
         onFocus={() => suggest.notifyFocus()}
         onBlur={() => { suggest.notifyBlur(); onCancel() }}
         className="input input-mono w-full"

--- a/studio/web/src/components/TagsInput.tsx
+++ b/studio/web/src/components/TagsInput.tsx
@@ -85,7 +85,7 @@ export function TagListInput({ value, onChange, placeholder, disabled, className
           }}
           onKeyDown={(e) => { suggest.handleKeyDown(e) }}
           onKeyUp={() => { suggest.notifySelect() }}
-          onClick={() => { suggest.notifySelect() }}
+          onClick={() => { suggest.notifyClick() }}
           onFocus={() => { suggest.notifyFocus() }}
           onBlur={() => {
             suggest.notifyBlur()

--- a/studio/web/src/components/tagSuggest/useTagSuggest.test.tsx
+++ b/studio/web/src/components/tagSuggest/useTagSuggest.test.tsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useRef, useState } from 'react'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { __setStateForTest } from '../../tagDict/store'
+import { TagSuggestList } from './TagSuggestList'
+import { useTagSuggest } from './useTagSuggest'
+
+/** 注入一个小词典（绕过网络），让 findSuggestions 有东西可匹配。 */
+function seedDict() {
+  const entries = new Map<string, string[]>([
+    ['solo', ['单人']],
+    ['long hair', ['长发']],
+  ])
+  const tagKeys = Array.from(entries.keys())
+  __setStateForTest({
+    status: 'ready',
+    entries,
+    tagKeys,
+    compactedKeys: tagKeys.map((t) => t.replace(/[\s_]/g, '')),
+    reverse: [],
+    meta: null,
+    error: null,
+  })
+}
+
+/** 复刻真实 caller 的接线（PromptList / TagsInput 同构）。 */
+function Harness({ initial = '' }: { initial?: string }) {
+  const [value, setValue] = useState(initial)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const suggest = useTagSuggest({
+    value,
+    inputRef,
+    onPick: ({ suggestion }) => setValue(suggestion.tag),
+  })
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        value={value}
+        onChange={(e) => { setValue(e.target.value); suggest.notifyChange() }}
+        onKeyDown={(e) => { suggest.handleKeyDown(e) }}
+        onKeyUp={() => suggest.notifySelect()}
+        onClick={() => suggest.notifyClick()}
+        onFocus={() => suggest.notifyFocus()}
+        onBlur={() => suggest.notifyBlur()}
+      />
+      <TagSuggestList
+        open={suggest.open}
+        suggestions={suggest.suggestions}
+        activeIdx={suggest.activeIdx}
+        onPick={(s) => suggest.pickAt(suggest.suggestions.indexOf(s))}
+        onHover={suggest.setActiveIdx}
+        inputRef={inputRef}
+        cursor={suggest.cursor}
+        positionDeps={[value]}
+      />
+    </div>
+  )
+}
+
+describe('useTagSuggest 弹出规则', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    seedDict()
+  })
+
+  it('鼠标点进已有内容的输入框不弹候选（只有输入变化才弹）', async () => {
+    const user = userEvent.setup()
+    render(<Harness initial="sol" />)
+    await user.click(screen.getByRole('textbox'))
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+
+  it('输入变化后弹出候选', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    await user.type(screen.getByRole('textbox'), 'sol')
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+    expect(screen.getByText('solo')).toBeInTheDocument()
+  })
+
+  it('候选弹出后鼠标点击输入框（挪光标）→ 候选消失', async () => {
+    const user = userEvent.setup()
+    const input = () => screen.getByRole('textbox')
+    render(<Harness />)
+    await user.type(input(), 'sol')
+    expect(await screen.findByRole('listbox')).toBeInTheDocument()
+    await user.click(input())
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+
+  it('全局开关关闭后，输入也不弹候选', async () => {
+    localStorage.setItem('studio.tag.autocomplete', '0')
+    const user = userEvent.setup()
+    render(<Harness />)
+    await user.type(screen.getByRole('textbox'), 'sol')
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+
+  it('鼠标点选候选仍然生效（onMouseDown pick 不被 click-close 挡掉）', async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+    await user.type(screen.getByRole('textbox'), 'sol')
+    const option = await screen.findByText('solo')
+    await user.click(option)
+    expect(screen.getByRole('textbox')).toHaveValue('solo')
+    expect(screen.queryByRole('listbox')).toBeNull()
+  })
+})

--- a/studio/web/src/components/tagSuggest/useTagSuggest.ts
+++ b/studio/web/src/components/tagSuggest/useTagSuggest.ts
@@ -3,6 +3,10 @@
  * 设计原则：hook 不修改用户的 value，仅在用户选中候选时回调 `onPick`。
  * caller 决定怎么落进数据（替换 token range / 推到 tags 数组 / append）。
  *
+ * 弹出规则：候选只在输入变化（notifyChange）后弹出；聚焦 / 鼠标点击移动光标
+ * 不弹，点击还会关掉已弹出的候选。全局开关（Settings「Tag 翻译词典」区）关掉
+ * 后所有入口都不弹。
+ *
  * 两种 token 模式：
  *   - `wholeAsToken: false`（默认）：根据 cursor + 逗号边界算当前 token，commit
  *     时给 caller `range` 以便切片替换。
@@ -12,6 +16,7 @@
 import { useEffect, useMemo, useState } from 'react'
 import type React from 'react'
 
+import { useTagAutocompleteEnabled } from '../../tagDict/autocompleteToggle'
 import { useTagDict } from '../../tagDict/store'
 import { extractCurrentToken, findSuggestions } from '../../tagDict/suggest'
 import type { TagSuggestion } from '../../tagDict/types'
@@ -42,13 +47,15 @@ export interface TagSuggestApi {
   cursor: number
   /** 在 input 的 onKeyDown 里第一句调；返回 true 表示已处理（caller 应 return）。 */
   handleKeyDown: (e: React.KeyboardEvent) => boolean
-  /** 在 input 的 onChange 里调（cursor 跟踪 + 自动 open）。 */
+  /** 在 input 的 onChange 里调（cursor 跟踪 + 自动 open）。唯一的弹出入口。 */
   notifyChange: () => void
-  /** 在 input 的 onFocus 里调。 */
+  /** 在 input 的 onFocus 里调（只跟踪 cursor，不弹候选）。 */
   notifyFocus: () => void
   /** 在 input 的 onBlur 里调（延迟关闭，给点击留时间）。 */
   notifyBlur: () => void
-  /** 在 input 的 onClick / onKeyUp 里调（用户移动光标）。 */
+  /** 在 input 的 onClick 里调：鼠标点击移动光标 → 关掉已弹出的候选。 */
+  notifyClick: () => void
+  /** 在 input 的 onKeyUp 里调（键盘移动光标时跟踪 cursor）。 */
   notifySelect: () => void
   /** 鼠标点选 / 程序触发用。 */
   pickAt: (i: number) => void
@@ -58,6 +65,8 @@ export function useTagSuggest({
   value, inputRef, onPick, wholeAsToken = false, disabled = false,
 }: Args): TagSuggestApi {
   const dict = useTagDict()
+  const [acEnabled] = useTagAutocompleteEnabled()
+  const off = disabled || !acEnabled
   const [open, setOpen] = useState(false)
   const [activeIdx, setActiveIdx] = useState(0)
   const [cursor, setCursor] = useState(0)
@@ -68,7 +77,7 @@ export function useTagSuggest({
   }, [value, cursor, wholeAsToken])
 
   const suggestions = useMemo(() => {
-    if (disabled || !open || dict.status !== 'ready' || !tokenInfo.token) return []
+    if (off || !open || dict.status !== 'ready' || !tokenInfo.token) return []
     return findSuggestions(tokenInfo.token, {
       entries: dict.entries,
       tagKeys: dict.tagKeys,
@@ -76,7 +85,7 @@ export function useTagSuggest({
       reverse: dict.reverse,
     })
   }, [
-    disabled, open, tokenInfo.token,
+    off, open, tokenInfo.token,
     dict.status, dict.entries, dict.tagKeys, dict.compactedKeys, dict.reverse,
   ])
 
@@ -98,7 +107,7 @@ export function useTagSuggest({
   }
 
   const handleKeyDown = (e: React.KeyboardEvent): boolean => {
-    if (disabled) return false
+    if (off) return false
     if (!open || suggestions.length === 0) return false
     if (e.key === 'ArrowDown') {
       e.preventDefault(); setActiveIdx((activeIdx + 1) % suggestions.length); return true
@@ -120,10 +129,13 @@ export function useTagSuggest({
     open, suggestions, activeIdx, setActiveIdx, setOpen,
     cursor,
     handleKeyDown,
-    notifyChange: () => { syncCursor(); if (!disabled) setOpen(true) },
-    notifyFocus: () => { syncCursor(); if (!disabled) setOpen(true) },
+    notifyChange: () => { syncCursor(); if (!off) setOpen(true) },
+    // focus 只跟踪 cursor：候选只在输入变化后弹出，点进 prompt 中间不该弹
+    notifyFocus: () => { syncCursor() },
     // 100ms 延迟：给 onMouseDown(pick) 时间完成；用户切到别处不会卡 popover
     notifyBlur: () => { setTimeout(() => setOpen(false), 120) },
+    // 鼠标点击 = 用户在挪光标，不是在补全 → 关掉候选
+    notifyClick: () => { syncCursor(); setOpen(false) },
     notifySelect: () => { syncCursor() },
     pickAt,
   }

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -924,6 +924,7 @@
       "uploadLabel": "Custom dictionary",
       "uploadHint": "CSV / TXT format: one line per `english_tag,zh1 zh2`. Replaces (not merges) the current dictionary. Max 10MB / 200k entries.",
       "resetButton": "Restore default dictionary",
+      "resetBusy": "Downloading…",
       "resetHint": "Re-download the ffdkj Danbooru tag Chinese translation table from GitHub (~30MB, top 200k tags by popularity, updated daily)",
       "confirmReset": "Restore default dictionary? The current one will be overwritten.",
       "resetOk": "Default dictionary restored",
@@ -931,7 +932,9 @@
       "uploadOk": "Loaded {{name}}",
       "uploadFail": "Upload failed",
       "showToggleLabel": "Show translations on chips",
-      "showToggleHint": "Display English + Chinese on tag chips. UI-only — does not modify caption data."
+      "showToggleHint": "Display English + Chinese on tag chips. UI-only — does not modify caption data.",
+      "autocompleteToggleLabel": "Tag autocomplete while typing",
+      "autocompleteToggleHint": "Pop up completion candidates (from this dictionary) while typing in prompt / tag inputs. Turning this off disables the popup in all inputs."
     },
     "modelSource": "Model download source",
     "evalMetricModels": "Eval metric models",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -924,6 +924,7 @@
       "uploadLabel": "自定义词典",
       "uploadHint": "CSV / TXT 格式：每行 `english_tag,中文1 中文2`。上传后替换当前词典（不合并）。最大 10MB / 20 万条。",
       "resetButton": "恢复默认词典",
+      "resetBusy": "下载中…",
       "resetHint": "从 GitHub 重新下载 ffdkj Danbooru 标签中文翻译表（约 30MB，收录热度前 20 万条，每日更新）",
       "confirmReset": "恢复默认词典？当前词典会被覆盖。",
       "resetOk": "已恢复默认词典",
@@ -931,7 +932,9 @@
       "uploadOk": "已加载 {{name}}",
       "uploadFail": "上传失败",
       "showToggleLabel": "在 chip 上显示翻译",
-      "showToggleHint": "tag chip 上显示英文 + 中文，便于扫读。仅前端显示，不改 caption 数据。"
+      "showToggleHint": "tag chip 上显示英文 + 中文，便于扫读。仅前端显示，不改 caption 数据。",
+      "autocompleteToggleLabel": "输入时自动补全 tag",
+      "autocompleteToggleHint": "在 prompt / tag 输入框输入时弹出候选补全（基于本词典）。关闭后所有页面的输入框都不再弹出候选。"
     },
     "modelSource": "模型下载源",
     "evalMetricModels": "评估指标模型",

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -1381,6 +1381,7 @@ function ExcludeTags({
                 addCustom()
               }
             }}
+            onClick={() => suggest.notifyClick()}
             onFocus={() => suggest.notifyFocus()}
             onBlur={() => suggest.notifyBlur()}
             placeholder={t('reg.excludePlaceholder')}

--- a/studio/web/src/pages/tools/generate/NegPromptInput.tsx
+++ b/studio/web/src/pages/tools/generate/NegPromptInput.tsx
@@ -37,7 +37,7 @@ export default function NegPromptInput({ value, onChange }: {
         onChange={(e) => { onChange(e.target.value); suggest.notifyChange() }}
         onKeyDown={(e) => { suggest.handleKeyDown(e) }}
         onKeyUp={() => suggest.notifySelect()}
-        onClick={() => suggest.notifySelect()}
+        onClick={() => suggest.notifyClick()}
         onFocus={() => suggest.notifyFocus()}
         onBlur={() => suggest.notifyBlur()}
       />

--- a/studio/web/src/pages/tools/generate/PromptList.tsx
+++ b/studio/web/src/pages/tools/generate/PromptList.tsx
@@ -47,7 +47,7 @@ export default function PromptList({ prompts, onChange }: {
         onChange={(e) => { onChange([e.target.value]); suggest.notifyChange() }}
         onKeyDown={(e) => { suggest.handleKeyDown(e) }}
         onKeyUp={() => suggest.notifySelect()}
-        onClick={() => suggest.notifySelect()}
+        onClick={() => suggest.notifyClick()}
         onFocus={() => suggest.notifyFocus()}
         onBlur={() => suggest.notifyBlur()}
         placeholder={t('generate.positivePlaceholder')}

--- a/studio/web/src/pages/tools/settings/sections.tsx
+++ b/studio/web/src/pages/tools/settings/sections.tsx
@@ -14,6 +14,7 @@ import {
 import { useDialog } from '../../../components/Dialog'
 import { InfoButton } from '../../../components/InfoButton'
 import PathPicker from '../../../components/PathPicker'
+import { useTagAutocompleteEnabled } from '../../../tagDict/autocompleteToggle'
 import { useShowTagTranslation } from '../../../tagDict/showToggle'
 import { useTagDict, reloadDict } from '../../../tagDict/store'
 import { useToast } from '../../../components/Toast'
@@ -495,9 +496,15 @@ export function TagDictionarySection() {
   const { toast } = useToast()
   const dialog = useDialog()
   const dict = useTagDict()
+  const { runSave } = useSettingsData()
   const [show, setShow] = useShowTagTranslation()
+  const [acEnabled, setAcEnabled] = useTagAutocompleteEnabled()
   const [busy, setBusy] = useState<null | 'reset' | 'upload'>(null)
   const fileRef = useRef<HTMLInputElement>(null)
+
+  // localStorage 即时设置也包一层 runSave：驱动右上角「已保存」指示，反馈跟
+  // 其他 instant-apply 设置一致（fn 同步落盘，不会失败）。
+  const applyLocal = (fn: () => void) => { void runSave(async () => { fn() }) }
 
   const meta = dict.meta
   const sourceLabel = meta?.kind === 'default'
@@ -585,7 +592,7 @@ export function TagDictionarySection() {
             className="btn btn-secondary btn-sm"
             title={t('settings.tagDictionary.resetHint')}
           >
-            {busy === 'reset' ? t('common.downloading') : t('settings.tagDictionary.resetButton')}
+            {busy === 'reset' ? t('settings.tagDictionary.resetBusy') : t('settings.tagDictionary.resetButton')}
           </button>
         </div>
       </SettingsField>
@@ -594,7 +601,14 @@ export function TagDictionarySection() {
         label={t('settings.tagDictionary.showToggleLabel')}
         desc={t('settings.tagDictionary.showToggleHint')}
       >
-        <Bool value={show} onChange={setShow} />
+        <Bool value={show} onChange={(v) => applyLocal(() => setShow(v))} />
+      </SettingsField>
+
+      <SettingsField
+        label={t('settings.tagDictionary.autocompleteToggleLabel')}
+        desc={t('settings.tagDictionary.autocompleteToggleHint')}
+      >
+        <Bool value={acEnabled} onChange={(v) => applyLocal(() => setAcEnabled(v))} />
       </SettingsField>
     </SettingsSection>
   )

--- a/studio/web/src/tagDict/autocompleteToggle.ts
+++ b/studio/web/src/tagDict/autocompleteToggle.ts
@@ -1,0 +1,30 @@
+/** 全局 toggle：tag 输入框是否启用 autocomplete 候选弹出。默认开。
+ *
+ * 实现走 localStorage + 模块级 subscribers，跟 showToggle.ts 同风格（裸 KV + try-catch）。
+ * 所有 autocomplete 入口（useTagSuggest）订阅此开关，Settings 里关掉即全站生效。
+ */
+import { useSyncExternalStore } from 'react'
+
+const STORAGE_KEY = 'studio.tag.autocomplete'
+
+const listeners = new Set<() => void>()
+
+function compute(): boolean {
+  // 没设过 = 开（默认打开，只有显式 '0' 才关）
+  try { return localStorage.getItem(STORAGE_KEY) !== '0' } catch { return true }
+}
+
+function subscribe(l: () => void): () => void {
+  listeners.add(l)
+  return () => { listeners.delete(l) }
+}
+
+/** 给 React 组件订阅：返回 [enabled, setEnabled]。 */
+export function useTagAutocompleteEnabled(): [boolean, (next: boolean) => void] {
+  const value = useSyncExternalStore(subscribe, compute, compute)
+  const setter = (next: boolean) => {
+    try { localStorage.setItem(STORAGE_KEY, next ? '1' : '0') } catch { /* ignore */ }
+    listeners.forEach((l) => l())
+  }
+  return [value, setter]
+}


### PR DESCRIPTION
## 背景 / 动机

各页面 tag 输入框的 autocomplete 原来在聚焦 / 点击时就弹候选：鼠标点进 prompt 中间挪个光标也会弹出一屏 popover，挡住正在读的内容；且没有任何办法全局关掉。

## 改动概要

**弹出规则收紧（`useTagSuggest.ts`，全部输入框统一生效）**

- 候选只在 value onChange 后弹出；`notifyFocus` 只跟踪光标不再弹出
- 新增 `notifyClick`：候选已弹出时鼠标点击输入框（挪光标）→ 立即关闭；点击页面其他位置仍走原有 blur 延迟关闭
- 键盘行为不变（↑↓/Tab/Enter 选中、Escape 关闭、左右移动光标照常刷新候选）；候选列表点选走 `onMouseDown` + `preventDefault`，不受 click-close 影响
- 6 处调用方接线：Generate 正/负 prompt、TagEditor（chip draft + text 两模式）、TagsInput、正则化排除 tag、Tag 统计重命名

**全局开关（默认开）**

- 新模块 `tagDict/autocompleteToggle.ts`：localStorage + 模块级订阅，与 `showToggle.ts` 同风格；`useTagSuggest` 内部订阅，Settings 一处关全站生效
- Settings「Tag 翻译词典」区新增「输入时自动补全 tag」开关（zh/en 词条已补）

**顺带修复（同区两个反馈问题）**

- 词典区两个前端开关（chip 翻译 / autocomplete）接入 `runSave`，变更时右上角出「已保存」指示，与其他 instant-apply 设置反馈一致
- 「恢复默认词典」按钮 busy 态引用了不存在的 `t('common.downloading')`（渲染 raw key），改为新增的 `settings.tagDictionary.resetBusy`

## 测试方式

- 新增 `useTagSuggest.test.tsx` 5 条行为测试：点击不弹 / 输入才弹 / 点击关闭 / 开关关闭后输入也不弹 / 鼠标点选候选仍生效
- `npx vitest run` 全量 488 过；`npm run build`（lint + tsc -b + vite）过
- 手测（serve-dist）：Generate prompt、打标页、Settings 开关与保存指示均按预期

🤖 Generated with [Claude Code](https://claude.com/claude-code)