### PR TITLE
docs(design): 多模型支持设计文档（Krea 2 作为第二模型族）

### DIFF
--- a/docs/design/multi-model/00-decisions.md
+++ b/docs/design/multi-model/00-decisions.md
@@ -1,0 +1,83 @@
+# 多模型支持：决策记录（Krea 2 为首个第二模型族）
+
+- 状态：已确认决策的记录。架构细化（目录结构 / 代码归属 / 接口冻结面）由同目录三份视角文档深化，最终在 `04-synthesis.md` 收敛。
+- 日期：2026-07-13
+- 相关：`01-code-layout.md`（代码归属视角）、`02-ecosystem-survey.md`（训练器生态对标）、`03-interface-evolution.md`（接口契约与演化压力测试）
+
+## 1. 背景与目标
+
+训练器目前只支持 Anima 一个模型族，全链路对其硬编码。本次引入 Krea 2（下称 K2）作为第二个模型族，并借此机会建立能支撑未来更多模型族的架构。本文只记录已确认决策；未确认事项全部收在 §7 Open Questions。
+
+## 2. Krea 2 档案（训练视角）
+
+| 组件 | 内容 |
+|---|---|
+| 主干 | 12.9B 单流 MMDiT：28 blocks、width 6144、GQA（48Q/12KV）+ gated sigmoid attention、QKNorm、zero-center RMSNorm、SwiGLU 4x、3D axial RoPE |
+| 训练目标 | rectified flow / v-parameterization（与 Anima 同族） |
+| Timestep shift | 分辨率感知动态 shift（base_shift 0.5 → max_shift 1.15，按 image_seq_len 插值）；1024px 约等效 discrete shift 2.5（musubi 推荐值） |
+| 文本条件 | Qwen3-VL-4B-Instruct，取 12 个中间层堆叠 `(B, 512, 12, 2560)`，融合层在 DiT 权重内；max_seq_len 512；自然语言 prompt，非 tag 生态 |
+| VAE | Qwen-Image VAE（f8、16ch），**与 Anima 完全同款、归一化统计一致**；patch=2 → align 16 也与 Anima 一致 |
+| 权重 | `krea/Krea-2-Raw`（训练用）+ Turbo（TDM 蒸馏 8 步，推理/验证用）；guidance 约定 `cond + g·(cond−uncond)` |
+| 许可 | 社区许可：年营收 <$1M 且 <50 席位免费商用，明确允许 LoRA 训练；部署方有内容安全义务 |
+| 参考实现 | diffusers v0.39 `Krea2Pipeline`/`Krea2Transformer2DModel`；kohya musubi-tuner 实验性支持（fp8_scaled + blocks_to_swap≤26、默认 target 全部 264 个 Linear、dim32/alpha32、`krea2_shift` 分辨率感知 timestep 采样） |
+
+## 3. 现状关键事实（2026-07-13 勘察）
+
+- 无任何模型族抽象层；`TrainingConfig` 无 arch 字段，仅 4 个权重路径字段（默认指向 Anima）。
+- 模型结构靠 `load_anima_model` 从 checkpoint 张量形状推断（`runtime/training/models.py:397-427`，只认 2048/5120 两档）。
+- `forward_with_optional_checkpoint`（`runtime/training/model_loading.py:33-59`）与 `navit.py` 直接调用 DiT 内部 API（`prepare_embedded_sequence`/`blocks`/`final_layer`/`unpatchify`）。
+- LoRA target 写死在 `utils/lokr_preset.py:ANIMA_PRESET`。
+- `sample_image`（`runtime/training/sampling.py`）为 Comfy KSampler parity：er_sde/dpmpp_3m_sde、shift=3.0、CONST flow。
+- 文本条件每步在线编码（Qwen3-0.6B 末层 + T5 IDs 进 LLMAdapter），**无文本缓存**。
+- 隐患：latent npz 缓存无模型/VAE 指纹（`dataset.py:_is_cache_valid`，换 VAE 同桶尺寸会静默复用错 latent）；`z_dim=16 / stride 8 / patch 2` 散落 ≥8 处无单一来源；前端 `anima_main`/`selected_anima` 固化单模型假设。
+- 已有 7 套 plugin registry（optimizer/scheduler/loss/timestep_sampler/inference_sampler/adapter/eval），均非架构级——但证明 registry 文化已就位。
+
+## 4. 已确认决策
+
+| # | 决策 | 备注 |
+|---|---|---|
+| D1 | 采用 **ModelFamily 适配层 + registry**（路线 A） | 否决「按模型分训练脚本」（loop 功能维护 ×2）与「外挂 musubi 当后端」（产品一致性）；musubi 仅作 Phase 0 验证工具 |
+| D2 | **显存基建（fp8 / block swap）搁置**；K2 支持下限 = 32GB（bf16） | 24GB 数学上不可行（bf16 权重 ~25.8GB）；未来要下探 24GB 的唯一解锁是 fp8_scaled |
+| D3 | K2 文本条件走 **varlen 预缓存**（只存非 padding token；失效键 = caption 内容 hash + TE 指纹） | K2 是自然语言 prompt 模型，tag shuffle/dropout/keep_tokens 对它语义不适用 → 门控关闭，非功能损失。Anima 维持每步在线编码不变 |
+| D4 | `model_family` 落在**训练版本级** | 同一项目可并存 Anima/K2 版本，数据集与打标共享 |
+| D5 | K2 v1 能力集 = 核心循环 + masked loss + latent/text 缓存 + 训练中采样 | NaViT / SRA / LeapAlign / torch.compile 分块编译 = Anima-only 门控（family 声明能力集 + 复用 `show_when` 裁剪机制）；后续按需逐个开放 |
+| D6 | latent 指纹：Anima 与 K2 同为 `wan21-f8c16` → **latent 缓存跨族共享** | 同一数据集两边训不重算 |
+| D7 | schema：新增 `model_family`（默认 `anima`，老配置零迁移）；`transformer_path/vae_path/text_encoder_path` 三字段跨族复用；`t5_tokenizer_path` 转 Anima-only `show_when` | K2 的 vae_path 指向同一个 Qwen-Image VAE 文件，无需新下载 |
+| D8 | 派发点：supervisor/cmd_builder 不动，入口脚本不变，`phases/models.py` 按 `model_family` 查 registry | |
+| D9 | K2 数据集打标推荐链路 = LLM tagger 自然语言 caption | WD14 tag 链路机制上仍可用但非推荐；trigger word 前置继续有效 |
+
+## 5. 分阶段计划
+
+- **Phase 0 — 验证（不写代码）**：musubi-tuner 手动训一个 K2 LoRA。产出：32GB Windows（WDDM）真实显存峰值、速度、质量、Comfy 推理链路核对。若撞显存崖，最小兜底为 K2 专属小规模 block swap，而非整套显存基建。
+- **Phase 1 — 纯重构（对 Anima 零行为变化）**：
+  - PR-1：散落的 z_dim/stride/patch 收敛进 ModelSpec + latent npz 缓存加指纹与 layout 版本（现存隐患，独立价值）。
+  - PR-2：ModelFamily registry + AnimaFamily 包住现有 loader/forward/sampler；`forward_with_optional_checkpoint`/`navit.py` 移入 AnimaFamily。
+  - PR-3：schema 加 `model_family` + 能力集门控管道。
+  - PR-4：studio 侧 `ModelsConfig`/catalog 把 `selected_anima` 泛化为 per-family。
+- **Phase 2 — 文本缓存基建**（varlen 格式、缓存阶段接入 phases）。
+- **Phase 3 — Krea2Family**：modeling 移植（diffusers + musubi 双参考）、加载器、FlowMatchEuler 动态 shift 采样、KREA2_PRESET、下载 catalog（Krea-2-Raw + Turbo + Qwen3-VL-4B）。
+- **Phase 4 — UI**：版本级模型族选择、Settings 下载卡、Generate 页接入。
+
+## 6. ModelFamily 接缝草案（待三份视角文档压力测试后冻结）
+
+1. **ModelSpec（声明式常量）**：latent 规格（z_dim/stride/patch/归一化/指纹）、文本规格（seq_len/缓存策略/embed 形状）、默认值 overlay（shift/sampler 白名单/采样默认）、能力集。
+2. **ModelFamily 适配器（行为）**：`load_dit / load_text / load_vae`、`encode_text`、`forward_train(model, noisy, t, cond) → v_pred`（梯度检查点为 family 内部职责）、`lora_preset()`、`build_sampler()`。
+3. **共享循环边界**：凡只消费 `(latents, noise, t, loss, mask)` 的功能（InfoNoise、masked loss、losses、noise offsets、optimizer/scheduler、LoRA/LoKr 等算法）留在共享循环，零修改。
+4. **派发**：`phases/models.py` 查 registry；registry 模式与现有 7 套 plugin registry 同款。
+
+## 7. Open Questions
+
+- 目录结构与代码归属（→ `01-code-layout.md`）：modeling/ 多族布局、runtime 入口与姊妹脚本、utils/ 归属（含此前延后的 utils 重构方案如何衔接）、exec-load 与 `find_diffusion_pipe_root` 机制去留。
+- 生态对标启示（→ `02-ecosystem-survey.md`）：kohya/musubi、diffusers、ai-toolkit、OneTrainer、SimpleTuner、diffusion-pipe 的多模型切分方式与反模式。
+- 接口冻结面与演化（→ `03-interface-evolution.md`）：接口 v1 冻结哪些方法、预留哪些扩展点、明确不抽象什么；用未来候选模型压力测试。
+- 入口脚本 `anima_train.py` 是否改名/泛化（涉及 supervisor cmd_builder 与文档）。
+- text cache 的存放位置与文件格式细节（sidecar vs 集中缓存目录）。
+- Comfy 侧 K2 LoRA 键名约定核对（musubi 产物 vs ComfyUI 加载，决定我们的保存格式）。
+- 32GB Windows WDDM 实测余量（Phase 0 产出）。
+
+## 8. 参考
+
+- Krea 2 Technical Report: https://www.krea.ai/blog/krea-2-technical-report
+- diffusers Krea2Pipeline: https://huggingface.co/docs/diffusers/api/pipelines/krea2
+- musubi-tuner K2 文档: https://github.com/kohya-ss/musubi-tuner/blob/main/docs/krea2.md
+- Krea 2 商业许可: https://www.krea.ai/krea-2-commercial-license

--- a/docs/design/multi-model/01-code-layout.md
+++ b/docs/design/multi-model/01-code-layout.md
@@ -1,0 +1,406 @@
+# 多模型支持 · 01 目录结构与代码归属（视角一）
+
+- 状态：设计稿，供 `04-synthesis.md` 收敛。
+- 日期：2026-07-13
+- 前置阅读：[`00-decisions.md`](00-decisions.md)（K2 档案、已锁定决策 D1-D9、分阶段计划）。本文不推翻任何已锁定决策，只在其框架内回答「代码放哪里」。
+- 姊妹视角：`02-ecosystem-survey.md`（生态对标）、`03-interface-evolution.md`（接口冻结面）。接口的**方法签名**归 03，本文只定**文件归属**；两者边界在 §4.3 说明。
+
+## TL;DR
+
+- **推荐按层切（方案 A）**：`modeling/<family>/` 放结构定义、`runtime/training/families/<family>/` 放行为适配（ModelFamily 实现，即 D1 的适配层）、`studio/services/models/families/<family>.py` 放资产清单。族名字符串（`anima` / `krea2`）是贯穿三层的唯一 join key，由 `validate_schema_consistency` 模式（与既有 7 套 plugin registry 同款）在启动期锁一致。否决按族切自包含包：一个族横跨「有 torch 的训练子进程」与「无 torch 的 studio server」两种运行时，塞进一个包要么全 lazy import 要么拆两半，等于退化回按层切但丢了依赖方向卫生（`modeling → utils → runtime → studio`，`docs/AGENTS.md` §3.1）。
+- **加第 3 个模型族** = 新建约 8 个文件（三层各一个目录/文件）+ 4 处一行式注册（runtime registry、studio registry、schema Literal、能力集默认值），共享循环（masked loss / InfoNoise / losses / optimizer / eval）**零修改**。
+- **入口脚本不改名**（D8 已锁定）。`anima_` 前缀解释为产品名（Anima LoRA Studio）而非模型族限定，文档口径统一；未来若要改名的完整成本清单收录在 §5.2 备查。
+- **exec-load 退役，改正常 import**。该机制是外部 diffusion-pipe checkout 时代的遗产（初始 commit `c6bd6b64` 即有；PR #303 移入 `modeling/` 后仅把新位置加到候选最前）。今天它的唯一现实产出是「双模块身份」病：attention backend 全局开关要跨至多 6 个模块别名传播（`runtime/training/model_loading.py:81-88`、`runtime/training/models.py:365-368`），多一族别名矩阵翻倍。`find_diffusion_pipe_root` 函数名保留（sister script 契约「可加不可减」），实现塌缩为常量 shim。
+- **utils/**：算法（族无关）与 preset（族相关）分离——`ANIMA_PRESET` 迁入 `families/anima/preset.py`，`AnimaLycorisAdapter` 改为 preset 注入参数并更名 `LycorisAdapter`。与此前延后的「utils 完整重构方案」（lora/ 顶层包 + 4 helper + optimizer 拍扁）是**衔接关系、非前置非取代**，仅修订其中一项：preset 不再进 lora/ 包私有文件，归 families/。
+- **磁盘模型目录不按族分**。维持 `models_root/{diffusion_models,vae,text_encoders,...}` 按资产类型组织：D6/D7 决定了 VAE 与 latent 缓存本来就是跨族共享资产，按族分目录会制造重复下载；唯一冲突点是 `text_encoders/` 扁平布局，新增族的 TE 一律落 `text_encoders/<safe_dir_name(repo)>/` 子目录，Anima 存量扁平布局保留识别、不迁移。
+- **最大争议点**：`modeling/` 是否随本次改造把 Anima 文件下沉到 `modeling/anima/`（本文推荐做，随 exec-load 退役同刀，PR-2a）。不做的话 K2 文件与 Anima 文件在 `modeling/` 根目录混排（kohya 式扁平），机制上无害但每加一族根目录多 2-3 个文件、`find_diffusion_pipe_root` 锚点文件名也无法退役。退让方案在 §4.4 备查。
+
+---
+
+## 1. 范围与前提
+
+本文回答 `00-decisions.md` §7 第一条 open question：modeling/ 多族布局、runtime 入口与姊妹脚本、utils/ 归属（含延后的 utils 重构衔接）、exec-load 与 `find_diffusion_pipe_root` 去留，外加 studio 侧 `services/models/` 的 per-family 化与磁盘目录、测试布局、迁移步骤。
+
+约束（来自已锁定决策）：
+
+| 决策 | 对本文的约束 |
+|---|---|
+| D1 ModelFamily 适配层 + registry | 必须存在一个「族适配器」的物理居所；registry 形态对齐既有 7 套 plugin registry |
+| D5 K2 v1 能力集裁剪 | NaViT / SRA / LeapAlign 是 Anima-only 代码，归属必须体现这一点 |
+| D6 latent 缓存跨族共享 | VAE 结构代码与磁盘 VAE 权重不能被划成 Anima 专属 |
+| D7 三路径字段跨族复用 | `TrainingConfig` 的路径字段不拆 per-family 命名 |
+| D8 supervisor/cmd_builder 不动、入口脚本不变 | §5 只在「不改名」前提下讨论语义表达 |
+| §6 接缝草案 | ModelSpec（声明）与 ModelFamily（行为）分开，本文给它们各自的文件位置 |
+
+---
+
+## 2. 现状代码归属地图（2026-07-13 勘察）
+
+按五个区域列出每个文件的多族判定。行数为当前实测。
+
+### 2.1 `modeling/` — 结构定义层（无上游依赖，只 torch/einops）
+
+| 文件 | 行数 | 判定 | 依据 |
+|---|---|---|---|
+| `modeling/anima_modeling.py` | 257 | Anima 专属 | Anima DiT / LLMAdapter 包装层 |
+| `modeling/cosmos_predict2_modeling.py` | 2068 | Anima 专属 | Anima 的 Cosmos 主干；且是 attention backend 状态机的 owner（`modeling/cosmos_predict2_modeling.py:38` 自述「本模块是 anima_modeling.py 的 owner」），K2 的 MMDiT 与它无共享 |
+| `modeling/wan/vae2_1.py` | 658 | **跨族共享** | D6：Anima 与 K2 同用 Qwen-Image VAE（= Wan2.1 latent 空间） |
+
+历史：PR #303（commit `3e9160e5`，2026-06-21）把这三个文件从 `models/` git mv 到 `modeling/`，确立依赖方向 `modeling → utils → runtime → studio → tools`。`modeling/` 无 `__init__.py`，靠 namespace package + repo root 在 sys.path 上被正常 import（测试即如此：`tests/test_navit_packed_objective.py:17`）。
+
+### 2.2 `runtime/` 入口脚本
+
+| 文件 | 行数 | 判定 |
+|---|---|---|
+| `runtime/anima_train.py` | 140 | 共享编排壳。main() 只调 6 个 phase（`runtime/anima_train.py:118-136`）；顶部 re-export 段（`runtime/anima_train.py:58-111`）是 sister script 契约层 |
+| `runtime/anima_daemon.py` | 1036 | 共享壳 + Anima 加载调用。经 `import anima_train as _T` 取 `find_diffusion_pipe_root` / `load_anima_model` 等（`runtime/anima_daemon.py:246,299`） |
+| `runtime/anima_generate.py` | 411 | 同上（`runtime/anima_generate.py:136`） |
+| `runtime/anima_reg_ai.py` | 519 | 同上（`runtime/anima_reg_ai.py:426`） |
+| `runtime/train_monitor.py` | 214 | 共享（无族耦合，名字也无前缀） |
+
+Sister script 契约（`docs/AGENTS.md` §3.2）：7 个名字 `find_diffusion_pipe_root / load_anima_model / load_vae / load_text_encoders / sample_image / enable_xformers / resolve_path_best_effort` 在 `anima_train.py` 顶层 re-export，「可加不可减不可改签名」，`tests/test_anima_generate_xy.py` 捕获破坏。
+
+### 2.3 `runtime/training/` 子包
+
+| 文件 | 行数 | 判定 | 关键耦合点 |
+|---|---|---|---|
+| `loop.py` | 784 | **共享循环** | 但模块级 import Anima 专属件：`loop.py:21-31`（leap、navit、`forward_with_optional_checkpoint`）；每步在线文本编码 `loop.py:229-236`（encode_qwen + T5）；masked loss reduction `loop.py:111-127` 与 timestep_sampler 派发 `loop.py:256-258` 是族无关的 |
+| `context.py` / `phases/`（6 个） | 206 + ~920 | 共享 | 派发点 `phases/models.py:33-84`：find root → `load_anima_model` → `load_vae` → `load_text_encoders`；SRA 构造 `phases/models.py:99-117` 是 Anima 专属段 |
+| `models.py` | 524 | **混居，待拆** | `load_anima_model`（形状推断只认 2048/5120，`models.py:397-427`）+ `load_text_encoders`（Qwen3-0.6B + T5，`models.py:481-524`）Anima 专属；`VAEWrapper` + `load_vae`（`models.py:34-478`，含 z_dim=16 硬编码 `models.py:284`、归一化统计 `models.py:468-475`）跨族共享（D6） |
+| `model_loading.py` | 314 | **混居，待拆** | checkpoint 前缀推断 / 容错加载（`model_loading.py:170-314`）族无关；`forward_with_optional_checkpoint`（`model_loading.py:33-59`，直调 `prepare_embedded_sequence`/`blocks`/`final_layer`/`unpatchify`）Anima 专属；`find_diffusion_pipe_root`（`model_loading.py:125-154`）与 exec-load（`model_loading.py:157-163`）见 §6 |
+| `text_encoding.py` | 382 | Anima 专属 | encode_qwen（Qwen3-0.6B 末层）+ T5 加权 tokenize + Comfy conditioning；K2 文本路径完全不同（Qwen3-VL-4B 12 中间层堆叠 + varlen 预缓存，D3） |
+| `comfy_qwen.py` | 334 | Anima 专属 | ComfyUI parity 的 Qwen3-0.6B standalone encoder |
+| `sampling.py` | 472 | Anima 专属 | Comfy KSampler parity 的 `sample_image`（er_sde/dpmpp_3m_sde、CONST flow、`sampling.py:33` 白名单）；K2 走 FlowMatchEuler 动态 shift |
+| `navit.py` / `leap.py` / `sra_align.py` | 160/416/259 | Anima 专属 | D5 明文列为 Anima-only 门控 |
+| `dataset.py` | 1591 | 共享 | z_dim/stride/patch 散点待 PR-1 收敛进 ModelSpec |
+| `noise.py` / `loss_weighting.py` / `timestep_sampling.py` / `state.py` / `snapshot.py` / `observability.py` / `sample_runner.py` / `bootstrap.py` / `cli.py` | — | 共享 | 只消费 `(latents, noise, t, loss, mask)` 或与模型无关（§6.3 边界） |
+| 7 套 plugin registry（`adapters/ optimizers/ schedulers/ inference_samplers/ timestep_samplers/ losses/` + studio 侧 eval） | — | 共享 | families/ 将成为第 8 套，且是首个架构级 registry |
+
+### 2.4 `utils/`
+
+| 文件 | 行数 | 判定 |
+|---|---|---|
+| `lycoris_adapter.py` | 542 | 算法族无关，但两处 Anima 耦合：模块级 `from utils.lokr_preset import apply as apply_anima_preset`（`utils/lycoris_adapter.py:27`）+ `inject()` 内 `apply_anima_preset(LycorisNetwork)`（`utils/lycoris_adapter.py:95`）；类名 `AnimaLycorisAdapter` 本身即族名 |
+| `lokr_preset.py` | 34 | **Anima 专属**（`ANIMA_PRESET`，`utils/lokr_preset.py:14-26`：target_name 通配、排除 `llm_adapter*`、`lora_prefix="lora_unet"`） |
+| `lycoris_patch.py` / `optimizer_utils.py` / `soap_optimizer.py` / `ortho_adapter.py` / `caption_utils.py` | 110/1796/708/391/301 | 族无关，本次不动 |
+
+### 2.5 `studio/`
+
+| 位置 | 判定 |
+|---|---|
+| `studio/services/models/paths.py`（443 行） | 混居：`ANIMA_REPO/ANIMA_VARIANTS/ANIMA_VAE_PATH/QWEN_*/T5_*`（`paths.py:22-52`）+ 4 个 target 函数（`paths.py:246-263`）+ `selected_anima` 解析三件套（`paths.py:355-402`）+ `default_paths_for_new_version`（`paths.py:427-443`）是 Anima 族资产；`models_root/safe_dir_name`（`paths.py:218-243`）与工具模型（WD14/CLTagger/upscaler/eval/taeflux，`paths.py:54-212,266-337`）族无关——**工具模型不是模型族，不参与 per-family 化** |
+| `studio/services/models/catalog.py`（336）/ `downloader.py`（564）/ `sources.py`（370） | 消费 paths 常量，随 registry 化改遍历 |
+| `studio/infrastructure/secrets.py:490-514` | `ModelsConfig.selected_anima: str = "1.0"` 单模型假设，PR-4 泛化 |
+| `studio/domain/training.py:38-57` | 4 个权重路径字段（默认值指向 Anima）；D7 已定跨族复用 + `t5_tokenizer_path` 转 Anima-only show_when |
+| `studio/supervisor/cmd_builder.py:49-53` | 按 task_type 选脚本，D8 锁定不动 |
+| `studio/services/inference/daemon.py:48` / `studio/services/eval_samples.py:546,590` | 引用 `anima_daemon.py` 路径 / `import anima_train as _T`，随 §5 不改名而不动 |
+
+---
+
+## 3. 核心抉择：per-family 代码怎么切
+
+### 3.1 候选方案
+
+**方案 A — 按层切**：保持现有四层（modeling / runtime/training / utils / studio），每层内为族开子目录或子文件；族的「行为聚合点」是 `runtime/training/families/<fam>/`，即 D1 的 ModelFamily 适配器所在地。结构定义与资产清单按层留在原地。
+
+**方案 B — 按族切**：顶层 `families/anima/`、`families/krea2/` 自包含包，一个族的 modeling + 加载 + 采样 + preset + 下载清单全在一个包里；共享循环 / registry 单独成 `core/`（或留 `runtime/training/`）。
+
+**方案 C — 混合**：方案 A 的骨架 + 一条强纪律：「一个族 = 三层各一个同名单元」，族名字符串是唯一 join key，启动期校验三处对齐。——实践中 C 就是 A 的严格化，下表把 C 并入 A 评估，差异只在纪律是否落进校验代码（本文推荐落）。
+
+### 3.2 对比
+
+| 维度 | A/C 按层切（推荐） | B 按族切 |
+|---|---|---|
+| **加第 3 个模型族** | 新建 ~8 文件：`modeling/<fam>/`（1-2）、`runtime/training/families/<fam>/`（4-6）、`studio/services/models/families/<fam>.py`（1）；修改 4 处一行注册（两个 registry `__init__`、schema `model_family` Literal、能力集默认值表）。共享循环 0 修改 | 新建 1 个自包含包（文件数相近）+ 1-2 处注册。表面更整洁 |
+| **共享循环功能演进**（masked loss / InfoNoise / eval / 新 loss） | 单点：`loop.py` / `losses/` / `timestep_samplers/` / studio eval 各改一处，所有族自动获得（只要功能停留在 §6.3 边界内）。族目录零触碰 | 取决于纪律：族包若只含适配器则同左；但自包含包天然诱导把 step 逻辑吸进族包，一旦发生就是 N 份漂移——这正是 D1 否决「按模型分训练脚本」时点名的维护 ×2 风险的回潮通道 |
+| **import 与打包机制** | 维持现状：无 pip 打包、入口注入 sys.path（`runtime/anima_train.py:34-38`、`tests/conftest.py:19-20`）、`modeling → utils → runtime → studio` 单向依赖不变。studio 侧族文件保持无 torch（`paths.py` 现在就是纯路径计算，被 server 启动路径同步调用） | 族包同时被「torch 训练子进程」与「无 torch 的 FastAPI server」import。要么包内全部 lazy import（脆弱、易被一行顶层 import 打破），要么包内再分 `runtime 半区 / studio 半区`——那就是按层切套了一层壳，还把单向依赖变成了双向穿包 |
+| **与 exec-load 机制的兼容 / 演化** | `modeling/` 仍是唯一模型结构代码根；exec-load 退役后 `from modeling.<fam> import ...` 一步到位，`find_diffusion_pipe_root` 收缩成 shim（§6） | 结构代码进族包后「模型代码根目录」概念消失，find root / DIFFUSION_PIPE_ROOT 外部 checkout 兼容必须同刀连根拔，无渐进路径 |
+| **测试布局** | flat `tests/` 不动（CI 全量门禁按 `tests/` 路径收集，见 §9），新文件按命名约定归族 | 要么测试进族包（破坏 CI 收集约定与 conftest sys.path 注入）要么仍 flat（「自包含」名不副实） |
+| **与 D1-D9 / 既有工程文化契合** | D8 派发点 `phases/models.py` 查 registry 直接落地；registry 形态与 7 套 plugin registry 同款（`runtime/training/README.md:59-88` 的「加变体 = 加文件 + 字典一行」文化直接复用） | 也能实现 D1-D8，但 PR-4 的 studio 泛化要跨进族包，依赖方向需要重新立法 + AGENTS.md §3.1 改写 |
+| **风险** | 一个族散在三处，靠命名 + 校验维系整体感；新人找「K2 的全部代码」要看三个目录 | 族内混层导致的 import 事故是运行时才炸（server 启动拉起 torch、显存被 server 进程占用等） |
+
+### 3.3 推荐与理由
+
+**推荐方案 A（含 C 的纪律强化）**。决定性理由按权重排序：
+
+1. **运行时形态**：本项目一个「族」横跨两种进程——训练子进程（torch、独占 GPU）与 studio server（常驻、无 torch、Windows 下要秒启动）。按族切的自包含包在这个前提下不可能真自包含，B 的核心卖点不成立。
+2. **共享循环是本项目的主要资产**（masked loss、InfoNoise、7 套 registry、eval 体系、暂停恢复、观测），D1 的选型逻辑就是保它单点演进。按层切让「共享的留在层里、族有的进族目录」有一条物理防线：任何人往 `families/<fam>/` 提交 step 逻辑在 review 里一眼可见。
+3. **迁移是渐进的**：方案 A 的每一步都是 `git mv` + import 修正，Phase 1「对 Anima 零行为变化」可逐 PR 验证；方案 B 需要一次性重立依赖方向。
+
+「新人找 K2 全部代码要看三处」的缓解：三处目录名严格同名（`anima` / `krea2`），并在 `runtime/training/families/README.md` 放一张「一个族的三个居所」导览表（迁移 PR-2b 附带）。
+
+---
+
+## 4. 目标目录树（推荐方案）
+
+标注：**[不动]** 原地保留；**[git mv]** 整文件移动保历史；**[抽出]** 函数级搬移（源文件保留并瘦身）；**[新建]**；**[Phase 3]** K2 阶段才出现。
+
+### 4.1 全树
+
+```
+modeling/                                    # 层 1：结构定义（只依赖 torch/einops）
+├── __init__.py                              # [新建] 空占位（namespace → regular package）
+├── anima/
+│   ├── __init__.py                          # [新建] re-export Anima / set_attention_backend
+│   ├── anima_modeling.py                    # [git mv] ← modeling/anima_modeling.py
+│   └── cosmos_predict2_modeling.py          # [git mv] ← modeling/cosmos_predict2_modeling.py
+├── krea2/                                   # [Phase 3]
+│   ├── __init__.py
+│   └── krea2_modeling.py                    # diffusers Krea2Transformer2DModel + musubi 双参考移植
+└── wan/
+    ├── __init__.py                          # [新建]
+    └── vae2_1.py                            # [不动] 跨族共享 VAE（D6），不进任何族目录
+
+runtime/
+├── anima_train.py                           # [不动] D8；顶层 re-export 兼容层继续（§5）
+├── anima_generate.py / anima_daemon.py
+│   / anima_reg_ai.py / train_monitor.py     # [不动]
+└── training/
+    ├── loop.py / context.py / dataset.py / noise.py / loss_weighting.py
+    │   / timestep_sampling.py / state.py / snapshot.py / observability.py
+    │   / sample_runner.py / bootstrap.py / cli.py / phases/                 # [不动] 共享循环
+    │                                        #（loop.py / phases/models.py 内部改为经 ctx.family 派发，见 §4.3）
+    ├── models.py                            # [瘦身] 只留 VAEWrapper + load_vae（跨族共享）
+    ├── model_loading.py                     # [瘦身] 只留前缀推断/容错加载/resolve_path/enable_xformers
+    │                                        #  + find_diffusion_pipe_root shim（§6）
+    ├── text_cache.py                        # [Phase 2 新建] varlen 文本缓存共享基建（格式族无关，编码器由 family 提供）
+    ├── adapters/ optimizers/ schedulers/ inference_samplers/
+    │   timestep_samplers/ losses/           # [不动] 7 套 plugin registry
+    │                                        #（inference_samplers/ Phase 3 加 flow_euler.py：solver 实现共享，
+    │                                        #  族只在 ModelSpec overlay 里选默认值与白名单）
+    └── families/                            # [新建] 第 8 套 registry（首个架构级）
+        ├── __init__.py                      # FAMILIES dict + get_family() + validate_schema_consistency()
+        ├── protocol.py                      # ModelFamily Protocol（方法集由 03 冻结）
+        ├── spec.py                          # ModelSpec frozen dataclass（§6.1 声明式常量）
+        ├── README.md                        # 「一个族的三个居所」导览 + 加族步骤
+        ├── anima/
+        │   ├── __init__.py                  # AnimaFamily 组装 + ANIMA_SPEC
+        │   ├── loader.py                    # [抽出] ← models.py 的 load_anima_model / load_text_encoders
+        │   ├── forward.py                   # [抽出] ← model_loading.py 的 forward_with_optional_checkpoint
+        │   ├── text_encoding.py             # [git mv] ← training/text_encoding.py（encode_qwen + T5 加权，见 §4.2）
+        │   ├── comfy_qwen.py                # [git mv] ← training/comfy_qwen.py
+        │   ├── sampling.py                  # [git mv] ← training/sampling.py（Comfy parity sample_image）
+        │   ├── navit.py                     # [git mv] ← training/navit.py（D5 Anima-only）
+        │   ├── leap.py                      # [git mv] ← training/leap.py（D5）
+        │   ├── sra_align.py                 # [git mv] ← training/sra_align.py（D5）
+        │   └── preset.py                    # [抽出] ← utils/lokr_preset.py 的 ANIMA_PRESET（§7）
+        └── krea2/                           # [Phase 3]
+            ├── __init__.py                  # Krea2Family + KREA2_SPEC（分辨率感知动态 shift 参数在 spec overlay）
+            ├── loader.py                    # Krea-2-Raw 加载 + fp8/block-swap 兜底挂点（D2 搁置，仅留位置）
+            ├── text_encoding.py             # Qwen3-VL-4B 12 层堆叠提取（D3 varlen 缓存的编码端）
+            ├── sampling.py                  # FlowMatchEuler 动态 shift 采样组装
+            └── preset.py                    # KREA2_PRESET（musubi 参考：264 个 Linear 全 target）
+
+utils/
+├── lycoris_adapter.py                       # [改] preset 改注入参数；AnimaLycorisAdapter → LycorisAdapter + 兼容别名（§7）
+├── lokr_preset.py                           # [删] 内容迁 families/anima/preset.py；保留 1 个 release 的 re-export shim（§7.3）
+└── lycoris_patch.py / optimizer_utils.py
+    / soap_optimizer.py / ortho_adapter.py / caption_utils.py               # [不动]
+
+studio/
+├── domain/training.py                       # [改·PR-3] + model_family 字段 + 能力集门控；位置不动
+├── infrastructure/secrets.py                # [改·PR-4] ModelsConfig.selected_anima → per-family map + 迁移
+├── supervisor/cmd_builder.py                # [不动] D8
+└── services/models/
+    ├── paths.py                             # [瘦身] 留 models_root / safe_dir_name / 工具模型（wd14、cltagger、
+    │                                        #  upscaler、eval、taeflux——它们不是模型族）
+    ├── families/                            # [新建]
+    │   ├── __init__.py                      # FAMILY_ASSETS registry（key 与 runtime 侧一致）
+    │   ├── anima.py                         # [抽出] ← paths.py 的 ANIMA_*/QWEN_*/T5_* 常量 + 4 个 target 函数
+    │   │                                    #  + selected 解析 + default_paths_for_new_version
+    │   └── krea2.py                         # [Phase 3] Krea-2-Raw / Turbo / Qwen3-VL-4B 清单
+    ├── catalog.py / downloader.py / sources.py   # [改] 遍历 FAMILY_ASSETS 出各族 section
+
+tests/                                       # [不动] flat 布局维持（§9）
+```
+
+### 4.2 任务点名的 Anima 专属代码归属
+
+| 代码 | 现位置 | 归属 | 说明 |
+|---|---|---|---|
+| `navit.py` | `runtime/training/navit.py` | `families/anima/navit.py` | D5 Anima-only；`loop.py:31` 的模块级 import 改为能力门控内 lazy import |
+| `leap.py` | `runtime/training/leap.py` | `families/anima/leap.py` | 同上（`loop.py:21-24`） |
+| `sra_align.py` | `runtime/training/sra_align.py` | `families/anima/sra_align.py` | 构造点 `phases/models.py:99-117` 一并挪进 AnimaFamily 的加载后 hook |
+| `comfy_qwen.py` | `runtime/training/comfy_qwen.py` | `families/anima/comfy_qwen.py` | 只被 `load_text_encoders`（`models.py:496-498`）引用，跟着 loader 走 |
+| `text_encoding.py` 的 T5 部分 | `runtime/training/text_encoding.py` | **整文件**进 `families/anima/text_encoding.py` | T5 加权 tokenize（喂 LLMAdapter 的 T5 IDs）是 Anima 独有；encode_qwen（Qwen3-0.6B 末层）同样不被 K2 复用（K2 取 Qwen3-VL 12 中间层，提取方式不同）。其中 `_parse_weighted_tag` 的 `(tag:1.2)` 权重语法解析理论上通用，但 D3 已定 K2 关闭 tag 生态门控，不预先上提（YAGNI）；未来第三个 tag 系模型出现时再抽到共享层 |
+| `lokr_preset.py` 的 `ANIMA_PRESET` | `utils/lokr_preset.py:14-26` | `families/anima/preset.py` | 见 §7 |
+| `forward_with_optional_checkpoint` | `model_loading.py:33-59` | `families/anima/forward.py` | 直调 Anima 内部 API（00-decisions §3 点名）；梯度检查点是 family 内部职责（§6.2） |
+| `load_anima_model` / `load_text_encoders` | `models.py:339-447,481-524` | `families/anima/loader.py` | 形状推断 2048/5120 两档、llm_adapter 缺失兜底都是族知识 |
+| `sample_image` 及 Comfy parity 管线 | `sampling.py` | `families/anima/sampling.py` | er_sde/dpmpp_3m_sde 的 **solver 实现**留在共享 `inference_samplers/`；`sampling.py` 里的编排（sigma 调度 shift=3.0、CONST flow、conditioning 组装）是族行为 |
+
+**留在共享层的边界样本**（防止「Anima 用的都算 Anima 的」扩大化）：`VAEWrapper` 与 `load_vae`（D6 跨族）、`make_noise`、`compute_loss_weight`、`sample_t`、masked loss reduction（`loop.py:111-127`）、7 套 plugin registry 全部、`dataset.py`（z_dim 等经 ModelSpec 参数化后完全族无关）。
+
+### 4.3 与 03（接口视角）的边界
+
+本文只声明：ModelFamily 的**物理形状**是「`families/<fam>/__init__.py` 组装 + 若干实现模块」，registry 是「`FAMILIES: dict[str, ModelFamily]` + `get_family()` + schema 一致性校验」。`forward_train / encode_text / build_sampler / lora_preset` 等方法的签名、能力集的表达形式（字符串集合 vs 字段）、`loop.py` 里 navit/leap 分支改「family 能力门控 + lazy import」还是「family 提供 step 策略对象」——归 `03-interface-evolution.md` 冻结。无论 03 选哪种，文件归属不变。
+
+### 4.4 退让方案（若不动 `modeling/`）
+
+保持 `modeling/` 根目录扁平，K2 以 `modeling/krea2_modeling.py`（或 `modeling/krea2/`）加入，Anima 文件不动。省去 PR-2a 的 3 个文件移动与 ~6 处 import 修正；代价：目录不对称、exec-load 的锚点文件名 `anima_modeling.py`（`model_loading.py:150`）永久保留、attention backend 别名传播列表无法收缩。机制上无害，纯观感与长期维护取舍。**本文推荐移动**，理由：反正 exec-load 退役（§6）要动同一批 import 与传播列表，边际成本接近零，不动等于把一次性成本换成永久不对称。
+
+---
+
+## 5. 入口脚本与命名
+
+### 5.1 结论：不改名（D8 已锁定），语义靠口径不靠文件名
+
+D8 明文「supervisor/cmd_builder 不动，入口脚本不变」。本节只回答不改名之下泛化语义怎么表达：
+
+1. **口径统一**：`anima_` 前缀解释为**产品名**（Anima LoRA Studio）的历史入口名，非模型族限定。落点：`runtime/anima_train.py` 模块 docstring 第一行加一句「入口名中的 anima 指产品线，模型族由 `--model-family` / yaml `model_family` 决定」；`docs/architecture/project-structure.md` 与 `runtime/training/README.md` 同步一句话。
+2. **派发不变**：`studio/supervisor/cmd_builder.py:49-53` 继续按 task_type 选脚本；族派发发生在脚本内部 `phases/models.py` 查 registry（D8），对 supervisor 完全透明——K2 训练任务的命令行和 Anima 一模一样，只是 yaml 里 `model_family: krea2`。
+3. **`train_monitor.py` 先例**：runtime 下本就有无前缀脚本，说明前缀从来不是硬约定。
+
+### 5.2 改名成本清单（备查，不建议 Phase 1-4 执行）
+
+若未来（K2 稳定后）仍想改名 `anima_train.py → train.py` 等，触碰面实测如下：
+
+- `studio/supervisor/cmd_builder.py:49-53`（3 处路径）
+- `studio/services/inference/daemon.py:48`（`_DAEMON_SCRIPT`）
+- `studio/services/eval_samples.py:546`（`import anima_train as _T`）
+- sister script 三处 `import anima_train as _T`（`anima_daemon.py` / `anima_generate.py` / `anima_reg_ai.py`）+ `tools/spike/vae_stress.py:109`
+- tests：`test_anima_train_migration.py` / `test_anima_generate_xy.py` / `test_anima_reg_caption.py` / `test_anima_daemon_comfy_parity_runtime.py` 等 ≥4 文件
+- 文档：`docs/AGENTS.md` §3.2、`runtime/training/README.md:255-257`、ADR 0003、user-guide 若干
+- 用户侧：裸 CLI 用户的命令行习惯 + 各处教程截图——这是唯一不可 grep 的成本，需要 release note + 旧名 shim（`anima_train.py` 只剩 `from train import *; main()`）保一个大版本
+
+结论维持：改名收益纯观感，成本里含用户习惯这种长尾项，D8 的锁定是对的。
+
+---
+
+## 6. exec-load 机制去留
+
+### 6.1 考证：它为什么存在
+
+- **初始 commit（`c6bd6b64`）即有**。项目脱胎于「训练脚本 + 外部 diffusion-pipe checkout」工作流：模型结构代码不在本仓库，靠 `DIFFUSION_PIPE_ROOT` 环境变量或约定目录（`runtime/models/`、`repo/models/` 等）定位，再用 `importlib.util.spec_from_file_location` 按文件路径 exec 加载（`model_loading.py:157-163`）。`find_diffusion_pipe_root` 的候选链与函数名本身就是这段历史的化石（`model_loading.py:128-133` 注释列举「CLI 直接 cd 进 scripts/ 跑」「外部 diffusion-pipe checkout 把代码放 models/」两个场景）。
+- **PR #303（`3e9160e5`）** 把模型代码收进仓库 `modeling/` 后，**只是把新位置加到候选最前**，全部旧候选与 exec-load 原样保留，commit message 明言「保留 models/ + DIFFUSION_PIPE_ROOT 作为 fallback（兼容外部 diffusion-pipe checkout）」。
+
+### 6.2 今天的真实状态与代价
+
+- 模型代码 100% 随仓库发布；tests 已在正常 import（`tests/test_models_flash_attn.py:180`、`tests/test_navit_packed_objective.py:17`、`tests/test_packed_navit_forward.py:22` 均 `from modeling.anima_modeling import ...`）；所有入口都已把 repo root 注入 sys.path（`runtime/anima_train.py:34-38`、`tests/conftest.py:19-20`）。exec-load 与正常 import **并存**。
+- 并存的直接病灶：**双模块身份**。exec-load 产出裸名 `anima_modeling` 模块对象，与 import 系统里的 `modeling.anima_modeling` 是两个独立对象，模块级全局状态（attention backend 开关）互不可见。于是 `enable_xformers` 要向 6 个候选模块名广播（`model_loading.py:81-88`），`load_anima_model` 再广播 4 个（`models.py:365-368`）。每加一个模型族，这个别名矩阵翻倍，漏一条就是静默性能退化（fast path 没开、无报错）。
+- `load_vae` 同样 exec-load `wan/vae2_1.py`（`models.py:452`），同病。
+
+### 6.3 结论：改正常 import，exec-load 与外部 checkout 兼容退役
+
+多族下**不保留 per-family exec**——K2 从第一天起 `from modeling.krea2 import ...`，Anima 在 PR-2a 切换：
+
+1. `families/anima/loader.py` 用 `from modeling.anima.anima_modeling import Anima`（正常 import，单一模块身份）；`load_vae` 用 `from modeling.wan.vae2_1 import WanVAE_`。attention backend 传播列表塌缩为真名一条。
+2. **`find_diffusion_pipe_root` 名字保留**（sister 契约 7 名之一，「可加不可减不可改签名」，`docs/AGENTS.md` §3.2），实现塌缩为返回 `modeling/anima/` 目录的常量 shim + docstring 标注 deprecated。`load_anima_model(transformer_path, device, dtype, repo_root, ...)` 等契约签名不动，`repo_root` 参数改为忽略（shim 层注释说明）。
+3. **`DIFFUSION_PIPE_ROOT` 与外部 checkout 候选链删除**，环境变量保留一个 release：检测到设置时打 warning「外部模型代码目录已不支持，忽略该变量」，下个 release 删检测。（是否需要这一个 release 的缓冲，见 §11 待拍板。）
+4. `load_module_from_path` 函数删除；`tests/test_find_diffusion_pipe_root.py` 收缩为 shim 行为断言（或整文件删除，其 ast 抽取式测试手法随机制退役失去意义）。
+
+---
+
+## 7. utils/ 归属：算法与 preset 分离
+
+### 7.1 切法
+
+原则：**算法族无关，target 选择（preset）族相关**。LyCORIS 的 lokr/loha/lora 数学对任何 Linear 堆都成立；「打哪些层、排除什么、保存键名前缀」才是族知识。
+
+1. `ANIMA_PRESET` → `families/anima/preset.py`。K2 的 `KREA2_PRESET`（Phase 3）对照 musubi 默认（全部 264 个 Linear、dim32/alpha32 起点）放 `families/krea2/preset.py`。**注意 `lora_prefix` / 保存键名是 Comfy 生态契约的一部分**，K2 的键名约定是 00-decisions §7 的 open question（等 musubi 产物 vs ComfyUI 加载核对），preset 文件是该结论未来的落点。
+2. `utils/lycoris_adapter.py`：删掉 `utils/lycoris_adapter.py:27` 的模块级 preset import；`__init__` 增加 `preset: dict` 必填参数，`inject()`（`utils/lycoris_adapter.py:95`）改 `LycorisNetwork.apply_preset(self._preset)`。类名 `AnimaLycorisAdapter → LycorisAdapter`，旧名保留别名（`studio/services/inference` 侧引用与 tests 逐步切换）。
+3. 接线：`runtime/training/adapters/lycoris.py` 的 `build(args)` 从 family registry 取 `get_family(args.model_family).lora_preset()` 传入——adapter plugin registry（管「什么算法」）与 family registry（管「打哪些层」）正交，互不吞并。
+
+### 7.2 与延后的「utils 完整重构方案」的关系：衔接，一处修订
+
+此前（2026-05-14）三方 review 形成、用户决定延后的方案要点：顶层 `lora/` 包（protocol + 4 helper + lycoris 算法 + 私有 preset/patch）、optimizer_utils 拍扁进 `runtime/training/optimizers/`、caption_utils 进 studio。与本方案的关系：
+
+- **不是前置**：多模型 Phase 1 只需要 §7.1 的三步外科手术，不触发该方案的执行条件；不要为多模型顺手做 lora/ 包（scope creep）。
+- **不冲突，方向一致**：该方案的核心（把混杂 concern 从 lycoris_adapter 拆出）与本次「把族知识从算法层拿出」同向。
+- **一处修订**：该方案原目标树把 preset 放 `lora/_lokr_preset.py`（包内私有）。多族之后 preset 是 per-family 资产，**归 `families/<fam>/preset.py`，不进 lora/ 包**——将来执行 utils 重构时以本文档为准；lora/ 包只收算法 + protocol + helpers。其余部分（helpers 四件套、optimizer 拍扁、caption_utils 迁移）与多模型改造正交，何时执行仍按原触发条件。
+
+### 7.3 兼容期
+
+`utils/lokr_preset.py` 保留 1 个 release 的 re-export shim（`from runtime 侧新位置 import ANIMA_PRESET` 不可行——utils 不能反向依赖 runtime，见 AGENTS.md §3.1；shim 直接内联同字面 dict + DeprecationWarning，或干脆一步删除并 grep 确认仓库内零残留引用后不留 shim）。倾向**直接删**：`lokr_preset` 只有 `lycoris_adapter.py:27` 一个仓库内 caller，无外部 pin 面。
+
+---
+
+## 8. studio/services/models 的 per-family 化
+
+### 8.1 代码：常量按族收编，工具模型不动
+
+- `studio/services/models/families/anima.py` [抽出]：`ANIMA_REPO / ANIMA_VARIANTS / LATEST_ANIMA / ANIMA_VAE_PATH`（`paths.py:22-33`）、`QWEN_REPO / QWEN_FILES`（`paths.py:35-45`）、`T5_REPO / T5_FILES`（`paths.py:47-52`）、4 个 target 函数（`paths.py:246-263`）、`find_anima_main / selected_anima_variant / selected_anima_transformer_path / anima_transformer_path_for`（`paths.py:340-402`）、`default_paths_for_new_version`（`paths.py:427-443`，签名加 `family: str = "anima"`）。
+- `families/__init__.py` 定义 `FAMILY_ASSETS: dict[str, FamilyAssets]`：每族声明「repo 清单（含 size 预估）、target 路径函数、selected 解析、新建 version 默认路径」。`catalog.py` / `downloader.py` 从点名 import 常量（`catalog.py:14-44` 现状）改为遍历 registry 出 per-family section；`sources.py`（HF/MS 镜像路由）族无关不动。
+- `paths.py` 瘦身后保留：`models_root / safe_dir_name` + WD14 / CLTagger / upscaler / eval / taeflux / CCIP 全部工具模型段落。**判定标准**：出现在 `TrainingConfig` 权重路径字段里的是「模型族资产」，其余（打标 / 放大 / 评估 / 预览解码）是「工具模型」，永远不进 families/。
+- `secrets.ModelsConfig`（`studio/infrastructure/secrets.py:514`）：`selected_anima: str` → `selected: dict[str, str]`（family → variant key 或 custom 路径），pydantic before-validator 读老键迁移（老配置 `selected_anima: "1.0"` → `selected: {"anima": "1.0"}`），与既有字段重命名迁移模式一致。API 层 `studio/api/routers/models.py:106-107` 等引用点同步。
+
+### 8.2 磁盘：不按族分目录，按资产类型 + repo 子目录
+
+现状 `models_root/` 固定子目录：`diffusion_models/`（扁平文件）、`vae/`、`text_encoders/`（Qwen3-0.6B 文件**直接平铺**）、`t5_tokenizer/`、加各工具模型目录。逐一裁决：
+
+| 目录 | 决定 | 理由 |
+|---|---|---|
+| `diffusion_models/` | 保持扁平，K2 权重直接落 `krea2-raw-*.safetensors` / turbo 同 | 上游文件名本身携带族名且全局唯一（ANIMA_VARIANTS 的文件名模式即先例）；按族分目录得不到任何消歧收益 |
+| `vae/` | 保持，K2 的 `vae_path` 指向**同一个** `qwen_image_vae.safetensors` | D7 明文：无需新下载。按族分目录 = 强制复制或 symlink（Windows 上 symlink 有权限坑），纯负收益 |
+| `text_encoders/` | **唯一需要改的点**：新增族的 TE 落 `text_encoders/<safe_dir_name(repo)>/`（如 `text_encoders/Qwen_Qwen3-VL-4B-Instruct/`）；Anima 的 Qwen3-0.6B 存量扁平布局保留识别（探测顺序：族清单声明的子目录 → 扁平 legacy），不做迁移 | 现状 `qwen_dir()` 返回 `root/"text_encoders"` 且文件平铺（`paths.py:258-259` + `downloader.py:107-109`），第二个 TE 直接落进来会文件名冲突（都有 `config.json` / `model.safetensors`）。零存量迁移遵循「老 schema 读兼容」偏好 |
+| `t5_tokenizer/` | 保持；D7 已把 `t5_tokenizer_path` 定为 Anima-only show_when 字段 | K2 无此概念 |
+| 工具模型目录 | 全部不动 | 与族无关 |
+
+不按族分的总依据：D6（latent 缓存跨族共享）与 D7（VAE 文件共享）已经决定了磁盘资产的自然键是「内容/repo」而不是「族」；族与资产是多对多（VAE 一对二），目录树表达不了多对多，registry 里的清单才是权威映射。
+
+---
+
+## 9. 测试布局
+
+- **flat `tests/` 维持**。CI 全量门禁按 `tests/` 路径收集（本机跑全量也必须带 `tests/` 路径避开 `tmp/`），`tests/conftest.py` 的 sys.path 注入是所有测试的共同地基，不随族拆包。
+- 命名约定（新文件生效，存量不重命名）：`test_families_<fam>_*.py`（族内单元：preset 内容、spec 常量、loader 的纯逻辑部分）+ `test_model_families.py`（registry 三件套：FAMILIES ↔ schema Literal 一致性、get_family 派发、能力集门控与 show_when 裁剪联动）。
+- CI 无 GPU 的现实约束下，per-family 可测面 = spec / preset / registry / 派发 / schema 一致性；真加载与前向靠用户真卡验证（ADR 0003 验收策略 R2 先例）。`test_plugin_registry.py` 的防回归断言模式（「`phases/models.py` 不该再出现 `load_anima_model(` 直调字面量」）复制一条给 families registry。
+- 迁移期专项：`tests/test_anima_generate_xy.py`（sister `_T.X` 契约）与 `tests/test_anima_train_migration.py` 在每个迁移 PR 都必须绿——它们就是「对 Anima 零行为变化」的机器裁判。`tests/test_find_diffusion_pipe_root.py` 随 §6.3 收缩或删除。
+
+---
+
+## 10. 迁移步骤（与 00-decisions Phase 1 PR-1..PR-4 对齐）
+
+所有整文件移动用 `git mv`（PR #303 先例）；函数级拆分遵循「大块留原文件保历史，小块移出」。PR-2 因同时含机械移动与行为适配，拆 2a/2b 两刀（细化不改变 00-decisions 的四刀总量语义）。
+
+### PR-1 — ModelSpec + latent 指纹（无移动，纯新建 + 收敛）
+
+| 动作 | 文件 |
+|---|---|
+| 新建 | `runtime/training/families/__init__.py`（暂只暴露 SPECS）、`families/spec.py`（ModelSpec frozen dataclass：z_dim/stride/patch/归一化统计/latent 指纹 `wan21-f8c16`/文本规格/默认值 overlay/能力集）、`families/anima/__init__.py`（ANIMA_SPEC 实例） |
+| 修改 | `runtime/training/dataset.py`（z_dim/stride/patch ≥8 处散点 → spec；`_is_cache_valid` 加模型指纹 + layout 版本）、`runtime/training/models.py:284`（z_dim 硬编码）、`runtime/training/models.py:468-475`（归一化统计移入 spec、load_vae 读 spec） |
+| 测试 | 新建 `tests/test_model_spec.py` |
+
+### PR-2a — modeling 归位 + exec-load 退役（机械刀）
+
+| 动作 | 文件 |
+|---|---|
+| git mv | `modeling/anima_modeling.py → modeling/anima/anima_modeling.py`、`modeling/cosmos_predict2_modeling.py → modeling/anima/cosmos_predict2_modeling.py` |
+| 新建 | `modeling/__init__.py`、`modeling/anima/__init__.py`、`modeling/wan/__init__.py` |
+| 修改 | `runtime/training/models.py`（exec-load → 正常 import；传播列表塌缩）、`runtime/training/model_loading.py`（find_diffusion_pipe_root → shim、删 load_module_from_path、enable_xformers 别名表塌缩、DIFFUSION_PIPE_ROOT 弃用警告）、`modeling/anima/anima_modeling.py` 内部相对引用、3 个直接 import 的测试（`test_models_flash_attn.py:180` 等）、`THIRD_PARTY_NOTICES.md:35`、`docs/architecture/project-structure.md`（中英） |
+| 验证 | 用户真卡跑一次训练 + 测试出图（PR #303 同款要求：真实加载无自动化覆盖） |
+
+### PR-2b — AnimaFamily 行为适配器（对 Anima 零行为变化）
+
+| 动作 | 文件 |
+|---|---|
+| 新建 | `families/protocol.py`（接 03 冻结面）、`families/anima/` 组装代码、`families/README.md` |
+| git mv | `runtime/training/{text_encoding,comfy_qwen,sampling,navit,leap,sra_align}.py → runtime/training/families/anima/` |
+| 抽出 | `models.py` 的 `load_anima_model`/`load_text_encoders` → `families/anima/loader.py`（models.py 留 VAEWrapper + load_vae）；`model_loading.py` 的 `forward_with_optional_checkpoint` → `families/anima/forward.py`；`utils/lokr_preset.py` 的 ANIMA_PRESET → `families/anima/preset.py`（utils 侧删文件，§7.3） |
+| 修改 | `phases/models.py`（查 registry 派发，D8）、`loop.py`（`loop.py:21-31` 模块级 import 改经 family / 能力门控 lazy import；`loop.py:229-236` 文本编码经 family）、`sample_runner.py`、`utils/lycoris_adapter.py`（preset 注入 + 更名）、`adapters/lycoris.py`（build 接 preset）、`anima_train.py` re-export 段改 import 来源（**对外 7 名不变**）、`phases/bootstrap.py` 挂 families 的 validate_schema_consistency |
+| 测试 | `test_anima_generate_xy.py` / `test_anima_train_migration.py` 全绿为硬门禁；新增 `test_model_families.py` |
+
+### PR-3 — schema `model_family` + 能力集门控（无移动）
+
+`studio/domain/training.py` 加 `model_family: Literal["anima"] = "anima"`（Phase 3 扩 `"krea2"`；默认值保证老配置零迁移，D7）+ Anima-only 字段批量加 `show_when="model_family=='anima'"`（复用落盘裁剪机制）；`argparse_bridge` 自动获得 CLI 字段；families registry 的 schema 一致性校验开始生效。
+
+### PR-4 — studio 侧 per-family 化
+
+| 动作 | 文件 |
+|---|---|
+| 新建 | `studio/services/models/families/{__init__,anima}.py` |
+| 抽出 | `paths.py` 的 Anima 段落（§8.1 清单）→ `families/anima.py`，paths.py 瘦身 |
+| 修改 | `catalog.py` / `downloader.py`（遍历 FAMILY_ASSETS）、`secrets.py` ModelsConfig 迁移、`studio/api/routers/models.py` 引用点、前端 Settings 模型卡（读 catalog 新结构） |
+
+### Phase 2 / Phase 3 增量（本文范围内的文件动作）
+
+- Phase 2：新建 `runtime/training/text_cache.py`（varlen 格式族无关）+ `phases/` 加缓存 phase；存放位置（sidecar vs 集中目录）是 00-decisions §7 open question，不在本文裁决。
+- Phase 3：新建 `modeling/krea2/`、`families/krea2/`（5 文件）、`studio/services/models/families/krea2.py`、`inference_samplers/flow_euler.py`；修改 4 处一行注册。**这份清单就是 §3.2「加第 3 个模型族」维度的实测口径**——K2 自己先走一遍。
+
+---
+
+## 11. 待拍板（超出本文决定权）
+
+1. `DIFFUSION_PIPE_ROOT` 退役节奏：保留一个 release 的弃用警告（本文倾向）vs PR-2a 直接删。
+2. `runtime/training/models.py` 瘦身后是否顺手 `git mv` 为 `vae.py`（名实相符 vs 又多一处 import 修正；本文倾向改名，成本仅仓库内 grep 可尽的引用）。
+3. `modeling/` 下沉 `modeling/anima/`（§4.4 退让方案 vs 推荐方案）——本文推荐做，若用户选退让方案，PR-2a 缩为纯 exec-load 退役、目标树相应保持扁平。
+4. K2 LoRA 保存键名（`families/krea2/preset.py` 的 `lora_prefix`）等 Comfy 侧核对结论——00-decisions §7 已列，Phase 3 前必须闭环。

--- a/docs/design/multi-model/02-ecosystem-survey.md
+++ b/docs/design/multi-model/02-ecosystem-survey.md
@@ -1,0 +1,262 @@
+# 多模型支持：训练器生态对标调研（02-ecosystem-survey）
+
+- 状态：调研完成。结论供 `04-synthesis.md` 收敛时引用。
+- 日期：2026-07-13
+- 相关：`00-decisions.md`（已确认决策）、`01-code-layout.md`（代码归属视角）、`03-interface-evolution.md`（接口契约视角）
+- 调研对象：kohya sd-scripts、kohya musubi-tuner、diffusers、ostris ai-toolkit、OneTrainer、tdrussell diffusion-pipe，补充 SimpleTuner 与 ComfyUI（model detection 机制）。全部基于 2026-07 时点的真实仓库目录树、源码与 PR/commit/issue 证据；推断处单独标注。
+
+## TL;DR
+
+1. **全行业收敛到同一形态**：共享训练循环/基建 + 每族一个「适配单元」（薄子类 / 自治目录 / adapter 类），差别只在单元的胖瘦与登记方式。没有一家靠「每族复制完整训练脚本」活得好——diffusers examples（同一 bug 修 10 个脚本）与 sd-scripts full-finetune 线是现成反面教材。我们 D1 选 ModelFamily 适配层与全行业一致。
+2. **声明式常量与行为方法分离**是共同结构：ComfyUI 的 `supported_models` 声明类 + `LatentFormat` 类、SimpleTuner 的类属性、musubi 的架构常量，对应我们 §6 的 ModelSpec；load/forward/save 行为对应 ModelFamily 适配器。§6 的两分法得到全生态印证。
+3. **加新族的黄金标准 diff**：以新增文件为主、共享代码改动 < 100 行、登记点少而可数（musubi 3 处、ai-toolkit 2 行、SimpleTuner 3 处）。我们应用现有 `validate_schema_consistency` 模式把登记点做成启动期校验——这一点可以做得比所有对标项目更好。
+4. **缓存指纹的正确做法是 ai-toolkit 式**：hash 掺 `latent_space_version`（空间标识而非族名），天然支持我们 D6 的 Anima/K2 跨族共享缓存；musubi 按族短名隔离反而做不到共享。OneTrainer 缓存无模型标识、靠训前清缓存兜底，是明确反模式（我们现状同病，PR-1 要修的正是它）。
+5. **最大的两类债**：巨型共享文件沉积（train_util.py 曾 6888 行、SimpleTuner common.py 6205 行）与「每族各写一份近乎相同代码」的复制漂移（diffusion-pipe 每个 adapter 复制 timestep 采样）。对我们的直接推论：**timestep 采样必须留在共享循环**，K2 的分辨率感知 shift 应做成 timestep_sampler registry 的新策略 + ModelSpec 默认值指向它，而不是塞进 family 的 forward。
+6. 旁注：Anima 已被 sd-scripts、diffusion-pipe、OneTrainer、ComfyUI、diffusers（LoRA 键名转换）全部收编，各家的 Anima 实现（shift 默认值、LoRA 键名、target 选择）可作为我们接口决策的交叉参照。
+
+---
+
+## 1. kohya sd-scripts —— 模板方法胖基类 + 薄入口脚本 + strategy 体系
+
+SD 生态最老牌 LoRA 训练器。main 分支现含 SD1/2、SDXL、SD3、FLUX(+Chroma)、Lumina、HunyuanImage、Anima 共 7+ 族。
+
+**边界与接口**：每族一个薄入口 `{family}_train_network.py`，继承 [train_network.py](https://github.com/kohya-ss/sd-scripts/blob/main/train_network.py) 的 `NetworkTrainer`（2047 行；`train()` 主循环约 950 行不被覆写）。基类默认实现即 SD1.5 行为——SD1.5 没有自己的子类。可覆写 hook 约 27 个，关键的有：`load_target_model`、`get_tokenize_strategy`、`get_latents_caching_strategy`、`get_text_encoding_strategy`、`cache_text_encoder_outputs_if_needed`、`call_unet`、`get_noise_scheduler`、`get_noise_pred_and_target`、`post_process_loss`、`sample_images`、`on_step_start`。覆写量与「离 SD1.5 的距离」成正比：SDXL 子类 183 行/13 个方法（同为 eps-pred，噪声/损失全继承）；SD3 500 行、Flux 555 行、各约 20 个方法——flow matching 族整体替换 `get_noise_pred_and_target` 绕开 `call_unet`。
+
+library/ 下每族固定「三件套 + strategy」：`{family}_models.py`（网络结构自带实现）、`{family}_utils.py`（权重加载/键名转换）、`{family}_train_utils.py`（采样/argparse/timestep）；[strategy_base.py](https://github.com/kohya-ss/sd-scripts/blob/main/library/strategy_base.py)（647 行）定义 `TokenizeStrategy` / `TextEncodingStrategy` / `TextEncoderOutputsCachingStrategy` / `LatentsCachingStrategy` 四个抽象类，每族一个 `strategy_{family}.py` 实现——这是 TE 数量（1/2/3 个）与缓存格式差异的收口点。kohya 自评这套体系 "better than the chaos it was in before"（[issue #1924](https://github.com/kohya-ss/sd-scripts/issues/1924)）。
+
+**加新族 diff**：[Anima PR #2260](https://github.com/kohya-ss/sd-scripts/pull/2260)（2026-02）是最干净实证——新建 9 个文件（入口 ×2、`anima_models/`_utils`/_train_utils`/_vae`、`strategy_anima.py`、`networks/lora_anima.py`）+ tokenizer 资产/docs/tests，只改 2 个共享文件（strategy_base.py、train_util.py）。历史上 SD3/FLUX 直接开在 `sd3` 分支上由 kohya 本人 push（无 PR），该分支承担主开发约 1.5 年后才随 v0.10.0 合回 main。
+
+**LoRA target/键名**：每族一个整文件复制的 [networks/lora_{family}.py](https://github.com/kohya-ss/sd-scripts/blob/main/networks/lora_flux.py)（lora.py 1410 行 vs lora_flux.py 1451 行，大量重复），差异集中在类常量：`UNET_TARGET_REPLACE_MODULE=["Transformer2DModel"]`（SD）vs `["DoubleStreamBlock"]/["SingleStreamBlock"]`（Flux）vs `["SingleDiTBlock"]`（SD3）。键名前缀 DiT 族**故意沿用 `lora_unet`**，lora_flux.py 内注释原文 `# make ComfyUI compatible`。近期新增 `networks/network_base.py` 试图收敛，但各复制文件仍在。
+
+**缓存防串用**：per-model npz 文件名后缀——`{stem}_{W:04d}x{H:04d}_sd.npz` / `_sdxl.npz` / `_sd3.npz` / `_flux.npz`（基类 `cache_suffix` property），TE 输出同理 `_flux_te.npz`。纯文件名约定，无哈希校验。
+
+**timestep 异参**：三层表达——per-family argparse 默认值（[flux_train_utils.py](https://github.com/kohya-ss/sd-scripts/blob/main/library/flux_train_utils.py) `--discrete_flow_shift` 默认 3.0、`--timestep_sampling` choices 含 `flux_shift`；SD3 侧 `--training_shift` 默认 1.0 + `--weighting_scheme`）、代码 if/elif 分支、运行时权重探测族内变体（dev/schnell）。坑的实证：shift 只对部分 sampling 模式生效曾造成用户困惑（[issue #2383](https://github.com/kohya-ss/sd-scripts/issues/2383)），后来专门加日志解释。
+
+**痛点**：`train_util.py` 拆分前 **6888 行**（v0.9.1 时 5729 行），2026-06 [PR #2372](https://github.com/kohya-ss/sd-scripts/pull/2372) 才拆成单一职责模块，PR 标题即 "Refactor for ai agents"。full-finetune 线（`sd3_train.py`/`flux_train.py`/`anima_train.py`）不走 NetworkTrainer 基类、互为复制。kohya 在 #1924 自述："*Musubi tuner is much simpler to implement, so maybe sd-scripts can be simplified by dropping less used features*"——此后新架构一律只进 musubi（[musubi issue #411](https://github.com/kohya-ss/musubi-tuner/issues/411)）。
+
+## 2. kohya musubi-tuner —— 无历史包袱的重写：胖基类 + 每族薄包 + 缓存文件名内嵌架构短名
+
+kohya 的新一代 DiT/视频训练器（2024-12 起），2026-07 已支持 14 族（HunyuanVideo、Wan2.1/2.2、FramePack、FLUX Kontext/FLUX.2、Qwen-Image 三变体、Z-Image、Kandinsky 5、HiDream-O1、Ideogram 4、**Krea 2**）。是本次调研与我们处境最接近的参照（较新代码库 + 已支持 K2）。
+
+**边界与接口**：基类 [training/trainer_base.py](https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/training/trainer_base.py)（约 2500 行，2026-05 [PR #950](https://github.com/kohya-ss/musubi-tuner/pull/950) 从 hv_train_network.py 抽出）。**abstract hooks**（源码标注 `# region model specific`）：`architecture`/`architecture_full_name`（property）、`handle_model_specific_args`（子类必须设 `_i2v_training`、`default_guidance_scale`，可设 `default_discrete_flow_shift`）、`load_vae`/`load_transformer`/`compile_transformer`、`scale_shift_latents`、`call_dit(...) -> DiTOutput`、`process_sample_prompts`/`do_inference`、`convert_weight_keys`（默认恒等）。另有 **extension seams**（`process_batch`、`compute_loss`、`on_transformer_loaded`、`on_train_start`、`on_post_optimizer_step`、`on_before/after_sample_images`、`extra_trainable_params` 等），注释明言 "*no API stability guarantees... if you fork, expect breakage*"。模板方法 `train()` 拆成私有步骤；`get_noisy_model_input_and_timesteps`、optimizer/scheduler、`sample_images` 全共享。
+
+子类覆写实例：`WanNetworkTrainer` 额外覆写 timestep 采样（Wan2.2 high/low 双 DiT 按 `timestep_boundary` 切换）；`QwenImageNetworkTrainer` 的 `architecture` property 是动态的（按 is_edit/is_layered 返回 `qi`/`qie`/`qil` 三个架构名 = 三个缓存命名空间）；`Krea2NetworkTrainer` 覆写 `on_before/after_sample_images` 做 RAW 训练 / Turbo 采样的基座权重热切换（`--turbo_dit`）。
+
+**缓存脚本共享**：公共模块 [cache_latents.py](https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/cache_latents.py) 提供 `encode_datasets` + `setup_parser_common`；每族脚本极薄——[krea2_cache_latents.py](https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/krea2_cache_latents.py) 全文 86 行，只做「建数据集（带 `ARCHITECTURE_KREA2`）+ 定义本族 `encode_and_save_batch` + 回调公共 `encode_datasets`」。Krea 2 直接复用 `qwen_image_utils.load_vae`（同款 VAE，与我们 D6/D7 同一判断）。
+
+**LoRA target/键名**：与 sd-scripts 相反，[networks/lora.py](https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/networks/lora.py) 是唯一通用实现；每族的 `lora_wan.py`/`lora_qwen_image.py`/`lora_krea2.py` 只有 65-72 行：target 常量（`["WanAttentionBlock"]`、`["QwenImageTransformerBlock"]`、**Krea2 = `None` 即全模型所有 Linear**，对应官方推荐练全部 264 个 Linear）+ 默认 exclude_patterns（qwen 必须排 `.*(_mod_).*` modulation Linear；K2 的 modulation 是裸 Parameter 天然不会被包）+ `create_arch_network` 委托。**键名前缀全族统一 `"lora_unet"`**。ComfyUI 键名差异用独立转换脚本解决（`convert_z_image_lora_to_comfy.py` 等）。
+
+**缓存防串用（双层）**：[architectures.py](https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/dataset/architectures.py) 给每族短名+全名（`"wan"`、`"qi"`、`"kr2"`）；主防线是**文件名**——latent 缓存 `{basename}_{W:04d}x{H:04d}_{短名}.safetensors`、TE 缓存 `{basename}_{短名}_te.safetensors`，数据集扫描按 `glob(f"*_{arch}.safetensors")` 天然隔离；次防线是 safetensors metadata `{"architecture": 全名, "format_version": "1.0.1"}`（cache_io.py，加载侧未见强校验——推断：文件名即隔离机制，metadata 供人查验）。cache_io.py 文件头注释自嘲 "*We use simple if-else approach to support multiple architectures*"。
+
+**timestep 异参**：`--timestep_sampling` 的 **choices 本身就是 per-model 菜单**——`sigma/uniform/sigmoid/shift/flux_shift/flux2_shift/ideogram4_shift/qwen_shift/krea2_shift/logsnr/...`（[parser_common.py](https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/training/parser_common.py)）。`krea2_shift` 在共享基类内实现为 `get_lin_function(x1=256, y1=0.5, x2=6400, y2=1.15)` 的分辨率动态 mu（与我们 00-decisions §2 的 base_shift 0.5→max_shift 1.15 互证）。**per-model 推荐值不进代码默认值而进 docs**：[docs/krea2.md](https://github.com/kohya-ss/musubi-tuner/blob/main/docs/krea2.md) 推荐 discrete 2.5@1024²，变分辨率直接用 `krea2_shift`；[docs/qwen_image.md](https://github.com/kohya-ss/musubi-tuner/blob/main/docs/qwen_image.md) 推荐 2.2。基类残留 `default_discrete_flow_shift = 14.5`（HunyuanVideo 遗产，带 `TODO may be None is better`）。
+
+**加新族真实 diff**：[Krea 2 PR #980](https://github.com/kohya-ss/musubi-tuner/pull/980)（2026-06，+2978/−8，24 文件）：新建 21 个（`krea2/` 包 4 文件 + 4 入口 ×src/root 双份 + `lora_krea2.py` + docs + tests）；修改共享文件仅 7 个且极小（architectures.py +2、parser_common.py +1、trainer_base.py +5、cache_io.py +36、attention.py +38）。[Qwen-Image PR #408](https://github.com/kohya-ss/musubi-tuner/pull/408) 同模式。**加一族 ≈ 纯新增 + 共享改动 <100 行，无中央 registry，登记点 3 处靠人记**。
+
+**痛点**：14 族 × 4 脚本 ≈ 60 个入口 + root 层 4 行 shim 镜像（无统一 CLI）；但 gh 搜索 "too many scripts" 零结果——社区答案是第三方 GUI（[issue #55](https://github.com/kohya-ss/musubi-tuner/issues/55)）。kohya 在写给 AI agent 的 [.ai/context/overview.md](https://github.com/kohya-ss/musubi-tuner/blob/main/.ai/context/overview.md) 自述模式："*Each architecture follows the same pattern: an architecture-specific subdirectory for model code, plus top-level scripts... that share the common training/ and dataset/ infrastructure*"，并承认 "*No formal test suite*"。新族一律标 experimental，社区贡献由 kohya 以 follow-up PR 收口。
+
+## 3. diffusers —— 刻意不抽象的 single-file policy：库的哲学，不是应用的哲学
+
+**政策边界**（[官方哲学文档](https://huggingface.co/docs/diffusers/conceptual/philosophy)）：pipeline 主体、scheduler、模型 forward **必须复制**（"prefer copy-pasted code over hasty abstractions"；新模型的做法是 "copy the existing file as a starting point and adapt it"）；共享白名单极窄——`embeddings.py`、`normalization.py`、attention processor，外加整个基础设施层（`from_pretrained`/loaders/mixins）。即：**「论文数学」层复制，「基础设施」层抽象**。
+
+**训练脚本现实**：`examples/dreambooth/` 下 **20 个 `train_*.py` 变体**，每个约 2000 行；实测 flux 版与 sd3 版 **约 85% 的行完全相同**。`# Copied from` + `make fix-copies` 机制只覆盖 `src/diffusers`（check_copies.py 硬编码路径），**examples/ 同步纯靠人肉**。直接后果：[PR #13899](https://github.com/huggingface/diffusers/pull/13899) "Fix fp16 LoRA unscale crash... in **remaining** DreamBooth LoRA scripts" 一次改 10 个脚本（标题的 remaining 说明此前已有另一批）。官方立场（examples README）：examples "are just that – examples"，预期用户自己改，不追求生产级。
+
+**LoRA 键名的账单**：[lora_conversion_utils.py](https://github.com/huggingface/diffusers/blob/main/src/diffusers/loaders/lora_conversion_utils.py) 约 3000+ 行、**26 个手写转换函数**，按「模型 × 训练器生态」逐个实现（`_convert_kohya_flux_lora_to_diffusers` 独占约 570 行；**含 `_convert_non_diffusers_anima_lora_to_diffusers`**）。单文件 checkpoint 识别同理：[single_file_utils.py](https://github.com/huggingface/diffusers/blob/main/src/diffusers/loaders/single_file_utils.py) 的 `CHECKPOINT_KEY_NAMES` 是「模型 → 特征张量键名」指纹表 + 平铺 if 链。
+
+**适用条件（对我们最重要的一课）**：这套哲学的前提是「产物被读和 fork 多于被调用、模型发布后静态」（[设计哲学博文](https://huggingface.co/blog/transformers-design-philosophy)）；官方自己也说构建 feature-complete 应用要用 Modular Diffusers 而非 pipeline。训练器应用不满足前提：功能（暂停/恢复、masked loss、eval）跨模型持续演进、训练脚本恰恰不是静态的——#13899 式 10 连修就是 "model stasis" 假设在训练侧失效的证明（推断）。**diffusers 能容忍 examples 失同步是因为定位就是教学参考；产品级训练器没有这个退路。**
+
+## 4. ostris ai-toolkit —— arch 注册 + 窄 hook + 缓存版本号：单人维护 20+ 族的低摩擦配方
+
+config 驱动的流行训练器（11.3k stars），几乎所有新模型第一时间收编。
+
+**边界与接口**：[toolkit/models/base_model.py](https://github.com/ostris/ai-toolkit/blob/main/toolkit/models/base_model.py) 的 `BaseModel`（约 1600 行），子类以类属性 `arch` 为唯一标识。**必须实现**：`load_model`、`get_generation_pipeline`/`generate_single_image`（采样只收 embeds 不收文本）、`get_noise_prediction`（训练前向；timestep 契约统一 0..1000，模型内部自行换算）、`get_prompt_embeds`、`get_model_has_grad`/`get_te_has_grad`。**可选窄 hook**：`encode_images`/`decode_latents`（VAE 差异）、`condition_noisy_latents`（control/edit 注入点）、`get_loss_target`、`convert_lora_weights_before_save/load`、`get_transformer_block_names` 等。基类还有一排**能力 flag**：`is_flow_matching`、`is_multistage`、`do_masked_loss`、`latent_space_version` 等。训练循环在共享的 `BaseSDTrainProcess`（2806 行）+ `SDTrainer`（2186 行），按「缓存/编码 latent → 采 timestep 加噪 → `condition_noisy_latents` → `predict_noise` → `get_loss_target` → MSE → `scale_loss`」的固定序列调 hook。
+
+**注册机制**：`get_all_models()` 用 pkgutil 扫 `extensions_built_in/` 收集模块级 `AI_TOOLKIT_MODELS` 列表；config yaml 里 `model.arch: "qwen_image"` 选型；匹配不到 fallback 到 legacy `StableDiffusion` god-class。**双世代并存是现实痛点**：老族（sd1/sdxl/flux 等）走 legacy 类，训练代码里仍有 `if self.sd.is_flux or 'flex' in self.sd.arch` 式特判泄漏（BaseSDTrainProcess.py:1196）。
+
+**加新族 diff**：[Krea2 commit 99be3d96](https://github.com/ostris/ai-toolkit/commit/99be3d96)（PR #906，+1307/−1）：新增 `krea2/` 目录（注册 3 行 + 主类 474 行 + vendor 的 `src/{mmdit,pipeline,text_encoder}.py`）；改动仅 `__init__.py` +2 行注册、UI options.ts +21、README/version 各 +1。**共享训练代码零改动**。官方还有逐行注释的 [example_model 模板](https://github.com/ostris/ai-toolkit/blob/main/extensions_built_in/diffusion_models/example_model/README.md)（明说给人和 AI agent 用）。
+
+**LoRA**：模型类设 `self.target_lora_modules = ["QwenImageTransformer2DModel"]`（顶层模块类名），共享 `LoRASpecialNetwork` 递归包裹；保存键名转换是 per-model 方法 `convert_lora_weights_before_save`（qwen: `"transformer." → "diffusion_model."`，即 ComfyUI 约定）。
+
+**缓存防串用（本次调研最优解）**：latent 缓存文件名 = `{stem}_{md5(info_dict)}.safetensors`，[info_dict 掺 `latent_space_version`](https://github.com/ostris/ai-toolkit/blob/main/toolkit/dataloader_mixins.py) 连同 crop/scale/flip 一起入 hash；文本嵌入同理掺 `text_embedding_space_version`（默认返回 arch）。版本值优先取模型声明——**共享 latent 空间的模型声明同值即可复用缓存**（与我们 D6「Anima/K2 同为 wan21-f8c16 跨族共享」完全同构）；模型实现破坏兼容时 bump 版本作废用户缓存。
+
+**timestep 异参**：模型类可提供 `get_train_scheduler()` 静态方法 + 文件顶部自己的 `scheduler_config` dict（qwen: shift 1.0/dynamic shifting）；采样分布是全局旋钮 `timestep_type`（sigmoid/linear/lognorm_blend/...）。即「**分布归 config、shift 参数归模型 scheduler**」。多专家模型用 `is_multistage + multistage_boundaries` 裁 timestep 采样区间。
+
+**痛点**：贡献极度集中（作者 1241 commits，第二名 5）；缓存相关 bug 反复（#374/#405/#425/#689/#779）；[issue #693](https://github.com/ostris/ai-toolkit/issues/693)（Z-Image 训练质量差被社区点名）反映「模型接得快、per-model 调优跟不上」；模型类本身还在世代迁移（z_image 后来才移到新基类）。
+
+## 5. OneTrainer —— 族 × 训练方法矩阵式工厂：维护者亲证的 boilerplate 之痛与瘦身路线
+
+带 GUI 的多模型训练器，与我们「上面有一层 UI」的处境最像。ModelType 枚举 29 个成员（含 **ANIMA**、KREA2）× TrainingMethod 4 种（FINE_TUNE/LORA/EMBEDDING/FINE_TUNE_VAE）。
+
+**目录职责**（[官方 ProjectStructure.md](https://github.com/Nerogar/OneTrainer/blob/master/docs/ProjectStructure.md)）：`modules/model/`（数据类，族内自带 `encode_text`/`pack_latents`/`calculate_timestep_shift` 等模型知识）、`modelSetup/`（训练准备，基类抽象 `create_parameters`/`setup_model`/`predict`/`calculate_loss`/`after_optimizer_step`）、`modelLoader/`、`modelSaver/`、`modelSampler/`、`dataLoader/`（基于自研 MGDS）；`GenericTrainer` 拼装一切——训练循环模型无关。
+
+**矩阵与工厂**：2026-01 前是散落 if/elif；[PR #1211](https://github.com/Nerogar/OneTrainer/pull/1211)「Factory pattern for model components」（动机原文："*make it easier to implement new models by having the model-specific code less spread around the entire codebase*"）+ [PR #1498](https://github.com/Nerogar/OneTrainer/pull/1498) 改成装饰器注册表：`@factory.register(BaseModelSetup, ModelType.FLUX_DEV_1, TrainingMethod.LORA)`，factory.py 仅 37 行（重复注册 raise），`create_*` 一行分派，sampler/dataLoader 支持按 `(type)` 降级查找。**实测规模**：modelSetup/ 70 个文件（45 具体类 + 18 族中间 Base + 7 mixin）、modelLoader/ 83、modelSaver/ 96——modules/ 全部 557 个 py。跨族算法复用全靠 mixin：`ModelSetupDiffusionLossMixin`（masked loss/MinSNR/debiased/log-cosh）、`ModelSetupNoiseMixin`（offset noise/timestep 采样）、`ModelSetupFlowMatchingMixin` 等。
+
+**加新族 diff**：[Anima PR #1487](https://github.com/Nerogar/OneTrainer/pull/1487)（2026-07 合并）：23 文件 +1436 行——**新增 15 个文件**（11 py：Model/DataLoader/Loader/Sampler/saver ×4/BaseAnimaSetup+FineTune+LoRA Setup）+ **8 处横切修改**（ModelType 枚举、3 个 UI View、muon_util 层规则等）。[Z-Image PR #1195](https://github.com/Nerogar/OneTrainer/pull/1195) 结构几乎相同（26 文件 +1611）。注意 Anima 的 loader 已因 `Generic*ModelLoader` 类工厂从老族的 6 文件缩到 1 文件。
+
+**LoRA**：共享 `LoRAModuleWrapper(root_module, prefix, config, module_filter, ...)`，族差异在 (a) Setup 传的 prefix；(b) 族 Base 类的 `LAYER_PRESETS` 字典（attn-mlp/attn-only/blocks/full）；(c) `fusion_groups()` 处理 qkv 融合。对外格式在 `convert_lora_util.py`（[PR #1563](https://github.com/Nerogar/OneTrainer/pull/1563) 支持 Diffusers/Kohya/Comfy/Legacy 四种输出）；键名坑真实存在（PR #1294 Z-Image prefix workaround、#1589 Ideogram qkv 修复）。
+
+**缓存（反模式）**：MGDS `DiskCache` 的 group key 是 concept 路径/seed 等子配置的 sha256，**不含模型标识**；防串台靠 `clear_cache_before_training` 默认 True + workspace 隔离——用户责任而非键控（推断：有意换取实现简单）。
+
+**timestep 异参**：mixin 分层（通用 `_get_timestep_discrete/_continuous` + shift 参数；flow 族混入 `_add_noise_discrete`）+ 族 `Base<Family>Setup.predict()` 内的特有逻辑（Flux 的 `calculate_timestep_shift(h, w)` 动态 shift，`config.dynamic_timestep_shifting` 开关）。
+
+**痛点（维护者自述，非推断）**：现任维护者 dxqb 开着 [issue #1203](https://github.com/Nerogar/OneTrainer/issues/1203)「[Feat]: Simpler new model support」，直言 "*With the amount of new models released, it could be easier to implement new models*"，点名：dataLoader/Loader/Saver 各处 boilerplate、**sampler 与 `predict()` 重复前向代码（训练/采样条件不一致风险）**、tokenization 每族重复、「改这些会破坏既有模型、需要大量测试」。OneTrainer 的演化方向不是消灭矩阵，而是**把格子越做越薄**——公共体沉入 mixin/类工厂，格子只剩注册装饰器 + 族差异（推断）。
+
+## 6. tdrussell diffusion-pipe —— models/ 每族一个 adapter 类：接口最接近我们 §6 草案的一家
+
+DeepSpeed pipeline-parallel 训练器，26 族。分派是 [train.py](https://github.com/tdrussell/diffusion-pipe/blob/main/train.py) L310-379 的 `if model_type == 'flux': ... elif ...` 硬编码链。
+
+**基类结构**：[models/base.py](https://github.com/tdrussell/diffusion-pipe/blob/main/models/base.py) 实为三类——`CommonPipeline`（共享：`configure_adapter`、采样、媒体预处理、类属性默认 `spatial_compression=8`/`channels=16`）、`BasePipeline`（老路线，手工加载权重）、`ComfyPipeline`（2025-11 改 GPL-3 后新路线：直接复用 ComfyUI 的模型/VAE/CLIP 加载代码，支持从 Comfy fp8_scaled 权重直训）。
+
+**接口清单**：类属性 `name`（缓存目录键）/`checkpointable_layers`/`adapter_target_modules`；方法 `load_diffusion_model`（缓存完成后才加载 DiT）、`get_vae`/`get_text_encoders`、`get_call_vae_fn`/`get_call_text_encoder_fn`（返回闭包，输出待缓存 dict）、**`prepare_inputs`（核心：缓存 batch → 采 timestep、加噪、算 flow target、mask 下采样，返回 tensor tuple）**、`to_layers`（切 pipeline stage；一切跨层数据必须是 flat tensor tuple——接口最大的形状约束）、`save_adapter`/`save_model`（per-model 格式）、`get_param_groups`（**Anima 覆写做 `llm_adapter_lr`**）、`get_loss_fn`（默认 MSE+mask 加权 fp32）、`enable_block_swap`（默认 NotImplemented）。
+
+**加新族 diff**：Ideogram4（[commit d6a8f562](https://github.com/tdrussell/diffusion-pipe/commit/d6a8f562)）：新建 models/ideogram4.py(+352) + train.py(+8/-2 一个 elif) + dataset.py(+3/-2)。**Anima（[commit 3abbfff5](https://github.com/tdrussell/diffusion-pipe/commit/3abbfff5)）不建新文件**——作为 Cosmos-Predict2 变体改 `models/cosmos_predict2.py`(+227/-59) + 新 `llm_adapter.py`，train.py 仅 1 行（两个 model_type 共用一个 Pipeline 类，类内 `self.name = 'anima'`）。README 自称 "Easily add new models by implementing a single subclass"，从 diff 看基本属实（300-600 行/族）。
+
+**LoRA**：`adapter_target_modules = ['QwenImageTransformerBlock']`（模块类名），共享 `configure_adapter` 收集匹配模块下所有 Linear 全名 → `peft.LoraConfig`（也支持 LoKr）。保存格式 per-model，[docs/supported_models.md](https://github.com/tdrussell/diffusion-pipe/blob/main/docs/supported_models.md) 逐一标注：SDXL=Kohya 格式、Flux/SD3=Diffusers 格式、**Wan/Qwen-Image/Anima 等=ComfyUI 格式**。
+
+**缓存**：写在每个数据集目录内 `{dataset}/cache/{model.name}/`，按模型族名分子目录（Anima 与 cosmos 共用类但 `name` 不同 → 缓存自然隔离），配 fingerprint（utils/cache.py）+ `--regenerate_cache`/`--trust_cache` flags。换族免清缓存；但**同族实现变更时要手动清**（README：Flux2 改 attention masking 后 "Delete cache folder... or else you might get Tensor shape errors"）。代价：text embeds 全缓存 → 不支持训 TE（SDXL 靠 `model.name == 'sdxl'` 特判例外——共享代码里的族名 if，坏味道实证）。
+
+**timestep 异参（反面教材）**：**没有共享实现**——每个 adapter 在 `prepare_inputs` 里各写一份近乎相同的采样代码（qwen_image.py 与 cosmos_predict2.py 结构一致），共享的只有 `time_shift`/`get_lin_function` helper。旋钮在 config `[model]` 节（`timestep_sample_method`/`sigmoid_scale`/`shift`/`flux_shift`）。**Anima 示例 config 不设 shift（即 ≈1.0）**，只建议更低 LR + `llm_adapter_lr = 0`——可作我们 timestep_shift A/B（baseline 3.0 vs 更低）的旁证。
+
+**痛点**：README 明说原生 Windows "difficult or impossible"（DeepSpeed 硬依赖，须 WSL2；[issue #268](https://github.com/tdrussell/diffusion-pipe/issues/268) 用户自述装环境数小时）；feature × model 矩阵不齐（Full Fine Tune 8 族 ❌、fp8 5 族 ❌、block swap 非全族）；TOML config 无 schema 校验；缓存类 issue 多（#444/#492/#509/#313）。
+
+## 7. 补充一：SimpleTuner —— 声明式类属性 + 惰性注册表 + 按族扇出的文档债
+
+37 族注册（含 anima、krea2），每族一个自治目录 `simpletuner/helpers/models/{family}/`（`model.py` + vendor 的 `pipeline.py`/`transformer.py`——不从 diffusers import，隔离好但上游修 bug 不自动同步）。
+
+**接口**：[common.py](https://github.com/bghira/SimpleTuner/blob/main/simpletuner/helpers/models/common.py)（**6205 行**）分层基类 `ModelFoundation → ImageModelFoundation / VideoModelFoundation / AudioModelFoundation`；抽象方法仅 `model_predict`、`_encode_prompts` 等少数几个，**大头是类属性声明**：`NAME`、`PREDICTION_TYPE`、`AUTOENCODER_CLASS`、`LATENT_CHANNEL_COUNT`、`PIPELINE_CLASSES`、`HUGGINGFACE_PATHS`（flavour→repo 映射，承担同族多版本）、`TEXT_ENCODER_CONFIGURATION`、`DEFAULT_LORA_TARGET`。通用 load 逻辑读属性完成加载。
+
+**注册**：每族 `ModelRegistry.register("qwen_image", QwenImage)` + `model_metadata.json` + `LazyModelClass` 惰性导入（CLI 列 flavour 不触发重依赖 import，为启动速度）。加新族（[krea2 首 commit 08b05a94](https://github.com/bghira/SimpleTuner/commit/08b05a942654cd2ac006cfc741072896e8b35258)，2312 行/11 文件）= 新目录 4 文件 + metadata/common/WebUI 三处一行级登记 + 单测。
+
+**缓存**：text embed 文件名 = `md5(key) + f"-{model_family}"`（族名直接编进文件名）；VAE 缓存靠目录 `cache/vae/{model_family}/{dataset_id}`。v2.0 release 明言升级后缓存需重建。
+
+**痛点**：横切特性（TREAD/CREPA/量化/block-swap）全沉积在 6205 行基类；横切改动按族扇出（维护者自开 issue 集群 #2601–#2607，multi-stage validation 要给每族各开一张票）；文档扇出更重——quickstart 234 个文件（每族 × 6 语言），AGENTS.md 强制改文档同步所有翻译。open issue 仅 20，但与激进关票风格及单维护者高强度投入有关，不能直接推出架构无维护成本（推断）。
+
+## 8. 补充二：ComfyUI —— 键名指纹检测 + 声明类 + LatentFormat：推理侧的 ModelSpec 样板
+
+非训练器，但其「从 checkpoint 自动识别模型族」与声明式模型档案值得单列。
+
+**两段式识别**（[model_detection.py](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/model_detection.py)）：先统计权重前缀，再用**指纹键存在性判族 + 张量形状反推超参**（`'{}txt_norm.weight' → "qwen_image"`、`'{}txtfusion.projector.weight' → "krea2"`；层数用 `count_blocks` 数出来）。然后对 [supported_models.py](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/supported_models.py)（约 100 个类）线性扫描、首个 `matches()` 命中即胜——列表顺序是语义的一部分（特化子类必须排前，推断）。
+
+**声明类**：每族一个 class 只声明 `unet_config` 匹配模板、`sampling_settings`（**Anima shift=3.0、Qwen-Image shift=1.15**）、`latent_format = latent_formats.Wan21`（类引用）、`supported_inference_dtypes`、`memory_usage_factor`、`get_model()`、`clip_target()`。[latent_formats.py](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/latent_formats.py) 约 35 个子类，字段：`scale_factor`/`latent_channels`/`latent_rgb_factors`（零成本预览）/`taesd_decoder_name`；`Wan21`（**Anima/Qwen-Image 同用**）用逐通道 mean/std 归一化——与我们「Anima=Qwen-Image VAE=Wan2.1 latent 空间」的既有结论互证。LoRA 键名转换集中在 [comfy/lora.py](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/lora.py)，把 diffusers/PEFT/kohya 键统一映射到内部 `diffusion_model.*`。
+
+**加新族 diff 极小**：Qwen-Image（[commit c0124002](https://github.com/comfyanonymous/ComfyUI/commit/c012400240d4867cd63a45220eb791b91ad47617)）8 文件 +561 行；Anima（[commit abe2ec26](https://github.com/comfyanonymous/ComfyUI/commit/abe2ec26a61ff670b9c0e71e4821c873368c8728)，PR #12012）6 文件 +326 行，**model_detection.py 仅 +2 行**（复用 cosmos_predict2 检测分支改标签）。用户零配置、单 checkpoint 自动定族。
+
+## 9. 横向对比总表
+
+| 项目 | 适配单元形态 | 接口风格 | 加一族真实 diff | LoRA target/键名 | 缓存防串用 | timestep 异参表达 | 最痛的债 |
+|---|---|---|---|---|---|---|---|
+| **sd-scripts** | 薄入口子类 + library 三件套 + strategy_* | 模板方法胖基类，~27 hook | Anima #2260：新建 9 文件、改 2 共享 | 每族整文件复制 lora_*.py；前缀统一 `lora_unet`（Comfy 兼容） | npz 文件名后缀 `_sd`/`_flux`… | per-family argparse 默认 + if/elif + 权重探测变体 | train_util 6888 行巨石（已拆）；FFT 线复制；长寿 sd3 分支 |
+| **musubi-tuner** | 每族包 + 4 个薄入口脚本 | 胖基类 abstract hooks + extension seams（不保稳定） | Krea2 #980：24 文件、新建 21、共享 <100 行 | lora.py 通用 + 每族 ~70 行常量；前缀统一 `lora_unet` | **文件名内嵌架构短名** + metadata（无强校验） | `--timestep_sampling` choices 菜单；推荐值进 docs 不进 default | 14 族 × 4 ≈ 60 入口；登记点靠人记；无测试套件 |
+| **diffusers** | 每 pipeline/每脚本整份复制 | 刻意不抽象（single-file policy） | 复制现有文件再改 | peft 统一 + 3000 行外来格式转换账单 | n/a | 每脚本自带 | 同一 bug 修 10 个脚本；examples 无 fix-copies 覆盖 |
+| **ai-toolkit** | 每族 extension 目录 + BaseModel 子类 | 基类 + 窄 hook + 能力 flag；`arch` 属性扫描注册 | Krea2：新目录 + 2 行注册，**共享零改动** | `target_lora_modules` 属性 + per-model 保存键名转换 | **hash 掺 latent_space_version（可跨族共享）** | per-model scheduler_config + 全局 timestep_type | 单人瓶颈；legacy 双轨并存、arch 特判泄漏 |
+| **OneTrainer** | 族 × 训练方法矩阵格子 + 装饰器工厂 | 注册表 + 族 Base + 7 组 mixin | Anima #1487：15 新文件 + **8 处横切修改**（含 3 个 UI View） | 共享 Wrapper + prefix + LAYER_PRESETS + 4 格式导出 | **无模型标识**；默认训前清缓存（用户责任） | mixin 分层 + 族 Setup.predict 内特有逻辑 | 矩阵 boilerplate（维护者自开 #1203）；sampler/predict 双份前向 |
+| **diffusion-pipe** | models/ 每族 adapter 类 | 类属性 + 方法；train.py if/elif 链分派 | Ideogram4：新 py+352 + elif 一行；Anima 寄生 cosmos 文件 | `adapter_target_modules` 类名匹配 → peft；save per-model（Anima=Comfy 格式） | 缓存目录按 `model.name` 分 + fingerprint | **各 adapter 的 prepare_inputs 内复制**（反面教材） | Windows 不可用；feature × model 矩阵不齐 |
+| **SimpleTuner** | 每族自治目录（vendor 实现） | 声明式类属性 + 6205 行分层基类 + 惰性注册表 | Krea2：11 文件、新目录 4 + 3 处一行登记 | `DEFAULT_LORA_TARGET` 类属性 | text 文件名带族名；VAE 按族目录 | `PREDICTION_TYPE` 属性 + per-族 model.py | 横切特性沉积基类；改动/文档按族扇出 |
+| **ComfyUI**（推理） | supported_models 声明类 + LatentFormat 类 | 键名指纹自动检测 + 声明式档案 | Anima：6 文件 +326、检测 +2 行 | comfy/lora.py 集中多生态键映射 | n/a | `sampling_settings` per-族声明 | 首命中线性扫描的顺序语义；集中文件持续膨胀 |
+
+## 10. 对我们的启示
+
+### 10.1 值得采纳的模式
+
+- **P1 适配单元 = 「声明常量 + 行为方法」两件套**。ComfyUI（unet_config/sampling_settings/latent_format 声明类）、SimpleTuner（类属性）、ai-toolkit（能力 flag + 窄 hook）三家从不同方向收敛到同一结构。我们 §6 的 ModelSpec / ModelFamily 两分法与之同构，方向正确；ComfyUI 的 `LatentFormat` 类（scale/channels/latent_rgb_factors 每族一份）就是 ModelSpec latent 部分的现成样板——我们的 latent2rgb 预览系数也应进 ModelSpec。
+- **P2 加新族 = 纯新增文件 + 少而可数且有校验的登记点**。musubi（3 处登记）、ai-toolkit（2 行）、SimpleTuner（3 处）都做到共享代码近零改动，但登记一致性全靠人记。我们已有 `validate_schema_consistency()` 模式（losses registry ↔ schema Literal 启动期双向校验），把它扩展到 `model_family`（registry keys ↔ schema Literal ↔ catalog 条目），可以做到全生态没人做到的「登记漏一处启动即 fail」。
+- **P3 缓存指纹 = 空间标识 + layout 版本，而非族名**。ai-toolkit 的 `latent_space_version`/`text_embedding_space_version` 掺 hash 是最优解：既防串用，又允许同 latent 空间的族声明同值共享缓存——这正是 D6（Anima/K2 同 `wan21-f8c16`）需要的机制；musubi 按族短名隔离反而使同 VAE 的 Krea2/Qwen-Image 各存一份。PR-1 给 npz 缓存加指纹时应直接采用「指纹 = latent 空间标识 + layout 版本」，族名不入键。同族实现变更 bump 版本作废旧缓存（ai-toolkit / diffusion-pipe README 都有「不清缓存报 shape error」的教训）。
+- **P4 timestep：算法进共享 registry 菜单，数值默认进 per-family overlay**。musubi 把 `krea2_shift` 做成共享基类内的 `--timestep_sampling` choices 项、推荐数值放 docs；ai-toolkit「分布归 config、shift 归模型 scheduler_config」；ComfyUI `sampling_settings` 声明。共同点是**分辨率感知 shift 这类算法只实现一次**。
+- **P5 键名约定向 ComfyUI 看齐是行业事实标准**。musubi 全族统一 `lora_unet` 前缀、sd-scripts 注释明写 "make ComfyUI compatible"、diffusion-pipe/ai-toolkit 用 `diffusion_model.` 前缀保存。且**保存键名转换是 per-model 的窄钩子**（musubi `convert_weight_keys`、ai-toolkit `convert_lora_weights_before_save`），不要试图写通用映射——diffusers 那 3000 行 `lora_conversion_utils.py` 是被动承接全生态格式的账单，训练器只需管好自己的输出格式。
+- **P6 studio 层是我们的差异化优势，不是负担**。各家加新族最横切的改动恰是 UI/文档：OneTrainer 要手改 3 个 UI View、ai-toolkit 要改 options.ts、SimpleTuner 文档按族 × 语言扇出 234 份。我们 pydantic schema 驱动表单 + `show_when`/能力集裁剪意味着 family 声明能力集后 UI 自动收敛——没有任何对标项目有这个机制（他们的 GUI 都是手写的）。D5 的能力集门控要坚持走 schema 管道而非前端 if。
+- **P7 用「检测」做防呆而非选型**。ComfyUI 的键名指纹检测支撑「用户丢任意 checkpoint 自动定族」；我们 v1 用显式 `model_family` 字段（D7）更简单可控，但可以把现有 `load_anima_model` 的形状推断泛化为 family 声明的「指纹校验」：加载时验证 checkpoint 与所选 family 匹配，防止用户给 K2 版本配了 Anima 权重路径——消费级用户场景里这类错误必然出现。
+
+### 10.2 反模式警告
+
+- **A1 巨型共享文件沉积**。train_util.py 6888 行（kohya 最后靠 "Refactor for ai agents" 拆掉）、SimpleTuner common.py 6205 行、ai-toolkit BaseSDTrainProcess 2806 行。横切功能（我们的 InfoNoise/masked loss/eval/暂停恢复）必须继续走 plugin registry/独立模块，禁止向 ModelFamily 基类或共享 loop 文件堆积。
+- **A2 复制漂移**。diffusers examples 同 bug 修 10 遍；diffusion-pipe 每个 adapter 复制一份 timestep 采样；sd-scripts FFT 线整脚本复制。判据：**凡「每族各写一份近乎相同代码」的面，迟早还债**。接口设计时如果发现两个 family 的某方法实现将逐字相同，说明该逻辑应上移到共享循环或 spec 参数。
+- **A3 矩阵爆炸**。OneTrainer 族 × 方法 → modelSaver/ 96 个文件，维护者自开 issue 求简化。我们只有 LoRA/LoKr 一种训练方法，天然免疫；但若未来加全参微调，**必须作为 family 内的一个模式参数而非第二维度的类矩阵**。
+- **A4 双世代并存 / 迁移不彻底**。ai-toolkit legacy `StableDiffusion` god-class 与 `BaseModel` 两套并存多年，`is_flux` 特判泄漏进训练循环至今。对我们：Phase 1 PR-2 必须把 Anima **完整**迁入 AnimaFamily（含 `forward_with_optional_checkpoint`/navit.py），不留「Anima 走老路径、K2 走新路径」的过渡态——过渡态会永久化。
+- **A5 族名 if 泄漏进共享代码**。diffusion-pipe 的 `model.name == 'sdxl'` 特判、ai-toolkit 的 `'flex' in self.sd.arch`。执行纪律：共享循环里出现 `if family == "anima"` 即为坏味道，一律改为能力 flag / spec 字段查询（D5 的能力集就是为此准备的）。
+- **A6 长寿开发分支**。sd-scripts 的 sd3 分支承担主开发 1.5 年不合 main。我们 Phase 1-4 的小步 PR 序列是对的，坚持每个 PR 独立可合。
+- **A7 缓存无标识 + 「用户自己清」**。OneTrainer 默认训前清缓存、diffusion-pipe/musubi 换实现要手动清且报错难懂。消费级 Windows 用户不会读 README——指纹失配必须自动重算并在 UI 提示，不能抛 shape error。
+- **A8 入口脚本线性膨胀**（musubi 60 个入口）。对我们影响有限（supervisor 拉起单入口，D8 已定派发点在 `phases/models.py`），但印证了「入口不动、内部派发」的选择：不要走 per-family 姊妹脚本路线。
+
+### 10.3 对 00-decisions §6 接缝草案的对标修正意见
+
+逐条对照 §6 草案与各家真实接口后的具体建议（供 03/04 文档冻结接口时采纳）：
+
+1. **§6.1 ModelSpec：整体印证，建议补 3 项**。(a) `latent_rgb_factors`（预览投影系数，学 ComfyUI LatentFormat——我们已知 Anima 必须用 Wan21 系数的教训）；(b) 能力集之外再留**布尔能力 flag 面**（学 ai-toolkit `is_flow_matching`/`do_masked_loss`），供共享循环做细粒度查询，能力集列表管 UI 裁剪、flag 管代码路径，两者职责不同；(c) 缓存指纹字段明确为「空间标识 + layout version」两段（见 P3），族名不参与。
+2. **§6.2 适配器方法：草案 7 个方法覆盖了 musubi abstract hooks 的最小集，建议增 1 改 1**。**增**：`convert_weight_keys` / 保存键名钩子（musubi、ai-toolkit 都单列；我们的 `lora_preset()` 目前只管 target，键名约定与 Comfy 兼容转换也需 per-family 落点，且 §7 的「Comfy 键名核对」open question 正落在这里——v1 就要冻结）。**改**：`forward_train` 的签名建议对齐 musubi `call_dit -> DiTOutput`（返回 pred+target 数据类而非裸 `v_pred`）——K2 与 Anima 虽同为 RF，但保留 target 构造的族内自由度可以吸收未来非 v-pred 族，而 loss 仍留共享循环。**明确不加**：per-family 的 timestep 采样钩子（见下条）与 `handle_model_specific_args` 型配置校验钩子（pydantic schema + show_when 已覆盖，这是 studio 层替我们省掉的一类接口）。
+3. **§6.3 共享循环边界：印证，外加一条硬规则**。「凡只消费 (latents, noise, t, loss, mask) 的功能留共享循环」得到全部对标印证（OneTrainer 的 masked loss 就在 DiffusionLossMixin 一次实现全族生效）。硬规则：**timestep 采样属于共享循环**——diffusion-pipe 把它放进 adapter 导致每族复制（A2 实证），musubi 把它放在共享基类 + choices 菜单（P4 正解）。K2 的分辨率感知 shift 应实现为我们现有 timestep_sampler registry 的新策略（如 `krea2_dynamic_shift`），ModelSpec 的默认值 overlay 指向它；不要做成 Krea2Family 的方法。
+4. **§6.4 派发：印证 + 升级**。registry 派发与 OneTrainer factory（37 行、重复注册 raise）/ai-toolkit 扫描注册同款；我们的升级空间是 P2 的启动期一致性校验（schema Literal ↔ registry ↔ 下载 catalog 三方对齐），把 musubi「3 处登记靠人记」的弱点变成我们的强项。
+5. **两条 §7 open question 的生态答案**。(a) 入口脚本改名：对标支持「不改」——ComfyUI/ai-toolkit/SimpleTuner 都是稳定入口 + 内部派发，musubi 的 per-family 入口是它没有 config schema 层的补偿（A8）；`anima_train.py` 文件名的历史兼容成本远低于动 supervisor。(b) text cache 位置：diffusion-pipe（数据集目录内 per-model 子目录）与我们 mask sidecar 的同目录哲学最接近，但 text cache 按 D3 带 caption hash + TE 指纹，集中或 sidecar 均可，关键是失效键设计（P3）而非位置。
+6. **Phase 0/3 的直接输入**：musubi K2 参考面——target = 全部 264 Linear（`KREA2_TARGET_REPLACE_MODULES = None`）、dim32/alpha32、`krea2_shift` 或 discrete 2.5@1024²、训练 RAW / 采样可热切 Turbo（`--turbo_dit`，实现在 `on_before/after_sample_images`）——我们 `build_sampler()` 设计时需决定验证采样用 Raw 还是 Turbo，musubi 已给出可抄的答案。另：diffusion-pipe Anima 示例 shift≈1.0 + ComfyUI Anima 声明 shift=3.0，两者并存恰说明「训练 shift 与推理 shift 是两个旋钮」，也旁证我们 timestep_shift A/B（3.0 vs 更低）值得做。
+
+## Sources
+
+**kohya sd-scripts**
+- https://github.com/kohya-ss/sd-scripts/blob/main/train_network.py （NetworkTrainer 基类与 hooks）
+- https://github.com/kohya-ss/sd-scripts/blob/main/sdxl_train_network.py 、sd3_train_network.py 、flux_train_network.py 、anima_train_network.py （子类覆写量）
+- https://github.com/kohya-ss/sd-scripts/blob/main/library/strategy_base.py 、strategy_sd.py 、strategy_flux.py （strategy 体系与缓存后缀）
+- https://github.com/kohya-ss/sd-scripts/blob/main/library/flux_train_utils.py 、sd3_train_utils.py （per-family argparse 默认值、flux_shift）
+- https://github.com/kohya-ss/sd-scripts/blob/main/networks/lora.py 、lora_flux.py 、lora_sd3.py （target 常量、lora_unet 前缀、Comfy 兼容注释）
+- https://github.com/kohya-ss/sd-scripts/pull/2260 （Anima 支持 PR，加新族文件清单）
+- https://github.com/kohya-ss/sd-scripts/pull/2372 （train_util 拆分 "Refactor for ai agents"）
+- https://github.com/kohya-ss/sd-scripts/issues/1924 （kohya 自述 "Musubi tuner is much simpler"）
+- https://github.com/kohya-ss/sd-scripts/issues/2383 （shift 只对部分采样模式生效的用户困惑）
+
+**kohya musubi-tuner**
+- https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/training/trainer_base.py （abstract hooks + extension seams）
+- https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/training/parser_common.py （timestep_sampling choices 菜单）
+- https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/cache_latents.py 、krea2_cache_latents.py （缓存脚本共享模式）
+- https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/dataset/architectures.py 、cache_io.py 、image_video_dataset.py （架构短名与缓存文件名）
+- https://github.com/kohya-ss/musubi-tuner/blob/main/src/musubi_tuner/networks/lora.py 、lora_wan.py 、lora_qwen_image.py 、lora_krea2.py （通用 LoRA + 每族常量）
+- https://github.com/kohya-ss/musubi-tuner/pull/980 （Krea 2 支持 PR）、pull/408 （Qwen-Image）、pull/950 （基类抽出重构）
+- https://github.com/kohya-ss/musubi-tuner/blob/main/docs/krea2.md 、docs/qwen_image.md （per-model 推荐值进 docs）
+- https://github.com/kohya-ss/musubi-tuner/blob/main/.ai/context/overview.md （kohya 架构自述）
+- https://github.com/kohya-ss/musubi-tuner/issues/411 、issues/55
+
+**diffusers**
+- https://huggingface.co/docs/diffusers/conceptual/philosophy （single-file policy 定义与共享白名单）
+- https://huggingface.co/blog/transformers-design-philosophy （反 DRY 论证、Copied-from 起源）
+- https://github.com/huggingface/diffusers/tree/main/examples/dreambooth （20 个 train 变体；flux/sd3 版 85% 相同为实测）
+- https://github.com/huggingface/diffusers/blob/main/examples/README.md （examples 定位四原则）
+- https://github.com/huggingface/diffusers/blob/main/utils/check_copies.py （fix-copies 只覆盖 src/）
+- https://github.com/huggingface/diffusers/pull/13899 （同一 bug 修 10 个脚本）
+- https://github.com/huggingface/diffusers/blob/main/src/diffusers/loaders/lora_conversion_utils.py （26 个键名转换函数，含 Anima）
+- https://github.com/huggingface/diffusers/blob/main/src/diffusers/loaders/single_file_utils.py （CHECKPOINT_KEY_NAMES 指纹）
+
+**ostris ai-toolkit**
+- https://github.com/ostris/ai-toolkit/blob/main/toolkit/models/base_model.py （BaseModel 接口与能力 flag）
+- https://github.com/ostris/ai-toolkit/blob/main/toolkit/util/get_model.py 、toolkit/extension.py 、extensions_built_in/diffusion_models/__init__.py （arch 扫描注册）
+- https://github.com/ostris/ai-toolkit/blob/main/extensions_built_in/diffusion_models/example_model/README.md （官方加模型模板）
+- https://github.com/ostris/ai-toolkit/blob/main/toolkit/dataloader_mixins.py 、toolkit/data_loader.py （latent_space_version 掺 hash）
+- https://github.com/ostris/ai-toolkit/blob/main/jobs/process/BaseSDTrainProcess.py 、extensions_built_in/sd_trainer/SDTrainer.py （共享循环调 hook 序列）
+- https://github.com/ostris/ai-toolkit/commit/99be3d96 （Krea2 添加 diff）
+- https://github.com/ostris/ai-toolkit/issues/693 （Z-Image 训练质量社区批评）
+
+**OneTrainer**
+- https://github.com/Nerogar/OneTrainer/blob/master/docs/ProjectStructure.md （目录职责官方说明）
+- https://github.com/Nerogar/OneTrainer/pull/1211 、pull/1498 （if/elif → 装饰器工厂重构）
+- https://github.com/Nerogar/OneTrainer/pull/1487 （Anima 支持 PR：15 新文件 + 8 处横切）、pull/1195 （Z-Image）
+- https://github.com/Nerogar/OneTrainer/pull/1563 、pull/1294 （LoRA 多格式导出与键名坑）
+- https://github.com/Nerogar/OneTrainer/issues/1203 （维护者自述矩阵 boilerplate 痛点）
+- 源码：modules/util/factory.py、modules/modelSetup/BaseModelSetup.py、BaseFluxSetup.py、modules/module/LoRAModule.py、Nerogar/mgds DiskCache.py
+
+**tdrussell diffusion-pipe**
+- https://github.com/tdrussell/diffusion-pipe （README：Windows 不可用、ComfyPipeline 转向）
+- https://github.com/tdrussell/diffusion-pipe/blob/main/models/base.py （CommonPipeline/BasePipeline/ComfyPipeline 接口）
+- https://github.com/tdrussell/diffusion-pipe/blob/main/train.py （if/elif 分派链、共享循环）
+- https://github.com/tdrussell/diffusion-pipe/blob/main/utils/dataset.py （cache/{model.name} 目录、sdxl 特判）
+- https://github.com/tdrussell/diffusion-pipe/blob/main/docs/supported_models.md （per-model 保存格式与 feature 矩阵）
+- https://github.com/tdrussell/diffusion-pipe/commit/3abbfff5 （Anima 寄生 cosmos_predict2）、commit/d6a8f562 （Ideogram4）
+- issues：#268（WSL2 之痛）、#313、#420、#434、#444、#488、#492、#509
+
+**SimpleTuner**
+- https://github.com/bghira/SimpleTuner/blob/main/simpletuner/helpers/models/common.py （6205 行分层基类与类属性声明面）
+- https://github.com/bghira/SimpleTuner/blob/main/simpletuner/helpers/models/registry.py 及 model_metadata.json（惰性注册表）
+- https://github.com/bghira/SimpleTuner/blob/main/simpletuner/helpers/caching/text_embeds.py 、caching/vae.py 、data_backend/factory.py （缓存带族名）
+- https://github.com/bghira/SimpleTuner/commit/08b05a942654cd2ac006cfc741072896e8b35258 （krea2 初始 commit）
+- https://github.com/bghira/SimpleTuner/releases/tag/v2.0 、AGENTS.md、issues #2601–#2607（横切扇出）
+
+**ComfyUI**
+- https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/model_detection.py （键名指纹 + 形状反推）
+- https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/supported_models.py 、supported_models_base.py （声明类与 matches 机制）
+- https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/latent_formats.py （LatentFormat 体系、Wan21 逐通道归一）
+- https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/lora.py （多生态键名集中映射）
+- https://github.com/comfyanonymous/ComfyUI/commit/c012400240d4867cd63a45220eb791b91ad47617 （Qwen-Image）、commit/abe2ec26a61ff670b9c0e71e4821c873368c8728 （Anima，检测仅 +2 行）

--- a/docs/design/multi-model/03-interface-evolution.md
+++ b/docs/design/multi-model/03-interface-evolution.md
@@ -1,0 +1,455 @@
+# 03 — ModelFamily 接口契约与长期演化（压力测试视角）
+
+- 状态：视角文档，供 `04-synthesis.md` 收敛。不推翻 `00-decisions.md` D1–D9；本文把其 §6 接缝草案细化到方法签名级别，并给出修正建议（§4.5）。
+- 日期：2026-07-13
+- 前置阅读：`00-decisions.md`（背景、K2 档案、已锁定决策）。
+
+## TL;DR
+
+- **v1 冻结面（现在定死）**：`ModelSpec` 纯数据字段集；`ModelFamily` 八个方法的名字与签名（`load_dit / load_vae / load_text / encode_text_for_batch / forward_train / sample_image / lora_preset / lora_metadata`）；共享循环七条不变量 —— 其中最硬的三条是 **latent 恒 5D `(B,C,T,H,W)` 且 v1 内 `T==1`**、**t ∈ (0,1) 连续、x_t=(1−t)·x₀+t·ε、target=ε−x₀（rectified flow，唯一支持的 objective）**、**text cond 对循环完全 opaque**。
+- **最大裂点（实地核对发现）**：D8 说「派发点 = `phases/models.py`」，但 loader 三件套 + `sample_image` 有 **5 个循环外调用方**（`anima_generate` / `anima_daemon` / `anima_reg_ai` / `studio/services/eval_samples` / `sample_runner`），K2 的 Generate/评估/RegAI 会全部绕过派发直接崩 —— registry 必须暴露在 `anima_train` 公共命名空间这一个咽喉上（§1.3、§4.5-①）。
+- **压力测试结论**：Qwen-Image 几乎零裂（证明接口够用）；Wan 2.2 视频裂在 dataset/预览而非 forward（→ `temporal` 拒绝位字段，不进 v1 功能面）；SDXL 裂在 t 语义与 target 代数（→ `objective` 拒绝位字段，共享循环只做 rectified flow）；自回归 token 模型全线崩（证明「接口拒绝它」正确 —— 那是另一个产品，不是 family #N）。
+- **反过度抽象**：采样器数值代码、文本编码内部、checkpoint 形状推断、显存策略、guidance 约定 —— 全部明确不抽象，宁可将来 per-family 重复（§4.3、§4.4）。
+
+---
+
+## 1. 实地核对：接口切点 vs 真实调用面
+
+先盘点今天代码里「换一个模型族就必须变」的每一处，作为接口切分的证据基础。
+
+### 1.1 训练主循环（`runtime/training/loop.py`）
+
+| 触点 | 位置 | 事实 |
+|---|---|---|
+| batch 键 | `loop.py:201-219` | `captions`（恒有）、`latents`（缓存路径，5D）或 `pixel_values`（非缓存）、`navit_latents`（list，Anima-only）、`masks` / `loss_weight` / `is_reg`（可选） |
+| 非缓存 VAE encode | `loop.py:215-219` | `pixels.unsqueeze(2)` → `[B,C,1,H,W]` 后 `vae.model.encode` —— 单帧假设写死在 unsqueeze |
+| 文本编码（每步在线） | `loop.py:222-254` | Qwen 编码 + T5 tokenize + `ctx.model.preprocess_text_embeds(qwen_emb, t5_ids, t5xxl_weights)`（:242，融合层在 DiT 权重内）+ **pad 到 512**（:243-244）+ **kv_trim 桶截断**（:247-254）。全部 Anima 私货，但目前裸露在循环里 |
+| t 采样 | `loop.py:258` | `ctx.timestep_sampler.sample(bs, device)` —— 已是 plugin（`timestep_samplers/baseline.py:30-38`），t ∈ (0,1)（`timestep_sampling.py:23`） |
+| 分辨率 shift 修正 | `loop.py:263-270` | opt-in，SD3 sqrt 规则（`timestep_sampling.py:105-123`），`patch_spatial=2` 写死在 token 计数（`timestep_sampling.py:87-102`） |
+| 加噪 + 目标 | `loop.py:288, 399-400` | `t_exp = t.view(-1,1,1,1,1)`（5D）；`noisy = (1-t)*latents + t*noise`；`target = noise - latents` —— rectified flow 代数在循环里 |
+| pad_mask 构造 | `loop.py:310` | `zeros(bs,1,h,w)` —— Anima `concat_padding_mask` 的私有输入，循环替模型造 |
+| 前向 | `loop.py:401-404` | `forward_with_optional_checkpoint(ctx.model, noisy, t.view(-1,1), cross, pad_mask, use_checkpoint)`；整个调用在 `torch.autocast`（:315）内 |
+| 梯度检查点 | `model_loading.py:33-59` | 手工展开 Anima 内部 API：`prepare_embedded_sequence` / `t_embedder` / `t_embedding_norm` / `blocks` / `final_layer` / `unpatchify` —— 换族必换 |
+| masked loss | `loop.py:408-411, 447-450` | `masks` (B,h,w) latent 分辨率 → `view(bs,1,1,h,w)` 广播到 (B,C,T,H,W)；加权 reduction `_masked_mean`（:111-120）只吃形状，family 无关 |
+| loss / InfoNoise record / 加权 | `loop.py:413-446` | 全部只消费 `(pred, target, t, mask, loss_weight)` —— 符合 §6 草案「共享循环边界」判据 |
+| NaViT 路径 | `loop.py:316-345`，`navit.py:113-129` | 调 `model.patchify_latents_to_tokens` / `model.forward_packed_navit` —— Anima 专属内部 API，D5 已定为 Anima-only 能力 |
+| leap / SRA | `loop.py:346-396, 453-467` | 直接拿 `ctx.model` 多次前向 / 挂 hook —— 同为 Anima-only 能力（D5） |
+
+**结论**：循环里真正需要搬进 family 的只有四块 —— 文本编码块（:222-254）、pad_mask 构造（:310）、前向派发（:401-404 + checkpoint 展开）、非缓存 encode 的 5D 组装（:215-219）。噪声/目标/loss/mask/权重代数全部留在循环（不变量见 §2.7）。
+
+### 1.2 phase 协议（`runtime/training/phases/`）
+
+编排顺序 `bootstrap → models → dataset → optimizer → resume → loop → finalize`（`phases/__init__.py:7`，`anima_train.py:130-136`）。每个 phase 是 `run(ctx: TrainingContext) -> None` 原地改 ctx。family 接口在各阶段的被调面：
+
+| Phase | family 触点 | 证据 |
+|---|---|---|
+| bootstrap | **解析 family**（新增）：读 `args.model_family` 查 registry、能力校验；pause snapshot 覆盖 args（含未来的 `model_family`，snapshot freeze 天然保住跨 pause 的族一致性） | `phases/bootstrap.py:149-151`（snapshot 覆盖）、`178-188`（dtype 决策，family 无关） |
+| models | **loader 三件套 + LoRA preset**：`load_anima_model`（:68-70）→ attention backend 开关（:63-75）→ `load_vae`（:78-79）→ `load_text_encoders`（:82-84）→ `build_adapter().inject()`（:89-91）→ `resume_lora`（:94-96）→ SRA（:99-117，Anima-only） | `phases/models.py` |
+| dataset | 只消费 **latent 规格**：桶对齐 16px（`dataset.py:67`）、mask 下采样 //8（`dataset.py:719`）、token 计数 `patch_spatial=2`（`dataset.py:1077-1094`）、缓存判据（§1.4）；masked×navit 互斥闸（`phases/dataset.py:100-107`） | `phases/dataset.py:109-192` |
+| optimizer | 零触点（`injector.get_param_groups` 走 adapter，`build_timestep_sampler` 走 plugin） | `phases/optimizer.py:31-91` |
+| resume | `load_training_state` 灌 LoRA/optimizer/RNG（§1.5）；step-0 基线采样调 `run_sample`（:118-130） | `phases/resume.py:62-68` |
+| finalize | `injector.save(final_path)`（LoRA 产物 metadata，§1.4）+ `eval_training_finished` 事件 | `phases/finalize.py:29-38` |
+
+### 1.3 循环外调用面 —— D8 的修正证据（最重要的实地发现）
+
+loader 三件套与 `sample_image` 的**全部**调用方：
+
+| 调用方 | 位置 | 用途 |
+|---|---|---|
+| `phases/models.py` | `:68-84` | 训练 |
+| `runtime/anima_generate.py` | `:136-160`（loader）、`:214, 380`（sample_image） | 测试页出图 CLI |
+| `runtime/anima_daemon.py` | `:246-320`（loader）、`:744, 879`（sample_image） | Generate 常驻 daemon |
+| `runtime/anima_reg_ai.py` | `:426-445`（loader）、`:491`（sample_image） | reg_ai 生成 |
+| `studio/services/eval_samples.py` | `:546-628`（`import anima_train as _T` 后 `_T.load_anima_model` / `_T.load_vae` / `_T.load_text_encoders` / `_T.sample_image`） | 训练后评估出图 |
+| `runtime/training/sample_runner.py` | `:78-86` | 训练中预览 |
+
+`00-decisions.md` §6 草案与 D8 只写了「`phases/models.py` 查 registry」。**若只改这一点，K2 版本的 Generate / RegAI / 训练后评估会继续走 `load_anima_model` 直接崩**（`models.py:406-411` 只认 2048/5120 两档 `model_channels`，K2 width 6144 直接 `RuntimeError`）。好消息是所有旁路调用方都统一经过 `anima_train` 公共命名空间（`anima_train.py:88-94` re-export），派发只需要收口在这一个咽喉：registry 查询函数进 `anima_train` 公共 API（§2.3）。这不推翻 D8（supervisor/cmd_builder 不动、入口脚本不变依旧成立），是对派发面的补全。
+
+### 1.4 缓存与产物
+
+- **latent npz**：键 = `latent` / `latent_flipped` / `mask` / `mask_flipped` / `bucket_w` / `bucket_h`（`dataset.py:1160-1198`）；latent 存 `(16,1,h,w)`，collate stack 成 5D（`dataset.py:1320-1331`）。判据 = 存在性 + mtime + bucket 尺寸 + 键存在性（`dataset.py:985-1039`），**无任何模型/VAE 指纹**（`00-decisions.md` §3 已列为隐患，Phase-1 PR-1 修）。不兼容缓存有现成的「删除重 encode」路径（`dataset.py:1008-1011`）可挂新判据。
+- **LoRA 产物 metadata**：`ss_network_dim/alpha/module` + `ss_network_args`（`utils/lycoris_adapter.py:363-380`），其中 `preset: "anima_full"` 已经是事实上的 per-family 标记但没有正式字段；target 列表与 `lora_prefix="lora_unet"` 写死在 `utils/lokr_preset.py:14-26`。
+- **文本缓存**：现状无（每步在线，`loop.py:222-254`）；D3 给 K2 引入 varlen 预缓存。
+
+### 1.5 恢复 / 暂停
+
+`save_training_state`（`state.py:35-68`）存：`lora_state_dict` / `optimizer` / `scheduler` / `rng` / `monitor` / `timestep_sampler` / `sra_aligner` / `scaler` —— **不含任何基模型权重，也不含 family 标识**。pause snapshot 冻结整份 args（`phases/bootstrap.py:25-62`），未来 `model_family` 字段随 args 冻结，跨 pause 族一致性由 snapshot 机制免费获得。但**跨族误 resume 无防护**：`injector.load_state_dict(strict=False)` 对键完全不匹配的跨族 LoRA 只发 warning（`state.py:95-102`），会静默变成「全 missing 冷启动」继续训 —— 比崩溃更糟（§4.5-⑦）。
+
+### 1.6 schema 与门控机制现状
+
+- `TrainingConfig`（`studio/domain/training.py:24-30`，`extra="ignore"`）每字段带 `json_schema_extra={"group","control","show_when"?}`（:10-11）；4 个权重路径字段（:38-57）默认指向 Anima。
+- `show_when` 求值器是**纯字段值比较**文法：`==` / `!=` / `||` / `&&`（`studio/domain/config_prune.py:49-66`），前端 `schema.ts` 逐字镜像；求值为假的字段落盘时被裁剪（`config_prune.py:69-90`）。**能力位不能直接进表达式** —— 门控必须编译成 `model_family==xxx` 形式的字段比较（§2.4）。
+- 采样默认值（shift=3.0、er_sde/simple 白名单）写死在 `sampling.py:32-33, 344`。
+
+---
+
+## 2. 接口 v1 精确定义
+
+### 2.1 `ModelSpec` —— 纯数据（frozen dataclass，声明式常量）
+
+```python
+# runtime/training/families/spec.py（示意；全部 frozen dataclass，无行为）
+
+@dataclass(frozen=True)
+class LatentSpec:
+    fingerprint: str        # 缓存指纹，如 "wan21-f8c16"（D6：Anima 与 K2 同值 → 缓存共享）
+    channels: int           # 16（今天散落在 models.py:456 / dataset.py:1284 / sampling.py:239 等 ≥8 处）
+    spatial_stride: int     # 8（VAE f8；dataset.py:719 的 //8、sampling.py:332 的 //8 的单一来源）
+    patch_spatial: int      # 2（models.py:416 / dataset.py:1080 / timestep_sampling.py:87 的单一来源）
+    patch_temporal: int     # 1
+    temporal: bool          # v1 恒 False —— 视频拒绝位（§3.2 结论），不是功能开关
+    # 派生属性：align_px = spatial_stride * patch_spatial（=16，桶/采样尺寸对齐用，
+    # 对应 dataset.py:67 与 sample_runner.py:54-55 两处写死的 16）
+    # 注意：VAE 归一化 mean/std 向量不进 spec —— 那是权重侧事实，属 load_vae 内部（models.py:468-475）
+
+@dataclass(frozen=True)
+class TextSpec:
+    strategy: Literal["online", "cached_varlen"]   # D3：Anima=online，K2=cached_varlen
+    max_seq_len: int                               # 两族都是 512
+    fingerprint: str                               # TE 指纹（cached_varlen 的缓存键成分；online 时仅记录用）
+    # embed 内部形状（Anima (B,512,1024) 融合后 / K2 (B,≤512,12,2560) 堆叠）不进 spec：
+    # cond 对循环 opaque（§2.7-4），形状是 family 内部事务
+
+@dataclass(frozen=True)
+class SamplingDefaults:
+    samplers: tuple[str, ...]        # 白名单（Anima: ("er_sde","dpmpp_3m_sde")，对应 sampling.py:32）
+    schedulers: tuple[str, ...]      # ("simple","sgm_uniform")
+    default_sampler: str
+    default_scheduler: str
+    default_steps: int               # 25
+    default_cfg: float               # 4.0
+    shift_policy: ConstantShift | ResolutionAwareShift
+    # ConstantShift(3.0)＝Anima（sampling.py:344）；
+    # ResolutionAwareShift(base_shift=0.5, max_shift=1.15, ref_seq_len=...)＝K2。
+    # typed union 而非裸 float —— 这就是版本化的能力位：新增策略＝加一个 dataclass 成员，
+    # 不改方法签名。仅影响「采样端 sigma 表 + schema 默认值 overlay」；
+    # 训练端 t 采样仍走 timestep_sampler plugin（family 只供默认参数，见 §4.5-⑨）。
+
+@dataclass(frozen=True)
+class ModelSpec:
+    family_id: str                   # "anima" / "krea2" —— registry 键 & schema enum 值，永不改名
+    display_name: str
+    objective: Literal["rectified_flow"]   # v1 唯一合法值 —— eps/DDPM 拒绝位（§3.3 结论）
+    latent: LatentSpec
+    text: TextSpec
+    sampling: SamplingDefaults
+    capabilities: frozenset[str]     # 词表见 §2.4
+    lora: LoraOutputSpec             # prefix（"lora_unet"）、preset_name（"anima_full"/"krea2_full"）
+    config_defaults: Mapping[str, Any]
+    # 创建 version 时叠进初始 yaml 的 per-family 默认值 overlay（如 K2 timestep_shift=2.5）。
+    # 作者写时落盘，不做 runtime 魔法 —— 用户在 Train 页看到的就是生效值。
+```
+
+**错误约定**：`ModelSpec` 构造后由 registry 注册时做一次自洽校验（能力词表合法、`cached_varlen` ⇒ 不含 `caption_tag_ops` 能力等），违反 → `ValueError`，进程启动即死（对齐 `phases/bootstrap.py:121-128` 的 plugin schema 启动期校验风格）。
+
+### 2.2 `ModelFamily` —— 行为（逐方法契约）
+
+```python
+class TextStack(Protocol):
+    """family 私有的文本编码器持有物（Anima: Qwen+qwen_tok+t5_tok；K2: Qwen3-VL）。
+    对外唯一承诺：encode 永远成功 —— cached_varlen 实现在 cache miss 时懒加载 TE 权重、
+    编码、写缓存（预期只在用户临时改采样 prompt 时发生）。"""
+
+@dataclass
+class LoadedModels:
+    dit: nn.Module
+    vae: "VAELike"       # 协议同 VAEWrapper：encode (B,3,T,H,W)->(B,C,T,h,w)、
+                         # decode (B,C,T,h,w)->(B,3,T,H*8,W*8)、.dtype、tiling 内部自治
+                         # （models.py:130-203 现有语义原样冻结；dataset 缓存 dataset.py:1115
+                         #  与 roundtrip 自检 phases/dataset.py:260-261 直接依赖）
+    text: TextStack
+
+
+class ModelFamily(Protocol):
+    spec: ModelSpec
+
+    # ───────────────────────────── 加载（models_phase + 全部旁路调用方，§1.3）
+    def load_dit(self, path: str, device, dtype, *,
+                 attention_backend: str,       # "flash_attn" | "xformers" | "none"
+                 repo_root: Path) -> nn.Module:
+        """替代 load_anima_model（models.py:339-447）。
+        副作用自治：sys.path 注入、modeling 模块全局 attention 开关、
+        checkpoint 形状推断（models.py:397-427）全是 family 内部事务。
+        错误：权重覆盖率低 / 关键层缺失 → RuntimeError 带可操作文案
+        （沿用 _load_weights_best_effort 风格，model_loading.py:302-308）。"""
+
+    def load_vae(self, path: str, device, dtype, *, tiling: str) -> "VAELike": ...
+        # Anima 与 K2 同款 Qwen-Image VAE（D6/D7）——两个 family 可以共同调用同一个
+        # 共享 loader 工具函数，但方法本身在 family 上（第 3 族 VAE 不同款时零迁移）。
+
+    def load_text(self, paths: TextPaths, device, dtype, *,
+                  purpose: Literal["train", "generate"]) -> TextStack: ...
+        # 替代 load_text_encoders（models.py:481-524）。purpose 保留现有
+        # comfy_qwen 分叉语义（sampling.py:263-265：Generate runtime 用 comfy 编码器）。
+
+    # ───────────────────────────── 文本条件（loop.py:222-254 整块下沉）
+    def prepare_text_cache(self, captions: Iterable[str],
+                           extra_prompts: Iterable[str]) -> None:
+        """cached_varlen 族的预缓存钩子（Phase 2 接入 dataset_phase 之后、loop 之前）；
+        extra_prompts = sample_prompts + negative（bootstrap 后已知，resume.py:110-113）。
+        online 族实现为 no-op。缓存键 = sha256(caption) + spec.text.fingerprint（D3）。
+        预缓存完成后 family 可自行释放 TE 权重（K2 省 ~8GB 常驻；TextStack.encode
+        的懒加载承诺保证之后仍可用）。"""
+
+    def encode_text_for_batch(self, text: TextStack, dit: nn.Module,
+                              captions: list[str], device, dtype) -> "TextCond":
+        """每步调用（loop 内、no_grad 下）。返回 opaque cond，循环原样透传给
+        forward_train —— pad-to-512（loop.py:243-244）、kv_trim（loop.py:247-254）、
+        preprocess_text_embeds（loop.py:242，融合层在 DiT 权重内所以需要 dit 参数）
+        全部收进 AnimaFamily 实现。K2 实现＝查缓存（命中率应为 100%，
+        tag ops 已被能力门控关闭 → caption 逐步确定，见 §2.4 交叉不变量）。
+        约定：cond 首维语义上对应 batch，但循环不得索引/切片/pad 它。"""
+
+    # ───────────────────────────── 训练前向（loop.py:401-404 + model_loading.py:33-59 下沉）
+    def forward_train(self, dit: nn.Module,
+                      noisy: Tensor,      # (B,C,T,H,W)，autocast dtype，T==1（v1 不变量）
+                      t: Tensor,          # (B,) float32，t∈(0,1)
+                      cond: "TextCond",
+                      *, use_checkpoint: bool) -> Tensor:
+        """返回 v_pred，形状 == noisy。
+        - 调用点：标准路径每 micro-batch 一次（loop.py:401），autocast 上下文内
+          （loop.py:315）——family 不得自行开 autocast。
+        - t 的 reshape 自治：Anima 内部 view(-1,1)（今天 loop.py:402 替它做的）；
+          采样端 1D expand（sampling.py:371-377）与训练端 (B,1) 的差异证明
+          t 形状按摩本来就是 family 私事。
+        - padding_mask（loop.py:310）由 family 内部构造 —— 它是 Anima
+          concat_padding_mask 的私有输入，不是共享循环概念。
+        - 梯度检查点策略（逐 block 重算，model_loading.py:39-58）family 内部自治。
+        - 错误：不做 NaN 检查（循环已有，loop.py:476-479）；形状违约 → ValueError。"""
+
+    # ───────────────────────────── 采样（sampling.py:248-472 整函数级别成为 family 方法）
+    def sample_image(self, models: LoadedModels, prompt: str, *,
+                     height: int = 1024, width: int = 1024,
+                     steps: int = 25, cfg_scale: float = 4.0,
+                     negative_prompt: str | None = None,
+                     sampler_name: str | None = None,     # None → spec.sampling.default_sampler
+                     scheduler: str | None = None,
+                     device="cuda", dtype=torch.bfloat16,
+                     step_callback=None, phase_callback=None,
+                     seed: int | None = None) -> "PIL.Image.Image":
+        """现有 sample_image 签名（sampling.py:248-259）就是 6 个调用方的事实标准，
+        原样冻结，只把「5 个模型位置参数」收拢成 LoadedModels。
+        sigma 表 / CFG 合批 / CONST x0 换算（sampling.py:402）/ 初始噪声 / VAE decode
+        offload 决策全部 family 内部。不支持的 sampler/scheduler → ValueError
+        （沿用 _resolve_parity_sampler_scheduler 风格，sampling.py:36-41）。
+        不做 build_sampler() 细粒度拆分 —— 见 §4.5-④。"""
+
+    # ───────────────────────────── LoRA（models_phase :89-91 / finalize :31-32）
+    def lora_preset(self) -> dict[str, Any]:
+        """lycoris apply_preset 字典（今天的 ANIMA_PRESET，utils/lokr_preset.py:14-26）。
+        target_name / exclude_name / lora_prefix 全在这里。"""
+
+    def lora_metadata(self) -> dict[str, str]:
+        """附加进 safetensors metadata 的 per-family 键值，至少含
+        {"ss_model_family": spec.family_id}；merge 进现有 ss_network_args
+        （lycoris_adapter.py:363-380）。Comfy 侧 K2 键名约定（00-decisions §7
+        open question）关闭后可能追加键，追加不算破坏契约。"""
+```
+
+**不进接口的方法（明确否决过的候选）**：`build_noise`（噪声与 offset 族无关，`noise.py` 共享）、`compute_target`（rectified flow 代数是循环不变量，§3.3）、`bucket_strategy`（dataset 只消费 `LatentSpec`）、`memory_plan`（D2 搁置，显存策略不是 family 轴）。
+
+### 2.3 registry 与派发
+
+```python
+# runtime/training/families/__init__.py（与现有 7 套 plugin registry 同款，D1/§6-4）
+_REGISTRY: dict[str, ModelFamily] = {}
+
+def get_family(family_id: str) -> ModelFamily:
+    """未知 id → ValueError，文案列出已注册 id（对齐 optimizers/losses registry 风格）。"""
+
+def resolve_family(args) -> ModelFamily:
+    return get_family(str(getattr(args, "model_family", "anima") or "anima"))
+```
+
+- 训练侧：`phases/bootstrap.py` 里 `ctx.family = resolve_family(args)`（能力校验也在此，fail-fast 于任何权重下载/加载之前）；`phases/models.py` 全部 `load_*` 与 `lora_preset` 改经 `ctx.family`。
+- **旁路侧（§1.3 修正）**：`anima_train.py` 公共命名空间新增 re-export `get_family / resolve_family`；`anima_generate` / `anima_daemon` / `anima_reg_ai` / `eval_samples` 把 `_T.load_anima_model(...)` 三件套 + `_T.sample_image(...)` 替换为 `family = _T.resolve_family(cfg)` 后走 family 方法。cmd_builder / supervisor / 入口脚本零改动（D8 保持）。
+- `TrainingContext` 增 `family: ModelFamily` 与 `models: LoadedModels`；`ctx.qwen_model / qwen_tok / t5_tok`（`context.py:58-60`）退役为 AnimaFamily 的 TextStack 内部字段（Phase-1 PR-2 迁移点）。
+
+### 2.4 能力集（capabilities）与 schema / show_when / validator 接线
+
+**词表（v1）**：`navit`、`sra`、`leap`、`compile_blocks`、`caption_tag_ops`（shuffle/dropout/keep_tokens 一组）、`online_text`、`text_cache`、`masked_loss`。Anima = 全量减 `text_cache`；K2 = `{masked_loss, text_cache}`（D5）。加词零成本（frozenset），删词/改语义 = 破坏性变更须过 04-synthesis。
+
+**接线三层（利用现状机制，零新文法）**：
+
+1. **schema 层（作者写时展开）**：`show_when` 求值器只认字段值比较（`config_prune.py:49-66`），能力位不能直接进表达式。在 `studio/domain/common.py` 加 authoring-time helper：
+
+   ```python
+   def cap_gate(capability: str) -> str:
+       """从静态能力矩阵渲染 show_when 表达式。
+       cap_gate("navit") → "model_family==anima"
+       第 3 族支持 navit 时 → "model_family==anima||model_family==foo"（改矩阵一处）。"""
+   ```
+
+   `navit_packing` 等字段的 `_meta(...)` 追加 `show_when=cap_gate("navit")`（与现有 show_when 用 `&&` 复合）。前端 `schema.ts` / 落盘裁剪 `config_prune.py` / YAML 预览三个求值器**全部零改动** —— 它们看到的仍是普通字段比较表达式。这符合「作者写时规范化」而非 runtime 解析新文法。
+2. **validator 层（双保险）**：`TrainingConfig` 加 `model_validator`：字段开启但 family 无对应能力 → 校验错误（拦手写 yaml / 裸 CLI，schema 层只管 UI 可见性与落盘裁剪）。
+3. **runtime 层（最后防线）**：`phases/bootstrap.py` 里 `ctx.family` 解析后跑同一份校验（config 可能绕过 studio 直达 CLI）。
+
+**交叉不变量**：`spec.text.strategy == "cached_varlen"` ⇒ `caption_tag_ops ∉ capabilities`。缓存键是 caption 内容 hash（D3），tag shuffle/dropout 会让每步 caption 漂移、缓存永 miss；registry 注册时校验（§2.1 错误约定），不留给各族自觉。
+
+**D7 落地**：`model_family: Literal["anima","krea2"] = "anima"`（老配置零迁移）；`t5_tokenizer_path` 加 `show_when="model_family==anima"`；`transformer_path/vae_path/text_encoder_path` 三字段跨族复用不动。
+
+### 2.5 缓存指纹协议
+
+**latent npz（Phase-1 PR-1，独立价值）**：
+
+- npz 追加两个标量键：`latent_fingerprint`（bytes，如 `b"wan21-f8c16"`）与 `layout_version`（int，v1=1）。键集其余六项（§1.4）冻结。
+- `_is_cache_valid`（`dataset.py:985-1039`）追加两条判据：`latent_fingerprint != family.spec.latent.fingerprint` 或 `layout_version` 不识别 → 走既有「删除重 encode」路径（`dataset.py:1008-1011`）。
+- **grandfather 规则**：无指纹键的存量 npz 视为 `wan21-f8c16`（历史上只有这一个 VAE 产出过缓存）——避免升级即全量重 encode。写入侧从 PR-1 起恒写指纹。
+- D6 兑现方式：指纹是**latent 空间身份**而非 family 身份 —— Anima 与 K2 同为 `wan21-f8c16`，同一数据集两族互训零重算，无需任何显式「共享」逻辑。
+
+**文本缓存（Phase 2，K2 起用）**：
+
+- 键 = `sha256(caption 最终文本)` + `spec.text.fingerprint`（TE 权重指纹）+ 格式版本。caption 最终文本 = trigger 前置后的确定串（§2.4 交叉不变量保证确定性）。
+- 存储 varlen（只存非 padding token，D3）；位置/文件格式是 `00-decisions.md` §7 open question，不在本文冻结 —— 本文只冻结**键协议**与「family 内部自治、dataset 层零感知」的边界：batch 恒带 `captions`，K2 family 在 `encode_text_for_batch` 里自己查缓存。dataset.py 因此对文本缓存零改动。
+
+### 2.6 LoRA 产物与恢复态的 per-family 约定
+
+- **safetensors metadata**：`ss_network_args` 增 `"model_family"` 键（经 `lora_metadata()` 注入）；`preset` 字段值改为 `spec.lora.preset_name`。Anima 存量产物无此键 → 读取侧视为 `"anima"`（grandfather）。
+- **resume state**：`save_training_state`（`state.py:35-47`）的 dict 增 `"model_family"` 顶层键；`load_training_state` 校验与当前 family 不符 → `RuntimeError`（修 §1.5 的静默冷启动隐患）。老 state 无键 → 视为 `"anima"`。
+- **resume_lora**（`phases/models.py:94-96`）：加载前读 metadata 校验 family，同上 fail-fast。
+- Comfy 侧 K2 键名（`lora_prefix` 取值）等 musubi 产物核对结论出来前，`KREA2_PRESET` 的 `lora_prefix` 不冻结 —— 这是 spec 数据不是接口形状，晚定不破坏契约。
+
+### 2.7 共享循环对 family 的不变量要求（v1 冻结）
+
+凡实现 `ModelFamily` 者必须满足；循环端以这些为公理，不做防御分支：
+
+1. **latent 恒 5D `(B,C,T,H,W)`，且 v1 内 `T == 1`**（`spec.latent.temporal=False` 的运行时体现）。C/stride/patch 以 spec 为准。桶保证 batch 内同尺寸（`phases/dataset.py:222-250`）。
+2. **t 语义**：`(B,)` float32，t ∈ (0,1)（`timestep_sampling.py:23`），t→1 为纯噪声端。加噪 `x_t = (1−t)·x₀ + t·ε`、目标 `target = ε − x₀`（`loop.py:399-400`）是**循环的**代数，family 不得重定义 —— `spec.objective` 只有 `"rectified_flow"` 一个合法值。
+3. **v_pred 同形**：`forward_train` 返回值形状 == `noisy`；loss plugin（`loop.py:413`）、InfoNoise record（`loop.py:418-438`）、masked mean（`loop.py:447-450`）都靠这一条。
+4. **cond opaque**：循环对 `encode_text_for_batch` 的返回值零操作（不 pad、不 trim、不 cat）——CFG 合批之类的 cond 拼接只发生在 family 自己的 `sample_image` 内（`sampling.py:379-389` 是先例）。
+5. **mask 口径**：`(B,h,w)` float ∈ [0,1]，latent 分辨率（`dataset.py:719` 下采样、`loop.py:408-411` 广播）。mask 语义（0=零梯度区）族无关。
+6. **autocast 归循环**：`forward_train` 在循环的 autocast 内被调（`loop.py:315`），family 不自行嵌套。
+7. **RNG 纪律**：family 方法内不得消耗全局 torch RNG 做「可选路径」决策（先例教训：`loop.py:296-307` leap 掷骰子刻意用 Python random 保对照实验可比）；采样 seed 由调用方管理（`sample_runner.py:76-77`）。
+
+凡只消费 `(latents, noise, t, pred, target, loss, mask, loss_weight, is_reg)` 的功能（InfoNoise、masked loss、losses、noise offsets、loss weighting、optimizer/scheduler、LoRA/LoKr 算法、梯度累积、NaN 防护、state save）—— 留在共享循环，对新 family **零修改**（§6-3 原样确认，实地核对 §1.1 证明成立）。
+
+---
+
+## 3. 压力测试：4 个假想的「第 3 个模型族」
+
+方法：逐一把假想族按 §2 接口走一遍 bootstrap→models→dataset→loop→sampling→产物全链路，记录裂点。「裂」定义为：接口方法签名或循环不变量必须改变才能容纳。
+
+### 3.1 Qwen-Image（20B MMDiT，同 VAE 同 latent 空间 —— 最近邻）
+
+理论上最顺的一族：rectified flow、f8c16 同款 VAE（与 Anima/K2 同一 latent 空间）、自然语言 prompt（Qwen2.5-VL 编码器）、Linear-only LoRA target。
+
+| 裂点 | 位置 | 裂法 | 处置 |
+|---|---|---|---|
+| 无 | forward/loop/dataset/mask | t∈(0,1)、v-pred、5D、f8c16 全部命中不变量 | — |
+| 文本编码器不同（Qwen2.5-VL vs Qwen3-VL） | `encode_text_for_batch` | 不裂：cond opaque + cached_varlen 机制直接复用 | 走 K2 同款策略 |
+| latent 指纹 | §2.5 | 不裂反而增益：同为 `wan21-f8c16` → 三族共享 latent 缓存 | 零代码 |
+| 采样 guidance / 动态 shift（Flux 风格） | `sample_image` | 不裂：整函数在 family 内，`shift_policy` union 已容纳 | 加 dataclass 成员即可 |
+| 20B 权重 → bf16 ~40GB，超 D2 的 32GB 下限 | 资源面 | **不是接口裂点** —— fp8/block swap 是 D2 显式搁置的正交轴 | 拒绝把 `memory_plan` 塞进 family（§2.2 否决清单） |
+
+**判决：接口零修改容纳。** 这一族的意义是正向证明：`ModelSpec` 声明 + opaque cond + family 级 `sample_image` 的切分对「同世代 MMDiT」是充分的。它训不训得动是显存问题，不是抽象问题。
+
+### 3.2 Wan 2.2 类视频模型（T > 1 —— 时间维全线冲击）
+
+| 裂点 | 位置 | 裂法 | 处置 |
+|---|---|---|---|
+| 数据加载 | `dataset.py` 全文件 | ImageDataset 读单图；视频要抽帧/片段采样/帧数桶（token 数 ∝ T×h×w，打包与桶策略全变） | **out-of-scope**，拒绝位挡住 |
+| npz 布局 | `dataset.py:1160-1198` | latent `(C,1,h,w)` 的 T=1 是隐式的；视频 latent 体积 ×T，npz 单文件策略、mtime 判据、`bucket_w/h` 二维键全部不够 | `layout_version` 预留了升级通道，但 v1 不实现 |
+| token 计数 / res-shift | `timestep_sampling.py:87-102`、`dataset.py:1077-1094` | `h//ps × w//ps` 漏乘 T 维 patch 数 | 同上 |
+| masked loss | `dataset.py:719`、`loop.py:408-411` | mask 是 (h,w) 单帧；视频需要 per-frame 或广播语义决策 | 同上 |
+| 非缓存 encode | `loop.py:215-219` | `unsqueeze(2)` 写死单帧 | 该行随 §2.2 收进 family，裂点已内化 |
+| **forward / loss / 不变量代数** | `loop.py:288, 399-450` | **不裂**：`t.view(-1,1,1,1,1)`、噪声、target、masked mean 全是 5D 广播代数，T>1 天然成立 —— 这是继承 Wan 血统 5D 布局的意外红利 | 保持 5D 布局正是为此 |
+| 预览/评估 | `sample_image` 返回单张 PIL；eval 管线、Generate UI、monitor 缩略图全部图片假设 | 返回类型都得变 | out-of-scope |
+
+**判决：视频不进 v1 接口，显式 out-of-scope。** 但拒绝方式是**字段而非散落断言**：`LatentSpec.temporal` v1 恒 `False`，dataset_phase 与 registry 注册校验各查一次。关键洞察：裂区集中在 dataset/预览两端，**循环中段（forward→loss）因 5D 布局天然免疫** —— 将来若做视频，是「新增 VideoDataset + sample_video 方法」的加法演化，不是 v2 接口断裂。因此 v1 唯一要付的成本就是保住 5D 不变量不许任何人「优化」成 4D（squeeze T 的诱惑在 S3 会出现，必须顶住）。
+
+### 3.3 SDXL 级 UNet（eps-pred + DDPM 离散 timestep + 4ch VAE + CLIP 双 encoder）
+
+| 裂点 | 位置 | 裂法 | 处置 |
+|---|---|---|---|
+| t 语义 | 不变量 #2、`timestep_samplers/*` | 离散 0..999 int vs 连续 (0,1)；全部 6 种采样 mode、InfoNoise 的 I-MMSE 统计、`timestep_schedule_shift` Möbius 代数失效 | **拒绝**：`spec.objective` 拒绝位 |
+| target 代数 | `loop.py:399-400` | `target = ε − x₀` ≠ ε；若把 target 计算下放 family，InfoNoise record（:418-438）、loss_weighting 的 SNR 公式（`loss_weighting.py`）、leap 轨迹构造全要跟着参数化 —— 「共享循环」名存实亡 | 同上：target 留循环，非 RF 不支持 |
+| min_snr 等加权 | `loop.py:444-446` | SNR 由 alphas_cumprod 定义，与 RF 的 t 参数化完全不同源 | 同上 |
+| 4ch VAE | `LatentSpec.channels=4` | **不裂**：channels 本来就是 spec 字段；指纹 `sdxl-f8c4` 自动隔离缓存 | spec 已容纳 |
+| UNet 前向签名 | `forward_train` | **不裂**：UNet 想要 4D 就在 family 内 `squeeze(2)/unsqueeze(2)` —— 5D 循环布局保住，转换是 family 私事 | 已容纳（也验证了 §3.2 的「顶住 4D 诱惑」） |
+| CLIP 双 encoder + pooled embeds | cond | **不裂**：cond opaque，family 返回自定义 struct（text_embeds + pooled + time_ids） | opaque 边界的正向验证 |
+| conv LoRA target | `lora_preset` | **不裂**：preset 字典本来就有 `enable_conv`（`lokr_preset.py:15`） | 已容纳 |
+| 采样器 | `sample_image` | DDPM/DPM++ 离散 scheduler 栈与 CONST flow 栈无共享价值 | family 内部，本就不共享 |
+
+**判决：坚持「共享循环只做 rectified flow」，SDXL 明确不支持。** 裂的三处（t 语义、target 代数、SNR 加权）恰好都是循环的**心脏**而非边缘 —— 参数化它们等于把循环拆成 per-objective 双份，这正是 D1 否决过的「按模型分训练脚本」换了个马甲。而**没裂**的四处（4ch、UNet 4D、双 encoder cond、conv target）证明 spec 字段 + opaque cond + family 内 sample_image 的边界画对了位置。SDXL 用户有成熟的 kohya 生态，本产品瞄准的 Anima/K2/Qwen-Image/Wan 一代全是 flow matching —— `objective` 字段留着，真要支持 eps 系那天，付「循环 v2 或 per-objective loop」的全价，不预付。
+
+### 3.4 极端案例（自选）：自回归 token 图像模型（LlamaGen / Janus 风格）
+
+离散 VQ codebook + causal transformer + cross-entropy loss，「LoRA 微调」在这种模型上完全成立 —— 所以它是对「接口边界在哪」最诚实的探针。
+
+| 接口件 | 遭遇 |
+|---|---|
+| `load_vae` | 要装的是 VQ tokenizer，`encode` 返回 int token 而非连续 latent —— VAELike 协议（5D float）语义崩塌 |
+| `LatentSpec` | channels/stride/patch 无意义；「latent 缓存」变成 token 序列缓存，指纹协议勉强能借壳但判据全错 |
+| t / noise / target | 不存在。`forward_train(noisy, t, cond)` 三个参数两个没有意义 |
+| loss | cross-entropy over codebook —— losses plugin（mse/huber）、masked loss 的空间广播、loss_weighting 全部无对象 |
+| `sample_image` | 自回归解码循环，与 sigma 表/CFG 合批完全异构（这条倒是能实现——唯一能实现的方法） |
+| timestep_sampler / InfoNoise / noise offsets | 整个 plugin 生态失去存在前提 |
+
+**判决：接口拒绝它，且拒绝是对的。** 8 个方法里 6 个要么无法实现要么实现为谎言（空转 stub）。这不是「能力集关掉几个开关」能表达的残缺 —— 是**身份**不同：本训练器的身份 = 「连续 latent 空间 + 连续时间 rectified flow 的回归式 LoRA 训练器」。压力测试的价值在于分清两类假设：
+
+- **身份假设**（拒绝位承载）：存在 VAE 连续 latent、存在连续 t、回归式逐元素 loss → `objective` + `temporal` + VAELike 协议；
+- **偶然假设**（spec/方法承载）：通道数、stride、文本 stack、shift 公式、LoRA target、采样器 → 全部已参数化。
+
+AR 模型想进来，正确姿势是新产品线（新 loop + 新 dataset 契约），不是 family #N。接口不为它留任何钩子。
+
+---
+
+## 4. 结论
+
+### 4.1 v1 冻结面（现在定死，破坏须过 synthesis 评审）
+
+1. `ModelSpec` 字段集（§2.1）：`family_id / display_name / objective / latent / text / sampling / capabilities / lora / config_defaults`；`family_id` 字符串永不改名（它进 yaml、进 LoRA metadata、进 resume state）。
+2. `ModelFamily` 八方法的名字与位置参数（§2.2）。演化只走 keyword-only 带默认值的追加（§4.2-②）。
+3. 共享循环七不变量（§2.7），特别是：5D `T==1`、t∈(0,1) 连续、`x_t=(1−t)x₀+tε`、`target=ε−x₀`、v_pred 同形、cond opaque、autocast 归循环。
+4. npz 缓存键集（6 旧键 + `latent_fingerprint` + `layout_version`）与 grandfather 规则（§2.5）。
+5. 文本缓存**键协议**（caption hash + TE 指纹 + 版本）与「dataset 零感知」边界（§2.5）；存储格式不冻结。
+6. 产物/恢复态 family 标记与 fail-fast 校验（§2.6）。
+7. registry 派发协议：字符串 id、未知 id 报错列已注册项、经 `anima_train` 公共命名空间覆盖全部 6 个调用面（§2.3）。
+8. 能力门控三层接线（cap_gate 展开 → pydantic validator → bootstrap 校验）与 `cached_varlen ⇒ ¬caption_tag_ops` 交叉不变量（§2.4）。
+
+### 4.2 预留扩展点（版本化 / 能力位，不实现只留缝）
+
+1. `capabilities` frozenset —— 加词零成本，是最主要的软演化轴。
+2. 方法追加参数一律 **keyword-only 且带默认值**；**禁止 `**kwargs` 黑洞**（吞 typo、掩盖契约漂移；需要从 dataset 向 forward 穿新数据时走 batch dict 或 cond struct，不走签名）。
+3. `shift_policy` typed union（§2.1）—— 新采样时刻表策略 = 加成员，不改签名。
+4. `spec.objective`：v1 仅 `"rectified_flow"`；将来若扩 = 明知要付 per-objective loop 的全价（§3.3）。
+5. `LatentSpec.temporal`：v1 恒 False；视频解锁点已定位在 dataset/预览两端（§3.2），循环免改。
+6. npz `layout_version`：视频/新布局的升级通道。
+7. `lora_metadata()` 返回 dict 可追加键（Comfy K2 键名核对结论的落点）。
+8. `TextStack` / `TextCond` 是 per-family opaque 类型 —— 内部表示（融合张量 vs 12 层堆叠 vs 双 encoder struct）演化自由。
+
+### 4.3 明确不抽象清单（宁可将来 per-family 重复）
+
+| 不抽象项 | 理由 |
+|---|---|
+| 采样器/调度器数值代码（er_sde / dpmpp_3m_sde / K2 的 FlowMatchEuler 动态 shift） | Comfy parity 栈（`sampling.py` 全文件，含刻意复刻的「二次 shift」怪癖 :149-169）与 musubi 参考实现根本不同源；共享 Sampler 基类只会制造伪共性。inference_samplers plugin registry 保留为 **Anima 内部**组织方式，不上升为跨族契约 |
+| 文本编码内部（Qwen+T5+LLMAdapter 融合 vs Qwen3-VL 中间层堆叠） | 连 helper 都不共享 —— `text_encoding.py` 400 行 T5 权重语法解析对 K2 是纯噪音 |
+| checkpoint 形状推断 / 前缀 remap 启发式 | `_load_weights_best_effort`（`model_loading.py:272-314`）作为**工具函数**可被两族调用，但「从形状猜配置」（`models.py:397-427`）的推断逻辑 per-family 各写各的 |
+| 梯度检查点展开策略（`model_loading.py:39-58`） | 逐 block 结构是模型私货 |
+| attention backend 全局开关注入（`models.py:361-394`、`model_loading.py:66-118`） | 模块级全局变量开关是 Anima modeling 的历史私货，K2 modeling 按自己的方式来 |
+| guidance 约定（K2 的 `cond + g·(cond−uncond)` vs Anima CFG） | `sample_image` 内部事务 |
+| 显存策略（fp8 / block swap / offload 阈值） | D2 显式搁置；资源轴 ⊥ family 轴（§3.1） |
+| eps/DDPM target、离散 timestep | §3.3 判决 |
+| dataset / 桶 / 打包 / mask 管线 | 只消费 `LatentSpec` 四个整数，family 零注入点 |
+
+### 4.4 反过度抽象论证
+
+- **n=2，且第 2 个还没跑通**。抽象的最低成本时点是「第 2 个实例落地时」，最低风险形态是「刚好覆盖两个实例都被证实需要的面」。本文接口的每个方法都对应 §1 里一处**已存在的** Anima 调用点 + 一处 K2 档案里**已确认的**差异（`00-decisions.md` §2）—— 没有一个方法是为假想族预置的。压力测试产出的是两个**拒绝位字段**（`objective` / `temporal`）和若干「将来加法演化」的定位结论，不是预置钩子。
+- **diffusers「刻意复制」哲学的适用面**：diffusers 在 pipeline/模型层逐模型复制而不建基类森林，代价是改一个 bug 要改 N 份 —— 它们有几百个 pipeline，我们只有 2-4 个族，复制成本更低、而错误抽象的耦合成本一样高。§4.3 清单里的每一项都是「两族实现看似相似但不同源」的地方 —— 共享它们意味着 Phase-1 的「对 Anima 零行为变化」承诺（`00-decisions.md` §5）要在每次 K2 改动时重新验证一遍。
+- **既有 7 套 plugin registry 的经验边界**：它们成功是因为 plugin 是**叶子**（optimizer/loss 单点行为，接口 1-3 个方法，实例可长到几十个）；ModelFamily 是**枝干**（横跨 6 个 phase + 5 个旁路调用面），实例只会有个位数。所以 family 接口宁可方法粗（`sample_image` 整函数级）不要细（否决 `build_sampler()`），细粒度留给族内部的 plugin registry 去做。
+- **克制的具体体现**：不抽象 target 计算（S3 会舒服些但代价是循环心脏参数化）；不抽象 dataset（S2 会舒服些但代价是给图片管线塞视频钩子）；不做 `**kwargs`；不做能力位新文法（编译成现有 show_when）；`load_vae` 明知两族同款也放 family 上而不是共享单例（第 3 族 VAE 不同款时零迁移，成本只是一行委托）。
+
+### 4.5 对 `00-decisions.md` §6 草案的修正建议清单
+
+| # | 草案原文 | 修正 | 依据 |
+|---|---|---|---|
+| ① | D8/§6-4「派发点 = `phases/models.py` 查 registry」 | 派发收口在 `anima_train` 公共命名空间（`get_family/resolve_family` re-export），覆盖 `anima_generate`:136 / `anima_daemon`:246,299 / `anima_reg_ai`:426 / `eval_samples.py`:582 / `sample_runner`:78 共 5 个旁路调用面；否则 K2 的 Generate/评估/RegAI 直接 `RuntimeError`（`models.py:411`） | §1.3 |
+| ② | `encode_text` 一笔带过 | 明确 cond 对循环 **opaque**：pad-to-512（`loop.py:243-244`）与 kv_trim（`loop.py:247-254`）必须随编码块下沉进 AnimaFamily —— 草案不写清这两行会留在循环里成为暗桩 | §1.1、§2.2 |
+| ③ | `forward_train(model, noisy, t, cond)` | 追加：pad_mask 构造（`loop.py:310`）收进 family（Anima 私有输入）；t 形状按摩 family 自治；autocast 归循环 | §2.2、§2.7-6 |
+| ④ | `build_sampler()` 独立方法 | 撤销：冻结面直接是 `sample_image(...)` 整函数（现有 6 caller 的签名已是事实标准，`sampling.py:248-259`）；sigma/CFG/decode-offload 是一体的，细拆无收益 | §2.2 |
+| ⑤ | ModelSpec 无拒绝位 | 增 `objective`（v1 仅 `"rectified_flow"`）与 `LatentSpec.temporal`（v1 恒 False）—— 把 S2/S3 判决固化为字段 + registry 注册校验，不散落断言 | §3.2、§3.3 |
+| ⑥ | 「latent 指纹」只提概念 | 定协议细节：指纹 + `layout_version` 写进 npz 键（非文件名）；`_is_cache_valid` 加两判据走既有删除路径（`dataset.py:1008-1011`）；**无键存量缓存 grandfather 为 `wan21-f8c16`**，避免升级全量重 encode | §2.5 |
+| ⑦ | 未提恢复面 | resume state 与 LoRA metadata 各加 `model_family` 标记 + 加载时 fail-fast：现状跨族 resume 会因 `strict=False`（`state.py:96`）静默全 missing 冷启动 | §1.5、§2.6 |
+| ⑧ | D5「复用 show_when 裁剪机制」未给接线 | 求值器只认字段比较（`config_prune.py:49-66`）→ 能力位经 authoring-time `cap_gate()` 展开成 `model_family==...` 表达式，三个求值器零改动；另加 pydantic validator + bootstrap 双保险；补交叉不变量 `cached_varlen ⇒ ¬caption_tag_ops` | §2.4 |
+| ⑨ | K2 分辨率感知 shift 的归属未定 | 定为 `spec.sampling.shift_policy`（typed union），只影响采样端 sigma 表与 schema 默认值 overlay；训练端 t 采样仍走 timestep_sampler plugin —— 且**不要**与现有 opt-in `timestep_shift_resolution_aware`（`loop.py:174-182`，SD3 sqrt 规则）合并，两者公式不同、语义不同（前者是族默认时刻表，后者是多分辨率校准修正） | §2.1 |
+| ⑩ | 文本缓存只定了失效键（D3） | 补边界决策：缓存 family 内部自治、dataset 零感知（batch 恒带 `captions`）；`TextStack.encode` 承诺「永远成功」（miss 懒加载 TE）；预缓存范围 = 数据集 caption + sample_prompts + negative（使 K2 训练期可释放 ~8GB TE 常驻） | §2.2、§2.5 |

--- a/docs/design/multi-model/04-synthesis.md
+++ b/docs/design/multi-model/04-synthesis.md
@@ -1,0 +1,115 @@
+# 多模型支持 · 04 综合裁决
+
+- 状态：三视角（01 代码归属 / 02 生态对标 / 03 接口契约）收敛后的最终设计。与 `00-decisions.md` 一起构成本改造的权威口径；两者冲突时以本文为准（本文对 00 的修订在 §4 逐条列出）。
+- 日期：2026-07-14
+- 输入：`01-code-layout.md`、`02-ecosystem-survey.md`、`03-interface-evolution.md`
+
+## 1. TL;DR
+
+- 三视角高度收敛：**「共享循环 + ModelSpec（声明）/ ModelFamily（行为）两分 + registry 派发」**被代码现状（01）、全行业实践（02）、压力测试（03）三方独立确认。02 的结论尤其有分量：8 家对标项目全部收敛到这一形态，没有一家靠复制训练脚本活得好。
+- 目录方案采 01：**按层切 + 族聚合纪律**，一个族 = `modeling/<fam>/` + `runtime/training/families/<fam>/` + `studio/services/models/families/<fam>.py` 三处同名单元，族名字符串是唯一 join key，启动期校验三处一致（02-P2：这一点做到位即超越所有对标项目）。exec-load 退役改正常 import。
+- 接口冻结面采 03 §4.1 全文为规范文本（八方法 + 七不变量 + 两个拒绝位 `objective`/`temporal`），外加本文 §3 的四处裁决修正（最主要：新增第九方法 `convert_lora_state_dict`，采纳 02 的生态证据）。
+- **D8 修订**（03 的最重要实地发现）：派发不能只落在 `phases/models.py`——loader 三件套 + `sample_image` 有 5 个循环外调用方，必须经 `anima_train` 公共命名空间收口（supervisor/cmd_builder/入口脚本仍然不动）。
+- 反模式纪律（02）全部采纳为执行红线：共享循环禁止族名 if、禁止向共享文件堆积横切功能、PR-2 必须把 Anima 完整迁入不留双世代过渡态、缓存指纹失配自动重算不抛 shape error。
+
+## 2. 三视角一致确认的主干（不再讨论，直接执行）
+
+1. **形态**：ModelFamily 适配层 + 第 8 套 registry；加第 3 个族 = 新建约 8 文件 + 4 处一行注册，共享循环零修改（01 §3.2；02-P2 生态黄金标准 <100 行共享改动；03 §3.1 Qwen-Image 压测零裂验证）。
+2. **ModelSpec / ModelFamily 两分**：声明常量与行为方法分离（02-P1：ComfyUI `LatentFormat`+`sampling_settings`、SimpleTuner 类属性、ai-toolkit 能力 flag 三家印证；03 §2.1/§2.2 给出精确形状）。
+3. **缓存指纹 = latent 空间身份 + layout 版本，族名不入键**（02-P3 ai-toolkit `latent_space_version` 方案；03 §2.5 协议细节 + grandfather 规则）。D6 的跨族共享由此免费兑现。
+4. **timestep 双旋钮双归属**：训练端 t 采样留在共享 `timestep_samplers/` registry（K2 分辨率感知 shift 实现为新策略，如 `krea2_shift`，仅实现一次——02-P4/A2，diffusion-pipe 每族复制是反面教材）；推理端 sigma 时刻表归 family `sample_image` + `spec.sampling.shift_policy`（03-⑨）。两者不与现有 `timestep_shift_resolution_aware`（SD3 sqrt 修正）合并——公式与语义都不同。
+5. **入口脚本不改名**，`anima_` 前缀定为产品名口径（01 §5；02 §10.3-5a 生态支持；改名成本清单存档于 01 §5.2 备查）。
+6. **键名向 ComfyUI 生态看齐**是行业事实标准，且保存键名转换是 per-family 窄钩子、不写通用映射（02-P5，diffusers 3000 行转换账单为戒）。
+7. **能力门控走 schema 管道**：`cap_gate()` 作者写时展开成 `model_family==...` 表达式，三个 show_when 求值器零改动；pydantic validator + bootstrap 双保险；交叉不变量 `cached_varlen ⇒ ¬caption_tag_ops` 在 registry 注册期校验（03 §2.4；02-P6 确认 schema 驱动 UI 是我们对全部对标项目的差异化优势）。
+8. **utils/ 切法**：算法族无关、preset 族相关——`ANIMA_PRESET` 迁 `families/anima/preset.py`，`AnimaLycorisAdapter` 改 preset 注入并更名；与延后的 utils 完整重构是衔接关系，仅修订「preset 不进 lora/ 包」一项（01 §7）。
+9. **磁盘 models root 不按族分**，唯一改动：新族 TE 落 `text_encoders/<safe_dir_name(repo)>/` 子目录，Anima 存量扁平布局零迁移（01 §8.2）。
+10. **测试布局**：flat `tests/` 不动；新增 `test_model_spec.py` / `test_model_families.py`（registry ↔ schema Literal ↔ catalog 三方一致性断言）+「`phases/models.py` 不得再出现 `load_anima_model(` 字面量」防回归断言（01 §9）。
+
+## 3. 冲突点裁决
+
+三视角仅四处真实分歧，逐条裁决如下。
+
+### C1 · K2 采样器代码放共享 `inference_samplers/` 还是族内？—— 裁：族内（从 03）
+
+01 目标树曾把 `flow_euler.py` 画进共享 `inference_samplers/`；03 §4.3 论证采样器数值代码不跨族抽象（Comfy parity 栈与 musubi/diffusers 参考实现不同源，共享基类只会制造伪共性），`inference_samplers/` registry 保留为 **Anima 内部**组织方式。**裁决**：K2 的 FlowMatchEuler 动态 shift 栈整体落 `families/krea2/sampling.py`；01 目标树相应修订（删去 `inference_samplers/flow_euler.py` 一行）。第 3 个 flow-matching 族落地时若发现 solver 真重复，再上提——那时有两个已证实的实例，符合 03 §4.4 的抽象时点纪律。
+
+### C2 · `forward_train` 返回 pred 还是 pred+target 数据类？—— 裁：只返回 v_pred（从 03）
+
+02 §10.3-2 建议对齐 musubi `call_dit → DiTOutput`（返回 pred+target），理由是给未来非 v-pred 族留自由度。03 的 SDXL 压测恰好否决了这个自由度：target 代数 `ε−x₀` 是共享循环的心脏（InfoNoise record、loss_weighting、leap 全部依赖），下放 family 等于「共享循环」名存实亡，非 RF 族的正确答案是 `objective` 拒绝位 + 将来付 per-objective loop 全价。**裁决**：`forward_train → v_pred`（形状同 noisy），target 留循环，`spec.objective` v1 仅 `"rectified_flow"`。musubi 需要 DiTOutput 是因为它同时支持 I2V/多模态目标，我们的产品边界不含这些。
+
+### C3 · 能力位要不要 frozenset 之外再加布尔 flag 面？—— 裁：单一 frozenset（收窄 02）
+
+02-P1(b) 建议学 ai-toolkit 同时提供能力集合（管 UI）与布尔 flag（管代码路径）。**裁决**：只保留 `capabilities: frozenset[str]` 单一事实源——UI 经 `cap_gate()` 编译查询，代码经 `"navit" in spec.capabilities` 查询，两个消费面共享同一数据。ai-toolkit 的双面并存是它 legacy 迁移不彻底的产物（02-A4 恰好点名），不是值得复制的设计。
+
+### C4 · LoRA 保存键名转换钩子要不要进 v1 冻结面？—— 裁：要，作为第九方法（从 02）
+
+03 冻结了 `lora_preset()` + `lora_metadata()` 两方法，键名约定藏在 preset 的 `lora_prefix` 里；02 的生态证据（musubi `convert_weight_keys` 默认恒等、ai-toolkit `convert_lora_weights_before_save`、OneTrainer 四格式导出、diffusion-pipe per-model 保存格式）表明「target 选择」与「保存键名变换」是两个独立关注点，且 K2 的 Comfy 键名核对（open question）很可能需要前缀之外的结构性变换。**裁决**：v1 冻结面增补第九方法：
+
+```python
+def convert_lora_state_dict(self, sd: dict[str, Tensor]) -> dict[str, Tensor]:
+    """保存前的键名/结构变换钩子，默认恒等。Comfy 侧 K2 键名核对结论的落点。"""
+```
+
+默认恒等实现放 protocol 层，Anima 不覆写。现在加成本为零，Phase 3 才发现要加则是契约破坏。
+
+## 4. 对 `00-decisions.md` 的修订与增补
+
+| # | 内容 | 来源 |
+|---|---|---|
+| **D8′（修订）** | supervisor/cmd_builder/入口脚本不动**维持**；但派发收口点从「`phases/models.py`」改为「`anima_train` 公共命名空间 re-export `get_family/resolve_family`，覆盖 phases + `anima_generate`/`anima_daemon`/`anima_reg_ai`/`eval_samples`/`sample_runner` 全部 6 个调用面」 | 03 §1.3 |
+| D10 | 目录方案：按层切 + 族聚合纪律，目标树以 01 §4.1 为准（含 C1 修订）；exec-load 退役、`find_diffusion_pipe_root` 塌缩为 shim（sister 契约 7 名不减） | 01 §3/§6 |
+| D11 | 接口规范：03 §4.1 冻结面 + §4.2 扩展点 + §4.3 不抽象清单整体采纳，外加本文 C1-C4 修订（九方法版） | 03 |
+| D12 | 缓存协议：npz 增 `latent_fingerprint`+`layout_version` 两键；无键存量 grandfather 为 `wan21-f8c16`；失配走既有删除重编码路径（自动、无用户动作） | 03 §2.5、02-P3/A7 |
+| D13 | 恢复与产物防串：resume state 与 LoRA metadata 各加 `model_family` 标记，跨族加载 fail-fast（修 `strict=False` 静默冷启动隐患）；存量无标记 grandfather 为 anima | 03 §2.6/§4.5-⑦ |
+| D14 | 训练端 K2 shift = `timestep_samplers/` 新策略（共享实现一次）；推理端 = `spec.sampling.shift_policy` typed union；不与 `timestep_shift_resolution_aware` 合并 | 02-P4、03-⑨ |
+| D15 | 执行红线：共享循环禁止 `if family == ...`（一律能力位/spec 字段）；横切功能禁止堆进 family 基类或共享大文件；PR-2b 后 `TrainingContext.qwen_model/qwen_tok/t5_tok` 必须退役，不留 Anima 旧路径 | 02-A1/A4/A5 |
+| D16 | family 加载器必须对「checkpoint 与所选 family 不匹配」fail-fast 并给可操作文案（消费级用户拿 Anima 权重配 K2 版本的错误必然发生） | 02-P7 |
+| D17 | `latent_rgb_factors`（latent2rgb 预览投影系数）进 `LatentSpec`——`anima_daemon` 硬编码的 Wan21 系数收编，K2 同 latent 空间直接复用 | 02-P1(a) |
+| D18 | K2 v1 训练中预览用 Raw 权重 + CFG 采样（模型已在显存里）；Turbo 热切换（musubi `--turbo_dit` 模式）不进 v1，Turbo 作为 Generate 页可选底模留给 Phase 4 评估 | 02 §10.3-6 |
+| D19 | text cache 与 latent npz 缓存同域：放数据集 train/ 目录随图 sidecar。理由：caption 本身在 train/ 下、与 VAE 缓存一致、直接被既有项目导出 npz bundle 机制（PR #391）覆盖。同 caption 跨图重复存储的代价接受。失效判据仍按 D3/D12（文件内嵌 caption hash + TE 指纹，失配自动重编码）；非 caption prompt（sample/negative）的聚合缓存文件同放 train/ 下，命名与格式为 Phase 2 实现细节 | 用户裁定 2026-07-14（取代本文原「集中式内容寻址」倾向） |
+
+## 5. 更新后的 Phase 1 执行序列
+
+在 00 §5 基础上合入三文档的范围增补（PR-2 拆 2a/2b 采 01 §10）：
+
+- **PR-1**：ModelSpec 常量收敛（含 D17 的 rgb factors）+ npz 指纹/layout 版本 + grandfather（D12）。新增 `tests/test_model_spec.py`。
+- **PR-2a（机械刀）**：`modeling/anima/` 归位（git mv）+ exec-load 退役 + attention backend 别名表塌缩 + `find_diffusion_pipe_root` shim 化。验证：用户真卡跑训练 + 出图（PR #303 先例）。
+- **PR-2b（适配刀）**：`families/` registry + protocol（九方法版）+ AnimaFamily 完整迁入（loader/forward/text_encoding/comfy_qwen/sampling/navit/leap/sra/preset 全部归位，`loop.py:222-254` 文本块与 pad_mask 构造下沉）+ **派发经 `anima_train` 公共命名空间收口 6 个调用面（D8′）** + resume/metadata family 标记（D13）+ lycoris preset 注入改造 + `TrainingContext` 字段退役（D15）。硬门禁：`test_anima_generate_xy.py` / `test_anima_train_migration.py` 全绿。
+- **PR-3**：schema `model_family` Literal + `cap_gate()` 三层接线 + `t5_tokenizer_path` show_when + validator（含 `cached_varlen ⇒ ¬caption_tag_ops`）。
+- **PR-4**：studio `FAMILY_ASSETS` registry + `ModelsConfig.selected` per-family 迁移 + catalog/downloader 遍历化 + TE 子目录布局。
+
+Phase 2（text cache 基建）、Phase 3（Krea2Family，含 D16 指纹校验、`krea2_shift` 策略、`families/krea2/sampling.py`）、Phase 4（UI + Turbo 评估）不变。
+
+## 6. 拍板结果（2026-07-14，全部闭环）
+
+| # | 事项 | 结论 |
+|---|---|---|
+| 1 | `modeling/anima/` 下沉 | **做**，随 PR-2a（与 exec-load 退役同刀） |
+| 2 | `DIFFUSION_PIPE_ROOT` 退役节奏 | 保留一个 release 的弃用 warning，下版删 |
+| 3 | `models.py` 瘦身后改名 `vae.py` | 做，随 PR-2b |
+| 4 | text cache 存放位置 | **train/ 目录随图 sidecar，与 latent 缓存同域**（用户裁定，见 D19；本文原「集中式内容寻址」倾向作废） |
+| 5 | K2 LoRA Comfy 键名核对 | Phase 3 前闭环；落点已备好（`KREA2_PRESET.lora_prefix` + `convert_lora_state_dict`） |
+| 6 | Phase 0（真卡验证） | 已执行，结果见 §7 |
+
+## 7. Phase 0 结果（2026-07-14 记录，用户真卡实测）
+
+实际用 **ai-toolkit**（而非 musubi）完成 K2 LoRA 训练验证：
+
+1. **32GB 可训但余量≈0**（「刚刚好，差一点 OOM」）。D2 的 32GB 下限成立，但无安全边际。推论：
+   - Phase 3 的「K2 专属小规模 block swap 兜底」从备选**提升为计划内可选项**（默认关、撞显存开）；fp8 基建仍按 D2 搁置。
+   - K2 v1 默认强制 grad checkpointing；TE 预缓存后必须释放（03-⑩ 已定）；训练中预览的采样期峰值需专门关注。
+   - 风险提示：近满载峰值在 Windows WDDM 有换页崖先例（VAE decode 190s 事件，PR #281）——「差一点 OOM」的工况正是崖区，实现时优先保峰值而非平均占用。
+   - 已确认（2026-07-14 补）：当次训练**底模无 fp8 量化（bf16）**——与我们计划的 bf16 实现直接可比，32GB 结论原样采信。
+2. **ComfyUI 升级后可加载并跑通该 LoRA** → K2 推理链路验证通过。
+
+### 7.1 键名核对结论（拍板项 5 闭环；实物：`chenbin_style_krea2_v2.safetensors`）
+
+对 ai-toolkit 产物 safetensors 头部的实测（518 tensors = 259 个 Linear × lora_A/lora_B）：
+
+- **格式为 ComfyUI 原生 / PEFT 风格**：`diffusion_model.<模块路径>.lora_A.weight` / `.lora_B.weight`，bf16，**无 `.alpha` 键**，rank 32。非 kohya `lora_unet_*` 风格。
+- target 覆盖实证：每 block `attn.{wq,wk,wv,wo,gate}` + `mlp.{up,down}`（7×28=196），外加 `txtfusion.refiner_blocks.*`、`txtmlp.*` 等文本融合段共 259 个 Linear——**`attn.gate`（gated sigmoid attention 的输出门）与文本融合层都在 target 内**，与 musubi「全模型 Linear」口径一致，`KREA2_PRESET` 照此定。wq [6144]/wk·wv [1536] 的形状差同时实证了 GQA 48Q/12KV。
+- **saver 决策（2026-07-14 修订：与 Anima 统一为 kohya 风格）**：经对本地 ComfyUI（`G:\ComfyUI-aki-v1.6\ComfyUI`，已含 Krea2 支持）源码核实，三条链路全部走通，K2 产物**直接沿用 Anima 的 kohya 格式**（`lora_unet_*` + `lora_up/lora_down` + `.alpha`，`lora_prefix="lora_unet"`），`convert_lora_state_dict` 两族都保持恒等（第九方法保留为逃生舱）：
+  1. `comfy/lora.py:191-196`：对模型 state dict 中每个 `diffusion_model.*.weight` 自动生成 `lora_unet_{path 下划线扁平}` 映射——由 state dict 动态构建，对含 Krea2 在内的所有族生效；
+  2. `comfy/weight_adapter/lora.py:160,47`：kohya `lora_up/lora_down` 命名与 `.alpha` 键（scale=alpha/rank）原生支持，与 PEFT `lora_A/B` 并列识别；
+  3. `comfy/ldm/krea2/model.py`：内部模块命名 `blocks.N.attn.{wq,wk,wv,gate,wo}` / `blocks.N.mlp.{gate,up,down}`（SwiGLU 三 Linear）/ `txtfusion.refiner_blocks.*` / `txtmlp.N`，与 ai-toolkit 产物键路径一致。
+- **由此产生的硬约束（Phase 3 移植要求）**：我们的 `modeling/krea2/` 模块命名必须与 ComfyUI 内部命名逐字一致（kohya 键编码的就是模块路径），移植时以 `comfy/ldm/krea2/model.py` 的命名为准（结构可参考 diffusers，命名跟 Comfy）；并加单测钉死若干扁平键样本（如 `lora_unet_blocks_0_attn_wq`、`lora_unet_txtmlp_1`）防止重命名破坏产物兼容。


### PR DESCRIPTION
## 内容

`docs/design/multi-model/` 五份文档，多模型支持改造的完整设计口径：

- **00-decisions** — Krea 2 档案（12.9B 单流 MMDiT / Qwen3-VL-4B 12 层文本条件 / Qwen-Image VAE 与 Anima 同 latent 空间）+ 已锁定决策 D1-D9 + Phase 0-4 计划
- **01-code-layout** — 目录结构与代码归属：按层切 + 族聚合纪律，exec-load 退役，utils preset 拆分，迁移 PR 切法
- **02-ecosystem-survey** — 8 家训练器（kohya 两代 / diffusers / ai-toolkit / OneTrainer / diffusion-pipe / SimpleTuner / ComfyUI）多模型组织方式对标，模式与反模式
- **03-interface-evolution** — ModelFamily 接口契约（八方法 + 七不变量 + 两拒绝位），用 4 个假想未来族压力测试划定抽象边界
- **04-synthesis** — 综合裁决（权威口径）：D8' 派发面修正 + D10-D19 + 三视角冲突裁决 + Phase 0 真卡实测结果 + LoRA 键名核对终版

## 关联

实施序列 PR-1..PR-4 按 04-synthesis §5 逐个提交；首刀为 #405（ModelSpec + 缓存指纹）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)