### PR TITLE
refactor(train): ModelSpec 收敛 latent 常量 + latent 缓存指纹（多模型 PR-1）

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -585,29 +585,14 @@ def _build_preview_callback(
 # Anima 的 VAE 是 Qwen-Image VAE（models/vae/qwen_image_vae.safetensors），其 latent
 # 空间就是 Wan2.1 的 16-ch 空间——ComfyUI supported_models.py 里
 # `QwenImage.latent_format = latent_formats.Wan21`，且本仓库 models.py 的 VAE
-# 归一化 mean/std 与 ComfyUI Wan21.latents_mean/std 逐位一致。系数与 bias 取自
-# ComfyUI comfy/latent_formats.py 的 `Wan21.latent_rgb_factors[_bias]`（latent2rgb
-# 快速预览，即"模糊但能看出图"）。之前误用 TAEFlux（Flux VAE 的 tiny decoder）解码
-# 这个 WAN latent，空间不匹配 → 颜色反相/错乱，已废弃。
-_WAN21_LATENT_RGB_FACTORS = [
-    [-0.1299, -0.1692, 0.2932],
-    [0.0671, 0.0406, 0.0442],
-    [0.3568, 0.2548, 0.1747],
-    [0.0372, 0.2344, 0.1420],
-    [0.0313, 0.0189, -0.0328],
-    [0.0296, -0.0956, -0.0665],
-    [-0.3477, -0.4059, -0.2925],
-    [0.0166, 0.1902, 0.1975],
-    [-0.0412, 0.0267, -0.1364],
-    [-0.1293, 0.0740, 0.1636],
-    [0.0680, 0.3019, 0.1128],
-    [0.0032, 0.0581, 0.0639],
-    [-0.1251, 0.0927, 0.1699],
-    [0.0060, -0.0633, 0.0005],
-    [0.3477, 0.2275, 0.2950],
-    [0.1984, 0.0913, 0.1861],
-]
-_WAN21_LATENT_RGB_BIAS = [-0.1835, -0.0868, -0.3360]
+# latent2rgb 快速预览系数（"模糊但能看出图"）。系数表已收编进 ModelSpec
+# （families/anima，D17）——单一来源，K2 同 latent 空间时直接复用。之前误用
+# TAEFlux（Flux VAE 的 tiny decoder）解码这个 WAN latent，空间不匹配 →
+# 颜色反相/错乱，已废弃。
+from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC  # noqa: E402
+
+_WAN21_LATENT_RGB_FACTORS = [list(r) for r in _ANIMA_SPEC.latent.rgb_factors]
+_WAN21_LATENT_RGB_BIAS = list(_ANIMA_SPEC.latent.rgb_bias)
 # 预览放大目标（最长边像素）。latent 是 1/8 分辨率（1024²→128²），latent2rgb 直出
 # 128²；放大到 512 让前端铺满时不至于过糊，JPEG 仍很小。
 _PREVIEW_TARGET_PX = 512

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -27,6 +27,17 @@ from pathlib import Path
 import torch
 from torch.utils.data import Dataset
 
+from training.families.anima import ANIMA_SPEC
+
+# ── latent 规格单一来源（多模型 PR-1）─────────────────────────────────────
+# 单一族时代的桥接常量；PR-2b 起由 ctx.family.spec 传入各调用点。
+_ANIMA_LATENT = ANIMA_SPEC.latent
+#: latent npz 缓存布局版本（键集 / 张量布局变更时 bump，失配 → 删除重 encode）
+LATENT_CACHE_LAYOUT_VERSION = 1
+#: 无指纹键的存量缓存 grandfather 值：历史上只有 Wan21/Qwen-Image 这一个 VAE
+#: 产出过缓存（04-synthesis D12），避免升级即全量重 encode。
+_LEGACY_CACHE_FINGERPRINT = "wan21-f8c16"
+
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +66,7 @@ def plan_native_fit_image(
     *,
     max_tokens: int = 0,
     max_side_tokens: int = 0,
-    align: int = 16,
+    align: int = _ANIMA_LATENT.align_px,
     over_budget: str = "downscale",
 ) -> NativeFitImagePlan:
     """规划单张图的原生定尺寸（floor 对齐到 ``align``，可选超预算 downscale）。
@@ -248,7 +259,7 @@ class ImageDataset(Dataset):
                  resolutions=None, aspect_ratio_limit=2.0,
                  native_resolution=False, native_token_budget=0,
                  native_over_budget="downscale", native_max_side_tokens=0,
-                 native_align=16, load_masks=False):
+                 native_align=_ANIMA_LATENT.align_px, load_masks=False):
         self.data_dir = Path(data_dir)
         self.resolution = resolution
         # 多分辨率：bucket_mgr 是 base 分辨率的 manager（向后兼容，单一 ARB 路径仍走它，
@@ -266,7 +277,7 @@ class ImageDataset(Dataset):
         self.native_token_budget = int(native_token_budget or 0)
         self.native_over_budget = str(native_over_budget or "downscale").lower()
         self.native_max_side_tokens = int(native_max_side_tokens or 0)
-        self.native_align = int(native_align or 16)
+        self.native_align = int(native_align or _ANIMA_LATENT.align_px)
         if self.native_resolution and len(self.resolutions) > 1:
             logger.warning(
                 "[navit-native] navit_native_resolution 下多分辨率 fan-out 无意义"
@@ -716,7 +727,8 @@ class ImageDataset(Dataset):
             m = m.crop((left, top, left + tw, top + th))
             if flip:
                 m = m.transpose(Image.FLIP_LEFT_RIGHT)
-            m = m.resize((max(1, tw // 8), max(1, th // 8)), Image.BOX)
+            _vs = _ANIMA_LATENT.spatial_stride
+            m = m.resize((max(1, tw // _vs), max(1, th // _vs)), Image.BOX)
             # 灰度 255=学 / 0=不学 → [0,1] loss 空间权重
             mask_tensor = torch.from_numpy(
                 np.array(m).astype(np.float32) / 255.0
@@ -894,10 +906,17 @@ class CachedLatentDataset(Dataset):
     50% 数据被永久镜像污染；新版通过 _is_cache_valid 检测缺 latent_flipped
     键，自动重 encode 修复。
     """
+
+    #: latent 规格（指纹进缓存判据 / 写入）。类级默认 = Anima；__init__ 可覆盖，
+    #: PR-2b 起由 ctx.family.spec.latent 传入。
+    latent_spec = _ANIMA_LATENT
+
     def __init__(self, base_dataset, vae, device, dtype, cache_dir=None, cache_batch_size=1,
                  encode_tiled=False, encode_tile_px=1024, encode_tile_overlap=128,
-                 encode_max_pixels=0):
+                 encode_max_pixels=0, latent_spec=None):
         import numpy as np
+        if latent_spec is not None:
+            self.latent_spec = latent_spec
         self.base_dataset = base_dataset
         self.base_image_dataset = self._get_base_image_dataset(base_dataset)
         self.np = np
@@ -986,6 +1005,9 @@ class CachedLatentDataset(Dataset):
         """检查缓存是否有效（图像未修改，且格式兼容当前 flip_augment 设置）。
 
         - 缺 `latent` 键 / 其他模型的不兼容缓存 → 删除重 encode
+        - latent 指纹 / 布局版本失配（换 VAE latent 空间或缓存布局升级）→
+          删除重 encode；无指纹键的存量缓存 grandfather 为 wan21-f8c16
+          （历史唯一 VAE，避免升级即全量重 encode，04-synthesis D12）
         - flip_augment=True 且 npz 缺 `latent_flipped` 键 → 失效重 encode（旧
           单份 cache 即"flip 永久 baked"的污染状态，必须重 encode 修复）
         - flip_augment=False 且 npz 有 `latent_flipped` → 仍视为有效（双份
@@ -1008,6 +1030,25 @@ class CachedLatentDataset(Dataset):
                 if "latent" not in data.files:
                     npz_path.unlink()
                     logger.debug(f"已删除不兼容缓存: {npz_path.name}")
+                    return False
+                cache_fp = (
+                    str(data["latent_fingerprint"].item())
+                    if "latent_fingerprint" in data.files
+                    else _LEGACY_CACHE_FINGERPRINT
+                )
+                cache_ver = (
+                    int(data["layout_version"])
+                    if "layout_version" in data.files
+                    else LATENT_CACHE_LAYOUT_VERSION
+                )
+                if (cache_fp != self.latent_spec.fingerprint
+                        or cache_ver != LATENT_CACHE_LAYOUT_VERSION):
+                    npz_path.unlink()
+                    logger.debug(
+                        f"已删除指纹失配缓存: {npz_path.name} "
+                        f"({cache_fp} v{cache_ver} != "
+                        f"{self.latent_spec.fingerprint} v{LATENT_CACHE_LAYOUT_VERSION})"
+                    )
                     return False
                 if getattr(self, "flip_augment", False) and "latent_flipped" not in data.files:
                     return False
@@ -1077,7 +1118,7 @@ class CachedLatentDataset(Dataset):
         Also fills token_count_for_index (NaViT packer reads it; patch_spatial=2)."""
         self.bucket_for_index = [None] * len(self.samples)
         self.token_count_for_index = [0] * len(self.samples)
-        patch_spatial = 2
+        patch_spatial = _ANIMA_LATENT.patch_spatial
         for i in range(len(self.samples)):
             npz_path = self._get_npz_path(
                 self.samples[i]["image"], self.samples[i].get("target_reso"))
@@ -1168,6 +1209,8 @@ class CachedLatentDataset(Dataset):
                         npz_path,
                         bucket_w=entry["bucket_w"],
                         bucket_h=entry["bucket_h"],
+                        latent_fingerprint=self.latent_spec.fingerprint,
+                        layout_version=LATENT_CACHE_LAYOUT_VERSION,
                         **npz_kwargs,
                     )
                     encoded_count += 1
@@ -1194,6 +1237,8 @@ class CachedLatentDataset(Dataset):
                     npz_path,
                     bucket_w=entry["bucket_w"],
                     bucket_h=entry["bucket_h"],
+                    latent_fingerprint=self.latent_spec.fingerprint,
+                    layout_version=LATENT_CACHE_LAYOUT_VERSION,
                     **npz_kwargs,
                 )
                 encoded_count += 1
@@ -1308,7 +1353,11 @@ def collate_fn(batch):
     pixels = torch.stack([b["pixel_values"] for b in batch])
     captions = [b["caption"] for b in batch]
     result = {"pixel_values": pixels, "captions": captions}
-    masks = _stack_masks(batch, pixels.shape[-2] // 8, pixels.shape[-1] // 8)
+    masks = _stack_masks(
+        batch,
+        pixels.shape[-2] // _ANIMA_LATENT.spatial_stride,
+        pixels.shape[-1] // _ANIMA_LATENT.spatial_stride,
+    )
     if masks is not None:
         result["masks"] = masks
     if "loss_weight" in batch[0]:
@@ -1447,7 +1496,7 @@ def _walk_attr_list(dataset, attr):
     return None
 
 
-def dataset_token_counts(dataset, patch_spatial=2):
+def dataset_token_counts(dataset, patch_spatial=_ANIMA_LATENT.patch_spatial):
     """NaViT 打包的逐索引 token 数。
 
     优先用已填充的 ``token_count_for_index``（CachedLatentDataset 填充）。若该字段

--- a/runtime/training/families/__init__.py
+++ b/runtime/training/families/__init__.py
@@ -1,0 +1,43 @@
+"""模型族 registry —— 第 8 套 plugin registry，首个架构级（多模型支持 Phase 1）。
+
+PR-1 只承载 ModelSpec（声明式常量单一来源 + latent 缓存指纹协议）；
+ModelFamily 行为接口与 get_family() 派发随 PR-2b 落地，派发经 anima_train
+公共命名空间收口全部 6 个调用面（docs/design/multi-model/04-synthesis.md D8'/§5）。
+"""
+
+from __future__ import annotations
+
+from training.families.spec import (  # noqa: F401  (re-export)
+    ConstantShift,
+    KNOWN_CAPABILITIES,
+    LatentSpec,
+    LoraOutputSpec,
+    ModelSpec,
+    ResolutionAwareShift,
+    SamplingDefaults,
+    TextSpec,
+    validate_spec,
+)
+from training.families.anima import ANIMA_SPEC
+
+SPECS: dict[str, ModelSpec] = {}
+
+
+def _register(spec: ModelSpec) -> None:
+    validate_spec(spec)
+    if spec.family_id in SPECS:
+        raise ValueError(f"模型族重复注册: {spec.family_id}")
+    SPECS[spec.family_id] = spec
+
+
+_register(ANIMA_SPEC)
+
+
+def get_spec(family_id: str) -> ModelSpec:
+    """按族 id 取 ModelSpec。未知 id → ValueError 并列出已注册项。"""
+    try:
+        return SPECS[str(family_id)]
+    except KeyError:
+        raise ValueError(
+            f"未知模型族 '{family_id}'，已注册: {sorted(SPECS)}"
+        ) from None

--- a/runtime/training/families/anima/__init__.py
+++ b/runtime/training/families/anima/__init__.py
@@ -1,0 +1,77 @@
+"""Anima 族的声明式常量（PR-1 只有 ANIMA_SPEC；行为适配器随 PR-2b 落地）。"""
+
+from __future__ import annotations
+
+from training.families.spec import (
+    ConstantShift,
+    LatentSpec,
+    LoraOutputSpec,
+    ModelSpec,
+    SamplingDefaults,
+    TextSpec,
+)
+
+# latent2rgb 快速预览的线性投影系数（"模糊但能看出图"）。取自 ComfyUI
+# comfy/latent_formats.py 的 `Wan21.latent_rgb_factors[_bias]` —— Anima 的
+# Qwen-Image VAE 与 Wan2.1 同 latent 空间（docs/design/multi-model/00 §2、D17）。
+_WAN21_RGB_FACTORS: tuple[tuple[float, float, float], ...] = (
+    (-0.1299, -0.1692, 0.2932),
+    (0.0671, 0.0406, 0.0442),
+    (0.3568, 0.2548, 0.1747),
+    (0.0372, 0.2344, 0.1420),
+    (0.0313, 0.0189, -0.0328),
+    (0.0296, -0.0956, -0.0665),
+    (-0.3477, -0.4059, -0.2925),
+    (0.0166, 0.1902, 0.1975),
+    (-0.0412, 0.0267, -0.1364),
+    (-0.1293, 0.0740, 0.1636),
+    (0.0680, 0.3019, 0.1128),
+    (0.0032, 0.0581, 0.0639),
+    (-0.1251, 0.0927, 0.1699),
+    (0.0060, -0.0633, 0.0005),
+    (0.3477, 0.2275, 0.2950),
+    (0.1984, 0.0913, 0.1861),
+)
+_WAN21_RGB_BIAS: tuple[float, float, float] = (-0.1835, -0.0868, -0.3360)
+
+
+ANIMA_SPEC = ModelSpec(
+    family_id="anima",
+    display_name="Anima",
+    objective="rectified_flow",
+    latent=LatentSpec(
+        # latent 空间身份：Qwen-Image VAE = Wan2.1 latent 空间，f8、16ch。
+        # Krea 2 同值 → latent 缓存跨族共享（D6）。
+        fingerprint="wan21-f8c16",
+        channels=16,
+        spatial_stride=8,
+        patch_spatial=2,
+        patch_temporal=1,
+        temporal=False,
+        rgb_factors=_WAN21_RGB_FACTORS,
+        rgb_bias=_WAN21_RGB_BIAS,
+    ),
+    text=TextSpec(
+        # 每步在线编码（Qwen3-0.6B 末层 + T5 IDs 进 LLMAdapter），无文本缓存
+        strategy="online",
+        max_seq_len=512,
+        fingerprint="anima-qwen3-0.6b-t5xxl",
+    ),
+    sampling=SamplingDefaults(
+        # 白名单与默认值对应 sampling.py Comfy KSampler parity 现状
+        samplers=("er_sde", "dpmpp_3m_sde"),
+        schedulers=("simple", "sgm_uniform"),
+        default_sampler="er_sde",
+        default_scheduler="simple",
+        default_steps=25,
+        default_cfg=4.0,
+        shift_policy=ConstantShift(shift=3.0),
+    ),
+    # D5：Anima = 全量能力减 text_cache
+    capabilities=frozenset({
+        "navit", "sra", "leap", "compile_blocks",
+        "caption_tag_ops", "online_text", "masked_loss",
+    }),
+    lora=LoraOutputSpec(prefix="lora_unet", preset_name="anima_full"),
+    config_defaults={},
+)

--- a/runtime/training/families/spec.py
+++ b/runtime/training/families/spec.py
@@ -1,0 +1,151 @@
+"""ModelSpec —— 模型族的声明式常量（多模型支持 PR-1）。
+
+纯数据、frozen、无行为。设计出处：docs/design/multi-model/03-interface-evolution.md
+§2.1（字段集为 v1 冻结面）+ 04-synthesis.md D11/D12/D17。
+
+本文件在 PR-1 阶段先承担两件事：
+- 把散落在 dataset / sampling / timestep_sampling / phases 的 latent 规格
+  （z_dim / stride / patch / 对齐单元 / latent2rgb 系数）收敛为单一来源；
+- 为 latent npz 缓存提供指纹（fingerprint 是 **latent 空间身份**而非族名：
+  Anima 与 Krea 2 同为 ``wan21-f8c16`` → 缓存跨族共享，D6）。
+
+ModelFamily 行为接口（八方法 + convert_lora_state_dict）在 PR-2b 落地。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal, Mapping, Union
+
+
+@dataclass(frozen=True)
+class ConstantShift:
+    """固定 timestep shift（Anima：3.0，对应 Comfy parity sampling_settings）。"""
+
+    shift: float
+
+
+@dataclass(frozen=True)
+class ResolutionAwareShift:
+    """分辨率感知动态 shift（Krea 2：base 0.5 → max 1.15 按 image_seq_len 插值）。
+
+    只影响采样端 sigma 时刻表与 schema 默认值 overlay；训练端 t 采样走
+    timestep_samplers plugin（04-synthesis D14）。
+    """
+
+    base_shift: float
+    max_shift: float
+    base_image_seq_len: int
+    max_image_seq_len: int
+
+
+ShiftPolicy = Union[ConstantShift, ResolutionAwareShift]
+
+
+@dataclass(frozen=True)
+class LatentSpec:
+    #: latent 空间身份（非族名），进 npz 缓存指纹键
+    fingerprint: str
+    #: z_dim（VAE latent 通道数）
+    channels: int
+    #: VAE 空间下采样倍数（f8）
+    spatial_stride: int
+    #: DiT patchify 空间边长（2 → 1 token = 16×16 px）
+    patch_spatial: int
+    patch_temporal: int
+    #: 视频拒绝位（03 §3.2）：v1 恒 False，registry 注册期校验
+    temporal: bool
+    #: latent2rgb 预览线性投影 [channels][3]（D17，取自 ComfyUI LatentFormat）
+    rgb_factors: tuple[tuple[float, float, float], ...]
+    rgb_bias: tuple[float, float, float]
+
+    @property
+    def align_px(self) -> int:
+        """桶 / 采样尺寸的像素对齐单元 = spatial_stride × patch_spatial。"""
+        return self.spatial_stride * self.patch_spatial
+
+
+@dataclass(frozen=True)
+class TextSpec:
+    #: Anima=online（每步在线编码）；K2=cached_varlen（varlen 预缓存，D3）
+    strategy: Literal["online", "cached_varlen"]
+    max_seq_len: int
+    #: TE 指纹（cached_varlen 的缓存键成分；online 族仅记录用）
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class SamplingDefaults:
+    #: sampler / scheduler 白名单与默认值（schema overlay 与采样端消费）
+    samplers: tuple[str, ...]
+    schedulers: tuple[str, ...]
+    default_sampler: str
+    default_scheduler: str
+    default_steps: int
+    default_cfg: float
+    shift_policy: ShiftPolicy
+
+
+@dataclass(frozen=True)
+class LoraOutputSpec:
+    #: 保存键名前缀（两族统一 "lora_unet"，04-synthesis §7.1）
+    prefix: str
+    #: lycoris preset 标识（进 ss_network_args.preset）
+    preset_name: str
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    #: registry 键 & schema enum 值，永不改名（进 yaml / LoRA metadata / resume state）
+    family_id: str
+    display_name: str
+    #: 非 rectified-flow 拒绝位（03 §3.3）：v1 唯一合法值
+    objective: Literal["rectified_flow"]
+    latent: LatentSpec
+    text: TextSpec
+    sampling: SamplingDefaults
+    capabilities: frozenset[str]
+    lora: LoraOutputSpec
+    #: 创建 version 时叠进初始 yaml 的 per-family 默认值 overlay（作者写时落盘）
+    config_defaults: Mapping[str, Any] = field(default_factory=dict)
+
+
+#: 能力词表（03 §2.4）。加词零成本；删词 / 改语义须过 04-synthesis 评审。
+KNOWN_CAPABILITIES = frozenset({
+    "navit", "sra", "leap", "compile_blocks",
+    "caption_tag_ops", "online_text", "text_cache", "masked_loss",
+})
+
+
+def validate_spec(spec: ModelSpec) -> None:
+    """registry 注册期自洽校验（违反 → ValueError，进程启动即死）。"""
+    unknown = spec.capabilities - KNOWN_CAPABILITIES
+    if unknown:
+        raise ValueError(
+            f"ModelSpec[{spec.family_id}] 未知能力位: {sorted(unknown)}"
+        )
+    if spec.text.strategy == "cached_varlen" and "caption_tag_ops" in spec.capabilities:
+        # 交叉不变量（03 §2.4）：缓存键 = caption 内容 hash，tag shuffle/dropout
+        # 会让每步 caption 漂移、缓存永 miss。
+        raise ValueError(
+            f"ModelSpec[{spec.family_id}] cached_varlen 与 caption_tag_ops 互斥"
+        )
+    if spec.latent.temporal:
+        raise ValueError(
+            f"ModelSpec[{spec.family_id}] temporal=True：v1 不支持视频族（03 §3.2）"
+        )
+    if len(spec.latent.rgb_factors) != spec.latent.channels:
+        raise ValueError(
+            f"ModelSpec[{spec.family_id}] rgb_factors 行数 "
+            f"{len(spec.latent.rgb_factors)} != channels {spec.latent.channels}"
+        )
+    if any(len(row) != 3 for row in spec.latent.rgb_factors) or len(spec.latent.rgb_bias) != 3:
+        raise ValueError(f"ModelSpec[{spec.family_id}] rgb_factors/bias 必须是 RGB 三元")
+    if spec.sampling.default_sampler not in spec.sampling.samplers:
+        raise ValueError(
+            f"ModelSpec[{spec.family_id}] default_sampler 不在白名单 {spec.sampling.samplers}"
+        )
+    if spec.sampling.default_scheduler not in spec.sampling.schedulers:
+        raise ValueError(
+            f"ModelSpec[{spec.family_id}] default_scheduler 不在白名单 {spec.sampling.schedulers}"
+        )

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -9,6 +9,7 @@ import logging
 from pathlib import Path
 
 from training.context import TrainingContext
+from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC
 from training.model_loading import (
     enable_xformers,
     find_diffusion_pipe_root,
@@ -110,7 +111,7 @@ def run(ctx: TrainingContext) -> None:
             patch_spatial=ctx.model.patch_spatial,
             patch_temporal=ctx.model.patch_temporal,
             model_channels=model_channels,
-            vae_channels=16,
+            vae_channels=_ANIMA_SPEC.latent.channels,
             device=ctx.device,
             dtype=ctx.dtype,
             normalize=bool(getattr(args, "sra_normalize", True)),

--- a/runtime/training/sample_runner.py
+++ b/runtime/training/sample_runner.py
@@ -17,6 +17,7 @@ from typing import Optional
 import torch
 
 from training.context import TrainingContext
+from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC
 from training.sampling import sample_image
 from utils.optimizer_utils import optimizer_eval_mode
 
@@ -50,9 +51,11 @@ def run_sample(
     base_reso = int(_res[0]) if isinstance(_res, (list, tuple)) and _res else int(_res)
     s_w = int(getattr(args, "sample_width", 0) or 0) or base_reso
     s_h = int(getattr(args, "sample_height", 0) or 0) or base_reso
-    # 必须 16 的倍数（VAE 8 × patch_spatial 2），否则 cosmos_predict2 spatial_patch 断言失败
-    s_w = max(16, (s_w // 16) * 16)
-    s_h = max(16, (s_h // 16) * 16)
+    # 必须 align_px（VAE stride 8 × patch_spatial 2 = 16）的倍数，
+    # 否则 cosmos_predict2 spatial_patch 断言失败
+    _align = _ANIMA_SPEC.latent.align_px
+    s_w = max(_align, (s_w // _align) * _align)
+    s_h = max(_align, (s_h // _align) * _align)
     s_cfg = float(getattr(args, "sample_cfg_scale", 4.0) or 4.0)
     s_neg = str(getattr(args, "sample_negative_prompt", "") or "")
     s_seed = int(getattr(args, "sample_seed", 0) or 0)

--- a/runtime/training/sampling.py
+++ b/runtime/training/sampling.py
@@ -20,10 +20,13 @@ import sys
 import torch
 import torch.nn.functional as F
 
+from training.families.anima import ANIMA_SPEC
 from training.text_encoding import (
     build_comfy_anima_conditioning_inputs,
     encode_qwen,
 )
+
+_ANIMA_LATENT = ANIMA_SPEC.latent
 
 
 logger = logging.getLogger(__name__)
@@ -229,13 +232,15 @@ def _prepare_comfy_ksampler_txt2img_latent(
 ) -> torch.Tensor:
     """Build the same empty latent shape path as the target Comfy workflow."""
     latent = torch.zeros(
-        (1, 4, height // 8, width // 8),
+        # (1, 4, ...) 是 ResolutionMaster workflow parity（4ch 空 latent → repeat 补齐），
+        # 4 不是本模型的 latent 通道数，保持字面量
+        (1, 4, height // _ANIMA_LATENT.spatial_stride, width // _ANIMA_LATENT.spatial_stride),
         device=device,
         dtype=torch.float32,
     )
     return _fix_comfy_empty_latent_channels(
         latent,
-        latent_channels=16,
+        latent_channels=_ANIMA_LATENT.channels,
         latent_dimensions=3,
     )
 
@@ -329,7 +334,8 @@ def sample_image(
         raise e
 
     # sigmas（对齐 ComfyUI supported_models.Anima: shift=3.0, multiplier=1.0）
-    lat_h, lat_w = height // 8, width // 8
+    lat_h = height // _ANIMA_LATENT.spatial_stride
+    lat_w = width // _ANIMA_LATENT.spatial_stride
     _scheduler_builders = {
         "simple": _flow_sigmas_simple,
         "sgm_uniform": _flow_sigmas_sgm_uniform,

--- a/runtime/training/timestep_sampling.py
+++ b/runtime/training/timestep_sampling.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 
 import torch
 
+from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC
+
 
 def sample_t(
     bs,
@@ -84,7 +86,9 @@ def _apply_timestep_schedule_shift(t: torch.Tensor, timestep_schedule_shift: flo
     return ((t * s) / (1 + (s - 1) * t)).clamp(1e-4, 1 - 1e-4)
 
 
-def latent_token_counts(latents, patch_spatial: int = 2) -> list[int]:
+def latent_token_counts(
+    latents, patch_spatial: int = _ANIMA_SPEC.latent.patch_spatial
+) -> list[int]:
     """每样本的 patch-token 数（``timestep_shift_resolution_aware`` 用）。
 
     - list/tuple（NaViT 逐图 latent，各 ``[.,C,T,h_i,w_i]``，形状可异构）→ 逐图计数；

--- a/tests/test_model_spec.py
+++ b/tests/test_model_spec.py
@@ -1,0 +1,147 @@
+"""ModelSpec / latent 缓存指纹（多模型支持 PR-1）单元测试。
+
+设计出处：docs/design/multi-model/03-interface-evolution.md §2.1/§2.5、
+04-synthesis.md D12/D17。
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import pytest
+
+from training.families import SPECS, get_spec
+from training.families.anima import ANIMA_SPEC
+from training.families.spec import (
+    LoraOutputSpec,
+    ModelSpec,
+    TextSpec,
+    validate_spec,
+)
+
+
+# ── spec 与 registry ─────────────────────────────────────────────────────
+
+def test_anima_spec_registered():
+    assert get_spec("anima") is ANIMA_SPEC
+    assert SPECS["anima"].family_id == "anima"
+
+
+def test_unknown_family_raises_with_registered_list():
+    with pytest.raises(ValueError, match="anima"):
+        get_spec("no-such-family")
+
+
+def test_anima_latent_constants():
+    lat = ANIMA_SPEC.latent
+    assert lat.fingerprint == "wan21-f8c16"
+    assert lat.channels == 16
+    assert lat.spatial_stride == 8
+    assert lat.patch_spatial == 2
+    assert lat.align_px == 16
+    assert not lat.temporal
+    assert len(lat.rgb_factors) == lat.channels
+    assert all(len(r) == 3 for r in lat.rgb_factors)
+    assert len(lat.rgb_bias) == 3
+
+
+def test_spec_matches_vae_wrapper_constants():
+    # VAEWrapper 内部常量是权重侧事实（03 §4.3 不抽象清单，刻意不读 spec）；
+    # 此断言把 spec 与它的一致性 codify，防止两处漂移。
+    from training.models import VAEWrapper
+
+    assert VAEWrapper._UPSAMPLE == ANIMA_SPEC.latent.spatial_stride
+
+
+def _spec_with(text_strategy, caps):
+    return ModelSpec(
+        family_id="x",
+        display_name="X",
+        objective="rectified_flow",
+        latent=ANIMA_SPEC.latent,
+        text=TextSpec(strategy=text_strategy, max_seq_len=512, fingerprint="f"),
+        sampling=ANIMA_SPEC.sampling,
+        capabilities=frozenset(caps),
+        lora=LoraOutputSpec(prefix="lora_unet", preset_name="x"),
+    )
+
+
+def test_cached_varlen_excludes_caption_tag_ops():
+    # 交叉不变量（03 §2.4）：缓存键 = caption 内容 hash，与 tag shuffle/dropout 互斥
+    with pytest.raises(ValueError):
+        validate_spec(_spec_with("cached_varlen", {"caption_tag_ops"}))
+    validate_spec(_spec_with("cached_varlen", {"masked_loss", "text_cache"}))
+
+
+def test_unknown_capability_rejected():
+    with pytest.raises(ValueError):
+        validate_spec(_spec_with("online", {"warp_drive"}))
+
+
+# ── latent npz 缓存指纹判据（grandfather / 失配删除）────────────────────
+
+def _bare_cached_dataset():
+    from training.dataset import CachedLatentDataset
+
+    ds = CachedLatentDataset.__new__(CachedLatentDataset)
+    ds.np = np
+    ds.flip_augment = False
+    ds.load_masks = False
+    ds.base_image_dataset = None
+    # 绕过 bucket 尺寸校验（None → 跳过），只测指纹判据
+    ds._expected_bucket_size = lambda img_path, target_reso=None: None
+    ds.latent_spec = ANIMA_SPEC.latent
+    return ds
+
+
+def _write_pair(tmp_path, name, **npz_kwargs):
+    """写 img + npz，并把 img mtime 拨到过去（缓存必须新于图）。"""
+    img = tmp_path / f"{name}.png"
+    img.write_bytes(b"fake")
+    npz = tmp_path / f"{name}.npz"
+    np.savez(npz, latent=np.zeros((16, 1, 4, 4), dtype=np.float32), **npz_kwargs)
+    past = npz.stat().st_mtime - 3600
+    os.utime(img, (past, past))
+    return img, npz
+
+
+def test_legacy_cache_without_fingerprint_is_grandfathered(tmp_path):
+    ds = _bare_cached_dataset()
+    img, npz = _write_pair(tmp_path, "legacy", bucket_w=64, bucket_h=64)
+    assert ds._is_cache_valid(img, npz) is True
+    assert npz.exists()
+
+
+def test_cache_with_matching_fingerprint_is_valid(tmp_path):
+    from training.dataset import LATENT_CACHE_LAYOUT_VERSION
+
+    ds = _bare_cached_dataset()
+    img, npz = _write_pair(
+        tmp_path, "ok",
+        latent_fingerprint=ANIMA_SPEC.latent.fingerprint,
+        layout_version=LATENT_CACHE_LAYOUT_VERSION,
+    )
+    assert ds._is_cache_valid(img, npz) is True
+
+
+def test_cache_with_wrong_fingerprint_is_deleted(tmp_path):
+    ds = _bare_cached_dataset()
+    img, npz = _write_pair(
+        tmp_path, "alien",
+        latent_fingerprint="sdxl-f8c4",
+        layout_version=1,
+    )
+    assert ds._is_cache_valid(img, npz) is False
+    assert not npz.exists()
+
+
+def test_cache_with_unknown_layout_version_is_deleted(tmp_path):
+    ds = _bare_cached_dataset()
+    img, npz = _write_pair(
+        tmp_path, "future",
+        latent_fingerprint=ANIMA_SPEC.latent.fingerprint,
+        layout_version=999,
+    )
+    assert ds._is_cache_valid(img, npz) is False
+    assert not npz.exists()


### PR DESCRIPTION
多模型支持实施序列第 1 刀（设计见 #404，04-synthesis §5）。对 Anima 零行为变化。

## 改动

- 新增 `runtime/training/families/`（第 8 套 registry 的地基）：`spec.py` 定义 ModelSpec 冻结面（LatentSpec / TextSpec / SamplingDefaults / 能力集 / 拒绝位 `objective`+`temporal`）+ 注册期自洽校验（含 `cached_varlen ⇒ ¬caption_tag_ops` 交叉不变量）；`anima/` 提供 ANIMA_SPEC
- latent 规格散点收敛为单一来源：dataset（align / mask 下采样 / patch token / collate //8）、timestep_sampling、sampling（空 latent 形状 / 16ch）、phases/models（SRA vae_channels）、sample_runner（采样尺寸对齐）改读 spec；latent2rgb 预览系数收编进 LatentSpec（D17），anima_daemon 改引用
- **latent npz 缓存加指纹**（独立价值，修复现存隐患「换 VAE 同桶尺寸静默复用错 latent」）：写入 `latent_fingerprint`（latent 空间身份 `wan21-f8c16`，非族名 → 未来 K2 跨族共享缓存）+ `layout_version`；`_is_cache_valid` 失配即删除重 encode；**无键存量缓存 grandfather 为 wan21-f8c16**，升级不触发全量重 encode
- VAEWrapper 内部常量刻意不读 spec（03 §4.3 权重侧事实），以单测钉两处一致性防漂移

## 测试

- 新增 `tests/test_model_spec.py`（10 条：registry / 常量 / 校验 / grandfather / 失配删除）
- 受影响面 18 个测试文件 236 条全绿
- `test_anima_daemon_comfy_parity_runtime` 两条在特定合跑顺序下失败为存量顺序敏感问题：无本改动的基线（stash 后）同组合同样失败，单独跑全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)