### PR TITLE
fix(supervisor): Windows 进程终止回退 + CLI 测试隔离

### DIFF
--- a/studio/supervisor/process.py
+++ b/studio/supervisor/process.py
@@ -14,6 +14,63 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 
+def _kill_process_tree_psutil(pid: int) -> None:
+    """taskkill 不可用/被策略拒绝时的 Windows fallback。
+
+    psutil 是项目必需依赖。先杀最深子进程再杀根，尽量保留 taskkill 的 tree
+    语义；NoSuchProcess 是并发退出的正常竞态。
+    """
+    import psutil
+
+    try:
+        root = psutil.Process(pid)
+        descendants = root.children(recursive=True)
+    except psutil.NoSuchProcess:
+        return
+    except Exception:
+        logger.exception("psutil enumerate process tree failed for pid %d", pid)
+        descendants = []
+        try:
+            root = psutil.Process(pid)
+        except psutil.NoSuchProcess:
+            return
+
+    for proc in reversed(descendants):
+        try:
+            proc.kill()
+        except psutil.NoSuchProcess:
+            pass
+        except Exception:
+            logger.exception("psutil kill failed for child pid %d", proc.pid)
+    try:
+        root.kill()
+    except psutil.NoSuchProcess:
+        pass
+    except Exception:
+        logger.exception("psutil kill failed for root pid %d", pid)
+
+
+def _kill_process_tree_windows(pid: int) -> None:
+    """Windows taskkill 主路径；失败时保证落到 psutil tree fallback。"""
+    try:
+        result = subprocess.run(
+            ["taskkill", "/T", "/F", "/PID", str(pid)],
+            check=False, capture_output=True, timeout=10,
+        )
+        if result.returncode == 0:
+            return
+        detail = (result.stderr or result.stdout or b"").decode(
+            errors="replace"
+        ).strip()
+        logger.warning(
+            "taskkill failed for pid %d (rc=%d): %s; falling back to psutil",
+            pid, result.returncode, detail or "no output",
+        )
+    except Exception:
+        logger.exception("taskkill /T /F failed for pid %d", pid)
+    _kill_process_tree_psutil(pid)
+
+
 def _kill_process_tree(pid: int) -> None:
     """杀掉以 pid 为根的整棵进程树。
 
@@ -22,13 +79,7 @@ def _kill_process_tree(pid: int) -> None:
     递归到整个进程树。POSIX 用 killpg。
     """
     if os.name == "nt":
-        try:
-            subprocess.run(
-                ["taskkill", "/T", "/F", "/PID", str(pid)],
-                check=False, capture_output=True, timeout=10,
-            )
-        except Exception:
-            logger.exception("taskkill /T /F failed for pid %d", pid)
+        _kill_process_tree_windows(pid)
     else:
         try:
             os.killpg(os.getpgid(pid), signal.SIGKILL)

--- a/tests/test_studio_cli.py
+++ b/tests/test_studio_cli.py
@@ -238,6 +238,9 @@ def test_run_passes_host_port(
     fake_dist = tmp_path / "dist"
     fake_dist.mkdir()
     monkeypatch.setattr(cli, "WEB_DIST", fake_dist)
+    # 本测试只验证 host/port 透传；前端新鲜度另有专项测试。若不隔离，结果会
+    # 依赖 checkout src mtime 与本机 npm 是否安装，违反测试卫生。
+    monkeypatch.setattr(cli, "_web_dist_is_stale", lambda: False)
     cli.main(["run", "--host", "0.0.0.0", "--port", "9999"])
     server_call = next(
         c for c in fake_calls if "studio.server" in " ".join(c)

--- a/tests/test_supervisor_process.py
+++ b/tests/test_supervisor_process.py
@@ -1,0 +1,59 @@
+"""进程树终止的跨平台、无机器状态单元测试。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from studio.supervisor import process
+
+
+def test_windows_taskkill_success_does_not_use_fallback(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        process.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=0, stderr=b"", stdout=b"",
+        ),
+    )
+    monkeypatch.setattr(
+        process, "_kill_process_tree_psutil", lambda pid: calls.append(pid),
+    )
+
+    process._kill_process_tree_windows(123)
+
+    assert calls == []
+
+
+def test_windows_taskkill_nonzero_uses_psutil_fallback(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        process.subprocess,
+        "run",
+        lambda *args, **kwargs: SimpleNamespace(
+            returncode=1, stderr=b"ERROR: Access denied", stdout=b"",
+        ),
+    )
+    monkeypatch.setattr(
+        process, "_kill_process_tree_psutil", lambda pid: calls.append(pid),
+    )
+
+    process._kill_process_tree_windows(456)
+
+    assert calls == [456]
+
+
+def test_windows_taskkill_exception_uses_psutil_fallback(monkeypatch):
+    calls = []
+
+    def fail(*args, **kwargs):
+        raise FileNotFoundError("taskkill missing")
+
+    monkeypatch.setattr(process.subprocess, "run", fail)
+    monkeypatch.setattr(
+        process, "_kill_process_tree_psutil", lambda pid: calls.append(pid),
+    )
+
+    process._kill_process_tree_windows(789)
+
+    assert calls == [789]


### PR DESCRIPTION
Phase 2 开工前的全量测试门禁清障。#409 合并后执行 `pytest tests/ -q`，Windows 环境稳定暴露两个失败；按 `CONTRIBUTING.md` 的测试卫生要求，不能归为“本机问题”或靠重跑绕过，因此独立修复，不混入多模型 Phase 2 功能提交。

## 根因

- `test_run_passes_host_port` 只验证 CLI 参数透传，却没有隔离前端构建新鲜度判断；空的 fake dist 被判定为 stale，测试意外进入 `npm` 构建路径，结果依赖开发机是否安装 npm。
- Windows 上 `taskkill /T /F` 可能返回 `Access denied` 等非零状态；原实现忽略 return code 并直接返回，supervisor 随后仍观察到进程处于 `running`。

## 改动

- CLI host/port 单测显式固定 `_web_dist_is_stale`，让测试只覆盖声明的参数透传边界。
- Windows 进程树终止检查 `taskkill` 返回码；失败或抛出异常时，回退到 psutil 递归终止子进程与父进程。
- 新增 `tests/test_supervisor_process.py`，覆盖 taskkill 成功、非零返回和异常三条路径。

## 行为边界

- taskkill 成功路径保持原行为。
- 非 Windows 路径不变。
- 无 UI、API 或多模型运行时行为变更；本 PR 只解除 Phase 2 前的全量测试门禁。

## 测试

- 定向回归：`48 passed`
- 相关安全网：`33 passed`
- 全量：`pytest tests/ -q` → `2857 passed`