### PR TITLE
feat(train): varlen 文本缓存 sidecar + phase 接线（多模型 Phase 2）

### DIFF
--- a/docs/architecture/project-structure.en.md
+++ b/docs/architecture/project-structure.en.md
@@ -6,12 +6,12 @@ Top-level repository layout. For Studio's internal module structure see [`studio
 AnimaLoraStudio/
 ├── runtime/                       # Anima runtime core (standalone process; launched by Studio as a subprocess or run via CLI)
 │   ├── anima_train.py             # Training entry
-│   ├── training/                  # Training stack subpackage: context / phases / loop / sample_runner
+│   ├── training/                  # Training stack: context / phases / text cache / loop / sample_runner
 │   │   ├── adapters/              # plugin: lokr / loha / lora
 │   │   ├── optimizers/            # plugin: adamw / automagic / came / lion / prodigy / prodigy_plus_schedulefree / soap / soap_sf
 │   │   ├── schedulers/            # plugin: cosine / cosine_with_restart / cosine_with_warmup / none
 │   │   ├── inference_samplers/    # plugin: er_sde, etc.
-│   │   └── phases/                # bootstrap / models / dataset / optimizer / resume / finalize
+│   │   └── phases/                # bootstrap / models / dataset / text_cache / optimizer / resume / finalize
 │   ├── anima_generate.py          # Image generation: single image / XY matrix
 │   ├── anima_daemon.py            # Inference daemon: keeps the base model and LoRA loaded in GPU
 │   ├── anima_reg_ai.py            # AI prior generation: no LoRA, base model produces reg set

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -6,12 +6,12 @@
 AnimaLoraStudio/
 ├── runtime/                       # Anima 运行时核心（独立进程；Studio 通过 subprocess 拉起，也可单独 CLI 跑）
 │   ├── anima_train.py             # 训练入口
-│   ├── training/                  # 训练栈子包：context / phases / loop / sample_runner
+│   ├── training/                  # 训练栈子包：context / phases / text cache / loop / sample_runner
 │   │   ├── adapters/              # plugin: lokr / loha / lora
 │   │   ├── optimizers/            # plugin: adamw / automagic / came / lion / prodigy / prodigy_plus_schedulefree / soap / soap_sf
 │   │   ├── schedulers/            # plugin: cosine / cosine_with_restart / cosine_with_warmup / none
 │   │   ├── inference_samplers/    # plugin: er_sde 等
-│   │   └── phases/                # bootstrap / models / dataset / optimizer / resume / finalize
+│   │   └── phases/                # bootstrap / models / dataset / text_cache / optimizer / resume / finalize
 │   ├── anima_generate.py          # 出图：单图 / XY 矩阵
 │   ├── anima_daemon.py            # 推理 daemon：常驻 GPU 加载 LoRA 和底模
 │   ├── anima_reg_ai.py            # AI 先验生成：无 LoRA 直接用底模出 reg 集

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -130,6 +130,7 @@ def main():
     phases.bootstrap.run(ctx)
     phases.models.run(ctx)
     phases.dataset.run(ctx)
+    phases.text_cache.run(ctx)
     phases.optimizer.run(ctx)
     phases.resume.run(ctx)
     loop.run(ctx)

--- a/runtime/training/README.md
+++ b/runtime/training/README.md
@@ -1,6 +1,6 @@
 # `runtime/training/` — 训练流水线包
 
-`anima_train.py` 调起的训练全流程实现。ADR 0003 把原 2901 行单文件拆成本子包，**main()** 现在只是 11 行编排：
+`anima_train.py` 调起的训练全流程实现。ADR 0003 把原 2901 行单文件拆成本子包，**main()** 现在只保留 phase 编排：
 
 ```python
 def main():
@@ -9,6 +9,7 @@ def main():
     phases.bootstrap.run(ctx)
     phases.models.run(ctx)
     phases.dataset.run(ctx)
+    phases.text_cache.run(ctx)
     phases.optimizer.run(ctx)
     phases.resume.run(ctx)
     loop.run(ctx)
@@ -35,6 +36,7 @@ runtime/training/
 ├── state.py                ← save / load_training_state
 ├── snapshot.py             ← pause / resume 用的 state snapshot helpers（ADR 0006）
 ├── dataset.py              ← BucketManager + ImageDataset + 5 衍生类 + collate + navit sampler/collate
+├── text_cache.py           ← varlen 文本 sidecar / train/.text-cache prompt bundle 协议与原子 safetensors I/O
 ├── sampling.py             ← 推理用 sample_image + sigma 调度（被 sister script 也用）
 ├── timestep_sampling.py    ← 训练 step 用 sample_t（logit_normal / uniform / mode）；
 │                            被 timestep_samplers/baseline.py 复用
@@ -46,11 +48,12 @@ runtime/training/
 │                            注意：是 *loss 权重*（Flow Matching 步级缩放系数），
 │                            跟 *loss 类型*（mse / huber，见 losses/）正交
 │
-├── phases/                 ← main() 的 6 个 phase；每个 run(ctx) in-place mutate
+├── phases/                 ← main() 的 7 个 phase；每个 run(ctx) in-place mutate
 │   ├── bootstrap.py        ← yaml + 交互 + seed + device + wandb + monitor_state writer +
 │   │                          调 6 个 plugin 子包的 validate_schema_consistency
 │   ├── models.py           ← path resolve + 加载 transformer/vae/text encoders + LoRA inject
 │   ├── dataset.py          ← build 主集 + 正则集 + dataloader + VAE roundtrip 自检
+│   ├── text_cache.py       ← cached_varlen 族预扫最终 caption + 调 family 编码缓存
 │   ├── optimizer.py        ← build_optimizer + validate + scheduler + total_steps +
 │   │                          build_timestep_sampler + build_loss
 │   ├── resume.py           ← init_progress + state recovery + SIGINT + sample prompts + baseline
@@ -96,9 +99,11 @@ TrainingContext(args=args)             │
         ↓                              │
 phases.bootstrap.run(ctx)              │  填 device / dtype / output_dir / wandb / monitor
         ↓                              │
-phases.models.run(ctx)                 │  填 repo_root / model / vae / qwen* / t5_tok / injector
+phases.models.run(ctx)                 │  填 repo_root / model / vae / text_stack / injector
         ↓                              ├─ 一次性 setup
 phases.dataset.run(ctx)                │  填 bucket_mgr / dataset / reg_dataset / dataloader
+        ↓                              │
+phases.text_cache.run(ctx)             │  cached_varlen 族写随图 sidecar；online 族 no-op
         ↓                              │
 phases.optimizer.run(ctx)              │  填 optimizer / scheduler / total_steps / trainable_params
         ↓                              │

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -660,6 +660,26 @@ class ImageDataset(Dataset):
             return None
         return mask
 
+    def caption_for_sample(self, sample) -> str:
+        """解析一个 sample 的最终 caption，不打开图片。
+
+        训练 ``__getitem__``、latent cache wrapper 与 Phase 2 text-cache 预扫共用
+        同一事实源，避免三处 JSON/TXT/override 优先级漂移。caption shuffle/dropout
+        仍由既有处理函数决定；cached_varlen 族在 registry 层禁止这些随机操作，
+        因而预缓存与训练批次得到完全相同的确定文本。
+        """
+        caption = None
+        if self.caption_override is not None:
+            caption = self.caption_override
+        elif sample.get("json_path"):
+            caption = self._process_caption_json(sample["json_path"])
+
+        if caption is None and sample.get("txt_path"):
+            caption = sample["txt_path"].read_text(encoding="utf-8").strip()
+            caption = self._process_caption_txt(caption)
+
+        return "" if caption is None else str(caption)
+
     def __getitem__(self, idx):
         # 默认 path：DataLoader 不能传额外参数，所以由 flip_augment 决定是否随机翻转。
         # CachedLatentDataset 想显式控制 flip 时直接调 get_with_flip(idx, flip=...)，
@@ -680,18 +700,7 @@ class ImageDataset(Dataset):
         img = Image.open(sample["image"]).convert("RGB")
 
         # 获取 caption（正则集可用 caption_override 统一覆盖）
-        caption = None
-        if self.caption_override is not None:
-            caption = self.caption_override
-        elif sample.get("json_path"):
-            caption = self._process_caption_json(sample["json_path"])
-
-        if caption is None and sample.get("txt_path"):
-            caption = sample["txt_path"].read_text(encoding="utf-8").strip()
-            caption = self._process_caption_txt(caption)
-
-        if caption is None:
-            caption = ""
+        caption = self.caption_for_sample(sample)
 
         # 目标尺寸：ARB 桶（native 关）或原生 floor-16 定尺寸（native 开）。统一走
         # _target_size_for；返回 None（base 方桶不分桶档）时退回 target_reso 方桶。
@@ -1311,20 +1320,23 @@ class CachedLatentDataset(Dataset):
         while hasattr(base, "dataset"):
             base = base.dataset
         
-        # 处理 caption（正则集 caption_override 优先）
-        caption = None
-        if getattr(base, "caption_override", None) is not None:
-            caption = base.caption_override
-        elif sample.get("json_path") and hasattr(base, "_process_caption_json"):
-            caption = base._process_caption_json(sample["json_path"])
-        
-        if caption is None and sample.get("txt_path"):
-            caption = sample["txt_path"].read_text(encoding="utf-8").strip()
-            if hasattr(base, "_process_caption_txt"):
-                caption = base._process_caption_txt(caption)
-        
-        if caption is None:
-            caption = ""
+        # 处理 caption（与 ImageDataset / text-cache 预扫共用同一事实源）
+        if hasattr(base, "caption_for_sample"):
+            caption = base.caption_for_sample(sample)
+        else:  # 非 ImageDataset 的第三方 wrapper：保留 Phase 2 前的 duck-type 行为
+            caption = None
+            if getattr(base, "caption_override", None) is not None:
+                caption = base.caption_override
+            elif sample.get("json_path") and hasattr(base, "_process_caption_json"):
+                caption = base._process_caption_json(sample["json_path"])
+
+            if caption is None and sample.get("txt_path"):
+                caption = sample["txt_path"].read_text(encoding="utf-8").strip()
+                if hasattr(base, "_process_caption_txt"):
+                    caption = base._process_caption_txt(caption)
+
+            if caption is None:
+                caption = ""
         
         return {
             "latent": latent,

--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -49,7 +49,9 @@ class AnimaFamily:
 
     # ── 文本条件 ─────────────────────────────────────────────────────────
     def prepare_text_cache(self, captions: Iterable[str],
-                           extra_prompts: Iterable[str]) -> None:
+                           extra_prompts: Iterable[str], *, cache_entries=(),
+                           cache_root=None, text=None, device=None,
+                           dtype=None) -> None:
         return None  # Anima 每步在线编码（spec.text.strategy="online"），无缓存
 
     def encode_text_for_batch(self, text, dit, captions, device, dtype, *,

--- a/runtime/training/families/protocol.py
+++ b/runtime/training/families/protocol.py
@@ -32,7 +32,9 @@ class ModelFamily(Protocol):
 
     # ── 文本条件 ─────────────────────────────────────────────────────────
     def prepare_text_cache(self, captions: Iterable[str],
-                           extra_prompts: Iterable[str]) -> None: ...
+                           extra_prompts: Iterable[str], *, cache_entries=(),
+                           cache_root=None, text=None, device=None,
+                           dtype=None) -> None: ...
 
     def encode_text_for_batch(self, text, dit, captions: list[str],
                               device, dtype, *, kv_trim: bool = True) -> Any: ...

--- a/runtime/training/families/spec.py
+++ b/runtime/training/families/spec.py
@@ -130,6 +130,14 @@ def validate_spec(spec: ModelSpec) -> None:
         raise ValueError(
             f"ModelSpec[{spec.family_id}] cached_varlen 与 caption_tag_ops 互斥"
         )
+    if spec.text.strategy == "cached_varlen" and "text_cache" not in spec.capabilities:
+        raise ValueError(
+            f"ModelSpec[{spec.family_id}] cached_varlen 必须声明 text_cache 能力"
+        )
+    if spec.text.strategy == "cached_varlen" and not spec.text.fingerprint.strip():
+        raise ValueError(
+            f"ModelSpec[{spec.family_id}] cached_varlen 必须声明非空 TE 指纹"
+        )
     if spec.latent.temporal:
         raise ValueError(
             f"ModelSpec[{spec.family_id}] temporal=True：v1 不支持视频族（03 §3.2）"

--- a/runtime/training/phases/__init__.py
+++ b/runtime/training/phases/__init__.py
@@ -1,9 +1,12 @@
 """训练 main() 的 phase 拆分（ADR 0003 PR-B）。
 
 每个 phase 是个 `run(ctx: TrainingContext) -> None` 函数，in-place mutate ctx。
-main() 编排成：bootstrap → models → dataset → optimizer → resume → train_loop → finalize。
+main() 编排成：bootstrap → models → dataset → text_cache → optimizer → resume →
+train_loop → finalize。
 """
 
-from training.phases import bootstrap, dataset, finalize, models, optimizer, resume
+from training.phases import bootstrap, dataset, finalize, models, optimizer, resume, text_cache
 
-__all__ = ["bootstrap", "models", "dataset", "optimizer", "resume", "finalize"]
+__all__ = [
+    "bootstrap", "models", "dataset", "text_cache", "optimizer", "resume", "finalize",
+]

--- a/runtime/training/phases/text_cache.py
+++ b/runtime/training/phases/text_cache.py
@@ -1,0 +1,103 @@
+"""text_cache_phase：构造随图 caption sidecar 计划并交给 ModelFamily 编码。
+
+位置固定在 dataset 之后、optimizer 之前。dataset 仍只产出 ``captions``；缓存命中
+与编码张量形状完全由 family 自治。Anima 的 online 策略走零开销 no-op。
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from training.context import TrainingContext
+from training.text_cache import TextCacheEntry
+
+
+logger = logging.getLogger(__name__)
+
+
+def _image_dataset(dataset):
+    """从 latent/repeat wrapper 中找到拥有 samples + caption resolver 的底层集。"""
+
+    seen = set()
+    current = dataset
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if hasattr(current, "samples") and hasattr(current, "caption_for_sample"):
+            return current
+        next_dataset = getattr(current, "base_image_dataset", None)
+        if next_dataset is None:
+            next_dataset = getattr(current, "base_dataset", None)
+        if next_dataset is None:
+            next_dataset = getattr(current, "dataset", None)
+        current = next_dataset
+    return None
+
+
+def _collect_entries(ctx: TrainingContext) -> list[TextCacheEntry]:
+    """主集 + 正则集按图片去重；分辨率 fan-out/repeat 不重复编码文本。"""
+
+    by_image: dict[str, TextCacheEntry] = {}
+    for dataset in (ctx.base_dataset, ctx.reg_dataset):
+        base = _image_dataset(dataset)
+        if base is None:
+            continue
+        for sample in base.samples:
+            image = Path(sample["image"])
+            caption = base.caption_for_sample(sample)
+            key = str(image)
+            existing = by_image.get(key)
+            if existing is not None:
+                if existing.caption != caption:
+                    raise ValueError(
+                        f"同一图片解析出两个不同 caption，无法建立文本缓存: {image}"
+                    )
+                continue
+            by_image[key] = TextCacheEntry.for_image(image, caption)
+    return list(by_image.values())
+
+
+def _extra_prompts(args) -> list[str]:
+    prompts = getattr(args, "sample_prompts", None) or []
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    out = [str(p) for p in prompts if p is not None]
+    single = getattr(args, "sample_prompt", "") or ""
+    if single and single not in out:
+        out.append(str(single))
+    sampling_enabled = bool(
+        int(getattr(args, "sample_steps", 0) or 0)
+        or int(getattr(args, "sample_every", 0) or 0)
+    )
+    if sampling_enabled and not out:
+        out.append("1girl, masterpiece")
+    # CFG 无条件分支也需要编码；空串是合法且有意义的 prompt。
+    out.append(str(getattr(args, "sample_negative_prompt", "") or ""))
+    return list(dict.fromkeys(out))
+
+
+def run(ctx: TrainingContext) -> None:
+    strategy = ctx.family.spec.text.strategy
+    if strategy == "online":
+        ctx.family.prepare_text_cache([], [])
+        return
+    if strategy != "cached_varlen":  # registry 正常会先拦，这里保留可操作错误
+        raise ValueError(f"未知文本策略: {strategy!r}")
+
+    entries = _collect_entries(ctx)
+    captions = [entry.caption for entry in entries]
+    extras = _extra_prompts(ctx.args)
+    cache_root = Path(ctx.args.data_dir)
+    logger.info(
+        "[text-cache] 预缓存 %d 张图片 caption + %d 条采样/负面 prompt（varlen）",
+        len(entries), len(extras),
+    )
+    ctx.family.prepare_text_cache(
+        captions,
+        extras,
+        cache_entries=entries,
+        cache_root=cache_root,
+        text=ctx.text_stack,
+        device=ctx.device,
+        dtype=ctx.dtype,
+    )

--- a/runtime/training/text_cache.py
+++ b/runtime/training/text_cache.py
@@ -1,0 +1,276 @@
+"""模型族文本条件缓存的共享存储基建（多模型 Phase 2）。
+
+本模块只负责缓存协议与磁盘 I/O，不知道 tokenizer / text encoder，也不 import
+任何 family：编码行为仍由 ``ModelFamily.prepare_text_cache`` 自治。
+
+协议（docs/design/multi-model/04-synthesis.md D19）：
+
+- 图片 caption 缓存与图片同目录，使用 ``<完整图片名>.text.safetensors`` sidecar；
+- key 由最终 caption、TE 指纹和格式版本共同决定；
+- tensor 保留可变 token 长度，不 pad 到 512；
+- sample / negative prompt 聚合到数据集根目录的一个 safetensors 文件；
+- 写入使用 sibling tmp + ``os.replace``，训练中断不会留下半文件。
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Mapping, Optional
+
+
+TEXT_CACHE_FORMAT_VERSION = 1
+_SIDECAR_SUFFIX = ".text.safetensors"
+_PROMPT_CACHE_DIR = ".text-cache"
+_PROMPT_CACHE_PREFIX = "prompts"
+_TENSOR_SEPARATOR = "::"
+
+
+@dataclass(frozen=True)
+class TextCacheEntry:
+    """一张图片的最终 caption 与其 sidecar 位置。"""
+
+    image_path: Path
+    caption: str
+    cache_path: Path
+
+    @classmethod
+    def for_image(cls, image_path, caption: str) -> "TextCacheEntry":
+        image = Path(image_path)
+        return cls(
+            image_path=image,
+            caption=str(caption),
+            cache_path=caption_sidecar_path(image),
+        )
+
+
+def caption_sha256(caption: str) -> str:
+    """最终 caption 内容 hash（D3/D19 的独立失效分量）。"""
+
+    return hashlib.sha256(str(caption).encode("utf-8")).hexdigest()
+
+
+def text_cache_key(
+    caption: str,
+    text_fingerprint: str,
+    *,
+    format_version: int = TEXT_CACHE_FORMAT_VERSION,
+) -> str:
+    """返回 caption + TE 指纹 + 格式版本的稳定内容键。"""
+
+    payload = (
+        f"text-cache-v{int(format_version)}\0{text_fingerprint}\0{caption}"
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def caption_sidecar_path(image_path) -> Path:
+    """图片 caption sidecar；保留原扩展名，避免 ``a.jpg``/``a.png`` 冲突。"""
+
+    image = Path(image_path)
+    return image.with_name(image.name + _SIDECAR_SUFFIX)
+
+
+def prompt_cache_path(root, text_fingerprint: str) -> Path:
+    """sample/negative prompt 聚合缓存路径（按 TE 指纹隔离）。
+
+    聚合文件放进 ``train/.text-cache/``：仍与数据集同域，同时保持 bundle 的
+    ``train/{folder}/{file}`` 两层结构，导入时无需为根目录文件增加例外。
+    """
+
+    fp_short = hashlib.sha256(str(text_fingerprint).encode("utf-8")).hexdigest()[:12]
+    return (
+        Path(root)
+        / _PROMPT_CACHE_DIR
+        / f"{_PROMPT_CACHE_PREFIX}.{fp_short}.safetensors"
+    )
+
+
+def _normalise_tensors(tensors: Mapping[str, object]) -> dict:
+    import torch
+
+    if not tensors:
+        raise ValueError("文本缓存至少需要一个 tensor")
+    out = {}
+    for name, value in tensors.items():
+        key = str(name)
+        if not key or _TENSOR_SEPARATOR in key:
+            raise ValueError(f"非法文本缓存 tensor 名: {name!r}")
+        if not isinstance(value, torch.Tensor):
+            raise TypeError(f"文本缓存值必须是 torch.Tensor: {key}")
+        out[key] = value.detach().cpu().contiguous()
+    return out
+
+
+def _atomic_save(
+    tensors: Mapping[str, object], metadata: Mapping[str, str], path: Path,
+) -> None:
+    from safetensors.torch import save_file
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # 同一数据集允许两个训练 task 并发预缓存：tmp 名带 pid/thread，最终文件仍由
+    # os.replace 竞争为任一完整版本，不会互相截断临时文件。
+    tmp_path = path.with_name(
+        f"{path.name}.{os.getpid()}.{threading.get_ident()}.tmp"
+    )
+    try:
+        save_file(dict(tensors), str(tmp_path), metadata=dict(metadata))
+        os.replace(tmp_path, path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def _load(path: Path) -> tuple[dict, dict[str, str]]:
+    from safetensors import safe_open
+
+    tensors = {}
+    with safe_open(str(path), framework="pt", device="cpu") as handle:
+        metadata = dict(handle.metadata() or {})
+        for key in handle.keys():
+            tensors[key] = handle.get_tensor(key)
+    return tensors, metadata
+
+
+class TextCacheStore:
+    """绑定一个 TE 指纹的 sidecar / prompt bundle 读写器。"""
+
+    def __init__(
+        self,
+        text_fingerprint: str,
+        *,
+        format_version: int = TEXT_CACHE_FORMAT_VERSION,
+    ) -> None:
+        fingerprint = str(text_fingerprint).strip()
+        if not fingerprint:
+            raise ValueError("text_fingerprint 不能为空")
+        self.text_fingerprint = fingerprint
+        self.format_version = int(format_version)
+
+    def key(self, caption: str) -> str:
+        return text_cache_key(
+            caption,
+            self.text_fingerprint,
+            format_version=self.format_version,
+        )
+
+    def write_caption(self, entry: TextCacheEntry, tensors: Mapping[str, object]) -> None:
+        payload = _normalise_tensors(tensors)
+        metadata = {
+            "cache_kind": "caption_sidecar",
+            "format_version": str(self.format_version),
+            "text_fingerprint": self.text_fingerprint,
+            "caption_sha256": caption_sha256(entry.caption),
+            "cache_key": self.key(entry.caption),
+        }
+        _atomic_save(payload, metadata, entry.cache_path)
+
+    def read_caption(self, entry: TextCacheEntry) -> Optional[dict]:
+        """命中返回 CPU tensors；缺失、损坏或任一指纹失配返回 ``None``。"""
+
+        if not entry.cache_path.is_file():
+            return None
+        try:
+            tensors, metadata = _load(entry.cache_path)
+        except Exception:
+            return None
+        expected = {
+            "cache_kind": "caption_sidecar",
+            "format_version": str(self.format_version),
+            "text_fingerprint": self.text_fingerprint,
+            "caption_sha256": caption_sha256(entry.caption),
+            "cache_key": self.key(entry.caption),
+        }
+        if any(metadata.get(k) != v for k, v in expected.items()):
+            return None
+        return tensors or None
+
+    def get_or_encode_caption(
+        self,
+        entry: TextCacheEntry,
+        encoder: Callable[[str], Mapping[str, object]],
+    ) -> tuple[dict, bool]:
+        """读取 sidecar；miss 时编码并原子覆盖。返回 ``(tensors, was_hit)``。"""
+
+        cached = self.read_caption(entry)
+        if cached is not None:
+            return cached, True
+        encoded = _normalise_tensors(encoder(entry.caption))
+        self.write_caption(entry, encoded)
+        return encoded, False
+
+    def write_prompt_bundle(
+        self,
+        root,
+        encoded: Mapping[str, Mapping[str, object]],
+    ) -> Path:
+        """原子覆盖 sample/negative prompt 聚合缓存，tensor 可各自不同长度。"""
+
+        payload = {}
+        metadata = {
+            "cache_kind": "prompt_bundle",
+            "format_version": str(self.format_version),
+            "text_fingerprint": self.text_fingerprint,
+        }
+        for caption, tensors in encoded.items():
+            digest = self.key(str(caption))
+            normalised = _normalise_tensors(tensors)
+            metadata[f"entry.{digest}"] = caption_sha256(str(caption))
+            for name, tensor in normalised.items():
+                payload[f"{digest}{_TENSOR_SEPARATOR}{name}"] = tensor
+        path = prompt_cache_path(root, self.text_fingerprint)
+        if payload:
+            _atomic_save(payload, metadata, path)
+        else:
+            path.unlink(missing_ok=True)
+        return path
+
+    def get_or_encode_prompts(
+        self,
+        root,
+        captions,
+        encoder: Callable[[str], Mapping[str, object]],
+    ) -> tuple[dict[str, dict], int]:
+        """批量读取聚合缓存并编码 misses；返回 ``(caption→tensors, hit 数)``。"""
+
+        unique = list(dict.fromkeys(str(caption) for caption in captions))
+        encoded: dict[str, dict] = {}
+        hit_count = 0
+        dirty = False
+        for caption in unique:
+            cached = self.read_prompt(root, caption)
+            if cached is not None:
+                encoded[caption] = cached
+                hit_count += 1
+                continue
+            encoded[caption] = _normalise_tensors(encoder(caption))
+            dirty = True
+        if dirty:
+            self.write_prompt_bundle(root, encoded)
+        return encoded, hit_count
+
+    def read_prompt(self, root, caption: str) -> Optional[dict]:
+        path = prompt_cache_path(root, self.text_fingerprint)
+        if not path.is_file():
+            return None
+        try:
+            tensors, metadata = _load(path)
+        except Exception:
+            return None
+        digest = self.key(caption)
+        if (
+            metadata.get("cache_kind") != "prompt_bundle"
+            or metadata.get("format_version") != str(self.format_version)
+            or metadata.get("text_fingerprint") != self.text_fingerprint
+            or metadata.get(f"entry.{digest}") != caption_sha256(caption)
+        ):
+            return None
+        prefix = f"{digest}{_TENSOR_SEPARATOR}"
+        found = {
+            key[len(prefix):]: value
+            for key, value in tensors.items()
+            if key.startswith(prefix)
+        }
+        return found or None

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -53,6 +53,12 @@ PRESETS_PREFIX = "presets/"
 CAPTION_EXTS = {".txt"}
 # VAE latent 缓存（CachedLatentDataset 的 {名}.npz / {名}.r{reso}.npz，紧挨图片）
 LATENT_CACHE_EXT = ".npz"
+# Phase 2 文本缓存：随图 sidecar + train/.text-cache/ 下的 prompt 聚合缓存。
+# 继续复用现有 train_latent_cache / reg_latent_cache bundle 选项：两者表达的
+# 是“携带可重建训练缓存”，不改变默认导出体积。
+TEXT_CACHE_SIDECAR_SUFFIX = ".text.safetensors"
+TEXT_CACHE_PROMPT_DIR = ".text-cache"
+TEXT_CACHE_EXT = ".safetensors"
 # 训练 mask sidecar（train/{folder}/{stem}.mask，与图同目录，详
 # services/preprocess/masks.py）。arcname 两段与图片同构。
 MASK_SUFFIX = ".mask"
@@ -366,12 +372,13 @@ def _collect_train(
     image_count = 0
     tagged_count = 0
     latent_cache_count = 0
+    text_cache_count = 0
     mask_count = 0
 
     if not train_dir.exists():
         return payload, {
             "image_count": 0, "tagged_count": 0, "concepts": [],
-            "latent_cache_count": 0, "mask_count": 0,
+            "latent_cache_count": 0, "text_cache_count": 0, "mask_count": 0,
         }
 
     for sub in sorted(train_dir.iterdir()):
@@ -393,6 +400,15 @@ def _collect_train(
             elif ext == LATENT_CACHE_EXT and include_latent_cache:
                 latent_cache_count += 1
                 payload.append((f, f"{TRAIN_PREFIX}{sub.name}/{f.name}"))
+            elif include_latent_cache and (
+                f.name.endswith(TEXT_CACHE_SIDECAR_SUFFIX)
+                or (
+                    sub.name == TEXT_CACHE_PROMPT_DIR
+                    and ext == TEXT_CACHE_EXT
+                )
+            ):
+                text_cache_count += 1
+                payload.append((f, f"{TRAIN_PREFIX}{sub.name}/{f.name}"))
             elif ext == MASK_SUFFIX and include_masks:
                 mask_count += 1
                 payload.append((f, f"{TRAIN_PREFIX}{sub.name}/{f.name}"))
@@ -408,6 +424,7 @@ def _collect_train(
         "tagged_count": tagged_count,
         "concepts": concepts,
         "latent_cache_count": latent_cache_count,
+        "text_cache_count": text_cache_count,
         "mask_count": mask_count,
     }
 
@@ -419,9 +436,12 @@ def _collect_reg(
     payload: list[tuple[Path, str]] = []
     image_count = 0
     latent_cache_count = 0
+    text_cache_count = 0
 
     if not reg_dir.exists():
-        return payload, {"image_count": 0, "latent_cache_count": 0}
+        return payload, {
+            "image_count": 0, "latent_cache_count": 0, "text_cache_count": 0,
+        }
 
     # meta.json
     meta = reg_dir / "meta.json"
@@ -445,6 +465,12 @@ def _collect_reg(
                 elif ext == LATENT_CACHE_EXT and include_latent_cache:
                     latent_cache_count += 1
                     payload.append((f, f"{REG_PREFIX}{item.name}/{f.name}"))
+                elif (
+                    include_latent_cache
+                    and f.name.endswith(TEXT_CACHE_SIDECAR_SUFFIX)
+                ):
+                    text_cache_count += 1
+                    payload.append((f, f"{REG_PREFIX}{item.name}/{f.name}"))
                 elif ext in CAPTION_EXTS and include_captions:
                     pass  # 由图片侧 include
         elif item.is_file() and item.suffix.lower() in IMAGE_EXTS:
@@ -453,7 +479,11 @@ def _collect_reg(
             image_count += 1
             payload.append((item, f"{REG_PREFIX}{item.name}"))
 
-    return payload, {"image_count": image_count, "latent_cache_count": latent_cache_count}
+    return payload, {
+        "image_count": image_count,
+        "latent_cache_count": latent_cache_count,
+        "text_cache_count": text_cache_count,
+    }
 
 
 def export_bundle(
@@ -565,6 +595,10 @@ def export_bundle(
             "latent_cache_count": (
                 train_stats.get("latent_cache_count", 0)
                 + reg_stats.get("latent_cache_count", 0)
+            ),
+            "text_cache_count": (
+                train_stats.get("text_cache_count", 0)
+                + reg_stats.get("text_cache_count", 0)
             ),
             "train_mask_count": train_stats.get("mask_count", 0),
         },

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -49,6 +49,37 @@ def test_cached_latent_invalidates_when_resolution_bucket_changes(tmp_path: Path
     assert cached._is_cache_valid(img_path, npz_path) is True
 
 
+def test_cached_latent_keeps_third_party_caption_fallback(tmp_path: Path) -> None:
+    """Phase 2 resolver 抽取不能把 duck-typed dataset 的 caption 变成空串。"""
+    pytest.importorskip("torch")
+    import numpy as np
+
+    from runtime.training.dataset import CachedLatentDataset
+
+    image = tmp_path / "third-party.png"
+    image.write_bytes(b"fake")
+    caption_path = image.with_suffix(".txt")
+    caption_path.write_text("raw caption", encoding="utf-8")
+    np.savez(image.with_suffix(".npz"), latent=np.zeros((16, 1, 2, 2)))
+
+    class ThirdPartyDataset:
+        caption_override = None
+
+        @staticmethod
+        def _process_caption_txt(caption):
+            return f"processed: {caption}"
+
+    cached = object.__new__(CachedLatentDataset)
+    cached.base_dataset = ThirdPartyDataset()
+    cached.samples = [{"image": image, "txt_path": caption_path}]
+    cached.np = np
+    cached.flip_augment = False
+    cached.load_masks = False
+    cached._multi_reso = set()
+
+    assert cached[0]["caption"] == "processed: raw caption"
+
+
 def test_cached_latent_invalidates_when_flip_augment_added(tmp_path: Path) -> None:
     """老 cache（只有 latent，无 latent_flipped）+ flip_augment=True → 失效重 encode。
 

--- a/tests/test_model_spec.py
+++ b/tests/test_model_spec.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import os
+from dataclasses import replace
 
 import numpy as np
 import pytest
@@ -72,6 +73,15 @@ def test_cached_varlen_excludes_caption_tag_ops():
     with pytest.raises(ValueError):
         validate_spec(_spec_with("cached_varlen", {"caption_tag_ops"}))
     validate_spec(_spec_with("cached_varlen", {"masked_loss", "text_cache"}))
+
+
+def test_cached_varlen_requires_capability_and_text_fingerprint():
+    with pytest.raises(ValueError, match="text_cache"):
+        validate_spec(_spec_with("cached_varlen", {"masked_loss"}))
+    spec = _spec_with("cached_varlen", {"masked_loss", "text_cache"})
+    spec = replace(spec, text=replace(spec.text, fingerprint=""))
+    with pytest.raises(ValueError, match="TE 指纹"):
+        validate_spec(spec)
 
 
 def test_unknown_capability_rejected():

--- a/tests/test_text_cache.py
+++ b/tests/test_text_cache.py
@@ -1,0 +1,133 @@
+"""Phase 2 文本缓存协议：key、sidecar、varlen safetensors 与失效重算。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+
+from training.text_cache import (
+    TEXT_CACHE_FORMAT_VERSION,
+    TextCacheEntry,
+    TextCacheStore,
+    caption_sidecar_path,
+    prompt_cache_path,
+    text_cache_key,
+)
+
+
+def test_key_covers_caption_fingerprint_and_format_version():
+    base = text_cache_key("a cat", "qwen-v1")
+    assert base != text_cache_key("a dog", "qwen-v1")
+    assert base != text_cache_key("a cat", "qwen-v2")
+    assert base != text_cache_key(
+        "a cat", "qwen-v1", format_version=TEXT_CACHE_FORMAT_VERSION + 1,
+    )
+
+
+def test_sidecar_keeps_full_image_name_to_avoid_extension_collision(tmp_path):
+    jpg = tmp_path / "same.jpg"
+    png = tmp_path / "same.png"
+    assert caption_sidecar_path(jpg).name == "same.jpg.text.safetensors"
+    assert caption_sidecar_path(png).name == "same.png.text.safetensors"
+    assert caption_sidecar_path(jpg) != caption_sidecar_path(png)
+
+
+def test_caption_roundtrip_preserves_varlen_bfloat16_and_is_atomic(tmp_path):
+    entry = TextCacheEntry.for_image(tmp_path / "image.webp", "final caption")
+    store = TextCacheStore("qwen3-vl-test")
+    encoded = {
+        "hidden_states": torch.randn(7, 12, 8, dtype=torch.bfloat16),
+        "attention_mask": torch.ones(7, dtype=torch.int64),
+    }
+
+    store.write_caption(entry, encoded)
+    loaded = store.read_caption(entry)
+
+    assert loaded is not None
+    assert loaded["hidden_states"].shape == (7, 12, 8)  # varlen，未 pad 512
+    assert loaded["hidden_states"].dtype == torch.bfloat16
+    assert torch.equal(loaded["attention_mask"], encoded["attention_mask"])
+    assert not list(tmp_path.glob(entry.cache_path.name + ".*.tmp"))
+
+
+def test_caption_mismatch_or_corruption_is_cache_miss(tmp_path):
+    entry = TextCacheEntry.for_image(tmp_path / "image.png", "old caption")
+    store = TextCacheStore("te-v1")
+    store.write_caption(entry, {"hidden": torch.ones(3, 2)})
+
+    changed = TextCacheEntry.for_image(entry.image_path, "new caption")
+    assert store.read_caption(changed) is None
+    assert TextCacheStore("te-v2").read_caption(entry) is None
+
+    entry.cache_path.write_bytes(b"not safetensors")
+    assert store.read_caption(entry) is None
+
+
+def test_get_or_encode_reuses_hit_and_reencodes_stale_caption(tmp_path):
+    entry = TextCacheEntry.for_image(tmp_path / "image.png", "caption v1")
+    store = TextCacheStore("te-v1")
+    calls = []
+
+    def encode(caption):
+        calls.append(caption)
+        return {"hidden": torch.full((len(caption), 2), float(len(calls)))}
+
+    first, first_hit = store.get_or_encode_caption(entry, encode)
+    second, second_hit = store.get_or_encode_caption(entry, encode)
+    changed = TextCacheEntry.for_image(entry.image_path, "caption v2")
+    third, third_hit = store.get_or_encode_caption(changed, encode)
+
+    assert first_hit is False
+    assert second_hit is True
+    assert third_hit is False
+    assert calls == ["caption v1", "caption v2"]
+    assert torch.equal(first["hidden"], second["hidden"])
+    assert not torch.equal(second["hidden"], third["hidden"])
+
+
+def test_prompt_bundle_supports_multiple_variable_lengths(tmp_path):
+    store = TextCacheStore("te-v1")
+    path = store.write_prompt_bundle(tmp_path, {
+        "short": {"hidden": torch.randn(2, 4)},
+        "a much longer prompt": {"hidden": torch.randn(11, 4)},
+        "": {"hidden": torch.randn(1, 4)},
+    })
+
+    assert path == prompt_cache_path(tmp_path, "te-v1")
+    assert path.parent == tmp_path / ".text-cache"
+    assert path.name.startswith("prompts.")
+    assert store.read_prompt(tmp_path, "short")["hidden"].shape == (2, 4)
+    assert store.read_prompt(tmp_path, "a much longer prompt")["hidden"].shape == (11, 4)
+    assert store.read_prompt(tmp_path, "")["hidden"].shape == (1, 4)
+    assert store.read_prompt(tmp_path, "missing") is None
+
+
+def test_get_or_encode_prompts_only_encodes_bundle_misses(tmp_path):
+    store = TextCacheStore("te-v1")
+    calls = []
+
+    def encode(caption):
+        calls.append(caption)
+        return {"hidden": torch.ones(max(1, len(caption)), 2)}
+
+    first, first_hits = store.get_or_encode_prompts(
+        tmp_path, ["positive", "", "positive"], encode,
+    )
+    second, second_hits = store.get_or_encode_prompts(
+        tmp_path, ["positive", ""], encode,
+    )
+
+    assert list(first) == ["positive", ""]
+    assert first_hits == 0
+    assert second_hits == 2
+    assert calls == ["positive", ""]
+    assert torch.equal(first["positive"]["hidden"], second["positive"]["hidden"])
+
+
+def test_tensor_names_reject_bundle_separator(tmp_path):
+    entry = TextCacheEntry.for_image(tmp_path / "image.png", "caption")
+    store = TextCacheStore("te-v1")
+    with pytest.raises(ValueError, match="tensor"):
+        store.write_caption(entry, {"bad::name": torch.ones(1)})

--- a/tests/test_text_cache_phase.py
+++ b/tests/test_text_cache_phase.py
@@ -1,0 +1,101 @@
+"""dataset → text_cache → optimizer 生命周期接线。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from training.context import TrainingContext
+from training.phases import text_cache
+
+
+class _Dataset:
+    def __init__(self, samples, captions):
+        self.samples = samples
+        self._captions = captions
+
+    def caption_for_sample(self, sample):
+        return self._captions[str(sample["image"])]
+
+
+class _Family:
+    def __init__(self, strategy):
+        self.spec = SimpleNamespace(text=SimpleNamespace(strategy=strategy))
+        self.call = None
+
+    def prepare_text_cache(self, captions, extra_prompts, **kwargs):
+        self.call = (list(captions), list(extra_prompts), kwargs)
+
+
+def _args(data_dir):
+    return SimpleNamespace(
+        data_dir=str(data_dir),
+        sample_prompts=["trigger, portrait"],
+        sample_prompt="",
+        sample_negative_prompt="blurry",
+        sample_steps=20,
+        sample_every=0,
+    )
+
+
+def test_cached_varlen_phase_collects_main_reg_and_deduplicates_fanout(tmp_path):
+    image_a = tmp_path / "a.png"
+    image_b = tmp_path / "reg" / "b.png"
+    main = _Dataset(
+        [
+            {"image": image_a, "target_reso": 1024},
+            {"image": image_a, "target_reso": 768},
+        ],
+        {str(image_a): "caption a"},
+    )
+    reg = _Dataset(
+        [{"image": image_b, "target_reso": 1024}],
+        {str(image_b): "class caption"},
+    )
+    family = _Family("cached_varlen")
+    ctx = TrainingContext(args=_args(tmp_path), family=family)
+    ctx.base_dataset = main
+    ctx.reg_dataset = reg
+    ctx.text_stack = object()
+    ctx.device = "cuda"
+
+    text_cache.run(ctx)
+
+    captions, extras, kwargs = family.call
+    assert captions == ["caption a", "class caption"]
+    assert extras == ["trigger, portrait", "blurry"]
+    assert [e.image_path for e in kwargs["cache_entries"]] == [image_a, image_b]
+    assert kwargs["cache_entries"][0].cache_path.parent == image_a.parent
+    assert kwargs["cache_root"] == tmp_path
+    assert kwargs["text"] is ctx.text_stack
+    assert kwargs["device"] == "cuda"
+
+
+def test_online_strategy_is_noop_and_does_not_scan_dataset(tmp_path):
+    class _ExplodingDataset:
+        @property
+        def samples(self):  # pragma: no cover - access is the failure
+            raise AssertionError("online family 不应扫描 caption")
+
+    family = _Family("online")
+    ctx = TrainingContext(args=_args(tmp_path), family=family)
+    ctx.base_dataset = _ExplodingDataset()
+
+    text_cache.run(ctx)
+
+    assert family.call[0] == []
+    assert family.call[1] == []
+    assert family.call[2] == {}
+
+
+def test_sampling_default_and_empty_negative_are_cached(tmp_path):
+    args = _args(tmp_path)
+    args.sample_prompts = []
+    args.sample_negative_prompt = ""
+    family = _Family("cached_varlen")
+    ctx = TrainingContext(args=args, family=family)
+    ctx.base_dataset = _Dataset([], {})
+
+    text_cache.run(ctx)
+
+    assert family.call[1] == ["1girl, masterpiece", ""]

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -277,18 +277,26 @@ def test_export_bundle_records_version_and_preset_names(isolated, tmp_path: Path
     assert manifest["source"]["preset_name"] == "style_preset"
 
 
-def test_export_bundle_latent_cache_roundtrip(isolated, tmp_path: Path) -> None:
-    """latent_cache=True：train/reg 的 npz 一并打包；导入后 npz mtime ≥ 图片
-    mtime（_is_cache_valid 的不变量，否则缓存白搬）。"""
+def test_export_bundle_training_caches_roundtrip(isolated, tmp_path: Path) -> None:
+    """cache=True：train/reg 的 latent + text cache 一并打包。
+
+    导入后 npz mtime ≥ 图片 mtime（_is_cache_valid 的不变量，否则缓存白搬）；
+    text cache 只按文件内指纹失效，无 mtime 要求。
+    """
     p, v, train = _make_project_with_train(isolated)
     (train / "1_data").mkdir(parents=True, exist_ok=True)
     (train / "1_data" / "a.png").write_bytes(_png())
     (train / "1_data" / "a.npz").write_bytes(b"fake-latent")
     (train / "1_data" / "a.r512.npz").write_bytes(b"fake-latent-512")
+    (train / "1_data" / "a.png.text.safetensors").write_bytes(b"fake-text")
+    prompt_cache = train / ".text-cache" / "prompts.123456789abc.safetensors"
+    prompt_cache.parent.mkdir()
+    prompt_cache.write_bytes(b"fake-prompts")
     reg = train.parent / "reg" / "girl"
     reg.mkdir(parents=True)
     (reg / "r.png").write_bytes(_png(b"r"))
     (reg / "r.npz").write_bytes(b"fake-reg-latent")
+    (reg / "r.png.text.safetensors").write_bytes(b"fake-reg-text")
 
     dest = tmp_path / "cache.bundle.zip"
     with db.connection_for(isolated["db"]) as conn:
@@ -303,11 +311,15 @@ def test_export_bundle_latent_cache_roundtrip(isolated, tmp_path: Path) -> None:
     assert result["manifest"]["includes"]["train_latent_cache"] is True
     assert result["manifest"]["includes"]["reg_latent_cache"] is True
     assert result["manifest"]["stats"]["latent_cache_count"] == 3
+    assert result["manifest"]["stats"]["text_cache_count"] == 3
     with zipfile.ZipFile(dest) as zf:
         names = set(zf.namelist())
     assert "train/1_data/a.npz" in names
     assert "train/1_data/a.r512.npz" in names
     assert "reg/girl/r.npz" in names
+    assert "train/1_data/a.png.text.safetensors" in names
+    assert "train/.text-cache/prompts.123456789abc.safetensors" in names
+    assert "reg/girl/r.png.text.safetensors" in names
 
     with db.connection_for(isolated["db"]) as conn:
         imported = train_io.import_bundle(conn, dest, presets_base=tmp_path / "presets")
@@ -321,8 +333,12 @@ def test_export_bundle_latent_cache_roundtrip(isolated, tmp_path: Path) -> None:
     img = new_dir / "train" / "1_data" / "a.png"
     reg_npz = new_dir / "reg" / "girl" / "r.npz"
     reg_img = new_dir / "reg" / "girl" / "r.png"
+    text_cache = new_dir / "train" / "1_data" / "a.png.text.safetensors"
+    prompts = new_dir / "train" / ".text-cache" / "prompts.123456789abc.safetensors"
+    reg_text_cache = new_dir / "reg" / "girl" / "r.png.text.safetensors"
     assert npz.exists() and (new_dir / "train" / "1_data" / "a.r512.npz").exists()
     assert reg_npz.exists()
+    assert text_cache.exists() and prompts.exists() and reg_text_cache.exists()
     # zip 内 npz 按字典序先于图片落盘，没有 touch 修正会比图片旧
     assert npz.stat().st_mtime >= img.stat().st_mtime
     assert reg_npz.stat().st_mtime >= reg_img.stat().st_mtime
@@ -333,6 +349,7 @@ def test_export_bundle_excludes_latent_cache_by_default(isolated, tmp_path: Path
     (train / "1_data").mkdir(parents=True, exist_ok=True)
     (train / "1_data" / "a.png").write_bytes(_png())
     (train / "1_data" / "a.npz").write_bytes(b"fake-latent")
+    (train / "1_data" / "a.png.text.safetensors").write_bytes(b"fake-text")
 
     dest = tmp_path / "nocache.bundle.zip"
     with db.connection_for(isolated["db"]) as conn:
@@ -343,8 +360,10 @@ def test_export_bundle_excludes_latent_cache_by_default(isolated, tmp_path: Path
     assert result["manifest"]["includes"]["train_latent_cache"] is False
     assert result["manifest"]["includes"]["reg_latent_cache"] is False
     assert result["manifest"]["stats"]["latent_cache_count"] == 0
+    assert result["manifest"]["stats"]["text_cache_count"] == 0
     with zipfile.ZipFile(dest) as zf:
         assert not [n for n in zf.namelist() if n.endswith(".npz")]
+        assert not [n for n in zf.namelist() if n.endswith(".text.safetensors")]
 
 
 def _named_bundle(tmp_path: Path, *, with_preset: bool) -> Path:


### PR DESCRIPTION
多模型系列 Phase 2，承接设计 PR #404 与 Phase 1 #405–#409。按 `docs/design/multi-model/03-interface-evolution.md` 的 D3 键协议和 `04-synthesis.md` D19 的存储裁定，先落地 Krea2 接入前可独立验证的 varlen 文本缓存基建；本 PR 不引入 Krea2 权重或 UI，对 Anima 保持零行为变化。

## 改动

### varlen safetensors 缓存协议

- 新增 `runtime/training/text_cache.py`：缓存键覆盖最终 caption、TE fingerprint 与 format version。
- 图片 caption 使用同目录 `<完整图片名>.text.safetensors` sidecar，避免同 stem 不同图片扩展名碰撞。
- tensor 原样保留可变 token 长度与 dtype，不 pad 到固定 512。
- sample / negative prompt 聚合到 `train/.text-cache/prompts.<fingerprint>.safetensors`。
- metadata 同时记录 caption hash、TE fingerprint、format version 与完整 cache key；缺失、损坏或失配统一视为 miss。
- sibling tmp + `os.replace` 原子写入；中断不会留下半成品目标文件。

### phase 与 family 接线

- 训练顺序新增 `dataset → text_cache → optimizer`，cached_varlen 族在进入 loop 前预扫主集、正则集与 sample/negative prompts。
- `ModelFamily.prepare_text_cache` 仅追加 keyword-only 可选上下文，保留冻结的位置参数协议；实际编码与张量布局仍由 family 自治。
- `ImageDataset.caption_for_sample` 统一 JSON / TXT / override 的最终 caption 解析，训练、latent wrapper 与预扫共用同一事实源。
- fan-out / repeat 按原图去重；同一图片解析出不同 caption 时 fail-fast。
- `cached_varlen` spec 必须声明 `text_cache` capability 与非空 TE fingerprint。

### 数据生命周期

- 现有 bundle 缓存选项同时携带随图 text sidecar 与 prompt bundle，导入后原样恢复。
- 默认不包含缓存的行为不变，不增加默认 bundle 体积。
- bundle manifest 新增 `text_cache_count` 统计。

## 行为边界

- Anima 的 `spec.text.strategy=online` 直接 no-op：不扫描 dataset、不写 text cache、训练与采样链路不变。
- 本 PR 只提供 Phase 2 存储与调度基建；Krea2 的 Qwen3-VL 编码实现、TE lazy load/release 与 batch 消费属于 Phase 3。
- 无 UI、API 请求格式或模型下载行为变化。

## 测试

- 相关缓存 / dataset / bundle：`72 passed`
- 多模型硬门禁 + resume/optimizer 回归：`56 passed`
- 后端全量：`python -m pytest tests/ -q` → `2870 passed`
- 前端 Vitest：`54 files / 488 tests passed`
- ESLint：`0 errors`（2 条既有 warning）
- TypeScript：`tsc --noEmit` 通过

## 截图

非 UI 改动，无截图。