### PR TITLE
feat(train): Krea2 动态 timestep shift 地基（多模型 Phase 3）

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -194,6 +194,19 @@
   reference 代码。Anima 在 Flow Matching `t ∈ (0,1)` 空间内做了 `σ = t/(1-t)` 适配，
   与论文 σ-空间设计保持一致。
 
+### kohya-ss / musubi-tuner — Krea2 training timestep shift (Apache-2.0)
+
+- **来源**：[`kohya-ss/musubi-tuner`](https://github.com/kohya-ss/musubi-tuner)；
+  固定参考 commit `8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6`
+- **许可**：Apache-2.0（上游 README `License` 段声明 other code 适用 Apache-2.0）
+- **涉及文件**：
+  - `runtime/training/timestep_samplers/krea2_shift.py` — Krea2 `krea2_shift` 的 image-sequence
+    length 线性 `mu`、`exp(mu)` 与 Möbius shift 公式；端点同时与 Hugging Face diffusers
+    Krea2 inference pipeline（Apache-2.0，commit
+    `bc529a5f677db9c4b3fc72c76962c4e2f61567e1`）交叉核对
+
+实现按本项目 timestep sampler protocol 重写，未复制上游类结构。
+
 ---
 
 ## Pip 依赖（许可随各自 wheel 分发）

--- a/runtime/training/README.md
+++ b/runtime/training/README.md
@@ -78,10 +78,11 @@ runtime/training/
     │   └── __init__.py     ← BUILDERS + build_inference_sampler
     │
     ├── timestep_samplers/  ← 训练 timestep 采样器（PR #66 引入）
-    │   ├── protocol.py     ← TimestepSamplerProtocol（1 必需 + 3 可选 hook）
+    │   ├── protocol.py     ← TimestepSamplerProtocol（可选 token_counts batch context）
     │   ├── baseline.py     ← sample_t 4 mode 的 thin wrapper（非自适应）
     │   ├── infonoise.py    ← InfoNoise I-MMSE 自适应采样器（arxiv 2602.18647）
-    │   └── __init__.py     ← BUILDERS + build_timestep_sampler（bool 派发，非 Literal）
+    │   ├── krea2_shift.py  ← Krea2 动态 resolution shift（Phase 3 family 接线前暂不暴露 schema）
+    │   └── __init__.py     ← BUILDERS + build_timestep_sampler
     │
     └── losses/             ← 训练 loss 类型（mse / huber / ...）
         ├── protocol.py     ← LossProtocol（compute(pred, target, t) → Tensor）
@@ -164,7 +165,9 @@ phases.finalize.run(ctx)               ──  final save + cleanup
 3. **派发**：同文件 `build_timestep_sampler` 加 if 分支（按优先级 `args.{name}_enabled == True`）
 4. **schema**：`studio/schema.py` 加 `{name}_enabled: bool` + 该采样器专属字段
 
-`loop.py` / `phases/optimizer.py` / `context.py` **零改动**（接口已通过 plugin 抽象屏蔽）。
+普通采样器对 `loop.py` / `phases/optimizer.py` / `context.py` **零改动**。如果算法需要
+逐样本 latent token 数，令 sampler 声明 `requires_token_counts = True`；共享循环会通过
+`sample(..., token_counts=...)` 注入通用 batch context，不得按 family 名称分支。
 
 如果将来有 ≥3 个 adaptive sampler，可考虑重构成 `timestep_sampler_kind: Literal["baseline",
 "infonoise", "min_snr_aware", ...]` 的 Literal 派发 + `validate_schema_consistency()`，跟

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -135,6 +135,17 @@ def _accumulation_step(batch_idx, dl_len, grad_accum):
     return group_size, is_group_end
 
 
+def _sample_timesteps(timestep_sampler, bs: int, device, latents) -> torch.Tensor:
+    """按 sampler 能力声明按需注入 batch context，避免 family 分支进入共享循环。"""
+    if getattr(timestep_sampler, "requires_token_counts", False):
+        return timestep_sampler.sample(
+            bs,
+            device,
+            token_counts=latent_token_counts(latents),
+        )
+    return timestep_sampler.sample(bs, device)
+
+
 def run(ctx: TrainingContext) -> None:
     """跑训练直到 args.epochs 或 args.max_steps 上限。"""
     args = ctx.args
@@ -164,6 +175,10 @@ def run(ctx: TrainingContext) -> None:
             "（基准档 %dpx），作用于采样后的 t。",
             res_shift_base_tokens, _base_reso,
         )
+        if getattr(ctx.timestep_sampler, "applies_resolution_shift", False):
+            raise ValueError(
+                "timestep_shift_resolution_aware 不能与自带分辨率 shift 的 timestep sampler 同时启用"
+            )
 
     for epoch in range(ctx.start_epoch, args.epochs):
         ctx.current_epoch = epoch
@@ -213,7 +228,12 @@ def run(ctx: TrainingContext) -> None:
 
             # Flow Matching：统一通过 timestep_sampler plugin 接口采样
             # （baseline = 4 种 mode；adaptive = InfoNoise 等；接口在 ADR 0003 plugin registry）
-            t = ctx.timestep_sampler.sample(bs, ctx.device)
+            t = _sample_timesteps(
+                ctx.timestep_sampler,
+                bs,
+                ctx.device,
+                navit_latents if navit_latents is not None else latents,
+            )
 
             # 分辨率相关 shift 修正（见 run() 顶部 setup）：navit 逐图 latent 各算各的
             # token 数；批量网格 batch 内同尺寸 → 等值向量。后续 record / sigma_t /

--- a/runtime/training/timestep_samplers/__init__.py
+++ b/runtime/training/timestep_samplers/__init__.py
@@ -3,6 +3,7 @@
 `build_timestep_sampler(args, total_steps)` 按 args 派发到具体采样器：
 - 默认走 baseline（包装 sample_t 的 4 种 mode）
 - args.infonoise_enabled == True 时走 InfoNoise 自适应采样
+- args.timestep_sampling == "krea2_shift" 时走 Krea2 resolution-aware 采样
 
 加新采样器：
 1. 写 timestep_samplers/{name}.py 含 `build(args, total_steps) -> TimestepSamplerProtocol`
@@ -13,7 +14,7 @@
 
 from __future__ import annotations
 
-from training.timestep_samplers import baseline, infonoise
+from training.timestep_samplers import baseline, infonoise, krea2_shift
 from training.timestep_samplers.protocol import TimestepSamplerProtocol
 
 __all__ = [
@@ -28,14 +29,20 @@ __all__ = [
 BUILDERS: dict[str, callable] = {
     "baseline": baseline.build,
     "infonoise": infonoise.build,
+    "krea2_shift": krea2_shift.build,
 }
 
 
 def build_timestep_sampler(args, total_steps) -> TimestepSamplerProtocol:
     """按 args 派发到对应采样器；总是返回非 None 实例（baseline 兜底）。
 
-    优先级：infonoise > baseline。未来加更多 adaptive sampler 时在此列出。
+    Krea2 dynamic shift 与 InfoNoise 都定义 timestep 分布，不能同时启用。
     """
+    mode = str(getattr(args, "timestep_sampling", "logit_normal") or "logit_normal").lower()
+    if mode == "krea2_shift":
+        if getattr(args, "infonoise_enabled", False):
+            raise ValueError("krea2_shift 与 infonoise_enabled 不能同时启用")
+        return BUILDERS["krea2_shift"](args, total_steps)
     if getattr(args, "infonoise_enabled", False):
         return BUILDERS["infonoise"](args, total_steps)
     return BUILDERS["baseline"](args, total_steps)

--- a/runtime/training/timestep_samplers/baseline.py
+++ b/runtime/training/timestep_samplers/baseline.py
@@ -27,7 +27,7 @@ class BaselineTimestepSampler:
         self.mix_low_prob = mix_low_prob
         self.timestep_schedule_shift = timestep_schedule_shift
 
-    def sample(self, bs: int, device) -> torch.Tensor:
+    def sample(self, bs: int, device, *, token_counts=None) -> torch.Tensor:
         return sample_t(
             bs,
             device,

--- a/runtime/training/timestep_samplers/infonoise.py
+++ b/runtime/training/timestep_samplers/infonoise.py
@@ -97,7 +97,7 @@ class InfoNoiseScheduler:
         self._refresh_degraded_count: int = 0
         self._warned_cold_start: bool = False
 
-    def sample(self, bs: int, device) -> torch.Tensor:
+    def sample(self, bs: int, device, *, token_counts=None) -> torch.Tensor:
         """采样 t ∈ (0,1)。热身期用 logit-normal baseline，之后用自适应 CDF。"""
         if self._cdf_values is None:
             return self._sample_baseline(bs, device)

--- a/runtime/training/timestep_samplers/krea2_shift.py
+++ b/runtime/training/timestep_samplers/krea2_shift.py
@@ -1,0 +1,106 @@
+"""Krea2 resolution-aware training timestep sampler.
+
+Derived formula: Copyright 2026 Kohya S. and musubi-tuner contributors.
+Licensed under the Apache License, Version 2.0.
+
+The dynamic-shift formula and Krea2 endpoints follow musubi-tuner's
+``NetworkTrainer`` implementation and Krea2 timestep tests (Apache-2.0),
+cross-checked against the Hugging Face diffusers Krea2 inference pipeline:
+
+- https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/training/trainer_base.py
+- https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/tests/test_krea2_timesteps.py
+- https://github.com/huggingface/diffusers/blob/bc529a5f677db9c4b3fc72c76962c4e2f61567e1/src/diffusers/pipelines/krea2/pipeline_krea2.py
+
+This is deliberately separate from ``apply_resolution_shift``: that helper is
+the existing SD3 sqrt(token/base) correction, while Krea2 linearly interpolates
+``mu`` from image sequence length and applies ``exp(mu)`` as a Möbius shift.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+BASE_IMAGE_SEQ_LEN = 256
+MAX_IMAGE_SEQ_LEN = 6400
+BASE_SHIFT = 0.5
+MAX_SHIFT = 1.15
+
+
+def krea2_mu(token_counts, *, device=None) -> torch.Tensor:
+    """Return Krea2's per-image dynamic-shift ``mu`` (without endpoint clamp)."""
+    counts = torch.as_tensor(token_counts, dtype=torch.float32, device=device)
+    if counts.ndim != 1:
+        raise ValueError("Krea2 token_counts 必须是一维序列")
+    if not torch.isfinite(counts).all() or (counts <= 0).any():
+        raise ValueError("Krea2 token_counts 必须全部为有限正数")
+
+    slope = (MAX_SHIFT - BASE_SHIFT) / (MAX_IMAGE_SEQ_LEN - BASE_IMAGE_SEQ_LEN)
+    intercept = BASE_SHIFT - slope * BASE_IMAGE_SEQ_LEN
+    return counts * slope + intercept
+
+
+def apply_krea2_dynamic_shift(t: torch.Tensor, token_counts) -> torch.Tensor:
+    """Apply Krea2's per-image ``exp(mu)`` Möbius shift to base timesteps."""
+    if t.ndim != 1:
+        raise ValueError("Krea2 timestep 必须是一维 tensor")
+    mu = krea2_mu(token_counts, device=t.device)
+    if mu.numel() != t.numel():
+        raise ValueError(
+            f"Krea2 token_counts 数量必须等于 batch size：{mu.numel()} != {t.numel()}"
+        )
+    shift = mu.exp().to(dtype=t.dtype)
+    return ((t * shift) / (1 + (shift - 1) * t)).clamp(1e-4, 1 - 1e-4)
+
+
+class Krea2ShiftTimestepSampler:
+    """Logit-normal sampling followed by Krea2's per-resolution dynamic shift."""
+
+    requires_token_counts = True
+    applies_resolution_shift = True
+
+    def __init__(self, sigmoid_scale: float = 1.0):
+        self.sigmoid_scale = float(sigmoid_scale)
+        if not math.isfinite(self.sigmoid_scale) or self.sigmoid_scale <= 0:
+            raise ValueError("Krea2 sigmoid_scale 必须为有限正数")
+
+    def sample(self, bs: int, device, *, token_counts=None) -> torch.Tensor:
+        if token_counts is None:
+            raise ValueError("Krea2 timestep sampler 需要每个样本的 token_counts")
+        counts = torch.as_tensor(token_counts)
+        if counts.ndim != 1 or counts.numel() != bs:
+            raise ValueError(
+                f"Krea2 token_counts 数量必须等于 batch size：{counts.numel()} != {bs}"
+            )
+        base_t = torch.randn(bs, device=device, dtype=torch.float32)
+        base_t = torch.sigmoid(base_t * self.sigmoid_scale)
+        return apply_krea2_dynamic_shift(base_t, token_counts)
+
+    def record(self, t: torch.Tensor, raw_mse: torch.Tensor) -> None:
+        return None
+
+    def maybe_refresh(self, global_step: int) -> None:
+        return None
+
+    def status(self) -> dict:
+        return {
+            "kind": "krea2_shift",
+            "sigmoid_scale": self.sigmoid_scale,
+            "base_image_seq_len": BASE_IMAGE_SEQ_LEN,
+            "max_image_seq_len": MAX_IMAGE_SEQ_LEN,
+            "base_shift": BASE_SHIFT,
+            "max_shift": MAX_SHIFT,
+        }
+
+    def state_dict(self) -> dict:
+        return {}
+
+    def load_state_dict(self, state: dict) -> None:
+        return None
+
+
+def build(args, total_steps) -> Krea2ShiftTimestepSampler:
+    """Build the Krea2 sampler; Phase 3 currently fixes upstream scale at 1.0."""
+    return Krea2ShiftTimestepSampler(sigmoid_scale=1.0)

--- a/runtime/training/timestep_samplers/protocol.py
+++ b/runtime/training/timestep_samplers/protocol.py
@@ -1,7 +1,7 @@
 """TimestepSamplerProtocol：所有 timestep 采样器的统一接口（ADR 0003 plugin registry）。
 
 设计模仿 training/adapters/protocol.py：
-- 必需 1 个方法：sample(bs, device) -> Tensor
+- 必需 1 个方法：sample(bs, device, *, token_counts=None) -> Tensor
 - 3 个可选 hook：record / maybe_refresh / status —— 默认 no-op；
   自适应采样器（InfoNoise 等）按需 override，纯分布采样器（logit_normal 等）保持 no-op
 
@@ -26,8 +26,13 @@ class TimestepSamplerProtocol(Protocol):
     不想强制继承。runtime_checkable 让单测 `isinstance` 校验仍然能用。
     """
 
-    def sample(self, bs: int, device) -> torch.Tensor:
-        """采样 bs 个 t ∈ (0, 1)。"""
+    def sample(self, bs: int, device, *, token_counts=None) -> torch.Tensor:
+        """采样 bs 个 t ∈ (0, 1)。
+
+        ``token_counts`` 是可选 batch context；需要它的 resolution-aware sampler
+        用 ``requires_token_counts = True`` 声明，loop 才会计算并传入。普通 sampler
+        不承担额外的逐 batch 计算。
+        """
         ...
 
     # ─── 可选 hook：默认 no-op；自适应采样器按需 override ───

--- a/tests/test_krea2_timestep_sampler.py
+++ b/tests/test_krea2_timestep_sampler.py
@@ -1,0 +1,156 @@
+"""Phase 3 Krea2 dynamic-shift timestep sampler tests."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from training.loop import _sample_timesteps, run
+from training.timestep_samplers import BUILDERS, build_timestep_sampler
+from training.timestep_samplers.krea2_shift import (
+    Krea2ShiftTimestepSampler,
+    apply_krea2_dynamic_shift,
+    krea2_mu,
+)
+from training.timestep_samplers.protocol import TimestepSamplerProtocol
+
+
+def test_krea2_mu_matches_upstream_endpoints_and_1024_anchor() -> None:
+    mu = krea2_mu([256, 4096, 6400])
+    torch.testing.assert_close(
+        mu,
+        torch.tensor([0.5, 0.90625, 1.15]),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+def test_krea2_mu_does_not_clamp_outside_reference_endpoints() -> None:
+    mu = krea2_mu([128, 8000])
+    assert mu[0] < 0.5
+    assert mu[1] > 1.15
+
+
+def test_krea2_shift_matches_known_1024_midpoint() -> None:
+    out = apply_krea2_dynamic_shift(torch.tensor([0.5]), [4096])
+    shift = math.exp(0.90625)
+    expected = shift / (1 + shift)
+    assert out.item() == pytest.approx(expected, abs=1e-6)
+    assert out.item() == pytest.approx(0.7122, abs=1e-4)
+
+
+def test_krea2_shift_is_per_sample_and_resolution_monotonic() -> None:
+    out = apply_krea2_dynamic_shift(
+        torch.full((3,), 0.5),
+        [256, 4096, 6400],
+    )
+    assert out[0] < out[1] < out[2]
+
+
+def test_krea2_sampler_uses_logit_normal_then_dynamic_shift(monkeypatch) -> None:
+    monkeypatch.setattr(
+        torch,
+        "randn",
+        lambda bs, *, device, dtype: torch.zeros(bs, device=device, dtype=dtype),
+    )
+    sampler = Krea2ShiftTimestepSampler()
+    out = sampler.sample(3, torch.device("cpu"), token_counts=[256, 4096, 6400])
+    expected = apply_krea2_dynamic_shift(torch.full((3,), 0.5), [256, 4096, 6400])
+    torch.testing.assert_close(out, expected)
+
+
+@pytest.mark.parametrize(
+    ("token_counts", "match"),
+    [
+        (None, "需要每个样本"),
+        ([256], "数量必须等于 batch size"),
+        ([256, 0], "有限正数"),
+    ],
+)
+def test_krea2_sampler_rejects_invalid_batch_context(token_counts, match) -> None:
+    sampler = Krea2ShiftTimestepSampler()
+    with pytest.raises(ValueError, match=match):
+        sampler.sample(2, torch.device("cpu"), token_counts=token_counts)
+
+
+@pytest.mark.parametrize("scale", [0.0, -1.0, float("inf"), float("nan")])
+def test_krea2_sampler_rejects_invalid_sigmoid_scale(scale: float) -> None:
+    with pytest.raises(ValueError, match="sigmoid_scale"):
+        Krea2ShiftTimestepSampler(sigmoid_scale=scale)
+
+
+def test_krea2_sampler_satisfies_protocol_and_is_stateless() -> None:
+    sampler = Krea2ShiftTimestepSampler()
+    assert isinstance(sampler, TimestepSamplerProtocol)
+    assert sampler.state_dict() == {}
+    assert sampler.status() == {
+        "kind": "krea2_shift",
+        "sigmoid_scale": 1.0,
+        "base_image_seq_len": 256,
+        "max_image_seq_len": 6400,
+        "base_shift": 0.5,
+        "max_shift": 1.15,
+    }
+
+
+def test_registry_selects_krea2_shift_without_schema_exposure() -> None:
+    assert "krea2_shift" in BUILDERS
+    args = argparse.Namespace(timestep_sampling="krea2_shift", infonoise_enabled=False)
+    sampler = build_timestep_sampler(args, total_steps=100)
+    assert isinstance(sampler, Krea2ShiftTimestepSampler)
+
+
+def test_registry_rejects_krea2_shift_with_infonoise() -> None:
+    args = argparse.Namespace(timestep_sampling="krea2_shift", infonoise_enabled=True)
+    with pytest.raises(ValueError, match="不能同时启用"):
+        build_timestep_sampler(args, total_steps=100)
+
+
+def test_loop_injects_token_counts_for_capability_sampler() -> None:
+    class RecordingSampler:
+        requires_token_counts = True
+
+        def sample(self, bs, device, *, token_counts=None):
+            self.token_counts = token_counts
+            return torch.full((bs,), 0.25, device=device)
+
+    sampler = RecordingSampler()
+    latents = torch.zeros(2, 16, 1, 128, 128)
+    out = _sample_timesteps(sampler, 2, torch.device("cpu"), latents)
+    assert sampler.token_counts == [4096, 4096]
+    torch.testing.assert_close(out, torch.tensor([0.25, 0.25]))
+
+
+def test_loop_keeps_ordinary_sampler_on_context_free_path(monkeypatch) -> None:
+    class OrdinarySampler:
+        def sample(self, bs, device):
+            return torch.full((bs,), 0.75, device=device)
+
+    monkeypatch.setattr(
+        "training.loop.latent_token_counts",
+        lambda latents: pytest.fail("普通 sampler 不应计算 token_counts"),
+    )
+    out = _sample_timesteps(
+        OrdinarySampler(),
+        2,
+        torch.device("cpu"),
+        torch.zeros(2, 16, 1, 128, 128),
+    )
+    torch.testing.assert_close(out, torch.tensor([0.75, 0.75]))
+
+
+def test_loop_rejects_double_resolution_shift_before_training() -> None:
+    ctx = SimpleNamespace(
+        args=argparse.Namespace(
+            timestep_shift_resolution_aware=True,
+            resolution=1024,
+        ),
+        dataloader=[],
+        timestep_sampler=Krea2ShiftTimestepSampler(),
+    )
+    with pytest.raises(ValueError, match="不能与自带分辨率 shift"):
+        run(ctx)


### PR DESCRIPTION
## 背景 / 动机

docs/design/multi-model/04-synthesis D14 要求 Krea2 训练侧动态 shift 作为共享 timestep_samplers/ 新策略实现，D15 要求共享训练循环不出现 family 特判。

完整 Krea2Family 同时包含 modeling、权重加载、文本编码、训练前向、推理采样、preset 与资产 catalog，超出一个可审查 unit。本 PR 先落地可独立验证的训练 timestep 基础设施；后续 PR 再注册 Krea2 family 和 schema/UI。

## 改动概要

- 新增 krea2_shift sampler：
  - image sequence length 端点 256 → mu 0.5、6400 → mu 1.15；
  - 每样本计算 exp(mu)，对 logit-normal t 做 Möbius shift；
  - 支持异构分辨率 batch，端点外保持上游线性外推语义。
- TimestepSamplerProtocol 增加 keyword-only 可选 token_counts batch context。
- 共享 loop 按 requires_token_counts 能力声明按需注入 token 数，不按 family 名称分支；普通 sampler 不增加额外计算。
- krea2_shift 与 InfoNoise 或既有 SD3 sqrt resolution shift 双开时 fail-fast，避免错误的复合分布。
- 补齐 sampler registry、状态契约、数值锚点、异构 batch、错误配置和 loop 接线测试。
- 更新 runtime README 与 THIRD_PARTY_NOTICES。

## 本 PR 边界

- 不注册半成品 Krea2Family。
- 不增加 schema/UI 入口。
- 不包含 Krea2 modeling、loader、inference sampling 或 assets。
- Anima 默认配置与现有 baseline/InfoNoise 行为不变。

## 外部来源与许可

- 公式派生自 kohya-ss/musubi-tuner（Apache-2.0），固定参考 commit 8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6：
  - https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/training/trainer_base.py
  - https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/tests/test_krea2_timesteps.py
- 端点与 Hugging Face diffusers Krea2 inference pipeline（Apache-2.0，commit bc529a5f677db9c4b3fc72c76962c4e2f61567e1）交叉核对：
  - https://github.com/huggingface/diffusers/blob/bc529a5f677db9c4b3fc72c76962c4e2f61567e1/src/diffusers/pipelines/krea2/pipeline_krea2.py
- 派生文件已保留版权/许可说明，并在 THIRD_PARTY_NOTICES.md 登记。

## 测试

- related timestep suites: 64 passed
- CONTRIBUTING cross-cut safety net: 33 passed
- python -m studio test: 2888 passed
- 前端未改动；studio test 按设计提示 npm 未安装并跳过 vitest