### PR TITLE
feat(train): Krea2 Raw checkpoint 严格加载器（多模型 Phase 3）

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -211,6 +211,8 @@
   - `modeling/krea2/krea2_modeling.py` — 训练 tensor 布局、三轴 RoPE 与逐 block
     gradient checkpointing 参考 `src/musubi_tuner/krea2/krea2_mmdit.py`；模型配置与结构同时
     对照 Hugging Face diffusers `transformer_krea2.py`（Apache-2.0，同上固定 commit）
+  - `runtime/training/families/krea2/loader.py` — meta-device + `assign=True` 的大权重
+    加载策略参考 `src/musubi_tuner/krea2/krea2_utils.py`；结构指纹、前缀归一和错误诊断为本仓库实现
 
 实现按本项目 timestep sampler protocol / 纯 torch modeling 边界适配；具体派生关系见各文件头。
 

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -1,0 +1,1 @@
+"""Krea2 family implementation package (Phase 3, not registered yet)."""

--- a/runtime/training/families/krea2/loader.py
+++ b/runtime/training/families/krea2/loader.py
@@ -1,0 +1,233 @@
+"""Strict Krea2 Raw checkpoint inspection and loading.
+
+The meta-device + ``assign=True`` loading strategy was adapted from
+kohya-ss/musubi-tuner (Apache-2.0):
+Copyright 2026 Kohya S. and musubi-tuner contributors.
+https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/krea2/krea2_utils.py
+
+Fingerprint validation, prefix handling, and diagnostics are original to this
+repository. The loader deliberately accepts the Comfy/musubi ``raw.safetensors``
+layout, not diffusers' renamed sharded transformer layout.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from safetensors import safe_open
+
+from modeling.krea2 import KREA2_CONFIG, Krea2Config, SingleStreamDiT
+
+
+_PREFIX_CANDIDATES = (
+    "",
+    "diffusion_model.",
+    "model.diffusion_model.",
+    "module.",
+    "model.",
+    "transformer.",
+)
+_FLOAT_DTYPES = {
+    "BF16",
+    "F16",
+    "F32",
+    "F64",
+    "F8_E4M3",
+    "F8_E5M2",
+}
+
+
+@dataclass(frozen=True)
+class Krea2CheckpointInfo:
+    path: Path
+    prefix: str
+    key_count: int
+    parameter_count: int
+
+
+def _checkpoint_path(path: str | Path) -> Path:
+    resolved = Path(path).expanduser()
+    if not resolved.exists():
+        raise FileNotFoundError(f"Krea2 checkpoint 不存在：{resolved}")
+    if resolved.is_dir():
+        raise ValueError(
+            "Krea2 loader 需要单文件 raw.safetensors，不能传 diffusers transformer "
+            f"分片目录：{resolved}"
+        )
+    if resolved.suffix.lower() != ".safetensors":
+        raise ValueError(f"Krea2 checkpoint 必须是 .safetensors 文件：{resolved}")
+    return resolved
+
+
+def _expected_state(config: Krea2Config):
+    with torch.device("meta"):
+        model = SingleStreamDiT(config)
+    return model, {
+        key: tuple(value.shape)
+        for key, value in model.state_dict().items()
+    }
+
+
+def _choose_prefix(source_keys: list[str], expected_keys: set[str]) -> str:
+    best_prefix = ""
+    best_score = -1
+    for prefix in _PREFIX_CANDIDATES:
+        normalized = {
+            key[len(prefix):] if prefix and key.startswith(prefix) else key
+            for key in source_keys
+        }
+        score = len(normalized & expected_keys)
+        if score > best_score:
+            best_prefix = prefix
+            best_score = score
+    if best_score <= 0:
+        diffusers_hint = any(
+            key.startswith(("transformer_blocks.", "img_in.", "text_fusion."))
+            for key in source_keys
+        )
+        hint = (
+            "；检测到 diffusers 风格键，请改用仓库根目录的 raw.safetensors"
+            if diffusers_hint
+            else ""
+        )
+        raise ValueError(f"不是可识别的 Krea2 Raw checkpoint：结构指纹零命中{hint}")
+    return best_prefix
+
+
+def _normalize_key(key: str, prefix: str) -> str:
+    return key[len(prefix):] if prefix and key.startswith(prefix) else key
+
+
+def _format_key_delta(label: str, keys: set[str]) -> str:
+    sample = ", ".join(sorted(keys)[:5])
+    suffix = " ..." if len(keys) > 5 else ""
+    return f"{label} {len(keys)} 个：{sample}{suffix}"
+
+
+def _inspect(
+    path: str | Path,
+    config: Krea2Config,
+    *,
+    expected_shapes: dict[str, tuple[int, ...]] | None = None,
+) -> tuple[Krea2CheckpointInfo, dict[str, str]]:
+    checkpoint = _checkpoint_path(path)
+    if expected_shapes is None:
+        _, expected_shapes = _expected_state(config)
+    expected_keys = set(expected_shapes)
+
+    with safe_open(str(checkpoint), framework="pt", device="cpu") as handle:
+        source_keys = list(handle.keys())
+        prefix = _choose_prefix(source_keys, expected_keys)
+        normalized_to_source: dict[str, str] = {}
+        for source_key in source_keys:
+            normalized = _normalize_key(source_key, prefix)
+            if normalized in normalized_to_source:
+                raise ValueError(f"Krea2 checkpoint 前缀归一后键冲突：{normalized}")
+            normalized_to_source[normalized] = source_key
+
+        actual_keys = set(normalized_to_source)
+        missing = expected_keys - actual_keys
+        unexpected = actual_keys - expected_keys
+        errors = []
+        if missing:
+            errors.append(_format_key_delta("缺少", missing))
+        if unexpected:
+            errors.append(_format_key_delta("多出", unexpected))
+
+        shape_mismatches = []
+        dtype_mismatches = []
+        for normalized in sorted(expected_keys & actual_keys):
+            source_key = normalized_to_source[normalized]
+            tensor_slice = handle.get_slice(source_key)
+            actual_shape = tuple(tensor_slice.get_shape())
+            expected_shape = expected_shapes[normalized]
+            if actual_shape != expected_shape:
+                shape_mismatches.append(
+                    f"{normalized}: {actual_shape} != {expected_shape}"
+                )
+            actual_dtype = tensor_slice.get_dtype()
+            if actual_dtype not in _FLOAT_DTYPES:
+                dtype_mismatches.append(f"{normalized}: {actual_dtype}")
+        if shape_mismatches:
+            sample = "; ".join(shape_mismatches[:5])
+            suffix = " ..." if len(shape_mismatches) > 5 else ""
+            errors.append(f"shape 不匹配 {len(shape_mismatches)} 个：{sample}{suffix}")
+        if dtype_mismatches:
+            sample = "; ".join(dtype_mismatches[:5])
+            suffix = " ..." if len(dtype_mismatches) > 5 else ""
+            errors.append(f"非浮点 tensor {len(dtype_mismatches)} 个：{sample}{suffix}")
+        if errors:
+            raise ValueError("Krea2 checkpoint 结构指纹不匹配；" + "；".join(errors))
+
+    parameter_count = sum(
+        math_product(shape) for shape in expected_shapes.values()
+    )
+    return (
+        Krea2CheckpointInfo(
+            path=checkpoint,
+            prefix=prefix,
+            key_count=len(source_keys),
+            parameter_count=parameter_count,
+        ),
+        normalized_to_source,
+    )
+
+
+def math_product(shape: tuple[int, ...]) -> int:
+    result = 1
+    for dimension in shape:
+        result *= dimension
+    return result
+
+
+def inspect_krea2_checkpoint(
+    path: str | Path,
+    *,
+    config: Krea2Config = KREA2_CONFIG,
+) -> Krea2CheckpointInfo:
+    """Validate keys and shapes from the safetensors header without reading payloads."""
+    info, _ = _inspect(path, config)
+    return info
+
+
+def load_krea2_model(
+    path: str | Path,
+    device: str | torch.device,
+    dtype: torch.dtype,
+    *,
+    config: Krea2Config = KREA2_CONFIG,
+) -> SingleStreamDiT:
+    """Strict-load a Krea2 Raw checkpoint into a frozen meta-created model."""
+    if dtype not in {torch.float16, torch.bfloat16, torch.float32, torch.float64}:
+        raise ValueError(f"Krea2 loader 不支持 dtype={dtype}")
+    target_device = torch.device(device)
+    if target_device.type == "meta":
+        raise ValueError("Krea2 loader 的目标 device 不能是 meta")
+
+    model, expected_shapes = _expected_state(config)
+    _, normalized_to_source = _inspect(
+        path,
+        config,
+        expected_shapes=expected_shapes,
+    )
+
+    state_dict = {}
+    checkpoint = _checkpoint_path(path)
+    with safe_open(str(checkpoint), framework="pt", device="cpu") as handle:
+        for normalized, source_key in normalized_to_source.items():
+            tensor = handle.get_tensor(source_key)
+            if not tensor.is_floating_point():
+                raise ValueError(
+                    f"Krea2 checkpoint 含非浮点参数 {source_key}: {tensor.dtype}"
+                )
+            state_dict[normalized] = tensor.to(
+                device=target_device,
+                dtype=dtype,
+            )
+
+    model.load_state_dict(state_dict, strict=True, assign=True)
+    del state_dict
+    model.requires_grad_(False)
+    return model

--- a/tests/test_krea2_loader.py
+++ b/tests/test_krea2_loader.py
@@ -1,0 +1,274 @@
+"""Krea2 Raw checkpoint header validation and strict meta-device loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+import training.families.krea2.loader as krea2_loader
+from modeling.krea2 import Krea2Config, SingleStreamDiT
+from training.families.krea2.loader import (
+    inspect_krea2_checkpoint,
+    load_krea2_model,
+)
+
+
+def _tiny_config() -> Krea2Config:
+    return Krea2Config(
+        features=64,
+        tdim=16,
+        txtdim=32,
+        heads=4,
+        kvheads=2,
+        multiplier=2,
+        layers=2,
+        patch=2,
+        channels=4,
+        txtlayers=3,
+        txtheads=4,
+        txtkvheads=2,
+    )
+
+
+def _state_dict(config: Krea2Config) -> dict[str, torch.Tensor]:
+    torch.manual_seed(17)
+    return {
+        key: value.detach().contiguous()
+        for key, value in SingleStreamDiT(config).state_dict().items()
+    }
+
+
+def _write_checkpoint(
+    path: Path,
+    state_dict: dict[str, torch.Tensor],
+    *,
+    prefix: str = "",
+) -> None:
+    save_file({f"{prefix}{key}": value for key, value in state_dict.items()}, str(path))
+
+
+@pytest.mark.parametrize("prefix", ["", "diffusion_model.", "model.diffusion_model."])
+def test_inspect_accepts_supported_raw_prefixes(tmp_path: Path, prefix: str) -> None:
+    config = _tiny_config()
+    state_dict = _state_dict(config)
+    checkpoint = tmp_path / "raw.safetensors"
+    _write_checkpoint(checkpoint, state_dict, prefix=prefix)
+
+    info = inspect_krea2_checkpoint(checkpoint, config=config)
+
+    assert info.path == checkpoint
+    assert info.prefix == prefix
+    assert info.key_count == len(state_dict)
+    assert info.parameter_count == sum(value.numel() for value in state_dict.values())
+
+
+def test_load_casts_assigns_and_freezes_all_parameters(tmp_path: Path) -> None:
+    config = _tiny_config()
+    expected = _state_dict(config)
+    checkpoint = tmp_path / "raw.safetensors"
+    _write_checkpoint(checkpoint, expected, prefix="diffusion_model.")
+
+    loaded = load_krea2_model(
+        checkpoint,
+        device="cpu",
+        dtype=torch.float64,
+        config=config,
+    )
+
+    assert isinstance(loaded, SingleStreamDiT)
+    assert loaded.config == config
+    assert all(parameter.device.type == "cpu" for parameter in loaded.parameters())
+    assert all(parameter.dtype == torch.float64 for parameter in loaded.parameters())
+    assert not any(parameter.requires_grad for parameter in loaded.parameters())
+    for key, tensor in loaded.state_dict().items():
+        torch.testing.assert_close(tensor, expected[key].to(torch.float64))
+
+
+@pytest.mark.parametrize("kind", ["missing", "unexpected", "shape"])
+def test_inspect_rejects_inexact_structure(tmp_path: Path, kind: str) -> None:
+    config = _tiny_config()
+    state_dict = _state_dict(config)
+    target_key = "first.weight"
+    if kind == "missing":
+        del state_dict[target_key]
+        message = "缺少 1 个"
+    elif kind == "unexpected":
+        state_dict["not_a_krea2_parameter"] = torch.zeros(1)
+        message = "多出 1 个"
+    else:
+        state_dict[target_key] = state_dict[target_key][:-1].contiguous()
+        message = "shape 不匹配 1 个"
+    checkpoint = tmp_path / "bad.safetensors"
+    _write_checkpoint(checkpoint, state_dict)
+
+    with pytest.raises(ValueError, match=message):
+        inspect_krea2_checkpoint(checkpoint, config=config)
+
+
+def test_diffusers_layout_error_points_to_raw_checkpoint(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "diffusers.safetensors"
+    save_file({"transformer_blocks.0.attn.to_q.weight": torch.zeros(2, 2)}, str(checkpoint))
+
+    with pytest.raises(ValueError, match="diffusers.*raw.safetensors"):
+        inspect_krea2_checkpoint(checkpoint, config=_tiny_config())
+
+
+def test_inspect_rejects_non_floating_checkpoint_tensor(tmp_path: Path) -> None:
+    config = _tiny_config()
+    state_dict = _state_dict(config)
+    state_dict["first.weight"] = torch.zeros_like(
+        state_dict["first.weight"],
+        dtype=torch.int16,
+    )
+    checkpoint = tmp_path / "integer.safetensors"
+    _write_checkpoint(checkpoint, state_dict)
+
+    with pytest.raises(ValueError, match="非浮点 tensor 1 个.*first.weight: I16"):
+        inspect_krea2_checkpoint(checkpoint, config=config)
+
+
+def test_load_validates_header_before_reading_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config = _tiny_config()
+    expected = _state_dict(config)
+    target_key = "first.weight"
+    checkpoint = tmp_path / "header-only.safetensors"
+    checkpoint.touch()
+
+    class _Slice:
+        def __init__(self, shape: tuple[int, ...]) -> None:
+            self._shape = shape
+
+        def get_shape(self) -> tuple[int, ...]:
+            return self._shape
+
+        def get_dtype(self) -> str:
+            return "F32"
+
+    class _HeaderOnly:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def keys(self):
+            return expected.keys()
+
+        def get_slice(self, key: str) -> _Slice:
+            shape = tuple(expected[key].shape)
+            return _Slice(shape[:-1] + (shape[-1] + 1,) if key == target_key else shape)
+
+        def get_tensor(self, _key: str) -> torch.Tensor:
+            raise AssertionError("payload must not be read before header validation")
+
+    monkeypatch.setattr(krea2_loader, "safe_open", lambda *_args, **_kwargs: _HeaderOnly())
+
+    with pytest.raises(ValueError, match="shape 不匹配 1 个"):
+        load_krea2_model(checkpoint, "cpu", torch.float32, config=config)
+
+
+def test_load_moves_each_payload_to_target_before_assign(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkpoint = tmp_path / "streamed.safetensors"
+    checkpoint.touch()
+    events = []
+
+    class _Payload:
+        dtype = torch.float32
+
+        def __init__(self, key: str) -> None:
+            self.key = key
+
+        def is_floating_point(self) -> bool:
+            return True
+
+        def to(self, *, device: torch.device, dtype: torch.dtype) -> torch.Tensor:
+            events.append(("move", self.key, device, dtype))
+            return torch.zeros(1, device=device, dtype=dtype)
+
+    class _PayloadHandle:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+        def get_tensor(self, key: str) -> _Payload:
+            return _Payload(key)
+
+    class _Model:
+        def load_state_dict(self, state_dict, *, strict: bool, assign: bool) -> None:
+            events.append(("assign", tuple(state_dict), strict, assign))
+
+        def requires_grad_(self, value: bool):
+            events.append(("requires_grad", value))
+            return self
+
+    model = _Model()
+    mapping = {"first.weight": "raw.first", "last.weight": "raw.last"}
+    info = krea2_loader.Krea2CheckpointInfo(checkpoint, "raw.", 2, 2)
+    monkeypatch.setattr(
+        krea2_loader,
+        "_expected_state",
+        lambda _config: (model, {key: (1,) for key in mapping}),
+    )
+    monkeypatch.setattr(
+        krea2_loader,
+        "_inspect",
+        lambda *_args, **_kwargs: (info, mapping),
+    )
+    monkeypatch.setattr(
+        krea2_loader,
+        "safe_open",
+        lambda *_args, **_kwargs: _PayloadHandle(),
+    )
+
+    loaded = load_krea2_model(
+        checkpoint,
+        device="cpu",
+        dtype=torch.float64,
+        config=_tiny_config(),
+    )
+
+    assert loaded is model
+    assert events == [
+        ("move", "raw.first", torch.device("cpu"), torch.float64),
+        ("move", "raw.last", torch.device("cpu"), torch.float64),
+        ("assign", ("first.weight", "last.weight"), True, True),
+        ("requires_grad", False),
+    ]
+
+
+def test_checkpoint_path_validation_is_actionable(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="不存在"):
+        inspect_krea2_checkpoint(tmp_path / "missing.safetensors", config=_tiny_config())
+    with pytest.raises(ValueError, match="单文件 raw.safetensors"):
+        inspect_krea2_checkpoint(tmp_path, config=_tiny_config())
+    wrong_suffix = tmp_path / "raw.bin"
+    wrong_suffix.touch()
+    with pytest.raises(ValueError, match=r"必须是 \.safetensors"):
+        inspect_krea2_checkpoint(wrong_suffix, config=_tiny_config())
+
+
+@pytest.mark.parametrize("dtype", [torch.int64, torch.bool])
+def test_load_rejects_non_floating_target_dtype(tmp_path: Path, dtype: torch.dtype) -> None:
+    with pytest.raises(ValueError, match="不支持 dtype"):
+        load_krea2_model(tmp_path / "unused.safetensors", "cpu", dtype, config=_tiny_config())
+
+
+def test_load_rejects_meta_target_device(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="不能是 meta"):
+        load_krea2_model(
+            tmp_path / "unused.safetensors",
+            "meta",
+            torch.float32,
+            config=_tiny_config(),
+        )


### PR DESCRIPTION
## 背景 / 动机

PR #413 已落地 Krea2 single-stream MMDiT，并按 docs/design/multi-model/04-synthesis D16 将真实 Raw checkpoint 的严格加载留给独立 Loader 单元。完整 Krea2Family 仍包含 Qwen3-VL 文本缓存、family/spec/preset、训练前向与预览采样；为保持一个 PR 一个完整 unit，本 PR 只提供可独立验收的权重加载基础。

## 改动概要

- 新增 Krea2 Raw 单文件 safetensors 检查与加载入口。
- 在读取约 26GB payload 前，仅从 header 严格校验：
  - 430 个完整参数键；
  - 每个 tensor 的 shape；
  - 浮点 dtype；
  - 总参数量。
- 归一常见的 diffusion_model.、model.diffusion_model.、module.、model. 与 transformer. 前缀。
- 对缺键、多键、shape 错误、非浮点参数、零结构命中和 diffusers 分片目录给出可操作诊断。
- 在 meta device 构造 12.8B 模型，并使用 load_state_dict(assign=True) 避免默认初始化的双份权重。
- 每个 payload tensor 读取后立即转换到目标 device/dtype，再统一 strict assign；CUDA 加载不再要求整份 CPU state dict 常驻内存。
- 加载完成后冻结全部底模参数。
- 更新 THIRD_PARTY_NOTICES，并使用 tiny safetensors 覆盖结构错误、前缀、header-before-payload、逐 tensor 转移、dtype/device 与冻结行为。

## 真实模型验收

使用 models/diffusion_models/krea2-raw-bf16.safetensors（26,283,332,608 bytes）在 RTX 5090 上验证：

- header：430 keys，12,820,073,036 参数，prefix 为空；
- BF16 CUDA strict load：19.7s；
- 加载后显存：23.88GiB；峰值：23.89GiB；
- 模型 device/dtype：cuda:0 / torch.bfloat16；全部参数 frozen；
- 最小前向：0.65s，输出 shape (1, 16, 2, 2)，dtype BF16，全部 finite；
- 释放后 torch allocated：0.01GiB。

真实加载同时验证了逐 tensor 目标设备转换：旧的整份 CPU state dict 路径在可用 RAM 较低时会触发严重分页；当前实现将同一 checkpoint 的加载时间恢复到约 20 秒。

## 本 PR 边界

- 不注册 Krea2Family、ModelSpec、capability 或 schema/UI。
- 不接 Qwen3-VL text encoder/cache。
- 不包含 KREA2_PRESET、adapter family 注入或 forward_train。
- 不包含训练 preview、推理 sampler、Turbo 或 block swap。

## 外部来源与许可

- meta-device + assign 加载策略参考 kohya-ss/musubi-tuner（Apache-2.0），固定参考 commit 8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6：
  - https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/krea2/krea2_utils.py
- checkpoint 结构指纹、前缀归一、header-first 校验与错误诊断为本仓库实现。
- 派生关系、版权与许可已写入文件头和 THIRD_PARTY_NOTICES.md。

## 测试

- tests/test_krea2_loader.py：15 passed
- python -m studio test：2929 passed，0 failed
- git diff --check：通过
- 前端未改动；studio test 按环境提示 npm 未安装并跳过 vitest