### PR TITLE
feat(train): Krea2 LoRA preset 与 adapter 族注入（多模型 Phase 3）

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -213,6 +213,8 @@
     对照 Hugging Face diffusers `transformer_krea2.py`（Apache-2.0，同上固定 commit）
   - `runtime/training/families/krea2/loader.py` — meta-device + `assign=True` 的大权重
     加载策略参考 `src/musubi_tuner/krea2/krea2_utils.py`；结构指纹、前缀归一和错误诊断为本仓库实现
+  - `runtime/training/families/krea2/preset.py` — 全部 Linear target 与统一
+    `lora_unet` 前缀参考 `src/musubi_tuner/networks/lora_krea2.py`
 
 实现按本项目 timestep sampler protocol / 纯 torch modeling 边界适配；具体派生关系见各文件头。
 

--- a/runtime/training/adapters/__init__.py
+++ b/runtime/training/adapters/__init__.py
@@ -1,7 +1,7 @@
 """LoRA adapter plugin registry（ADR 0003 PR-C）。
 
 加新变体的步骤（参考 ADR 0003 Case 2-5 落地案例）：
-1. 写 training/adapters/{variant}.py 含 `build(args) -> AdapterProtocol`
+1. 写 training/adapters/{variant}.py 含 `build(args, *, preset) -> AdapterProtocol`
 2. 本文件 BUILDERS 字典加一行
 3. studio/schema.py 的 `lora_type: Literal[...]` 加一个枚举值 + 该变体专属字段
 4. 完。phases/models.py / loop.py / main() 0 改动。
@@ -11,7 +11,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 from training.adapters import lycoris, ortho, tlora
 from training.adapters.protocol import AdapterProtocol, StepContext
@@ -30,14 +30,14 @@ BUILDERS: dict[str, Callable[..., AdapterProtocol]] = {
 }
 
 
-def build_adapter(args) -> AdapterProtocol:
-    """按 args.lora_type 派发到对应 build()。"""
+def build_adapter(args, *, preset: dict[str, Any]) -> AdapterProtocol:
+    """按 args.lora_type 派发，并显式注入当前模型族的 target preset。"""
     lora_type = args.lora_type
     if lora_type not in BUILDERS:
         raise ValueError(
             f"未知 lora_type={lora_type!r}；已注册: {sorted(BUILDERS)}"
         )
-    return BUILDERS[lora_type](args)
+    return BUILDERS[lora_type](args, preset=preset)
 
 
 def validate_schema_consistency() -> None:

--- a/runtime/training/adapters/lycoris.py
+++ b/runtime/training/adapters/lycoris.py
@@ -1,6 +1,6 @@
 """LyCORIS 后端的 adapter build 函数（lokr / loha / lora）。
 
-抽自 phases/models.py 里的 AnimaLycorisAdapter 实例化逻辑（ADR 0003 PR-C）。
+抽自 phases/models.py 里的 LycorisAdapter 实例化逻辑（ADR 0003 PR-C）。
 
 由 training/adapters/__init__.py 的 BUILDERS 字典派发：
     BUILDERS["lokr"] = build
@@ -13,15 +13,16 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from training.adapters.protocol import AdapterProtocol
 
 
-def build(args) -> AdapterProtocol:
-    """从 args 读 lora_type / lora_rank / ... 实例化 AnimaLycorisAdapter。"""
-    from training.families.anima.preset import ANIMA_PRESET
+def build(args, *, preset: dict[str, Any]) -> AdapterProtocol:
+    """从 args 与显式 family preset 实例化 LycorisAdapter。"""
     from utils.lycoris_adapter import LycorisAdapter
     return LycorisAdapter(
-        preset=ANIMA_PRESET,
+        preset=preset,
         algo=args.lora_type,
         rank=args.lora_rank,
         alpha=args.lora_alpha,

--- a/runtime/training/adapters/ortho.py
+++ b/runtime/training/adapters/ortho.py
@@ -1,16 +1,16 @@
 """OrthoLoRA adapter builder."""
 from __future__ import annotations
 
+from typing import Any
+
 from training.adapters.protocol import AdapterProtocol
 
 
-def build(args) -> AdapterProtocol:
+def build(args, *, preset: dict[str, Any]) -> AdapterProtocol:
     from utils.ortho_adapter import OrthoLoRAAdapter
 
-    from training.families.anima.preset import ANIMA_PRESET
-
     return OrthoLoRAAdapter(
-        preset=ANIMA_PRESET,
+        preset=preset,
         rank=args.lora_rank,
         alpha=args.lora_alpha,
         dropout=float(getattr(args, "lora_dropout", 0.0) or 0.0),

--- a/runtime/training/adapters/tlora.py
+++ b/runtime/training/adapters/tlora.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from training.adapters.protocol import AdapterProtocol
 
 
-def build(args) -> AdapterProtocol:
+def build(args, *, preset: dict[str, Any]) -> AdapterProtocol:
     if bool(getattr(args, "tlora_use_ortho", False)):
-        from training.families.anima.preset import ANIMA_PRESET
         from utils.ortho_adapter import OrthoLoRAAdapter
 
         return OrthoLoRAAdapter(
-            preset=ANIMA_PRESET,
+            preset=preset,
             rank=args.lora_rank,
             alpha=args.lora_alpha,
             dropout=float(getattr(args, "lora_dropout", 0.0) or 0.0),
@@ -22,11 +23,10 @@ def build(args) -> AdapterProtocol:
             tlora_alpha_rank_scale=float(getattr(args, "tlora_alpha_rank_scale", 1.0)),
         )
 
-    from training.families.anima.preset import ANIMA_PRESET
     from utils.lycoris_adapter import LycorisAdapter
 
     return LycorisAdapter(
-        preset=ANIMA_PRESET,
+        preset=preset,
         algo="tlora",
         rank=args.lora_rank,
         alpha=args.lora_alpha,

--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -128,7 +128,10 @@ class AnimaFamily:
         return ANIMA_PRESET
 
     def lora_metadata(self) -> dict[str, str]:
-        return {"model_family": self.spec.family_id}
+        return {
+            "model_family": self.spec.family_id,
+            "preset": self.spec.lora.preset_name,
+        }
 
     def convert_lora_state_dict(self, sd: dict) -> dict:
         return sd  # kohya 格式即产物格式（04 §7.1），恒等

--- a/runtime/training/families/krea2/preset.py
+++ b/runtime/training/families/krea2/preset.py
@@ -1,0 +1,28 @@
+"""Krea2 LoRA/LoKr target preset.
+
+The all-Linear target and ``lora_unet`` prefix follow kohya-ss/musubi-tuner
+(Apache-2.0), fixed commit 8934cfb:
+Copyright 2026 Kohya S. and musubi-tuner contributors.
+https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/networks/lora_krea2.py
+
+The musubi ``target=None`` contract means every ``nn.Linear`` in the Krea2 DiT.
+For this repository's LyCORIS/Ortho preset walkers, ``target_name=["*"]`` with
+convolution disabled is the equivalent representation. It covers all 264
+Linear modules, including attention gates and the text-fusion stack.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+KREA2_PRESET: dict[str, Any] = {
+    "enable_conv": False,
+    "target_module": [],
+    "target_name": ["*"],
+    "exclude_name": [],
+    "use_fnmatch": True,
+    "lora_prefix": "lora_unet",
+    "module_algo_map": {},
+    "name_algo_map": {},
+}

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -84,7 +84,7 @@ def run(ctx: TrainingContext) -> None:
     # training/adapters/__init__.py docstring
     logger.info(f"注入 {args.lora_type.upper()}...")
     from training.adapters import build_adapter
-    ctx.injector = build_adapter(args)
+    ctx.injector = build_adapter(args, preset=ctx.family.lora_preset())
     ctx.injector.metadata_extra = ctx.family.lora_metadata()  # D13：产物族标记
     ctx.injector.inject(ctx.model)
 

--- a/tests/test_families_krea2_preset.py
+++ b/tests/test_families_krea2_preset.py
@@ -1,0 +1,112 @@
+"""Krea2 LoRA preset target and Comfy/kohya key contract."""
+
+from __future__ import annotations
+
+from fnmatch import fnmatch
+import json
+from pathlib import Path
+
+import pytest
+import torch
+from safetensors import safe_open
+
+from modeling.krea2 import SingleStreamDiT
+from training.families.krea2.preset import KREA2_PRESET
+
+
+def _targeted_linear_names() -> list[str]:
+    with torch.device("meta"):
+        model = SingleStreamDiT()
+    patterns = KREA2_PRESET["target_name"]
+    excluded = KREA2_PRESET["exclude_name"]
+    return [
+        name
+        for name, module in model.named_modules()
+        if isinstance(module, torch.nn.Linear)
+        and any(fnmatch(name, pattern) for pattern in patterns)
+        and not any(fnmatch(name, pattern) for pattern in excluded)
+    ]
+
+
+def test_krea2_preset_targets_all_264_linear_modules() -> None:
+    targets = _targeted_linear_names()
+
+    assert len(targets) == 264
+    assert len(targets) == len(set(targets))
+    assert {
+        "first",
+        "blocks.0.attn.wq",
+        "blocks.0.attn.gate",
+        "blocks.0.mlp.up",
+        "txtfusion.refiner_blocks.0.attn.wo",
+        "txtmlp.1",
+        "last.linear",
+        "tproj.1",
+    } <= set(targets)
+
+
+def test_krea2_preset_matches_musubi_and_comfy_key_contract() -> None:
+    assert KREA2_PRESET["enable_conv"] is False
+    assert KREA2_PRESET["target_module"] == []
+    assert KREA2_PRESET["target_name"] == ["*"]
+    assert KREA2_PRESET["exclude_name"] == []
+    assert KREA2_PRESET["use_fnmatch"] is True
+    assert KREA2_PRESET["lora_prefix"] == "lora_unet"
+
+    flattened = {
+        f'{KREA2_PRESET["lora_prefix"]}_{name.replace(".", "_")}'
+        for name in _targeted_linear_names()
+    }
+    assert "lora_unet_blocks_0_attn_wq" in flattened
+    assert "lora_unet_blocks_0_attn_gate" in flattened
+    assert "lora_unet_txtfusion_refiner_blocks_0_attn_wo" in flattened
+    assert "lora_unet_txtmlp_1" in flattened
+
+
+def test_krea2_preset_injects_264_lycoris_modules_on_meta() -> None:
+    pytest.importorskip("lycoris")
+    from utils.lycoris_adapter import LycorisAdapter
+
+    with torch.device("meta"):
+        model = SingleStreamDiT()
+        adapter = LycorisAdapter(
+            preset=KREA2_PRESET,
+            algo="lora",
+            rank=2,
+            alpha=2,
+        )
+        injected = adapter.inject(model)
+
+    assert len(injected) == 264
+    assert {
+        "lora_unet_blocks_0_attn_wq",
+        "lora_unet_blocks_0_attn_gate",
+        "lora_unet_txtfusion_refiner_blocks_0_attn_wo",
+        "lora_unet_txtmlp_1",
+    } <= set(injected)
+    assert all(parameter.device.type == "meta" for parameter in adapter.get_params())
+
+
+def test_lycoris_save_uses_family_metadata(tmp_path: Path) -> None:
+    pytest.importorskip("lycoris")
+    from utils.lycoris_adapter import LycorisAdapter
+
+    model = torch.nn.Sequential(torch.nn.Linear(4, 4, bias=False))
+    adapter = LycorisAdapter(
+        preset=KREA2_PRESET,
+        algo="lora",
+        rank=2,
+        alpha=2,
+    )
+    adapter.metadata_extra = {
+        "model_family": "krea2",
+        "preset": "krea2_full",
+    }
+    adapter.inject(model)
+    checkpoint = tmp_path / "krea2-lora.safetensors"
+    adapter.save(checkpoint)
+
+    with safe_open(str(checkpoint), framework="pt", device="cpu") as handle:
+        args = json.loads(handle.metadata()["ss_network_args"])
+    assert args["model_family"] == "krea2"
+    assert args["preset"] == "krea2_full"

--- a/tests/test_model_families.py
+++ b/tests/test_model_families.py
@@ -39,7 +39,10 @@ def test_resolve_family_defaults_and_carriers():
 
 def test_family_lora_contract():
     fam = get_family("anima")
-    assert fam.lora_metadata() == {"model_family": "anima"}
+    assert fam.lora_metadata() == {
+        "model_family": "anima",
+        "preset": ANIMA_SPEC.lora.preset_name,
+    }
     sd = {"k": torch.zeros(1)}
     assert fam.convert_lora_state_dict(sd) is sd  # 恒等（04 §7.1）
     assert fam.lora_preset()["lora_prefix"] == ANIMA_SPEC.lora.prefix

--- a/tests/test_ortho_adapter.py
+++ b/tests/test_ortho_adapter.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from pathlib import Path
 
@@ -8,6 +9,7 @@ import pytest
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from safetensors import safe_open
 from safetensors.torch import load_file
 from training.families.anima.preset import ANIMA_PRESET
 
@@ -45,12 +47,20 @@ def test_ortho_adapter_injects_and_saves_plain_lora(tmp_path: Path) -> None:
     assert out.shape == x.shape
 
     path = tmp_path / "ortho.safetensors"
+    adapter.metadata_extra = {
+        "model_family": "krea2",
+        "preset": "krea2_full",
+    }
     adapter.save(path)
     sd = load_file(str(path))
 
     assert "lora_unet_q_proj.lora_down.weight" in sd
     assert "lora_unet_q_proj.lora_up.weight" in sd
     assert not any(key.endswith(".S_p") or key.endswith(".S_q") for key in sd)
+    with safe_open(str(path), framework="pt", device="cpu") as handle:
+        args = json.loads(handle.metadata()["ss_network_args"])
+    assert args["model_family"] == "krea2"
+    assert args["preset"] == "krea2_full"
 
 
 def test_ortho_distilled_lora_matches_runtime_delta() -> None:
@@ -122,7 +132,7 @@ def test_tlora_builder_defaults_to_plain_lycoris_tlora() -> None:
         tlora_alpha_rank_scale=1.0,
         tlora_use_ortho=False,
     )
-    adapter = build_adapter(args)
+    adapter = build_adapter(args, preset=ANIMA_PRESET)
 
     assert isinstance(adapter, AnimaLycorisAdapter)
     assert adapter.algo == "tlora"
@@ -144,7 +154,7 @@ def test_tlora_builder_uses_ortho_timestep_mask_when_enabled() -> None:
         tlora_use_ortho=True,
     )
     model = MockDiT()
-    adapter = build_adapter(args)
+    adapter = build_adapter(args, preset=ANIMA_PRESET)
     adapter.inject(model)
 
     adapter.on_step_begin(StepContext(0, 10, 0, torch.tensor([1.0]), args))

--- a/tests/test_plugin_registry.py
+++ b/tests/test_plugin_registry.py
@@ -75,7 +75,25 @@ def test_build_adapter_raises_on_unknown_lora_type() -> None:
     from training.adapters import build_adapter
     args = argparse.Namespace(lora_type="bogus_xyz")
     with pytest.raises(ValueError, match="未知 lora_type"):
-        build_adapter(args)
+        build_adapter(args, preset=ANIMA_PRESET)
+
+
+def test_build_adapter_forwards_explicit_family_preset(monkeypatch) -> None:
+    from training.adapters import BUILDERS, build_adapter
+
+    family_preset = {"target_name": ["family-only"]}
+    sentinel = object()
+
+    def _build(args, *, preset):
+        assert args.lora_type == "lora"
+        assert preset is family_preset
+        return sentinel
+
+    monkeypatch.setitem(BUILDERS, "lora", _build)
+    assert build_adapter(
+        argparse.Namespace(lora_type="lora"),
+        preset=family_preset,
+    ) is sentinel
 
 
 def test_build_scheduler_returns_none_when_lr_scheduler_is_none() -> None:
@@ -455,6 +473,14 @@ def test_no_lora_type_dispatch_in_phases_models() -> None:
     text = (RUNTIME_DIR / "training" / "phases" / "models.py").read_text(encoding="utf-8")
     # 应该看不到 AnimaLycorisAdapter 直接实例化（被 build_adapter 替代）
     assert "AnimaLycorisAdapter(preset=ANIMA_PRESET, " not in text
+    assert "build_adapter(args, preset=ctx.family.lora_preset())" in text
+
+
+def test_adapter_builders_do_not_import_anima_preset() -> None:
+    adapters_dir = RUNTIME_DIR / "training" / "adapters"
+    for filename in ("lycoris.py", "ortho.py", "tlora.py"):
+        text = (adapters_dir / filename).read_text(encoding="utf-8")
+        assert "families.anima.preset" not in text
 
 
 def test_no_lr_scheduler_dispatch_in_phases_optimizer() -> None:

--- a/utils/lycoris_adapter.py
+++ b/utils/lycoris_adapter.py
@@ -371,7 +371,6 @@ class LycorisAdapter:
         ss_args: dict[str, Any] = {
             "algo": self.algo,
             "factor": self.factor,
-            "preset": "anima_full",
             "dropout": self.dropout,
             "rank_dropout": self.rank_dropout,
             "module_dropout": self.module_dropout,

--- a/utils/ortho_adapter.py
+++ b/utils/ortho_adapter.py
@@ -366,21 +366,22 @@ class OrthoLoRAAdapter:
         sd: dict[str, torch.Tensor] = {}
         for layer in self.loras:
             sd.update(layer.distilled_lora_state())
+        ss_args = {
+            "algo": "lora",
+            "source_algo": "tlora_ortho" if self.use_timestep_mask else "ortho",
+            "factor": 8,
+            "dropout": self.dropout,
+            "rank_dropout": self.rank_dropout,
+            "module_dropout": self.module_dropout,
+            "weight_decompose": False,
+            "rs_lora": False,
+        }
+        ss_args.update(getattr(self, "metadata_extra", None) or {})
         meta = {
             "ss_network_dim": str(self.rank),
             "ss_network_alpha": str(self.alpha),
             "ss_network_module": "lycoris.kohya",
-            "ss_network_args": json.dumps({
-                "algo": "lora",
-                "source_algo": "tlora_ortho" if self.use_timestep_mask else "ortho",
-                "factor": 8,
-                "preset": "anima_full",
-                "dropout": self.dropout,
-                "rank_dropout": self.rank_dropout,
-                "module_dropout": self.module_dropout,
-                "weight_decompose": False,
-                "rs_lora": False,
-            }),
+            "ss_network_args": json.dumps(ss_args),
         }
         save_file(sd, str(path), metadata=meta)
         logger.info("OrthoLoRA 保存到: %s (baked as plain LoRA)", path)


### PR DESCRIPTION
## 背景 / 动机

docs/design/multi-model/01 §7 与 02 §3 已确定：Krea2 默认训练全部 264 个 Linear，LoRA 产物沿用 Comfy/kohya 的 lora_unet 前缀；04-synthesis §7.1 要求参数模块路径与 ComfyUI 逐字兼容。

当前 family protocol 已能返回 lora_preset()，但 adapter registry 的 lokr/loha/lora/ortho/tlora builders 仍直接 import ANIMA_PRESET，共享 LyCORIS/Ortho 保存端也写死 preset=anima_full。若直接注册 Krea2Family，会把 K2 target 静默替换成 Anima target，并生成错误 metadata。

为保持一个 PR 一个完整 unit，本 PR 只闭环 KREA2_PRESET、adapter family preset 注入和产物 metadata，不注册半成品 Krea2Family。

## 改动概要

- 新增 KREA2_PRESET：
  - enable_conv=false；
  - target_name=[*]，等价于 musubi 的 target=None，即 Krea2 DiT 全部 Linear；
  - 无 exclude；
  - use_fnmatch=true；
  - lora_prefix=lora_unet。
- build_adapter(args, *, preset=...) 改为显式接收模型族 preset。
- lokr / loha / lora / ortho / tlora 三个 builder 文件全部移除 ANIMA_PRESET import，并原样转交 family preset。
- models phase 统一调用 ctx.family.lora_preset()；共享 phase 不增加 family == ... 分支。
- AnimaFamily.lora_metadata() 同步写入 spec.lora.preset_name，保持现有 Anima 产物为 anima_full。
- LyCORIS 与 Ortho 保存端移除 anima_full 硬编码，由 family metadata 注入 model_family 与 preset。
- Ortho 蒸馏为 plain LoRA 的现有 tensor/key 行为不变。
- 更新 THIRD_PARTY_NOTICES。

## Krea2 target / 键名验收

在 meta device 上对完整 SingleStreamDiT 使用真实 LyCORIS walker 注入：

- Linear 总数：264；
- LyCORIS module：264；
- 重复或遗漏：0；
- adapter 参数保持 meta，不分配 12.8B 底模 payload；
- 关键 kohya/Comfy 键存在：
  - lora_unet_blocks_0_attn_wq
  - lora_unet_blocks_0_attn_gate
  - lora_unet_txtfusion_refiner_blocks_0_attn_wo
  - lora_unet_txtmlp_1

safetensors 保存回归同时验证 LyCORIS 与 Ortho 均写入 model_family=krea2、preset=krea2_full，不再泄漏 anima_full。

## 本 PR 边界

- 不注册 Krea2Family / KREA2_SPEC。
- 不修改 TrainingConfig schema 或 UI capability gating。
- 不接 Qwen3-VL text encoder/cache。
- 不包含 forward_train、训练 preview、推理 sampler 或 block swap。
- 不改变 rank/alpha 的用户配置默认值；musubi 推荐的 32/32 由后续 K2 schema overlay 落地。

## 外部来源与许可

- 全 Linear target、默认 264 层口径与 lora_unet 前缀参考 kohya-ss/musubi-tuner（Apache-2.0），固定 commit 8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6：
  - https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/networks/lora_krea2.py
- 本仓库将 musubi target=None 映射为 LyCORIS/Ortho 的 target_name=[*] + 禁用 conv；adapter registry 注入与 metadata 契约为本仓库实现。
- 派生关系、版权与许可已写入文件头和 THIRD_PARTY_NOTICES.md。

## 测试

- tests/test_families_krea2_preset.py：4 passed
- related adapter / family suites：75 passed
- python -m studio test：2935 passed，0 failed
- git diff --check：通过
- 前端未改动；studio test 按环境提示 npm 未安装并跳过 vitest