### PR TITLE
feat(train): Krea2 Qwen3-VL 文本栈与可选缓存生命周期（多模型 Phase 3）

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -215,6 +215,11 @@
     加载策略参考 `src/musubi_tuner/krea2/krea2_utils.py`；结构指纹、前缀归一和错误诊断为本仓库实现
   - `runtime/training/families/krea2/preset.py` — 全部 Linear target 与统一
     `lora_unet` 前缀参考 `src/musubi_tuner/networks/lora_krea2.py`
+  - `runtime/training/families/krea2/text_encoding.py` — Qwen3-VL prompt 模板、12 层
+    hidden-state 选择、有效 token gather 与 `(seq, 12, 2560)` 缓存布局派生自
+    `src/musubi_tuner/krea2/krea2_encoder.py` 和
+    `src/musubi_tuner/krea2_cache_text_encoder_outputs.py`；本仓库改为读取官方 HF
+    sharded 目录并接入共享 sidecar 协议与可选的 TE 惰性加载/释放生命周期
 
 实现按本项目 timestep sampler protocol / 纯 torch modeling 边界适配；具体派生关系见各文件头。
 

--- a/docs/design/multi-model/00-decisions.md
+++ b/docs/design/multi-model/00-decisions.md
@@ -45,6 +45,7 @@
 | D7 | schema：新增 `model_family`（默认 `anima`，老配置零迁移）；`transformer_path/vae_path/text_encoder_path` 三字段跨族复用；`t5_tokenizer_path` 转 Anima-only `show_when` | K2 的 vae_path 指向同一个 Qwen-Image VAE 文件，无需新下载 |
 | D8 | 派发点：supervisor/cmd_builder 不动，入口脚本不变，`phases/models.py` 按 `model_family` 查 registry | |
 | D9 | K2 数据集打标推荐链路 = LLM tagger 自然语言 caption | WD14 tag 链路机制上仍可用但非推荐；trigger word 前置继续有效 |
+| D10 | K2 的 TE 缓存是训练配置且默认开启；关闭时完全不读写文本 sidecar，Qwen3-VL 常驻并逐 batch 在线编码 | 默认路径用磁盘换显存，预缓存后释放约 9GB TE；80/100GB 云端但本地盘紧张时可关闭，用显存换磁盘。Anima 行为不变；schema/UI 字段在 K2 family 接线阶段落地 |
 
 ## 5. 分阶段计划
 

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -1,1 +1,10 @@
 """Krea2 family implementation package (Phase 3, not registered yet)."""
+
+from training.families.krea2.text_encoding import (
+    Krea2TextCondition,
+    Krea2TextStack,
+    load_krea2_text_stack,
+)
+
+
+__all__ = ["Krea2TextCondition", "Krea2TextStack", "load_krea2_text_stack"]

--- a/runtime/training/families/krea2/text_encoding.py
+++ b/runtime/training/families/krea2/text_encoding.py
@@ -1,0 +1,458 @@
+"""Krea2 Qwen3-VL text conditioning and variable-length cache lifecycle.
+
+The prompt template, selected hidden layers, interior-padding gather, and output
+layout are adapted from kohya-ss/musubi-tuner's Krea2 text encoder and cache
+implementation at commit 8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6.
+Copyright 2026 Kohya S. and musubi-tuner contributors. Apache-2.0.
+https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/krea2/krea2_encoder.py
+https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/krea2_cache_text_encoder_outputs.py
+
+This repository loads the official sharded Hugging Face directory, uses the
+shared ``TextCacheStore`` sidecar protocol, and owns the lazy load/release
+lifecycle needed to keep the 4B text encoder out of VRAM after pre-caching.
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable, Mapping, Sequence
+
+import torch
+from torch import Tensor
+
+from training.text_cache import TextCacheEntry, TextCacheStore
+
+
+logger = logging.getLogger(__name__)
+
+KREA2_TEXT_FINGERPRINT = "qwen3-vl-4b-instruct-krea2-12x2560-v1"
+KREA2_MAX_LENGTH = 512
+KREA2_SELECTED_LAYERS = (2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 35)
+KREA2_TEXT_WIDTH = 2560
+
+_PROMPT_PREFIX = (
+    "<|im_start|>system\n"
+    "Describe the image by detailing the color, shape, size, texture, quantity, "
+    "text, spatial relationships of the objects and background:<|im_end|>\n"
+    "<|im_start|>user\n"
+)
+_PROMPT_SUFFIX = "<|im_end|>\n<|im_start|>assistant\n"
+_PREFIX_TOKENS = 34
+_SUFFIX_TOKENS = 5
+_CACHE_TENSOR_KEY = "context"
+
+
+@dataclass(frozen=True)
+class Krea2TextCondition:
+    """Padded Krea2 text condition consumed by the DiT."""
+
+    context: Tensor
+    attention_mask: Tensor
+
+
+def gather_valid_text(hidden_states: Tensor, attention_mask: Tensor) -> list[Tensor]:
+    """Gather valid tokens in order, including suffix tokens after interior padding."""
+
+    if hidden_states.ndim < 3:
+        raise ValueError("Krea2 hidden_states 必须至少为 (B, seq, features)")
+    if attention_mask.ndim != 2:
+        raise ValueError("Krea2 attention_mask 必须为 (B, seq)")
+    if hidden_states.shape[:2] != attention_mask.shape:
+        raise ValueError(
+            "Krea2 hidden_states 与 attention_mask 的 batch/seq 维不一致："
+            f"{tuple(hidden_states.shape[:2])} != {tuple(attention_mask.shape)}"
+        )
+
+    mask = attention_mask.to(dtype=torch.bool, device=hidden_states.device)
+    gathered = [hidden_states[index][mask[index]] for index in range(mask.shape[0])]
+    if any(item.shape[0] == 0 for item in gathered):
+        raise ValueError("Krea2 文本条件不能没有有效 token")
+    return gathered
+
+
+def pad_text_conditions(
+    contexts: Sequence[Tensor],
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> Krea2TextCondition:
+    """Right-pad variable-length ``(seq, layers, width)`` tensors for one batch."""
+
+    if not contexts:
+        raise ValueError("Krea2 文本 batch 不能为空")
+    shape = tuple(contexts[0].shape[1:])
+    if contexts[0].ndim != 3 or any(
+        item.ndim != 3 or tuple(item.shape[1:]) != shape or item.shape[0] == 0
+        for item in contexts
+    ):
+        raise ValueError("Krea2 context 必须是非空且层数/宽度一致的 (seq, layers, width)")
+
+    target = torch.device(device)
+    max_length = max(item.shape[0] for item in contexts)
+    padded = torch.zeros(
+        len(contexts), max_length, *shape, device=target, dtype=dtype,
+    )
+    mask = torch.zeros(len(contexts), max_length, device=target, dtype=torch.bool)
+    for index, item in enumerate(contexts):
+        length = item.shape[0]
+        padded[index, :length].copy_(item.to(device=target, dtype=dtype))
+        mask[index, :length] = True
+    return Krea2TextCondition(context=padded, attention_mask=mask)
+
+
+def _default_model_loader(
+    model_path: Path,
+    device: torch.device,
+    dtype: torch.dtype,
+):
+    try:
+        from transformers import Qwen3VLForConditionalGeneration
+    except ImportError as exc:  # pragma: no cover - dependency error is environment-specific
+        raise RuntimeError(
+            "当前 transformers 不含 Qwen3VLForConditionalGeneration；请安装支持 "
+            "Qwen3-VL 的版本"
+        ) from exc
+
+    if not model_path.is_dir():
+        raise ValueError(f"Krea2 文本编码器必须是 Hugging Face 模型目录：{model_path}")
+    logger.info("加载 Krea2 Qwen3-VL 文本编码器：%s", model_path)
+    model = Qwen3VLForConditionalGeneration.from_pretrained(
+        str(model_path),
+        dtype=dtype,
+        local_files_only=True,
+        low_cpu_mem_usage=True,
+        device_map={"": str(device)},
+    )
+    return model.eval().requires_grad_(False)
+
+
+def _load_tokenizer(model_path: Path):
+    try:
+        from transformers import AutoTokenizer
+    except ImportError as exc:  # pragma: no cover - dependency error is environment-specific
+        raise RuntimeError("Krea2 文本编码需要 transformers") from exc
+
+    tokenizer = AutoTokenizer.from_pretrained(str(model_path), local_files_only=True)
+    prefix_tokens = tokenizer(_PROMPT_PREFIX, add_special_tokens=False)["input_ids"]
+    suffix_tokens = tokenizer(_PROMPT_SUFFIX, add_special_tokens=False)["input_ids"]
+    if len(prefix_tokens) != _PREFIX_TOKENS or len(suffix_tokens) != _SUFFIX_TOKENS:
+        raise ValueError(
+            "Krea2 tokenizer 与 Qwen3-VL-4B-Instruct prompt 模板不兼容："
+            f"prefix={len(prefix_tokens)}, suffix={len(suffix_tokens)}"
+        )
+    return tokenizer
+
+
+class Krea2TextStack:
+    """Lazy Qwen3-VL conditioner with cached and storage-free online modes."""
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        *,
+        device: torch.device | str,
+        dtype: torch.dtype = torch.bfloat16,
+        cache_enabled: bool = True,
+        tokenizer=None,
+        model_loader: Callable[[Path, torch.device, torch.dtype], Any] | None = None,
+        text_fingerprint: str = KREA2_TEXT_FINGERPRINT,
+        max_length: int = KREA2_MAX_LENGTH,
+        selected_layers: Sequence[int] = KREA2_SELECTED_LAYERS,
+        hidden_width: int = KREA2_TEXT_WIDTH,
+        cache_batch_size: int = 1,
+    ) -> None:
+        self.model_path = Path(model_path)
+        self.device = torch.device(device)
+        self.dtype = dtype
+        self.cache_enabled = bool(cache_enabled)
+        self.tokenizer = tokenizer if tokenizer is not None else _load_tokenizer(self.model_path)
+        self._model_loader = model_loader or _default_model_loader
+        self._model = None
+        self.store = TextCacheStore(text_fingerprint)
+        self.max_length = int(max_length)
+        self.selected_layers = tuple(int(index) for index in selected_layers)
+        self.hidden_width = int(hidden_width)
+        self.cache_batch_size = int(cache_batch_size)
+        self._caption_entries: dict[str, list[TextCacheEntry]] = {}
+        self._prompt_captions: list[str] = []
+        self._cache_root: Path | None = None
+
+        if self.max_length <= 0 or not self.selected_layers or self.hidden_width <= 0:
+            raise ValueError("Krea2 文本编码配置必须为正数且 selected_layers 不能为空")
+        if self.cache_batch_size <= 0:
+            raise ValueError("Krea2 cache_batch_size 必须为正数")
+
+    @property
+    def is_model_loaded(self) -> bool:
+        return self._model is not None
+
+    def ensure_model(self):
+        if self._model is None:
+            self._model = self._model_loader(self.model_path, self.device, self.dtype)
+        return self._model
+
+    def release_model(self) -> None:
+        """Release the cached-mode TE before the 12.9B DiT occupies the device."""
+
+        if self._model is None:
+            return
+        self._model = None
+        gc.collect()
+        if self.device.type == "cuda" and torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def _tokenize(self, captions: Sequence[str]) -> tuple[Tensor, Tensor]:
+        text = [_PROMPT_PREFIX + str(caption) for caption in captions]
+        suffix = [_PROMPT_SUFFIX] * len(text)
+        encoded = self.tokenizer(
+            text,
+            truncation=True,
+            return_length=False,
+            return_overflowing_tokens=False,
+            padding="max_length",
+            max_length=self.max_length + _PREFIX_TOKENS - _SUFFIX_TOKENS,
+            return_tensors="pt",
+        )
+        suffix_encoded = self.tokenizer(suffix, return_tensors="pt")
+        input_ids = torch.cat(
+            [encoded["input_ids"], suffix_encoded["input_ids"]], dim=1,
+        ).to(self.device, non_blocking=True)
+        mask = torch.cat(
+            [encoded["attention_mask"].bool(), suffix_encoded["attention_mask"].bool()],
+            dim=1,
+        ).to(self.device, non_blocking=True)
+        return input_ids, mask
+
+    def _encode_many(self, captions: Sequence[str]) -> list[Tensor]:
+        if not captions:
+            return []
+        model = self.ensure_model()
+        input_ids, mask = self._tokenize(captions)
+        backbone = getattr(model, "model", model)
+        with torch.inference_mode():
+            outputs = backbone(
+                input_ids=input_ids,
+                attention_mask=mask,
+                output_hidden_states=True,
+                use_cache=False,
+                return_dict=True,
+            )
+        hidden_states = outputs.hidden_states
+        if hidden_states is None or max(self.selected_layers) >= len(hidden_states):
+            count = 0 if hidden_states is None else len(hidden_states)
+            raise RuntimeError(
+                f"Qwen3-VL 返回 hidden_states 层数不足：{count}，"
+                f"需要索引 {max(self.selected_layers)}"
+            )
+        stacked = torch.stack(
+            [hidden_states[index] for index in self.selected_layers], dim=2,
+        )[:, _PREFIX_TOKENS:]
+        cropped_mask = mask[:, _PREFIX_TOKENS:]
+        contexts = gather_valid_text(stacked, cropped_mask)
+        for context in contexts:
+            self._validate_context(context, source="Qwen3-VL 输出")
+        return contexts
+
+    def _encode_in_chunks(self, captions: Sequence[str]) -> dict[str, Tensor]:
+        encoded: dict[str, Tensor] = {}
+        unique = list(dict.fromkeys(str(caption) for caption in captions))
+        for start in range(0, len(unique), self.cache_batch_size):
+            chunk = unique[start:start + self.cache_batch_size]
+            contexts = self._encode_many(chunk)
+            for caption, context in zip(chunk, contexts):
+                encoded[caption] = context.detach().cpu().contiguous()
+        return encoded
+
+    def _validate_context(self, context: object, *, source: str) -> Tensor:
+        if not isinstance(context, Tensor):
+            raise ValueError(f"{source} 缺少 tensor context")
+        expected = (len(self.selected_layers), self.hidden_width)
+        if (
+            context.ndim != 3
+            or context.shape[0] == 0
+            or tuple(context.shape[1:]) != expected
+            or not context.is_floating_point()
+        ):
+            raise ValueError(
+                f"{source} context 必须为非空浮点 (seq, {expected[0]}, {expected[1]})，"
+                f"实际 {tuple(context.shape)} / {context.dtype}"
+            )
+        return context
+
+    def _context_from_payload(self, payload: Mapping[str, object] | None) -> Tensor | None:
+        if payload is None:
+            return None
+        context = payload.get(_CACHE_TENSOR_KEY)
+        try:
+            return self._validate_context(context, source="Krea2 文本缓存")
+        except ValueError:
+            return None
+
+    @staticmethod
+    def _payload(context: Tensor) -> dict[str, Tensor]:
+        return {_CACHE_TENSOR_KEY: context}
+
+    def _prepare_caption_sidecars(self) -> None:
+        contexts: dict[str, Tensor] = {}
+        missing_entries: dict[str, list[TextCacheEntry]] = {}
+        for caption, entries in self._caption_entries.items():
+            context = None
+            for entry in entries:
+                cached = self._context_from_payload(self.store.read_caption(entry))
+                if cached is None:
+                    missing_entries.setdefault(caption, []).append(entry)
+                elif context is None:
+                    context = cached
+            if context is not None:
+                contexts[caption] = context
+
+        contexts.update(
+            self._encode_in_chunks(
+                [caption for caption in self._caption_entries if caption not in contexts],
+            )
+        )
+        for caption, entries in missing_entries.items():
+            for entry in entries:
+                self.store.write_caption(entry, self._payload(contexts[caption]))
+
+    def _prepare_prompt_bundle(self) -> None:
+        if not self._prompt_captions:
+            return
+        if self._cache_root is None:
+            raise ValueError("Krea2 prompt 缓存需要 cache_root")
+        payloads: dict[str, dict[str, Tensor]] = {}
+        missing = []
+        for caption in self._prompt_captions:
+            context = self._context_from_payload(
+                self.store.read_prompt(self._cache_root, caption),
+            )
+            if context is None:
+                missing.append(caption)
+            else:
+                payloads[caption] = self._payload(context)
+        for caption, context in self._encode_in_chunks(missing).items():
+            payloads[caption] = self._payload(context)
+        if missing:
+            self.store.write_prompt_bundle(self._cache_root, payloads)
+
+    def prepare_text_cache(
+        self,
+        captions: Iterable[str],
+        extra_prompts: Iterable[str],
+        *,
+        cache_entries: Iterable[TextCacheEntry] = (),
+        cache_root: str | Path | None = None,
+    ) -> None:
+        """Populate all known text caches, or retain the TE for online mode."""
+
+        entries = list(cache_entries)
+        self._caption_entries = {}
+        for entry in entries:
+            self._caption_entries.setdefault(entry.caption, []).append(entry)
+        caption_list = list(dict.fromkeys(str(caption) for caption in captions))
+        prompt_list = [str(prompt) for prompt in extra_prompts]
+        prompt_list.extend(
+            caption for caption in caption_list if caption not in self._caption_entries
+        )
+        self._prompt_captions = list(dict.fromkeys(prompt_list))
+        self._cache_root = Path(cache_root) if cache_root is not None else None
+
+        if not self.cache_enabled:
+            self.ensure_model()
+            return
+        try:
+            self._prepare_caption_sidecars()
+            self._prepare_prompt_bundle()
+        finally:
+            self.release_model()
+
+    def _repair_prompt_bundle(self, required: Sequence[str]) -> dict[str, Tensor]:
+        if self._cache_root is None:
+            raise ValueError("Krea2 cached 模式编码未知 prompt 时需要 cache_root")
+        self._prompt_captions = list(dict.fromkeys([*self._prompt_captions, *required]))
+        contexts: dict[str, Tensor] = {}
+        missing = []
+        for caption in self._prompt_captions:
+            context = self._context_from_payload(
+                self.store.read_prompt(self._cache_root, caption),
+            )
+            if context is None:
+                missing.append(caption)
+            else:
+                contexts[caption] = context
+        contexts.update(self._encode_in_chunks(missing))
+        if missing:
+            self.store.write_prompt_bundle(
+                self._cache_root,
+                {caption: self._payload(context) for caption, context in contexts.items()},
+            )
+        return contexts
+
+    def encode_text_for_batch(
+        self,
+        captions: Sequence[str],
+        *,
+        device: torch.device | str,
+        dtype: torch.dtype,
+    ) -> Krea2TextCondition:
+        """Return a padded condition; cached misses are repaired transparently."""
+
+        caption_list = [str(caption) for caption in captions]
+        if not caption_list:
+            raise ValueError("Krea2 文本 batch 不能为空")
+        if not self.cache_enabled:
+            contexts = self._encode_many(caption_list)
+            return pad_text_conditions(contexts, device=device, dtype=dtype)
+
+        unique = list(dict.fromkeys(caption_list))
+        contexts: dict[str, Tensor] = {}
+        missing_sidecars: list[str] = []
+        missing_prompts: list[str] = []
+        for caption in unique:
+            entries = self._caption_entries.get(caption)
+            if entries:
+                context = None
+                for entry in entries:
+                    context = self._context_from_payload(self.store.read_caption(entry))
+                    if context is not None:
+                        break
+                if context is None:
+                    missing_sidecars.append(caption)
+                else:
+                    contexts[caption] = context
+            else:
+                missing_prompts.append(caption)
+
+        try:
+            repaired = self._encode_in_chunks(missing_sidecars)
+            for caption, context in repaired.items():
+                contexts[caption] = context
+                for entry in self._caption_entries[caption]:
+                    self.store.write_caption(entry, self._payload(context))
+            if missing_prompts:
+                contexts.update(self._repair_prompt_bundle(missing_prompts))
+        finally:
+            self.release_model()
+
+        ordered = [contexts[caption] for caption in caption_list]
+        return pad_text_conditions(ordered, device=device, dtype=dtype)
+
+
+def load_krea2_text_stack(
+    model_path: str | Path,
+    *,
+    device: torch.device | str,
+    dtype: torch.dtype = torch.bfloat16,
+    cache_enabled: bool = True,
+) -> Krea2TextStack:
+    """Create a lazy Krea2 text stack; only the small tokenizer loads immediately."""
+
+    return Krea2TextStack(
+        model_path,
+        device=device,
+        dtype=dtype,
+        cache_enabled=cache_enabled,
+    )

--- a/tests/test_krea2_text_encoding.py
+++ b/tests/test_krea2_text_encoding.py
@@ -1,0 +1,209 @@
+"""Krea2 Qwen3-VL varlen encoding, cache lifecycle, and online fallback."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from training.families.krea2.text_encoding import (
+    Krea2TextStack,
+    gather_valid_text,
+    pad_text_conditions,
+)
+from training.text_cache import TextCacheEntry
+
+
+class _FakeTokenizer:
+    def __call__(self, text, **kwargs):
+        texts = [text] if isinstance(text, str) else list(text)
+        if kwargs.get("return_tensors") != "pt":
+            if "assistant" in texts[0]:
+                return {"input_ids": list(range(5))}
+            return {"input_ids": list(range(34))}
+
+        max_length = kwargs.get("max_length")
+        if max_length is None:  # fixed five-token suffix
+            return {
+                "input_ids": torch.arange(5).repeat(len(texts), 1),
+                "attention_mask": torch.ones(len(texts), 5, dtype=torch.long),
+            }
+
+        ids = torch.zeros(len(texts), max_length, dtype=torch.long)
+        mask = torch.zeros_like(ids)
+        for index, value in enumerate(texts):
+            caption = value.rsplit("user\n", 1)[-1]
+            valid = min(max_length, 34 + len(caption))
+            ids[index] = torch.arange(max_length)
+            mask[index, :valid] = 1
+        return {"input_ids": ids, "attention_mask": mask}
+
+
+class _FakeBackbone:
+    def __init__(self, width=4, layers=4):
+        self.width = width
+        self.layers = layers
+        self.calls = 0
+
+    def __call__(self, *, input_ids, attention_mask, **kwargs):
+        self.calls += 1
+        batch, seq = input_ids.shape
+        positions = torch.arange(seq, device=input_ids.device, dtype=torch.float32)
+        positions = positions.view(1, seq, 1).expand(batch, seq, self.width)
+        hidden_states = tuple(positions + layer * 100 for layer in range(self.layers))
+        return SimpleNamespace(hidden_states=hidden_states)
+
+
+class _FakeModel:
+    def __init__(self):
+        self.model = _FakeBackbone()
+
+
+class _Loader:
+    def __init__(self):
+        self.calls = 0
+        self.models = []
+
+    def __call__(self, model_path, device, dtype):
+        self.calls += 1
+        model = _FakeModel()
+        self.models.append(model)
+        return model
+
+
+def _stack(tmp_path, loader, *, cache_enabled):
+    return Krea2TextStack(
+        tmp_path / "qwen",
+        device="cpu",
+        dtype=torch.float32,
+        cache_enabled=cache_enabled,
+        tokenizer=_FakeTokenizer(),
+        model_loader=loader,
+        max_length=8,
+        selected_layers=(1, 3),
+        hidden_width=4,
+        text_fingerprint="krea2-test-v1",
+        cache_batch_size=2,
+    )
+
+
+def test_gather_valid_text_preserves_suffix_after_interior_padding():
+    hidden = torch.arange(7, dtype=torch.float32).view(1, 7, 1)
+    mask = torch.tensor([[True, True, False, False, False, True, True]])
+
+    gathered = gather_valid_text(hidden, mask)
+
+    assert gathered[0].flatten().tolist() == [0.0, 1.0, 5.0, 6.0]
+
+
+def test_pad_text_conditions_builds_bool_mask_and_requested_dtype():
+    condition = pad_text_conditions(
+        [torch.ones(2, 2, 4), torch.full((4, 2, 4), 2.0)],
+        device="cpu",
+        dtype=torch.bfloat16,
+    )
+
+    assert condition.context.shape == (2, 4, 2, 4)
+    assert condition.context.dtype == torch.bfloat16
+    assert condition.attention_mask.dtype == torch.bool
+    assert condition.attention_mask.tolist() == [
+        [True, True, False, False],
+        [True, True, True, True],
+    ]
+    assert torch.count_nonzero(condition.context[0, 2:]) == 0
+
+
+def test_online_mode_never_writes_cache_and_keeps_model_loaded(tmp_path):
+    loader = _Loader()
+    stack = _stack(tmp_path, loader, cache_enabled=False)
+    entry = TextCacheEntry.for_image(tmp_path / "image.png", "ab")
+
+    stack.prepare_text_cache(
+        ["ab"], [""], cache_entries=[entry], cache_root=tmp_path,
+    )
+    condition = stack.encode_text_for_batch(
+        ["ab", "c"], device="cpu", dtype=torch.float32,
+    )
+
+    assert loader.calls == 1
+    assert stack.is_model_loaded
+    assert not entry.cache_path.exists()
+    assert not (tmp_path / ".text-cache").exists()
+    assert condition.context.shape == (2, 7, 2, 4)
+    assert condition.attention_mask.sum(dim=1).tolist() == [7, 6]
+    # For "ab": positions 34/35, interior pad 36 skipped, suffix 37..41 retained.
+    assert condition.context[0, :, 0, 0].tolist() == [
+        134.0, 135.0, 137.0, 138.0, 139.0, 140.0, 141.0,
+    ]
+
+
+def test_cached_mode_precaches_reuses_and_releases_model(tmp_path):
+    first_loader = _Loader()
+    first = _stack(tmp_path, first_loader, cache_enabled=True)
+    entries = [
+        TextCacheEntry.for_image(tmp_path / "one.png", "ab"),
+        TextCacheEntry.for_image(tmp_path / "two.png", "ab"),
+        TextCacheEntry.for_image(tmp_path / "three.png", "c"),
+    ]
+
+    first.prepare_text_cache(
+        ["ab", "ab", "c"], ["sample", ""],
+        cache_entries=entries,
+        cache_root=tmp_path,
+    )
+
+    assert first_loader.calls == 1
+    assert not first.is_model_loaded
+    assert all(entry.cache_path.is_file() for entry in entries)
+    assert first_loader.models[0].model.calls == 2
+
+    def fail_loader(*args):
+        raise AssertionError("完整缓存命中不应加载 Qwen3-VL")
+
+    second = _stack(tmp_path, fail_loader, cache_enabled=True)
+    second.prepare_text_cache(
+        ["ab", "ab", "c"], ["sample", ""],
+        cache_entries=entries,
+        cache_root=tmp_path,
+    )
+    condition = second.encode_text_for_batch(
+        ["c", "ab", "sample"], device="cpu", dtype=torch.float32,
+    )
+
+    assert not second.is_model_loaded
+    assert condition.attention_mask.sum(dim=1).tolist() == [6, 7, 8]
+
+
+def test_invalid_sidecar_is_reencoded_and_released(tmp_path):
+    loader = _Loader()
+    stack = _stack(tmp_path, loader, cache_enabled=True)
+    entry = TextCacheEntry.for_image(tmp_path / "image.png", "ab")
+    stack.store.write_caption(entry, {"context": torch.ones(2, 99, 4)})
+
+    stack.prepare_text_cache(
+        ["ab"], [], cache_entries=[entry], cache_root=tmp_path,
+    )
+    cached = stack.store.read_caption(entry)
+
+    assert loader.calls == 1
+    assert not stack.is_model_loaded
+    assert cached["context"].shape == (7, 2, 4)
+
+
+def test_cached_batch_miss_repairs_sidecar_after_prepare(tmp_path):
+    loader = _Loader()
+    stack = _stack(tmp_path, loader, cache_enabled=True)
+    entry = TextCacheEntry.for_image(tmp_path / "image.png", "ab")
+    stack.prepare_text_cache(
+        ["ab"], [], cache_entries=[entry], cache_root=tmp_path,
+    )
+    entry.cache_path.unlink()
+
+    condition = stack.encode_text_for_batch(
+        ["ab"], device="cpu", dtype=torch.float32,
+    )
+
+    assert loader.calls == 2
+    assert entry.cache_path.is_file()
+    assert not stack.is_model_loaded
+    assert condition.attention_mask.sum().item() == 7


### PR DESCRIPTION
## 背景 / 动机

docs/design/multi-model/00-decisions D3 已确定：Krea2 使用 Qwen3-VL-4B-Instruct 的 12 层 varlen 文本条件，数据集 caption 预缓存后释放 TE；03-interface-evolution §2.2/§2.5 将缓存自治收口在 family 内部，dataset 与共享 loop 只传 captions。

真实硬件验证显示 Krea2 Raw DiT BF16 占约 23.9 GiB，Qwen3-VL 文本栈峰值约 8.4 GiB；32GB 本地开发机无法让两者安全常驻。另一方面，80/100GB 云端 GPU 通常显存充足但本地盘有限，因此缓存不能是不可关闭的硬编码行为。D10 现明确：K2 后续 schema 默认开启 TE cache；关闭时完全不读写 sidecar，改用 TE 常驻在线编码。

为保持一个 PR 一个完整 unit，本 PR 只闭环 Krea2 TextStack、Qwen3-VL 编码协议和两种缓存生命周期；仍不注册半成品 Krea2Family。

## 改动概要

- 新增 Krea2 Qwen3-VL 文本栈：
  - 从本地官方 HF sharded 目录惰性加载 `Qwen3VLForConditionalGeneration`；tokenizer 仅读本地文件；
  - 使用 Krea2 system/user/assistant 模板，max sequence length 512；
  - 固定选取 hidden-state index `2,5,8,...,35`，输出 `(B, seq, 12, 2560)`；
  - 直接调用 Qwen3VL backbone，避免为训练条件计算无用的 LM logits。
- 正确处理 interior padding：
  - 先裁掉 34-token prefix；
  - 再按 bool attention mask gather 有效 token；
  - 保留位于 max-length padding 之后的 5-token assistant suffix，不能用简单 prefix trim。
- batch 端将 varlen `(seq, 12, 2560)` right-pad 到 batch max，并生成 bool attention mask。
- cached 模式：
  - 复用 Phase 2 `TextCacheStore`，图片 caption 写同目录 sidecar，sample/negative prompt 写聚合 bundle；
  - 相同 caption 只编码一次并可补齐多个图片 sidecar；缺失 caption 按 `cache_batch_size` 分批编码；
  - 缓存 shape/dtype 不合法视为 miss，自动重编码；训练期 miss 也会惰性加载、修复缓存并再次释放 TE；
  - 预缓存完成后 `gc.collect + cuda.empty_cache` 释放 Qwen3-VL。
- cache disabled 模式：
  - 不读、不写任何 sidecar / prompt bundle；
  - 首次准备时加载 Qwen3-VL，逐 batch 在线编码并保持常驻；
  - 用于 80/100GB 显存充足但磁盘受限的云端环境。
- 文本指纹固定为 `qwen3-vl-4b-instruct-krea2-12x2560-v1`，覆盖权重族和 extraction layout。
- 更新 D10 设计记录、package export 与 THIRD_PARTY_NOTICES。

## 真实模型验收

本地资产：`models/text_encoders/Qwen_Qwen3-VL-4B-Instruct/`，官方两片 safetensors，共约 8.88GB；GPU 为 RTX 5090 32GB。

- BF16 惰性加载 + 单 prompt 编码：15.36s；
- 输出：`(1, 13, 12, 2560)`；
- attention mask：bool，13 个有效 token；
- context dtype：bfloat16；
- 数值：全部 finite；
- CUDA peak allocated：8.403 GiB；
- `release_model()` 后 allocated：0.008 GiB。

## 本 PR 边界

- 不注册 `Krea2Family` / `KREA2_SPEC`。
- 不修改 `TrainingConfig` schema 或 UI；`text_encoder_cache` 的默认值与展示在后续 family/schema 接线 PR 落地。
- 不调整 phase 顺序；32GB 下必须在后续接线时保证 cached 模式先完成 TE 预缓存/释放，再加载 23.9GiB DiT。
- 不包含 `forward_train`、训练 preview、Turbo sampling、CFG 或 block swap。
- Anima 的在线 Qwen3-0.6B + T5 路径不变。

## 外部来源与许可

- prompt 模板、12 层选择、prefix/suffix index、有效 token gather 与缓存 layout 派生自 kohya-ss/musubi-tuner（Apache-2.0），固定 commit `8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6`：
  - https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/krea2/krea2_encoder.py
  - https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/krea2_cache_text_encoder_outputs.py
- 本仓库的官方 HF sharded directory loader、`TextCacheStore` sidecar 接线、缓存开关、惰性修复和 TE 释放生命周期为项目适配。
- 派生关系、版权与许可已写入文件头和 `THIRD_PARTY_NOTICES.md`。

## 测试

- `tests/test_krea2_text_encoding.py` + text-cache related：17 passed
- Krea2/model-family related suites：77 passed
- CONTRIBUTING cross-cut safety net：33 passed
- `python -m studio test`：2941 passed，0 failed（最终代码跑了两轮全量，均通过）
- `git diff --cached --check`：通过
- 真实 Qwen3-VL BF16 smoke：通过，数据见上
- 前端未改动；`studio test` 按环境提示 npm 未安装并跳过 vitest
