### PR TITLE
feat(train): Krea2 FlowMatchEuler 动态 shift 采样（多模型 Phase 3）

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -220,6 +220,10 @@
     `src/musubi_tuner/krea2/krea2_encoder.py` 和
     `src/musubi_tuner/krea2_cache_text_encoder_outputs.py`；本仓库改为读取官方 HF
     sharded 目录并接入共享 sidecar 协议与可选的 TE 惰性加载/释放生命周期
+  - `runtime/training/families/krea2/sampling.py` — 分辨率对齐、动态 `mu`、指数
+    timestep shift 与 FlowMatchEuler 循环派生自 `src/musubi_tuner/krea2/krea2_sampling.py`；
+    Raw/TDM 默认值和 Krea guidance `cond + g*(cond-uncond)` 同时对照 diffusers
+    `pipeline_krea2.py` 与 `scheduling_flow_match_euler_discrete.py`（固定 commit 见文件头）
 
 实现按本项目 timestep sampler protocol / 纯 torch modeling 边界适配；具体派生关系见各文件头。
 

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -5,6 +5,18 @@ from training.families.krea2.text_encoding import (
     Krea2TextStack,
     load_krea2_text_stack,
 )
+from training.families.krea2.sampling import (
+    Krea2SamplingCondition,
+    prepare_sampling_condition,
+    sample_image,
+)
 
 
-__all__ = ["Krea2TextCondition", "Krea2TextStack", "load_krea2_text_stack"]
+__all__ = [
+    "Krea2SamplingCondition",
+    "Krea2TextCondition",
+    "Krea2TextStack",
+    "load_krea2_text_stack",
+    "prepare_sampling_condition",
+    "sample_image",
+]

--- a/runtime/training/families/krea2/sampling.py
+++ b/runtime/training/families/krea2/sampling.py
@@ -1,0 +1,351 @@
+"""Krea2 FlowMatchEuler sampling with resolution-aware dynamic shifting.
+
+The Euler loop, resolution alignment, and shifted timestep schedule are adapted
+from kohya-ss/musubi-tuner's Krea2 sampler at fixed commit
+8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6 (Apache-2.0).
+Copyright 2026 Kohya S. and musubi-tuner contributors.
+https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/krea2/krea2_sampling.py
+
+The Krea guidance convention (``cond + g * (cond - uncond)``), Raw/TDM
+defaults, and FlowMatchEuler scheduler behavior are cross-checked against
+Hugging Face diffusers at commit bc529a5f677db9c4b3fc72c76962c4e2f61567e1
+(Apache-2.0):
+https://github.com/huggingface/diffusers/blob/bc529a5f677db9c4b3fc72c76962c4e2f61567e1/src/diffusers/pipelines/krea2/pipeline_krea2.py
+https://github.com/huggingface/diffusers/blob/bc529a5f677db9c4b3fc72c76962c4e2f61567e1/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
+"""
+
+from __future__ import annotations
+
+import contextlib
+import gc
+import math
+from dataclasses import dataclass
+
+import torch
+from torch import Tensor
+
+from training.families.krea2.text_encoding import Krea2TextCondition
+
+
+KREA2_SAMPLER = "euler"
+KREA2_SCHEDULER = "krea2_shift"
+KREA2_RAW_STEPS = 28
+KREA2_RAW_GUIDANCE = 4.5
+KREA2_TURBO_STEPS = 8
+KREA2_TURBO_GUIDANCE = 0.0
+KREA2_DISTILLED_MU = 1.15
+KREA2_BASE_IMAGE_SEQ_LEN = 256
+KREA2_MAX_IMAGE_SEQ_LEN = 6400
+KREA2_BASE_SHIFT = 0.5
+KREA2_MAX_SHIFT = 1.15
+
+
+@dataclass(frozen=True)
+class Krea2SamplingCondition:
+    """Positive and optional negative Qwen3-VL conditions for one image."""
+
+    positive: Krea2TextCondition
+    negative: Krea2TextCondition | None = None
+
+
+def _validate_guidance(value: float) -> float:
+    guidance = float(value)
+    if not math.isfinite(guidance) or guidance < 0:
+        raise ValueError("Krea2 guidance scale 必须为有限非负数")
+    return guidance
+
+
+def resolve_sampling_settings(
+    *,
+    distilled: bool,
+    steps: int | None,
+    cfg_scale: float | None,
+    sampler_name: str | None,
+    scheduler: str | None,
+) -> tuple[int, float]:
+    """Resolve Raw/Turbo defaults and reject sampler names from another family."""
+
+    sampler = KREA2_SAMPLER if sampler_name is None else str(sampler_name).lower().strip()
+    schedule = KREA2_SCHEDULER if scheduler is None else str(scheduler).lower().strip()
+    if sampler != KREA2_SAMPLER or schedule != KREA2_SCHEDULER:
+        raise ValueError(
+            "Krea2 仅支持 euler+krea2_shift，实际 "
+            f"{sampler or '<empty>'}+{schedule or '<empty>'}"
+        )
+
+    default_steps = KREA2_TURBO_STEPS if distilled else KREA2_RAW_STEPS
+    default_guidance = KREA2_TURBO_GUIDANCE if distilled else KREA2_RAW_GUIDANCE
+    resolved_steps = default_steps if steps is None else int(steps)
+    if resolved_steps <= 0:
+        raise ValueError("Krea2 sampling steps 必须为正数")
+    guidance = _validate_guidance(
+        default_guidance if cfg_scale is None else cfg_scale,
+    )
+    return resolved_steps, guidance
+
+
+def calculate_krea2_mu(
+    image_seq_len: int,
+    *,
+    base_image_seq_len: int = KREA2_BASE_IMAGE_SEQ_LEN,
+    max_image_seq_len: int = KREA2_MAX_IMAGE_SEQ_LEN,
+    base_shift: float = KREA2_BASE_SHIFT,
+    max_shift: float = KREA2_MAX_SHIFT,
+) -> float:
+    """Linearly interpolate Krea2 ``mu`` from image token count, without clamp."""
+
+    seq_len = int(image_seq_len)
+    if seq_len <= 0:
+        raise ValueError("Krea2 image_seq_len 必须为正数")
+    if max_image_seq_len <= base_image_seq_len:
+        raise ValueError("Krea2 max_image_seq_len 必须大于 base_image_seq_len")
+    values = (float(base_shift), float(max_shift))
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError("Krea2 shift 端点必须为有限数")
+    slope = (values[1] - values[0]) / (max_image_seq_len - base_image_seq_len)
+    return slope * seq_len + (values[0] - slope * base_image_seq_len)
+
+
+def build_krea2_sigmas(
+    image_seq_len: int,
+    steps: int,
+    *,
+    distilled: bool = False,
+    device: torch.device | str = "cpu",
+) -> Tensor:
+    """Build the shifted ``1 → 0`` FlowMatchEuler sigma grid."""
+
+    if int(steps) <= 0:
+        raise ValueError("Krea2 sampling steps 必须为正数")
+    mu = (
+        KREA2_DISTILLED_MU
+        if distilled
+        else calculate_krea2_mu(image_seq_len)
+    )
+    base = torch.linspace(
+        1.0, 0.0, int(steps) + 1, device=device, dtype=torch.float32,
+    )
+    shift = math.exp(mu)
+    return (shift * base) / (1.0 + (shift - 1.0) * base)
+
+
+def align_krea2_resolution(value: int, *, align: int = 16) -> int:
+    """Round a requested pixel dimension up to the VAE-stride × DiT-patch grid."""
+
+    dimension = int(value)
+    if dimension <= 0 or int(align) <= 0:
+        raise ValueError("Krea2 resolution 与 align 必须为正数")
+    return ((dimension + int(align) - 1) // int(align)) * int(align)
+
+
+def prepare_sampling_condition(
+    text_stack,
+    prompt: str,
+    *,
+    negative_prompt: str | None = None,
+    cfg_scale: float = KREA2_RAW_GUIDANCE,
+    device: torch.device | str,
+    dtype: torch.dtype,
+    phase_callback=None,
+) -> Krea2SamplingCondition:
+    """Resolve cached/online text for sampling before entering the Euler loop."""
+
+    guidance = _validate_guidance(cfg_scale)
+    captions = [str(prompt)]
+    if guidance > 0:
+        captions.append("" if negative_prompt is None else str(negative_prompt))
+    if phase_callback is not None:
+        phase_callback("clip")
+    encoded = text_stack.encode_text_for_batch(captions, device=device, dtype=dtype)
+    positive = Krea2TextCondition(
+        context=encoded.context[0:1],
+        attention_mask=encoded.attention_mask[0:1],
+    )
+    negative = None
+    if guidance > 0:
+        negative = Krea2TextCondition(
+            context=encoded.context[1:2],
+            attention_mask=encoded.attention_mask[1:2],
+        )
+    return Krea2SamplingCondition(positive=positive, negative=negative)
+
+
+def _move_condition(
+    condition: Krea2TextCondition,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> Krea2TextCondition:
+    if condition.context.ndim != 4 or condition.attention_mask.ndim != 2:
+        raise ValueError("Krea2 sampling condition 形状必须为 context 4D + mask 2D")
+    if condition.context.shape[:2] != condition.attention_mask.shape:
+        raise ValueError("Krea2 sampling context 与 attention mask 的 batch/seq 不一致")
+    if condition.context.shape[0] != 1:
+        raise ValueError("Krea2 sample_image 当前一次只生成一张图")
+    return Krea2TextCondition(
+        context=condition.context.to(device=device, dtype=dtype),
+        attention_mask=condition.attention_mask.to(device=device, dtype=torch.bool),
+    )
+
+
+def _autocast_context(device: torch.device, dtype: torch.dtype):
+    if device.type in {"cuda", "cpu"} and dtype in {torch.float16, torch.bfloat16}:
+        return torch.autocast(device_type=device.type, dtype=dtype)
+    return contextlib.nullcontext()
+
+
+@torch.no_grad()
+def sample_latents(
+    model,
+    condition: Krea2SamplingCondition,
+    *,
+    height: int = 1024,
+    width: int = 1024,
+    steps: int | None = None,
+    cfg_scale: float | None = None,
+    sampler_name: str | None = None,
+    scheduler: str | None = None,
+    distilled: bool = False,
+    device: torch.device | str = "cuda",
+    dtype: torch.dtype = torch.bfloat16,
+    seed: int | None = None,
+    latents: Tensor | None = None,
+    step_callback=None,
+) -> Tensor:
+    """Run Krea2's deterministic shifted FlowMatchEuler loop and return 5D latents."""
+
+    steps, guidance = resolve_sampling_settings(
+        distilled=distilled,
+        steps=steps,
+        cfg_scale=cfg_scale,
+        sampler_name=sampler_name,
+        scheduler=scheduler,
+    )
+    target = torch.device(device)
+    patch = int(model.config.patch)
+    channels = int(model.config.channels)
+    align = 8 * patch
+    aligned_height = align_krea2_resolution(height, align=align)
+    aligned_width = align_krea2_resolution(width, align=align)
+    latent_height = aligned_height // 8
+    latent_width = aligned_width // 8
+    image_seq_len = (latent_height // patch) * (latent_width // patch)
+
+    positive = _move_condition(condition.positive, device=target, dtype=dtype)
+    negative = None
+    if guidance > 0:
+        if condition.negative is None:
+            raise ValueError("Krea2 guidance > 0 时必须提供 negative condition")
+        negative = _move_condition(condition.negative, device=target, dtype=dtype)
+
+    expected_shape = (1, channels, 1, latent_height, latent_width)
+    if latents is None:
+        generator = None
+        if seed is not None:
+            generator = torch.Generator(device="cpu").manual_seed(int(seed))
+        latents = torch.randn(expected_shape, generator=generator, dtype=torch.float32)
+    elif tuple(latents.shape) != expected_shape:
+        raise ValueError(
+            f"Krea2 初始 latent 形状应为 {expected_shape}，实际 {tuple(latents.shape)}"
+        )
+    image = latents.to(device=target, dtype=dtype)
+    sigmas = build_krea2_sigmas(
+        image_seq_len, steps, distilled=distilled, device=target,
+    )
+
+    was_training = bool(getattr(model, "training", False))
+    model.eval()
+    try:
+        with _autocast_context(target, dtype):
+            for index, (sigma, next_sigma) in enumerate(zip(sigmas[:-1], sigmas[1:])):
+                timestep = sigma.expand(image.shape[0]).to(device=target, dtype=image.dtype)
+                velocity = model(
+                    image,
+                    timestep,
+                    positive.context,
+                    attention_mask=positive.attention_mask,
+                )
+                if guidance > 0:
+                    uncond_velocity = model(
+                        image,
+                        timestep,
+                        negative.context,
+                        attention_mask=negative.attention_mask,
+                    )
+                    # Krea convention: g=0 is conditional-only; equivalent standard
+                    # CFG scale is (1 + g).
+                    velocity = velocity + guidance * (velocity - uncond_velocity)
+
+                if step_callback is not None:
+                    denoised = image - sigma.to(dtype=image.dtype) * velocity
+                    try:
+                        step_callback(index, steps, denoised)
+                    except Exception:
+                        pass
+                image = image + (next_sigma - sigma).to(dtype=image.dtype) * velocity
+    finally:
+        model.train(was_training)
+    return image
+
+
+def _decode_to_pil(vae, latents: Tensor):
+    import numpy as np
+    from PIL import Image
+
+    pixels = vae.decode(latents)
+    if pixels.ndim != 5 or pixels.shape[0] != 1 or pixels.shape[1] != 3:
+        raise ValueError(
+            "Krea2 VAE decode 应返回单张 (1,3,T,H,W)，实际 "
+            f"{tuple(pixels.shape)}"
+        )
+    pixels = (pixels[:, :, 0].clamp(-1, 1) + 1) / 2
+    array = pixels[0].permute(1, 2, 0).cpu().float().numpy()
+    return Image.fromarray((array * 255).clip(0, 255).astype(np.uint8))
+
+
+@torch.no_grad()
+def sample_image(
+    model,
+    vae,
+    condition: Krea2SamplingCondition,
+    *,
+    height: int = 1024,
+    width: int = 1024,
+    steps: int | None = None,
+    cfg_scale: float | None = None,
+    sampler_name: str | None = None,
+    scheduler: str | None = None,
+    distilled: bool = False,
+    device: torch.device | str = "cuda",
+    dtype: torch.dtype = torch.bfloat16,
+    step_callback=None,
+    phase_callback=None,
+    seed: int | None = None,
+):
+    """Generate one PIL image from pre-encoded Krea2 sampling conditions."""
+
+    if phase_callback is not None:
+        phase_callback("sample")
+    latents = sample_latents(
+        model,
+        condition,
+        height=height,
+        width=width,
+        steps=steps,
+        cfg_scale=cfg_scale,
+        sampler_name=sampler_name,
+        scheduler=scheduler,
+        distilled=distilled,
+        device=device,
+        dtype=dtype,
+        seed=seed,
+        step_callback=step_callback,
+    )
+    if phase_callback is not None:
+        phase_callback("vae")
+    image = _decode_to_pil(vae, latents)
+    del latents
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return image

--- a/tests/test_krea2_sampling.py
+++ b/tests/test_krea2_sampling.py
@@ -1,0 +1,247 @@
+"""Krea2 FlowMatchEuler schedule, CFG convention, and image orchestration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from modeling.krea2 import Krea2Config, SingleStreamDiT
+from training.families.krea2.sampling import (
+    KREA2_RAW_GUIDANCE,
+    KREA2_RAW_STEPS,
+    KREA2_TURBO_GUIDANCE,
+    KREA2_TURBO_STEPS,
+    Krea2SamplingCondition,
+    align_krea2_resolution,
+    build_krea2_sigmas,
+    calculate_krea2_mu,
+    prepare_sampling_condition,
+    resolve_sampling_settings,
+    sample_image,
+    sample_latents,
+)
+from training.families.krea2.text_encoding import Krea2TextCondition
+
+
+def _condition(value: float, *, layers=2, width=4) -> Krea2TextCondition:
+    return Krea2TextCondition(
+        context=torch.full((1, 3, layers, width), value),
+        attention_mask=torch.tensor([[True, True, False]]),
+    )
+
+
+class _VelocityModel(nn.Module):
+    def __init__(self, *, channels=2, patch=2):
+        super().__init__()
+        self.config = SimpleNamespace(channels=channels, patch=patch)
+        self.calls = []
+
+    def forward(self, x, timesteps, context, attention_mask=None):
+        value = float(context[0, 0, 0, 0])
+        self.calls.append((value, timesteps.detach().clone(), attention_mask.clone()))
+        return torch.full_like(x, value)
+
+
+class _FakeVAE:
+    def decode(self, latents):
+        batch, _channels, frames, height, width = latents.shape
+        return torch.zeros(batch, 3, frames, height * 8, width * 8)
+
+
+def test_mu_matches_reference_endpoints_and_1024_anchor():
+    assert calculate_krea2_mu(256) == pytest.approx(0.5)
+    assert calculate_krea2_mu(4096) == pytest.approx(0.90625)
+    assert calculate_krea2_mu(6400) == pytest.approx(1.15)
+    assert calculate_krea2_mu(8000) > 1.15  # upstream does not endpoint-clamp
+
+
+def test_shifted_sigmas_match_exponential_mobius_schedule():
+    sigmas = build_krea2_sigmas(4096, 4)
+    base = torch.linspace(1.0, 0.0, 5)
+    shift = torch.tensor(0.90625).exp()
+    expected = shift * base / (1 + (shift - 1) * base)
+
+    torch.testing.assert_close(sigmas, expected)
+    assert sigmas[0] == 1
+    assert sigmas[-1] == 0
+    assert torch.all(sigmas[:-1] > sigmas[1:])
+
+
+def test_distilled_schedule_pins_mu_independent_of_resolution():
+    low = build_krea2_sigmas(256, 8, distilled=True)
+    high = build_krea2_sigmas(6400, 8, distilled=True)
+    raw_low = build_krea2_sigmas(256, 8, distilled=False)
+
+    torch.testing.assert_close(low, high)
+    assert not torch.equal(low, raw_low)
+
+
+def test_raw_and_turbo_defaults_and_sampler_validation():
+    assert resolve_sampling_settings(
+        distilled=False, steps=None, cfg_scale=None,
+        sampler_name=None, scheduler=None,
+    ) == (KREA2_RAW_STEPS, KREA2_RAW_GUIDANCE)
+    assert resolve_sampling_settings(
+        distilled=True, steps=None, cfg_scale=None,
+        sampler_name=None, scheduler=None,
+    ) == (KREA2_TURBO_STEPS, KREA2_TURBO_GUIDANCE)
+
+    with pytest.raises(ValueError, match="仅支持"):
+        resolve_sampling_settings(
+            distilled=False, steps=28, cfg_scale=4.5,
+            sampler_name="er_sde", scheduler="simple",
+        )
+
+
+def test_prepare_condition_only_encodes_negative_when_guidance_enabled():
+    calls = []
+    phases = []
+
+    class FakeTextStack:
+        def encode_text_for_batch(self, captions, *, device, dtype):
+            calls.append(list(captions))
+            batch = len(captions)
+            return Krea2TextCondition(
+                context=torch.arange(batch, dtype=dtype).view(batch, 1, 1, 1),
+                attention_mask=torch.ones(batch, 1, dtype=torch.bool),
+            )
+
+    guided = prepare_sampling_condition(
+        FakeTextStack(), "positive", negative_prompt=None, cfg_scale=4.5,
+        device="cpu", dtype=torch.float32, phase_callback=phases.append,
+    )
+    unguided = prepare_sampling_condition(
+        FakeTextStack(), "turbo", negative_prompt="ignored", cfg_scale=0,
+        device="cpu", dtype=torch.float32,
+    )
+
+    assert calls == [["positive", ""], ["turbo"]]
+    assert phases == ["clip"]
+    assert guided.negative is not None
+    assert unguided.negative is None
+
+
+def test_euler_uses_krea_guidance_and_reports_denoised_preview():
+    model = _VelocityModel()
+    condition = Krea2SamplingCondition(
+        positive=_condition(2.0),
+        negative=_condition(1.0),
+    )
+    initial = torch.zeros(1, 2, 1, 2, 2)
+    previews = []
+
+    output = sample_latents(
+        model,
+        condition,
+        height=16,
+        width=16,
+        steps=1,
+        cfg_scale=4.5,
+        device="cpu",
+        dtype=torch.float32,
+        latents=initial,
+        step_callback=lambda step, total, denoised: previews.append(
+            (step, total, denoised.clone())
+        ),
+    )
+
+    # cond + 4.5 * (cond - uncond) = 2 + 4.5 * (2 - 1) = 6.5
+    torch.testing.assert_close(output, torch.full_like(initial, -6.5))
+    torch.testing.assert_close(previews[0][2], torch.full_like(initial, -6.5))
+    assert previews[0][:2] == (0, 1)
+    assert [call[0] for call in model.calls] == [2.0, 1.0]
+    assert model.training  # caller's original mode is restored
+
+
+def test_turbo_default_disables_negative_forward_and_runs_eight_steps():
+    model = _VelocityModel()
+    model.eval()
+    condition = Krea2SamplingCondition(
+        positive=_condition(2.0),
+        negative=_condition(99.0),
+    )
+
+    output = sample_latents(
+        model,
+        condition,
+        height=16,
+        width=16,
+        distilled=True,
+        device="cpu",
+        dtype=torch.float32,
+        latents=torch.zeros(1, 2, 1, 2, 2),
+    )
+
+    # Krea g=0 means conditional-only (not unconditional and not standard CFG=0).
+    torch.testing.assert_close(output, torch.full_like(output, -2.0))
+    assert len(model.calls) == KREA2_TURBO_STEPS
+    assert all(call[0] == 2.0 for call in model.calls)
+    assert not model.training
+
+
+def test_sample_image_rounds_up_to_16_and_emits_phases():
+    model = _VelocityModel(channels=2, patch=2)
+    phases = []
+
+    image = sample_image(
+        model,
+        _FakeVAE(),
+        Krea2SamplingCondition(positive=_condition(0.0)),
+        height=17,
+        width=19,
+        steps=1,
+        cfg_scale=0,
+        device="cpu",
+        dtype=torch.float32,
+        phase_callback=phases.append,
+        seed=123,
+    )
+
+    assert align_krea2_resolution(17) == 32
+    assert align_krea2_resolution(32) == 32
+    assert image.size == (32, 32)
+    assert phases == ["sample", "vae"]
+
+
+def test_sampling_runs_through_real_tiny_krea2_forward():
+    config = Krea2Config(
+        features=64,
+        tdim=16,
+        txtdim=16,
+        heads=4,
+        multiplier=2,
+        layers=1,
+        patch=2,
+        channels=2,
+        bias=False,
+        theta=1000.0,
+        kvheads=2,
+        txtlayers=2,
+        txtheads=2,
+        txtkvheads=1,
+    )
+    model = SingleStreamDiT(config)
+    condition = Krea2SamplingCondition(
+        positive=Krea2TextCondition(
+            context=torch.randn(1, 3, 2, 16),
+            attention_mask=torch.tensor([[True, True, False]]),
+        )
+    )
+
+    output = sample_latents(
+        model,
+        condition,
+        height=16,
+        width=16,
+        steps=1,
+        cfg_scale=0,
+        device="cpu",
+        dtype=torch.float32,
+        latents=torch.zeros(1, 2, 1, 2, 2),
+    )
+
+    assert output.shape == (1, 2, 1, 2, 2)
+    assert torch.isfinite(output).all()


### PR DESCRIPTION
## 背景 / 动机

docs/design/multi-model/04-synthesis C1 已裁定：Krea2 的 FlowMatchEuler 动态 shift 数值栈整体归 `families/krea2/sampling.py`，不复用 Anima 的 Comfy `er_sde/dpmpp_3m_sde` registry；D14 则将推理 shift 归入 family sampling，与训练端 `krea2_shift` timestep sampler 保持不同接缝。

#417 已完成 Qwen3-VL varlen 文本栈及 TE 释放生命周期，但还没有把预编码条件送入真实 Krea2 Raw DiT 的推理路径。若直接复用 Anima sampling，会得到错误的 scheduler、CFG 公式和 latent 编排。

为保持一个 PR 一个完整 unit，本 PR 只闭环 Krea2 sampling 数值栈与 PIL decode 编排；仍不注册半成品 `Krea2Family`，不修改 schema/UI。

## Raw / Turbo 契约

| variant | steps | shift | guidance |
|---|---:|---|---|
| Raw | 28 | 按 image sequence length 动态插值 `mu` | `cond + 4.5 × (cond−uncond)` |
| Turbo / TDM | 8 | 固定 `mu=1.15` | `0`，即 conditional-only |

Krea 的 guidance scale 与常见 CFG 的数值差 1：`g=4.5` 等价于传统 `uncond + 5.5 × (cond−uncond)`；`g=0` 不是 unconditional，而是只跑 positive condition。

## 改动概要

- 新增族内 `families/krea2/sampling.py`：
  - `calculate_krea2_mu()`：在 image sequence length 256→6400 间线性映射 0.5→1.15，不做 endpoint clamp；
  - `build_krea2_sigmas()`：uniform `1→0` 网格经 `exp(mu)` Möbius shift；
  - `sample_latents()`：确定性 FlowMatchEuler，更新式为 `x_next = x + (sigma_next−sigma) × velocity`；
  - `sample_image()`：5D latent → 共享 Qwen-Image VAE → PIL。
- 分辨率向上对齐 `VAE stride 8 × DiT patch`，当前 Krea2 即 16px；与 diffusers/musubi 一致，不静默向下裁尺寸。
- CFG 使用 Krea 官方约定 `cond + g × (cond−uncond)`；positive/negative 分两次 forward，避免 32GB 上 CFG 合批导致 activation 峰值翻倍。
- 新增 `Krea2SamplingCondition`：sampling 消费预编码的 positive/negative 条件，不持有 tokenizer/TE。
- 新增 `prepare_sampling_condition()`：
  - guidance > 0 时一次请求 positive + negative；negative `None` 归一为空 prompt；
  - guidance = 0 时只编码 positive，Turbo 不做无用 negative forward；
  - cached 模式只读 #417 sidecar，online 模式仍由 TextStack 保持 TE 常驻。
- 保持调用方 model train/eval 状态；CPU seeded 初始噪声；step callback 收到 `x0 = x−sigma×velocity` 供中间预览。
- sampler/scheduler 严格限定 `euler+krea2_shift`，误传 Anima 的 `er_sde+simple` 时 fail-fast。
- 更新 Krea2 package exports 与 THIRD_PARTY_NOTICES。

## 真实模型验收

执行顺序严格模拟 32GB 目标路径：

1. 真实 Qwen3-VL-4B BF16 编码 prompt；
2. 将 `(L,12,2560)` condition 移到 CPU；
3. 释放 TE；
4. 严格加载 12.8B Krea2 Raw BF16；
5. 运行 64×64、1-step、guidance 0 的真实 Euler forward。

结果：

- 输出：`(1, 16, 1, 8, 8)`；
- dtype：bfloat16；
- 数值：全部 finite；
- DiT load + forward：20.63s；
- CUDA peak allocated：23.901 GiB；
- 释放后 allocated：0.009 GiB。

## 本 PR 边界

- 不注册 `Krea2Family` / `KREA2_SPEC`。
- 不修改 `TrainingConfig` 的 sampler/scheduler Literal、默认 steps/guidance 或 UI。
- 不修改共享 `inference_samplers/` registry；Krea2 Euler 明确保留族内。
- 不调整 models/text-cache phase 顺序；32GB 下“先 TE、后 DiT”的接线留给 family integration PR。
- 不实现 Turbo 权重加载/热切、训练 preview 调用方迁移、Generate/Daemon/RegAI 派发或 block swap。
- Anima sampling 行为完全不变。

## 外部来源与许可

- 分辨率对齐、动态 `mu`、指数 timestep shift 与 FlowMatchEuler 循环派生自 kohya-ss/musubi-tuner（Apache-2.0），固定 commit `8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6`：
  - https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/krea2/krea2_sampling.py
- Raw/TDM steps、固定 `mu=1.15`、Krea guidance 公式与 FlowMatchEuler scheduler 同时对照 Hugging Face diffusers（Apache-2.0），固定 commit `bc529a5f677db9c4b3fc72c76962c4e2f61567e1`：
  - https://github.com/huggingface/diffusers/blob/bc529a5f677db9c4b3fc72c76962c4e2f61567e1/src/diffusers/pipelines/krea2/pipeline_krea2.py
  - https://github.com/huggingface/diffusers/blob/bc529a5f677db9c4b3fc72c76962c4e2f61567e1/src/diffusers/schedulers/scheduling_flow_match_euler_discrete.py
- 本仓库的 `Krea2SamplingCondition`、TextStack 接线、5D model API 适配、callback/mode/PIL 编排为项目实现。
- 派生关系、版权与许可已写入文件头和 `THIRD_PARTY_NOTICES.md`。

## 测试

- `tests/test_krea2_sampling.py`：9 passed
- Krea2 / family related：75 passed
- CONTRIBUTING cross-cut safety net：33 passed
- `git diff --cached --check`：通过
- 真实 Qwen3-VL + Krea2 Raw BF16 一步 smoke：通过，数据见上
- 按项目本地测试规范未重复运行完整 suite；完整 backend/frontend 门禁交本 PR CI
- 前端未改动
