### PR TITLE
feat(train): Krea2 family 注册与接线（多模型 Phase 3）

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -55,11 +55,14 @@
     `runtime/anima_daemon.py`、`runtime/training/sample_runner.py`、
     `studio/api/routers/generate.py` — 将测试出图与训练 sample 接到 Comfy-style
     parity runtime 的本项目 glue/config 代码
-  - `runtime/anima_daemon.py` — 中间步预览的 `_WAN21_LATENT_RGB_FACTORS` /
-    `_WAN21_LATENT_RGB_BIAS` 常量取自 ComfyUI `comfy/latent_formats.py` 的 `Wan21`
-    （Qwen-Image VAE 复用 Wan2.1 latent 空间：`comfy/supported_models.py`
-    `QwenImage.latent_format = Wan21`）；`_decode_latent2rgb_preview` 的投影 + 范围
-    映射对齐 ComfyUI `latent_preview.py` `Latent2RGBPreviewer`
+  - `runtime/anima_daemon.py`、`runtime/training/families/anima/__init__.py`、
+    `runtime/training/families/krea2/__init__.py` — 中间步预览的
+    `_WAN21_LATENT_RGB_FACTORS` / `_WAN21_LATENT_RGB_BIAS` 常量取自 ComfyUI
+    `comfy/latent_formats.py` 的 `Wan21`（Qwen-Image VAE 复用 Wan2.1 latent 空间：
+    `comfy/supported_models.py` `QwenImage.latent_format = Wan21`；Anima 与 Krea2
+    同此 latent 空间，各自 `ModelSpec.latent.rgb_factors` 持同值）；
+    `_decode_latent2rgb_preview` 的投影 + 范围映射对齐 ComfyUI `latent_preview.py`
+    `Latent2RGBPreviewer`
 
 > 由于包含/派生自 GPL-3.0 代码，本项目整体以 GPL-3.0 发布（见 `LICENSE`）。
 

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -131,6 +131,7 @@ def main():
     phases.models.run(ctx)
     phases.dataset.run(ctx)
     phases.text_cache.run(ctx)
+    phases.models.finish(ctx)
     phases.optimizer.run(ctx)
     phases.resume.run(ctx)
     loop.run(ctx)

--- a/runtime/training/README.md
+++ b/runtime/training/README.md
@@ -10,6 +10,7 @@ def main():
     phases.models.run(ctx)
     phases.dataset.run(ctx)
     phases.text_cache.run(ctx)
+    phases.models.finish(ctx)
     phases.optimizer.run(ctx)
     phases.resume.run(ctx)
     loop.run(ctx)
@@ -81,7 +82,7 @@ runtime/training/
     │   ├── protocol.py     ← TimestepSamplerProtocol（可选 token_counts batch context）
     │   ├── baseline.py     ← sample_t 4 mode 的 thin wrapper（非自适应）
     │   ├── infonoise.py    ← InfoNoise I-MMSE 自适应采样器（arxiv 2602.18647）
-    │   ├── krea2_shift.py  ← Krea2 动态 resolution shift（Phase 3 family 接线前暂不暴露 schema）
+    │   ├── krea2_shift.py  ← Krea2 动态 resolution shift（按每图 token 数修正）
     │   └── __init__.py     ← BUILDERS + build_timestep_sampler
     │
     └── losses/             ← 训练 loss 类型（mse / huber / ...）
@@ -100,11 +101,13 @@ TrainingContext(args=args)             │
         ↓                              │
 phases.bootstrap.run(ctx)              │  填 device / dtype / output_dir / wandb / monitor
         ↓                              │
-phases.models.run(ctx)                 │  填 repo_root / model / vae / text_stack / injector
+phases.models.run(ctx)                 │  常规族填完整模型栈；cached_varlen 族先填 VAE / text_stack
         ↓                              ├─ 一次性 setup
 phases.dataset.run(ctx)                │  填 bucket_mgr / dataset / reg_dataset / dataloader
         ↓                              │
 phases.text_cache.run(ctx)             │  cached_varlen 族写随图 sidecar；online 族 no-op
+        ↓                              │
+phases.models.finish(ctx)              │  TE 释放后补载 deferred DiT + injector（常规族 no-op）
         ↓                              │
 phases.optimizer.run(ctx)              │  填 optimizer / scheduler / total_steps / trainable_params
         ↓                              │

--- a/runtime/training/families/README.md
+++ b/runtime/training/families/README.md
@@ -18,6 +18,8 @@
   凡这些之外的模型知识（文本编码、pad_mask、检查点展开、采样栈）归族内。
 - **共享代码禁止 `if family == "..."` 分支**——一律查 `spec.capabilities` 或 spec 字段。
 - 缓存指纹是 latent 空间身份（`wan21-f8c16`）而非族名：同空间的族自动共享缓存。
+- Krea2 的 `text_encoder_cache=true` 先预缓存并释放 Qwen3-VL、再加载 DiT；关闭时
+  完全不读写文本 sidecar，TE 与 DiT 常驻，供大显存/小磁盘云端逐 batch 编码。
 - 演化：方法追加参数一律 keyword-only 带默认值；禁止 `**kwargs`。
 
 ## 加第 3 个族的步骤

--- a/runtime/training/families/__init__.py
+++ b/runtime/training/families/__init__.py
@@ -19,6 +19,7 @@ from training.families.spec import (  # noqa: F401  (re-export)
     validate_spec,
 )
 from training.families.anima import ANIMA_SPEC
+from training.families.krea2 import KREA2_SPEC
 
 SPECS: dict[str, ModelSpec] = {}
 
@@ -31,6 +32,7 @@ def _register(spec: ModelSpec) -> None:
 
 
 _register(ANIMA_SPEC)
+_register(KREA2_SPEC)
 
 
 _FAMILIES: dict[str, object] = {}
@@ -45,6 +47,10 @@ def get_family(family_id: str):
             from training.families.anima.family import AnimaFamily
 
             fam = AnimaFamily()
+        elif family_id == "krea2":
+            from training.families.krea2 import Krea2Family
+
+            fam = Krea2Family()
         else:  # pragma: no cover - registry 与 SPECS 同步维护
             raise ValueError(f"模型族 '{family_id}' 缺少 ModelFamily 实现")
         _FAMILIES[family_id] = fam

--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -38,7 +38,8 @@ class AnimaFamily:
 
     def load_text(self, text_encoder_path, device, dtype, *,
                   t5_tokenizer_path: str = "", comfy_qwen: bool = False,
-                  t5_fast: bool = False, purpose: str = "train"):
+                  t5_fast: bool = False, purpose: str = "train",
+                  cache_enabled: bool = True):
         from training.families.anima.loader import load_text_encoders
 
         return load_text_encoders(
@@ -118,10 +119,10 @@ class AnimaFamily:
             use_checkpoint=use_checkpoint,
         )
 
-    def sample_image(self, *args, **kwargs):
+    def sample_image(self, model, vae, text, prompt, **kwargs):
         from training.families.anima.sampling import sample_image
 
-        return sample_image(*args, **kwargs)
+        return sample_image(model, vae, *text, prompt, **kwargs)
 
     # ── LoRA 产物 ────────────────────────────────────────────────────────
     def lora_preset(self) -> dict[str, Any]:

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -1,18 +1,225 @@
-"""Krea2 family implementation package (Phase 3, not registered yet)."""
+"""Krea2 ModelSpec and ModelFamily implementation (multi-model Phase 3)."""
 
-from training.families.krea2.text_encoding import (
-    Krea2TextCondition,
-    Krea2TextStack,
-    load_krea2_text_stack,
-)
+from __future__ import annotations
+
+import logging
+from typing import Any, Iterable
+
+from training.families.krea2.preset import KREA2_PRESET
 from training.families.krea2.sampling import (
+    KREA2_BASE_IMAGE_SEQ_LEN,
+    KREA2_BASE_SHIFT,
+    KREA2_MAX_IMAGE_SEQ_LEN,
+    KREA2_MAX_SHIFT,
+    KREA2_RAW_GUIDANCE,
+    KREA2_RAW_STEPS,
+    KREA2_SAMPLER,
+    KREA2_SCHEDULER,
     Krea2SamplingCondition,
     prepare_sampling_condition,
     sample_image,
 )
+from training.families.krea2.text_encoding import (
+    KREA2_TEXT_FINGERPRINT,
+    Krea2TextCondition,
+    Krea2TextStack,
+    load_krea2_text_stack,
+)
+from training.families.spec import (
+    LatentSpec,
+    LoraOutputSpec,
+    ModelSpec,
+    ResolutionAwareShift,
+    SamplingDefaults,
+    TextSpec,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# Krea2 与 Anima 共用 Qwen-Image VAE / Wan2.1 latent 空间。系数来自
+# ComfyUI comfy/latent_formats.py 的 Wan21；registry 测试锁死两族一致。
+_WAN21_RGB_FACTORS: tuple[tuple[float, float, float], ...] = (
+    (-0.1299, -0.1692, 0.2932),
+    (0.0671, 0.0406, 0.0442),
+    (0.3568, 0.2548, 0.1747),
+    (0.0372, 0.2344, 0.1420),
+    (0.0313, 0.0189, -0.0328),
+    (0.0296, -0.0956, -0.0665),
+    (-0.3477, -0.4059, -0.2925),
+    (0.0166, 0.1902, 0.1975),
+    (-0.0412, 0.0267, -0.1364),
+    (-0.1293, 0.0740, 0.1636),
+    (0.0680, 0.3019, 0.1128),
+    (0.0032, 0.0581, 0.0639),
+    (-0.1251, 0.0927, 0.1699),
+    (0.0060, -0.0633, 0.0005),
+    (0.3477, 0.2275, 0.2950),
+    (0.1984, 0.0913, 0.1861),
+)
+_WAN21_RGB_BIAS = (-0.1835, -0.0868, -0.3360)
+
+
+KREA2_SPEC = ModelSpec(
+    family_id="krea2",
+    display_name="Krea 2",
+    objective="rectified_flow",
+    latent=LatentSpec(
+        fingerprint="wan21-f8c16",
+        channels=16,
+        spatial_stride=8,
+        patch_spatial=2,
+        patch_temporal=1,
+        temporal=False,
+        rgb_factors=_WAN21_RGB_FACTORS,
+        rgb_bias=_WAN21_RGB_BIAS,
+    ),
+    text=TextSpec(
+        strategy="cached_varlen",
+        max_seq_len=512,
+        fingerprint=KREA2_TEXT_FINGERPRINT,
+    ),
+    sampling=SamplingDefaults(
+        samplers=(KREA2_SAMPLER,),
+        schedulers=(KREA2_SCHEDULER,),
+        default_sampler=KREA2_SAMPLER,
+        default_scheduler=KREA2_SCHEDULER,
+        default_steps=KREA2_RAW_STEPS,
+        default_cfg=KREA2_RAW_GUIDANCE,
+        shift_policy=ResolutionAwareShift(
+            base_shift=KREA2_BASE_SHIFT,
+            max_shift=KREA2_MAX_SHIFT,
+            base_image_seq_len=KREA2_BASE_IMAGE_SEQ_LEN,
+            max_image_seq_len=KREA2_MAX_IMAGE_SEQ_LEN,
+        ),
+    ),
+    capabilities=frozenset({"masked_loss", "text_cache"}),
+    lora=LoraOutputSpec(prefix="lora_unet", preset_name="krea2_full"),
+    config_defaults={
+        "shuffle_caption": False,
+        "keep_tokens": 0,
+        "tag_dropout": 0.0,
+        "text_encoder_cache": True,
+        "attention_backend": "none",
+        "timestep_sampling": "krea2_shift",
+        "timestep_shift_resolution_aware": False,
+        "sample_sampler_name": KREA2_SAMPLER,
+        "sample_scheduler": KREA2_SCHEDULER,
+        "sample_infer_steps": KREA2_RAW_STEPS,
+        "sample_cfg_scale": KREA2_RAW_GUIDANCE,
+    },
+)
+
+
+class Krea2Family:
+    spec = KREA2_SPEC
+
+    def load_dit(self, path, device, dtype, *,
+                 attention_backend: str = "flash_attn", repo_root=None):
+        from training.families.krea2.loader import load_krea2_model
+
+        if attention_backend != "none":
+            logger.info(
+                "Krea2 当前固定使用 PyTorch SDPA；忽略 attention_backend=%s",
+                attention_backend,
+            )
+        return load_krea2_model(path, device, dtype)
+
+    def load_vae(self, path, device, dtype, *, tiling: str = "auto"):
+        from training.vae import load_vae
+
+        return load_vae(path, device, dtype, None, tiling=tiling)
+
+    def load_text(self, text_encoder_path, device, dtype, *,
+                  t5_tokenizer_path: str = "", comfy_qwen: bool = False,
+                  t5_fast: bool = False, purpose: str = "train",
+                  cache_enabled: bool = True):
+        return load_krea2_text_stack(
+            text_encoder_path,
+            device=device,
+            dtype=dtype,
+            cache_enabled=cache_enabled,
+        )
+
+    def prepare_text_cache(self, captions: Iterable[str],
+                           extra_prompts: Iterable[str], *, cache_entries=(),
+                           cache_root=None, text=None, device=None,
+                           dtype=None) -> None:
+        if text is None:
+            raise ValueError("Krea2 prepare_text_cache 需要 Krea2TextStack")
+        text.prepare_text_cache(
+            captions,
+            extra_prompts,
+            cache_entries=cache_entries,
+            cache_root=cache_root,
+        )
+
+    def encode_text_for_batch(self, text, dit, captions, device, dtype, *,
+                              comfy_encoding: bool = True,
+                              kv_trim: bool = True):
+        return text.encode_text_for_batch(captions, device=device, dtype=dtype)
+
+    def forward_train(self, dit, noisy, t, cond, *, use_checkpoint: bool = False):
+        return dit(
+            noisy,
+            t,
+            cond.context,
+            attention_mask=cond.attention_mask,
+            use_checkpoint=use_checkpoint,
+        )
+
+    def sample_image(self, model, vae, text, prompt, *,
+                     height: int = 1024, width: int = 1024,
+                     steps: int | None = None,
+                     cfg_scale: float = KREA2_RAW_GUIDANCE,
+                     negative_prompt: str = "",
+                     sampler_name: str | None = None,
+                     scheduler: str | None = None,
+                     device="cuda", dtype=None, step_callback=None,
+                     phase_callback=None, seed: int | None = None):
+        condition = prepare_sampling_condition(
+            text,
+            prompt,
+            negative_prompt=negative_prompt,
+            cfg_scale=cfg_scale,
+            device=device,
+            dtype=dtype,
+            phase_callback=phase_callback,
+        )
+        return sample_image(
+            model,
+            vae,
+            condition,
+            height=height,
+            width=width,
+            steps=steps,
+            cfg_scale=cfg_scale,
+            sampler_name=sampler_name,
+            scheduler=scheduler,
+            device=device,
+            dtype=dtype,
+            step_callback=step_callback,
+            phase_callback=phase_callback,
+            seed=seed,
+        )
+
+    def lora_preset(self) -> dict[str, Any]:
+        return KREA2_PRESET
+
+    def lora_metadata(self) -> dict[str, str]:
+        return {
+            "model_family": self.spec.family_id,
+            "preset": self.spec.lora.preset_name,
+        }
+
+    def convert_lora_state_dict(self, sd: dict) -> dict:
+        return sd
 
 
 __all__ = [
+    "KREA2_SPEC",
+    "Krea2Family",
     "Krea2SamplingCondition",
     "Krea2TextCondition",
     "Krea2TextStack",

--- a/runtime/training/families/protocol.py
+++ b/runtime/training/families/protocol.py
@@ -28,7 +28,8 @@ class ModelFamily(Protocol):
 
     def load_text(self, text_encoder_path: str, device, dtype, *,
                   t5_tokenizer_path: str = "", comfy_qwen: bool = False,
-                  t5_fast: bool = False, purpose: str = "train") -> Any: ...
+                  t5_fast: bool = False, purpose: str = "train",
+                  cache_enabled: bool = True) -> Any: ...
 
     # ── 文本条件 ─────────────────────────────────────────────────────────
     def prepare_text_cache(self, captions: Iterable[str],
@@ -37,7 +38,8 @@ class ModelFamily(Protocol):
                            dtype=None) -> None: ...
 
     def encode_text_for_batch(self, text, dit, captions: list[str],
-                              device, dtype, *, kv_trim: bool = True) -> Any: ...
+                              device, dtype, *, comfy_encoding: bool = True,
+                              kv_trim: bool = True) -> Any: ...
 
     # ── 训练前向 / 采样 ──────────────────────────────────────────────────
     def forward_train(self, dit, noisy, t, cond, *, use_checkpoint: bool = False): ...

--- a/runtime/training/phases/__init__.py
+++ b/runtime/training/phases/__init__.py
@@ -1,8 +1,9 @@
 """训练 main() 的 phase 拆分（ADR 0003 PR-B）。
 
 每个 phase 是个 `run(ctx: TrainingContext) -> None` 函数，in-place mutate ctx。
-main() 编排成：bootstrap → models → dataset → text_cache → optimizer → resume →
-train_loop → finalize。
+main() 编排成：bootstrap → models.run → dataset → text_cache → models.finish →
+optimizer → resume → train_loop → finalize。``models.finish`` 只为缓存后延迟加载
+DiT 的族补齐模型栈，其余族是 no-op。
 """
 
 from training.phases import bootstrap, dataset, finalize, models, optimizer, resume, text_cache

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -1,6 +1,8 @@
-"""models_phase：path resolve + transformer/vae/text_encoders + LoRA inject。
+"""models_phase: paths + family-owned weights + LoRA injection.
 
-抽自 main() L187-255（ADR 0003 PR-B）。
+Cached-varlen families may defer their large DiT until dataset captions have
+been cached and the text encoder released. ``finish(ctx)`` closes that deferred
+half immediately after ``text_cache`` and before optimizer construction.
 """
 
 from __future__ import annotations
@@ -9,8 +11,8 @@ import logging
 from pathlib import Path
 
 from training.context import TrainingContext
-from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC
 from training.families import resolve_family
+from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC
 from training.model_loading import (
     find_diffusion_pipe_root,
     resolve_path_best_effort,
@@ -20,27 +22,14 @@ from training.model_loading import (
 logger = logging.getLogger(__name__)
 
 
-def run(ctx: TrainingContext) -> None:
-    """
-    - find_diffusion_pipe_root + path resolution（args 路径多 base 兜底）
-    - 按 attention_backend 加载 transformer + xformers / flash_attn / sdpa
-    - 加载 vae + text encoders
-    - 注入 LoRA + 可选 resume_lora
-    """
+def _resolve_paths(ctx: TrainingContext) -> None:
     args = ctx.args
-    if ctx.family is None:
-        ctx.family = resolve_family(args)
-
-    # 查找模型代码
     ctx.repo_root = find_diffusion_pipe_root()
-    logger.info(f"模型代码路径: {ctx.repo_root}")
+    logger.info("模型代码路径: %s", ctx.repo_root)
 
-    # 解析路径：相对路径优先按 config 位置 / AnimaLoraToolkit 目录解析
-    # 注：原 main() 用 Path(__file__).resolve().parent 拿 runtime/；本模块在
-    # runtime/training/phases/ 下，往上两级才是 runtime/，三级是 repo_root。
-    phases_dir = Path(__file__).resolve().parent           # runtime/training/phases
-    training_dir = phases_dir.parent                        # runtime/training
-    runtime_dir = training_dir.parent                       # runtime
+    phases_dir = Path(__file__).resolve().parent
+    training_dir = phases_dir.parent
+    runtime_dir = training_dir.parent
     bases = [
         Path.cwd(),
         ctx.config_dir,
@@ -59,54 +48,79 @@ def run(ctx: TrainingContext) -> None:
     if reg_data_dir:
         args.reg_data_dir = resolve_path_best_effort(reg_data_dir, bases)
 
-    # 经 ModelFamily 派发（D8'）；attention backend 决策收进 family.load_dit
+
+def _load_dit(ctx: TrainingContext) -> None:
+    args = ctx.args
     backend = getattr(args, "attention_backend", "flash_attn")
     if backend == "none":
-        logger.info("attention_backend=none，flash_attn / xformers 都不启用，走 PyTorch SDPA")
-
+        logger.info(
+            "attention_backend=none，flash_attn / xformers 都不启用，走 PyTorch SDPA"
+        )
     logger.info("加载 Transformer...")
     ctx.model = ctx.family.load_dit(
-        args.transformer_path, ctx.device, ctx.dtype,
-        attention_backend=backend, repo_root=ctx.repo_root,
+        args.transformer_path,
+        ctx.device,
+        ctx.dtype,
+        attention_backend=backend,
+        repo_root=ctx.repo_root,
     )
 
-    logger.info("加载 VAE...")
-    ctx.vae = ctx.family.load_vae(args.vae_path, ctx.device, ctx.vae_dtype,
-                                  tiling=getattr(args, "vae_tiling", "auto"))
 
+def _load_vae(ctx: TrainingContext) -> None:
+    args = ctx.args
+    logger.info("加载 VAE...")
+    ctx.vae = ctx.family.load_vae(
+        args.vae_path,
+        ctx.device,
+        ctx.vae_dtype,
+        tiling=getattr(args, "vae_tiling", "auto"),
+    )
+
+
+def _load_text(ctx: TrainingContext) -> None:
+    args = ctx.args
     logger.info("加载文本编码器...")
     ctx.text_stack = ctx.family.load_text(
-        args.text_encoder_path, ctx.device, ctx.dtype,
+        args.text_encoder_path,
+        ctx.device,
+        ctx.dtype,
         t5_tokenizer_path=args.t5_tokenizer_path,
+        cache_enabled=bool(getattr(args, "text_encoder_cache", True)),
     )
 
-    # 注入 LoRA — PR-C 通过 adapters/ plugin registry 派发，加新变体见
-    # training/adapters/__init__.py docstring
-    logger.info(f"注入 {args.lora_type.upper()}...")
+
+def _inject_adapter(ctx: TrainingContext) -> None:
+    args = ctx.args
+    logger.info("注入 %s...", args.lora_type.upper())
     from training.adapters import build_adapter
+
     ctx.injector = build_adapter(args, preset=ctx.family.lora_preset())
-    ctx.injector.metadata_extra = ctx.family.lora_metadata()  # D13：产物族标记
+    ctx.injector.metadata_extra = ctx.family.lora_metadata()
     ctx.injector.inject(ctx.model)
 
-    # 从已有 LoRA 继续训练（D13：跨族 fail-fast；无标记存量产物 grandfather 为 anima）
     if getattr(args, "resume_lora", "") and Path(args.resume_lora).exists():
-        _lora_family = _read_lora_family(args.resume_lora)
-        if _lora_family != ctx.family.spec.family_id:
+        lora_family = _read_lora_family(args.resume_lora)
+        if lora_family != ctx.family.spec.family_id:
             raise RuntimeError(
-                f"resume_lora 跨模型族被拒绝：{args.resume_lora} 属于 '{_lora_family}'，"
+                f"resume_lora 跨模型族被拒绝：{args.resume_lora} 属于 '{lora_family}'，"
                 f"当前 model_family='{ctx.family.spec.family_id}'"
             )
         ctx.injector.load(args.resume_lora)
-        logger.info(f"将从已有 LoRA 继续训练: {args.resume_lora}")
+        logger.info("将从已有 LoRA 继续训练: %s", args.resume_lora)
 
-    # SRA v2 表征对齐（LoRA 注入后构造）
     if getattr(args, "sra_enabled", False):
         from training.families.anima.sra_align import SRAAligner
+
         model_channels = ctx.model.model_channels
         block_idx = int(getattr(args, "sra_block", 4))
         num_blocks = len(ctx.model.blocks)
         if block_idx >= num_blocks:
-            logger.warning(f"sra_block={block_idx} >= 模型 blocks 数({num_blocks})，clamp 到 {num_blocks - 1}")
+            logger.warning(
+                "sra_block=%d >= 模型 blocks 数(%d)，clamp 到 %d",
+                block_idx,
+                num_blocks,
+                num_blocks - 1,
+            )
             block_idx = num_blocks - 1
         ctx.sra_aligner = SRAAligner(
             model=ctx.model,
@@ -121,15 +135,53 @@ def run(ctx: TrainingContext) -> None:
         )
 
 
+def _defer_dit_for_text_cache(ctx: TrainingContext) -> bool:
+    return (
+        ctx.family.spec.text.strategy == "cached_varlen"
+        and bool(getattr(ctx.args, "text_encoder_cache", True))
+    )
+
+
+def run(ctx: TrainingContext) -> None:
+    """Resolve paths and load either the complete stack or the cache-first half."""
+    if ctx.family is None:
+        ctx.family = resolve_family(ctx.args)
+    _resolve_paths(ctx)
+
+    if _defer_dit_for_text_cache(ctx):
+        logger.info(
+            "文本缓存已开启：先加载 VAE/Qwen3-VL，缓存并释放 TE 后再加载 Transformer"
+        )
+        _load_vae(ctx)
+        _load_text(ctx)
+        return
+
+    # Preserve the historical Anima order. Storage-free Krea2 deliberately keeps
+    # the DiT resident while its text encoder is loaded for per-batch encoding.
+    _load_dit(ctx)
+    _load_vae(ctx)
+    _load_text(ctx)
+    _inject_adapter(ctx)
+
+
+def finish(ctx: TrainingContext) -> None:
+    """Load/inject a DiT deferred by cached text preparation; otherwise no-op."""
+    if ctx.model is not None:
+        return
+    logger.info("文本缓存完成且文本编码器已释放；继续加载 Transformer...")
+    _load_dit(ctx)
+    _inject_adapter(ctx)
+
+
 def _read_lora_family(path) -> str:
-    """从 safetensors metadata 读产物所属族；无标记 grandfather 为 anima（D13）。"""
+    """Read artifact family; legacy unmarked safetensors grandfather to Anima."""
     import json
 
     from safetensors import safe_open
 
     try:
-        with safe_open(str(path), framework="pt", device="cpu") as f:
-            meta = f.metadata() or {}
+        with safe_open(str(path), framework="pt", device="cpu") as handle:
+            meta = handle.metadata() or {}
         args = json.loads(meta.get("ss_network_args") or "{}")
         return str(args.get("model_family") or "anima")
     except Exception:

--- a/runtime/training/phases/text_cache.py
+++ b/runtime/training/phases/text_cache.py
@@ -84,6 +84,19 @@ def run(ctx: TrainingContext) -> None:
     if strategy != "cached_varlen":  # registry 正常会先拦，这里保留可操作错误
         raise ValueError(f"未知文本策略: {strategy!r}")
 
+    if not bool(getattr(ctx.args, "text_encoder_cache", True)):
+        logger.info(
+            "[text-cache] 缓存已关闭：不扫描/读写 sidecar，文本编码器常驻并逐 batch 编码"
+        )
+        ctx.family.prepare_text_cache(
+            [],
+            [],
+            text=ctx.text_stack,
+            device=ctx.device,
+            dtype=ctx.dtype,
+        )
+        return
+
     entries = _collect_entries(ctx)
     captions = [entry.caption for entry in entries]
     extras = _extra_prompts(ctx.args)

--- a/runtime/training/sample_runner.py
+++ b/runtime/training/sample_runner.py
@@ -17,8 +17,6 @@ from typing import Optional
 import torch
 
 from training.context import TrainingContext
-from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC
-from training.families.anima.sampling import sample_image
 from utils.optimizer_utils import optimizer_eval_mode
 
 
@@ -53,15 +51,26 @@ def run_sample(
     s_h = int(getattr(args, "sample_height", 0) or 0) or base_reso
     # 必须 align_px（VAE stride 8 × patch_spatial 2 = 16）的倍数，
     # 否则 cosmos_predict2 spatial_patch 断言失败
-    _align = _ANIMA_SPEC.latent.align_px
+    spec = ctx.family.spec
+    _align = spec.latent.align_px
     s_w = max(_align, (s_w // _align) * _align)
     s_h = max(_align, (s_h // _align) * _align)
-    s_cfg = float(getattr(args, "sample_cfg_scale", 4.0) or 4.0)
+    s_cfg_value = getattr(args, "sample_cfg_scale", spec.sampling.default_cfg)
+    s_cfg = float(spec.sampling.default_cfg if s_cfg_value is None else s_cfg_value)
     s_neg = str(getattr(args, "sample_negative_prompt", "") or "")
     s_seed = int(getattr(args, "sample_seed", 0) or 0)
-    s_steps = int(getattr(args, "sample_infer_steps", 25) or 25)
-    s_sampler = str(getattr(args, "sample_sampler_name", "er_sde") or "er_sde")
-    s_sched = str(getattr(args, "sample_scheduler", "simple") or "simple")
+    s_steps = int(
+        getattr(args, "sample_infer_steps", spec.sampling.default_steps)
+        or spec.sampling.default_steps
+    )
+    s_sampler = str(
+        getattr(args, "sample_sampler_name", spec.sampling.default_sampler)
+        or spec.sampling.default_sampler
+    )
+    s_sched = str(
+        getattr(args, "sample_scheduler", spec.sampling.default_scheduler)
+        or spec.sampling.default_scheduler
+    )
 
     # T-LoRA：与 ControlGenAI/T-LoRA 官方推理一致 —— sample 阶段不应用 timestep
     # mask。官方 inferencer 不传 sigma_mask, forward 内 fallback 出全 1 mask =
@@ -78,8 +87,8 @@ def run_sample(
             ctx.model.eval()
             if s_seed:
                 torch.manual_seed(s_seed + seed_offset)
-            img = sample_image(
-                ctx.model, ctx.vae, *ctx.text_stack,
+            img = ctx.family.sample_image(
+                ctx.model, ctx.vae, ctx.text_stack,
                 prompt, height=s_h, width=s_w, steps=s_steps, cfg_scale=s_cfg,
                 negative_prompt=s_neg,
                 sampler_name=s_sampler,

--- a/studio/domain/common.py
+++ b/studio/domain/common.py
@@ -22,6 +22,26 @@ FAMILY_CAPABILITIES: dict[str, frozenset] = {
         "navit", "sra", "leap", "compile_blocks",
         "caption_tag_ops", "online_text", "masked_loss",
     }),
+    "krea2": frozenset({"masked_loss", "text_cache"}),
+}
+
+# ModelSpec.config_defaults 的 studio 镜像。server 不反向 import runtime；同步由
+# tests/test_model_family_gating.py 双向锁死。只在字段缺失时 overlay，显式配置不改写。
+FAMILY_CONFIG_DEFAULTS: dict[str, dict[str, Any]] = {
+    "anima": {},
+    "krea2": {
+        "shuffle_caption": False,
+        "keep_tokens": 0,
+        "tag_dropout": 0.0,
+        "text_encoder_cache": True,
+        "attention_backend": "none",
+        "timestep_sampling": "krea2_shift",
+        "timestep_shift_resolution_aware": False,
+        "sample_sampler_name": "euler",
+        "sample_scheduler": "krea2_shift",
+        "sample_infer_steps": 28,
+        "sample_cfg_scale": 4.5,
+    },
 }
 
 #: schema model_family Literal 的值域（顺序即 UI 下拉顺序）

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -17,7 +17,13 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from .common import AttentionBackend, _meta, cap_gate, capability_violations
+from .common import (
+    AttentionBackend,
+    FAMILY_CONFIG_DEFAULTS,
+    _meta,
+    cap_gate,
+    capability_violations,
+)
 from .migrations import migrate_legacy_save_keys, migrate_noise_enhancement_type
 
 
@@ -35,10 +41,9 @@ class TrainingConfig(BaseModel):
     # Train 页看到的总是无歧义的绝对路径，不用考虑相对路径锚定。
     # 这里的默认值仅 fallback：裸 CLI 跑训练 + yaml 完全没填时，按 repo
     # 相对路径解析（与历史行为一致）。
-    model_family: Literal["anima"] = Field(
+    model_family: Literal["anima", "krea2"] = Field(
         "anima",
-        description="模型族。决定训练走哪套模型实现；其余字段按族能力自动显隐（多模型 D7，"
-                    "当前仅 Anima，Krea 2 随 Phase 3 加入）",
+        description="模型族。决定训练走哪套模型实现；其余字段按族能力自动显隐",
         json_schema_extra=_meta("model", advanced=True),
     )
     transformer_path: str = Field(
@@ -61,6 +66,13 @@ class TrainingConfig(BaseModel):
         description="T5 tokenizer 目录（Anima 族专用）",
         json_schema_extra=_meta("model", "path", cli_alias="--t5-tokenizer",
                                 show_when="model_family==anima"),
+    )
+    text_encoder_cache: bool = Field(
+        True,
+        description="预缓存文本条件并释放文本编码器（推荐，节省约 9GB 显存）；关闭后不读写文本 sidecar，Qwen3-VL 常驻并逐 batch 编码，适合大显存但磁盘紧张的云端",
+        json_schema_extra=_meta(
+            "model", show_when=cap_gate("text_cache"), advanced=True,
+        ),
     )
 
     # ----------------------------------------------------------------- 数据集
@@ -601,9 +613,10 @@ class TrainingConfig(BaseModel):
         "mode",
         "mixed_uniform_low",
         "mixed_uniform_logit",
+        "krea2_shift",
     ] = Field(
         "logit_normal",
-        description="采样分布。logit_normal 偏中段（SD3/Anima 默认）；uniform 等概率；mode 单峰偏移；mixed_* 混合 uniform 与偏置端（比例由 timestep_mix_low_prob 控制）",
+        description="采样分布。logit_normal 偏中段（SD3/Anima 默认）；krea2_shift 按每图 token 数动态 shift；uniform 等概率；mode 单峰偏移；mixed_* 混合 uniform 与偏置端（比例由 timestep_mix_low_prob 控制）",
         json_schema_extra=_meta(
             "timestep_sampling",
             alt_description="【时间步采样】InfoNoise 启用时作为热身期 baseline，正式阶段由自适应 CDF 接管；Leap 启用时 leap 路径恒用 U(0,1)，本字段仅作用于 (1-leap_ratio) 比例的标准 step",
@@ -910,6 +923,18 @@ class TrainingConfig(BaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def _apply_family_config_defaults(cls, data: Any) -> Any:
+        """Overlay ModelSpec defaults only when a family-specific field is absent."""
+        if not isinstance(data, dict):
+            return data
+        payload = dict(data)
+        family = str(payload.get("model_family") or "anima")
+        for field, value in FAMILY_CONFIG_DEFAULTS.get(family, {}).items():
+            payload.setdefault(field, value)
+        return payload
+
+    @model_validator(mode="before")
+    @classmethod
     def _migrate_save_keys(cls, data: Any) -> Any:
         return migrate_legacy_save_keys(data)
 
@@ -925,10 +950,21 @@ class TrainingConfig(BaseModel):
         config 可能存了其他值（如 euler，当年走 inline Euler 兜底）。统一
         归并到默认值而不是让整个 config 加载失败。"""
         if isinstance(data, dict):
-            if data.get("sample_sampler_name") not in (None, "er_sde", "dpmpp_3m_sde"):
-                data["sample_sampler_name"] = "er_sde"
-            if data.get("sample_scheduler") not in (None, "simple", "sgm_uniform"):
-                data["sample_scheduler"] = "simple"
+            family = str(data.get("model_family") or "anima")
+            if family == "krea2":
+                samplers = (None, "euler")
+                schedulers = (None, "krea2_shift")
+                default_sampler = "euler"
+                default_scheduler = "krea2_shift"
+            else:
+                samplers = (None, "er_sde", "dpmpp_3m_sde")
+                schedulers = (None, "simple", "sgm_uniform")
+                default_sampler = "er_sde"
+                default_scheduler = "simple"
+            if data.get("sample_sampler_name") not in samplers:
+                data["sample_sampler_name"] = default_sampler
+            if data.get("sample_scheduler") not in schedulers:
+                data["sample_scheduler"] = default_scheduler
         return data
 
     @model_validator(mode="before")
@@ -1215,13 +1251,13 @@ class TrainingConfig(BaseModel):
         description="CFG Scale",
         json_schema_extra=_meta("sample"),
     )
-    sample_sampler_name: Literal["er_sde", "dpmpp_3m_sde"] = Field(
+    sample_sampler_name: Literal["er_sde", "dpmpp_3m_sde", "euler"] = Field(
         "er_sde",
         description="采样器。er_sde 默认；dpmpp_3m_sde 与 ComfyUI 同款"
                     "（BrownianTree 噪声，需要 torchsde）",
         json_schema_extra=_meta("sample"),
     )
-    sample_scheduler: Literal["simple", "sgm_uniform"] = Field(
+    sample_scheduler: Literal["simple", "sgm_uniform", "krea2_shift"] = Field(
         "simple",
         description="调度器。simple 默认；sgm_uniform 为 ComfyUI 的 SGM 均匀切分",
         json_schema_extra=_meta("sample"),

--- a/tests/test_comfy_parity_contract.py
+++ b/tests/test_comfy_parity_contract.py
@@ -88,8 +88,12 @@ def test_training_config_caption_comfy_encoding_default_true() -> None:
 def test_training_config_sampler_scheduler_are_enums() -> None:
     """收紧为 Literal 后 UI 自动渲染下拉，非法值在 config 层就挡掉。"""
     schema = TrainingConfig.model_json_schema()
-    assert set(schema["properties"]["sample_sampler_name"]["enum"]) == {"er_sde", "dpmpp_3m_sde"}
-    assert set(schema["properties"]["sample_scheduler"]["enum"]) == {"simple", "sgm_uniform"}
+    assert set(schema["properties"]["sample_sampler_name"]["enum"]) == {
+        "er_sde", "dpmpp_3m_sde", "euler",
+    }
+    assert set(schema["properties"]["sample_scheduler"]["enum"]) == {
+        "simple", "sgm_uniform", "krea2_shift",
+    }
 
 
 def test_training_config_coerces_legacy_sampler_values() -> None:

--- a/tests/test_family_assets.py
+++ b/tests/test_family_assets.py
@@ -17,7 +17,6 @@ def test_family_assets_cover_runtime_families():
 
     assert set(FAMILY_CAPABILITIES) == set(SPECS)
     assert set(FAMILY_ASSETS) >= set(SPECS)
-    assert set(FAMILY_ASSETS) - set(SPECS) == {"krea2"}
 
 
 def test_get_assets_unknown_lists_registered():

--- a/tests/test_krea2_family_integration.py
+++ b/tests/test_krea2_family_integration.py
@@ -1,0 +1,67 @@
+"""Krea2 family registration and cache-aware model loading lifecycle."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from training.context import TrainingContext
+from training.families.krea2 import KREA2_SPEC
+from training.phases import models
+
+
+def _ctx(*, cache_enabled: bool) -> TrainingContext:
+    args = SimpleNamespace(text_encoder_cache=cache_enabled)
+    family = SimpleNamespace(spec=KREA2_SPEC)
+    return TrainingContext(args=args, family=family)
+
+
+def _patch_loaders(monkeypatch, events: list[str]) -> None:
+    monkeypatch.setattr(models, "_resolve_paths", lambda ctx: events.append("paths"))
+
+    def load_dit(ctx):
+        events.append("dit")
+        ctx.model = object()
+
+    def load_vae(ctx):
+        events.append("vae")
+        ctx.vae = object()
+
+    def load_text(ctx):
+        events.append("text")
+        ctx.text_stack = object()
+
+    def inject(ctx):
+        events.append("inject")
+        ctx.injector = object()
+
+    monkeypatch.setattr(models, "_load_dit", load_dit)
+    monkeypatch.setattr(models, "_load_vae", load_vae)
+    monkeypatch.setattr(models, "_load_text", load_text)
+    monkeypatch.setattr(models, "_inject_adapter", inject)
+
+
+def test_cached_krea2_defers_dit_until_after_text_cache(monkeypatch):
+    events: list[str] = []
+    _patch_loaders(monkeypatch, events)
+    ctx = _ctx(cache_enabled=True)
+
+    models.run(ctx)
+    assert events == ["paths", "vae", "text"]
+    assert ctx.model is None
+
+    events.append("text-cache-release")
+    models.finish(ctx)
+    assert events == [
+        "paths", "vae", "text", "text-cache-release", "dit", "inject",
+    ]
+
+
+def test_storage_free_krea2_keeps_dit_and_te_resident(monkeypatch):
+    events: list[str] = []
+    _patch_loaders(monkeypatch, events)
+    ctx = _ctx(cache_enabled=False)
+
+    models.run(ctx)
+    models.finish(ctx)
+
+    assert events == ["paths", "dit", "vae", "text", "inject"]

--- a/tests/test_lycoris_tlora.py
+++ b/tests/test_lycoris_tlora.py
@@ -148,6 +148,7 @@ def test_run_sample_clears_tlora_mask() -> None:
     用 stub injector 验证 hook 被调；不实际跑模型。"""
     from unittest.mock import MagicMock
     from runtime.training import sample_runner as sr
+    from runtime.training.families.anima import ANIMA_SPEC
     from runtime.training.sample_runner import run_sample
 
     clear_called = {"n": 0}
@@ -175,8 +176,11 @@ def test_run_sample_clears_tlora_mask() -> None:
     ctx.monitor_server = None
     ctx.dtype = torch.float32
     ctx.device = torch.device("cpu")
+    # 采样经 ctx.family 派发：spec 要真的（run_sample 拿 align_px / 采样默认值
+    # 做算术），出图本身由 MagicMock ctx 自动 stub 掉，不真跑模型。
+    ctx.family.spec = ANIMA_SPEC
 
-    # stub 掉 sample_image / optimizer_eval_mode，让 run_sample 不真跑模型
+    # stub 掉 optimizer_eval_mode
     from contextlib import contextmanager
 
     @contextmanager
@@ -184,16 +188,13 @@ def test_run_sample_clears_tlora_mask() -> None:
         yield
 
     orig_eval = sr.optimizer_eval_mode
-    orig_sample = sr.sample_image
     sr.optimizer_eval_mode = _noop_ctx  # type: ignore[assignment]
-    sr.sample_image = MagicMock(return_value=MagicMock(save=MagicMock()))  # type: ignore[assignment]
     ctx.emit = MagicMock()
 
     try:
         run_sample(ctx, prompt="x", sample_path=MagicMock())
     finally:
         sr.optimizer_eval_mode = orig_eval  # type: ignore[assignment]
-        sr.sample_image = orig_sample  # type: ignore[assignment]
 
     assert clear_called["n"] == 1, (
         "run_sample 必须调 injector.clear_timestep_mask() 让 sample 走满 rank"
@@ -205,6 +206,7 @@ def test_run_sample_no_clear_method_does_not_crash() -> None:
     run_sample 必须安全跳过，不能 AttributeError。"""
     from unittest.mock import MagicMock
     from runtime.training import sample_runner as sr
+    from runtime.training.families.anima import ANIMA_SPEC
     from runtime.training.sample_runner import run_sample
 
     class _NonTloraInjector:
@@ -230,6 +232,7 @@ def test_run_sample_no_clear_method_does_not_crash() -> None:
     ctx.monitor_server = None
     ctx.dtype = torch.float32
     ctx.device = torch.device("cpu")
+    ctx.family.spec = ANIMA_SPEC
 
     from contextlib import contextmanager
 
@@ -238,9 +241,7 @@ def test_run_sample_no_clear_method_does_not_crash() -> None:
         yield
 
     orig_eval = sr.optimizer_eval_mode
-    orig_sample = sr.sample_image
     sr.optimizer_eval_mode = _noop_ctx  # type: ignore[assignment]
-    sr.sample_image = MagicMock(return_value=MagicMock(save=MagicMock()))  # type: ignore[assignment]
     ctx.emit = MagicMock()
 
     try:
@@ -248,7 +249,6 @@ def test_run_sample_no_clear_method_does_not_crash() -> None:
         run_sample(ctx, prompt="x", sample_path=MagicMock())
     finally:
         sr.optimizer_eval_mode = orig_eval  # type: ignore[assignment]
-        sr.sample_image = orig_sample  # type: ignore[assignment]
 
 
 # ── test 4: bypass_mode invariant ──────────────────────────────────────────

--- a/tests/test_model_families.py
+++ b/tests/test_model_families.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 
 from training.families import get_family, get_spec, resolve_family
 from training.families.anima import ANIMA_SPEC
+from training.families.krea2 import KREA2_SPEC
 from training.families.protocol import ModelFamily
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -33,8 +34,7 @@ def test_resolve_family_defaults_and_carriers():
     assert resolve_family(SimpleNamespace()).spec.family_id == "anima"
     assert resolve_family({}).spec.family_id == "anima"
     assert resolve_family({"model_family": "anima"}).spec.family_id == "anima"
-    with pytest.raises(ValueError):
-        resolve_family({"model_family": "krea2"})  # Phase 3 前未注册
+    assert resolve_family({"model_family": "krea2"}).spec is KREA2_SPEC
 
 
 def test_family_lora_contract():
@@ -47,6 +47,46 @@ def test_family_lora_contract():
     assert fam.convert_lora_state_dict(sd) is sd  # 恒等（04 §7.1）
     assert fam.lora_preset()["lora_prefix"] == ANIMA_SPEC.lora.prefix
     assert fam.prepare_text_cache([], []) is None  # online 族 no-op
+
+    krea2 = get_family("krea2")
+    assert krea2 is get_family("krea2")
+    assert krea2.spec is KREA2_SPEC is get_spec("krea2")
+    assert isinstance(krea2, ModelFamily)
+    assert krea2.lora_preset()["lora_prefix"] == "lora_unet"
+    assert krea2.lora_metadata() == {
+        "model_family": "krea2",
+        "preset": "krea2_full",
+    }
+
+
+def test_krea2_and_anima_share_latent_space_identity():
+    assert KREA2_SPEC.latent == ANIMA_SPEC.latent
+
+
+def test_krea2_forward_train_passes_varlen_mask_and_checkpoint():
+    class _Condition:
+        context = torch.zeros(2, 7, 12, 2560)
+        attention_mask = torch.ones(2, 7, dtype=torch.bool)
+
+    class _FakeDiT(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.seen = None
+
+        def forward(self, noisy, t, context, *, attention_mask, use_checkpoint):
+            self.seen = (t, context, attention_mask, use_checkpoint)
+            return noisy
+
+    fam = get_family("krea2")
+    dit = _FakeDiT()
+    noisy = torch.zeros(2, 16, 1, 8, 8)
+    t = torch.rand(2)
+    out = fam.forward_train(dit, noisy, t, _Condition(), use_checkpoint=True)
+    assert out.shape == noisy.shape
+    assert dit.seen[0] is t
+    assert dit.seen[1] is _Condition.context
+    assert dit.seen[2] is _Condition.attention_mask
+    assert dit.seen[3] is True
 
 
 def test_forward_train_shapes_and_padding_mask():

--- a/tests/test_model_family_gating.py
+++ b/tests/test_model_family_gating.py
@@ -13,6 +13,7 @@ import pytest
 
 from studio.domain.common import (
     FAMILY_CAPABILITIES,
+    FAMILY_CONFIG_DEFAULTS,
     FIELD_CAPABILITY_REQUIREMENTS,
     MODEL_FAMILIES,
     cap_gate,
@@ -30,6 +31,7 @@ def test_capability_matrix_mirrors_runtime_specs():
         assert FAMILY_CAPABILITIES[fid] == spec.capabilities, (
             f"studio 镜像与 runtime SPECS['{fid}'].capabilities 失同步"
         )
+        assert FAMILY_CONFIG_DEFAULTS[fid] == dict(spec.config_defaults)
 
 
 def test_schema_literal_matches_families():
@@ -44,13 +46,25 @@ def test_cap_gate_renders_field_comparison():
         cap_gate("warp_drive")
 
 
-def test_gated_fields_show_when_true_for_anima():
-    """当前只有 anima → 所有门控表达式恒真，对存量行为零变化。"""
+def test_gated_fields_follow_family_capabilities():
     values = {"model_family": "anima"}
     for field in ("t5_tokenizer_path", "navit_packing", "masked_loss",
                   "leap_enabled", "sra_enabled", "shuffle_caption"):
         extra = TrainingConfig.model_fields[field].json_schema_extra
         assert eval_show_when(extra.get("show_when"), values) is True, field
+    krea2 = {"model_family": "krea2"}
+    assert eval_show_when(
+        TrainingConfig.model_fields["masked_loss"].json_schema_extra["show_when"],
+        krea2,
+    ) is True
+    assert eval_show_when(
+        TrainingConfig.model_fields["text_encoder_cache"].json_schema_extra["show_when"],
+        krea2,
+    ) is True
+    for field in ("t5_tokenizer_path", "navit_packing", "leap_enabled",
+                  "sra_enabled", "shuffle_caption"):
+        extra = TrainingConfig.model_fields[field].json_schema_extra
+        assert eval_show_when(extra.get("show_when"), krea2) is False, field
 
 
 def test_default_config_valid_and_yaml_roundtrip():
@@ -58,6 +72,15 @@ def test_default_config_valid_and_yaml_roundtrip():
     assert cfg.model_family == "anima"
     # 显式开启 anima 支持的能力 → 合法
     TrainingConfig(navit_packing=True, masked_loss=True)
+    krea2 = TrainingConfig(model_family="krea2")
+    assert krea2.shuffle_caption is False
+    assert krea2.text_encoder_cache is True
+    assert krea2.attention_backend == "none"
+    assert krea2.timestep_sampling == "krea2_shift"
+    assert (krea2.sample_sampler_name, krea2.sample_scheduler) == (
+        "euler", "krea2_shift",
+    )
+    assert (krea2.sample_infer_steps, krea2.sample_cfg_scale) == (28, 4.5)
 
 
 def test_capability_violations_flags_unsupported(monkeypatch):
@@ -88,3 +111,12 @@ def test_prune_keeps_gated_fields_for_default_dump():
     for field in ("t5_tokenizer_path", "shuffle_caption", "masked_loss",
                   "navit_packing", "leap_enabled", "sra_enabled"):
         assert field in dumped, field
+
+    krea2 = prune_inactive_fields(
+        TrainingConfig(model_family="krea2").model_dump(mode="python")
+    )
+    assert krea2["text_encoder_cache"] is True
+    assert krea2["masked_loss"] is False
+    for field in ("t5_tokenizer_path", "shuffle_caption", "keep_tokens",
+                  "tag_dropout", "navit_packing", "leap_enabled", "sra_enabled"):
+        assert field not in krea2, field

--- a/tests/test_text_cache_phase.py
+++ b/tests/test_text_cache_phase.py
@@ -99,3 +99,24 @@ def test_sampling_default_and_empty_negative_are_cached(tmp_path):
     text_cache.run(ctx)
 
     assert family.call[1] == ["1girl, masterpiece", ""]
+
+
+def test_cached_strategy_disabled_keeps_te_online_without_scanning(tmp_path):
+    class _ExplodingDataset:
+        @property
+        def samples(self):  # pragma: no cover - access is the failure
+            raise AssertionError("关闭缓存后不应扫描 caption")
+
+    args = _args(tmp_path)
+    args.text_encoder_cache = False
+    family = _Family("cached_varlen")
+    ctx = TrainingContext(args=args, family=family)
+    ctx.base_dataset = _ExplodingDataset()
+    ctx.text_stack = object()
+    ctx.device = "cuda"
+
+    text_cache.run(ctx)
+
+    assert family.call[0] == []
+    assert family.call[1] == []
+    assert family.call[2]["text"] is ctx.text_stack

--- a/tests/test_training_sample_runner.py
+++ b/tests/test_training_sample_runner.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 from training import sample_runner
+from training.families.anima import ANIMA_SPEC
 
 
 class FakeImage:
@@ -44,8 +45,13 @@ def _ctx(*, sample_negative_prompt: str = "") -> SimpleNamespace:
         sample_sampler_name="er_sde",
         sample_scheduler="simple",
     )
+    family = SimpleNamespace(
+        spec=ANIMA_SPEC,
+        sample_image=lambda *_args, **_kwargs: FakeImage(),
+    )
     return SimpleNamespace(
         args=args,
+        family=family,
         model=torch.nn.Linear(1, 1),
         vae=object(),
         text_stack=(object(), object(), object()),
@@ -66,9 +72,8 @@ def test_run_sample_preserves_empty_negative_and_passes_seed(monkeypatch, tmp_pa
         records.append(kwargs)
         return FakeImage()
 
-    monkeypatch.setattr(sample_runner, "sample_image", fake_sample_image)
-
     ctx = _ctx(sample_negative_prompt="")
+    ctx.family.sample_image = fake_sample_image
     sample_runner.run_sample(ctx, prompt="1girl", sample_path=tmp_path / "sample.png")
 
     # 对齐 ComfyUI：空负面就是空，不注入隐式默认串
@@ -79,9 +84,8 @@ def test_run_sample_preserves_empty_negative_and_passes_seed(monkeypatch, tmp_pa
 
 def test_run_sample_clears_tlora_timestep_mask_before_sampling(monkeypatch, tmp_path) -> None:
     """#215 T-LoRA：sample 前必须清训练态 mask（merge 冲突解法的回归锚）。"""
-    monkeypatch.setattr(sample_runner, "sample_image", lambda *a, **k: FakeImage())
-
     ctx = _ctx()
+    ctx.family.sample_image = lambda *a, **k: FakeImage()
     sample_runner.run_sample(ctx, prompt="1girl", sample_path=tmp_path / "sample.png")
 
     assert ctx.injector.cleared == 1
@@ -91,9 +95,8 @@ def test_run_sample_logs_failure_and_restores_train_mode(monkeypatch, tmp_path) 
     def fail_sample_image(*_args, **_kwargs):
         raise RuntimeError("sample boom")
 
-    monkeypatch.setattr(sample_runner, "sample_image", fail_sample_image)
-
     ctx = _ctx()
+    ctx.family.sample_image = fail_sample_image
     ctx.model.train()
 
     sample_runner.run_sample(ctx, prompt="1girl", sample_path=tmp_path / "sample.png")


### PR DESCRIPTION
## 背景 / 动机

`docs/design/multi-model` 的 Phase 3 到 #418 为止已把 Krea2 的零件全部落地——modeling (#413)、`krea2_shift` 地基 (#412)、下载中心 (#414)、Raw checkpoint 严格加载器 (#415)、LoRA preset (#416)、Qwen3-VL 文本栈 (#417)、FlowMatchEuler 动态 shift 采样 (#418)——但一直**刻意不注册半成品 Krea2Family**。

本 PR 是 Phase 3 的收口刀：把这些零件注册进 registry 并接上 schema，krea2 自此可经 yaml/CLI 真正训练。Phase 4（UI 族选择 / Settings 下载卡 / Generate 页接入 / Turbo 评估）不在本刀范围。

## 改动概要

**registry**：`KREA2_SPEC` + `Krea2Family` 注册。spec 声明 latent（与 Anima 同 `wan21-f8c16` → latent 缓存跨族共享，D6）、`cached_varlen` 文本、采样默认值、能力集 `{masked_loss, text_cache}`（D5：NaViT / SRA / Leap / compile_blocks 维持 Anima-only）。

**缓存优先的两段式加载**（D10 + Phase 0 实测「32GB 余量≈0」）：

```
phases.models.run(ctx)     ← cached_varlen 族只加载 VAE + Qwen3-VL
phases.dataset.run(ctx)
phases.text_cache.run(ctx) ← 预缓存并释放约 9GB TE
phases.models.finish(ctx)  ← 新增：此时才加载 12.9B DiT + 注入 LoRA
phases.optimizer.run(ctx)
```

Anima 等常规族在 `run` 内一次加载完，`finish` 为 no-op，**加载顺序与既有行为逐字不变**。`text_encoder_cache=false` 时完全不读写 sidecar，TE 与 DiT 常驻逐 batch 编码，保留大显存 / 小磁盘云端的显存换磁盘路径。

**派发收口（D8'）**：`sample_runner` 改走 `ctx.family.sample_image`；采样默认值（`align_px` / steps / sampler / scheduler / cfg）一律取 `spec`，不再硬编码 Anima 常量。

**schema**：`model_family` Literal 加 `krea2`；新增 `text_encoder_cache`（`cap_gate("text_cache")` 门控）；`timestep_sampling` 加 `krea2_shift`；`FAMILY_CONFIG_DEFAULTS` 按族 overlay 默认值，**仅在字段缺失时填充**，显式配置不改写。studio 侧维持镜像不反向 import runtime，双向一致性由 `test_model_family_gating` 锁死。

**执行红线自检**：共享循环零 `if family == ...`——两段式判定走 `spec.text.strategy == "cached_varlen"`（D15）；`test_plugin_registry` 的字面量防回归 33 passed。

## 测试方式

- 新增 `test_krea2_family_integration.py`：钉死两段式加载时序（cached → `paths/vae/text` 再 `dit/inject`；storage-free → `paths/dit/vae/text/inject`）
- `test_family_assets`：去掉「krea2 仅有下载资产、未注册训练」的临时状态断言（`- SPECS == {"krea2"}`）——注册后该差集必然为空。真正的不变量「已支持训练的族必有下载清单」(`>=`) 保留；断言 `== set()` 是错的，会挡住下次「下载资产先于训练实现落地」
- `test_lycoris_tlora`：采样 stub 从模块级 `sr.sample_image` 改为经 `ctx.family` 派发（该符号已随 D8' 收口消失），并给 MagicMock ctx 挂真 `ANIMA_SPEC`（`run_sample` 要拿 `align_px` 做算术）
- **全量 `pytest tests/` 2955 passed**

## 未验证 / 需要 maintainer 确认

- **真卡训练未跑**（本机无 32GB 卡）。Phase 0 用 ai-toolkit 实测「刚刚好，差一点 OOM」，本刀的两段式加载正是冲这个余量去的，但**峰值是否真的落在崖下需要真卡确认**——尤其训练中采样期峰值（00 §7.1 记的 WDDM 换页崖先例）。
- 注册后 `model_family` 在训练配置表单里会自动多出 krea2 选项（SchemaForm 从 schema 渲染），而 Settings 下载卡与 Generate 页接入要等 Phase 4。这个中间态符合 D4（`model_family` 落训练版本级），但值得确认是否接受。

## 外部来源

Wan21 latent rgb 系数取自 ComfyUI `comfy/latent_formats.py`（GPL-3.0，与本仓库同许可）。本刀新增 krea2 侧同值副本（两族 `LatentSpec` 相等由 `test_krea2_and_anima_share_latent_space_identity` 断言），`THIRD_PARTY_NOTICES` 对应条目原只点 `anima_daemon.py`，已补准涉及文件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
