### PR TITLE
feat(schema): enum 选项按族过滤 + sampler 越族值按族处理（多模型 Phase 4）

### DIFF
--- a/studio/domain/common.py
+++ b/studio/domain/common.py
@@ -47,6 +47,68 @@ FAMILY_CONFIG_DEFAULTS: dict[str, dict[str, Any]] = {
 #: schema model_family Literal 的值域（顺序即 UI 下拉顺序）
 MODEL_FAMILIES: tuple[str, ...] = tuple(FAMILY_CAPABILITIES)
 
+# ─── 采样端白名单（多模型 P4-2，A13） ─────────────────────────────────────
+# runtime SPECS[fam].sampling.samplers/schedulers 的镜像（首项 = 族默认值）。
+# 与能力矩阵同一纪律：studio 不 import runtime，同步由
+# tests/test_model_family_gating.py 双向锁死。
+# 这两个字段是硬白名单——两族的 sample_image 都在入口对名单外的值 raise
+# （anima: families/anima/sampling.py Comfy parity 校验；krea2:
+# families/krea2/sampling.py 同款），所以跨族值在配置层就报错（fail-fast）。
+FAMILY_SAMPLING: dict[str, dict[str, tuple[str, ...]]] = {
+    "anima": {
+        "samplers": ("er_sde", "dpmpp_3m_sde"),
+        "schedulers": ("simple", "sgm_uniform"),
+    },
+    "krea2": {
+        "samplers": ("euler",),
+        "schedulers": ("krea2_shift",),
+    },
+}
+
+#: Literal 收紧（#256）前就存在的族：sampler/scheduler 白名单外的存量值按
+#: #256 迁移契约静默归并到族默认（grandfather，与 D12 npz 无键 / D13 LoRA
+#: 无标记同款）。Literal 时代出生的族没有 legacy 语料——白名单外的 union 值
+#: 一律报错（fail-fast + 可操作文案），不静默改写。
+LEGACY_SAMPLING_FAMILIES: frozenset = frozenset({"anima"})
+
+#: timestep_sampling 里按族门控的选项。其余选项是共享循环通用实现，全族可用。
+#: krea2_shift 机制上任何族都能跑（loop 按 requires_token_counts 供
+#: token_counts），但 mu 插值按 K2 校准——只做 UI 引导性隐藏，后端不设闸
+#: （A1：同代码不限制）。第 3 个 resolution-aware 族复用该策略时加进元组即可。
+TIMESTEP_SAMPLING_OPTION_FAMILIES: dict[str, tuple[str, ...]] = {
+    "krea2_shift": ("krea2",),
+}
+
+
+def option_gates(option_families: dict[str, tuple[str, ...]]) -> dict[str, str]:
+    """把「选项 → 支持它的族」编译成 option 级 show_when 表达式映射。
+
+    cap_gate 的 option 级版本：作者写时展开，三个 show_when 求值器零新文法。
+    产物进 Field 元信息 `option_show_when`，前端按当前 model_family 过滤下拉
+    选项。未出现在映射里的选项永远可见。
+    """
+    return {
+        opt: "||".join(f"model_family=={f}" for f in sorted(fams))
+        for opt, fams in option_families.items()
+    }
+
+
+def sampling_option_gates(kind: str) -> dict[str, str]:
+    """从 FAMILY_SAMPLING 推导 samplers / schedulers 的 option 门控映射。
+
+    全族都支持的值不设门（永远可见）；其余值按支持它的族展开表达式。
+    """
+    by_option: dict[str, list[str]] = {}
+    for fam, spec in FAMILY_SAMPLING.items():
+        for value in spec[kind]:
+            by_option.setdefault(value, []).append(fam)
+    all_families = set(FAMILY_SAMPLING)
+    return option_gates({
+        value: tuple(fams)
+        for value, fams in by_option.items()
+        if set(fams) != all_families
+    })
+
 #: 字段 → 所需能力位。驱动三层防线：show_when（作者写时经 cap_gate 展开）、
 #: TrainingConfig validator、trainer bootstrap 校验。判定口径：字段值为
 #: 真值/非零才算"启用"该能力（默认关闭的字段对任何族都合法）。

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -20,9 +20,14 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 from .common import (
     AttentionBackend,
     FAMILY_CONFIG_DEFAULTS,
+    FAMILY_SAMPLING,
+    LEGACY_SAMPLING_FAMILIES,
+    TIMESTEP_SAMPLING_OPTION_FAMILIES,
     _meta,
     cap_gate,
     capability_violations,
+    option_gates,
+    sampling_option_gates,
 )
 from .migrations import migrate_legacy_save_keys, migrate_noise_enhancement_type
 
@@ -622,6 +627,9 @@ class TrainingConfig(BaseModel):
             alt_description="【时间步采样】InfoNoise 启用时作为热身期 baseline，正式阶段由自适应 CDF 接管；Leap 启用时 leap 路径恒用 U(0,1)，本字段仅作用于 (1-leap_ratio) 比例的标准 step",
             alt_description_when="infonoise_enabled==true||leap_enabled==true",
             advanced=True,
+            # krea2_shift 的 mu 插值按 K2 校准，仅 UI 不向其他族展示；机制上
+            # 共享循环任何族都能跑，后端不设闸（A1），手改 yaml 尊重
+            option_show_when=option_gates(TIMESTEP_SAMPLING_OPTION_FAMILIES),
         ),
     )
     timestep_shift: float = Field(
@@ -946,25 +954,42 @@ class TrainingConfig(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _coerce_sample_sampler_scheduler(cls, data: Any) -> Any:
-        """sampler/scheduler 收紧为 Literal 前是自由文本，旧 preset / 旧版本
-        config 可能存了其他值（如 euler，当年走 inline Euler 兜底）。统一
-        归并到默认值而不是让整个 config 加载失败。"""
-        if isinstance(data, dict):
-            family = str(data.get("model_family") or "anima")
-            if family == "krea2":
-                samplers = (None, "euler")
-                schedulers = (None, "krea2_shift")
-                default_sampler = "euler"
-                default_scheduler = "krea2_shift"
+        """sampler / scheduler 白名单外值的按族处理（多模型 P4-2，还 #419 债）：
+
+        - **有 legacy 语料的族**（anima，Literal 收紧 #256 前就存在）：白名单外
+          一律静默归并到族默认——#256 的迁移契约原样保留（euler 等历史存量值
+          必须让老 config 能加载）。「UI 提供选项又静默改写」的 C1 病灶由
+          option_show_when 门控根除：UI 不再向 anima 展示 euler。
+        - **Literal 时代出生的族**（krea2 起）：无 legacy 语料。Literal 外的
+          垃圾值仍归并（加载健壮性）；**在 Literal 内但本族跑不了的值报错**
+          （两族 sample_image 都在入口 raise，配置层提前 fail-fast），不静默
+          改写显式配置。
+        """
+        if not isinstance(data, dict):
+            return data
+        family = str(data.get("model_family") or "anima")
+        allowed = FAMILY_SAMPLING.get(family)
+        if allowed is None:
+            return data  # 未知族由 model_family 的 Literal 校验报错，不在此重复
+        union: dict[str, tuple[str, ...]] = {}
+        for spec in FAMILY_SAMPLING.values():
+            for kind in ("samplers", "schedulers"):
+                union[kind] = tuple(dict.fromkeys(union.get(kind, ()) + spec[kind]))
+        legacy = family in LEGACY_SAMPLING_FAMILIES
+        for field, kind in (
+            ("sample_sampler_name", "samplers"),
+            ("sample_scheduler", "schedulers"),
+        ):
+            value = data.get(field)
+            if value is None or value in allowed[kind]:
+                continue
+            if legacy or value not in union[kind]:
+                data[field] = allowed[kind][0]  # grandfather / 垃圾值 → 族默认
             else:
-                samplers = (None, "er_sde", "dpmpp_3m_sde")
-                schedulers = (None, "simple", "sgm_uniform")
-                default_sampler = "er_sde"
-                default_scheduler = "simple"
-            if data.get("sample_sampler_name") not in samplers:
-                data["sample_sampler_name"] = default_sampler
-            if data.get("sample_scheduler") not in schedulers:
-                data["sample_scheduler"] = default_scheduler
+                raise ValueError(
+                    f"{field}='{value}' 不适用于 model_family='{family}'"
+                    f"（该族可用：{'、'.join(allowed[kind])}）"
+                )
         return data
 
     @model_validator(mode="before")
@@ -1253,14 +1278,20 @@ class TrainingConfig(BaseModel):
     )
     sample_sampler_name: Literal["er_sde", "dpmpp_3m_sde", "euler"] = Field(
         "er_sde",
-        description="采样器。er_sde 默认；dpmpp_3m_sde 与 ComfyUI 同款"
-                    "（BrownianTree 噪声，需要 torchsde）",
-        json_schema_extra=_meta("sample"),
+        description="采样器。er_sde / dpmpp_3m_sde 为 Anima 的 ComfyUI 同款栈"
+                    "（dpmpp_3m_sde 走 BrownianTree 噪声，需要 torchsde）；"
+                    "euler 为 Krea 2 的 FlowMatchEuler",
+        json_schema_extra=_meta(
+            "sample", option_show_when=sampling_option_gates("samplers"),
+        ),
     )
     sample_scheduler: Literal["simple", "sgm_uniform", "krea2_shift"] = Field(
         "simple",
-        description="调度器。simple 默认；sgm_uniform 为 ComfyUI 的 SGM 均匀切分",
-        json_schema_extra=_meta("sample"),
+        description="调度器。simple / sgm_uniform 为 Anima 的 ComfyUI 切分；"
+                    "krea2_shift 为 Krea 2 的分辨率感知动态 shift 时刻表",
+        json_schema_extra=_meta(
+            "sample", option_show_when=sampling_option_gates("schedulers"),
+        ),
     )
     sample_width: int = Field(
         0, ge=0,

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -42,6 +42,10 @@ export interface SchemaProperty {
   control?: string
   cli_alias?: string
   show_when?: string
+  /** option 级 show_when（多模型 P4-2）：enum 值 → 表达式（语法同 show_when），
+   * 求值为假的选项从下拉隐藏。未列出的选项永远可见；当前已选中的值即使被
+   * 门控也保留显示（表单如实反映 config，越族值由后端校验报错）。 */
+  option_show_when?: Record<string, string>
   /** 当此表达式为真时字段在 UI 上 disabled（值由 SchemaForm 自动回退到 default）。
    * 表达式语法与 show_when 一致：`key==value` / `key!=value`。
    * 例：lr_scheduler 在 optimizer_type=prodigy_plus_schedulefree 时被 disable。 */

--- a/studio/web/src/components/Field.tsx
+++ b/studio/web/src/components/Field.tsx
@@ -24,6 +24,9 @@ interface Props {
   /** path 字段右侧额外按钮槽（如「↺ 重置为全局默认」）。仅对 string/path
    * 字段渲染；其他类型字段忽略。 */
   suffix?: React.ReactNode
+  /** select 的可见选项覆盖（option_show_when 过滤后的 enum 子集，由
+   * SchemaForm 按当前 values 计算）。缺省渲染 prop.enum 全量。 */
+  enumOptions?: unknown[]
 }
 
 // input 覆盖 .input 默认值（更紧凑；背景用 canvas 而不是 surface）
@@ -41,6 +44,7 @@ const FieldHint = ({ children }: { children: React.ReactNode }) => (
 /** 单个表单字段，按 control kind 分发渲染。 */
 export default function Field({
   name, prop, value, onChange, disabled = false, hint, descriptionOverride, suffix,
+  enumOptions,
 }: Props) {
   const { t } = useTranslation()
   const kind = controlKind(prop)
@@ -111,7 +115,7 @@ export default function Field({
           disabled={disabled}
           className="input" style={inputStyle}
         >
-          {(prop.enum ?? []).map((opt) => (
+          {(enumOptions ?? prop.enum ?? []).map((opt) => (
             <option key={String(opt)} value={String(opt)}>
               {schemaEnumLabel(name, opt, t)}
             </option>

--- a/studio/web/src/components/SchemaForm.test.tsx
+++ b/studio/web/src/components/SchemaForm.test.tsx
@@ -203,3 +203,82 @@ describe('SchemaForm takeover behavior', () => {
   })
 
 })
+
+// ─── option_show_when：enum 选项按 model_family 过滤（多模型 P4-2） ─────────
+
+const gatedSchema: SchemaResponse = {
+  groups: [{ key: 'sample', label: '采样' }],
+  schema: {
+    properties: {
+      model_family: {
+        type: 'string',
+        enum: ['anima', 'krea2'],
+        default: 'anima',
+        group: 'sample',
+        description: 'Family',
+      },
+      sample_sampler_name: {
+        type: 'string',
+        enum: ['er_sde', 'dpmpp_3m_sde', 'euler'],
+        default: 'er_sde',
+        group: 'sample',
+        description: 'Sampler',
+        option_show_when: {
+          er_sde: 'model_family==anima',
+          dpmpp_3m_sde: 'model_family==anima',
+          euler: 'model_family==krea2',
+        },
+      },
+    },
+  },
+}
+
+describe('SchemaForm option_show_when filtering', () => {
+  const samplerSelect = () =>
+    screen
+      .getAllByRole('combobox')
+      .find((el) =>
+        Array.from((el as HTMLSelectElement).options).some((o) =>
+          ['er_sde', 'euler'].includes(o.value),
+        ),
+      ) as HTMLSelectElement
+
+  const optionValues = (el: HTMLSelectElement) =>
+    Array.from(el.options).map((o) => o.value)
+
+  it('hides options gated to another family', () => {
+    render(
+      <SchemaForm
+        schema={gatedSchema}
+        values={{ model_family: 'anima', sample_sampler_name: 'er_sde' }}
+        onChange={() => {}}
+      />,
+    )
+    expect(optionValues(samplerSelect())).toEqual(['er_sde', 'dpmpp_3m_sde'])
+  })
+
+  it('shows only the owning family options after switching family', () => {
+    render(
+      <SchemaForm
+        schema={gatedSchema}
+        values={{ model_family: 'krea2', sample_sampler_name: 'euler' }}
+        onChange={() => {}}
+      />,
+    )
+    expect(optionValues(samplerSelect())).toEqual(['euler'])
+  })
+
+  it('keeps the currently selected value visible even when gated out', () => {
+    // config 里存了越族值（如手改 yaml / 换族未迁移）：表单如实显示，
+    // 不凭空消失——拒绝该值是后端校验的职责
+    render(
+      <SchemaForm
+        schema={gatedSchema}
+        values={{ model_family: 'krea2', sample_sampler_name: 'er_sde' }}
+        onChange={() => {}}
+      />,
+    )
+    expect(optionValues(samplerSelect())).toEqual(['er_sde', 'euler'])
+    expect(samplerSelect().value).toBe('er_sde')
+  })
+})

--- a/studio/web/src/components/SchemaForm.tsx
+++ b/studio/web/src/components/SchemaForm.tsx
@@ -175,6 +175,17 @@ export default function SchemaForm({
                     evalShowWhen(prop.alt_description_when, values)
                       ? schemaAltDescription(name, prop.alt_description, t)
                       : schemaDescription(name, prop.description, t)
+                  // option_show_when：按当前 values 过滤下拉选项（多模型 P4-2）。
+                  // 当前已选中的值即使被门控也保留——表单如实反映 config，
+                  // 越族值由后端校验报错，不在 UI 里凭空消失。
+                  const gates = prop.option_show_when
+                  const enumOptions = gates
+                    ? (prop.enum ?? []).filter(
+                        (opt) =>
+                          evalShowWhen(gates[String(opt)], values) ||
+                          String(opt) === String(values[name] ?? '')
+                      )
+                    : undefined
                   return (
                     <Field
                       key={name}
@@ -186,6 +197,7 @@ export default function SchemaForm({
                       hint={hint}
                       descriptionOverride={descriptionOverride}
                       suffix={suffixes[name]}
+                      enumOptions={enumOptions}
                     />
                   )
                 })}

--- a/tests/test_model_family_gating.py
+++ b/tests/test_model_family_gating.py
@@ -14,10 +14,14 @@ import pytest
 from studio.domain.common import (
     FAMILY_CAPABILITIES,
     FAMILY_CONFIG_DEFAULTS,
+    FAMILY_SAMPLING,
     FIELD_CAPABILITY_REQUIREMENTS,
     MODEL_FAMILIES,
+    TIMESTEP_SAMPLING_OPTION_FAMILIES,
     cap_gate,
     capability_violations,
+    option_gates,
+    sampling_option_gates,
 )
 from studio.domain.config_prune import eval_show_when
 from studio.schema import TrainingConfig
@@ -32,6 +36,30 @@ def test_capability_matrix_mirrors_runtime_specs():
             f"studio 镜像与 runtime SPECS['{fid}'].capabilities 失同步"
         )
         assert FAMILY_CONFIG_DEFAULTS[fid] == dict(spec.config_defaults)
+
+
+def test_sampling_whitelist_mirrors_runtime_specs():
+    """FAMILY_SAMPLING 是 SPECS[fam].sampling 的镜像；首项 = 族默认值。"""
+    from training.families import SPECS
+
+    assert set(FAMILY_SAMPLING) == set(SPECS)
+    for fid, spec in SPECS.items():
+        mirror = FAMILY_SAMPLING[fid]
+        assert mirror["samplers"] == tuple(spec.sampling.samplers), fid
+        assert mirror["schedulers"] == tuple(spec.sampling.schedulers), fid
+        assert mirror["samplers"][0] == spec.sampling.default_sampler, fid
+        assert mirror["schedulers"][0] == spec.sampling.default_scheduler, fid
+
+
+def test_timestep_option_gate_targets_registered_strategy():
+    """门控的 timestep 选项必须真实存在于 Literal 与 runtime BUILDERS。"""
+    from training.timestep_samplers import BUILDERS
+
+    literal = set(get_args(TrainingConfig.model_fields["timestep_sampling"].annotation))
+    for option, fams in TIMESTEP_SAMPLING_OPTION_FAMILIES.items():
+        assert option in literal, option
+        assert option in BUILDERS, option
+        assert set(fams) <= set(MODEL_FAMILIES), option
 
 
 def test_schema_literal_matches_families():
@@ -81,6 +109,79 @@ def test_default_config_valid_and_yaml_roundtrip():
         "euler", "krea2_shift",
     )
     assert (krea2.sample_infer_steps, krea2.sample_cfg_scale) == (28, 4.5)
+
+
+# ─── option 级门控 + sampler 越族值报错（多模型 P4-2，A13/C1）────────────────
+
+
+def test_option_gates_render_expressions():
+    assert sampling_option_gates("samplers") == {
+        "er_sde": "model_family==anima",
+        "dpmpp_3m_sde": "model_family==anima",
+        "euler": "model_family==krea2",
+    }
+    assert option_gates(TIMESTEP_SAMPLING_OPTION_FAMILIES) == {
+        "krea2_shift": "model_family==krea2",
+    }
+
+
+def test_option_show_when_wired_into_schema_fields():
+    """三个 enum 字段带 option_show_when，且键都在各自 Literal 值域内。"""
+    for field, kind in (
+        ("sample_sampler_name", "samplers"),
+        ("sample_scheduler", "schedulers"),
+    ):
+        extra = TrainingConfig.model_fields[field].json_schema_extra
+        gates = extra.get("option_show_when")
+        assert gates == sampling_option_gates(kind), field
+        literal = set(get_args(TrainingConfig.model_fields[field].annotation))
+        assert set(gates) <= literal, field
+    ts_extra = TrainingConfig.model_fields["timestep_sampling"].json_schema_extra
+    assert ts_extra.get("option_show_when") == option_gates(
+        TIMESTEP_SAMPLING_OPTION_FAMILIES
+    )
+
+
+def test_cross_family_sampler_asymmetric_grandfather():
+    """白名单外值的按族处理（#419 债 C1 的修法）：
+
+    - anima（Literal 收紧前就存在）：euler 等历史存量静默归并——#256 迁移
+      契约保留（test_comfy_parity_contract 另有原契约测试锁死）
+    - krea2（Literal 时代出生，无 legacy 语料）：union 内跨族值报错，
+      不静默改写显式配置
+    """
+    legacy = TrainingConfig(
+        model_family="anima",
+        sample_sampler_name="euler", sample_scheduler="krea2_shift",
+    )
+    assert (legacy.sample_sampler_name, legacy.sample_scheduler) == (
+        "er_sde", "simple",
+    )
+    with pytest.raises(ValueError, match="er_sde"):
+        TrainingConfig(model_family="krea2", sample_sampler_name="er_sde")
+    with pytest.raises(ValueError, match="simple"):
+        TrainingConfig(model_family="krea2", sample_scheduler="simple")
+
+
+def test_legacy_garbage_sampler_still_migrates_to_family_default():
+    """Literal 外的垃圾值任何族都归并族默认（加载健壮性），config 不整体失败。"""
+    cfg = TrainingConfig(
+        sample_sampler_name="ancient_free_text", sample_scheduler="karras",
+    )
+    assert (cfg.sample_sampler_name, cfg.sample_scheduler) == ("er_sde", "simple")
+    krea2 = TrainingConfig(
+        model_family="krea2",
+        sample_sampler_name="ancient_free_text", sample_scheduler="karras",
+    )
+    assert (krea2.sample_sampler_name, krea2.sample_scheduler) == (
+        "euler", "krea2_shift",
+    )
+
+
+def test_krea2_shift_timestep_allowed_for_any_family():
+    """timestep_sampling 不设后端硬闸（A1：共享循环同代码）——仅 UI 门控。"""
+    cfg = TrainingConfig(model_family="anima", timestep_sampling="krea2_shift")
+    assert cfg.timestep_sampling == "krea2_shift"
 
 
 def test_capability_violations_flags_unsupported(monkeypatch):

--- a/tests/test_version_config.py
+++ b/tests/test_version_config.py
@@ -339,8 +339,10 @@ def test_fork_krea2_preset_syncs_krea2_paths(env, monkeypatch) -> None:
     from studio.services import models as model_downloader
     monkeypatch.setattr(preset_flow, "_auto_sync_paths", lambda: True)
     p, v = _make_pv(env)
-    # shuffle_caption 是 anima-only 能力（caption_tag_ops），krea2 preset 必须关
+    # krea2 preset 必须是自洽的族内值：shuffle_caption 关（anima-only 能力）、
+    # sampler/scheduler 用族白名单值（跨族值在 P4-2 起报错而非静默改写）
     _seed_preset(env, "tpl", model_family="krea2", shuffle_caption=False,
+                 sample_sampler_name="euler", sample_scheduler="krea2_shift",
                  transformer_path=_custom_path())
     cfg = preset_flow.fork_preset_for_version("tpl", p, v)
     assert cfg["model_family"] == "krea2"


### PR DESCRIPTION
## 背景 / 动机

P4-2（决策清单 A13 + C1）。#419 把 `sample_sampler_name` / `sample_scheduler` 的 Literal 加宽成两族 union 后，**Anima 用户能在下拉里看到跑不了的 `euler`，选了被静默改回 `er_sde`**——UI 主动提供选项又悄悄换掉，与「不加静默魔法保护」直接冲突。而 `show_when` 只能整字段显隐，做不到「同一个下拉按族过滤选项」，这是机制缺口。

> ⚠️ **Stacked on #420**：P4-1 的 krea2 preset fork 测试在本刀的 validator 下必须用族内 sampler 值（语义依赖），故本分支基于 `codex/phase4-family-dispatch`。**请先合 #420**，本 PR diff 会自动收窄；#420 squash 后我会 rebase 本分支。

## 改动概要

**option 级门控（A13 机制）**：
- `cap_gate` 哲学延伸到 enum 选项：新增 `option_show_when` 字段元信息（enum 值 → show_when 表达式），authoring-time 展开，复用既有表达式文法——三个求值器零新文法
- `FAMILY_SAMPLING` = runtime `SPECS[fam].sampling` 的 studio 镜像（首项 = 族默认值），与能力矩阵同一纪律，`test_model_family_gating` 双向锁死
- 前端 `SchemaForm` 按当前 values 过滤下拉选项；**当前已选中的值即使被门控也保留显示**——表单如实反映 config，拒绝越族值是后端校验的职责，不在 UI 里凭空消失
- `timestep_sampling` 的 `krea2_shift` 仅 UI 门控、**后端不设闸**：共享循环按 `requires_token_counts` 供数（`loop.py:140-144` 族无关），任何族机制上都能跑（A1：同代码不限制），手改 yaml 尊重

**validator 非对称 grandfather（C1 修法，比原计划多一层）**：

| 族 | 白名单外的值 | 理由 |
|---|---|---|
| anima（Literal 收紧 #256 前就存在） | **静默归并到族默认**（原契约保留） | `euler` 是 inline-Euler 兜底时代的历史存量，`test_comfy_parity_contract` 锁死的 #256 迁移契约要求老 config 能加载。C1 的真正病灶（UI 提供选项又改写）已由 option 门控根除 |
| krea2（Literal 时代出生） | union 内跨族值 → **报错** + 可操作文案；Literal 外垃圾值仍归并 | 无 legacy 语料，「krea2 + er_sde」只可能是换族未迁移或手改——fail-fast 并告知可用值 |

与 D12（npz 无键 grandfather）/ D13（LoRA 无标记 grandfather anima）同款先例。

**计划偏差说明**：决策文档原文是「在 union 内但本族跑不了 → 一律报错」。全量测试跑出 `test_comfy_parity_contract::test_training_config_coerces_legacy_sampler_values` 红——一律报错会撕毁 #256 的迁移契约（anima 老 config 存的 euler 从「可加载」变「422」）。非对称规则同时保住两个契约；如果你倾向严格一律报错，改一行 `LEGACY_SAMPLING_FAMILIES = frozenset()` 加改一条测试即可。

## 测试方式

- 后端 +6：`FAMILY_SAMPLING` ↔ SPECS 镜像锁（含首项=默认值）、门控表达式渲染、`option_show_when` 接线断言、非对称 grandfather 行为、krea2_shift 对任何族合法
- 前端 vitest +3：按族过滤 / 切族后只剩本族选项 / 越族存量值保留显示；全量 **492 passed**，lint 0 errors（2 warnings 为 PreprocessInpaint 存量），tsc 干净
- 全量 pytest **2966 passed**

## 浏览器视觉校验（AGENTS §5 新规范首次执行）

`npm run build` → 真服务（8899 端口，一次性项目）→ Chrome headless 实测 Train 页：

| | sampler 下拉 | scheduler 下拉 | timestep 下拉 |
|---|---|---|---|
| anima 版本 | `er_sde, dpmpp_3m_sde`（euler 已隐藏） | `simple, sgm_uniform` | 无 krea2_shift |
| krea2 版本 | `euler` | `krea2_shift` | 共享项 + krea2_shift |

krea2 版本同时确认族默认 overlay 生效（steps 28 / CFG 4.5）。截图 6 张已存本地（可贴 PR）。校验过程顺带发现 Train 页跟随**项目活动版本**而非 URL 里的 vid（与本刀无关，记录备查）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
