### PR TITLE
feat(generate): Generate/正则/评估全链路接入 krea2（含 Turbo）（多模型 Phase 4）

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -198,6 +198,8 @@ class ModelCache:
     """
 
     def __init__(self) -> None:
+        self.family_id: Optional[str] = None
+        self.family: Any = None
         self.transformer_path: Optional[str] = None
         self.vae_path: Optional[str] = None
         self.text_encoder_path: Optional[str] = None
@@ -212,9 +214,9 @@ class ModelCache:
         self.lora_dtype: Any = torch.float32
         self.model: Any = None
         self.vae: Any = None
-        self.qwen_model: Any = None
-        self.qwen_tok: Any = None
-        self.t5_tok: Any = None
+        # 族 opaque 文本栈（anima=(qwen_model, qwen_tok, t5_tok) 三元组，
+        # krea2=Krea2TextStack）——只经 family.sample_image 消费，daemon 不拆包
+        self.text_stack: Any = None
         # adapters 必须保持引用，否则 forward hook 失效（lycoris closure）
         self.adapters: list[Any] = []
         self.last_lora_specs: list[LoRASpec] = []
@@ -232,6 +234,7 @@ class ModelCache:
             cfg,
             force_exact_ksampler_backend=False,
         )
+        family_id = str(cfg.get("model_family") or "anima")
         backend = cfg.get("attention_backend", "none")
         precision = cfg.get("mixed_precision", "bf16")
         vae_precision = cfg.get("vae_precision", precision)
@@ -251,9 +254,10 @@ class ModelCache:
         if t5_tokenizer_path:
             t5_tokenizer_path = _T.resolve_path_best_effort(t5_tokenizer_path, bases)
 
-        # 比较是否需要 reload
+        # 比较是否需要 reload（换族 = 换整套模型栈，全重载）
         needs_reload = (
             not self.loaded
+            or self.family_id != family_id
             or self.transformer_path != transformer_path
             or self.vae_path != vae_path
             or self.text_encoder_path != text_encoder_path
@@ -268,6 +272,7 @@ class ModelCache:
         if needs_reload:
             self.unload()
             self._load(
+                family_id=family_id,
                 transformer_path=transformer_path,
                 vae_path=vae_path,
                 text_encoder_path=text_encoder_path,
@@ -283,6 +288,7 @@ class ModelCache:
     def _load(
         self,
         *,
+        family_id: str,
         transformer_path: str,
         vae_path: str,
         text_encoder_path: str,
@@ -300,8 +306,8 @@ class ModelCache:
         use_flash = backend == "flash_attn"
         use_xformers = backend == "xformers"
 
-        family = _T.get_family("anima")  # daemon 为 Anima 专属常驻壳（K2 接入形态 Phase 4 定）
-        logger.info("loading transformer %s", transformer_path)
+        family = _T.get_family(family_id)
+        logger.info("loading transformer [%s] %s", family_id, transformer_path)
         model = family.load_dit(
             transformer_path, device, dtype,
             attention_backend=("flash_attn" if use_flash else "none"), repo_root=repo_root,
@@ -316,18 +322,21 @@ class ModelCache:
         vae = family.load_vae(vae_path, device, vae_dtype)
 
         logger.info("loading text encoders %s", text_encoder_path)
-        qwen_model, qwen_tok, t5_tok = family.load_text(
+        # 族 opaque 文本栈，不拆包。generate 的 prompt 是 ad-hoc 交互输入，
+        # cached_varlen 族（krea2）关缓存让 TE 常驻逐 prompt 在线编码。
+        text_stack = family.load_text(
             text_encoder_path, device, dtype,
             t5_tokenizer_path=t5_tokenizer_path or None,
             comfy_qwen=text_encoder_backend == "comfy_qwen3",
             t5_fast=t5_tokenizer_backend == "fast",
+            cache_enabled=False,
         )
 
+        self.family_id = family_id
+        self.family = family
         self.model = model
         self.vae = vae
-        self.qwen_model = qwen_model
-        self.qwen_tok = qwen_tok
-        self.t5_tok = t5_tok
+        self.text_stack = text_stack
         self.transformer_path = transformer_path
         self.vae_path = vae_path
         self.text_encoder_path = text_encoder_path
@@ -421,7 +430,10 @@ class ModelCache:
         self.last_lora_specs = []
         self.last_lora_metas = []
 
-        self.adapters = apply_loras(self.model, specs, self.device, self.lora_dtype)
+        self.adapters = apply_loras(
+            self.model, specs, self.device, self.lora_dtype,
+            family_id=self.family_id or "anima",
+        )
         self.last_lora_specs = specs
         self.last_lora_metas = current_metas
         self.model.eval()
@@ -431,7 +443,13 @@ class ModelCache:
         if not self.device:
             return
         _move_module_to_device(self.model, self.device)
-        _move_module_to_device(self.qwen_model, self.device)
+        # anima 文本栈是 (qwen_model, qwen_tok, t5_tok) 三元组——采样内部的
+        # decode offload 会把 TE 挪去 CPU，这里搬回。自管 device 的栈
+        # （krea2 的 Krea2TextStack）没有裸模块成员，循环自然 no-op。
+        if isinstance(self.text_stack, (tuple, list)):
+            for member in self.text_stack:
+                if isinstance(member, torch.nn.Module):
+                    _move_module_to_device(member, self.device)
         for adapter in self.adapters:
             _move_adapter_to_device(adapter, self.device, self.lora_dtype)
 
@@ -441,9 +459,9 @@ class ModelCache:
         logger.info("unloading model")
         self.model = None
         self.vae = None
-        self.qwen_model = None
-        self.qwen_tok = None
-        self.t5_tok = None
+        self.text_stack = None
+        self.family_id = None
+        self.family = None
         self.adapters = []
         self.last_lora_specs = []
         self.last_lora_metas = []
@@ -581,21 +599,22 @@ def _build_preview_callback(
     return _cb
 
 
-# Wan2.1 VAE 的 latent→RGB 线性投影系数（16 通道 → RGB）。
-# Anima 的 VAE 是 Qwen-Image VAE（models/vae/qwen_image_vae.safetensors），其 latent
-# 空间就是 Wan2.1 的 16-ch 空间——ComfyUI supported_models.py 里
-# `QwenImage.latent_format = latent_formats.Wan21`，且本仓库 models.py 的 VAE
-# latent2rgb 快速预览系数（"模糊但能看出图"）。系数表已收编进 ModelSpec
-# （families/anima，D17）——单一来源，K2 同 latent 空间时直接复用。之前误用
-# TAEFlux（Flux VAE 的 tiny decoder）解码这个 WAN latent，空间不匹配 →
-# 颜色反相/错乱，已废弃。
-from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC  # noqa: E402
+# latent→RGB 线性投影系数按**当前加载族的 spec** 取（D17 收编进 ModelSpec，
+# 单一来源在 families/latent_spaces.py）。Anima 与 Krea2 同为 Wan2.1 16-ch
+# latent 空间（Qwen-Image VAE：ComfyUI supported_models.py
+# `QwenImage.latent_format = latent_formats.Wan21`）；未来不同 latent 空间的族
+# 接入时预览自动跟随。之前误用 TAEFlux（Flux 解码器）→ 颜色反相，已废弃。
+from training.families.latent_spaces import WAN21_F8C16 as _WAN21_F8C16  # noqa: E402
 
-_WAN21_LATENT_RGB_FACTORS = [list(r) for r in _ANIMA_SPEC.latent.rgb_factors]
-_WAN21_LATENT_RGB_BIAS = list(_ANIMA_SPEC.latent.rgb_bias)
 # 预览放大目标（最长边像素）。latent 是 1/8 分辨率（1024²→128²），latent2rgb 直出
 # 128²；放大到 512 让前端铺满时不至于过糊，JPEG 仍很小。
 _PREVIEW_TARGET_PX = 512
+
+
+def _preview_latent_spec():
+    """当前加载族的 LatentSpec；未加载（单测 / 启动早期）回退 Wan21 共享空间。"""
+    family = getattr(CACHE, "family", None)
+    return family.spec.latent if family is not None else _WAN21_F8C16
 
 
 def _decode_latent2rgb_preview(latent: Any) -> Optional[Any]:
@@ -609,13 +628,15 @@ def _decode_latent2rgb_preview(latent: Any) -> Optional[Any]:
     try:
         import numpy as np
         from PIL import Image
+        latent_spec = _preview_latent_spec()
         with torch.no_grad():
             x = latent[0, :, 0].float()  # [16, H, W]
             factors = torch.tensor(
-                _WAN21_LATENT_RGB_FACTORS, device=x.device, dtype=x.dtype,
+                [list(r) for r in latent_spec.rgb_factors],
+                device=x.device, dtype=x.dtype,
             )  # [16, 3]
             bias = torch.tensor(
-                _WAN21_LATENT_RGB_BIAS, device=x.device, dtype=x.dtype,
+                list(latent_spec.rgb_bias), device=x.device, dtype=x.dtype,
             )  # [3]
             rgb = torch.einsum("chw,cr->hwr", x, factors) + bias  # [H, W, 3]
             rgb = ((rgb + 1.0) / 2.0).clamp(0.0, 1.0)
@@ -689,6 +710,9 @@ def _run_generate(
     scheduler: str = cfg.get("scheduler", "simple")
     count: int = max(1, int(cfg.get("count", 1)))
     base_seed: int = int(cfg.get("seed", 0))
+    # 蒸馏推理底模（Krea2 Turbo）：studio 按 catalog variant purpose 检测后注入；
+    # anima family 接受并忽略
+    distilled: bool = bool(cfg.get("distilled", False))
 
     xy_matrix = cfg.get("xy_matrix")
     if xy_matrix is not None:
@@ -726,10 +750,9 @@ def _run_generate(
                 batch_idx=img_idx, batch_total=total, total_steps=steps,
             )
             try:
-                img = _T.sample_image(
-                    CACHE.model, CACHE.vae,
-                    CACHE.qwen_model, CACHE.qwen_tok, CACHE.t5_tok,
-                    prompt=prompt,
+                img = CACHE.family.sample_image(
+                    CACHE.model, CACHE.vae, CACHE.text_stack,
+                    prompt,
                     height=height,
                     width=width,
                     steps=steps,
@@ -737,6 +760,7 @@ def _run_generate(
                     negative_prompt=negative_prompt,
                     sampler_name=sampler_name,
                     scheduler=scheduler,
+                    distilled=distilled,
                     device=CACHE.device,
                     dtype=CACHE.dtype,
                     step_callback=preview_callback,
@@ -794,6 +818,7 @@ def _run_xy(
     y_spec = xy_matrix.get("y")
     x_values = x_spec["values"]
     y_values = y_spec["values"] if y_spec else [None]
+    distilled: bool = bool(cfg.get("distilled", False))
 
     if base_seed == 0:
         base_seed = random.randint(0, 2**31 - 1)
@@ -861,10 +886,9 @@ def _run_xy(
                 batch_idx=img_idx, batch_total=total, total_steps=cur_steps,
             )
             try:
-                img = _T.sample_image(
-                    CACHE.model, CACHE.vae,
-                    CACHE.qwen_model, CACHE.qwen_tok, CACHE.t5_tok,
-                    prompt=prompt,
+                img = CACHE.family.sample_image(
+                    CACHE.model, CACHE.vae, CACHE.text_stack,
+                    prompt,
                     height=height,
                     width=width,
                     steps=cur_steps,
@@ -874,6 +898,7 @@ def _run_xy(
                     negative_prompt=negative_prompt,
                     sampler_name=base_sampler,
                     scheduler=scheduler,
+                    distilled=distilled,
                     device=CACHE.device,
                     dtype=CACHE.dtype,
                     seed=cur_seed,

--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -97,6 +97,7 @@ def main() -> None:
     scheduler: str = cfg.get("scheduler", "simple")
     count: int = max(1, int(cfg.get("count", 1)))
     base_seed: int = int(cfg.get("seed", 0))
+    distilled: bool = bool(cfg.get("distilled", False))
     lora_configs: list[dict] = cfg.get("lora_configs", [])
     mixed_precision: str = cfg.get("mixed_precision", "bf16")
     vae_precision: str = cfg.get("vae_precision", mixed_precision)
@@ -158,11 +159,13 @@ def main() -> None:
                           tiling=str(cfg.get("vae_tiling", "auto")))
 
     logger.info("加载文本编码器...")
-    qwen_model, qwen_tok, t5_tok = family.load_text(
+    # 族 opaque 文本栈不拆包；ad-hoc prompt 关缓存（cached_varlen 族 TE 常驻）
+    text_stack = family.load_text(
         text_encoder_path, device, dtype,
         t5_tokenizer_path=t5_tokenizer_path or None,
         comfy_qwen=text_encoder_backend == "comfy_qwen3",
         t5_fast=t5_tokenizer_backend == "fast",
+        cache_enabled=False,
     )
 
     # 多 LoRA：每份独立 inject + multiplier=scale。adapters 必须保持引用，否则
@@ -171,7 +174,8 @@ def main() -> None:
         LoRASpec(path=str(lc.get("path", "")), scale=float(lc.get("scale", 1.0)))
         for lc in lora_configs
     ]
-    _adapters = apply_loras(model, specs, device, torch.float32)  # noqa: F841 — 保持引用
+    _adapters = apply_loras(model, specs, device, torch.float32,  # noqa: F841 — 保持引用
+                            family_id=family.spec.family_id)
 
     model.eval()
 
@@ -189,10 +193,10 @@ def main() -> None:
             base_cfg_scale=cfg_scale,
             base_sampler=sampler_name,
             scheduler=scheduler,
+            distilled=distilled,
             height=height,
             width=width,
-            model=model, vae=vae,
-            qwen_model=qwen_model, qwen_tok=qwen_tok, t5_tok=t5_tok,
+            family=family, model=model, vae=vae, text=text_stack,
             device=device, dtype=dtype,
             output_dir=output_dir,
             update_monitor=_update_monitor,
@@ -213,9 +217,9 @@ def main() -> None:
 
             logger.info(f"[{img_idx + 1}/{total}] seed={seed}  prompt={prompt[:60]}...")
             try:
-                img = _T.sample_image(
-                    model, vae, qwen_model, qwen_tok, t5_tok,
-                    prompt=prompt,
+                img = family.sample_image(
+                    model, vae, text_stack,
+                    prompt,
                     height=height,
                     width=width,
                     steps=steps,
@@ -223,6 +227,7 @@ def main() -> None:
                     negative_prompt=negative_prompt,
                     sampler_name=sampler_name,
                     scheduler=scheduler,
+                    distilled=distilled,
                     device=device,
                     dtype=dtype,
                     seed=seed,
@@ -305,10 +310,11 @@ def _run_xy_matrix(
     scheduler: str,
     height: int,
     width: int,
-    model, vae, qwen_model, qwen_tok, t5_tok,
+    family, model, vae, text,
     device: str, dtype,
     output_dir,
     update_monitor,
+    distilled: bool = False,
 ) -> None:
     """循环 (yi, xi) 出 N×M 张图。
 
@@ -379,9 +385,9 @@ def _run_xy_matrix(
                 f"steps={cur_steps} cfg={cur_cfg_scale} seed={cur_seed} sampler={cur_sampler}"
             )
             try:
-                img = _T.sample_image(
-                    model, vae, qwen_model, qwen_tok, t5_tok,
-                    prompt=prompt,
+                img = family.sample_image(
+                    model, vae, text,
+                    prompt,
                     height=height,
                     width=width,
                     steps=cur_steps,
@@ -389,6 +395,7 @@ def _run_xy_matrix(
                     negative_prompt=negative_prompt,
                     sampler_name=cur_sampler,
                     scheduler=scheduler,
+                    distilled=distilled,
                     device=device,
                     dtype=dtype,
                     seed=cur_seed,

--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -445,9 +445,11 @@ def main() -> None:
                           tiling=str(cfg.get("vae_tiling", "auto")))
 
     logger.info("加载文本编码器...")
-    qwen_model, qwen_tok, t5_tok = family.load_text(
+    # 族 opaque 文本栈不拆包；ad-hoc prompt 关缓存（cached_varlen 族 TE 常驻）
+    text_stack = family.load_text(
         text_encoder_path, device, dtype,
         t5_tokenizer_path=t5_tokenizer_path or None,
+        cache_enabled=False,
     )
 
     model.eval()
@@ -493,9 +495,9 @@ def main() -> None:
         logger.info(f"  prompt: {prompt[:80]}")
 
         try:
-            img = _T.sample_image(
-                model, vae, qwen_model, qwen_tok, t5_tok,
-                prompt=prompt,
+            img = family.sample_image(
+                model, vae, text_stack,
+                prompt,
                 height=height,
                 width=width,
                 steps=steps,

--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -122,6 +122,9 @@ class AnimaFamily:
     def sample_image(self, model, vae, text, prompt, **kwargs):
         from training.families.anima.sampling import sample_image
 
+        # distilled 是蒸馏推理族（Krea2 Turbo）的旋钮；Anima 无蒸馏变体，
+        # 接受并忽略（调用方按统一协议传，无需按族分支）。
+        kwargs.pop("distilled", None)
         return sample_image(model, vae, *text, prompt, **kwargs)
 
     # ── LoRA 产物 ────────────────────────────────────────────────────────

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -17,6 +17,7 @@ from training.families.krea2.sampling import (
     KREA2_SCHEDULER,
     Krea2SamplingCondition,
     prepare_sampling_condition,
+    resolve_sampling_settings,
     sample_image,
 )
 from training.families.krea2.text_encoding import (
@@ -141,17 +142,28 @@ class Krea2Family:
     def sample_image(self, model, vae, text, prompt, *,
                      height: int = 1024, width: int = 1024,
                      steps: int | None = None,
-                     cfg_scale: float = KREA2_RAW_GUIDANCE,
+                     cfg_scale: float | None = None,
                      negative_prompt: str = "",
                      sampler_name: str | None = None,
                      scheduler: str | None = None,
+                     distilled: bool = False,
                      device="cuda", dtype=None, step_callback=None,
                      phase_callback=None, seed: int | None = None):
+        # 先按 Raw/Turbo 解析步数与 guidance（steps/cfg 未显式给时用族默认：
+        # Raw 28 步 / 4.5，Turbo 8 步 / 0.0——TDM 蒸馏无 uncond，guidance=0
+        # 时 prepare 不编码 negative、采样跳过 uncond forward）。
+        resolved_steps, guidance = resolve_sampling_settings(
+            distilled=distilled,
+            steps=steps,
+            cfg_scale=cfg_scale,
+            sampler_name=sampler_name,
+            scheduler=scheduler,
+        )
         condition = prepare_sampling_condition(
             text,
             prompt,
             negative_prompt=negative_prompt,
-            cfg_scale=cfg_scale,
+            cfg_scale=guidance,
             device=device,
             dtype=dtype,
             phase_callback=phase_callback,
@@ -162,10 +174,11 @@ class Krea2Family:
             condition,
             height=height,
             width=width,
-            steps=steps,
-            cfg_scale=cfg_scale,
+            steps=resolved_steps,
+            cfg_scale=guidance,
             sampler_name=sampler_name,
             scheduler=scheduler,
+            distilled=distilled,
             device=device,
             dtype=dtype,
             step_callback=step_callback,

--- a/studio/api/deps.py
+++ b/studio/api/deps.py
@@ -29,7 +29,7 @@ def _supervisor() -> Supervisor:
     return sup
 
 
-def _resolve_anima_model_paths(
+def _resolve_model_paths(
     base_model: Optional[str] = None, *, family: str = "anima"
 ) -> dict[str, str]:
     """解析 base 模型默认路径（先验生成 / 测试出图共用）。

--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -34,7 +34,7 @@ from urllib.parse import quote
 from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
 from fastapi.responses import FileResponse, Response
 
-from ..deps import _resolve_anima_model_paths
+from ..deps import _resolve_model_paths
 from ..errors import _validate_component_or_400
 from ..schemas.generate import GenerateRequest
 from ... import db, secrets
@@ -168,8 +168,13 @@ _cleanup_xy_tmp_folders()
 def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
     """启动测试出图 task。"""
     from ...services.inference.core import generate_tempdir
+    from ...services.models.families import get_assets
 
-    model_paths = _resolve_anima_model_paths(body.base_model)
+    model_paths = _resolve_model_paths(body.base_model, family=body.model_family)
+    # Turbo 检测（A4/C9）：官方蒸馏 variant → daemon 走 8 步/guidance 0/固定 mu
+    # 的采样时刻表默认；custom 权重无 purpose 元数据按非蒸馏处理
+    distilled = bool(get_assets(body.model_family).is_distilled_path(
+        model_paths.get("transformer_path", "")))
 
     with db.connection_for() as conn:
         task_id = db.create_task(
@@ -204,6 +209,8 @@ def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
 
         cfg = GenerateConfig(
             **model_paths,
+            model_family=body.model_family,
+            distilled=distilled,
             output_dir=str(tempdir),
             prompts=body.prompts,
             negative_prompt=body.negative_prompt,

--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -40,7 +40,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, HTTPException
 from fastapi.responses import FileResponse
 
-from ...deps import _resolve_anima_model_paths
+from ...deps import _resolve_model_paths
 from ...errors import _safe_join_or_400
 from ..logs import read_task_log
 from ...responses import _thumb_response
@@ -439,8 +439,20 @@ def get_reg_caption(pid: int, vid: int, path: str) -> dict[str, Any]:
 
 @router.post("/api/projects/{pid}/versions/{vid}/reg/generate-prior")
 def reg_generate_prior(pid: int, vid: int, body: RegAiRequest) -> dict[str, Any]:
-    """启动先验生成 task —— base 模型给每张 train 图的 tag 反向出对照图。"""
-    model_paths = _resolve_anima_model_paths(body.base_model)
+    """启动先验生成 task —— base 模型给每张 train 图的 tag 反向出对照图。
+
+    模型族跟随该 version 的训练配置（先验生成是 version 级操作，不是请求级
+    选择）：无 config 或未声明时按 anima。
+    """
+    project, ver = _project_and_version_or_404(pid, vid)
+    family = "anima"
+    if version_config.has_version_config(project, ver):
+        try:
+            vc = version_config.read_version_config(project, ver)
+            family = str(vc.get("model_family") or "anima")
+        except version_config.VersionConfigError:
+            pass  # 坏 config 不阻塞先验生成，按 anima 兜底
+    model_paths = _resolve_model_paths(body.base_model, family=family)
     _, _, vdir = _version_dir_or_404(pid, vid)
     train = vdir / "train"
     has_image = train.exists() and any(
@@ -456,9 +468,12 @@ def reg_generate_prior(pid: int, vid: int, body: RegAiRequest) -> dict[str, Any]
     rdir = _reg_dir(vdir)
     rdir.mkdir(parents=True, exist_ok=True)
 
+    from ....domain.common import FAMILY_SAMPLING
     from ....services.runtime.xformers import detect_attention_backend
+    sampling = FAMILY_SAMPLING[family]
     cfg = RegAiConfig(
         **model_paths,
+        model_family=family,
         train_dir=str(train),
         reg_dir=str(rdir),
         excluded_tags=list(body.excluded_tags),
@@ -467,8 +482,8 @@ def reg_generate_prior(pid: int, vid: int, body: RegAiRequest) -> dict[str, Any]
         height=body.height,
         steps=body.steps,
         cfg_scale=body.cfg_scale,
-        sampler_name=body.sampler_name,
-        scheduler=body.scheduler,
+        sampler_name=body.sampler_name or sampling["samplers"][0],
+        scheduler=body.scheduler or sampling["schedulers"][0],
         seed=body.seed,
         incremental=body.incremental,
         mixed_precision=body.mixed_precision,

--- a/studio/api/schemas/generate.py
+++ b/studio/api/schemas/generate.py
@@ -15,14 +15,17 @@ class GenerateRequest(BaseModel):
     height: int = 1024
     steps: int = 25
     cfg_scale: float = 4.0
-    sampler_name: Literal["er_sde", "dpmpp_3m_sde"] = "er_sde"
-    scheduler: Literal["simple", "sgm_uniform"] = "simple"
+    sampler_name: Literal["er_sde", "dpmpp_3m_sde", "euler"] = "er_sde"
+    scheduler: Literal["simple", "sgm_uniform", "krea2_shift"] = "simple"
     count: int = 1
     seed: int = 0
     lora_configs: list[LoraEntry] = []
     mixed_precision: str = "bf16"
+    # 底模所属模型族（多模型 P4-4）：决定路径解析 / daemon 加载与采样栈；
+    # sampler 按族白名单校验（GenerateConfig validator，越族 422）
+    model_family: Literal["anima", "krea2"] = "anima"
     # 本次出图临时选用的底模（官方 variant key 或注册的本地 custom 路径）；
-    # None → 用 Settings 里 selected_anima。只换 transformer 权重。
+    # None → 用 Settings 里该族 selected。只换 transformer 权重。
     base_model: Optional[str] = None
     # commit C：attention_backend 默认从 secrets.generate.attention_backend 读，
     # 前端 Generate 页不再发这个字段；保留 Optional 兼容老客户端 / 临时覆盖。

--- a/studio/api/schemas/training.py
+++ b/studio/api/schemas/training.py
@@ -155,8 +155,10 @@ class RegAiRequest(BaseModel):
     height: int = 1024
     steps: int = 25
     cfg_scale: float = 4.0
-    sampler_name: str = "er_sde"
-    scheduler: str = "simple"
+    # None = 未指定 → 端点按 version 的模型族解析默认（anima er_sde/simple，
+    # krea2 euler/krea2_shift）。显式给值则按族白名单严格校验
+    sampler_name: Optional[str] = None
+    scheduler: Optional[str] = None
     seed: int = 0
     incremental: bool = False
     mixed_precision: str = "bf16"

--- a/studio/domain/generate.py
+++ b/studio/domain/generate.py
@@ -10,9 +10,32 @@ from typing import Any, Literal, Optional
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from .common import AttentionBackend
+from .common import FAMILY_SAMPLING, AttentionBackend
 from .lora import LoraEntry
 from .xy_matrix import XYMatrixSpec, _check_axis_values
+
+
+def validate_sampling_for_family(
+    family: str, sampler_name: str, scheduler: str,
+) -> None:
+    """generate / reg_ai 的 sampler 按族严格校验（多模型 P4-4）。
+
+    与训练 config 不同，这两份 config 是每任务临时 JSON——没有 legacy 语料，
+    不需要 grandfather：越族值直接报错 + 可操作文案（两族 sample_image 都在
+    入口对白名单外的值 raise，这里提前到 422）。
+    """
+    allowed = FAMILY_SAMPLING.get(family)
+    if allowed is None:
+        return  # 未知族由 model_family 的 Literal 校验报错
+    for label, value, kind in (
+        ("sampler_name", sampler_name, "samplers"),
+        ("scheduler", scheduler, "schedulers"),
+    ):
+        if value not in allowed[kind]:
+            raise ValueError(
+                f"{label}='{value}' 不适用于 model_family='{family}'"
+                f"（该族可用：{'、'.join(allowed[kind])}）"
+            )
 
 
 class GenerateConfig(BaseModel):
@@ -23,6 +46,12 @@ class GenerateConfig(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
+
+    # 模型族（服务端从请求填充；daemon 按此派发加载与采样栈）
+    model_family: Literal["anima", "krea2"] = Field("anima")
+    # 蒸馏推理底模（Krea2 Turbo：8 步 / guidance 0 / mu 固定 1.15）。
+    # 服务端按 catalog variant purpose 检测官方 Turbo 路径后注入
+    distilled: bool = Field(False)
 
     # 模型路径（服务端从 secrets 填充）
     transformer_path: str = Field("models/diffusion_models/anima-base-v1.0.safetensors")
@@ -40,8 +69,8 @@ class GenerateConfig(BaseModel):
     height: int = Field(1024, ge=256, le=4096)
     steps: int = Field(25, ge=1, le=150)
     cfg_scale: float = Field(4.0, ge=0.0, le=20.0)
-    sampler_name: Literal["er_sde", "dpmpp_3m_sde"] = Field("er_sde")
-    scheduler: Literal["simple", "sgm_uniform"] = Field("simple")
+    sampler_name: Literal["er_sde", "dpmpp_3m_sde", "euler"] = Field("er_sde")
+    scheduler: Literal["simple", "sgm_uniform", "krea2_shift"] = Field("simple")
     count: int = Field(1, ge=1, le=32, description="每个 prompt 生成张数")
     seed: int = Field(0, description="随机种子（0=随机）")
 
@@ -74,6 +103,12 @@ class GenerateConfig(BaseModel):
         "flash_attn",
         description="Attention backend：none（SDPA）/ xformers / flash_attn",
     )
+
+    @model_validator(mode="after")
+    def _validate_sampler_family(self) -> "GenerateConfig":
+        validate_sampling_for_family(
+            self.model_family, self.sampler_name, self.scheduler)
+        return self
 
     @model_validator(mode="after")
     def _validate_xy(self) -> "GenerateConfig":

--- a/studio/domain/reg.py
+++ b/studio/domain/reg.py
@@ -12,6 +12,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .common import AttentionBackend
+from .generate import validate_sampling_for_family
 
 
 class RegAiConfig(BaseModel):
@@ -23,6 +24,10 @@ class RegAiConfig(BaseModel):
     """
 
     model_config = ConfigDict(extra="forbid")
+
+    # 模型族（服务端从 version config 读取——先验生成是 version 级操作，
+    # 族跟随该 version 的训练配置，不是用户请求级选择）
+    model_family: Literal["anima", "krea2"] = Field("anima")
 
     # 模型路径（服务端从 secrets 填充）
     transformer_path: str = Field("")
@@ -44,8 +49,8 @@ class RegAiConfig(BaseModel):
     height: int = Field(1024, ge=256, le=4096)
     steps: int = Field(25, ge=1, le=150)
     cfg_scale: float = Field(4.0, ge=0.0, le=20.0)
-    sampler_name: Literal["er_sde", "dpmpp_3m_sde"] = Field("er_sde")
-    scheduler: Literal["simple", "sgm_uniform"] = Field("simple")
+    sampler_name: Literal["er_sde", "dpmpp_3m_sde", "euler"] = Field("er_sde")
+    scheduler: Literal["simple", "sgm_uniform", "krea2_shift"] = Field("simple")
     seed: int = Field(0, description="随机种子（0=随机）")
     incremental: bool = Field(
         False,
@@ -56,3 +61,9 @@ class RegAiConfig(BaseModel):
         "flash_attn",
         description="Attention backend：none（SDPA）/ xformers / flash_attn",
     )
+
+    @model_validator(mode="after")
+    def _validate_sampler_family(self) -> "RegAiConfig":
+        validate_sampling_for_family(
+            self.model_family, self.sampler_name, self.scheduler)
+        return self

--- a/studio/services/eval_samples.py
+++ b/studio/services/eval_samples.py
@@ -596,14 +596,17 @@ def _default_generator(
     if use_xformers:
         _T.enable_xformers(model)
     vae = family.load_vae(vae_path, device, dtype)
-    qwen_model, qwen_tok, t5_tok = family.load_text(
+    # 族 opaque 文本栈不拆包；eval prompt 是 ad-hoc 输入，关缓存
+    text_stack = family.load_text(
         text_encoder_path, device, dtype,
         t5_tokenizer_path=t5_tokenizer_path or None,
+        cache_enabled=False,
     )
 
     checkpoint = version_dir / run["checkpoint"]["path"]
     adapters = apply_loras(
-        model, [LoRASpec(path=str(checkpoint), scale=lora_scale)], device, dtype
+        model, [LoRASpec(path=str(checkpoint), scale=lora_scale)], device, dtype,
+        family_id=family.spec.family_id,
     )
     _ = adapters  # keep adapter references alive for forward hooks
     model.eval()
@@ -626,9 +629,9 @@ def _default_generator(
             f"prompt={str(item.get('prompt') or '')[:80]}"
         )
         try:
-            img = _T.sample_image(
-                model, vae, qwen_model, qwen_tok, t5_tok,
-                prompt=str(item.get("prompt") or ""),
+            img = family.sample_image(
+                model, vae, text_stack,
+                str(item.get("prompt") or ""),
                 height=height,
                 width=width,
                 steps=steps,

--- a/studio/services/inference/core.py
+++ b/studio/services/inference/core.py
@@ -70,6 +70,8 @@ class LoRAMeta:
     weight_decompose: bool = False
     rs_lora: bool = False
     lora_reg_dims: Optional[dict[str, int]] = None
+    #: 产物所属模型族（D13 标记）；无标记的存量产物 grandfather 为 anima
+    model_family: str = "anima"
 
 
 def read_lora_meta(path: str) -> LoRAMeta:
@@ -146,6 +148,7 @@ def read_lora_meta(path: str) -> LoRAMeta:
         weight_decompose=weight_decompose,
         rs_lora=rs_lora,
         lora_reg_dims=lora_reg_dims,
+        model_family=str(ss_args.get("model_family") or "anima"),
     )
 
 
@@ -154,6 +157,7 @@ def apply_loras(
     specs: Sequence[LoRASpec],
     device: str,
     dtype: Any,
+    family_id: str = "anima",
 ) -> list[Any]:
     """对每个 LoRA 单独 inject 一份 AnimaLycorisAdapter；forward 时 hook 累加 delta。
 
@@ -180,10 +184,19 @@ def apply_loras(
             continue
 
         meta = read_lora_meta(path)
-        from training.families.anima.preset import ANIMA_PRESET  # noqa: PLC0415
+        # 跨族 fail-fast（A5，与训练侧 resume_lora 检查同款）：krea2 LoRA 配
+        # anima 底模（或反之）用错 preset 注入 = 键全 miss 的静默坏结果——
+        # 提前报错并给可操作文案。无标记存量产物 grandfather 为 anima。
+        if meta.model_family != family_id:
+            raise ValueError(
+                f"LoRA 跨模型族被拒绝：{Path(path).name} 属于 "
+                f"'{meta.model_family}'，当前底模族为 '{family_id}'。"
+                f"请换用同族 LoRA 或切换底模。"
+            )
+        from training.families import get_family  # noqa: PLC0415
 
         adapter = AnimaLycorisAdapter(
-            preset=ANIMA_PRESET,
+            preset=get_family(family_id).lora_preset(),
             algo=meta.algo,
             rank=meta.rank,
             alpha=meta.alpha,

--- a/studio/services/models/families/anima.py
+++ b/studio/services/models/families/anima.py
@@ -233,6 +233,8 @@ class _AnimaAssets:
     transformer_path_for = staticmethod(anima_transformer_path_for)
     selected_variant = staticmethod(selected_anima_variant)
     catalog_sections = staticmethod(catalog_sections)
+    # Anima 无蒸馏推理 variant
+    is_distilled_path = staticmethod(lambda path: False)
 
 
 ASSETS = _AnimaAssets()

--- a/studio/services/models/families/krea2.py
+++ b/studio/services/models/families/krea2.py
@@ -150,6 +150,22 @@ def default_paths_for_new_version(base_model: Optional[str] = None) -> dict[str,
     }
 
 
+def is_distilled_path(path: str) -> bool:
+    """transformer 路径是否为官方 Turbo（TDM 蒸馏推理）variant。
+
+    Turbo 与 Raw 结构全等（430 键同形状），loader 指纹物理上无法区分——
+    只能按 catalog variant 的文件名判。用户注册的 custom 权重无 purpose
+    元数据，一律按非蒸馏处理（A1：不加白名单，采样参数由用户控制）。
+    """
+    if not path:
+        return False
+    name = Path(str(path)).name
+    return any(
+        info["purpose"] == "inference" and info["filename"] == name
+        for info in KREA2_VARIANTS.values()
+    )
+
+
 def _file_status(path: Path) -> dict[str, Any]:
     try:
         stat = path.stat()
@@ -217,6 +233,7 @@ class _Krea2Assets:
     transformer_path_for = staticmethod(krea2_transformer_path_for)
     selected_variant = staticmethod(selected_krea2_variant)
     catalog_sections = staticmethod(catalog_sections)
+    is_distilled_path = staticmethod(is_distilled_path)
 
 
 ASSETS = _Krea2Assets()

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1370,8 +1370,10 @@ export interface XYMatrixSpec {
 
 export interface GenerateRequest {
   prompts: string[]
+  /** 底模所属模型族（多模型 P4-4）；省略 = anima。 */
+  model_family?: 'anima' | 'krea2'
   /** 本次出图临时选用的底模（官方 variant key 或本地 custom 路径）；
-   *  省略 → server 用 Settings 里的 selected_anima。 */
+   *  省略 → server 用 Settings 里该族的 selected。 */
   base_model?: string
   negative_prompt?: string
   width?: number

--- a/studio/web/src/components/BaseModelSelect.test.tsx
+++ b/studio/web/src/components/BaseModelSelect.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import '../i18n'
+
+vi.mock('../api/client', () => ({
+  api: { getModelsCatalog: vi.fn() },
+}))
+
+import { api } from '../api/client'
+import BaseModelSelect from './BaseModelSelect'
+
+const catalog = {
+  anima_main: {
+    variants: [
+      { variant: '1.0', exists: true },
+      { variant: 'preview2', exists: false },
+    ],
+    custom: [{ path: 'G:/m/ft.safetensors', name: 'ft.safetensors', exists: true }],
+    selected: '1.0',
+  },
+  krea2_main: {
+    variants: [
+      { variant: 'raw', exists: true, purpose: 'training' },
+      { variant: 'turbo', exists: true, purpose: 'inference' },
+    ],
+    custom: [],
+    selected: 'raw',
+  },
+} as never
+
+function optionValues() {
+  return Array.from(
+    (screen.getByRole('combobox') as HTMLSelectElement).options,
+  ).map((o) => o.value)
+}
+
+describe('BaseModelSelect per family（多模型 P4-4）', () => {
+  it('default family lists anima variants + custom, hiding missing files', async () => {
+    vi.mocked(api.getModelsCatalog).mockResolvedValue(catalog)
+    render(<BaseModelSelect value={null} onChange={() => {}} />)
+    await screen.findByRole('option', { name: '1.0' })
+    expect(optionValues()).toEqual(['1.0', 'G:/m/ft.safetensors'])
+  })
+
+  it('krea2 family lists raw/turbo with purpose badges', async () => {
+    vi.mocked(api.getModelsCatalog).mockResolvedValue(catalog)
+    render(<BaseModelSelect value={null} onChange={() => {}} family="krea2" />)
+    await screen.findByRole('option', { name: /raw/ })
+    expect(optionValues()).toEqual(['raw', 'turbo'])
+    // purpose 徽标（raw=训练 / turbo=推理）出现在 label 里
+    expect(screen.getByRole('option', { name: /turbo · 推理/ })).toBeInTheDocument()
+    // defaultValue 跟随该族 selected
+    expect((screen.getByRole('combobox') as HTMLSelectElement).value).toBe('raw')
+  })
+})

--- a/studio/web/src/components/BaseModelSelect.tsx
+++ b/studio/web/src/components/BaseModelSelect.tsx
@@ -1,22 +1,50 @@
 import { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { api, type ModelsCatalog } from '../api/client'
 
 /** 底模下拉的一个选项：value = 官方 variant key 或本地 custom 绝对路径。 */
 export interface BaseModelOption {
   value: string
   label: string
+  /** 官方 variant 的用途声明（krea2：raw=training / turbo=inference）；
+   *  custom 权重无此元数据。页面可据此应用蒸馏推理默认参数。 */
+  purpose?: 'training' | 'inference'
 }
 
-/** 从模型 catalog 拉「已下载的 Anima 主模型」列表 + 设置页当前选定值。
+/** 支持底模选择的模型族。catalog section 键 = `${family}_main`。 */
+export type BaseModelFamily = 'anima' | 'krea2'
+
+interface FamilyMainSection {
+  variants: Array<{
+    variant: string
+    exists: boolean
+    /** krea2 起 variant 带用途声明（raw=training / turbo=inference）。 */
+    purpose?: 'training' | 'inference'
+  }>
+  custom: Array<{ path: string; name: string; exists: boolean }>
+  selected: string
+}
+
+function mainSection(
+  catalog: ModelsCatalog | null, family: BaseModelFamily,
+): FamilyMainSection | null {
+  if (!catalog) return null
+  const section = family === 'krea2' ? catalog.krea2_main : catalog.anima_main
+  return (section as FamilyMainSection | undefined) ?? null
+}
+
+/** 从模型 catalog 拉「已下载的指定族主模型」列表 + 设置页当前选定值。
  *
  *  options 只含磁盘上存在的官方 variant + 注册的本地 custom（未下载的不出现，
- *  避免选了拉不到权重）；defaultValue = secrets.models.selected_anima（即设置页
- *  当前底模），作为下拉的初始 / 回退值。 */
-export function useBaseModelOptions(): {
+ *  避免选了拉不到权重）；defaultValue = 设置页该族当前选中底模，作为下拉的
+ *  初始 / 回退值。krea2 的 variant 带 purpose 徽标（raw=训练底模 /
+ *  turbo=推理底模，两者都可选——A1 不加白名单）。 */
+export function useBaseModelOptions(family: BaseModelFamily = 'anima'): {
   options: BaseModelOption[]
   defaultValue: string | null
   loaded: boolean
 } {
+  const { t } = useTranslation()
   const [catalog, setCatalog] = useState<ModelsCatalog | null>(null)
   useEffect(() => {
     let alive = true
@@ -24,20 +52,28 @@ export function useBaseModelOptions(): {
     return () => { alive = false }
   }, [])
   const options = useMemo<BaseModelOption[]>(() => {
-    const am = catalog?.anima_main
-    if (!am) return []
+    const section = mainSection(catalog, family)
+    if (!section) return []
     const out: BaseModelOption[] = []
-    for (const v of am.variants) {
-      if (v.exists) out.push({ value: v.variant, label: v.variant })
+    for (const v of section.variants) {
+      if (!v.exists) continue
+      const badge = v.purpose
+        ? ` · ${t(`baseModel.purpose.${v.purpose}`)}`
+        : ''
+      out.push({
+        value: v.variant,
+        label: `${v.variant}${badge}`,
+        purpose: v.purpose,
+      })
     }
-    for (const c of am.custom) {
+    for (const c of section.custom) {
       if (c.exists) out.push({ value: c.path, label: c.name })
     }
     return out
-  }, [catalog])
+  }, [catalog, family, t])
   return {
     options,
-    defaultValue: catalog?.anima_main.selected ?? null,
+    defaultValue: mainSection(catalog, family)?.selected ?? null,
     loaded: catalog !== null,
   }
 }
@@ -49,19 +85,21 @@ function basename(p: string): string {
 
 /** 底模下拉。受控：`value` 是「本次临时覆盖」（null = 跟随设置页默认）。
  *
+ *  `family` 决定列哪个族的主模型（默认 anima，向后兼容既有调用方）。
  *  `className` 让各页面把 select 样式对齐自己页面里的其它 input
  *  （正则集用 "select input"，测试页用 "input text-xs w-full"）。 */
 export default function BaseModelSelect({
-  value, onChange, className = 'select input', style, ariaLabel,
+  value, onChange, family = 'anima', className = 'select input', style, ariaLabel,
 }: {
   value: string | null
   onChange: (v: string) => void
+  family?: BaseModelFamily
   className?: string
   /** 内联样式透传（正则集页用它对齐训练配置页控件视觉）。 */
   style?: React.CSSProperties
   ariaLabel?: string
 }) {
-  const { options, defaultValue } = useBaseModelOptions()
+  const { options, defaultValue } = useBaseModelOptions(family)
   // 有效值：显式覆盖优先，否则跟随设置页默认。
   const effective = value ?? defaultValue ?? ''
   // effective 不在 options 里（例如设置页选的 variant 还没下载）时补一项，

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -348,11 +348,13 @@
       },
       "sampler": {
         "erSde": "ER SDE",
-        "dpmpp3mSde": "DPM++ 3M SDE"
+        "dpmpp3mSde": "DPM++ 3M SDE",
+        "euler": "Euler (FlowMatch)"
       },
       "scheduler": {
         "simple": "Simple",
-        "sgmUniform": "SGM Uniform"
+        "sgmUniform": "SGM Uniform",
+        "krea2Shift": "Krea2 Dynamic Shift"
       },
       "modelFamily": {
         "anima": "Anima",
@@ -1635,7 +1637,8 @@
     "noExportableXyData": "No exportable XY data",
     "allCellsLoadFailed": "All cell images failed to load (the originals may have been released)",
     "canvas2dUnavailable": "canvas 2d is unavailable",
-    "canvasToBlobNull": "canvas.toBlob returned null"
+    "canvasToBlobNull": "canvas.toBlob returned null",
+    "modelFamily": "Model family"
   },
   "overview": {
     "pipelineProgress": "Pipeline progress",
@@ -2855,5 +2858,11 @@
     "ok": "Switch",
     "empty": "(empty)",
     "failed": "Model family switch failed: {{error}}"
+  },
+  "baseModel": {
+    "purpose": {
+      "training": "training",
+      "inference": "inference"
+    }
   }
 }

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -348,11 +348,13 @@
       },
       "sampler": {
         "erSde": "ER SDE",
-        "dpmpp3mSde": "DPM++ 3M SDE"
+        "dpmpp3mSde": "DPM++ 3M SDE",
+        "euler": "Euler（FlowMatch）"
       },
       "scheduler": {
         "simple": "Simple",
-        "sgmUniform": "SGM Uniform"
+        "sgmUniform": "SGM Uniform",
+        "krea2Shift": "Krea2 动态 Shift"
       },
       "modelFamily": {
         "anima": "Anima",
@@ -1635,7 +1637,8 @@
     "noExportableXyData": "没有可导出的 XY 数据",
     "allCellsLoadFailed": "所有 cell 图都加载失败（可能原图已释放）",
     "canvas2dUnavailable": "canvas 2d 不可用",
-    "canvasToBlobNull": "canvas.toBlob 返回 null"
+    "canvasToBlobNull": "canvas.toBlob 返回 null",
+    "modelFamily": "模型族"
   },
   "overview": {
     "pipelineProgress": "流水线进度",
@@ -2855,5 +2858,11 @@
     "ok": "切换",
     "empty": "（空）",
     "failed": "模型族切换失败：{{error}}"
+  },
+  "baseModel": {
+    "purpose": {
+      "training": "训练",
+      "inference": "推理"
+    }
   }
 }

--- a/studio/web/src/lib/schema.ts
+++ b/studio/web/src/lib/schema.ts
@@ -191,10 +191,12 @@ export const SCHEMA_ENUM_LABEL_KEYS: Record<string, Record<string, string>> = {
   sample_sampler_name: {
     er_sde: 'schema.enums.sampler.erSde',
     dpmpp_3m_sde: 'schema.enums.sampler.dpmpp3mSde',
+    euler: 'schema.enums.sampler.euler',
   },
   sample_scheduler: {
     simple: 'schema.enums.scheduler.simple',
     sgm_uniform: 'schema.enums.scheduler.sgmUniform',
+    krea2_shift: 'schema.enums.scheduler.krea2Shift',
   },
 }
 

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -114,8 +114,24 @@ export default function RegularizationPage() {
   const [aiCfg, setAiCfg] = useState(4.0)
   const [aiSeed, setAiSeed] = useState(0)
   const [aiIncremental, setAiIncremental] = useState(false)
-  // 本次先验生成临时选用的底模（null = 跟随设置页 selected_anima）。
+  // 本次先验生成临时选用的底模（null = 跟随设置页该族 selected）。
   const [aiBaseModel, setAiBaseModel] = useState<string | null>(null)
+  // 先验生成的模型族跟随 version 训练配置（服务端权威解析；这里只为
+  // BaseModelSelect 列对族的底模）。无 config / 读失败 → anima。
+  const [aiFamily, setAiFamily] = useState<'anima' | 'krea2'>('anima')
+  useEffect(() => {
+    if (!vid) return
+    let alive = true
+    api.getVersionConfig(project.id, vid)
+      .then((r) => {
+        if (!alive) return
+        const fam = r.config?.model_family === 'krea2' ? 'krea2' : 'anima'
+        setAiFamily(fam)
+        setAiBaseModel(null)  // 族变 → 清临时底模覆盖（variant key 是族内值）
+      })
+      .catch(() => {})
+    return () => { alive = false }
+  }, [project.id, vid])
   const [aiBusy, setAiBusy] = useState(false)
   // AI 先验 task：同上；hydrate 时顺带把 aiBusy 同步到 task 真实状态
   const {
@@ -514,6 +530,7 @@ export default function RegularizationPage() {
                   cfg={aiCfg} onCfgChange={setAiCfg}
                   seed={aiSeed} onSeedChange={setAiSeed}
                   baseModel={aiBaseModel} onBaseModelChange={setAiBaseModel}
+                  family={aiFamily}
                   incremental={aiIncremental}
                   onIncrementalChange={setAiIncremental}
                 />
@@ -928,7 +945,7 @@ function AiForm({
   steps, onStepsChange,
   cfg, onCfgChange,
   seed, onSeedChange,
-  baseModel, onBaseModelChange,
+  baseModel, onBaseModelChange, family,
   incremental, onIncrementalChange,
 }: {
   trainTags: RegTagCount[]
@@ -942,6 +959,8 @@ function AiForm({
   cfg: number; onCfgChange: (v: number) => void
   seed: number; onSeedChange: (v: number) => void
   baseModel: string | null; onBaseModelChange: (v: string) => void
+  /** version 训练配置声明的模型族（底模列表按族列） */
+  family: 'anima' | 'krea2'
   incremental: boolean; onIncrementalChange: (v: boolean) => void
 }) {
   const { t } = useTranslation()
@@ -1041,6 +1060,7 @@ function AiForm({
           <BaseModelSelect
             value={baseModel}
             onChange={onBaseModelChange}
+            family={family}
             className="select input"
             style={fieldInputStyle}
             ariaLabel={t('reg.baseModelLabel')}

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -8,7 +8,7 @@ import {
   type Task,
   type XYMatrixSpec,
 } from '../../api/client'
-import BaseModelSelect from '../../components/BaseModelSelect'
+import BaseModelSelect, { useBaseModelOptions } from '../../components/BaseModelSelect'
 import PageHeader from '../../components/PageHeader'
 import { useToast } from '../../components/Toast'
 import { schemaEnumLabel } from '../../lib/schema'
@@ -47,8 +47,9 @@ import StatusBadge from './generate/StatusBadge'
 import ViewModeTabs, { type ViewMode } from './generate/ViewModeTabs'
 import {
   DEFAULT_NEG, DEFAULT_SAMPLER, DEFAULT_SCHEDULER,
-  SAMPLER_OPTIONS, SCHEDULER_OPTIONS,
-  type SamplerName, type SchedulerName,
+  DISTILLED_GENERATE_DEFAULTS, FAMILY_GENERATE_DEFAULTS,
+  SAMPLER_OPTIONS_BY_FAMILY, SCHEDULER_OPTIONS_BY_FAMILY,
+  type GenerateFamily, type SamplerName, type SchedulerName,
 } from './generate/types'
 import { useLoraCatalog } from './generate/useLoraCatalog'
 import { buildXYMatrix, cellCount, parseAxisValues, type XYAxisDraft } from './generate/xy'
@@ -57,6 +58,7 @@ const GENERATE_PREFS_KEY = 'studio:generate:params:v1'
 
 const DEFAULT_GENERATE_PREFS = {
   mode: 'single' as ViewMode,
+  modelFamily: 'anima' as GenerateFamily,
   prompts: ['newest, safe, 1girl, masterpiece, best quality'],
   negPrompt: DEFAULT_NEG,
   aspect: '1:1' as AspectName,
@@ -95,13 +97,27 @@ function normalizePrefs(p: GeneratePrefs): GeneratePrefs {
     return { ...d, loraIndex: xyLoras.length > 0 ? 0 : null }
   }
   const { loras: _legacy, count: _count, ...rest } = anyP  // count 已改瞬态，丢弃老持久值
-  return {
+  const merged = {
     ...DEFAULT_GENERATE_PREFS,
     ...rest,
     singleLoras,
     xyLoras,
     xDraft: clampIdx(rest.xDraft ?? DEFAULT_GENERATE_PREFS.xDraft) ?? DEFAULT_GENERATE_PREFS.xDraft,
     yDraft: clampIdx(rest.yDraft ?? null),
+  }
+  // 族与 sampler 一致性（多模型 P4-4）：老 prefs 无 modelFamily / 持久化的
+  // sampler 与当前族白名单不符时（越族值后端 422），落回族默认（首项）。
+  const family: GenerateFamily =
+    merged.modelFamily === 'krea2' ? 'krea2' : 'anima'
+  const samplers = SAMPLER_OPTIONS_BY_FAMILY[family] as readonly string[]
+  const schedulers = SCHEDULER_OPTIONS_BY_FAMILY[family] as readonly string[]
+  return {
+    ...merged,
+    modelFamily: family,
+    samplerName: (samplers.includes(merged.samplerName)
+      ? merged.samplerName : samplers[0]) as SamplerName,
+    scheduler: (schedulers.includes(merged.scheduler)
+      ? merged.scheduler : schedulers[0]) as SchedulerName,
   }
 }
 
@@ -132,7 +148,7 @@ export default function GeneratePage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const { mode, prompts, negPrompt, aspect, width, height, steps, cfgScale, samplerName, scheduler, seed, xDraft, yDraft, datasetPick } = prefs
+  const { mode, modelFamily, prompts, negPrompt, aspect, width, height, steps, cfgScale, samplerName, scheduler, seed, xDraft, yDraft, datasetPick } = prefs
   // LoRA 列表按 mode 完全独立：single 用 singleLoras，xy（含 compare 子视图）用
   // xyLoras。读写都按当前 mode 路由，切 mode 互不影响。
   const loras = mode === 'single' ? prefs.singleLoras : prefs.xyLoras
@@ -149,6 +165,19 @@ export default function GeneratePage() {
   const setSamplerName = (samplerName: SamplerName) => setPrefs((p) => ({ ...p, samplerName }))
   const setScheduler = (scheduler: SchedulerName) => setPrefs((p) => ({ ...p, scheduler }))
   const setSeed = (seed: number) => setPrefs((p) => ({ ...p, seed }))
+  /** 切模型族：sampler/scheduler/steps/cfg 落回目标族默认（越族值后端 422），
+   *  底模临时覆盖清空（variant key 是族内值）。 */
+  const setModelFamily = (family: GenerateFamily) => {
+    setBaseModel(null)
+    setPrefs((p) => ({
+      ...p,
+      modelFamily: family,
+      samplerName: SAMPLER_OPTIONS_BY_FAMILY[family][0] as SamplerName,
+      scheduler: SCHEDULER_OPTIONS_BY_FAMILY[family][0] as SchedulerName,
+      steps: FAMILY_GENERATE_DEFAULTS[family].steps,
+      cfgScale: FAMILY_GENERATE_DEFAULTS[family].cfgScale,
+    }))
+  }
   // 0.17 P-I：batch size（每次入队 task 数）是**瞬态** UI 值——不进 prefs、不持久化、
   // 不随点历史图回填（用户用 2 就一直 2）；刷新页面重置回 1。
   const [batchSize, setBatchSize] = useState(1)
@@ -212,6 +241,20 @@ export default function GeneratePage() {
   // 本次出图临时选用的底模（null = 跟随设置页 selected_anima）。不进 prefs
   // 持久化：每次进页面都回到「设置页默认底模」，符合「默认用设置里的」。
   const [baseModel, setBaseModel] = useState<string | null>(null)
+  // 当前族的底模选项（含 purpose 元数据）——选中蒸馏推理 variant（Krea2
+  // Turbo）时应用 8 步 / 无 CFG 的默认参数（可再改，A1 不加限制）
+  const { options: baseModelOptions } = useBaseModelOptions(modelFamily)
+  const onBaseModelChange = (v: string) => {
+    setBaseModel(v)
+    const picked = baseModelOptions.find((o) => o.value === v)
+    if (picked?.purpose === 'inference') {
+      setPrefs((p) => ({
+        ...p,
+        steps: DISTILLED_GENERATE_DEFAULTS.steps,
+        cfgScale: DISTILLED_GENERATE_DEFAULTS.cfgScale,
+      }))
+    }
+  }
   // monitor 走 useMonitorProgress hook (PR #37 增量协议)：currentTask 变 →
   // hook 自动重拉快照 + 订阅 SSE delta 合并；本组件只用 samples 字段，其余
   // 字段在这页生成场景下不需要。
@@ -509,6 +552,7 @@ export default function GeneratePage() {
       const base: GeneratePrefs = {
         ...prev,
         mode: applied.mode,
+        modelFamily: applied.modelFamily,
         prompts: applied.prompts.length > 0 ? applied.prompts : prev.prompts,
         negPrompt: applied.negPrompt,
         width: applied.width,
@@ -612,6 +656,7 @@ export default function GeneratePage() {
       const baseSnapshot: GenerateParamsSnapshot = {
         schema_version: PARAMS_SNAPSHOT_VERSION,
         mode,
+        model_family: modelFamily,
         prompts,
         negative_prompt: negPrompt,
         width, height, steps,
@@ -639,6 +684,7 @@ export default function GeneratePage() {
         const snap: GenerateParamsSnapshot = { ...baseSnapshot, seed: taskSeed }
         const body: GenerateRequest = {
           prompts: mergedPrompts,
+          model_family: modelFamily,
           base_model: baseModel ?? undefined,
           negative_prompt: negPrompt,
           width, height, steps,
@@ -907,8 +953,8 @@ export default function GeneratePage() {
                       onChange={(e) => setSamplerName(e.target.value as SamplerName)}
                       aria-label={t('generate.sampler')}
                     >
-                      {/* 文案与训练配置页共用 schema.enums.* 映射，两边保持一致 */}
-                      {SAMPLER_OPTIONS.map((s) => (
+                      {/* 文案与训练配置页共用 schema.enums.* 映射；选项按族白名单 */}
+                      {SAMPLER_OPTIONS_BY_FAMILY[modelFamily].map((s) => (
                         <option key={s} value={s}>{schemaEnumLabel('sample_sampler_name', s, t)}</option>
                       ))}
                     </select>
@@ -921,7 +967,7 @@ export default function GeneratePage() {
                       onChange={(e) => setScheduler(e.target.value as SchedulerName)}
                       aria-label={t('generate.scheduler')}
                     >
-                      {SCHEDULER_OPTIONS.map((s) => (
+                      {SCHEDULER_OPTIONS_BY_FAMILY[modelFamily].map((s) => (
                         <option key={s} value={s}>{schemaEnumLabel('sample_scheduler', s, t)}</option>
                       ))}
                     </select>
@@ -937,10 +983,23 @@ export default function GeneratePage() {
                   {t('generate.seedHint')}
                 </div>
                 <div>
+                  <label className="caption block mb-1">{t('generate.modelFamily')}</label>
+                  <select
+                    className="input text-xs w-full"
+                    value={modelFamily}
+                    onChange={(e) => setModelFamily(e.target.value as GenerateFamily)}
+                    aria-label={t('generate.modelFamily')}
+                  >
+                    <option value="anima">{schemaEnumLabel('model_family', 'anima', t)}</option>
+                    <option value="krea2">{schemaEnumLabel('model_family', 'krea2', t)}</option>
+                  </select>
+                </div>
+                <div>
                   <label className="caption block mb-1">{t('generate.baseModel')}</label>
                   <BaseModelSelect
                     value={baseModel}
-                    onChange={setBaseModel}
+                    onChange={onBaseModelChange}
+                    family={modelFamily}
                     className="input text-xs w-full"
                     ariaLabel={t('generate.baseModel')}
                   />

--- a/studio/web/src/pages/tools/generate/paramsSnapshot.ts
+++ b/studio/web/src/pages/tools/generate/paramsSnapshot.ts
@@ -16,7 +16,7 @@
 import type { LoraEntry, XYAxisType } from '../../../api/client'
 import type { DatasetPick } from './PromptFromDatasetPicker'
 import {
-  DEFAULT_SAMPLER, DEFAULT_SCHEDULER, SAMPLER_OPTIONS, SCHEDULER_OPTIONS,
+  SAMPLER_OPTIONS_BY_FAMILY, SCHEDULER_OPTIONS_BY_FAMILY,
   type SamplerName, type SchedulerName,
 } from './types'
 import type { XYAxisDraft } from './xy'
@@ -56,6 +56,8 @@ export interface GenerateParamsSnapshot {
   schema_version: number
   /** 当时的 mode；回填时按 mode 决定灌 singleLoras 还是 xyLoras + xDraft/yDraft */
   mode: 'single' | 'xy' | 'compare'
+  /** 当时的模型族（多模型 P4-4）；老快照无此字段 → anima */
+  model_family?: 'anima' | 'krea2'
   /** prefs.prompts 原文（未与 datasetPick.tags 合并） */
   prompts: string[]
   negative_prompt: string
@@ -141,6 +143,8 @@ export type SnapshotLoraResolver = (snap: SnapshotLora) => Promise<LoraEntry>
  */
 export interface AppliedSnapshot {
   mode: 'single' | 'xy'  // compare 视图回填映射到 xy
+  /** 当时的模型族；老快照缺省 anima */
+  modelFamily: 'anima' | 'krea2'
   prompts: string[]
   negPrompt: string
   width: number
@@ -176,12 +180,18 @@ function mergeTagsIntoFirstPrompt(prompts: string[], tags: string[]): string[] {
 }
 
 /** 快照里的 sampler/scheduler 归并到合法值 —— 老快照缺字段、或外部 PNG 带了
- *  本程序不支持的值（如 euler）时回退默认，而不是把非法值灌进 prefs。 */
-function coerceSampler(v: string | undefined): SamplerName {
-  return (SAMPLER_OPTIONS as readonly string[]).includes(v ?? '') ? (v as SamplerName) : DEFAULT_SAMPLER
+ *  本程序不支持的值时按族回退默认，而不是把非法值灌进 prefs。 */
+function coerceSampler(v: string | undefined, family: 'anima' | 'krea2'): SamplerName {
+  const allowed = SAMPLER_OPTIONS_BY_FAMILY[family] as readonly string[]
+  return allowed.includes(v ?? '')
+    ? (v as SamplerName)
+    : (allowed[0] as SamplerName)
 }
-function coerceScheduler(v: string | undefined): SchedulerName {
-  return (SCHEDULER_OPTIONS as readonly string[]).includes(v ?? '') ? (v as SchedulerName) : DEFAULT_SCHEDULER
+function coerceScheduler(v: string | undefined, family: 'anima' | 'krea2'): SchedulerName {
+  const allowed = SCHEDULER_OPTIONS_BY_FAMILY[family] as readonly string[]
+  return allowed.includes(v ?? '')
+    ? (v as SchedulerName)
+    : (allowed[0] as SchedulerName)
 }
 
 export async function applySnapshot(
@@ -206,16 +216,19 @@ export async function applySnapshot(
     datasetPick = null
   }
 
+  const family: 'anima' | 'krea2' =
+    snap.model_family === 'krea2' ? 'krea2' : 'anima'
   const applied: AppliedSnapshot = {
     mode,
+    modelFamily: family,
     prompts,
     negPrompt: snap.negative_prompt,
     width: snap.width,
     height: snap.height,
     steps: snap.steps,
     cfgScale: snap.cfg_scale,
-    samplerName: coerceSampler(snap.sampler_name),
-    scheduler: coerceScheduler(snap.scheduler),
+    samplerName: coerceSampler(snap.sampler_name, family),
+    scheduler: coerceScheduler(snap.scheduler, family),
     count: snap.count,
     seed: snap.seed,
     baseModel: snap.base_model ?? null,

--- a/studio/web/src/pages/tools/generate/types.ts
+++ b/studio/web/src/pages/tools/generate/types.ts
@@ -17,12 +17,36 @@ export interface ProjectLora {
 export const DEFAULT_NEG =
   'worst quality, low quality, score_1, score_2, score_3, blurry, jpeg artifacts, bad anatomy, bad hands, bad feet, missing fingers, extra fingers, text, watermark, logo, signature'
 
-/** 采样器 / 调度器选项 —— 与后端 GenerateParams 的 Literal 保持一致
- *  （studio/api/schemas/generate.py）；新增值两边要同步。 */
-export const SAMPLER_OPTIONS = ['er_sde', 'dpmpp_3m_sde'] as const
+/** 采样器 / 调度器选项 —— 与后端 GenerateRequest 的 Literal 保持一致
+ *  （studio/api/schemas/generate.py）；新增值两边要同步。
+ *  按族白名单（多模型 P4-4）：镜像 studio/domain/common.py FAMILY_SAMPLING
+ *  （首项 = 族默认值），越族值后端 422。 */
+export type GenerateFamily = 'anima' | 'krea2'
+
+export const SAMPLER_OPTIONS_BY_FAMILY = {
+  anima: ['er_sde', 'dpmpp_3m_sde'],
+  krea2: ['euler'],
+} as const satisfies Record<GenerateFamily, readonly string[]>
+
+export const SCHEDULER_OPTIONS_BY_FAMILY = {
+  anima: ['simple', 'sgm_uniform'],
+  krea2: ['krea2_shift'],
+} as const satisfies Record<GenerateFamily, readonly string[]>
+
+/** 切族时应用的生成参数默认值（steps/cfg 对齐族 SamplingDefaults）。 */
+export const FAMILY_GENERATE_DEFAULTS = {
+  anima: { steps: 25, cfgScale: 4.0 },
+  krea2: { steps: 28, cfgScale: 4.5 },
+} as const satisfies Record<GenerateFamily, { steps: number; cfgScale: number }>
+
+/** Turbo（蒸馏推理 variant）选中时的参数默认：8 步、无 CFG。 */
+export const DISTILLED_GENERATE_DEFAULTS = { steps: 8, cfgScale: 0.0 } as const
+
+// 全量集合（快照校验 / 类型用）；单页下拉请用 *_BY_FAMILY
+export const SAMPLER_OPTIONS = ['er_sde', 'dpmpp_3m_sde', 'euler'] as const
 export type SamplerName = (typeof SAMPLER_OPTIONS)[number]
 export const DEFAULT_SAMPLER: SamplerName = 'er_sde'
 
-export const SCHEDULER_OPTIONS = ['simple', 'sgm_uniform'] as const
+export const SCHEDULER_OPTIONS = ['simple', 'sgm_uniform', 'krea2_shift'] as const
 export type SchedulerName = (typeof SCHEDULER_OPTIONS)[number]
 export const DEFAULT_SCHEDULER: SchedulerName = 'simple'

--- a/tests/test_anima_custom_model.py
+++ b/tests/test_anima_custom_model.py
@@ -80,7 +80,7 @@ def test_default_paths_for_new_version_follows_custom(
 def test_generate_resolver_follows_selected_custom(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """测试/出图页 deps._resolve_anima_model_paths 跟随 selected_anima（含 custom），
+    """测试/出图页 deps._resolve_model_paths 跟随 selected_anima（含 custom），
     不再写死 v1.0。"""
     from studio.api import deps
 
@@ -90,7 +90,7 @@ def test_generate_resolver_follows_selected_custom(
         secrets, "load",
         lambda: _secrets(tmp_path, selected=str(custom), custom=[str(custom)]),
     )
-    assert deps._resolve_anima_model_paths()["transformer_path"] == str(custom)
+    assert deps._resolve_model_paths()["transformer_path"] == str(custom)
 
 
 # ---------------------------------------------------------------------------
@@ -144,14 +144,14 @@ def test_base_model_override_missing_custom_falls_back(
     assert resolved == str(model_downloader.anima_main_target(tmp_path, "1.0"))
 
 
-def test_resolve_anima_model_paths_threads_override(
+def test_resolve_model_paths_threads_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """deps._resolve_anima_model_paths(base_model) 透传到 transformer_path。"""
+    """deps._resolve_model_paths(base_model) 透传到 transformer_path。"""
     from studio.api import deps
 
     monkeypatch.setattr(secrets, "load", lambda: _secrets(tmp_path, selected="1.0"))
-    got = deps._resolve_anima_model_paths("preview3-base")["transformer_path"]
+    got = deps._resolve_model_paths("preview3-base")["transformer_path"]
     assert got == str(model_downloader.anima_main_target(tmp_path, "preview3-base"))
 
 

--- a/tests/test_anima_daemon_comfy_parity_runtime.py
+++ b/tests/test_anima_daemon_comfy_parity_runtime.py
@@ -88,6 +88,7 @@ def test_daemon_exact_ksampler_parity_fails_when_xformers_unavailable(monkeypatc
 
     with pytest.raises(RuntimeError, match="xformers"):
         cache._load(
+            family_id="anima",
             transformer_path="transformer.safetensors",
             vae_path="vae.safetensors",
             text_encoder_path="text_encoder",
@@ -105,12 +106,15 @@ def test_daemon_exact_ksampler_parity_fails_when_xformers_unavailable(monkeypatc
 def test_daemon_worker_reports_error_when_all_images_fail(monkeypatch, tmp_path) -> None:
     mod = importlib.import_module("anima_daemon")
 
+    class _BoomFamily:
+        def sample_image(self, *args, **kwargs):
+            raise RuntimeError("boom")
+
     class FakeCache:
         model = object()
         vae = object()
-        qwen_model = object()
-        qwen_tok = object()
-        t5_tok = object()
+        text_stack = (object(), object(), object())
+        family = _BoomFamily()
         device = "cpu"
         dtype = None
 
@@ -124,7 +128,6 @@ def test_daemon_worker_reports_error_when_all_images_fail(monkeypatch, tmp_path)
 
     monkeypatch.setattr(mod, "CACHE", FakeCache())
     monkeypatch.setattr(mod, "_emit_for", lambda req_id, kind, **extra: events.append({"id": req_id, "kind": kind, **extra}))
-    monkeypatch.setattr(mod._T, "sample_image", lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")))
 
     mod._run_generate_worker(
         "req-1",
@@ -152,12 +155,16 @@ def test_daemon_restores_runtime_to_device_after_successful_generate(monkeypatch
 
     events: list[str] = []
 
+    class _RecordingFamily:
+        def sample_image(self, *_args, **_kwargs):
+            events.append("sample_image")
+            return Image.new("RGB", (1, 1))
+
     class FakeCache:
         model = object()
         vae = object()
-        qwen_model = object()
-        qwen_tok = object()
-        t5_tok = object()
+        text_stack = (object(), object(), object())
+        family = _RecordingFamily()
         device = "cuda"
         dtype = None
 
@@ -171,12 +178,7 @@ def test_daemon_restores_runtime_to_device_after_successful_generate(monkeypatch
         def _move_runtime_to_device(self):
             events.append("restore_runtime")
 
-    def fake_sample_image(*_args, **_kwargs):
-        events.append("sample_image")
-        return Image.new("RGB", (1, 1))
-
     monkeypatch.setattr(mod, "CACHE", FakeCache())
-    monkeypatch.setattr(mod._T, "sample_image", fake_sample_image)
     monkeypatch.setattr(
         mod,
         "_emit_for",

--- a/tests/test_anima_generate_xy.py
+++ b/tests/test_anima_generate_xy.py
@@ -63,16 +63,26 @@ def _make_fake_img(tmp: Path):
 
 
 def _mock_sample_image(records: list, fake_img):
-    """sample_image 替身：记录每次入参 + 返回伪图。"""
+    """family.sample_image 替身：记录每次入参 + 返回伪图。
+
+    P4-4 起 CLI 经 family.sample_image(model, vae, text, prompt, **kw) 派发，
+    prompt 是第 4 个位置参数。"""
     def _stub(*args, **kwargs):
         records.append({
             "steps": kwargs.get("steps"),
             "cfg_scale": kwargs.get("cfg_scale"),
             "sampler_name": kwargs.get("sampler_name"),
-            "prompt": kwargs.get("prompt"),
+            "prompt": args[3] if len(args) > 3 else kwargs.get("prompt"),
         })
         return fake_img
     return _stub
+
+
+def _stub_family(sample_fn):
+    """duck-typed ModelFamily 替身：只带 sample_image。"""
+    fam = types.SimpleNamespace()
+    fam.sample_image = sample_fn
+    return fam
 
 
 # ---------------------------------------------------------------------------
@@ -162,7 +172,7 @@ def test_run_xy_matrix_x_only_no_y(gen_module, tmp_path, monkeypatch) -> None:
     """y=None 退化成 1×N（一行）。"""
     fake_img = _make_fake_img(tmp_path)
     records: list[dict] = []
-    monkeypatch.setattr(gen_module._T, "sample_image", _mock_sample_image(records, fake_img))
+    family = _stub_family(_mock_sample_image(records, fake_img))
 
     monitor_calls: list[dict] = []
     def fake_monitor(**kw):
@@ -177,7 +187,7 @@ def test_run_xy_matrix_x_only_no_y(gen_module, tmp_path, monkeypatch) -> None:
         base_steps=25, base_cfg_scale=4.0, base_sampler="er_sde",
         scheduler="simple",
         height=1024, width=1024,
-        model=None, vae=None, qwen_model=None, qwen_tok=None, t5_tok=None,
+        family=family, model=None, vae=None, text=None,
         device="cpu", dtype=None,
         output_dir=tmp_path,
         update_monitor=fake_monitor,
@@ -204,7 +214,7 @@ def test_run_xy_matrix_2d_traversal_order(gen_module, tmp_path, monkeypatch) -> 
     """2×3 网格按 (yi 外, xi 内) 遍历 = 6 cells。"""
     fake_img = _make_fake_img(tmp_path)
     records: list[dict] = []
-    monkeypatch.setattr(gen_module._T, "sample_image", _mock_sample_image(records, fake_img))
+    family = _stub_family(_mock_sample_image(records, fake_img))
 
     gen_module._run_xy_matrix(
         xy_matrix={
@@ -217,7 +227,7 @@ def test_run_xy_matrix_2d_traversal_order(gen_module, tmp_path, monkeypatch) -> 
         base_steps=25, base_cfg_scale=4.0, base_sampler="er_sde",
         scheduler="simple",
         height=512, width=512,
-        model=None, vae=None, qwen_model=None, qwen_tok=None, t5_tok=None,
+        family=family, model=None, vae=None, text=None,
         device="cpu", dtype=None,
         output_dir=tmp_path,
         update_monitor=None,
@@ -236,10 +246,7 @@ def test_run_xy_matrix_2d_traversal_order(gen_module, tmp_path, monkeypatch) -> 
 def test_run_xy_matrix_lora_scale_resets_each_cell(gen_module, tmp_path, monkeypatch) -> None:
     """每个 cell 进入前 multiplier 重置到 base_scale，再按 axis 值改。"""
     fake_img = _make_fake_img(tmp_path)
-    monkeypatch.setattr(
-        gen_module._T, "sample_image",
-        lambda *a, **k: fake_img,
-    )
+    family = _stub_family(lambda *a, **k: fake_img)
 
     fake_network = MagicMock()
     fake_network.loras = []
@@ -269,7 +276,7 @@ def test_run_xy_matrix_lora_scale_resets_each_cell(gen_module, tmp_path, monkeyp
         base_steps=25, base_cfg_scale=4.0, base_sampler="er_sde",
         scheduler="simple",
         height=512, width=512,
-        model=None, vae=None, qwen_model=None, qwen_tok=None, t5_tok=None,
+        family=family, model=None, vae=None, text=None,
         device="cpu", dtype=None,
         output_dir=tmp_path,
         update_monitor=None,
@@ -288,7 +295,7 @@ def test_run_xy_matrix_lora_scale_resets_each_cell(gen_module, tmp_path, monkeyp
 def test_run_xy_matrix_seed_axis_overrides_base(gen_module, tmp_path, monkeypatch) -> None:
     """axis=seed 时，cell 文件名用 axis 值而非 base_seed。"""
     fake_img = _make_fake_img(tmp_path)
-    monkeypatch.setattr(gen_module._T, "sample_image", lambda *a, **k: fake_img)
+    family = _stub_family(lambda *a, **k: fake_img)
 
     gen_module._run_xy_matrix(
         xy_matrix={"x": {"axis": "seed", "values": [100, 200, 300]}, "y": None},
@@ -298,7 +305,7 @@ def test_run_xy_matrix_seed_axis_overrides_base(gen_module, tmp_path, monkeypatc
         base_steps=25, base_cfg_scale=4.0, base_sampler="er_sde",
         scheduler="simple",
         height=512, width=512,
-        model=None, vae=None, qwen_model=None, qwen_tok=None, t5_tok=None,
+        family=family, model=None, vae=None, text=None,
         device="cpu", dtype=None,
         output_dir=tmp_path,
         update_monitor=None,
@@ -316,7 +323,7 @@ def test_run_xy_matrix_seed_axis_overrides_base(gen_module, tmp_path, monkeypatc
 def test_run_xy_matrix_zero_seed_randomizes_once(gen_module, tmp_path, monkeypatch) -> None:
     """base_seed=0 → 随机一次后所有 cell 共享。"""
     fake_img = _make_fake_img(tmp_path)
-    monkeypatch.setattr(gen_module._T, "sample_image", lambda *a, **k: fake_img)
+    family = _stub_family(lambda *a, **k: fake_img)
     # 固定 random.randint 返回值便于断言
     monkeypatch.setattr(gen_module.random, "randint", lambda a, b: 12345)
 
@@ -328,7 +335,7 @@ def test_run_xy_matrix_zero_seed_randomizes_once(gen_module, tmp_path, monkeypat
         base_steps=25, base_cfg_scale=4.0, base_sampler="er_sde",
         scheduler="simple",
         height=512, width=512,
-        model=None, vae=None, qwen_model=None, qwen_tok=None, t5_tok=None,
+        family=family, model=None, vae=None, text=None,
         device="cpu", dtype=None,
         output_dir=tmp_path,
         update_monitor=None,
@@ -350,7 +357,7 @@ def test_run_xy_matrix_skips_failing_cell(gen_module, tmp_path, monkeypatch) -> 
             raise RuntimeError("CUDA OOM 模拟")
         return fake_img
 
-    monkeypatch.setattr(gen_module._T, "sample_image", flaky_sample_image)
+    family = _stub_family(flaky_sample_image)
 
     gen_module._run_xy_matrix(
         xy_matrix={"x": {"axis": "steps", "values": [10, 20, 30]}, "y": None},
@@ -360,7 +367,7 @@ def test_run_xy_matrix_skips_failing_cell(gen_module, tmp_path, monkeypatch) -> 
         base_steps=25, base_cfg_scale=4.0, base_sampler="er_sde",
         scheduler="simple",
         height=512, width=512,
-        model=None, vae=None, qwen_model=None, qwen_tok=None, t5_tok=None,
+        family=family, model=None, vae=None, text=None,
         device="cpu", dtype=None,
         output_dir=tmp_path,
         update_monitor=None,

--- a/tests/test_generate_family.py
+++ b/tests/test_generate_family.py
@@ -1,0 +1,50 @@
+"""Generate / RegAI 按族接线（多模型 P4-4）：sampler 白名单 + Turbo 检测。"""
+
+from __future__ import annotations
+
+import pytest
+
+from studio.domain.generate import GenerateConfig
+from studio.domain.reg import RegAiConfig
+from studio.services.models.families import get_assets
+
+
+def test_generate_config_family_sampler_whitelist():
+    """每任务临时 config 无 legacy 语料——越族 sampler 直接报错（422）。"""
+    GenerateConfig(model_family="krea2", sampler_name="euler",
+                   scheduler="krea2_shift")
+    with pytest.raises(ValueError, match="er_sde"):
+        GenerateConfig(model_family="krea2", sampler_name="er_sde",
+                       scheduler="krea2_shift")
+    with pytest.raises(ValueError, match="euler"):
+        GenerateConfig(model_family="anima", sampler_name="euler")
+    with pytest.raises(ValueError, match="krea2_shift"):
+        GenerateConfig(model_family="anima", scheduler="krea2_shift")
+
+
+def test_reg_config_family_sampler_whitelist():
+    RegAiConfig(model_family="krea2", sampler_name="euler",
+                scheduler="krea2_shift")
+    with pytest.raises(ValueError, match="simple"):
+        RegAiConfig(model_family="krea2", sampler_name="euler",
+                    scheduler="simple")
+
+
+def test_generate_config_carries_family_and_distilled_to_daemon():
+    cfg = GenerateConfig(model_family="krea2", distilled=True,
+                         sampler_name="euler", scheduler="krea2_shift")
+    dumped = cfg.model_dump()
+    assert dumped["model_family"] == "krea2"
+    assert dumped["distilled"] is True
+
+
+def test_is_distilled_path_by_official_variant():
+    """Turbo 与 Raw 结构全等，loader 指纹无法区分——只能按 catalog 文件名判。"""
+    krea2 = get_assets("krea2")
+    assert krea2.is_distilled_path("G:/models/diffusion_models/krea2-turbo-bf16.safetensors")
+    assert not krea2.is_distilled_path("G:/models/diffusion_models/krea2-raw-bf16.safetensors")
+    # custom 权重无 purpose 元数据 → 非蒸馏（A1：不加白名单，参数用户控制）
+    assert not krea2.is_distilled_path("G:/models/my-community-turbo-mix.safetensors")
+    assert not krea2.is_distilled_path("")
+    assert not get_assets("anima").is_distilled_path(
+        "G:/models/diffusion_models/anima-base-v1.0.safetensors")

--- a/tests/test_generate_preview_latent2rgb.py
+++ b/tests/test_generate_preview_latent2rgb.py
@@ -17,10 +17,14 @@ from PIL import Image
 
 from runtime.anima_daemon import (
     _PREVIEW_TARGET_PX,
-    _WAN21_LATENT_RGB_BIAS,
-    _WAN21_LATENT_RGB_FACTORS,
     _decode_latent2rgb_preview,
+    _preview_latent_spec,
 )
+
+# 投影系数单一来源在 families/latent_spaces.py（P4-4 起 daemon 按当前族 spec
+# 取，未加载时回退 Wan21 共享空间——本测试即该回退路径）。
+_WAN21_LATENT_RGB_FACTORS = [list(r) for r in _preview_latent_spec().rgb_factors]
+_WAN21_LATENT_RGB_BIAS = list(_preview_latent_spec().rgb_bias)
 
 
 def test_wan21_factors_shape() -> None:

--- a/tests/test_inference_core.py
+++ b/tests/test_inference_core.py
@@ -112,6 +112,37 @@ def test_read_lora_meta_invalid_fields(tmp_path: Path) -> None:
     assert meta.algo == "lokr"
 
 
+# ── 跨族 LoRA fail-fast（A5，多模型 P4-4）───────────────────────────────────
+
+
+def test_read_lora_meta_model_family_grandfather(tmp_path: Path) -> None:
+    """ss_network_args.model_family 有标记读标记；无标记存量产物 = anima（D13）。"""
+    marked = tmp_path / "k2.safetensors"
+    save_file({"x": torch.zeros(1)}, str(marked), metadata={
+        "ss_network_args": json.dumps({"algo": "lokr", "model_family": "krea2"}),
+    })
+    assert read_lora_meta(str(marked)).model_family == "krea2"
+
+    legacy = tmp_path / "legacy.safetensors"
+    _write_lora_safetensors(legacy, rank=32, alpha=16.0, algo="lokr", factor=8)
+    assert read_lora_meta(str(legacy)).model_family == "anima"
+
+
+def test_apply_loras_rejects_cross_family(tmp_path: Path) -> None:
+    """krea2 LoRA 配 anima 底模（或反之）→ 报错含可操作文案，不静默注错 preset。"""
+    import pytest
+
+    from studio.services.inference.core import LoRASpec, apply_loras
+
+    p = tmp_path / "k2_style.safetensors"
+    save_file({"x": torch.zeros(1)}, str(p), metadata={
+        "ss_network_args": json.dumps({"algo": "lokr", "model_family": "krea2"}),
+    })
+    with pytest.raises(ValueError, match="krea2"):
+        apply_loras(object(), [LoRASpec(path=str(p), scale=1.0)],
+                    "cpu", torch.float32, family_id="anima")
+
+
 def test_read_lora_meta_dora_and_rs_lora(tmp_path: Path) -> None:
     """DoRA / RS-LoRA 训练标志必须从 ss_network_args 读回。
 
@@ -352,7 +383,7 @@ def test_model_cache_moves_offloaded_model_before_injecting_lora(tmp_path: Path,
         def load_state_dict(self, *_args, **_kwargs):
             return MagicMock(missing_keys=[], unexpected_keys=[])
 
-    def fake_apply_loras(model, specs, device, dtype):
+    def fake_apply_loras(model, specs, device, dtype, family_id="anima"):
         events.append("apply_loras")
         assert "model.to:cuda" in events
         assert dtype == torch.float32


### PR DESCRIPTION
## 背景 / 动机

P4-4（决策清单 C6/C7/C9/C10 + A4/A5），Phase 4 最大的一刀。开工前调查发现比预期严重：**Generate 链路端到端硬编码 anima**——

- daemon `runtime/anima_daemon.py:303` 写死 `get_family("anima")`（注释自己说「K2 接入形态 Phase 4 定」）
- 采样走 anima 专属 5-arg 约定（`_T.sample_image(model, vae, qwen_model, qwen_tok, t5_tok, ...)`），daemon/CLI/eval 三处
- LoRA 注入硬编码 `ANIMA_PRESET`（`inference/core.py`），LoRA metadata 的 D13 族标记在 generate 链路零读取——**跨族 LoRA 会静默注错 preset（键全 miss 的坏结果）**
- `model_family` 在请求 schema / config.json / daemon 全链路无处可传

krea2 权重进来会崩在模型加载或文本编码。本刀补全 D8' 六个旁路调用面（daemon / anima_generate / anima_reg_ai / eval_samples）的真派发。

## 改动概要

**Runtime**：daemon `ModelCache` 退役 `qwen_model/qwen_tok/t5_tok` → 族 opaque `text_stack` + `family_id`（换族=全重载，与 D15「TrainingContext 三字段退役」同款纪律）；两处采样 + CLI 两脚本 + eval_samples 全改 `family.sample_image(model, vae, text, prompt)`；latent2rgb 预览按当前族 spec（未加载回退 Wan21 共享空间）；cached_varlen 族在 generate 场景 `cache_enabled=False`（ad-hoc prompt 无 sidecar 语料，TE 常驻在线编码）。

**Turbo（C9 + A4）**：`Krea2Family.sample_image` 接线 `distilled`——Raw 28 步/4.5，Turbo 8 步/guidance 0（TDM 蒸馏无 uncond：不编码 negative、跳过 uncond forward、mu 固定 1.15，对齐 diffusers/musubi）。检测 = catalog variant purpose 按文件名判（**loader 指纹物理上无法区分 Raw/Turbo**——结构全等）；custom 权重按非蒸馏（A1 不加白名单）。`AnimaFamily` 接受并忽略（协议 keyword-only 追加）。

**A5 跨族 LoRA fail-fast**：`read_lora_meta` 读 D13 族标记（无标记 grandfather anima），LoRA 族 ≠ 底模族 → 报错含可操作文案；preset 经 `get_family(family_id).lora_preset()` 派发。

**Studio**：两 domain config 加 `model_family`+`distilled`，sampler union Literal + 按族严格校验（每任务临时 JSON 无 legacy 语料 → 越族 422，无 grandfather——与训练 config 的非对称规则刻意不同）；reg 端点**族从 version config 读**（先验生成是 version 级操作，非请求级选择），请求 sampler 改 `None=按族默认`（正则页本就不发 sampler，否则 krea2 version 必 422）；`_resolve_anima_model_paths` 更名 `_resolve_model_paths`（P4-1 预告兑现）。

**前端**：Generate 页模型族下拉（持久化）——切族 sampler/scheduler/steps/cfg 落族默认并清底模覆盖；选中蒸馏 variant 自动 8 步/CFG 0（可改）；`BaseModelSelect` 按族列 + purpose 徽标（`raw · 训练` / `turbo · 推理`，C10 落地）；正则页族跟随 version config；params_snapshot 带族、PNG 回放按族归并。

## 测试方式

- 后端 +9：A5 跨族拒绝/grandfather、按族 sampler 校验、Turbo 路径检测、daemon FakeCache/XY 契约测试同步更新、latent2rgb 回退路径。全量 **2979 passed**（1 条已知本机 taskkill 计时 flake，单跑绿，见 memory）
- 前端 +3（BaseModelSelect 双族/徽标/exists 过滤）；全量 **497 passed**，lint 0 errors，tsc 干净
- `test_anima_generate_xy` 的 CLI 契约（文件名/遍历序/lora_scale 重置/seed 语义）全部保留，仅模型参数 kwargs 按新约定更新

## 浏览器视觉校验（AGENTS §5）

**Generate 页**：族下拉 [Anima / Krea 2]；切 Krea 2 → sampler 只剩 `Euler（FlowMatch）`、调度器 `Krea2 动态 Shift`、步数/CFG 自动落 28/4.5；底模列出 `raw · 训练`（turbo 本机未下载，exists 过滤正确）。
**正则页**：krea2 version（经 #422 的 family-switch API 造）→ 底模下拉列出 `raw · 训练`，族跟随 version config 生效。截图 4 张已存本地。

## 已知边界

- 真机 krea2 出图未跑（本机 turbo/raw 26GB 权重下载与显存条件），**A8：Phase 4 完成后统一真卡端到端验证**——那时训练→预览→Generate→Turbo 一次走完。
- XY 轴 sampler 值不做按族过滤（越族值 cell 级失败不炸整图，daemon 单 cell 容错既有语义）。
- LoRA 列表前端不按族过滤（version API 不带族信息）；A5 后端报错是权威判定，用户拿到明确文案。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
