### PR TITLE
refactor(ui): Settings 模型区按族遍历化 + 统一 selected 写路径（多模型 Phase 4）

### DIFF
--- a/studio/api/routers/models.py
+++ b/studio/api/routers/models.py
@@ -139,33 +139,37 @@ def start_model_download(body: ModelDownloadRequest) -> dict[str, Any]:
     return {"key": key, "status": snap.get(key, {}).get("status", "running")}
 
 
-@router.post("/api/models/anima/custom")
-def add_custom_anima(body: AnimaCustomModelRequest) -> dict[str, Any]:
+def _assets_or_400(family: str):
+    from ...services.models.families import get_assets
+
+    try:
+        return get_assets(family)
+    except ValueError as exc:
+        raise ValidationError(
+            f"Unknown model family: {family}",
+            code="model.family_invalid", details={"reason": str(exc)},
+            http_status=400,
+        ) from exc
+
+
+@router.post("/api/models/{family}/custom")
+def add_custom_model(family: str, body: AnimaCustomModelRequest) -> dict[str, Any]:
     """注册一个本地 `.safetensors` 主模型权重（去重 append），返回新 catalog。
 
     仅登记路径，不下载 / 不复制。校验文件存在 + 后缀白名单。注册后可在设置页
-    选作默认主模型，驱动训练新建默认 + 测试出图（在微调权重上炼丹 / 验证）。
+    选作该族默认主模型，驱动训练新建默认 + 测试出图（在微调权重上炼丹 / 验证）。
+    路由按族参数化（多模型 P4-5）：未知族 400。
     """
-    return _add_custom_model("anima", body.path)
+    assets = _assets_or_400(family)
+    return _add_custom_model(assets.family_id, body.path)
 
 
-@router.delete("/api/models/anima/custom")
-def remove_custom_anima(body: AnimaCustomModelRequest) -> dict[str, Any]:
+@router.delete("/api/models/{family}/custom")
+def remove_custom_model(family: str, body: AnimaCustomModelRequest) -> dict[str, Any]:
     """注销一个本地 custom 主模型，返回新 catalog。
 
-    若被删路径正是当前默认（`selected_anima`），把默认重置回最新官方 variant，
+    若被删路径正是该族当前默认，把默认重置回最新官方 variant，
     避免训练 / 出图解析落到已注销的路径。
     """
-    return _remove_custom_model("anima", body.path, model_downloader.LATEST_ANIMA)
-
-
-@router.post("/api/models/krea2/custom")
-def add_custom_krea2(body: AnimaCustomModelRequest) -> dict[str, Any]:
-    """注册本地 Krea2 `.safetensors` 主模型，返回新 catalog。"""
-    return _add_custom_model("krea2", body.path)
-
-
-@router.delete("/api/models/krea2/custom")
-def remove_custom_krea2(body: AnimaCustomModelRequest) -> dict[str, Any]:
-    """注销本地 Krea2 主模型；若当前选中则回退 Raw。"""
-    return _remove_custom_model("krea2", body.path, model_downloader.LATEST_KREA2)
+    assets = _assets_or_400(family)
+    return _remove_custom_model(assets.family_id, body.path, assets.latest)

--- a/studio/infrastructure/secrets.py
+++ b/studio/infrastructure/secrets.py
@@ -704,6 +704,14 @@ def update(partial: dict[str, Any]) -> Secrets:
     - 未提及的字段沿用旧值。
     """
     current_dict = load().model_dump()
+    # 剥离 models 的 read-compat computed 键（selected_anima / custom_anima_paths）：
+    # 它们不是存储字段，留在 merge base 里会以「入站 legacy 键」的身份经
+    # _migrate_legacy_model_fields 覆盖 partial 新写入的 selected/custom。
+    # 真正入站的 legacy 键（老客户端）在 partial 里，照旧获胜。
+    models_base = current_dict.get("models")
+    if isinstance(models_base, dict):
+        models_base.pop("selected_anima", None)
+        models_base.pop("custom_anima_paths", None)
     merged = _deep_merge(current_dict, partial)
     new = Secrets.model_validate(merged)
     save(new)

--- a/studio/services/models/families/anima.py
+++ b/studio/services/models/families/anima.py
@@ -228,6 +228,8 @@ class _AnimaAssets:
 
     family_id = "anima"
     display_name = "Anima"
+    #: 注销 custom 时 selected 的回退目标（最新官方 variant key）
+    latest = LATEST_ANIMA
 
     default_paths_for_new_version = staticmethod(default_paths_for_new_version)
     transformer_path_for = staticmethod(anima_transformer_path_for)

--- a/studio/services/models/families/krea2.py
+++ b/studio/services/models/families/krea2.py
@@ -228,6 +228,8 @@ def catalog_sections(root: Path, models_cfg: Any) -> dict[str, Any]:
 class _Krea2Assets:
     family_id = "krea2"
     display_name = "Krea 2"
+    #: 注销 custom 时 selected 的回退目标（最新官方 variant key）
+    latest = LATEST_KREA2
 
     default_paths_for_new_version = staticmethod(default_paths_for_new_version)
     transformer_path_for = staticmethod(krea2_transformer_path_for)

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -602,10 +602,16 @@ export interface ModelFileStatus {
   mtime: number
 }
 
-export interface AnimaVariantInfo extends ModelFileStatus {
+/** 族主模型的官方 variant（多模型 P4-5 统一形状；anima 无 purpose/repo 细分）。 */
+export interface FamilyMainVariantInfo extends ModelFileStatus {
   variant: string
   is_latest: boolean
   target_path: string
+  /** variant 级 repo（krea2：Raw/Turbo 各自的 HF 仓库）；anima 用 section repo。 */
+  repo?: string
+  /** 用途声明（krea2：raw=training / turbo=inference）。 */
+  purpose?: 'training' | 'inference'
+  size_estimate?: number
 }
 
 /** 用户注册的本地 custom 主模型（PathPicker 选盘上已有的 .safetensors）。 */
@@ -616,17 +622,21 @@ export interface CustomModelInfo extends ModelFileStatus {
   name: string
 }
 
-export interface AnimaMainCatalog {
-  id: 'anima_main'
+/** 族主模型 catalog 区块的统一形状（anima_main / krea2_main 同构，P4-5）。 */
+export interface FamilyMainCatalog {
+  id: string
   name: string
   description: string
   repo: string
-  variants: AnimaVariantInfo[]
+  variants: FamilyMainVariantInfo[]
   /** 本地注册的 custom 主模型列表。 */
   custom: CustomModelInfo[]
   /** 当前选中的主模型：variant key 或 custom 路径。 */
   selected: string
   latest: string
+  /** 许可展示（krea2 社区许可；anima 无）。 */
+  license?: string
+  license_url?: string
 }
 
 export interface AnimaVaeCatalog extends ModelFileStatus {
@@ -635,29 +645,6 @@ export interface AnimaVaeCatalog extends ModelFileStatus {
   description: string
   repo: string
   target_path: string
-}
-
-export interface Krea2VariantInfo extends ModelFileStatus {
-  variant: 'raw' | 'turbo'
-  is_latest: boolean
-  repo: string
-  purpose: 'training' | 'inference'
-  size_estimate: number
-  target_path: string
-}
-
-export interface Krea2MainCatalog {
-  id: 'krea2_main'
-  name: string
-  description: string
-  repo: string
-  variants: Krea2VariantInfo[]
-  /** 本地注册的 Krea2 主模型列表。 */
-  custom: CustomModelInfo[]
-  selected: string
-  latest: string
-  license: string
-  license_url: string
 }
 
 export interface ModelDirCatalog {
@@ -778,11 +765,11 @@ export interface FamilySwitchResponse {
 
 export interface ModelsCatalog {
   models_root: string
-  anima_main: AnimaMainCatalog
+  anima_main: FamilyMainCatalog
   anima_vae: AnimaVaeCatalog
   qwen3: ModelDirCatalog
   t5_tokenizer: ModelDirCatalog
-  krea2_main: Krea2MainCatalog
+  krea2_main: FamilyMainCatalog
   krea2_text_encoder: ModelDirCatalog
   wd14: WD14Catalog
   cltagger: CLTaggerCatalog
@@ -2053,27 +2040,16 @@ export const api = {
       method: 'POST',
       body: JSON.stringify(body),
     }),
-  /** 注册一个本地 .safetensors 主模型（微调训练 / 微调上测试）。返回新 catalog。 */
-  addCustomAnima: (path: string) =>
-    req<ModelsCatalog>('/api/models/anima/custom', {
+  /** 注册一个本地 .safetensors 主模型到指定族（微调训练 / 微调上测试）。
+   *  返回新 catalog。路由按族参数化（多模型 P4-5）。 */
+  addCustomModel: (family: 'anima' | 'krea2', path: string) =>
+    req<ModelsCatalog>(`/api/models/${family}/custom`, {
       method: 'POST',
       body: JSON.stringify({ path }),
     }),
-  /** 注销一个本地 custom 主模型。返回新 catalog。 */
-  removeCustomAnima: (path: string) =>
-    req<ModelsCatalog>('/api/models/anima/custom', {
-      method: 'DELETE',
-      body: JSON.stringify({ path }),
-    }),
-  /** 注册一个本地 Krea2 .safetensors 主模型。返回新 catalog。 */
-  addCustomKrea2: (path: string) =>
-    req<ModelsCatalog>('/api/models/krea2/custom', {
-      method: 'POST',
-      body: JSON.stringify({ path }),
-    }),
-  /** 注销一个本地 Krea2 主模型。返回新 catalog。 */
-  removeCustomKrea2: (path: string) =>
-    req<ModelsCatalog>('/api/models/krea2/custom', {
+  /** 注销一个本地 custom 主模型；若为该族当前选中则回退最新官方 variant。 */
+  removeCustomModel: (family: 'anima' | 'krea2', path: string) =>
+    req<ModelsCatalog>(`/api/models/${family}/custom`, {
       method: 'DELETE',
       body: JSON.stringify({ path }),
     }),

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -465,6 +465,33 @@ describe('SettingsPage (PP0)', () => {
     expect(statusBadgeIndex).toBeGreaterThan(customBadgeIndex)
     expect(screen.getAllByRole('radio')).toHaveLength(3)
     expect(screen.queryByText(/推荐工作流/)).not.toBeInTheDocument()
+    // purpose 徽标（C10）：krea2 variant 行标注用途（raw=训练 / turbo=推理）
+    const rawRow = screen.getByText('raw').closest('li')!
+    const turboRow = screen.getByText('turbo').closest('li')!
+    expect(within(rawRow).getByText('训练')).toBeInTheDocument()
+    expect(within(turboRow).getByText('推理')).toBeInTheDocument()
+  })
+
+  it('picking a variant writes new-style selected.{family}（多模型 P4-5）', async () => {
+    const user = userEvent.setup()
+    renderPage()
+    await user.click(await screen.findByRole('button', { name: '训练' }))
+    await screen.findByRole('heading', { name: 'Krea 2 主模型' })
+    // fixture：官方 variants 都未下载（radio 禁用），只有 custom 可点
+    const customRow = screen.getByText('my-krea2.safetensors').closest('li')!
+    await user.click(within(customRow).getByRole('radio'))
+
+    await waitFor(() => {
+      const putCall = fetchMock.mock.calls.find(
+        ([url, init]) => String(url).includes('/api/secrets') && init?.method === 'PUT'
+      )
+      expect(putCall).toBeDefined()
+      const body = JSON.parse(String(putCall![1].body))
+      // 统一写 selected.{family} 新结构——不再有 anima 写 legacy 键的分叉
+      expect(body).toEqual({
+        models: { selected: { krea2: '/tmp/models/my-krea2.safetensors' } },
+      })
+    })
   })
 
   it('shows LLM request pool controls on the tagging settings tab', async () => {

--- a/studio/web/src/pages/tools/settings/sections.tsx
+++ b/studio/web/src/pages/tools/settings/sections.tsx
@@ -69,6 +69,33 @@ export function TrainingParamsSection() {
   )
 }
 
+/** 每个模型族在 Settings 页的区块配置（多模型 P4-5）。
+ *  加第 3 个族 = 此表加一行 + i18n 标题键；渲染完全遍历化。
+ *  encoderIds 是该族的目录型资产（文本编码器 / tokenizer 等 catalog section id）。 */
+const FAMILY_MODEL_SECTIONS = [
+  {
+    family: 'anima' as const,
+    sectionId: 'models',
+    titleKey: 'settings.animaModels',
+    mainKey: 'anima_main' as const,
+    fallbackSelected: '1.0',
+    encoderIds: ['qwen3', 't5_tokenizer'] as const,
+    // 下载日志分组：该族相关的下载 key 前缀（正向声明，不再反向 startsWith 排除）
+    downloadKeyPrefixes: ['anima_main', 'anima_vae', 'qwen3', 't5_tokenizer'],
+  },
+  {
+    family: 'krea2' as const,
+    sectionId: 'krea2-models',
+    titleKey: 'settings.krea2Models',
+    mainKey: 'krea2_main' as const,
+    fallbackSelected: 'raw',
+    encoderIds: ['krea2_text_encoder'] as const,
+    downloadKeyPrefixes: ['krea2_main', 'krea2_text_encoder'],
+  },
+]
+
+type FamilyId = (typeof FAMILY_MODEL_SECTIONS)[number]['family']
+
 export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, catalogError, t }: {
   catalog: ModelsCatalog | null
   busy: Set<string>
@@ -81,27 +108,31 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
   const { toast } = useToast()
   const dialog = useDialog()
   const { runSave } = useSettingsData()
-  const [selectedAnima, setSelectedAnima] = useState<string>('1.0')
-  const [selectedKrea2, setSelectedKrea2] = useState<string>('raw')
-  const [showPicker, setShowPicker] = useState(false)
-  const [showKrea2Picker, setShowKrea2Picker] = useState(false)
-  const [addingCustom, setAddingCustom] = useState(false)
-  const [addingKrea2Custom, setAddingKrea2Custom] = useState(false)
+  const [selected, setSelected] = useState<Record<FamilyId, string>>({
+    anima: '1.0', krea2: 'raw',
+  })
+  const [pickerFamily, setPickerFamily] = useState<FamilyId | null>(null)
+  const [addingFamily, setAddingFamily] = useState<FamilyId | null>(null)
 
-  // 一次性拉 secrets 取 selected_anima（独立 PUT，不进全局 dirty 流程）。模型
+  // 一次性拉 secrets 取各族 selected（独立 PUT，不进全局 dirty 流程）。模型
   // 根目录已挪到「系统 → 存储位置」、自动配置模型路径已挪到「训练参数」，不在此渲染。
   useEffect(() => {
     void api.getSecrets().then((sec) => {
-      setSelectedAnima(sec.models?.selected_anima ?? '1.0')
-      setSelectedKrea2(sec.models?.selected?.krea2 ?? 'raw')
+      setSelected((prev) => ({
+        ...prev,
+        anima: sec.models?.selected?.anima ?? sec.models?.selected_anima ?? '1.0',
+        krea2: sec.models?.selected?.krea2 ?? 'raw',
+      }))
     }).catch(() => { /* 显示用，拉不到不阻塞 */ })
   }, [])
 
-  const pickAnima = async (variant: string) => {
-    if (variant === selectedAnima) return
-    setSelectedAnima(variant)
+  // 统一写新结构 selected.{family}（update() 已剥 merge base 的 read-compat
+  // computed 键，不会被过期 legacy 值覆盖——P4-5 前 anima 必须写 legacy 键）
+  const pick = async (family: FamilyId, variant: string) => {
+    if (variant === selected[family]) return
+    setSelected((prev) => ({ ...prev, [family]: variant }))
     try {
-      await runSave(() => api.updateSecrets({ models: { selected_anima: variant } }))
+      await runSave(() => api.updateSecrets({ models: { selected: { [family]: variant } } }))
       toast(t('settings.mainModelSelected', { name: variant }), 'success')
       await reloadCatalog()
     } catch (e) {
@@ -110,80 +141,34 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
     }
   }
 
-  const pickKrea2 = async (variant: string) => {
-    if (variant === selectedKrea2) return
-    setSelectedKrea2(variant)
-    try {
-      await runSave(() => api.updateSecrets({ models: { selected: { krea2: variant } } }))
-      toast(t('settings.mainModelSelected', { name: variant }), 'success')
-      await reloadCatalog()
-    } catch (e) {
-      toast(String(e), 'error')
-      void reloadCatalog()
-    }
-  }
-
-  // PathPicker 选中本地 .safetensors → 注册到 custom_anima_paths（仅登记路径）。
+  // PathPicker 选中本地 .safetensors → 注册到该族 custom（仅登记路径）。
   // 注册后不自动选中：与官方 variant「下载完再点 radio」的流程一致。
-  const addCustom = async (picked: string) => {
-    setShowPicker(false)
+  const addCustom = async (family: FamilyId, picked: string) => {
+    setPickerFamily(null)
     const p = picked.trim()
     if (!p) return
     if (!p.toLowerCase().endsWith('.safetensors')) {
       toast(t('settings.localModelInvalidExt'), 'error')
       return
     }
-    setAddingCustom(true)
+    setAddingFamily(family)
     try {
-      await runSave(() => api.addCustomAnima(p))
+      await runSave(() => api.addCustomModel(family, p))
       toast(t('settings.localModelAdded', { name: p.split(/[\\/]/).pop() }), 'success')
       await reloadCatalog()
     } catch (e) {
       toast(String(e), 'error')
     } finally {
-      setAddingCustom(false)
+      setAddingFamily(null)
     }
   }
 
-  const removeCustom = async (p: string) => {
+  const removeCustom = async (family: FamilyId, fallback: string, p: string) => {
     const name = p.split(/[\\/]/).pop() || p
     if (!(await dialog.confirm(t('settings.confirmRemoveLocalModel', { name }), { tone: 'danger' }))) return
     try {
-      await runSave(() => api.removeCustomAnima(p))
-      if (p === selectedAnima) setSelectedAnima('1.0')
-      toast(t('settings.localModelRemoved'), 'success')
-      await reloadCatalog()
-    } catch (e) {
-      toast(String(e), 'error')
-    }
-  }
-
-  const addKrea2Custom = async (picked: string) => {
-    setShowKrea2Picker(false)
-    const path = picked.trim()
-    if (!path) return
-    if (!path.toLowerCase().endsWith('.safetensors')) {
-      toast(t('settings.localModelInvalidExt'), 'error')
-      return
-    }
-    setAddingKrea2Custom(true)
-    try {
-      await runSave(() => api.addCustomKrea2(path))
-      toast(t('settings.localModelAdded', { name: path.split(/[\\/]/).pop() }), 'success')
-      await reloadCatalog()
-    } catch (e) {
-      toast(String(e), 'error')
-    } finally {
-      setAddingKrea2Custom(false)
-    }
-  }
-
-  const removeKrea2Custom = async (path: string) => {
-    const name = path.split(/[\\/]/).pop() || path
-    if (!(await dialog.confirm(t('settings.confirmRemoveLocalModel', { name }), { tone: 'danger' }))) return
-    try {
-      await runSave(() => api.removeCustomKrea2(path))
-      if (path === selectedKrea2) setSelectedKrea2('raw')
+      await runSave(() => api.removeCustomModel(family, p))
+      if (p === selected[family]) setSelected((prev) => ({ ...prev, [family]: fallback }))
       toast(t('settings.localModelRemoved'), 'success')
       await reloadCatalog()
     } catch (e) {
@@ -207,12 +192,12 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
     )
   }
 
-  const renderDownloadLogs = (family: 'anima' | 'krea2') => {
+  const renderDownloadLogs = (prefixes: readonly string[]) => {
     if (!catalog) return null
-    const downloads = Object.values(catalog.downloads).filter((download) => {
-      if (family === 'krea2') return download.key.startsWith('krea2_')
-      return !download.key.startsWith('krea2_')
-    })
+    // 正向按前缀声明分组（此前用 startsWith('krea2_') 反判——第三族会全落
+    // 进 anima 桶）
+    const downloads = Object.values(catalog.downloads).filter((download) =>
+      prefixes.some((prefix) => download.key.startsWith(prefix)))
     const visible = downloads.filter((download) => download.status === 'running' || download.status === 'failed')
     if (visible.length === 0) return null
     return (
@@ -240,234 +225,139 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
 
   return (
     <>
-    <SettingsSection id="models" title={t('settings.animaModels')}>
-      <SourceSelect
-        opt={catalog?.download_source_options?.training}
-        onChange={(s) => void setSource('training', s)}
-      />
+    {FAMILY_MODEL_SECTIONS.map((section) => {
+      const main = catalog?.[section.mainKey]
+      return (
+        <SettingsSection key={section.sectionId} id={section.sectionId} title={t(section.titleKey)}>
+          <SourceSelect
+            opt={catalog?.download_source_options?.training}
+            onChange={(s) => void setSource('training', s)}
+          />
 
-      {error && <div className="text-err text-xs font-mono">{error}</div>}
-      {!catalog ? (
-        <p className="text-fg-tertiary text-xs">{t('settings.loadingModelCatalog')}</p>
-      ) : (
-        <div className="flex flex-col gap-2">
-          {/* Anima 主模型 */}
-          <ModelGroupCard
-            title={catalog.anima_main.name}
-            helpTooltip={
-              <>
-                <p><Trans i18nKey="settings.repoHelp" values={{ desc: translatedCatalogText(MODEL_DESCRIPTION_KEYS, 'anima_main', catalog.anima_main.description, t), repo: catalog.anima_main.repo }} components={{ code: <code /> }} /></p>
-                <p><Trans i18nKey="settings.defaultTransformerHelp" components={{ strong: <strong /> }} /></p>
-              </>
-            }
-          >
-            <ul className="list-none m-0 p-0 flex flex-col gap-1">
-              {catalog.anima_main.variants.map((v) => {
-                const key = `anima_main:${v.variant}`
-                const dl = catalog.downloads[key]
-                const isSel = v.variant === selectedAnima
-                const canSelect = v.exists && dl?.status !== 'running'
-                return (
-                  <li key={v.variant} className={`flex items-center gap-2 text-xs px-1.5 py-1 rounded-sm ${
-                    isSel ? 'bg-accent-soft border border-accent' : 'bg-transparent border border-transparent'
-                  }`}>
-                    <input type="radio" name="anima_variant" checked={isSel} disabled={!canSelect}
-                      onChange={() => void pickAnima(v.variant)}
-                      className="shrink-0"
-                      style={{ accentColor: 'var(--accent)' }}
-                      title={canSelect ? t('settings.selectDefaultMainModel') : v.exists ? t('settings.downloadInProgress') : t('settings.downloadRequiredFirst')}
-                    />
-                    <code className="font-mono text-fg-primary w-32 shrink-0">{v.variant}</code>
-                    <span className="flex-1" />
-                    <ModelStatusBadge exists={v.exists} size={v.size} status={dl?.status} />
-                    <DownloadButton exists={v.exists} status={dl?.status} busy={busy.has(key)} onClick={() => void start('anima_main', v.variant)} />
-                  </li>
-                )
-              })}
-              {/* 用户注册的本地 custom 主模型（微调权重 / 在微调上测试） */}
-              {catalog.anima_main.custom.map((c) => {
-                const isSel = c.path === selectedAnima
-                return (
-                  <li key={c.path} className={`flex items-center gap-2 text-xs px-1.5 py-1 rounded-sm ${
-                    isSel ? 'bg-accent-soft border border-accent' : 'bg-transparent border border-transparent'
-                  }`}>
-                    <input type="radio" name="anima_variant" checked={isSel} disabled={!c.exists}
-                      onChange={() => void pickAnima(c.path)}
-                      className="shrink-0"
-                      style={{ accentColor: 'var(--accent)' }}
-                      title={c.exists ? t('settings.selectDefaultMainModel') : t('settings.localModelMissing')}
-                    />
-                    <code className="font-mono text-fg-primary w-32 shrink-0 truncate" title={c.path}>{c.name}</code>
-                    <span className="flex-1" />
-                    <span className="text-2xs px-1 py-0.5 rounded-sm bg-overlay text-fg-tertiary shrink-0">{t('settings.storage.customBadge')}</span>
-                    {c.exists
-                      ? <ModelStatusBadge exists size={c.size} />
-                      : <span className="text-err text-2xs">{t('settings.localModelMissing')}</span>}
-                    <button
-                      onClick={() => void removeCustom(c.path)}
-                      className="btn btn-secondary btn-sm shrink-0 min-w-[5rem] justify-center"
-                      title={t('settings.removeLocalModel')}
-                    >🗑 {t('settings.removeLocalModelShort')}</button>
-                  </li>
-                )
-              })}
-            </ul>
-            <button
-              onClick={() => setShowPicker(true)}
-              disabled={addingCustom}
-              className="btn btn-ghost btn-sm self-start mt-1"
-            >
-              {addingCustom ? t('common.saving') : t('settings.addLocalModel')}
-            </button>
-          </ModelGroupCard>
-
-          {/* VAE */}
-          {renderSharedVae()}
-
-          {/* Qwen3 + T5（CLTagger 已挪到「打标」tab） */}
-          {(['qwen3', 't5_tokenizer'] as const).map((id) => {
-            const m = catalog[id]
-            const dl = catalog.downloads[id]
-            const allExist = m.files.every((f) => f.exists)
-            const totalSize = m.files.reduce((s, f) => s + f.size, 0)
-            return (
-              <ModelGroupCard key={id} title={m.name}>
-                <div className="flex items-center gap-2 text-xs">
-                  <span className="text-fg-tertiary">{translatedCatalogText(MODEL_DESCRIPTION_KEYS, id, m.description, t)} · <code>{m.repo}</code></span>
-                  <span style={{ flex: 1 }} />
-                  <ModelStatusBadge exists={allExist} size={totalSize} status={dl?.status} fileCount={m.files.length} existsCount={m.files.filter((f) => f.exists).length} />
-                  <DownloadButton exists={allExist} status={dl?.status} busy={busy.has(id)} onClick={() => void start(id)} />
-                </div>
+          {error && <div className="text-err text-xs font-mono">{error}</div>}
+          {!catalog || !main ? (
+            <p className="text-fg-tertiary text-xs">{t('settings.loadingModelCatalog')}</p>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {/* 族主模型：官方 variants + 本地 custom */}
+              <ModelGroupCard
+                title={main.name}
+                helpTooltip={
+                  <>
+                    <p><Trans i18nKey="settings.repoHelp" values={{ desc: translatedCatalogText(MODEL_DESCRIPTION_KEYS, section.mainKey, main.description, t), repo: main.repo }} components={{ code: <code /> }} /></p>
+                    {section.family === 'anima' && (
+                      <p><Trans i18nKey="settings.defaultTransformerHelp" components={{ strong: <strong /> }} /></p>
+                    )}
+                    {main.license_url && (
+                      <p>
+                        <a href={main.license_url} target="_blank" rel="noreferrer" className="text-accent hover:underline">
+                          {t('settings.krea2LicenseNotice', { license: main.license })}
+                        </a>
+                      </p>
+                    )}
+                  </>
+                }
+              >
+                <ul className="list-none m-0 p-0 flex flex-col gap-1">
+                  {main.variants.map((v) => {
+                    const key = `${section.mainKey}:${v.variant}`
+                    const dl = catalog.downloads[key]
+                    const isSel = v.variant === selected[section.family]
+                    const canSelect = v.exists && dl?.status !== 'running'
+                    return (
+                      <li key={v.variant} className={`flex items-center gap-2 text-xs px-1.5 py-1 rounded-sm ${
+                        isSel ? 'bg-accent-soft border border-accent' : 'bg-transparent border border-transparent'
+                      }`}>
+                        <input type="radio" name={`${section.family}_variant`} checked={isSel} disabled={!canSelect}
+                          onChange={() => void pick(section.family, v.variant)}
+                          className="shrink-0"
+                          style={{ accentColor: 'var(--accent)' }}
+                          title={canSelect ? t('settings.selectDefaultMainModel') : v.exists ? t('settings.downloadInProgress') : t('settings.downloadRequiredFirst')}
+                        />
+                        <code className="font-mono text-fg-primary w-32 shrink-0">{v.variant}</code>
+                        {/* purpose 徽标（C10）：raw=训练底模 / turbo=推理底模 */}
+                        {v.purpose && (
+                          <span className="text-2xs px-1 py-0.5 rounded-sm bg-overlay text-fg-tertiary shrink-0">
+                            {t(`baseModel.purpose.${v.purpose}`)}
+                          </span>
+                        )}
+                        <span className="flex-1" />
+                        <ModelStatusBadge exists={v.exists} size={v.size} status={dl?.status} />
+                        <DownloadButton exists={v.exists} status={dl?.status} busy={busy.has(key)} onClick={() => void start(section.mainKey, v.variant)} />
+                      </li>
+                    )
+                  })}
+                  {/* 用户注册的本地 custom 主模型（微调权重 / 在微调上测试） */}
+                  {main.custom.map((c) => {
+                    const isSel = c.path === selected[section.family]
+                    return (
+                      <li key={c.path} className={`flex items-center gap-2 text-xs px-1.5 py-1 rounded-sm ${
+                        isSel ? 'bg-accent-soft border border-accent' : 'bg-transparent border border-transparent'
+                      }`}>
+                        <input type="radio" name={`${section.family}_variant`} checked={isSel} disabled={!c.exists}
+                          onChange={() => void pick(section.family, c.path)}
+                          className="shrink-0"
+                          style={{ accentColor: 'var(--accent)' }}
+                          title={c.exists ? t('settings.selectDefaultMainModel') : t('settings.localModelMissing')}
+                        />
+                        <code className="font-mono text-fg-primary w-32 shrink-0 truncate" title={c.path}>{c.name}</code>
+                        <span className="flex-1" />
+                        <span className="text-2xs px-1 py-0.5 rounded-sm bg-overlay text-fg-tertiary shrink-0">{t('settings.storage.customBadge')}</span>
+                        {c.exists
+                          ? <ModelStatusBadge exists size={c.size} />
+                          : <span className="text-err text-2xs">{t('settings.localModelMissing')}</span>}
+                        <button
+                          onClick={() => void removeCustom(section.family, section.fallbackSelected, c.path)}
+                          className="btn btn-secondary btn-sm shrink-0 min-w-[5rem] justify-center"
+                          title={t('settings.removeLocalModel')}
+                        >🗑 {t('settings.removeLocalModelShort')}</button>
+                      </li>
+                    )
+                  })}
+                </ul>
+                <button
+                  onClick={() => setPickerFamily(section.family)}
+                  disabled={addingFamily === section.family}
+                  className="btn btn-ghost btn-sm self-start mt-1"
+                >
+                  {addingFamily === section.family ? t('common.saving') : t('settings.addLocalModel')}
+                </button>
               </ModelGroupCard>
-            )
-          })}
 
-          {renderDownloadLogs('anima')}
-        </div>
-      )}
-      {showPicker && (
-        <PathPicker
-          initialPath={catalog?.models_root ?? undefined}
-          onPick={(p) => void addCustom(p)}
-          onClose={() => setShowPicker(false)}
-        />
-      )}
-    </SettingsSection>
-    <SettingsSection id="krea2-models" title={t('settings.krea2Models')}>
-      <SourceSelect
-        opt={catalog?.download_source_options?.training}
-        onChange={(source) => void setSource('training', source)}
-      />
+              {/* 共享 Qwen-Image VAE（两族同一份文件，族无关资产） */}
+              {renderSharedVae()}
 
-      {error && <div className="text-err text-xs font-mono">{error}</div>}
-      {!catalog ? (
-        <p className="text-fg-tertiary text-xs">{t('settings.loadingModelCatalog')}</p>
-      ) : (
-        <div className="flex flex-col gap-2">
-          <ModelGroupCard
-            title={catalog.krea2_main.name}
-            helpTooltip={
-              <>
-                <p><Trans i18nKey="settings.repoHelp" values={{ desc: translatedCatalogText(MODEL_DESCRIPTION_KEYS, 'krea2_main', catalog.krea2_main.description, t), repo: catalog.krea2_main.repo }} components={{ code: <code /> }} /></p>
-                <p>
-                  <a href={catalog.krea2_main.license_url} target="_blank" rel="noreferrer" className="text-accent hover:underline">
-                    {t('settings.krea2LicenseNotice', { license: catalog.krea2_main.license })}
-                  </a>
-                </p>
-              </>
-            }
-          >
-            <ul className="list-none m-0 p-0 flex flex-col gap-1">
-              {catalog.krea2_main.variants.map((variant) => {
-                const key = `krea2_main:${variant.variant}`
-                const download = catalog.downloads[key]
-                const isSelected = variant.variant === selectedKrea2
-                const canSelect = variant.exists && download?.status !== 'running'
+              {/* 该族的目录型资产（文本编码器 / tokenizer；CLTagger 在「打标」tab） */}
+              {section.encoderIds.map((id) => {
+                const m = catalog[id]
+                const dl = catalog.downloads[id]
+                const allExist = m.files.every((f) => f.exists)
+                const totalSize = m.files.reduce((s, f) => s + f.size, 0)
                 return (
-                  <li key={variant.variant} className={`flex items-center gap-2 text-xs px-1.5 py-1 rounded-sm ${
-                    isSelected ? 'bg-accent-soft border border-accent' : 'bg-transparent border border-transparent'
-                  }`}>
-                    <input type="radio" name="krea2_variant" checked={isSelected} disabled={!canSelect}
-                      onChange={() => void pickKrea2(variant.variant)}
-                      className="shrink-0"
-                      style={{ accentColor: 'var(--accent)' }}
-                      title={canSelect ? t('settings.selectDefaultMainModel') : variant.exists ? t('settings.downloadInProgress') : t('settings.downloadRequiredFirst')}
-                    />
-                    <code className="font-mono text-fg-primary w-32 shrink-0">{variant.variant}</code>
-                    <span className="flex-1" />
-                    <ModelStatusBadge exists={variant.exists} size={variant.size} status={download?.status} />
-                    <DownloadButton exists={variant.exists} status={download?.status} busy={busy.has(key)} onClick={() => void start('krea2_main', variant.variant)} />
-                  </li>
+                  <ModelGroupCard key={id} title={m.name}>
+                    <div className="flex items-center gap-2 text-xs">
+                      <span className="text-fg-tertiary">{translatedCatalogText(MODEL_DESCRIPTION_KEYS, id, m.description, t)} · <code>{m.repo}</code></span>
+                      <span style={{ flex: 1 }} />
+                      <ModelStatusBadge exists={allExist} size={totalSize} status={dl?.status} fileCount={m.files.length} existsCount={m.files.filter((f) => f.exists).length} />
+                      <DownloadButton exists={allExist} status={dl?.status} busy={busy.has(id)} onClick={() => void start(id)} />
+                    </div>
+                  </ModelGroupCard>
                 )
               })}
-              {catalog.krea2_main.custom.map((custom) => {
-                const isSelected = custom.path === selectedKrea2
-                return (
-                  <li key={custom.path} className={`flex items-center gap-2 text-xs px-1.5 py-1 rounded-sm ${
-                    isSelected ? 'bg-accent-soft border border-accent' : 'bg-transparent border border-transparent'
-                  }`}>
-                    <input type="radio" name="krea2_variant" checked={isSelected} disabled={!custom.exists}
-                      onChange={() => void pickKrea2(custom.path)}
-                      className="shrink-0"
-                      style={{ accentColor: 'var(--accent)' }}
-                      title={custom.exists ? t('settings.selectDefaultMainModel') : t('settings.localModelMissing')}
-                    />
-                    <code className="font-mono text-fg-primary w-32 shrink-0 truncate" title={custom.path}>{custom.name}</code>
-                    <span className="flex-1" />
-                    <span className="text-2xs px-1 py-0.5 rounded-sm bg-overlay text-fg-tertiary shrink-0">{t('settings.storage.customBadge')}</span>
-                    {custom.exists
-                      ? <ModelStatusBadge exists size={custom.size} />
-                      : <span className="text-err text-2xs">{t('settings.localModelMissing')}</span>}
-                    <button
-                      onClick={() => void removeKrea2Custom(custom.path)}
-                      className="btn btn-secondary btn-sm shrink-0 min-w-[5rem] justify-center"
-                      title={t('settings.removeLocalModel')}
-                    >🗑 {t('settings.removeLocalModelShort')}</button>
-                  </li>
-                )
-              })}
-            </ul>
-            <button
-              onClick={() => setShowKrea2Picker(true)}
-              disabled={addingKrea2Custom}
-              className="btn btn-ghost btn-sm self-start mt-1"
-            >
-              {addingKrea2Custom ? t('common.saving') : t('settings.addLocalModel')}
-            </button>
-          </ModelGroupCard>
 
-          {/* Krea 2 与 Anima 共享同一份 Qwen-Image VAE。 */}
-          {renderSharedVae()}
-
-          {(() => {
-            const id = 'krea2_text_encoder' as const
-            const model = catalog[id]
-            const download = catalog.downloads[id]
-            const allExist = model.files.every((file) => file.exists)
-            const totalSize = model.files.reduce((sum, file) => sum + file.size, 0)
-            return (
-              <ModelGroupCard title={model.name}>
-                <div className="flex items-center gap-2 text-xs">
-                  <span className="text-fg-tertiary">{translatedCatalogText(MODEL_DESCRIPTION_KEYS, id, model.description, t)} · <code>{model.repo}</code></span>
-                  <span style={{ flex: 1 }} />
-                  <ModelStatusBadge exists={allExist} size={totalSize} status={download?.status} fileCount={model.files.length} existsCount={model.files.filter((file) => file.exists).length} />
-                  <DownloadButton exists={allExist} status={download?.status} busy={busy.has(id)} onClick={() => void start(id)} />
-                </div>
-              </ModelGroupCard>
-            )
-          })()}
-
-          {renderDownloadLogs('krea2')}
-        </div>
-      )}
-      {showKrea2Picker && (
-        <PathPicker
-          initialPath={catalog?.models_root ?? undefined}
-          onPick={(path) => void addKrea2Custom(path)}
-          onClose={() => setShowKrea2Picker(false)}
-        />
-      )}
-    </SettingsSection>
+              {renderDownloadLogs(section.downloadKeyPrefixes)}
+            </div>
+          )}
+          {pickerFamily === section.family && (
+            <PathPicker
+              initialPath={catalog?.models_root ?? undefined}
+              onPick={(p) => void addCustom(section.family, p)}
+              onClose={() => setPickerFamily(null)}
+            />
+          )}
+        </SettingsSection>
+      )
+    })}
     </>
   )
 }

--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 204,
+  "count": 202,
   "routes": [
     {
       "path": "/",
@@ -298,22 +298,6 @@
       "type": "APIRoute"
     },
     {
-      "path": "/api/models/anima/custom",
-      "methods": [
-        "DELETE"
-      ],
-      "name": "remove_custom_anima",
-      "type": "APIRoute"
-    },
-    {
-      "path": "/api/models/anima/custom",
-      "methods": [
-        "POST"
-      ],
-      "name": "add_custom_anima",
-      "type": "APIRoute"
-    },
-    {
       "path": "/api/models/catalog",
       "methods": [
         "GET"
@@ -338,27 +322,27 @@
       "type": "APIRoute"
     },
     {
-      "path": "/api/models/krea2/custom",
-      "methods": [
-        "DELETE"
-      ],
-      "name": "remove_custom_krea2",
-      "type": "APIRoute"
-    },
-    {
-      "path": "/api/models/krea2/custom",
-      "methods": [
-        "POST"
-      ],
-      "name": "add_custom_krea2",
-      "type": "APIRoute"
-    },
-    {
       "path": "/api/models/path-defaults",
       "methods": [
         "GET"
       ],
       "name": "get_models_path_defaults",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/models/{family}/custom",
+      "methods": [
+        "DELETE"
+      ],
+      "name": "remove_custom_model",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/models/{family}/custom",
+      "methods": [
+        "POST"
+      ],
+      "name": "add_custom_model",
       "type": "APIRoute"
     },
     {

--- a/tests/test_anima_custom_model.py
+++ b/tests/test_anima_custom_model.py
@@ -209,46 +209,46 @@ def fake_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
 def test_add_custom_anima_registers_and_dedupes(
     tmp_path: Path, fake_store
 ) -> None:
-    from studio.api.routers.models import add_custom_anima
+    from studio.api.routers.models import add_custom_model
     from studio.api.schemas.models import AnimaCustomModelRequest
 
     f = tmp_path / "ft.safetensors"
     f.write_bytes(b"x")
-    cat = add_custom_anima(AnimaCustomModelRequest(path=str(f)))
+    cat = add_custom_model("anima", AnimaCustomModelRequest(path=str(f)))
     assert fake_store["s"].models.custom_anima_paths == [str(f)]
     assert any(c["path"] == str(f) for c in cat["anima_main"]["custom"])
 
     # 重复添加不产生第二条
-    add_custom_anima(AnimaCustomModelRequest(path=str(f)))
+    add_custom_model("anima", AnimaCustomModelRequest(path=str(f)))
     assert fake_store["s"].models.custom_anima_paths == [str(f)]
 
 
 def test_add_custom_anima_rejects_bad_ext(tmp_path: Path, fake_store) -> None:
-    from studio.api.routers.models import add_custom_anima
+    from studio.api.routers.models import add_custom_model
     from studio.api.schemas.models import AnimaCustomModelRequest
     from studio.domain.errors import ValidationError
 
     bad = tmp_path / "evil.txt"
     bad.write_bytes(b"x")
     with pytest.raises(ValidationError) as exc:
-        add_custom_anima(AnimaCustomModelRequest(path=str(bad)))
+        add_custom_model("anima", AnimaCustomModelRequest(path=str(bad)))
     assert exc.value.code == "model.ext_invalid"
 
 
 def test_add_custom_anima_rejects_missing_file(tmp_path: Path, fake_store) -> None:
-    from studio.api.routers.models import add_custom_anima
+    from studio.api.routers.models import add_custom_model
     from studio.api.schemas.models import AnimaCustomModelRequest
     from studio.domain.errors import ValidationError
 
     with pytest.raises(ValidationError) as exc:
-        add_custom_anima(AnimaCustomModelRequest(path=str(tmp_path / "ghost.safetensors")))
+        add_custom_model("anima", AnimaCustomModelRequest(path=str(tmp_path / "ghost.safetensors")))
     assert exc.value.code == "model.not_found"
 
 
 def test_remove_custom_anima_resets_selected_when_current(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from studio.api.routers.models import remove_custom_anima
+    from studio.api.routers.models import remove_custom_model
     from studio.api.schemas.models import AnimaCustomModelRequest
 
     a = str(tmp_path / "a.safetensors")
@@ -257,7 +257,7 @@ def test_remove_custom_anima_resets_selected_when_current(
     monkeypatch.setattr(secrets, "load", lambda: state["s"])
     monkeypatch.setattr(secrets, "save", lambda s: state.update(s=s))
 
-    remove_custom_anima(AnimaCustomModelRequest(path=a))
+    remove_custom_model("anima", AnimaCustomModelRequest(path=a))
     assert state["s"].models.custom_anima_paths == [b]
     # 删的是当前默认 → 重置回最新官方 variant
     assert state["s"].models.selected_anima == model_downloader.LATEST_ANIMA
@@ -266,7 +266,7 @@ def test_remove_custom_anima_resets_selected_when_current(
 def test_remove_custom_anima_keeps_selected_when_other(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from studio.api.routers.models import remove_custom_anima
+    from studio.api.routers.models import remove_custom_model
     from studio.api.schemas.models import AnimaCustomModelRequest
 
     a = str(tmp_path / "a.safetensors")
@@ -275,6 +275,6 @@ def test_remove_custom_anima_keeps_selected_when_other(
     monkeypatch.setattr(secrets, "load", lambda: state["s"])
     monkeypatch.setattr(secrets, "save", lambda s: state.update(s=s))
 
-    remove_custom_anima(AnimaCustomModelRequest(path=b))
+    remove_custom_model("anima", AnimaCustomModelRequest(path=b))
     assert state["s"].models.custom_anima_paths == [a]
     assert state["s"].models.selected_anima == a  # 未动当前默认

--- a/tests/test_krea2_custom_model.py
+++ b/tests/test_krea2_custom_model.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 from studio import secrets
-from studio.api.routers.models import add_custom_krea2, remove_custom_krea2
+from studio.api.routers.models import add_custom_model, remove_custom_model
 from studio.api.schemas.models import AnimaCustomModelRequest
 from studio.services import models as model_downloader
 
@@ -45,8 +45,8 @@ def test_krea2_custom_endpoint_registers_dedupes_and_resets_selected(
     )
     request = AnimaCustomModelRequest(path=str(custom))
 
-    catalog = add_custom_krea2(request)
-    add_custom_krea2(request)
+    catalog = add_custom_model("krea2", request)
+    add_custom_model("krea2", request)
     assert state["settings"].models.custom["krea2"] == [str(custom)]
     assert catalog["krea2_main"]["custom"][0]["path"] == str(custom)
 
@@ -54,7 +54,7 @@ def test_krea2_custom_endpoint_registers_dedupes_and_resets_selected(
         "selected": {"anima": "1.0", "krea2": str(custom)},
     })
     state["settings"] = state["settings"].model_copy(update={"models": selected})
-    remove_custom_krea2(request)
+    remove_custom_model("krea2", request)
 
     assert state["settings"].models.custom["krea2"] == []
     assert state["settings"].models.selected["krea2"] == "raw"

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -740,3 +740,28 @@ def test_wandb_current_preset_falls_back_when_missing(secrets_file: Path) -> Non
     s = secrets.load()
     assert s.wandb.current_preset == "default"
     assert [p.id for p in s.wandb.presets] == ["default", "team_b"]
+
+
+# ---------------------------------------------------------------------------
+# update() 与 models 读兼容键（多模型 P4-5）
+# ---------------------------------------------------------------------------
+
+
+def test_update_new_style_selected_not_clobbered_by_stale_compat(secrets_file: Path) -> None:
+    """写新结构 selected.{family} 不被 merge base 里过期的 computed 读兼容键
+    （selected_anima）覆盖——修掉 Settings 双写路径（pickAnima 写 legacy /
+    pickKrea2 写新键）的根因。"""
+    secrets.update({"models": {"selected": {"anima": "1.0", "krea2": "raw"}}})
+    updated = secrets.update({"models": {"selected": {"anima": "preview2"}}})
+    assert updated.models.selected["anima"] == "preview2"
+    # deep-merge：另一族的 selected 不丢
+    assert updated.models.selected["krea2"] == "raw"
+    # 读兼容面跟随新值
+    assert updated.models.selected_anima == "preview2"
+
+
+def test_update_incoming_legacy_key_still_wins(secrets_file: Path) -> None:
+    """老客户端仍然只发 legacy 键：真正入站的 selected_anima 照旧生效。"""
+    secrets.update({"models": {"selected": {"anima": "1.0"}}})
+    updated = secrets.update({"models": {"selected_anima": "preview3-base"}})
+    assert updated.models.selected["anima"] == "preview3-base"


### PR DESCRIPTION
## 背景 / 动机

P4-5（决策清单 C8）。#414 交付 Krea2 下载中心时用**复制粘贴**做出了双族 Settings 区——`sections.tsx` 两大块几乎逐行重复，且藏着三处结构性问题：

1. **selected 双写路径**：`pickAnima` 写 legacy `selected_anima`、`pickKrea2` 写新 `selected.krea2`。调查发现这不是随意——`secrets.update()` 的 merge base（`model_dump()`）带着 computed 读兼容键，merge 后迁移 validator 会把**过期的** legacy 值当「入站」覆盖新写入的 `selected`。写 legacy 键是绕这个坑的 workaround。
2. **下载日志反判**：`startsWith('krea2_')` 二分——第三族的下载会全部落进 anima 桶。
3. custom 模型是 4 条按族硬路由 + 前端 4 个硬函数。

## 改动概要

**双写路径修根因**（后端一处 + 前端统一）：`update()` 在 merge 前剥离 base 里的 `selected_anima`/`custom_anima_paths`——它们是 computed 读面不是存储字段；真正入站的 legacy 键在 `partial` 里，老客户端照旧生效（回归测试双向锁死）。此后前端统一写 `selected.{family}` 新结构。

**遍历化**：两大块合成 `FAMILY_MODEL_SECTIONS` 配置表（sectionId / mainKey / encoderIds / 下载 key 前缀 / 注销回退值）+ 单个 map 渲染，**净 -82 行**。加第 3 个族 = 表加一行 + i18n 标题键。`ModelsCatalog` 的两个族接口统一为 `FamilyMainCatalog`（license / purpose 可选字段按存在渲染——anima 的 `defaultTransformerHelp` 与 krea2 的许可链接都保留）。

**顺带补齐**：Settings variant 行渲染 purpose 徽标（`raw · 训练` / `turbo · 推理`，C10 的 Settings 面此前后端声明了但 JSX 从未渲染）；下载日志改按族前缀**正向声明**；custom 路由参数化 `/api/models/{family}/custom`（未知族 400，注销回退目标从硬编码改 `assets.latest`），route snapshot 按机制重生成。

## 测试方式

- 后端 +2：`update()` 新写路径不被过期 compat 键覆盖 / 入站 legacy 键（老客户端）仍生效；custom 路由测试改参数化调用
- 前端 +2：purpose 徽标按行断言、pick 后 PUT body = `{models:{selected:{krea2:...}}}`（锁死统一写路径）
- 全量 pytest **2981 passed**（1 条已知本机 taskkill 计时 flake，单跑历史绿，见 memory）；vitest **498 passed**；lint 0 errors / tsc 干净

## 浏览器视觉校验（AGENTS §5）

真服务实测：两区卡片结构与重构前逐项一致（anima：主模型 / VAE / Qwen3 / T5，5 radio；krea2：主模型 / 共享 VAE / Qwen3-VL，3 radio）；krea2 variant 行新增 训练/推理 徽标；参数化路由实测 add/remove 200、未知族 400。截图 1 张已存本地。

## 备注

`downloader.trigger()` 的 if-chain（加族要改的另一处）不在本刀——它工作正常，属「第三族落地时的加族成本」，届时随 FAMILY_ASSETS 下载清单机制一起看。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
