### PR TITLE
fix(train): krea2 loader 拒绝 fp8 权重 + 多模型文案收尾（多模型 Phase 4）

### DIFF
--- a/runtime/training/families/krea2/loader.py
+++ b/runtime/training/families/krea2/loader.py
@@ -1,4 +1,9 @@
-"""Strict Krea2 Raw checkpoint inspection and loading.
+"""Strict single-file Krea2 checkpoint inspection and loading.
+
+接受 Comfy/musubi 单文件布局（非 diffusers 分片布局）。**Raw 与 Turbo
+结构全等（同键同形状）——本 loader 对两者一视同仁，无法也不尝试区分**；
+「Turbo 不建议做训练底模」的防呆靠 studio 侧 catalog variant 的 purpose
+元数据（P4-4），不在加载层。
 
 The meta-device + ``assign=True`` loading strategy was adapted from
 kohya-ss/musubi-tuner (Apache-2.0):
@@ -6,8 +11,7 @@ Copyright 2026 Kohya S. and musubi-tuner contributors.
 https://github.com/kohya-ss/musubi-tuner/blob/8934cfbbb4b9bcfa8071ce209129f0c5eb5df2e6/src/musubi_tuner/krea2/krea2_utils.py
 
 Fingerprint validation, prefix handling, and diagnostics are original to this
-repository. The loader deliberately accepts the Comfy/musubi ``raw.safetensors``
-layout, not diffusers' renamed sharded transformer layout.
+repository.
 """
 
 from __future__ import annotations
@@ -34,9 +38,11 @@ _FLOAT_DTYPES = {
     "F16",
     "F32",
     "F64",
-    "F8_E4M3",
-    "F8_E5M2",
 }
+# fp8 是运行时量化技术（load-time 量化 + Linear forward patch + scale buffer），
+# 不是 checkpoint 交换格式——社区的「纯 fp8 cast」权重若静默 upcast 回 bf16，
+# 显存零收益还丢精度（A7'/C13）。显式报错并指路 bf16 版本。
+_FP8_DTYPES = {"F8_E4M3", "F8_E5M2"}
 
 
 @dataclass(frozen=True)
@@ -92,7 +98,7 @@ def _choose_prefix(source_keys: list[str], expected_keys: set[str]) -> str:
             if diffusers_hint
             else ""
         )
-        raise ValueError(f"不是可识别的 Krea2 Raw checkpoint：结构指纹零命中{hint}")
+        raise ValueError(f"不是可识别的 Krea2 checkpoint：结构指纹零命中{hint}")
     return best_prefix
 
 
@@ -138,6 +144,7 @@ def _inspect(
 
         shape_mismatches = []
         dtype_mismatches = []
+        fp8_keys = []
         for normalized in sorted(expected_keys & actual_keys):
             source_key = normalized_to_source[normalized]
             tensor_slice = handle.get_slice(source_key)
@@ -148,8 +155,17 @@ def _inspect(
                     f"{normalized}: {actual_shape} != {expected_shape}"
                 )
             actual_dtype = tensor_slice.get_dtype()
-            if actual_dtype not in _FLOAT_DTYPES:
+            if actual_dtype in _FP8_DTYPES:
+                fp8_keys.append(normalized)
+            elif actual_dtype not in _FLOAT_DTYPES:
                 dtype_mismatches.append(f"{normalized}: {actual_dtype}")
+        if fp8_keys:
+            raise ValueError(
+                f"Krea2 checkpoint 含 fp8 参数（{len(fp8_keys)} 个，如 "
+                f"{fp8_keys[0]}）。fp8 是推理端运行时量化格式，本训练器不支持"
+                f"（静默转回 bf16 显存零收益还丢精度）——请下载 bf16 版本权重"
+                f"（官方 Raw/Turbo 均为 bf16）。"
+            )
         if shape_mismatches:
             sample = "; ".join(shape_mismatches[:5])
             suffix = " ..." if len(shape_mismatches) > 5 else ""
@@ -199,7 +215,7 @@ def load_krea2_model(
     *,
     config: Krea2Config = KREA2_CONFIG,
 ) -> SingleStreamDiT:
-    """Strict-load a Krea2 Raw checkpoint into a frozen meta-created model."""
+    """Strict-load a single-file Krea2 checkpoint into a frozen meta-created model."""
     if dtype not in {torch.float16, torch.bfloat16, torch.float32, torch.float64}:
         raise ValueError(f"Krea2 loader 不支持 dtype={dtype}")
     target_device = torch.device(device)

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -610,7 +610,7 @@ class TrainingConfig(BaseModel):
     )
     pyramid_noise_discount: float = Field(
         0.5, ge=0.1, le=0.9,
-        description="每层相对衰减系数（0.1-0.9）。控制低频强度的核心参数：anima 实现把整体噪声 std 归一化到 1，所以 discount 决定低频占比。0.1-0.4 归一化后噪声接近标准高斯，等价于关闭；0.5-0.7 显著改变低频结构",
+        description="每层相对衰减系数（0.1-0.9）。控制低频强度的核心参数：本实现把整体噪声 std 归一化到 1，所以 discount 决定低频占比。0.1-0.4 归一化后噪声接近标准高斯，等价于关闭；0.5-0.7 显著改变低频结构",
         json_schema_extra=_meta("noise_augmentation", show_when="noise_enhancement_type==pyramid", advanced=True),
     )
     timestep_sampling: Literal[

--- a/studio/web/src/components/FirstRunOnboardingModal.tsx
+++ b/studio/web/src/components/FirstRunOnboardingModal.tsx
@@ -54,6 +54,9 @@ interface ItemDerived {
 }
 
 // 从 catalog 派生底模套件状态（4 个子文件全 exists 算 done）。
+// 刻意只判 Anima 入门套件（约 30GB）：anima 是默认族（D7），首启一键装
+// krea2（Raw 26GB + Qwen3-VL 9GB）对新手不是好默认——文案已注明其它族
+// 去 设置 → 训练 下载（多模型 P4-6）。
 function deriveBaseStatus(c: ModelsCatalog | null, dl: Record<ItemKey, ItemStatus>): ItemDerived {
   if (!c) return { status: 'checking' }
   const animaLatest = c.anima_main.variants.find((v) => v.is_latest)

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -449,7 +449,7 @@
       "noise_enhancement_type": "Noise augmentation (default none). offset adds per-sample DC bias to noise; pyramid stacks low-frequency noise at multiple scales. Both alter low-frequency components through different mechanisms; mutually exclusive to prevent stacking. LoRA training defaults to none",
       "noise_offset": "DC bias strength (0-0.2, 0=off). Shifts noise mean away from 0, giving the model exposure to extreme brightness scenes (pure black / pure white / high contrast). Typical range 0.05-0.1; below 0.05 the noise is nearly identical to baseline, above 0.1 the initial loss rises substantially",
       "pyramid_noise_iters": "Number of pyramid noise levels (0-6, 0=off). Each level injects at spatial // 2^(k+1). Effective strength is controlled by pyramid_noise_discount — iters alone determines which frequency bands are covered; layer count makes little difference when discount is low",
-      "pyramid_noise_discount": "Per-level decay coefficient (0.1-0.9). Key knob for low-frequency strength: anima normalizes overall noise std to 1, so discount sets the low-frequency share. 0.1-0.4 leaves noise close to standard Gaussian after normalization (equivalent to off); 0.5-0.7 significantly alters low-frequency structure",
+      "pyramid_noise_discount": "Per-level decay coefficient (0.1-0.9). Key knob for low-frequency strength: this implementation normalizes overall noise std to 1, so discount sets the low-frequency share. 0.1-0.4 leaves noise close to standard Gaussian after normalization (equivalent to off); 0.5-0.7 significantly alters low-frequency structure",
       "timestep_sampling": "Sampling distribution. logit_normal biases the middle (SD3/Anima default); uniform is equal probability; mode is a single-peak shift; mixed_* blends uniform with a biased end (ratio controlled by timestep_mix_low_prob)",
       "timestep_shift": "Internal distribution shift for logit-normal / mode: >1 biases the high-noise end (coarse structure), <1 biases the low-noise end (details)",
       "timestep_mix_low_prob": "Ratio of samples sent to the biased end in mixed_* modes: 0 = all uniform; typical 0.15-0.30",
@@ -991,7 +991,7 @@
       "startMigrate": "Start migration",
       "restartNow": "Restart now",
       "modelsRootLabel": "Models root directory",
-      "modelsRootHelp": "Holds downloaded model weights (Anima / VAE / text encoder / tokenizer / WD14, etc.); defaults to models/ in the app root. Changing the location copies existing weights into a models subdirectory of the chosen directory and takes effect immediately (no restart); the original is kept.",
+      "modelsRootHelp": "Stores downloaded model weights (Anima / Krea 2 / VAE / text encoders / tokenizers / WD14, etc.), defaulting to models/ under the app root. Changing it copies existing weights into a models/ subfolder of the chosen directory and takes effect immediately (no restart); original data is kept.",
       "modelsMigrateTitle": "Migrate models root",
       "modelsKeepOriginalNote": "Data at the original location is kept, not deleted. Takes effect immediately after copying — no restart needed.",
       "modelsDoneNote": "Switched to the new models root, effective immediately (no restart). The original data is kept; delete it yourself once verified.",
@@ -1127,7 +1127,7 @@
     "savePath": "Save path",
     "trainingParams": "Training parameters",
     "autoSyncPathsLabel": "Auto-configure model paths",
-    "autoSyncPathsHelp": "ON (default / most users): when forking a preset to a version, the 4 model path fields (transformer/vae/text_encoder/t5_tokenizer) are auto-overwritten from Settings; these 4 fields are disabled in preset/project pages. OFF (custom-model users): fork respects the absolute paths stored in the preset; the 4 fields become editable with a picker.",
+    "autoSyncPathsHelp": "ON (default / most users): when forking a preset to a version, the model path fields (transformer / VAE / text encoder, varying by model family) are auto-overwritten from Settings; these fields are disabled in preset/project pages. OFF (custom-model users): fork respects the absolute paths stored in the preset; the fields become editable with a picker.",
     "autoSyncPathsOn": "On · fork auto-syncs global",
     "autoSyncPathsOff": "Off · fork respects preset values",
     "defaultTransformerHelp": "The selected version becomes the default transformer for <strong>new versions</strong>.",
@@ -2650,8 +2650,8 @@
     },
     "items": {
       "base": {
-        "label": "Base model bundle",
-        "description": "Anima main + VAE + Qwen3 + T5 — the core models needed for training (about 30 GB total)"
+        "label": "Anima base kit",
+        "description": "Anima main model + VAE + Qwen3 + T5 — the starter models for training (about 30 GB total). Other model families like Krea 2 can be downloaded later in Settings → Training"
       },
       "tagger": {
         "label": "Auto-tagging",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -449,7 +449,7 @@
       "noise_enhancement_type": "噪声增强机制（默认 none）。offset 在噪声上加 per-sample DC 偏置；pyramid 在多个尺度叠加低频噪声。两者机制不同，但都改变低频成分，互斥防双倍叠加。LoRA 训练默认保持 none",
       "noise_offset": "DC 偏置强度（0-0.2，0=关闭）。让噪声 mean 偏离 0，让模型有机会学习生成极端亮度场景（pure black / pure white / 强对比）。典型范围 0.05-0.1；0.05 以下噪声场跟 baseline 几乎一样，超过 0.1 起点 loss 会显著偏高",
       "pyramid_noise_iters": "金字塔噪声层数（0-6，0=关闭）。每层在 spatial // 2^(k+1) 尺度注入。实际效果强度由 pyramid_noise_discount 决定 —— iters 单独决定覆盖的频段范围，discount 低时层数多少差异很小",
-      "pyramid_noise_discount": "每层相对衰减系数（0.1-0.9）。控制低频强度的核心参数：anima 实现把整体噪声 std 归一化到 1，所以 discount 决定低频占比。0.1-0.4 归一化后噪声接近标准高斯，等价于关闭；0.5-0.7 显著改变低频结构",
+      "pyramid_noise_discount": "每层相对衰减系数（0.1-0.9）。控制低频强度的核心参数：本实现把整体噪声 std 归一化到 1，所以 discount 决定低频占比。0.1-0.4 归一化后噪声接近标准高斯，等价于关闭；0.5-0.7 显著改变低频结构",
       "timestep_sampling": "采样分布。logit_normal 偏中段（SD3/Anima 默认）；uniform 等概率；mode 单峰偏移；mixed_* 混合 uniform 与偏置端（比例由 timestep_mix_low_prob 控制）",
       "timestep_shift": "logit-normal / mode 内部的分布偏移：>1 偏向高噪声端（粗结构），<1 偏向低噪声端（细节）",
       "timestep_mix_low_prob": "mixed_* 模式下走偏置端的样本比例：0 = 全 uniform；典型 0.15-0.30",
@@ -991,7 +991,7 @@
       "startMigrate": "开始迁移",
       "restartNow": "立即重启",
       "modelsRootLabel": "模型根目录",
-      "modelsRootHelp": "存放下载的 Anima / VAE / 文本编码器 / tokenizer / WD14 等模型权重，默认在程序根目录的 models/。更改位置会把现有权重复制到所选目录的 models 子目录并立即生效（无需重启），原数据保留不删除。",
+      "modelsRootHelp": "存放下载的模型权重（Anima / Krea 2 / VAE / 文本编码器 / tokenizer / WD14 等），默认在程序根目录的 models/。更改位置会把现有权重复制到所选目录的 models 子目录并立即生效（无需重启），原数据保留不删除。",
       "modelsMigrateTitle": "迁移模型根目录",
       "modelsKeepOriginalNote": "原位置数据不会被删除。复制完成后立即生效，无需重启。",
       "modelsDoneNote": "已切换到新模型根目录，立即生效（无需重启）；原位置数据已保留，确认无误后可自行删除。",
@@ -1127,7 +1127,7 @@
     "savePath": "保存路径",
     "trainingParams": "训练参数",
     "autoSyncPathsLabel": "自动配置模型路径",
-    "autoSyncPathsHelp": "开启（默认 / 多数用户）：fork 预设到 version 时，4 个模型路径字段（transformer/vae/text_encoder/t5_tokenizer）自动用 Settings 全局值覆盖，预设里这 4 字段灰显不可改。关闭（独立模型用户）：fork 时尊重预设里的绝对路径，4 字段可编辑 + picker。",
+    "autoSyncPathsHelp": "开启（默认 / 多数用户）：fork 预设到 version 时，模型路径字段（transformer / VAE / 文本编码器等，按模型族而定）自动用 Settings 全局值覆盖，这些字段灰显不可改。关闭（独立模型用户）：fork 时尊重预设里的绝对路径，字段可编辑 + picker。",
     "autoSyncPathsOn": "已开启 · fork 自动同步全局",
     "autoSyncPathsOff": "已关闭 · fork 尊重预设值",
     "defaultTransformerHelp": "选中的版本会作为<strong>新建 version</strong> 的默认 transformer。",
@@ -2650,8 +2650,8 @@
     },
     "items": {
       "base": {
-        "label": "底模套件",
-        "description": "Anima 主模型 + VAE + Qwen3 + T5,训练所需基础模型(总计约 30GB)"
+        "label": "Anima 底模套件",
+        "description": "Anima 主模型 + VAE + Qwen3 + T5，入门训练所需基础模型（总计约 30GB）。Krea 2 等其它模型族可稍后在 设置 → 训练 下载"
       },
       "tagger": {
         "label": "打标功能",

--- a/tests/test_krea2_loader.py
+++ b/tests/test_krea2_loader.py
@@ -272,3 +272,18 @@ def test_load_rejects_meta_target_device(tmp_path: Path) -> None:
             torch.float32,
             config=_tiny_config(),
         )
+
+
+def test_inspect_rejects_fp8_checkpoint_with_actionable_error(tmp_path: Path) -> None:
+    """纯 fp8 cast 权重（社区推理格式）→ 显式报错，不静默 upcast 回 bf16
+    （显存零收益 + 丢精度，A7'/C13）。文案指路 bf16 版本。"""
+    config = _tiny_config()
+    state_dict = _state_dict(config)
+    fp8_state = {
+        key: value.to(torch.float8_e4m3fn) for key, value in state_dict.items()
+    }
+    checkpoint = tmp_path / "fp8.safetensors"
+    _write_checkpoint(checkpoint, fp8_state)
+
+    with pytest.raises(ValueError, match="fp8"):
+        inspect_krea2_checkpoint(checkpoint, config=config)


### PR DESCRIPTION
## 背景 / 动机

P4-6（决策清单 C11 剩余 / C12 / C13 / C14），**Phase 4 收尾刀**。四条小尾巴打包（两条 loader 同文件同主题，两条 UI 文案完整性——拆开每条都太碎）。

## 改动概要

**C13（唯一的行为变化）**：krea2 loader 对纯 fp8 cast 权重从「静默 upcast 回 bf16」改为**显式报错 + 可操作文案**。社区 fp8/NVFP4/INT8/GGUF 的 K2 权重大量存在（A7' 联网核实过），但全是推理端运行时量化生态——静默转 bf16 显存零收益还丢精度，用户以为在省显存实际 OOM 照旧。GGUF（非 safetensors）/ INT8（非浮点）/ fp8_scaled（多出 scale 键）此前已被既有校验拒绝，**这是最后一个能静默漏过的洞**，且经 `addCustomModel` 注册路径现实可达。回归测试锁死。

**C14**：loader docstring / 报错文案通篇写 "Raw"——会让人误以为加载层有 Raw/Turbo 防呆（结构全等，物理上不可能，A3）。改口径为「单文件 Comfy/musubi 布局」并注明防呆在 studio 侧 purpose 元数据。

**C12 —— 一个需要你确认的产品取舍**：首启 onboarding 的「底模套件」自称"训练所需基础模型"，实为 Anima 族套件。我**刻意维持 base = Anima 入门套件**而不是给 onboarding 加 krea2 一键装——anima 是默认族（D7），把 35GB（Raw 26GB + Qwen3-VL 9GB）塞进新手首启不是好默认。落地为修文案谎言：改名「Anima 底模套件」+ 注明「Krea 2 等其它模型族可稍后在 设置 → 训练 下载」，代码注释写明这是决策非遗漏。如果你想要 onboarding 里的 krea2 可选勾选项，说一声我加。

**C11 剩余**：`autoSyncPathsHelp` 不再写死「4 个路径字段」（krea2 仅 3 个有效）；`modelsRootHelp` 补 Krea 2；`pyramid_noise_discount` 的「anima 实现」→「本实现」（金字塔噪声是共享循环功能）。

## 测试方式

- +1 回归（tiny config 造 fp8 checkpoint → `pytest.raises(ValueError, match="fp8")`）
- 全量 pytest **2980 passed**（1 条已知本机 taskkill 计时 flake）；vitest **497 passed**；lint / tsc / build 干净

## 浏览器视觉校验（AGENTS §5）

首启 modal 实测新文案渲染（「Anima 底模套件」标签 + Krea 2 指路句）。**校验事故披露**：触发 onboarding 需清 done 键，而 modal 打开即写 `secrets.download_source`（既知副作用）——把维护者的设置改成了 modelscope，已当场恢复 huggingface。教训已记入 memory。

## Phase 4 状态

本刀合并后 **Phase 4 全部 6 刀完成**（#420 地基 / #421 option 门控 / #422 切换动作 / #423 Generate+Turbo / #424 Settings 遍历化 / 本刀收尾）。剩余收官事项：**A8 真卡端到端验证**（krea2 下载 → 建版本 → 训练带预览 → Generate 出图含 Turbo），需要维护者真卡执行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
