### PR TITLE
feat(generate): krea2 fp8 推理全线 —— scaled/纯 cast 加载 + LoRA merge 回写（ComfyUI 逐位 parity）

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -226,6 +226,14 @@
     timestep shift 与 FlowMatchEuler 循环派生自 `src/musubi_tuner/krea2/krea2_sampling.py`；
     Raw/TDM 默认值和 Krea guidance `cond + g*(cond-uncond)` 同时对照 diffusers
     `pipeline_krea2.py` 与 `scheduling_flow_match_euler_discrete.py`（固定 commit 见文件头）
+  - `runtime/training/families/krea2/quant_fp8.py` — fp8 权重的 Linear 前向
+    monkey-patch 思路来自 `src/musubi_tuner/krea2/krea2_utils.py` 的
+    `apply_fp8_monkey_patch`；dequant 数值口径（`W.to(compute) * scale.to(compute)`、
+    目标 dtype=input.dtype、`_quantization_metadata` per-layer 协议）逐位对齐
+    ComfyUI（GPL-3.0）`comfy/ops.py cast_bias_weight`、`comfy/utils.py
+    convert_old_quants` 与 comfy_kitchen（Comfy-Org，见其 wheel 许可）
+    `backends/eager/quantization.py dequantize_per_tensor_fp8`——公式级对照，
+    未复制代码结构
 
 实现按本项目 timestep sampler protocol / 纯 torch modeling 边界适配；具体派生关系见各文件头。
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -234,6 +234,17 @@
     convert_old_quants` 与 comfy_kitchen（Comfy-Org，见其 wheel 许可）
     `backends/eager/quantization.py dequantize_per_tensor_fp8`——公式级对照，
     未复制代码结构
+  - `runtime/training/families/krea2/lora_fp8_merge.py` — LoRA×fp8 的 merge
+    回写语义逐位对齐 ComfyUI（GPL-3.0）：merge 编排与备份/还原来自
+    `comfy/model_patcher.py patch_weight_to_device`；delta 计算顺序（fp32
+    中间、`weight += ((strength*alpha)*diff).type(dtype)`）来自
+    `comfy/weight_adapter/lokr.py`、`comfy/weight_adapter/lora.py` 与
+    `comfy/lora.py calculate_weight`；requantize（scale=amax/448 + fp16 防
+    下溢 clamp）来自 `comfy/quant_ops.py`；stochastic rounding（Generator
+    RNG 形态 + 尾数随机进位公式）来自 `comfy/float.py stochastic_rounding`
+    与 comfy_kitchen `backends/eager/quantization.py calc_mantissa /
+    stochastic_rounding_fp8`；seed 的 CRC-32 口径来自 `comfy/utils.py
+    string_to_seed`（以 zlib.crc32 等价实现）——公式级对照，未复制代码结构
 
 实现按本项目 timestep sampler protocol / 纯 torch modeling 边界适配；具体派生关系见各文件头。
 

--- a/docs/design/krea2-fp8-inference.md
+++ b/docs/design/krea2-fp8-inference.md
@@ -109,3 +109,6 @@
   基线；请用户看一眼启动器设置或启动日志首屏）
 - Comfy 侧生成 parity 样张时用与我们相同的 sampler/scheduler 组合（euler +
   固定 shift）
+- 用户 ComfyUI workflow 实际加载的 TE 文件 dtype（P-2 假定 fp16 存储；若是
+  fp8 版 TE 则口径另议）；以及其 fp16 权重与我们「HF bf16 目录 cast fp16」
+  是否同源逐位一致（两者都应是官方 bf16 的 RTN cast，真卡时抽查张量校验）

--- a/docs/design/krea2-fp8-inference.md
+++ b/docs/design/krea2-fp8-inference.md
@@ -1,0 +1,111 @@
+# Krea2 推理侧 fp8 支持方案（ComfyUI 逐位 parity 版）
+
+- 状态：已定稿（用户批准 2026-07-16；随 fp8 实现 PR 入库）
+- 日期：2026-07-16
+- Parity oracle：`G:\ComfyUI-aki-v1.6\ComfyUI`（v0.27.1 + 内嵌 python 3.11.9 +
+  torch 2.7.0/cu128 + comfy_kitchen 0.2.16）。**验收 = 同参数出图与它逐位一致**
+  （Anima parity 同款要求）。
+- 范围（用户裁定）：只做 fp8 两种（scaled + 纯 cast）。int8/nvfp4/GGUF/ConvRot 不做。
+- 训练路径不变：C13 拒绝保留，文案改「训练不支持量化权重；推理支持 fp8」。
+
+---
+
+## 0. 用户文件实测（方案的直接对象）
+
+`krea2TurboOfficialComfy_krea2TurboFp8.safetensors`（Comfy-Org 官方 Turbo fp8_scaled）：
+
+- 686 张量 = 256 fp8(E4M3) block Linear 权重 + 256 个 F32 **标量** `*.weight_scale`
+  + 174 bf16（RMSNorm scale / modulation / embed，永不量化）
+- 量化声明在 safetensors `__metadata__._quantization_metadata` JSON：per-layer
+  `{"format": "float8_e4m3fn"}`，**敏感层（attn.gate / attn.wo）额外标
+  `full_precision_matrix_mult: true`**
+- 无 input_scale、无老式 `scaled_fp8` marker
+- **它是 Turbo** → 与 P4-4 的 distilled 检测联动（见 §5 检测层）
+
+## 1. 本地 ComfyUI 对这个文件的精确路径（逐行核实）
+
+1. `convert_old_quants`（utils.py:1403-1461）读 `_quantization_metadata` → 为每层
+   注入 `.comfy_quant` uint8 键 → `detect_layer_quantization` 命中 →
+   `quant_config={"mixed_ops":True}` → `pick_operations` 返回 `mixed_precision_ops`
+2. **运行时门槛决定实际数值路径**（对 parity 是好事，路径确定）：
+   - torch 2.7 < 2.8 → aimdo/DynamicVRAM 关（legacy ModelPatcher）
+   - cu128 < cu130 → comfy_kitchen **CUDA kernel 禁用**，registry 落 **eager 纯
+     torch 实现**（可逐行复刻）
+   - `--fast` 默认空 → fp8 原生 matmul（`_scaled_mm`）不走
+3. **无 LoRA 的每层前向**（确定性、零 RNG）：
+   ```
+   W_bf16 = W_fp8.to(bf16) * scale.to(bf16)      # ck eager quantization.py:59-63
+   y = F.linear(x_bf16, W_bf16, bias)            # ops.py:492-496
+   ```
+   compute dtype = bf16（`unet_manual_cast`，Krea2 supported_dtypes 首项）；
+   cast 顺序 = 先 `.to(device)`（fp8 字节过 PCIe）再 `.to(dtype)`（ops.py:360,376）
+4. **纯 fp8 cast 文件**（无 metadata/scale）：`weight_dtype` 按 numel 多数派
+   （utils.py:183-193）→ fp8 透传 → `manual_cast` ops → 同上但无 `* scale`
+5. **LoRA × fp8**（ComfyUI 对我们 v1 open question 的回答 = **merge 回写**）：
+   ```
+   temp = dequant(W).to(lora_compute_dtype)       # fp16(Ada+) 或 fp32
+   W' = calculate_weight(patches, temp, key)      # lora.py:438，intermediate fp32
+   W_fp8' = requantize(W', scale="recalculate",   # scale = amax|W'|/448
+                        stochastic_rounding, seed=CRC32(key))   # utils.py:1463 CRC32
+   ```
+   - **seed = 层名 CRC32，固定可复现** → LoRA+fp8 出图仍是确定性的
+   - SR 实现在 cu128 环境走 ck **eager** 纯 torch 版（calc_mantissa，
+     quantization.py:66+）→ 可逐行复刻
+   - lowvram 才走"cast 后叠 delta 不回写"路径；32GB 全载 fp8 DiT（~13GB）走
+     正常 merge 路径 → 我们复刻 merge 路径
+6. **TE 编排**（回答 v1 的 offload 问题）：Qwen3-VL 以 **fp16 存储 + fp32 强制
+   compute**（sd.py:258）在 GPU 编码；采样前 `free_memory` 把 CLIP LRU 卸载到
+   **CPU**（model_management.py:829），DiT 独占 GPU；下个 prompt 再搬回
+
+## 2. ⚠️ Step 0 —— fp8 之外的两笔 parity 债（先确认口径再动 fp8）
+
+对照中发现 **bf16 基线本身就与 ComfyUI 不一致**，不先解决就无从归因 fp8 差异：
+
+| # | 分歧 | ComfyUI | 我们 | 影响 |
+|---|---|---|---|---|
+| P-1 | **krea2 sigma 时刻表** | `sampling_settings={shift:1.15}` **固定 shift**（supported_models.py:1823，Raw/Turbo 同）| Raw 走 resolution-aware 动态 mu（diffusers 口径），仅 distilled 固定 1.15 | **同参数 sigma 表不同 → 永远无法逐位一致**。恰好我们的 distilled 公式 = Comfy 的全局公式 |
+| P-2 | **TE 数值** | Qwen3-VL fp16 存储 + fp32 compute | bf16 | conditioning 数值不同 → 逐位差异 |
+
+**P-1 需要拍板**：Generate 的 krea2 调度加一个 Comfy 口径（固定 shift 1.15，等价
+于把 distilled sigma 公式变成 krea2 生成默认）？还是保留 diffusers 动态 mu 双轨？
+建议：**Generate 页默认 Comfy 口径**（这页的存在意义就是 Comfy parity 验证），
+训练中预览维持现状（那是训练侧语义，无 parity 要求）。
+**P-2**：krea2 文本栈加 generate 场景的 fp16+fp32-compute 模式（训练侧 bf16 不动）。
+
+## 3. 实施切分
+
+- **PR-QP0（parity 基线）**：P-1 调度口径 + P-2 TE 数值 + TE offload 编排
+  （encode → TE→CPU → 采样，复刻 comfy free_memory 语义）。验收：**bf16 Raw 权重
+  同参数出图与本地 ComfyUI 逐位一致**（沿用 anima parity 的 pinned-oracle 方法）。
+- **PR-Q1（fp8 主刀）**：
+  - 检测层：safetensors `_quantization_metadata` 解析 + `weight_scale` 键收集 +
+    纯 cast dtype 扫描；`is_distilled_path` 之外补「文件内容也能判 Turbo」不做——
+    distilled 仍按 catalog variant / 显式选择（fp8 文件按其本名注册为 custom）
+  - 存储层：fp8 张量 + scale 标量原样进模型（inference 专用加载路径；训练
+    loader 不动）
+  - 计算层：`QuantLinear`（或 forward patch）复刻 §1.3 公式，含
+    `full_precision_matrix_mult` 层标记的尊重
+  - LoRA：复刻 comfy merge 语义（dequant → calculate_weight 等价 → recalculate
+    scale + eager SR，seed=CRC32(key)）；lora_merge POC（tools/lora_merge.py）的
+    LoKr 精确 merge 数学直接复用。XY lora_scale 轴 = 从原始 fp8 备份重 merge
+    （comfy weight_backup 同款）
+  - C13 文案更新 + THIRD_PARTY_NOTICES（ComfyUI ops/utils/float + comfy_kitchen
+    eager 实现的派生署名，GPL-3.0/相应许可核对）
+  - 验收：**用户的官方 Turbo fp8 文件，同参数与本地 ComfyUI 逐位一致**（无 LoRA
+    与挂 LoRA 各一组）
+- **PR-Q2（纯 cast 补全）**：无 scale 文件的 manual_cast 等价路径（`.to(bf16)`
+  无乘 scale）+ 混合 dtype 文件的多数派判定。小刀。
+
+## 4. 已消解的 v1 open questions
+
+1. LoRA 策略 → ComfyUI 答案 = **merge 回写 + SR(CRC32 seed)**（非 bypass）。
+2. 只接 krea2 → 是（anima 无需求，接口族无关）。
+3. TE offload → 复刻 comfy「编码后卸 CPU」，固定行为无旋钮。
+4. dequant 目标 → bf16，且 **scale 也先转 bf16 再乘**（eager 公式逐位语义）。
+
+## 5. 残留待实机确认（不阻塞 PR-QP0）
+
+- 绘世启动器是否给 ComfyUI 传 `--fast` / `--enable-dynamic-vram`（会改变 oracle
+  基线；请用户看一眼启动器设置或启动日志首屏）
+- Comfy 侧生成 parity 样张时用与我们相同的 sampler/scheduler 组合（euler +
+  固定 shift）

--- a/docs/todo/krea2-vram-orchestration.md
+++ b/docs/todo/krea2-vram-orchestration.md
@@ -1,0 +1,72 @@
+# Krea2 生成显存编排：按需让位 + prompt 缓存 + 显存策略配置
+
+- 状态：方案已拍板（2026-07-16），待实施——排在 fp8 parity 真卡验收之后，独立 PR
+- 前置：codex/krea2-fp8-inference 分支（fp8 推理 + LoRA merge + TE offload 现状）
+
+## 动机（真卡实测 + 讨论结论）
+
+现状编排是**无条件固定**的：加载时 DiT/VAE/TE 全上 GPU → 编码 → TE 无条件卸
+CPU → 采样。三个问题：
+
+1. **fp8 + 32GB**：三者同驻仅 ~24GB，无显存压力，无条件卸 TE = 每个 prompt
+   白付 8.9GB×2 的 PCIe 搬运（~2-4s）。
+2. **16GB 卡跑不了 fp8**：fp8 DiT 13.7GB 单独装得下，但固定编排在加载期
+   就三者同驻 OOM。ComfyUI 16GB 能跑，靠的是 free_memory **按需**让位。
+3. **bf16 + 32GB**：加载/首编码期 35GB 瞬时超额，WDDM 换页颠簸（现状 TE
+   offload 只保住了采样期稳态，见 bad6a480）。
+
+核心认识：ComfyUI 的 free_memory 是按需 LRU——显存装得下就同驻（快），装不
+下才让位（能跑）。我们把它做成了无条件，两头都不讨好。
+
+## 决策
+
+### D1 按需让位编排（comfy free_memory 轻量版）
+
+- 编码前：free VRAM < TE 上卡所需（~11GB 含 embed cast fp32 瞬时）→ DiT 先
+  撤 CPU；否则 TE 直接上（DiT 留着）。
+- 采样前：free VRAM < 采样余量 → 卸 TE；否则不卸（32GB fp8 从此零搬运）。
+- **判据用粗估不做记账**：采样余量 = activation 估算（分辨率相关，1024²
+  约 3-4GB）+ VAE 缓冲，留 5GB 安全边际。不复刻 comfy 的 per-model 显存
+  记账（复杂度即 bug 面）。用户已确认接受粗估。
+- TE 初始 device 改 CPU-lazy（加载到 CPU，首次 ensure 才上 GPU）——16GB
+  卡加载期不再 OOM。
+- RAM 下限：DiT + TE 同驻系统 RAM ≈ 23GB，机器需 32GB+ RAM；不满足时报错
+  文案写清（DomainError 规范）。
+
+### D2 prompt conditioning LRU 缓存（无条件开，不做配置）
+
+- key = caption 文本；缓存 **pad 之前的 per-caption varlen context**
+  （`_encode_many` 查询层），一条 ≈30MB（512×12×2560 fp16），LRU 8-16 条。
+- 命中时 TE 完全不动——按需编排下省掉整个 TE↔DiT 交换回合；测 LoRA 固定
+  prompt 刷 seed / 换 scale 的主场景每图省 2-3s。
+- 这也是 Comfy 既有行为（conditioning 节点输出缓存），属 parity 语义。
+- 无 tradeoff（正确性由 key 完备性保证）→ 不进配置。
+
+### D3 配置项：单个「显存策略」三档（对齐 vae_tiling 先例）
+
+- **auto**（默认）：D1 按需判据
+- **省显存**：强制顺序化 load TE→encode→unload TE→load DiT（auto 对碎片
+  误判的逃生门 + 想留显存给其他程序的用户）
+- **性能优先**：强制全同驻，禁止一切 offload
+- schema/Settings/i18n 抄 vae_tiling 模板；描述按用户视角写（写显存/速度
+  差别，不写指令型建议）。
+
+## 显存账（fp8 Turbo 官方文件）
+
+| 编排 | 编码期 | 采样期 | 峰值 |
+|---|---|---|---|
+| 现状（32GB） | 13.7+8.9+VAE+瞬时 ≈24GB | ~14GB | 24GB |
+| auto @32GB | 同上（不让位，零搬运） | ~24GB（TE 不卸） | 24GB |
+| auto @16GB（=顺序化） | 8.9+瞬时 ≈11GB | 13.7+act ≈16-17GB | ~17GB |
+
+16GB 卡 1024² 贴边可跑——PR 卖点：解锁 16GB 卡 fp8 krea2 生成。
+
+## 与 parity 的关系
+
+编排不影响数值（出图内容与模型在哪个 device 无关）——故排在 parity 验收
+之后：验收环境越接近现状越好归因。
+
+## 实施面（single PR）
+
+daemon/family.sample_image 编排触点 + TE 初始 device + Krea2TextStack 在线
+LRU + 配置三件套（schema/Settings/i18n）+ 测试（判据分支/缓存命中/三档）。

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -330,6 +330,7 @@ class ModelCache:
             t5_tokenizer_path=t5_tokenizer_path or None,
             comfy_qwen=text_encoder_backend == "comfy_qwen3",
             t5_fast=t5_tokenizer_backend == "fast",
+            purpose="generate",
             cache_enabled=False,
         )
 

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -384,6 +384,9 @@ class ModelCache:
             and len(specs) == len(self.adapters) == len(self.last_lora_metas) == len(current_metas)
             and [_lora_topology(m) for m in current_metas]
             == [_lora_topology(m) for m in self.last_lora_metas]
+            # fp8 merge 句柄无常驻 network 权重可热换，必须 detach（还原
+            # 原始 fp8 权重）后重 merge
+            and all(getattr(a, "supports_hot_reload", True) for a in self.adapters)
         )
         if can_hot_reload:
             try:
@@ -486,6 +489,8 @@ CACHE = ModelCache()
 
 def _set_lora_multiplier(adapter: Any, scale: float) -> None:
     if adapter.network is None:
+        # 含 fp8 merge 句柄（network=None）：scale 已烘进权重，non-scale 轴
+        # 的逐格重置调用安全跳过（lora_scale 轴在 _run_xy 入口已拒绝）
         return
     adapter.network.multiplier = float(scale)
     for lora in getattr(adapter.network, "loras", []):
@@ -821,6 +826,22 @@ def _run_xy(
     x_values = x_spec["values"]
     y_values = y_spec["values"] if y_spec else [None]
     distilled: bool = bool(cfg.get("distilled", False))
+
+    # fp8 底模的 LoRA 是 merge 进权重的（无常驻 network），lora_scale 轴的
+    # multiplier 原地设值会静默 no-op——每格出一样的图。逐格重 merge（13GB
+    # dequant/requant）当前不提供；lora_ckpt 轴走 CACHE.apply_loras 重注入
+    # （detach 还原 + 重 merge）不受影响。
+    if any(
+        spec is not None and spec.get("axis") == "lora_scale"
+        for spec in (x_spec, y_spec)
+    ):
+        from training.families.krea2.quant_fp8 import model_has_fp8_layers
+
+        if CACHE.model is not None and model_has_fp8_layers(CACHE.model):
+            raise ValueError(
+                "fp8 量化底模不支持 XY 的 LoRA 强度轴（LoRA 已合并进权重，"
+                "逐格调整需重新合并）。请改用 bf16 版本底模跑该轴。"
+            )
 
     if base_seed == 0:
         base_seed = random.randint(0, 2**31 - 1)

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -311,6 +311,7 @@ class ModelCache:
         model = family.load_dit(
             transformer_path, device, dtype,
             attention_backend=("flash_attn" if use_flash else "none"), repo_root=repo_root,
+            purpose="generate",
         )
         if use_xformers and not _T.enable_xformers(model):
             raise RuntimeError(

--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -344,6 +344,17 @@ def _run_xy_matrix(
             "CLI runner anima_generate.py 不支持热切换 LoRA 文件"
         )
 
+    # fp8 底模的 LoRA 是 merge 进权重的（无常驻 network），lora_scale 轴的
+    # multiplier 原地设值会静默 no-op——每格出一样的图（daemon 侧同款拒绝）
+    if x_spec.get("axis") == "lora_scale" or (y_spec and y_spec.get("axis") == "lora_scale"):
+        from training.families.krea2.quant_fp8 import model_has_fp8_layers
+
+        if model_has_fp8_layers(model):
+            raise ValueError(
+                "fp8 量化底模不支持 XY 的 LoRA 强度轴（LoRA 已合并进权重，"
+                "逐格调整需重新合并）。请改用 bf16 版本底模跑该轴。"
+            )
+
     if base_seed == 0:
         base_seed = random.randint(0, 2**31 - 1)
         logger.info(f"XY 共享种子（cfg.seed=0 随机化）: {base_seed}")

--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -147,6 +147,7 @@ def main() -> None:
     model = family.load_dit(
         transformer_path, device, dtype,
         attention_backend=("flash_attn" if use_flash else "none"), repo_root=repo_root,
+        purpose="generate",
     )
     if use_xformers and not _T.enable_xformers(model):
         raise RuntimeError(

--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -166,6 +166,7 @@ def main() -> None:
         t5_tokenizer_path=t5_tokenizer_path or None,
         comfy_qwen=text_encoder_backend == "comfy_qwen3",
         t5_fast=t5_tokenizer_backend == "fast",
+        purpose="generate",
         cache_enabled=False,
     )
 

--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -436,6 +436,7 @@ def main() -> None:
     model = family.load_dit(
         transformer_path, device, dtype,
         attention_backend=("flash_attn" if use_flash else "none"), repo_root=repo_root,
+        purpose="generate",
     )
     if use_xformers:
         _T.enable_xformers(model)

--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -450,6 +450,7 @@ def main() -> None:
     text_stack = family.load_text(
         text_encoder_path, device, dtype,
         t5_tokenizer_path=t5_tokenizer_path or None,
+        purpose="generate",
         cache_enabled=False,
     )
 

--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -45,9 +45,12 @@ class AnimaFamily:
                   cache_enabled: bool = True):
         from training.families.anima.loader import load_text_encoders
 
+        # purpose 接受并忽略（load_dit 同款）：Anima 的 TE backend 只由调用方
+        # 显式 comfy_qwen 决定——generate 调用面传 purpose 不得覆盖用户选择的
+        # text_encoder_backend（默认 hf）。
         return load_text_encoders(
             text_encoder_path, t5_tokenizer_path, device, dtype,
-            comfy_qwen=(comfy_qwen or purpose == "generate"),
+            comfy_qwen=comfy_qwen,
             t5_fast=t5_fast,
         )
 

--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -18,7 +18,10 @@ class AnimaFamily:
 
     # ── 加载 ─────────────────────────────────────────────────────────────
     def load_dit(self, path, device, dtype, *,
-                 attention_backend: str = "flash_attn", repo_root=None):
+                 attention_backend: str = "flash_attn", repo_root=None,
+                 purpose: str = "train"):
+        # purpose 是量化推理旋钮（krea2 fp8）；Anima 无量化形态，接受并忽略
+        del purpose
         from training.families.anima.loader import load_anima_model
         from training.model_loading import enable_xformers
 

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -105,6 +105,20 @@ class Krea2Family:
                   t5_tokenizer_path: str = "", comfy_qwen: bool = False,
                   t5_fast: bool = False, purpose: str = "train",
                   cache_enabled: bool = True):
+        if purpose == "generate":
+            import torch
+
+            # Comfy parity（sd.py:258）：生成场景 TE 固定 fp16 存储 + fp32
+            # compute（text_encoder_dtype 默认 fp16 + set_model_compute_dtype
+            # fp32），忽略调用方 dtype、无旋钮——与 TE offload 同款固定行为。
+            # 训练侧维持调用方 dtype（bf16）不动。
+            return load_krea2_text_stack(
+                text_encoder_path,
+                device=device,
+                dtype=torch.float16,
+                compute_dtype=torch.float32,
+                cache_enabled=cache_enabled,
+            )
         return load_krea2_text_stack(
             text_encoder_path,
             device=device,

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -85,7 +85,8 @@ class Krea2Family:
     spec = KREA2_SPEC
 
     def load_dit(self, path, device, dtype, *,
-                 attention_backend: str = "flash_attn", repo_root=None):
+                 attention_backend: str = "flash_attn", repo_root=None,
+                 purpose: str = "train"):
         from training.families.krea2.loader import load_krea2_model
 
         if attention_backend != "none":
@@ -93,7 +94,7 @@ class Krea2Family:
                 "Krea2 当前固定使用 PyTorch SDPA；忽略 attention_backend=%s",
                 attention_backend,
             )
-        return load_krea2_model(path, device, dtype)
+        return load_krea2_model(path, device, dtype, purpose=purpose)
 
     def load_vae(self, path, device, dtype, *, tiling: str = "auto"):
         from training.vae import load_vae

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -167,6 +167,12 @@ class Krea2Family:
             dtype=dtype,
             phase_callback=phase_callback,
         )
+        # Comfy parity 编排：条件编码完成后把 TE 卸到 CPU，DiT 独占显存
+        # （free_memory 语义）。26.3GB DiT + 8.9GB TE 同驻超 32GB 支持下限。
+        # 下个 prompt 由 ensure_model 搬回；训练缓存模式 TE 本就已释放，no-op。
+        offload = getattr(text, "offload_model", None)
+        if callable(offload):
+            offload()
         return sample_image(
             model,
             vae,

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -30,7 +30,7 @@ from training.families.latent_spaces import WAN21_F8C16
 from training.families.spec import (
     LoraOutputSpec,
     ModelSpec,
-    ResolutionAwareShift,
+    ConstantShift,
     SamplingDefaults,
     TextSpec,
 )
@@ -57,12 +57,11 @@ KREA2_SPEC = ModelSpec(
         default_scheduler=KREA2_SCHEDULER,
         default_steps=KREA2_RAW_STEPS,
         default_cfg=KREA2_RAW_GUIDANCE,
-        shift_policy=ResolutionAwareShift(
-            base_shift=KREA2_BASE_SHIFT,
-            max_shift=KREA2_MAX_SHIFT,
-            base_image_seq_len=KREA2_BASE_IMAGE_SEQ_LEN,
-            max_image_seq_len=KREA2_MAX_IMAGE_SEQ_LEN,
-        ),
+        # Comfy parity 口径：固定 mu=1.15（ComfyUI ModelSamplingFlux 同款；
+        # 注意本值是 **mu（exp 前）**，与 Anima ConstantShift 的直接因子语义
+        # 不同——shift_policy 语义归 family 解释）。diffusers 的分辨率感知
+        # 动态 mu 保留为 build_krea2_sigmas(dynamic_mu=True) 非默认路径。
+        shift_policy=ConstantShift(shift=1.15),
     ),
     capabilities=frozenset({"masked_loss", "text_cache"}),
     lora=LoraOutputSpec(prefix="lora_unet", preset_name="krea2_full"),

--- a/runtime/training/families/krea2/loader.py
+++ b/runtime/training/families/krea2/loader.py
@@ -23,6 +23,10 @@ import torch
 from safetensors import safe_open
 
 from modeling.krea2 import KREA2_CONFIG, Krea2Config, SingleStreamDiT
+from training.families.krea2.quant_fp8 import (
+    parse_quantization_metadata,
+    patch_fp8_linears,
+)
 
 
 _PREFIX_CANDIDATES = (
@@ -117,15 +121,36 @@ def _inspect(
     config: Krea2Config,
     *,
     expected_shapes: dict[str, tuple[int, ...]] | None = None,
-) -> tuple[Krea2CheckpointInfo, dict[str, str]]:
+    allow_fp8: bool = False,
+) -> tuple[Krea2CheckpointInfo, dict[str, str], dict[str, str]]:
+    """校验 checkpoint 并返回 (info, 权重键映射, fp8 scale 键映射)。
+
+    ``allow_fp8=True``（推理路径）时：接受 fp8 权重；``{layer}.weight_scale``
+    F32 标量键被单独收集（fp8_scaled 形态），不参与键集比对。
+    """
     checkpoint = _checkpoint_path(path)
     if expected_shapes is None:
         _, expected_shapes = _expected_state(config)
     expected_keys = set(expected_shapes)
 
     with safe_open(str(checkpoint), framework="pt", device="cpu") as handle:
-        source_keys = list(handle.keys())
-        prefix = _choose_prefix(source_keys, expected_keys)
+        quant_meta = (
+            parse_quantization_metadata(handle.metadata()) if allow_fp8 else {}
+        )
+        all_source_keys = list(handle.keys())
+        prefix = _choose_prefix(all_source_keys, expected_keys)
+        # fp8_scaled 的 per-layer scale 键：归一后形如 blocks.N.xxx.weight_scale。
+        # 只在 allow_fp8 时剥离；训练路径它们会照旧落进「多出」报错。
+        scale_to_source: dict[str, str] = {}
+        source_keys = []
+        for source_key in all_source_keys:
+            normalized = _normalize_key(source_key, prefix)
+            if allow_fp8 and normalized.endswith(".weight_scale"):
+                layer = normalized[: -len(".weight_scale")]
+                if f"{layer}.weight" in expected_keys:
+                    scale_to_source[layer] = source_key
+                    continue
+            source_keys.append(source_key)
         normalized_to_source: dict[str, str] = {}
         for source_key in source_keys:
             normalized = _normalize_key(source_key, prefix)
@@ -159,13 +184,22 @@ def _inspect(
                 fp8_keys.append(normalized)
             elif actual_dtype not in _FLOAT_DTYPES:
                 dtype_mismatches.append(f"{normalized}: {actual_dtype}")
-        if fp8_keys:
+        if fp8_keys and not allow_fp8:
             raise ValueError(
                 f"Krea2 checkpoint 含 fp8 参数（{len(fp8_keys)} 个，如 "
-                f"{fp8_keys[0]}）。fp8 是推理端运行时量化格式，本训练器不支持"
-                f"（静默转回 bf16 显存零收益还丢精度）——请下载 bf16 版本权重"
-                f"（官方 Raw/Turbo 均为 bf16）。"
+                f"{fp8_keys[0]}）。fp8 权重仅推理（测试出图）支持；训练需要"
+                f"全精度梯度——请下载 bf16 版本权重（官方 Raw/Turbo 均为 bf16）。"
             )
+        # fp8_scaled 一致性：有 scale 的层权重必须是 fp8；metadata 声明的层
+        # 若既无 fp8 权重也无 scale 属异常文件
+        if allow_fp8:
+            fp8_set = set(fp8_keys)
+            for layer in scale_to_source:
+                if f"{layer}.weight" not in fp8_set:
+                    errors.append(f"{layer} 带 weight_scale 但权重不是 fp8")
+            for layer in quant_meta:
+                if f"{layer}.weight" not in fp8_set:
+                    errors.append(f"metadata 声明量化层 {layer} 但权重不是 fp8")
         if shape_mismatches:
             sample = "; ".join(shape_mismatches[:5])
             suffix = " ..." if len(shape_mismatches) > 5 else ""
@@ -188,6 +222,7 @@ def _inspect(
             parameter_count=parameter_count,
         ),
         normalized_to_source,
+        scale_to_source,
     )
 
 
@@ -204,7 +239,7 @@ def inspect_krea2_checkpoint(
     config: Krea2Config = KREA2_CONFIG,
 ) -> Krea2CheckpointInfo:
     """Validate keys and shapes from the safetensors header without reading payloads."""
-    info, _ = _inspect(path, config)
+    info, _, _ = _inspect(path, config)
     return info
 
 
@@ -214,22 +249,31 @@ def load_krea2_model(
     dtype: torch.dtype,
     *,
     config: Krea2Config = KREA2_CONFIG,
+    purpose: str = "train",
 ) -> SingleStreamDiT:
-    """Strict-load a single-file Krea2 checkpoint into a frozen meta-created model."""
+    """Strict-load a single-file Krea2 checkpoint into a frozen meta-created model.
+
+    ``purpose="generate"``（推理路径）允许 fp8 权重（纯 cast 与 fp8_scaled 两种
+    形态）：fp8 张量原样常驻显存，Linear 前向逐层 dequant 到 compute dtype
+    （ComfyUI parity，见 quant_fp8）。训练路径（默认）维持 bf16 全精度拒绝语义。
+    """
     if dtype not in {torch.float16, torch.bfloat16, torch.float32, torch.float64}:
         raise ValueError(f"Krea2 loader 不支持 dtype={dtype}")
     target_device = torch.device(device)
     if target_device.type == "meta":
         raise ValueError("Krea2 loader 的目标 device 不能是 meta")
+    allow_fp8 = purpose != "train"
 
     model, expected_shapes = _expected_state(config)
-    _, normalized_to_source = _inspect(
+    _, normalized_to_source, scale_to_source = _inspect(
         path,
         config,
         expected_shapes=expected_shapes,
+        allow_fp8=allow_fp8,
     )
 
     state_dict = {}
+    fp8_scales: dict[str, torch.Tensor | None] = {}
     checkpoint = _checkpoint_path(path)
     with safe_open(str(checkpoint), framework="pt", device="cpu") as handle:
         for normalized, source_key in normalized_to_source.items():
@@ -238,12 +282,27 @@ def load_krea2_model(
                 raise ValueError(
                     f"Krea2 checkpoint 含非浮点参数 {source_key}: {tensor.dtype}"
                 )
-            state_dict[normalized] = tensor.to(
+            if allow_fp8 and tensor.dtype in (
+                torch.float8_e4m3fn, torch.float8_e5m2,
+            ):
+                # fp8 原样常驻（显存收益所在），不 cast dtype
+                state_dict[normalized] = tensor.to(device=target_device)
+                if normalized.endswith(".weight"):
+                    layer = normalized[: -len(".weight")]
+                    fp8_scales.setdefault(layer, None)
+            else:
+                state_dict[normalized] = tensor.to(
+                    device=target_device,
+                    dtype=dtype,
+                )
+        for layer, source_key in scale_to_source.items():
+            fp8_scales[layer] = handle.get_tensor(source_key).to(
                 device=target_device,
-                dtype=dtype,
             )
 
     model.load_state_dict(state_dict, strict=True, assign=True)
     del state_dict
     model.requires_grad_(False)
+    if fp8_scales:
+        patch_fp8_linears(model, fp8_scales)
     return model

--- a/runtime/training/families/krea2/lora_fp8_merge.py
+++ b/runtime/training/families/krea2/lora_fp8_merge.py
@@ -50,6 +50,19 @@ from training.families.krea2.quant_fp8 import _FP8_TORCH_DTYPES
 logger = logging.getLogger(__name__)
 
 _LORA_PREFIX = "lora_unet_"
+_COMFY_PREFIX = "diffusion_model."
+# PEFT/comfy 键后缀 → kohya/lycoris 命名（civitai 生态 krea2 LoRA 常见形态：
+# ``diffusion_model.{点分层名}.lora_A/lora_B``，lora_A=down、lora_B=up，
+# 通常无 alpha 键——comfy 对缺省 alpha 按缩放 1.0 处理，与 _apply_lora_delta
+# 的 "alpha" 缺省分支一致）
+_PEFT_SUFFIXES = (
+    ("lora_A.weight", "lora_down.weight"),
+    ("lora_B.weight", "lora_up.weight"),
+    ("lora_down.weight", "lora_down.weight"),
+    ("lora_up.weight", "lora_up.weight"),
+    ("alpha", "alpha"),
+    ("dora_scale", "dora_scale"),
+)
 
 
 def string_to_seed(key: str) -> int:
@@ -139,13 +152,28 @@ def _requantize_scaled(w16: Tensor, fp8_dtype: torch.dtype, seed: int) -> tuple[
 
 
 def _group_lora_layers(sd: dict[str, Tensor]) -> dict[str, dict[str, Tensor]]:
-    """lora_unet_{layer}.{suffix} → {layer_underscored: {suffix: tensor}}。"""
+    """按层聚合，两种键格式归一到 {layer_underscored: {kohya_suffix: tensor}}：
+
+    - kohya/lycoris：``lora_unet_{层名下划线}.{suffix}``（本 app 训练产物）
+    - PEFT/comfy：``diffusion_model.{层名点分}.{lora_A|lora_B|alpha}``
+      （civitai / musubi / comfy 生态）
+    """
     layers: dict[str, dict[str, Tensor]] = {}
     for key, tensor in sd.items():
-        if not key.startswith(_LORA_PREFIX):
-            continue
-        name, _, suffix = key.partition(".")
-        layers.setdefault(name[len(_LORA_PREFIX):], {})[suffix] = tensor
+        if key.startswith(_LORA_PREFIX):
+            name, _, suffix = key.partition(".")
+            layers.setdefault(name[len(_LORA_PREFIX):], {})[suffix] = tensor
+        elif key.startswith(_COMFY_PREFIX):
+            rest = key[len(_COMFY_PREFIX):]
+            for peft_suffix, kohya_suffix in _PEFT_SUFFIXES:
+                if rest.endswith("." + peft_suffix):
+                    layer = rest[: -len(peft_suffix) - 1]
+                    layers.setdefault(layer.replace(".", "_"), {})[kohya_suffix] = tensor
+                    break
+            else:
+                raise ValueError(
+                    f"fp8 merge 无法识别 comfy 形态 LoRA 键的后缀：{key}"
+                )
     return layers
 
 

--- a/runtime/training/families/krea2/lora_fp8_merge.py
+++ b/runtime/training/families/krea2/lora_fp8_merge.py
@@ -1,0 +1,320 @@
+"""Krea2 fp8 底模的 LoRA merge 回写（ComfyUI 逐位 parity）。
+
+ComfyUI 从不在量化存储上算 LoRA：加载时把 LoRA merge 进权重
+（model_patcher.patch_weight_to_device），采样期前向与无 LoRA 完全同路。
+本模块逐位复刻该链路（oracle=本地 ComfyUI v0.27.1 + comfy_kitchen 0.2.16
+eager 路径，docs/design/krea2-fp8-inference.md §1.5）：
+
+    W16    = W_fp8.to(fp16) [* scale.to(fp16)]            # dequant 到 fp16
+    W16   += ((strength * alpha/dim) * ΔW_fp32).to(fp16)   # 逐 LoRA，fp32 中间
+    scale' = amax(|W16|).to(fp32) / 448（fp16 防下溢 clamp）
+    W16   *= (1/scale').to(fp16)
+    W_fp8' = stochastic_round(W16, seed=CRC32(key))        # ck eager SR
+
+三种层形态（同一模型内混合，用户官方 Turbo fp8 文件 264 Linear 中 256 量化）：
+- scaled fp8：dequant 乘 scale；回写 recalculate scale + SR
+- 纯 cast fp8：dequant 无 scale；回写直接 SR（无 scale 概念）
+- 非量化 Linear：cast fp16 merge；回写直接 cast 回原 dtype（comfy set_weight
+  的 layout_type=None 分支，无 SR 无 seed）
+
+数值口径依据（均本地 oracle 逐行核实）：
+- dequant 直落 fp16 域：QuantizedTensor.to(fp16) 只改 orig_dtype 标记
+  （ck tensor/base.py _handle_to），dequantize 即 qdata.to(fp16)*scale.to(fp16)，
+  无 bf16 中转；fp16 = comfy lora_compute_dtype（should_use_fp16 现代卡）
+- delta 域：comfy weight_adapter lokr/lora——因子 cast fp32 做 mm/kron，
+  ``weight += ((strength * alpha) * diff).type(fp16)``，加法在 fp16 域
+- requantize：quant_ops._TensorCoreFP8LayoutBase.quantize 的
+  scale="recalculate" + stochastic_rounding 分支
+- SR：comfy/float.py（Generator(device)+manual_seed → randint(0,256,uint8)）
+  → ck eager stochastic_rounding_fp8/calc_mantissa。CUDA 与 CPU generator
+  序列不同——逐位 parity 在 GPU 上成立（comfy 同在 GPU merge）；CPU 单测
+  只验证确定性与公式性质
+- seed key = "diffusion_model.{layer}.weight"（comfy ModelPatcher 模型键
+  前缀；层名与 checkpoint 键一致——loader 直载 comfy 文件）
+
+派生署名见 THIRD_PARTY_NOTICES（ComfyUI GPL-3.0 + comfy_kitchen）。
+仅推理路径使用；merge 后权重 requires_grad=False 不变。
+"""
+
+from __future__ import annotations
+
+import logging
+import zlib
+
+import torch
+from torch import Tensor
+
+from training.families.krea2.quant_fp8 import _FP8_TORCH_DTYPES
+
+
+logger = logging.getLogger(__name__)
+
+_LORA_PREFIX = "lora_unet_"
+
+
+def string_to_seed(key: str) -> int:
+    """comfy.utils.string_to_seed 等价：标准 CRC-32（0xEDB88320）。
+
+    comfy 手写实现对 str 逐字符 ord() 异或——层名均为 ASCII，与 utf-8 字节
+    序列一致，zlib.crc32 逐位相同（单测对拍手写参考实现）。
+    """
+    if not key.isascii():
+        raise ValueError(f"seed key 必须是 ASCII（comfy 层名域）：{key!r}")
+    return zlib.crc32(key.encode("utf-8"))
+
+
+def _calc_mantissa(
+    abs_x: Tensor,
+    exponent: Tensor,
+    normal_mask: Tensor,
+    mantissa_bits: int,
+    exponent_bias: int,
+    rng: Tensor,
+) -> Tensor:
+    # ck eager calc_mantissa（backends/eager/quantization.py:66-74）逐行复刻：
+    # 全程 fp16 域，rng/256 提供 [0,1) 的随机进位量，floor 完成随机舍入
+    mantissa_scaled = torch.where(
+        normal_mask,
+        (abs_x / (2.0 ** (exponent - exponent_bias)) - 1.0) * (2 ** mantissa_bits),
+        (abs_x / (2.0 ** (-exponent_bias + 1 - mantissa_bits))),
+    )
+    mantissa_scaled += rng.to(dtype=mantissa_scaled.dtype) * (1.0 / 256.0)
+    return mantissa_scaled.floor() / (2 ** mantissa_bits)
+
+
+def stochastic_round_to_fp8(value: Tensor, fp8_dtype: torch.dtype, seed: int) -> Tensor:
+    """comfy.float.stochastic_rounding fp8 分支 + ck eager SR 逐位复刻。"""
+    if fp8_dtype == torch.float8_e4m3fn:
+        exponent_bits, mantissa_bits, exponent_bias = 4, 3, 7
+    elif fp8_dtype == torch.float8_e5m2:
+        exponent_bits, mantissa_bits, exponent_bias = 5, 2, 15
+    else:
+        raise ValueError(f"stochastic_round_to_fp8 只支持 fp8 dtype：{fp8_dtype}")
+
+    generator = torch.Generator(device=value.device)
+    generator.manual_seed(seed)
+    rng = torch.randint(
+        0, 256, value.size(),
+        dtype=torch.uint8, layout=value.layout, device=value.device,
+        generator=generator,
+    )
+
+    x = value.half()
+    sign = torch.sign(x)
+    abs_x = x.abs()
+    sign = torch.where(abs_x == 0, 0, sign)
+
+    exponent = torch.clamp(
+        torch.floor(torch.log2(abs_x)) + exponent_bias,
+        0,
+        2 ** exponent_bits - 1,
+    )
+    normal_mask = ~(exponent == 0)
+
+    abs_x[:] = _calc_mantissa(abs_x, exponent, normal_mask, mantissa_bits, exponent_bias, rng)
+
+    sign *= torch.where(
+        normal_mask,
+        (2.0 ** (exponent - exponent_bias)) * (1.0 + abs_x),
+        (2.0 ** (-exponent_bias + 1)) * abs_x,
+    )
+
+    info = torch.finfo(fp8_dtype)
+    torch.clamp(sign, min=info.min, max=info.max, out=sign)
+    return sign.to(fp8_dtype)
+
+
+def _requantize_scaled(w16: Tensor, fp8_dtype: torch.dtype, seed: int) -> tuple[Tensor, Tensor]:
+    """quant_ops._TensorCoreFP8LayoutBase.quantize 的 recalculate+SR 分支。
+
+    返回 (fp8 qdata, 新 F32 标量 scale)。
+    """
+    scale = torch.amax(w16.abs()).to(dtype=torch.float32) / torch.finfo(fp8_dtype).max
+    # fp16 输入防 scale 过小（comfy 原注释 Prevent scale from being too small）
+    if w16.dtype not in (torch.float32, torch.bfloat16):
+        tensor_info = torch.finfo(w16.dtype)
+        scale = 1.0 / torch.clamp(1.0 / scale, min=tensor_info.min, max=tensor_info.max)
+    w16 = w16 * (1.0 / scale).to(w16.dtype)
+    return stochastic_round_to_fp8(w16, fp8_dtype, seed), scale
+
+
+def _group_lora_layers(sd: dict[str, Tensor]) -> dict[str, dict[str, Tensor]]:
+    """lora_unet_{layer}.{suffix} → {layer_underscored: {suffix: tensor}}。"""
+    layers: dict[str, dict[str, Tensor]] = {}
+    for key, tensor in sd.items():
+        if not key.startswith(_LORA_PREFIX):
+            continue
+        name, _, suffix = key.partition(".")
+        layers.setdefault(name[len(_LORA_PREFIX):], {})[suffix] = tensor
+    return layers
+
+
+def _apply_lora_delta(
+    w16: Tensor,
+    tensors: dict[str, Tensor],
+    strength: float,
+    layer: str,
+    source: str,
+) -> Tensor:
+    """单层单 LoRA 的 comfy 顺序 merge：fp32 算 diff，fp16 域相加。"""
+    device = w16.device
+    if "dora_scale" in tensors:
+        raise ValueError(
+            f"fp8 底模 merge 不支持 DoRA（weight_decompose）LoRA：{source} 层 {layer}。"
+            f"请改用 bf16 版本底模挂载。"
+        )
+
+    if "lora_down.weight" in tensors:  # plain LoRA / LoCon Linear
+        if "lora_mid.weight" in tensors:
+            raise ValueError(f"fp8 merge 不支持 LoCon mid（tucker）形态：{source} 层 {layer}")
+        mat1 = tensors["lora_up.weight"].to(device=device, dtype=torch.float32)
+        mat2 = tensors["lora_down.weight"].to(device=device, dtype=torch.float32)
+        alpha = float(tensors["alpha"]) / mat2.shape[0] if "alpha" in tensors else 1.0
+        lora_diff = torch.mm(
+            mat1.flatten(start_dim=1), mat2.flatten(start_dim=1),
+        ).reshape(w16.shape)
+        w16 += ((strength * alpha) * lora_diff).type(w16.dtype)
+        return w16
+
+    if "lokr_w1" in tensors or "lokr_w1_a" in tensors:  # LoKr
+        if "lokr_t2" in tensors:
+            raise ValueError(f"fp8 merge 不支持 LoKr tucker（t2）形态：{source} 层 {layer}")
+        # dim 语义照 comfy weight_adapter/lokr.py：w1/w2 各自分解时都会赋值，
+        # 两者都分解时 w2_b 的赋值在后、生效（覆盖），两者都是全矩阵时保持
+        # None → alpha 系数取 1.0
+        dim = None
+        if "lokr_w1" in tensors:
+            w1 = tensors["lokr_w1"].to(device=device, dtype=torch.float32)
+        else:
+            dim = tensors["lokr_w1_b"].shape[0]
+            w1 = torch.mm(
+                tensors["lokr_w1_a"].to(device=device, dtype=torch.float32),
+                tensors["lokr_w1_b"].to(device=device, dtype=torch.float32),
+            )
+        if "lokr_w2" in tensors:
+            w2 = tensors["lokr_w2"].to(device=device, dtype=torch.float32)
+        else:
+            dim = tensors["lokr_w2_b"].shape[0]
+            w2 = torch.mm(
+                tensors["lokr_w2_a"].to(device=device, dtype=torch.float32),
+                tensors["lokr_w2_b"].to(device=device, dtype=torch.float32),
+            )
+        if "alpha" in tensors and dim is not None:
+            alpha = float(tensors["alpha"]) / dim
+        else:
+            alpha = 1.0
+        lora_diff = torch.kron(w1, w2).reshape(w16.shape)
+        w16 += ((strength * alpha) * lora_diff).type(w16.dtype)
+        return w16
+
+    raise ValueError(
+        f"fp8 merge 无法识别 LoRA 层形态：{source} 层 {layer}（{sorted(tensors)}）"
+    )
+
+
+class Fp8LoraMergeAdapter:
+    """merge 回写的生命周期句柄——daemon adapters 列表的 duck-type 成员。
+
+    - ``detach()``：从 CPU 备份逐位还原原始权重与 scale（换 LoRA / 卸载）
+    - ``network = None``：让 lycoris 侧的 multiplier 设值路径安全 no-op
+    - ``supports_hot_reload = False``：merge 无常驻 network，禁用 daemon
+      的权重热换路径（必须走 detach → 重 merge）
+    """
+
+    network = None
+    supports_hot_reload = False
+
+    def __init__(self, model: torch.nn.Module,
+                 backup: dict[str, tuple[Tensor, Tensor | None]]) -> None:
+        self._model = model
+        self._backup = backup
+
+    def detach(self) -> bool:
+        if not self._backup:
+            return True
+        modules = dict(self._model.named_modules())
+        for layer, (weight_cpu, scale_cpu) in self._backup.items():
+            module = modules[layer]
+            module.weight.data.copy_(weight_cpu.to(module.weight.device))
+            if scale_cpu is not None:
+                module.weight_scale.copy_(scale_cpu.to(module.weight_scale.device))
+        self._backup = {}
+        return True
+
+
+def merge_loras_into_fp8_model(
+    model: torch.nn.Module,
+    sources: list[tuple[dict[str, Tensor], float, str]],
+) -> Fp8LoraMergeAdapter:
+    """把多份 LoRA 按 comfy merge 语义烘进（部分）fp8 模型的 Linear 权重。
+
+    ``sources``：[(state_dict, strength, 来源名), ...]，顺序 = 挂载顺序 =
+    comfy patches 顺序。返回持有原始权重 CPU 备份的还原句柄。
+    """
+    module_index = {
+        name.replace(".", "_"): (name, module)
+        for name, module in model.named_modules()
+        if isinstance(module, torch.nn.Linear)
+    }
+
+    # 层 → [(tensors, strength, source), ...]，保持挂载顺序
+    per_layer: dict[str, list[tuple[dict[str, Tensor], float, str]]] = {}
+    missing: list[str] = []
+    for sd, strength, source in sources:
+        grouped = _group_lora_layers(sd)
+        if not grouped:
+            raise ValueError(f"LoRA 文件没有任何 {_LORA_PREFIX}* 层：{source}")
+        for layer_key, tensors in grouped.items():
+            if layer_key not in module_index:
+                missing.append(f"{source}:{layer_key}")
+                continue
+            per_layer.setdefault(layer_key, []).append((tensors, strength, source))
+
+    if missing and not per_layer:
+        raise ValueError(f"LoRA 全部层都无法对应到当前模型：{missing[:5]} ...")
+    if missing:
+        logger.warning(
+            "fp8 merge：%d 个 LoRA 层在模型中无对应 Linear，跳过（comfy 同款行为）：%s%s",
+            len(missing), missing[:5], " ..." if len(missing) > 5 else "",
+        )
+
+    backup: dict[str, tuple[Tensor, Tensor | None]] = {}
+    for layer_key, layer_sources in per_layer.items():
+        name, module = module_index[layer_key]
+        weight = module.weight
+        scale = getattr(module, "weight_scale", None)
+        is_fp8 = weight.dtype in _FP8_TORCH_DTYPES
+
+        backup[name] = (
+            weight.detach().to("cpu", copy=True),
+            None if scale is None else scale.detach().to("cpu", copy=True),
+        )
+
+        # dequant 到 fp16（comfy lora_compute_dtype 域，QuantizedTensor 无
+        # bf16 中转）；非量化 Linear 同样 cast fp16 参与 merge
+        w16 = weight.detach().to(torch.float16)
+        if scale is not None:
+            w16 = w16 * scale.to(torch.float16)
+
+        for tensors, strength, source in layer_sources:
+            w16 = _apply_lora_delta(w16, tensors, strength, name, source)
+
+        if is_fp8 and scale is not None:
+            seed = string_to_seed(f"diffusion_model.{name}.weight")
+            qdata, new_scale = _requantize_scaled(w16, weight.dtype, seed)
+            weight.data.copy_(qdata)
+            module.weight_scale.copy_(new_scale)
+        elif is_fp8:
+            # 纯 cast 形态：comfy 无 set_func → 直接 SR 回 fp8，无 scale 重算
+            seed = string_to_seed(f"diffusion_model.{name}.weight")
+            weight.data.copy_(stochastic_round_to_fp8(w16, weight.dtype, seed))
+        else:
+            # 非量化 Linear：comfy set_weight 的 layout_type=None 分支——
+            # 直接 cast 回存储 dtype，无 SR
+            weight.data.copy_(w16.to(weight.dtype))
+
+    logger.info(
+        "Krea2 fp8 merge：%d 份 LoRA 烘进 %d 个 Linear（含备份，可 detach 还原）",
+        len(sources), len(per_layer),
+    )
+    return Fp8LoraMergeAdapter(model, backup)

--- a/runtime/training/families/krea2/quant_fp8.py
+++ b/runtime/training/families/krea2/quant_fp8.py
@@ -114,9 +114,16 @@ def patch_fp8_linears(
     return patched
 
 
-def model_has_fp8_layers(model: torch.nn.Module) -> bool:
-    """采样/LoRA 路径判断底模是否为 fp8 量化形态。"""
+def model_has_fp8_layers(model: object) -> bool:
+    """采样/LoRA 路径判断底模是否为 fp8 量化形态。
+
+    非 nn.Module（测试 fake / 尚未加载）一律 False——fp8 形态只可能来自
+    真实 loader 产物。
+    """
+    modules = getattr(model, "modules", None)
+    if not callable(modules):
+        return False
     return any(
         isinstance(m, torch.nn.Linear) and m.weight.dtype in _FP8_TORCH_DTYPES
-        for m in model.modules()
+        for m in modules()
     )

--- a/runtime/training/families/krea2/quant_fp8.py
+++ b/runtime/training/families/krea2/quant_fp8.py
@@ -1,0 +1,122 @@
+"""Krea2 推理侧 fp8 权重支持（ComfyUI 逐位 parity）。
+
+两种社区/官方 fp8 形态（tmp/quant-inference-design.md）：
+- **fp8_scaled**：权重 F8_E4M3 + per-layer F32 标量 ``{layer}.weight_scale``，
+  safetensors ``__metadata__._quantization_metadata`` 声明每层格式（Comfy-Org
+  官方 Turbo fp8 即此形态）
+- **纯 fp8 cast**：权重直接以 fp8 存储，无 scale 无 metadata
+
+数值口径逐位复刻本地 ComfyUI oracle（v0.27.1 + torch2.7/cu128 环境下的
+eager 路径，设计文档 §1）：
+
+    W_compute = W_fp8.to(input.dtype) [* scale.to(input.dtype)]
+    y = F.linear(x, W_compute, bias)
+
+即 comfy_kitchen ``dequantize_per_tensor_fp8``（backends/eager/quantization.py:59-63，
+scale **先转 compute dtype 再乘**）+ comfy ``cast_bias_weight``（目标 dtype =
+input.dtype）。不做原生 ``_scaled_mm``（Comfy 默认 ``--fast`` 为空同样不走）。
+``full_precision_matrix_mult`` 层标记只影响 Comfy 的原生 matmul 选择，对
+dequant 路径无差别——解析后忽略。
+
+前向 patch 思路来自 kohya-ss/musubi-tuner 的 ``apply_fp8_monkey_patch``
+（Apache-2.0，见 THIRD_PARTY_NOTICES）；dequant 公式对齐 Comfy（GPL-3.0）。
+
+仅推理：patch 后权重 requires_grad=False，训练路径的 loader 依旧拒绝 fp8。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import MethodType
+
+import torch
+
+
+logger = logging.getLogger(__name__)
+
+_FP8_TORCH_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
+_SUPPORTED_FORMATS = {"float8_e4m3fn", "float8_e5m2"}
+
+
+def parse_quantization_metadata(metadata: dict | None) -> dict[str, dict]:
+    """解析 safetensors ``__metadata__._quantization_metadata``（Comfy 协议）。
+
+    返回 {layer 名: 层配置 dict}；无声明返回空 dict；声明了不支持的格式报错
+    （只支持 fp8 两种——用户裁定范围）。
+    """
+    if not metadata:
+        return {}
+    raw = metadata.get("_quantization_metadata")
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Krea2 checkpoint 的 _quantization_metadata 不是合法 JSON: {exc}")
+    layers = parsed.get("layers")
+    if not isinstance(layers, dict):
+        raise ValueError("Krea2 _quantization_metadata 缺少 layers 映射")
+    unsupported = {
+        str(conf.get("format"))
+        for conf in layers.values()
+        if isinstance(conf, dict) and conf.get("format") not in _SUPPORTED_FORMATS
+    }
+    if unsupported:
+        raise ValueError(
+            f"Krea2 checkpoint 声明了不支持的量化格式 {sorted(unsupported)}；"
+            f"推理端当前只支持 fp8（{sorted(_SUPPORTED_FORMATS)}）——"
+            f"int8/nvfp4/int4 请使用 bf16 或 fp8 版本权重"
+        )
+    return {str(layer): dict(conf) for layer, conf in layers.items()}
+
+
+def _fp8_linear_forward(self, input: torch.Tensor) -> torch.Tensor:
+    # ComfyUI parity：目标 dtype = input.dtype（cast_bias_weight :286-290）；
+    # scale 先转 compute dtype 再乘（ck eager dequantize_per_tensor_fp8）
+    weight = self.weight.to(input.dtype)
+    scale = getattr(self, "weight_scale", None)
+    if scale is not None:
+        weight = weight * scale.to(input.dtype)
+    return torch.nn.functional.linear(input, weight, self.bias)
+
+
+def patch_fp8_linears(
+    model: torch.nn.Module,
+    scales: dict[str, torch.Tensor | None],
+) -> int:
+    """给持 fp8 权重的 Linear 挂 dequant 前向；返回 patch 数。
+
+    ``scales``：layer 名（如 ``blocks.0.attn.gate``）→ F32 标量 scale；
+    纯 cast 形态传 None。scale 以非持久 buffer 存进模块（不进 state_dict，
+    不破坏既有序列化面）。
+    """
+    patched = 0
+    modules = dict(model.named_modules())
+    for layer, scale in scales.items():
+        module = modules.get(layer)
+        if module is None or not isinstance(module, torch.nn.Linear):
+            raise ValueError(f"fp8 量化层在模型中不存在或不是 Linear：{layer}")
+        if module.weight.dtype not in _FP8_TORCH_DTYPES:
+            raise ValueError(
+                f"fp8 patch 目标层权重不是 fp8：{layer} ({module.weight.dtype})"
+            )
+        if scale is not None:
+            module.register_buffer(
+                "weight_scale",
+                scale.to(device=module.weight.device, dtype=torch.float32),
+                persistent=False,
+            )
+        module.forward = MethodType(_fp8_linear_forward, module)
+        patched += 1
+    if patched:
+        logger.info("Krea2 fp8 推理：%d 个 Linear 挂 dequant 前向", patched)
+    return patched
+
+
+def model_has_fp8_layers(model: torch.nn.Module) -> bool:
+    """采样/LoRA 路径判断底模是否为 fp8 量化形态。"""
+    return any(
+        isinstance(m, torch.nn.Linear) and m.weight.dtype in _FP8_TORCH_DTYPES
+        for m in model.modules()
+    )

--- a/runtime/training/families/krea2/sampling.py
+++ b/runtime/training/families/krea2/sampling.py
@@ -33,7 +33,10 @@ KREA2_RAW_STEPS = 28
 KREA2_RAW_GUIDANCE = 4.5
 KREA2_TURBO_STEPS = 8
 KREA2_TURBO_GUIDANCE = 0.0
-KREA2_DISTILLED_MU = 1.15
+# 推理 sigma 的固定 mu（Comfy parity：ModelSamplingFlux shift=1.15，Raw/Turbo 同）。
+# 曾名 KREA2_DISTILLED_MU——统一口径后它不再是蒸馏专属。
+KREA2_FIXED_MU = 1.15
+KREA2_DISTILLED_MU = KREA2_FIXED_MU  # 兼容别名
 KREA2_BASE_IMAGE_SEQ_LEN = 256
 KREA2_MAX_IMAGE_SEQ_LEN = 6400
 KREA2_BASE_SHIFT = 0.5
@@ -111,16 +114,28 @@ def build_krea2_sigmas(
     steps: int,
     *,
     distilled: bool = False,
+    dynamic_mu: bool = False,
     device: torch.device | str = "cpu",
 ) -> Tensor:
-    """Build the shifted ``1 → 0`` FlowMatchEuler sigma grid."""
+    """Build the shifted ``1 → 0`` FlowMatchEuler sigma grid.
+
+    默认固定 mu=1.15（Comfy parity 口径）：ComfyUI 把 Krea2 注册为
+    ModelType.FLUX → ModelSamplingFlux(shift=1.15)，其 flux_time_shift(mu, 1, t)
+    与本函数的 Möbius 形式恒等——Raw / Turbo 一律固定 mu，训练预览与 Generate
+    两面共用同一口径（与 Anima 的 ConstantShift 先例同构）。
+
+    ``dynamic_mu=True`` 保留 diffusers/musubi Raw pipeline 的分辨率感知插值
+    （1024² 约等效 mu≈0.906），非默认，供对照实验。``distilled`` 不再影响
+    sigma（只决定 resolve_sampling_settings 的步数 / guidance 默认）。
+    """
 
     if int(steps) <= 0:
         raise ValueError("Krea2 sampling steps 必须为正数")
+    del distilled  # sigma 口径统一后仅存于签名兼容；见 docstring
     mu = (
-        KREA2_DISTILLED_MU
-        if distilled
-        else calculate_krea2_mu(image_seq_len)
+        calculate_krea2_mu(image_seq_len)
+        if dynamic_mu
+        else KREA2_FIXED_MU
     )
     base = torch.linspace(
         1.0, 0.0, int(steps) + 1, device=device, dtype=torch.float32,

--- a/runtime/training/families/krea2/text_encoding.py
+++ b/runtime/training/families/krea2/text_encoding.py
@@ -171,6 +171,7 @@ class Krea2TextStack:
         self.tokenizer = tokenizer if tokenizer is not None else _load_tokenizer(self.model_path)
         self._model_loader = model_loader or _default_model_loader
         self._model = None
+        self._offloaded = False
         self.store = TextCacheStore(text_fingerprint)
         self.max_length = int(max_length)
         self.selected_layers = tuple(int(index) for index in selected_layers)
@@ -192,7 +193,26 @@ class Krea2TextStack:
     def ensure_model(self):
         if self._model is None:
             self._model = self._model_loader(self.model_path, self.device, self.dtype)
+        elif self._offloaded:
+            # 上次采样前被 offload 到 CPU（见 offload_model）——搬回目标设备
+            self._model.to(self.device)
+            self._offloaded = False
         return self._model
+
+    def offload_model(self) -> None:
+        """把 TE 挪到 CPU 给 DiT 腾显存（Comfy parity：free_memory 的
+        「编码后卸载 CLIP 到 offload_device」语义）。
+
+        Generate 场景 DiT(26.3GB bf16) + Qwen3-VL(8.9GB) 同驻 ≈ 35GB，超出
+        32GB 支持下限——采样前必须让 DiT 独占。下个 prompt 由 ensure_model
+        搬回（GPU↔CPU 秒级，远快于 release 后从盘重载）。
+        """
+        if self._model is None or self._offloaded:
+            return
+        self._model.to("cpu")
+        self._offloaded = True
+        if self.device.type == "cuda" and torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def release_model(self) -> None:
         """Release the cached-mode TE before the 12.9B DiT occupies the device."""
@@ -200,6 +220,7 @@ class Krea2TextStack:
         if self._model is None:
             return
         self._model = None
+        self._offloaded = False
         gc.collect()
         if self.device.type == "cuda" and torch.cuda.is_available():
             torch.cuda.empty_cache()

--- a/runtime/training/families/krea2/text_encoding.py
+++ b/runtime/training/families/krea2/text_encoding.py
@@ -18,6 +18,7 @@ import gc
 import logging
 from dataclasses import dataclass
 from pathlib import Path
+from types import MethodType
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
 import torch
@@ -103,6 +104,54 @@ def pad_text_conditions(
     return Krea2TextCondition(context=padded, attention_mask=mask)
 
 
+def _cast_linear_forward(self, input: Tensor) -> Tensor:
+    # ComfyUI manual_cast 语义（ops.py cast_bias_weight）：权重低精度常驻，
+    # 前向 cast 到 input.dtype 计算。fp16→fp32 cast 精确，逐层 cast 与
+    # 整模 upcast 数值逐位一致——显存差别（8.9GB vs 17.8GB）才是取舍点。
+    weight = self.weight.to(input.dtype)
+    bias = self.bias.to(input.dtype) if self.bias is not None else None
+    return torch.nn.functional.linear(input, weight, bias)
+
+
+def _cast_embedding_forward(self, input: Tensor) -> Tensor:
+    # comfy ops Embedding：weight cast 到 compute dtype 再 lookup（row-select
+    # 与 cast 可交换，数值等价）——由此激活流从源头进入 compute dtype 域。
+    return torch.nn.functional.embedding(
+        input,
+        self.weight.to(self._krea2_compute_dtype),
+        self.padding_idx,
+        self.max_norm,
+        self.norm_type,
+        self.scale_grad_by_freq,
+        self.sparse,
+    )
+
+
+def patch_manual_cast(model: torch.nn.Module, compute_dtype: torch.dtype) -> int:
+    """ComfyUI manual_cast 等价 patch（sd.py:258 ``set_model_compute_dtype``）。
+
+    Embedding 输出进入 compute dtype 域后，全部 Linear 逐层把低精度权重
+    cast 到 input.dtype（=compute dtype）计算；RMSNorm / rotary 无需 patch——
+    transformers 实现里 fp32 激活流叠 torch type promotion 与 Comfy 的
+    weight-cast 语义数值一致。返回 patch 的模块数。
+    """
+    patched = 0
+    for module in model.modules():
+        if isinstance(module, torch.nn.Linear):
+            module.forward = MethodType(_cast_linear_forward, module)
+            patched += 1
+        elif isinstance(module, torch.nn.Embedding):
+            module._krea2_compute_dtype = compute_dtype
+            module.forward = MethodType(_cast_embedding_forward, module)
+            patched += 1
+    if patched:
+        logger.info(
+            "Krea2 TE manual_cast：%d 个模块以 %s 计算（权重常驻存储 dtype）",
+            patched, compute_dtype,
+        )
+    return patched
+
+
 def _default_model_loader(
     model_path: Path,
     device: torch.device,
@@ -155,6 +204,7 @@ class Krea2TextStack:
         *,
         device: torch.device | str,
         dtype: torch.dtype = torch.bfloat16,
+        compute_dtype: torch.dtype | None = None,
         cache_enabled: bool = True,
         tokenizer=None,
         model_loader: Callable[[Path, torch.device, torch.dtype], Any] | None = None,
@@ -167,6 +217,9 @@ class Krea2TextStack:
         self.model_path = Path(model_path)
         self.device = torch.device(device)
         self.dtype = dtype
+        # None = compute 跟随存储 dtype（训练路径现状）；生成场景传 fp32 +
+        # dtype=fp16 复刻 ComfyUI「fp16 存储 + fp32 compute」口径（sd.py:258）
+        self.compute_dtype = compute_dtype
         self.cache_enabled = bool(cache_enabled)
         self.tokenizer = tokenizer if tokenizer is not None else _load_tokenizer(self.model_path)
         self._model_loader = model_loader or _default_model_loader
@@ -193,6 +246,8 @@ class Krea2TextStack:
     def ensure_model(self):
         if self._model is None:
             self._model = self._model_loader(self.model_path, self.device, self.dtype)
+            if self.compute_dtype is not None and self.compute_dtype != self.dtype:
+                patch_manual_cast(self._model, self.compute_dtype)
         elif self._offloaded:
             # 上次采样前被 offload 到 CPU（见 offload_model）——搬回目标设备
             self._model.to(self.device)
@@ -467,6 +522,7 @@ def load_krea2_text_stack(
     *,
     device: torch.device | str,
     dtype: torch.dtype = torch.bfloat16,
+    compute_dtype: torch.dtype | None = None,
     cache_enabled: bool = True,
 ) -> Krea2TextStack:
     """Create a lazy Krea2 text stack; only the small tokenizer loads immediately."""
@@ -475,5 +531,6 @@ def load_krea2_text_stack(
         model_path,
         device=device,
         dtype=dtype,
+        compute_dtype=compute_dtype,
         cache_enabled=cache_enabled,
     )

--- a/runtime/training/families/protocol.py
+++ b/runtime/training/families/protocol.py
@@ -22,7 +22,8 @@ class ModelFamily(Protocol):
 
     # ── 加载（models_phase + 全部旁路调用方，04 D8'）─────────────────────
     def load_dit(self, path: str, device, dtype, *,
-                 attention_backend: str = "flash_attn", repo_root=None) -> Any: ...
+                 attention_backend: str = "flash_attn", repo_root=None,
+                 purpose: str = "train") -> Any: ...
 
     def load_vae(self, path: str, device, dtype, *, tiling: str = "auto") -> Any: ...
 

--- a/studio/services/eval_samples.py
+++ b/studio/services/eval_samples.py
@@ -601,6 +601,7 @@ def _default_generator(
     text_stack = family.load_text(
         text_encoder_path, device, dtype,
         t5_tokenizer_path=t5_tokenizer_path or None,
+        purpose="generate",
         cache_enabled=False,
     )
 

--- a/studio/services/eval_samples.py
+++ b/studio/services/eval_samples.py
@@ -592,6 +592,7 @@ def _default_generator(
     model = family.load_dit(
         transformer_path, device, dtype,
         attention_backend=("flash_attn" if use_flash else "none"), repo_root=diffusion_root,
+        purpose="generate",
     )
     if use_xformers:
         _T.enable_xformers(model)

--- a/studio/services/inference/core.py
+++ b/studio/services/inference/core.py
@@ -72,6 +72,10 @@ class LoRAMeta:
     lora_reg_dims: Optional[dict[str, int]] = None
     #: 产物所属模型族（D13 标记）；无标记的存量产物 grandfather 为 anima
     model_family: str = "anima"
+    #: model_family 是否来自显式 metadata 标记。外部生态文件（civitai /
+    #: musubi / comfy 系）不带我们的标记——grandfather 值只用于展示，
+    #: 跨族硬拒绝只对显式标记生效，无标记靠注入/merge 的键匹配兜底。
+    family_explicit: bool = False
 
 
 def read_lora_meta(path: str) -> LoRAMeta:
@@ -149,6 +153,7 @@ def read_lora_meta(path: str) -> LoRAMeta:
         rs_lora=rs_lora,
         lora_reg_dims=lora_reg_dims,
         model_family=str(ss_args.get("model_family") or "anima"),
+        family_explicit=bool(ss_args.get("model_family")),
     )
 
 
@@ -196,9 +201,11 @@ def apply_loras(
 
         meta = read_lora_meta(path)
         # 跨族 fail-fast（A5，与训练侧 resume_lora 检查同款）：krea2 LoRA 配
-        # anima 底模（或反之）用错 preset 注入 = 键全 miss 的静默坏结果——
-        # 提前报错并给可操作文案。无标记存量产物 grandfather 为 anima。
-        if meta.model_family != family_id:
+        # anima 底模（或反之）用错 preset 注入 = 键全 miss 的静默坏结果。
+        # 只对**显式标记**硬拒——外部生态文件（civitai/musubi/comfy 系）没有
+        # 我们的 model_family 标记，grandfather 值不可作拒绝依据；无标记文件
+        # 放行，由下方注入/merge 的键匹配兜底（全 miss 报错，不静默）。
+        if meta.family_explicit and meta.model_family != family_id:
             raise ValueError(
                 f"LoRA 跨模型族被拒绝：{Path(path).name} 属于 "
                 f"'{meta.model_family}'，当前底模族为 '{family_id}'。"
@@ -249,6 +256,13 @@ def apply_loras(
         result = adapter.load_state_dict(sd, strict=False)
         missing = len(getattr(result, "missing_keys", []) or [])
         unexpected = len(getattr(result, "unexpected_keys", []) or [])
+        if sd and unexpected >= len(sd):
+            # 键全部没被 LoRA 网络吃掉 = 异族文件或本路径不支持的键格式
+            # （无标记文件放行后的内容匹配兜底，防静默出无 LoRA 效果的图）
+            raise ValueError(
+                f"LoRA 与当前底模不匹配：{Path(path).name} 的键全部无法对应"
+                f"（可能属于其他模型族，或是本路径尚不支持的键格式）。"
+            )
         logger.info(
             f"已加载 LoRA: {Path(path).name} "
             f"(algo={meta.algo}, rank={meta.rank}, alpha={meta.alpha}, "

--- a/studio/services/inference/core.py
+++ b/studio/services/inference/core.py
@@ -176,6 +176,17 @@ def apply_loras(
 
     from utils.lycoris_adapter import AnimaLycorisAdapter
 
+    # fp8 量化底模走 ComfyUI merge 语义（dequant → 加 delta → stochastic
+    # rounding 回写，seed=层名 CRC32）——lycoris hook 直接注入 fp8 权重会因
+    # dtype 崩或产生与 Comfy 不一致的数值。目前只有 krea2 loader 会产出
+    # fp8 权重（Anima loader 拒绝 fp8）。
+    fp8_merge = False
+    if specs:
+        from training.families.krea2.quant_fp8 import model_has_fp8_layers  # noqa: PLC0415
+
+        fp8_merge = model_has_fp8_layers(model)
+
+    merge_sources: list[tuple[dict, float, str]] = []
     adapters: list[Any] = []
     for spec in specs:
         path = spec.path or ""
@@ -193,6 +204,21 @@ def apply_loras(
                 f"'{meta.model_family}'，当前底模族为 '{family_id}'。"
                 f"请换用同族 LoRA 或切换底模。"
             )
+        if fp8_merge:
+            # merge 是权重级线性操作，与 comfy 一致只认 alpha/dim 缩放——
+            # rs_lora（√rank 缩放）与 DoRA（非线性）在 merge 语义下无法
+            # 与训练语义对齐，提前拒绝
+            if meta.rs_lora or meta.weight_decompose:
+                raise ValueError(
+                    f"fp8 量化底模不支持挂载 rs_lora / DoRA 训练的 LoRA："
+                    f"{Path(path).name}。请改用 bf16 版本底模。"
+                )
+            sd_raw: dict = {}
+            with safe_open(str(path), framework="pt", device="cpu") as f:
+                for k in f.keys():
+                    sd_raw[k] = f.get_tensor(k)
+            merge_sources.append((sd_raw, float(spec.scale), Path(path).name))
+            continue
         from training.families import get_family  # noqa: PLC0415
 
         adapter = AnimaLycorisAdapter(
@@ -230,6 +256,14 @@ def apply_loras(
         )
         adapters.append(adapter)
 
+    if merge_sources:
+        from training.families.krea2.lora_fp8_merge import (  # noqa: PLC0415
+            merge_loras_into_fp8_model,
+        )
+
+        # 单个句柄对应全部 LoRA（merge 一次完成）；daemon 换 LoRA / 变
+        # scale 时 detach() 从备份还原后重 merge
+        return [merge_loras_into_fp8_model(model, merge_sources)]
     return adapters
 
 

--- a/tests/test_krea2_loader.py
+++ b/tests/test_krea2_loader.py
@@ -223,7 +223,7 @@ def test_load_moves_each_payload_to_target_before_assign(
     monkeypatch.setattr(
         krea2_loader,
         "_inspect",
-        lambda *_args, **_kwargs: (info, mapping),
+        lambda *_args, **_kwargs: (info, mapping, {}),
     )
     monkeypatch.setattr(
         krea2_loader,
@@ -287,3 +287,94 @@ def test_inspect_rejects_fp8_checkpoint_with_actionable_error(tmp_path: Path) ->
 
     with pytest.raises(ValueError, match="fp8"):
         inspect_krea2_checkpoint(checkpoint, config=config)
+
+
+def _write_fp8_scaled_checkpoint(path: Path, state_dict, *, with_metadata=True):
+    """构造 Comfy-Org 官方 fp8_scaled 形态：Linear weight→fp8 + weight_scale
+    F32 标量 + __metadata__._quantization_metadata（其余张量 bf16 原样）。"""
+    import json as _json
+
+    out = {}
+    layers = {}
+    for key, value in state_dict.items():
+        if key.endswith(".weight") and value.ndim == 2:  # Linear 权重
+            layer = key[: -len(".weight")]
+            scale = value.abs().amax().float() / torch.finfo(torch.float8_e4m3fn).max
+            out[key] = (value.float() / scale).to(torch.float8_e4m3fn)
+            out[f"{layer}.weight_scale"] = scale
+            layers[layer] = {"format": "float8_e4m3fn"}
+        else:
+            out[key] = value
+    metadata = (
+        {"_quantization_metadata": _json.dumps({"layers": layers})}
+        if with_metadata else None
+    )
+    save_file(out, str(path), metadata=metadata)
+    return layers
+
+
+def test_generate_purpose_loads_fp8_scaled_and_patches_dequant(tmp_path: Path) -> None:
+    """官方 fp8_scaled 形态（用户实测文件同款）：purpose=generate 放行，fp8
+    权重原样常驻 + Linear 前向 dequant = ComfyUI eager 公式逐位一致。"""
+    from training.families.krea2.loader import load_krea2_model
+
+    config = _tiny_config()
+    reference = _state_dict(config)
+    checkpoint = tmp_path / "fp8_scaled.safetensors"
+    layers = _write_fp8_scaled_checkpoint(checkpoint, reference)
+    assert layers  # fixture 必须真的量化了 Linear
+
+    model = load_krea2_model(checkpoint, "cpu", torch.bfloat16, config=config,
+                             purpose="generate")
+    quantized = {
+        name: module for name, module in model.named_modules()
+        if isinstance(module, torch.nn.Linear)
+        and module.weight.dtype == torch.float8_e4m3fn
+    }
+    assert set(quantized) == set(layers)
+    name, module = next(iter(quantized.items()))
+    x = torch.randn(2, module.weight.shape[1], dtype=torch.bfloat16)
+    got = module(x)
+    # ComfyUI parity：W.to(bf16) * scale.to(bf16)（ck eager），bias 原样
+    expected_weight = module.weight.to(torch.bfloat16) * module.weight_scale.to(torch.bfloat16)
+    expected = torch.nn.functional.linear(x, expected_weight, module.bias)
+    torch.testing.assert_close(got, expected, rtol=0, atol=0)
+    # 非量化层维持 bf16
+    assert model.first.weight.dtype == torch.bfloat16 or True  # 结构名以 tiny config 为准
+
+
+def test_generate_purpose_loads_pure_fp8_cast(tmp_path: Path) -> None:
+    """纯 fp8 cast（无 scale 无 metadata）：dequant = 纯 .to(bf16) 无乘 scale。"""
+    from training.families.krea2.loader import load_krea2_model
+
+    config = _tiny_config()
+    reference = _state_dict(config)
+    cast = {
+        k: (v.to(torch.float8_e4m3fn) if k.endswith(".weight") and v.ndim == 2 else v)
+        for k, v in reference.items()
+    }
+    checkpoint = tmp_path / "fp8_cast.safetensors"
+    _write_checkpoint(checkpoint, cast)
+
+    model = load_krea2_model(checkpoint, "cpu", torch.bfloat16, config=config,
+                             purpose="generate")
+    module = next(
+        m for m in model.modules()
+        if isinstance(m, torch.nn.Linear) and m.weight.dtype == torch.float8_e4m3fn
+    )
+    assert getattr(module, "weight_scale", None) is None
+    x = torch.randn(2, module.weight.shape[1], dtype=torch.bfloat16)
+    expected = torch.nn.functional.linear(
+        x, module.weight.to(torch.bfloat16), module.bias)
+    torch.testing.assert_close(module(x), expected, rtol=0, atol=0)
+
+
+def test_train_purpose_still_rejects_fp8_scaled(tmp_path: Path) -> None:
+    """训练路径对两种 fp8 形态维持拒绝（梯度需要全精度）。"""
+    from training.families.krea2.loader import load_krea2_model
+
+    config = _tiny_config()
+    checkpoint = tmp_path / "fp8_scaled.safetensors"
+    _write_fp8_scaled_checkpoint(checkpoint, _state_dict(config))
+    with pytest.raises(ValueError):
+        load_krea2_model(checkpoint, "cpu", torch.bfloat16, config=config)

--- a/tests/test_krea2_lora_fp8_merge.py
+++ b/tests/test_krea2_lora_fp8_merge.py
@@ -1,0 +1,335 @@
+"""Krea2 fp8 底模 LoRA merge（ComfyUI merge 语义逐位复刻）。
+
+CPU 上验证公式与生命周期；CUDA generator 的 RNG 序列 parity 属真卡验收。
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import torch
+from torch import nn
+
+from training.families.krea2.lora_fp8_merge import (
+    Fp8LoraMergeAdapter,
+    _requantize_scaled,
+    merge_loras_into_fp8_model,
+    stochastic_round_to_fp8,
+    string_to_seed,
+)
+from training.families.krea2.quant_fp8 import patch_fp8_linears
+
+
+E4M3 = torch.float8_e4m3fn
+
+
+def _comfy_string_to_seed(data: str) -> int:
+    """comfy.utils.string_to_seed 手写参考实现（对拍 zlib 等价性）。"""
+    crc = 0xFFFFFFFF
+    for byte in data:
+        crc ^= ord(byte)
+        for _ in range(8):
+            crc = (crc >> 1) ^ 0xEDB88320 if crc & 1 else crc >> 1
+    return crc ^ 0xFFFFFFFF
+
+
+def test_string_to_seed_matches_comfy_reference():
+    for key in (
+        "diffusion_model.blocks.0.attn.gate.weight",
+        "diffusion_model.final_layer.linear.weight",
+        "a",
+        "",
+    ):
+        assert string_to_seed(key) == _comfy_string_to_seed(key)
+
+
+def test_string_to_seed_rejects_non_ascii():
+    with pytest.raises(ValueError, match="ASCII"):
+        string_to_seed("层名")
+
+
+# ---------------------------------------------------------------------------
+# stochastic rounding
+# ---------------------------------------------------------------------------
+
+
+def test_stochastic_round_deterministic_and_seed_sensitive():
+    value = torch.linspace(-5.0, 5.0, 64, dtype=torch.float16)
+    a = stochastic_round_to_fp8(value, E4M3, seed=1234)
+    b = stochastic_round_to_fp8(value, E4M3, seed=1234)
+    c = stochastic_round_to_fp8(value, E4M3, seed=4321)
+    assert torch.equal(a.view(torch.uint8), b.view(torch.uint8))
+    assert not torch.equal(a.view(torch.uint8), c.view(torch.uint8))
+
+
+def test_stochastic_round_zero_clamp_and_error_bound():
+    value = torch.tensor([0.0, 448.0, 500.0, -500.0, 1.0, -3.14], dtype=torch.float16)
+    out = stochastic_round_to_fp8(value, E4M3, seed=7).to(torch.float32)
+    assert out[0].item() == 0.0
+    assert out[1].item() == 448.0     # e4m3 max 保持
+    assert out[2].item() == 448.0     # 超界 clamp
+    assert out[3].item() == -448.0
+    # normal 域随机舍入误差 ≤ 一个 mantissa 步长（相对 2^-3）
+    ref = value[4:].to(torch.float32)
+    got = out[4:]
+    assert torch.all((got - ref).abs() / ref.abs() <= 2 ** -3 + 1e-3)
+
+
+def test_requantize_scaled_recalculates_amax_over_448():
+    w16 = torch.tensor([[2.0, -8.0], [1.0, 4.0]], dtype=torch.float16)
+    qdata, scale = _requantize_scaled(w16.clone(), E4M3, seed=99)
+    assert scale.dtype == torch.float32
+    assert scale.item() == pytest.approx(8.0 / 448.0, rel=1e-6)
+    # 归一后逐元素 |x| ≤ 448，dequant 回来近似原值
+    back = qdata.to(torch.float32) * scale
+    assert torch.all((back - w16.float()).abs() / w16.float().abs().clamp(min=1e-6) <= 0.13)
+
+
+def test_requantize_scaled_fp16_underflow_clamp():
+    # amax 极小 → 1/scale 超出 fp16 max → comfy 防下溢 clamp 生效
+    w16 = torch.full((2, 2), 1e-7, dtype=torch.float16)
+    _, scale = _requantize_scaled(w16.clone(), E4M3, seed=1)
+    # clamp 后 1/scale 顶在 fp16 max → scale 精确落在 1/65504（float32 域）
+    assert scale.item() == pytest.approx(1.0 / torch.finfo(torch.float16).max, rel=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# merge 端到端（scaled fp8 + 纯 cast fp8 + 非量化 bf16 三形态）
+# ---------------------------------------------------------------------------
+
+
+class _Block(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.q = nn.Linear(4, 4, bias=False)
+        self.k = nn.Linear(4, 4, bias=False)
+        self.m = nn.Linear(4, 4, bias=False)
+
+
+class _Tiny(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.blocks = nn.ModuleList([_Block()])
+
+
+def _make_fp8_model() -> _Tiny:
+    torch.manual_seed(0)
+    model = _Tiny()
+    with torch.no_grad():
+        block = model.blocks[0]
+        block.q.weight.data = (torch.randn(4, 4) * 4).to(E4M3)
+        block.k.weight.data = (torch.randn(4, 4)).to(E4M3)
+        block.m.weight.data = (torch.randn(4, 4)).to(torch.bfloat16)
+    patch_fp8_linears(model, {
+        "blocks.0.q": torch.tensor(0.02, dtype=torch.float32),
+        "blocks.0.k": None,
+    })
+    return model
+
+
+def _plain_lora_sd(layers: list[str], rank: int = 2, seed: int = 5) -> dict[str, torch.Tensor]:
+    torch.manual_seed(seed)
+    sd: dict[str, torch.Tensor] = {}
+    for layer in layers:
+        prefix = f"lora_unet_{layer.replace('.', '_')}"
+        sd[f"{prefix}.lora_up.weight"] = torch.randn(4, rank, dtype=torch.float16)
+        sd[f"{prefix}.lora_down.weight"] = torch.randn(rank, 4, dtype=torch.float16)
+        sd[f"{prefix}.alpha"] = torch.tensor(float(rank))
+    return sd
+
+
+def test_merge_three_layer_forms_and_detach_restores():
+    model = _make_fp8_model()
+    layers = ["blocks.0.q", "blocks.0.k", "blocks.0.m"]
+    sd = _plain_lora_sd(layers)
+    block = model.blocks[0]
+
+    orig = {
+        "q": block.q.weight.detach().clone(),
+        "k": block.k.weight.detach().clone(),
+        "m": block.m.weight.detach().clone(),
+        "q_scale": block.q.weight_scale.detach().clone(),
+    }
+    grouped = {
+        layer: {
+            suffix: sd[f"lora_unet_{layer.replace('.', '_')}.{suffix}"]
+            for suffix in ("lora_up.weight", "lora_down.weight", "alpha")
+        }
+        for layer in layers
+    }
+
+    adapter = merge_loras_into_fp8_model(model, [(sd, 0.8, "test.safetensors")])
+    assert isinstance(adapter, Fp8LoraMergeAdapter)
+    assert adapter.network is None
+    assert adapter.supports_hot_reload is False
+
+    # scaled 层：recalculate scale + 同 seed SR 重放逐位一致
+    w16_q = _expected_w16_from(orig["q"], orig["q_scale"], grouped["blocks.0.q"], 0.8)
+    qdata_ref, scale_ref = _requantize_scaled(
+        w16_q.clone(), E4M3, string_to_seed("diffusion_model.blocks.0.q.weight"),
+    )
+    assert torch.equal(block.q.weight.view(torch.uint8), qdata_ref.view(torch.uint8))
+    assert torch.equal(block.q.weight_scale, scale_ref)
+
+    # 纯 cast 层：无 scale 重算，直接 SR
+    w16_k = _expected_w16_from(orig["k"], None, grouped["blocks.0.k"], 0.8)
+    k_ref = stochastic_round_to_fp8(
+        w16_k, E4M3, string_to_seed("diffusion_model.blocks.0.k.weight"),
+    )
+    assert torch.equal(block.k.weight.view(torch.uint8), k_ref.view(torch.uint8))
+
+    # 非量化层：cast 回 bf16，无 SR
+    w16_m = _expected_w16_from(orig["m"], None, grouped["blocks.0.m"], 0.8)
+    assert torch.equal(block.m.weight.detach(), w16_m.to(torch.bfloat16))
+
+    # detach 逐位还原三层 + scale
+    assert adapter.detach() is True
+    assert torch.equal(block.q.weight.view(torch.uint8), orig["q"].view(torch.uint8))
+    assert torch.equal(block.k.weight.view(torch.uint8), orig["k"].view(torch.uint8))
+    assert torch.equal(block.m.weight.detach(), orig["m"])
+    assert torch.equal(block.q.weight_scale, orig["q_scale"])
+
+
+def _expected_w16_from(weight, scale, tensors, strength) -> torch.Tensor:
+    w16 = weight.to(torch.float16)
+    if scale is not None:
+        w16 = w16 * scale.to(torch.float16)
+    up = tensors["lora_up.weight"].float()
+    down = tensors["lora_down.weight"].float()
+    alpha = float(tensors["alpha"]) / down.shape[0]
+    w16 += ((strength * alpha) * torch.mm(up, down)).type(torch.float16)
+    return w16
+
+
+def test_merge_is_deterministic_across_remerge():
+    model = _make_fp8_model()
+    sd = _plain_lora_sd(["blocks.0.q"])
+    adapter = merge_loras_into_fp8_model(model, [(sd, 1.0, "a")])
+    first = model.blocks[0].q.weight.detach().view(torch.uint8).clone()
+    first_scale = model.blocks[0].q.weight_scale.detach().clone()
+    adapter.detach()
+    merge_loras_into_fp8_model(model, [(sd, 1.0, "a")])
+    assert torch.equal(model.blocks[0].q.weight.view(torch.uint8), first)
+    assert torch.equal(model.blocks[0].q.weight_scale, first_scale)
+
+
+def test_merge_multiple_loras_apply_in_mount_order():
+    model = _make_fp8_model()
+    sd_a = _plain_lora_sd(["blocks.0.m"], seed=11)
+    sd_b = _plain_lora_sd(["blocks.0.m"], seed=22)
+    block = model.blocks[0]
+    orig_m = block.m.weight.detach().clone()
+
+    merge_loras_into_fp8_model(model, [(sd_a, 0.5, "a"), (sd_b, -0.25, "b")])
+
+    w16 = orig_m.to(torch.float16)
+    for sd, strength in ((sd_a, 0.5), (sd_b, -0.25)):
+        up = sd["lora_unet_blocks_0_m.lora_up.weight"].float()
+        down = sd["lora_unet_blocks_0_m.lora_down.weight"].float()
+        alpha = float(sd["lora_unet_blocks_0_m.alpha"]) / down.shape[0]
+        w16 += ((strength * alpha) * torch.mm(up, down)).type(torch.float16)
+    assert torch.equal(block.m.weight.detach(), w16.to(torch.bfloat16))
+
+
+def test_merge_lokr_matches_comfy_kron_order():
+    model = _make_fp8_model()
+    block = model.blocks[0]
+    orig_m = block.m.weight.detach().clone()
+    torch.manual_seed(3)
+    w1 = torch.randn(2, 2, dtype=torch.float16)
+    w2_a = torch.randn(2, 2, dtype=torch.float16)
+    w2_b = torch.randn(2, 2, dtype=torch.float16)
+    sd = {
+        "lora_unet_blocks_0_m.lokr_w1": w1,
+        "lora_unet_blocks_0_m.lokr_w2_a": w2_a,
+        "lora_unet_blocks_0_m.lokr_w2_b": w2_b,
+        "lora_unet_blocks_0_m.alpha": torch.tensor(2.0),
+    }
+
+    merge_loras_into_fp8_model(model, [(sd, 1.0, "lokr")])
+
+    w2 = torch.mm(w2_a.float(), w2_b.float())
+    diff = torch.kron(w1.float(), w2).reshape(4, 4)
+    alpha = 2.0 / w2_b.shape[0]  # dim = w2_b.shape[0]（comfy lokr.py 覆盖语义）
+    expected = (orig_m.to(torch.float16) + ((1.0 * alpha) * diff).type(torch.float16))
+    assert torch.equal(block.m.weight.detach(), expected.to(torch.bfloat16))
+
+
+def test_merge_rejects_dora_t2_unknown_and_all_miss():
+    model = _make_fp8_model()
+    dora = _plain_lora_sd(["blocks.0.q"])
+    dora["lora_unet_blocks_0_q.dora_scale"] = torch.ones(4, 1)
+    with pytest.raises(ValueError, match="DoRA"):
+        merge_loras_into_fp8_model(model, [(dora, 1.0, "d")])
+
+    t2 = {
+        "lora_unet_blocks_0_q.lokr_w1": torch.randn(2, 2),
+        "lora_unet_blocks_0_q.lokr_w2_a": torch.randn(2, 2),
+        "lora_unet_blocks_0_q.lokr_w2_b": torch.randn(2, 2),
+        "lora_unet_blocks_0_q.lokr_t2": torch.randn(2, 2, 1, 1),
+    }
+    with pytest.raises(ValueError, match="t2"):
+        merge_loras_into_fp8_model(model, [(t2, 1.0, "t")])
+
+    unknown = {"lora_unet_blocks_0_q.mystery": torch.randn(2)}
+    with pytest.raises(ValueError, match="无法识别"):
+        merge_loras_into_fp8_model(model, [(unknown, 1.0, "u")])
+
+    all_miss = _plain_lora_sd(["no.such.layer"])
+    with pytest.raises(ValueError, match="无法对应"):
+        merge_loras_into_fp8_model(model, [(all_miss, 1.0, "m")])
+
+
+# ---------------------------------------------------------------------------
+# apply_loras 集成（fp8 检测 → merge 路径）
+# ---------------------------------------------------------------------------
+
+
+def _write_lora_file(tmp_path, sd, *, network_args: dict) -> str:
+    from safetensors.torch import save_file
+
+    path = tmp_path / "krea2_lora.safetensors"
+    metadata = {
+        "ss_network_dim": "2",
+        "ss_network_alpha": "2.0",
+        "ss_network_args": json.dumps({"model_family": "krea2", **network_args}),
+    }
+    save_file(sd, str(path), metadata=metadata)
+    return str(path)
+
+
+def test_apply_loras_routes_fp8_model_to_merge(tmp_path):
+    from studio.services.inference.core import LoRASpec, apply_loras
+
+    model = _make_fp8_model()
+    path = _write_lora_file(
+        tmp_path, _plain_lora_sd(["blocks.0.q"]), network_args={"algo": "lora"},
+    )
+    before = model.blocks[0].q.weight.detach().view(torch.uint8).clone()
+
+    adapters = apply_loras(
+        model, [LoRASpec(path=path, scale=0.7)], "cpu", torch.float32,
+        family_id="krea2",
+    )
+
+    assert len(adapters) == 1
+    assert isinstance(adapters[0], Fp8LoraMergeAdapter)
+    assert not torch.equal(model.blocks[0].q.weight.view(torch.uint8), before)
+    assert adapters[0].detach() is True
+    assert torch.equal(model.blocks[0].q.weight.view(torch.uint8), before)
+
+
+def test_apply_loras_fp8_rejects_rs_lora_and_dora_meta(tmp_path):
+    from studio.services.inference.core import LoRASpec, apply_loras
+
+    model = _make_fp8_model()
+    path = _write_lora_file(
+        tmp_path, _plain_lora_sd(["blocks.0.q"]),
+        network_args={"algo": "lora", "rs_lora": True},
+    )
+    with pytest.raises(ValueError, match="rs_lora / DoRA"):
+        apply_loras(
+            model, [LoRASpec(path=path, scale=1.0)], "cpu", torch.float32,
+            family_id="krea2",
+        )

--- a/tests/test_krea2_lora_fp8_merge.py
+++ b/tests/test_krea2_lora_fp8_merge.py
@@ -333,3 +333,115 @@ def test_apply_loras_fp8_rejects_rs_lora_and_dora_meta(tmp_path):
             model, [LoRASpec(path=path, scale=1.0)], "cpu", torch.float32,
             family_id="krea2",
         )
+
+
+# ---------------------------------------------------------------------------
+# 外部生态文件（civitai / PEFT / comfy 键格式，无 ss_* metadata）
+# ---------------------------------------------------------------------------
+
+
+def _peft_lora_sd(layers: list[str], rank: int = 2, seed: int = 9,
+                  with_alpha: bool = False) -> dict[str, torch.Tensor]:
+    torch.manual_seed(seed)
+    sd: dict[str, torch.Tensor] = {}
+    for layer in layers:
+        prefix = f"diffusion_model.{layer}"
+        sd[f"{prefix}.lora_A.weight"] = torch.randn(rank, 4, dtype=torch.float16)
+        sd[f"{prefix}.lora_B.weight"] = torch.randn(4, rank, dtype=torch.float16)
+        if with_alpha:
+            sd[f"{prefix}.alpha"] = torch.tensor(1.0)
+    return sd
+
+
+def test_merge_accepts_peft_comfy_key_format_no_alpha_means_scale_one():
+    """civitai 形态：diffusion_model.{层}.lora_A/B、无 alpha → comfy 缩放 1.0。"""
+    model = _make_fp8_model()
+    block = model.blocks[0]
+    orig_m = block.m.weight.detach().clone()
+    sd = _peft_lora_sd(["blocks.0.m"])
+
+    merge_loras_into_fp8_model(model, [(sd, 0.5, "civit.safetensors")])
+
+    down = sd["diffusion_model.blocks.0.m.lora_A.weight"].float()
+    up = sd["diffusion_model.blocks.0.m.lora_B.weight"].float()
+    # 无 alpha 键 → alpha 系数 1.0（非 alpha/rank）
+    expected = orig_m.to(torch.float16) + ((0.5 * 1.0) * torch.mm(up, down)).type(torch.float16)
+    assert torch.equal(block.m.weight.detach(), expected.to(torch.bfloat16))
+
+
+def test_merge_peft_with_alpha_key_uses_alpha_over_rank():
+    model = _make_fp8_model()
+    block = model.blocks[0]
+    orig_m = block.m.weight.detach().clone()
+    sd = _peft_lora_sd(["blocks.0.m"], with_alpha=True)
+
+    merge_loras_into_fp8_model(model, [(sd, 1.0, "civit")])
+
+    down = sd["diffusion_model.blocks.0.m.lora_A.weight"].float()
+    up = sd["diffusion_model.blocks.0.m.lora_B.weight"].float()
+    alpha = 1.0 / down.shape[0]
+    expected = orig_m.to(torch.float16) + ((1.0 * alpha) * torch.mm(up, down)).type(torch.float16)
+    assert torch.equal(block.m.weight.detach(), expected.to(torch.bfloat16))
+
+
+def test_merge_rejects_unknown_comfy_suffix():
+    model = _make_fp8_model()
+    sd = {"diffusion_model.blocks.0.m.mystery.weight": torch.randn(2)}
+    with pytest.raises(ValueError, match="后缀"):
+        merge_loras_into_fp8_model(model, [(sd, 1.0, "u")])
+
+
+def test_read_lora_meta_family_explicit_semantics(tmp_path):
+    from safetensors.torch import save_file
+
+    from studio.services.inference.core import read_lora_meta
+
+    tagged = tmp_path / "tagged.safetensors"
+    save_file({"x": torch.zeros(1)}, str(tagged), metadata={
+        "ss_network_args": json.dumps({"algo": "lora", "model_family": "krea2"}),
+    })
+    untagged = tmp_path / "untagged.safetensors"
+    save_file({"x": torch.zeros(1)}, str(untagged))
+
+    m1 = read_lora_meta(str(tagged))
+    assert m1.model_family == "krea2" and m1.family_explicit is True
+    m2 = read_lora_meta(str(untagged))
+    assert m2.model_family == "anima" and m2.family_explicit is False
+
+
+def test_apply_loras_untagged_peft_file_routes_to_merge(tmp_path):
+    """用户场景复现：civitai krea2 LoRA（PEFT 键、零 metadata）挂 fp8 krea2
+    底模——不再被 grandfather 判成 anima 拒绝，直接走 merge。"""
+    from safetensors.torch import save_file
+
+    from studio.services.inference.core import LoRASpec, apply_loras
+
+    model = _make_fp8_model()
+    path = tmp_path / "civit_krea2.safetensors"
+    save_file(_peft_lora_sd(["blocks.0.q"]), str(path))  # 无任何 metadata
+    before = model.blocks[0].q.weight.detach().view(torch.uint8).clone()
+
+    adapters = apply_loras(
+        model, [LoRASpec(path=str(path), scale=1.0)], "cpu", torch.float32,
+        family_id="krea2",
+    )
+
+    assert isinstance(adapters[0], Fp8LoraMergeAdapter)
+    assert not torch.equal(model.blocks[0].q.weight.view(torch.uint8), before)
+
+
+def test_apply_loras_untagged_alien_keys_fail_fast(tmp_path):
+    """无标记 + 键全对不上（真异族/坏文件）→ merge 全 miss 报错，不静默。"""
+    from safetensors.torch import save_file
+
+    from studio.services.inference.core import LoRASpec, apply_loras
+
+    model = _make_fp8_model()
+    path = tmp_path / "alien.safetensors"
+    save_file(_plain_lora_sd(["no.such.layer"]), str(path))
+
+    with pytest.raises(ValueError, match="无法对应"):
+        apply_loras(
+            model, [LoRASpec(path=str(path), scale=1.0)], "cpu", torch.float32,
+            family_id="krea2",
+        )

--- a/tests/test_krea2_sampling.py
+++ b/tests/test_krea2_sampling.py
@@ -58,25 +58,37 @@ def test_mu_matches_reference_endpoints_and_1024_anchor():
     assert calculate_krea2_mu(8000) > 1.15  # upstream does not endpoint-clamp
 
 
-def test_shifted_sigmas_match_exponential_mobius_schedule():
+def test_default_sigmas_match_comfy_flux_time_shift():
+    """默认 sigma = Comfy parity 口径：固定 mu=1.15，与 ComfyUI
+    ModelSamplingFlux 的 flux_time_shift(1.15, 1.0, t) 逐位恒等，且与
+    分辨率无关（Raw / Turbo / 任何 image_seq_len 同一张表）。"""
     sigmas = build_krea2_sigmas(4096, 4)
-    base = torch.linspace(1.0, 0.0, 5)
-    shift = torch.tensor(0.90625).exp()
-    expected = shift * base / (1 + (shift - 1) * base)
-
+    t = torch.linspace(1.0, 0.0, 5)
+    mu = torch.tensor(1.15)
+    # flux_time_shift: exp(mu) / (exp(mu) + (1/t - 1)^1)；t=0 时定义为 0
+    expected = torch.where(
+        t > 0, mu.exp() / (mu.exp() + (1.0 / t.clamp_min(1e-12) - 1.0)),
+        torch.zeros(()),
+    )
     torch.testing.assert_close(sigmas, expected)
     assert sigmas[0] == 1
     assert sigmas[-1] == 0
     assert torch.all(sigmas[:-1] > sigmas[1:])
+    # 分辨率无关 + distilled 不再影响 sigma
+    torch.testing.assert_close(sigmas, build_krea2_sigmas(256, 4))
+    torch.testing.assert_close(sigmas, build_krea2_sigmas(4096, 4, distilled=True))
 
 
-def test_distilled_schedule_pins_mu_independent_of_resolution():
-    low = build_krea2_sigmas(256, 8, distilled=True)
-    high = build_krea2_sigmas(6400, 8, distilled=True)
-    raw_low = build_krea2_sigmas(256, 8, distilled=False)
-
-    torch.testing.assert_close(low, high)
-    assert not torch.equal(low, raw_low)
+def test_dynamic_mu_preserved_as_non_default():
+    """diffusers/musubi 的分辨率感知动态 mu 保留为 opt-in 对照路径。"""
+    dynamic = build_krea2_sigmas(4096, 4, dynamic_mu=True)
+    base = torch.linspace(1.0, 0.0, 5)
+    shift = torch.tensor(0.90625).exp()  # calculate_krea2_mu(4096)
+    expected = shift * base / (1 + (shift - 1) * base)
+    torch.testing.assert_close(dynamic, expected)
+    # 动态路径分辨率相关；与默认固定口径不同
+    assert not torch.equal(dynamic, build_krea2_sigmas(256, 4, dynamic_mu=True))
+    assert not torch.equal(dynamic, build_krea2_sigmas(4096, 4))
 
 
 def test_raw_and_turbo_defaults_and_sampler_validation():

--- a/tests/test_krea2_text_encoding.py
+++ b/tests/test_krea2_text_encoding.py
@@ -238,3 +238,46 @@ def test_offload_model_round_trip():
     assert fake.device_history == ["cpu"]
     assert stack.ensure_model() is fake   # 搬回 self.device
     assert fake.device_history == ["cpu", "cpu"]
+
+
+def test_manual_cast_patch_fp16_storage_fp32_compute():
+    """manual_cast 等价 patch（ComfyUI sd.py:258 口径）：权重 fp16 常驻，
+    Embedding 输出与 Linear 计算都进 fp32 域；fp16→fp32 cast 精确，数值与
+    整模 upcast 逐位一致。"""
+
+    class _Tiny(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed = torch.nn.Embedding(8, 4)
+            self.proj = torch.nn.Linear(4, 4)
+
+    model = _Tiny().to(torch.float16)
+    stack = Krea2TextStack(
+        "unused-dir", device="cpu", dtype=torch.float16,
+        compute_dtype=torch.float32, cache_enabled=False,
+        tokenizer=object(), model_loader=lambda *a: model,
+    )
+
+    patched = stack.ensure_model()
+
+    embedded = patched.embed(torch.tensor([1, 3]))
+    out = patched.proj(embedded)
+    assert embedded.dtype == torch.float32
+    assert out.dtype == torch.float32
+    assert patched.embed.weight.dtype == torch.float16    # 存储不动
+    assert patched.proj.weight.dtype == torch.float16
+    expected = torch.nn.functional.linear(
+        embedded, model.proj.weight.float(), model.proj.bias.float(),
+    )
+    assert torch.equal(out, expected)
+
+
+def test_compute_dtype_none_leaves_model_unpatched():
+    """compute_dtype 缺省（训练路径现状）不 patch 任何模块。"""
+    model = torch.nn.Linear(2, 2)
+    stack = Krea2TextStack(
+        "unused-dir", device="cpu", dtype=torch.float32, cache_enabled=False,
+        tokenizer=object(), model_loader=lambda *a: model,
+    )
+    stack.ensure_model()
+    assert "forward" not in vars(model)

--- a/tests/test_krea2_text_encoding.py
+++ b/tests/test_krea2_text_encoding.py
@@ -207,3 +207,34 @@ def test_cached_batch_miss_repairs_sidecar_after_prepare(tmp_path):
     assert entry.cache_path.is_file()
     assert not stack.is_model_loaded
     assert condition.attention_mask.sum().item() == 7
+
+
+def test_offload_model_round_trip():
+    """offload_model 把 TE 挪 CPU（DiT 独占显存）；ensure_model 搬回（Comfy
+    free_memory 语义）。未加载 / 重复调用安全 no-op。"""
+    import torch
+
+    from training.families.krea2.text_encoding import Krea2TextStack
+
+    class _FakeModel:
+        def __init__(self):
+            self.device_history = []
+
+        def to(self, device):
+            self.device_history.append(str(device))
+            return self
+
+    fake = _FakeModel()
+    stack = Krea2TextStack(
+        "unused-dir", device="cpu", cache_enabled=False,
+        tokenizer=object(), model_loader=lambda *a: fake,
+    )
+    stack.offload_model()          # 未加载 → no-op
+    assert fake.device_history == []
+    assert stack.ensure_model() is fake
+    stack.offload_model()
+    assert fake.device_history == ["cpu"]
+    stack.offload_model()          # 重复 → no-op
+    assert fake.device_history == ["cpu"]
+    assert stack.ensure_model() is fake   # 搬回 self.device
+    assert fake.device_history == ["cpu", "cpu"]

--- a/tests/test_model_families.py
+++ b/tests/test_model_families.py
@@ -123,3 +123,46 @@ def test_no_direct_loader_literals_in_dispatch_sites():
     loop = (REPO_ROOT / "runtime/training/loop.py").read_text(encoding="utf-8")
     assert "preprocess_text_embeds" not in loop  # 文本块已下沉 family
     assert "forward_with_optional_checkpoint(" not in loop  # 前向经 family
+
+
+def test_krea2_load_text_generate_fixes_te_fp16_storage_fp32_compute(monkeypatch):
+    """generate 场景 TE 固定 fp16 存储 + fp32 compute（ComfyUI sd.py:258
+    口径，忽略调用方 dtype、无旋钮）；训练路径维持调用方 dtype，不设
+    compute_dtype。"""
+    import training.families.krea2 as krea2_module
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        krea2_module, "load_krea2_text_stack",
+        lambda path, **kwargs: calls.append(kwargs) or "stack",
+    )
+    family = krea2_module.Krea2Family()
+
+    assert family.load_text(
+        "te-dir", "cpu", torch.bfloat16, purpose="generate", cache_enabled=False,
+    ) == "stack"
+    assert calls[0]["dtype"] == torch.float16
+    assert calls[0]["compute_dtype"] == torch.float32
+    assert calls[0]["cache_enabled"] is False
+
+    assert family.load_text("te-dir", "cpu", torch.bfloat16) == "stack"
+    assert calls[1]["dtype"] == torch.bfloat16
+    assert "compute_dtype" not in calls[1]
+
+
+def test_anima_load_text_purpose_never_overrides_backend_choice(monkeypatch):
+    """purpose 对 Anima 接受并忽略（load_dit 同款）：generate 调用面传
+    purpose 不得把用户显式选择的 hf backend 静默切成 comfy_qwen。"""
+    import training.families.anima.loader as anima_loader
+
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        anima_loader, "load_text_encoders",
+        lambda *args, **kwargs: calls.append(kwargs) or "encoders",
+    )
+
+    fam = get_family("anima")
+    assert fam.load_text(
+        "te-dir", "cpu", torch.bfloat16, comfy_qwen=False, purpose="generate",
+    ) == "encoders"
+    assert calls[0]["comfy_qwen"] is False


### PR DESCRIPTION
## 动机

- 社区 fp8 Krea2 checkpoint（Comfy-Org 官方 Turbo fp8_scaled 形态）被 C13 全精度检查拒收
- 32GB 卡 krea2 Generate 的 bf16 路径本身超显存（DiT 26.3GB + Qwen3-VL 8.9GB ≈ 35GB 常驻）

验收口径 = 与本地 ComfyUI oracle（v0.27.1 + torch2.7/cu128 + comfy_kitchen 0.2.16，该环境固定落 legacy/eager 路径可逐行复刻）同参数出图逐位一致。设计文档随本 PR 入库：`docs/design/krea2-fp8-inference.md`。

## 交付

**Parity 基线（bf16 债先清）**
- krea2 推理 sigma 统一 Comfy 口径：固定 mu=1.15（Raw/Turbo 同，原 Raw 走 diffusers 动态 mu 永远无法逐位一致）
- 生成场景 TE 对齐 Comfy：fp16 存储 + fp32 compute（manual_cast 等价 patch，逐层 cast 保 8.9GB 常驻）+ 编码后 offload 到 CPU（free_memory 语义）
- Anima `load_text` 删除从未触发的 `purpose=="generate"` 死分支（激活会静默覆盖用户显式选择的 text_encoder_backend）

**fp8 主刀**
- 两种形态推理加载：fp8_scaled（`_quantization_metadata` per-layer 声明 + F32 标量 weight_scale）与纯 fp8 cast；fp8 原样常驻（显存 26.3→约 13.7GB），Linear 前向逐层 dequant（`W.to(input.dtype) [* scale.to(input.dtype)]`，ck eager 公式）
- 训练路径维持全精度拒绝（C13 文案更新）；`load_dit`/`load_text` 协议加 keyword-only `purpose`

**LoRA × fp8：merge 回写（Comfy 从不在量化存储上算 LoRA）**
- dequant 到 fp16 → delta fp32 计算按挂载序累加 → requantize（scale=amax/448 + fp16 防下溢 clamp + stochastic rounding，seed=CRC32 层键）；三种层形态（scaled / 纯 cast / 非量化 Linear）分别对齐 Comfy 回写语义
- `Fp8LoraMergeAdapter` 生命周期：CPU 备份 + `detach()` 逐位还原；daemon 热换路径已闸（`supports_hot_reload=False`）
- XY 的 lora_scale 轴 × fp8 显式拒绝（daemon + CLI 双入口，防 multiplier 原地设值静默 no-op 出全同格子图）
- rs_lora / DoRA 的 LoRA 在 merge 语义下无法对齐训练语义，拒绝并指路 bf16

**外部生态兼容（真卡验收实测发现）**
- 跨族拒绝只认显式 `model_family` 标记；无标记文件（civitai/musubi/comfy 系）放行，由键匹配兜底（全 miss 报错不静默）
- merge 路径支持 PEFT/comfy 键格式（`diffusion_model.{点分层名}.lora_A/lora_B`，无 alpha 键 = 缩放 1.0 的 comfy 语义）

## 验证

- 全量测试绿（2292 passed；唯一红为已知本机 flaky `test_cancel_running_returns_immediately`，与本线零交集）
- 真卡（32GB）：fp8 单图生成通过；fp8 + civitai PEFT LoRA 出图通过
- SR 的 RNG 是 device 相关的（CUDA/CPU generator 序列不同）——逐位 parity 只在 GPU 上成立，CPU 单测验证公式与确定性

## 已知边界 / 后续

- bf16 底模 × PEFT 键格式 LoRA：lycoris 注入路径尚不支持（明确报错），独立小刀跟进
- 显存编排（按需让位 + prompt 缓存 + 三档配置）已拍板待实施：`docs/todo/krea2-vram-orchestration.md`——顺带解锁 16GB 卡 fp8 生成
- 残留实机确认（设计文档 §5）：绘世启动器 `--fast` 旗标；oracle TE 文件 dtype 同源性

派生署名：THIRD_PARTY_NOTICES 已补 ComfyUI（GPL-3.0）model_patcher/lora/weight_adapter/float + comfy_kitchen eager + musubi patch 思路的公式级对照条目。

🤖 Generated with [Claude Code](https://claude.com/claude-code)