### PR TITLE
feat(generate): bf16 底模支持 PEFT/comfy 键格式 LoRA（civitai 生态）

### DIFF
--- a/studio/services/inference/core.py
+++ b/studio/services/inference/core.py
@@ -157,6 +157,72 @@ def read_lora_meta(path: str) -> LoRAMeta:
     )
 
 
+_PEFT_LORA_PREFIX = "diffusion_model."
+_PEFT_SUFFIX_MAP = {
+    "lora_A.weight": "lora_down.weight",
+    "lora_B.weight": "lora_up.weight",
+    "alpha": "alpha",
+}
+
+
+def _normalize_peft_lora_sd(
+    sd: dict,
+) -> Optional[tuple[dict, int, Optional[dict[str, int]]]]:
+    """PEFT/comfy 键格式（civitai 生态）归一到 kohya/lycoris 约定。
+
+    ``diffusion_model.{点分层名}.lora_A/lora_B`` → ``lora_unet_{下划线层名}.
+    lora_down/lora_up.weight``；无 alpha 键 = comfy 缩放 1.0 语义 → 补
+    per-layer ``alpha = rank``（alpha/rank 式 loader 得 1.0，数值一致）；
+    rank 从 lora_A 张量形状推断（此类文件无 ss_* metadata，header 读不到），
+    混秩层进 lora_reg_dims。返回 (归一 sd, max_rank, reg_dims)；非纯 PEFT
+    形态返回 None（kohya/lycoris 文件原样走）。
+    """
+    import torch  # noqa: PLC0415
+
+    if not sd or not all(key.startswith(_PEFT_LORA_PREFIX) for key in sd):
+        return None
+    grouped: dict[str, dict[str, Any]] = {}
+    for key, tensor in sd.items():
+        rest = key[len(_PEFT_LORA_PREFIX):]
+        for peft_suffix, kohya_suffix in _PEFT_SUFFIX_MAP.items():
+            if rest.endswith("." + peft_suffix):
+                layer = rest[: -len(peft_suffix) - 1]
+                grouped.setdefault(layer, {})[kohya_suffix] = tensor
+                break
+        else:
+            if rest.endswith(".dora_scale"):
+                raise ValueError(
+                    "PEFT 形态的 DoRA LoRA 不支持（dora_scale 非线性）；"
+                    "请改用 kohya 格式导出的版本。"
+                )
+            raise ValueError(f"无法识别的 PEFT LoRA 键：{key}")
+
+    normalized: dict[str, Any] = {}
+    ranks: dict[str, int] = {}
+    for layer, tensors in grouped.items():
+        down = tensors.get("lora_down.weight")
+        up = tensors.get("lora_up.weight")
+        if down is None or up is None:
+            raise ValueError(f"PEFT LoRA 层缺 lora_A/lora_B 对：{layer}")
+        rank = int(down.shape[0])
+        ranks[layer] = rank
+        prefix = f"lora_unet_{layer.replace('.', '_')}"
+        normalized[f"{prefix}.lora_down.weight"] = down
+        normalized[f"{prefix}.lora_up.weight"] = up
+        alpha = tensors.get("alpha")
+        normalized[f"{prefix}.alpha"] = (
+            alpha if alpha is not None else torch.tensor(float(rank))
+        )
+
+    max_rank = max(ranks.values())
+    reg_dims = {
+        f"lora_unet_{layer.replace('.', '_')}": rank
+        for layer, rank in ranks.items()
+        if rank != max_rank
+    } or None
+    return normalized, max_rank, reg_dims
+
+
 def apply_loras(
     model: Any,
     specs: Sequence[LoRASpec],
@@ -211,6 +277,22 @@ def apply_loras(
                 f"'{meta.model_family}'，当前底模族为 '{family_id}'。"
                 f"请换用同族 LoRA 或切换底模。"
             )
+        sd_raw: dict = {}
+        with safe_open(str(path), framework="pt", device="cpu") as f:
+            for k in f.keys():
+                sd_raw[k] = f.get_tensor(k)
+
+        # 外部生态 PEFT 键格式归一（civitai 常见）：转 kohya 键 + 从张量
+        # 形状推断 rank/reg_dims（这类文件零 ss_* metadata，meta 里的
+        # rank=32 只是回退默认，碰运气不可用）
+        rank, alpha, algo = meta.rank, meta.alpha, meta.algo
+        reg_dims = meta.lora_reg_dims
+        peft = _normalize_peft_lora_sd(sd_raw)
+        if peft is not None:
+            sd_raw, rank, reg_dims = peft
+            alpha = float(rank)   # per-layer alpha 已补进 sd，全局值仅建网用
+            algo = "lora"         # PEFT 双矩阵 = plain LoRA
+
         if fp8_merge:
             # merge 是权重级线性操作，与 comfy 一致只认 alpha/dim 缩放——
             # rs_lora（√rank 缩放）与 DoRA（非线性）在 merge 语义下无法
@@ -220,23 +302,19 @@ def apply_loras(
                     f"fp8 量化底模不支持挂载 rs_lora / DoRA 训练的 LoRA："
                     f"{Path(path).name}。请改用 bf16 版本底模。"
                 )
-            sd_raw: dict = {}
-            with safe_open(str(path), framework="pt", device="cpu") as f:
-                for k in f.keys():
-                    sd_raw[k] = f.get_tensor(k)
             merge_sources.append((sd_raw, float(spec.scale), Path(path).name))
             continue
         from training.families import get_family  # noqa: PLC0415
 
         adapter = AnimaLycorisAdapter(
             preset=get_family(family_id).lora_preset(),
-            algo=meta.algo,
-            rank=meta.rank,
-            alpha=meta.alpha,
+            algo=algo,
+            rank=rank,
+            alpha=alpha,
             factor=meta.factor,
             weight_decompose=meta.weight_decompose,
             rs_lora=meta.rs_lora,
-            lora_reg_dims=meta.lora_reg_dims,
+            lora_reg_dims=reg_dims,
         )
         adapter.inject(model)
         if adapter.network is not None:
@@ -248,10 +326,7 @@ def apply_loras(
                 if hasattr(lora, "multiplier"):
                     lora.multiplier = float(spec.scale)
 
-        sd: dict = {}
-        with safe_open(str(path), framework="pt", device="cpu") as f:
-            for k in f.keys():
-                sd[k] = f.get_tensor(k).to(device=device, dtype=dtype)
+        sd = {k: v.to(device=device, dtype=dtype) for k, v in sd_raw.items()}
 
         result = adapter.load_state_dict(sd, strict=False)
         missing = len(getattr(result, "missing_keys", []) or [])
@@ -265,7 +340,7 @@ def apply_loras(
             )
         logger.info(
             f"已加载 LoRA: {Path(path).name} "
-            f"(algo={meta.algo}, rank={meta.rank}, alpha={meta.alpha}, "
+            f"(algo={algo}, rank={rank}, alpha={alpha}, "
             f"scale={spec.scale}; missing={missing}, unexpected={unexpected})"
         )
         adapters.append(adapter)

--- a/tests/test_inference_core.py
+++ b/tests/test_inference_core.py
@@ -505,3 +505,108 @@ def test_cleanup_stale_generate_tempdirs(tmp_path: Path, monkeypatch: pytest.Mon
     assert not leak2.exists()
     assert keep.exists()  # 不带前缀的不动
     assert (keep / "important.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# 外部生态 PEFT 键格式（civitai）→ bf16 底模 lycoris 注入
+# ---------------------------------------------------------------------------
+
+
+def _peft_sd(layers: dict[str, int], *, with_alpha: bool = False, seed: int = 7) -> dict:
+    """构造 PEFT 形态 sd：{点分层名: rank}。"""
+    torch.manual_seed(seed)
+    sd: dict = {}
+    for layer, rank in layers.items():
+        sd[f"diffusion_model.{layer}.lora_A.weight"] = torch.randn(rank, 8, dtype=torch.float16)
+        sd[f"diffusion_model.{layer}.lora_B.weight"] = torch.randn(8, rank, dtype=torch.float16)
+        if with_alpha:
+            sd[f"diffusion_model.{layer}.alpha"] = torch.tensor(float(rank) / 2)
+    return sd
+
+
+def test_normalize_peft_lora_sd_converts_keys_and_infers_rank():
+    from studio.services.inference.core import _normalize_peft_lora_sd
+
+    sd = _peft_sd({"blocks.0.q": 4, "blocks.1.k": 2})
+    normalized, max_rank, reg_dims = _normalize_peft_lora_sd(sd)
+
+    assert max_rank == 4
+    assert reg_dims == {"lora_unet_blocks_1_k": 2}
+    assert set(normalized) == {
+        "lora_unet_blocks_0_q.lora_down.weight",
+        "lora_unet_blocks_0_q.lora_up.weight",
+        "lora_unet_blocks_0_q.alpha",
+        "lora_unet_blocks_1_k.lora_down.weight",
+        "lora_unet_blocks_1_k.lora_up.weight",
+        "lora_unet_blocks_1_k.alpha",
+    }
+    # 无 alpha 键 → 补 alpha=rank（comfy 缩放 1.0 语义）
+    assert float(normalized["lora_unet_blocks_0_q.alpha"]) == 4.0
+    assert float(normalized["lora_unet_blocks_1_k.alpha"]) == 2.0
+    # lora_A=down / lora_B=up 方向
+    assert normalized["lora_unet_blocks_0_q.lora_down.weight"].shape == (4, 8)
+    assert normalized["lora_unet_blocks_0_q.lora_up.weight"].shape == (8, 4)
+
+
+def test_normalize_peft_lora_sd_passthrough_and_rejects():
+    import pytest
+
+    from studio.services.inference.core import _normalize_peft_lora_sd
+
+    kohya = {"lora_unet_blocks_0_q.lora_down.weight": torch.zeros(2, 4)}
+    assert _normalize_peft_lora_sd(kohya) is None
+    assert _normalize_peft_lora_sd({}) is None
+
+    with_alpha = _peft_sd({"blocks.0.q": 2}, with_alpha=True)
+    normalized, _, _ = _normalize_peft_lora_sd(with_alpha)
+    assert float(normalized["lora_unet_blocks_0_q.alpha"]) == 1.0  # 保留原 alpha
+
+    dora = _peft_sd({"blocks.0.q": 2})
+    dora["diffusion_model.blocks.0.q.dora_scale"] = torch.ones(8, 1)
+    with pytest.raises(ValueError, match="DoRA"):
+        _normalize_peft_lora_sd(dora)
+
+    with pytest.raises(ValueError, match="无法识别"):
+        _normalize_peft_lora_sd({"diffusion_model.blocks.0.q.mystery": torch.zeros(1)})
+
+
+def test_apply_loras_bf16_model_accepts_peft_file(tmp_path: Path):
+    """用户场景：civitai PEFT 文件（零 metadata）挂 bf16 krea2 底模——
+    归一后 lycoris 正常注入，forward delta = scale × 1.0 × up@down。"""
+    import torch.nn as nn
+
+    from studio.services.inference.core import LoRASpec, apply_loras
+
+    class _Block(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.q = nn.Linear(8, 8, bias=False)
+
+    class _Tiny(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.blocks = nn.ModuleList([_Block()])
+
+        def forward(self, x):
+            return self.blocks[0].q(x)
+
+    torch.manual_seed(0)
+    model = _Tiny()
+    sd = _peft_sd({"blocks.0.q": 2})
+    path = tmp_path / "civit_peft.safetensors"
+    save_file(sd, str(path))  # 无任何 metadata
+
+    x = torch.randn(3, 8)
+    base = model(x).detach().clone()
+
+    adapters = apply_loras(
+        model, [LoRASpec(path=str(path), scale=0.7)], "cpu", torch.float32,
+        family_id="krea2",
+    )
+
+    assert len(adapters) == 1
+    out = model(x).detach()
+    up = sd["diffusion_model.blocks.0.q.lora_B.weight"].float()
+    down = sd["diffusion_model.blocks.0.q.lora_A.weight"].float()
+    expected = base + 0.7 * (x @ down.T @ up.T)   # scale=alpha/rank=1.0
+    assert torch.allclose(out, expected, atol=1e-5)


### PR DESCRIPTION
## 动机

#426 让 fp8 merge 路径吃下了 PEFT/comfy 键格式的社区 LoRA（`diffusion_model.{点分层名}.lora_A/lora_B`、无 alpha 键、零 ss_* metadata——civitai 实物实测形态），但 bf16 底模走的 lycoris 注入路径仍不认，报「键格式不支持」。

## 交付

`apply_loras` 读文件后加共享键归一层：

- `lora_A`(=down) / `lora_B`(=up) → kohya 命名；无 alpha 键按 comfy 缩放 1.0 语义补 per-layer `alpha = rank`（有 alpha 键保留原值）
- rank 从 lora_A 张量形状推断（此类文件零 metadata，`read_lora_meta` 的 rank=32 只是回退默认）；混秩层进 `lora_reg_dims`
- PEFT DoRA（dora_scale 非线性）拒绝指路 kohya 导出；未识别键 fail-fast
- fp8 merge 分支同吃归一后 sd（`alpha=rank` 与无 alpha 的 comfy 语义逐位等价）

## 验证

- 归一单元测试（键转换 / rank 推断 / 混秩 / alpha 保留 / 拒绝路径）
- bf16 小模型真 lycoris 注入端到端：forward delta 数值 == scale × 1.0 × up@down（comfy 缩放语义）
- 真卡：civitai krea2 LoRA（518 张量 / 259 层 / rank 32）挂 bf16 与 fp8 底模均出图正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)