### PR TITLE
fix(train): 相对导入修复桶分布预览 500 + 训练缓存日志可读性

### DIFF
--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -27,7 +27,9 @@ from pathlib import Path
 import torch
 from torch.utils.data import Dataset
 
-from training.families.anima import ANIMA_SPEC
+# 相对导入：本模块被 studio server 以 `runtime.training.dataset` 复用（bucket
+# 分布预览），那边 sys.path 只有仓库根，`training.*` 绝对导入会 ModuleNotFoundError。
+from .families.anima import ANIMA_SPEC
 
 # ── latent 规格单一来源（多模型 PR-1）─────────────────────────────────────
 # 单一族时代的桥接常量；PR-2b 起由 ctx.family.spec 传入各调用点。
@@ -922,10 +924,13 @@ class CachedLatentDataset(Dataset):
 
     def __init__(self, base_dataset, vae, device, dtype, cache_dir=None, cache_batch_size=1,
                  encode_tiled=False, encode_tile_px=1024, encode_tile_overlap=128,
-                 encode_max_pixels=0, latent_spec=None):
+                 encode_max_pixels=0, latent_spec=None, label=""):
         import numpy as np
         if latent_spec is not None:
             self.latent_spec = latent_spec
+        # 日志标注（如"训练集"/"正则集"）：主集与正则集各建一个实例，缓存日志
+        # 不标注会打出两段无法区分的"检查 VAE latent 缓存..."
+        self.label = str(label or "")
         self.base_dataset = base_dataset
         self.base_image_dataset = self._get_base_image_dataset(base_dataset)
         self.np = np
@@ -1097,7 +1102,8 @@ class CachedLatentDataset(Dataset):
         分辨率的图用 `img.r{reso}.npz` 分文件。按 npz_path 去重，每个 (图, reso) 最多
         encode 一次；否则同 npz 会被反复覆盖写 N 次（flip_augment 模式下再乘 2）。
         """
-        logger.info("检查 VAE latent 缓存...")
+        tag = f"（{self.label}）" if self.label else ""
+        logger.info(f"检查 VAE latent 缓存{tag}...")
         to_encode = []
         seen_npz = set()
         unique_total = 0
@@ -1113,10 +1119,10 @@ class CachedLatentDataset(Dataset):
                 to_encode.append(i)
 
         if to_encode:
-            logger.info(f"需要编码 {len(to_encode)}/{unique_total} 张图像...")
+            logger.info(f"需要编码 {len(to_encode)}/{unique_total} 张图像{tag}...")
             self._encode_and_save(to_encode, vae, device, dtype)
         else:
-            logger.info(f"所有 {unique_total} 张图像已缓存")
+            logger.info(f"所有 {unique_total} 张图像已缓存{tag}")
 
         self._fill_bucket_for_index()
 

--- a/runtime/training/families/__init__.py
+++ b/runtime/training/families/__init__.py
@@ -7,7 +7,10 @@ ModelFamily 行为接口与 get_family() 派发随 PR-2b 落地，派发经 anim
 
 from __future__ import annotations
 
-from training.families.spec import (  # noqa: F401  (re-export)
+# families 子树用相对导入：studio server 以 `runtime.training.*` 命名复用本子树
+# （bucket 分布预览经 dataset.py），那边 sys.path 只有仓库根，`training.*` 绝对
+# 导入会 ModuleNotFoundError（tests/test_bucket_histogram.py 有回归导入测试）。
+from .spec import (  # noqa: F401  (re-export)
     ConstantShift,
     KNOWN_CAPABILITIES,
     LatentSpec,
@@ -18,8 +21,8 @@ from training.families.spec import (  # noqa: F401  (re-export)
     TextSpec,
     validate_spec,
 )
-from training.families.anima import ANIMA_SPEC
-from training.families.krea2 import KREA2_SPEC
+from .anima import ANIMA_SPEC
+from .krea2 import KREA2_SPEC
 
 SPECS: dict[str, ModelSpec] = {}
 
@@ -44,11 +47,11 @@ def get_family(family_id: str):
     fam = _FAMILIES.get(family_id)
     if fam is None:
         if family_id == "anima":
-            from training.families.anima.family import AnimaFamily
+            from .anima.family import AnimaFamily
 
             fam = AnimaFamily()
         elif family_id == "krea2":
-            from training.families.krea2 import Krea2Family
+            from .krea2 import Krea2Family
 
             fam = Krea2Family()
         else:  # pragma: no cover - registry 与 SPECS 同步维护

--- a/runtime/training/families/anima/__init__.py
+++ b/runtime/training/families/anima/__init__.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
-from training.families.latent_spaces import WAN21_F8C16
-from training.families.spec import (
+# 相对导入：studio server 经 `runtime.training.dataset` 间接 import 本模块，
+# 那边 sys.path 没有 runtime/，`training.*` 绝对导入会 ModuleNotFoundError。
+from ..latent_spaces import WAN21_F8C16
+from ..spec import (
     ConstantShift,
     LoraOutputSpec,
     ModelSpec,

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -7,8 +7,8 @@ from typing import Any, Iterable
 
 import torch
 
-from training.families.krea2.preset import KREA2_PRESET
-from training.families.krea2.sampling import (
+from .preset import KREA2_PRESET
+from .sampling import (
     KREA2_BASE_IMAGE_SEQ_LEN,
     KREA2_BASE_SHIFT,
     KREA2_MAX_IMAGE_SEQ_LEN,
@@ -22,14 +22,14 @@ from training.families.krea2.sampling import (
     resolve_sampling_settings,
     sample_image,
 )
-from training.families.krea2.text_encoding import (
+from .text_encoding import (
     KREA2_TEXT_FINGERPRINT,
     Krea2TextCondition,
     Krea2TextStack,
     load_krea2_text_stack,
 )
-from training.families.latent_spaces import WAN21_F8C16
-from training.families.spec import (
+from ..latent_spaces import WAN21_F8C16
+from ..spec import (
     LoraOutputSpec,
     ModelSpec,
     ConstantShift,

--- a/runtime/training/families/krea2/sampling.py
+++ b/runtime/training/families/krea2/sampling.py
@@ -24,7 +24,7 @@ from dataclasses import dataclass
 import torch
 from torch import Tensor
 
-from training.families.krea2.text_encoding import Krea2TextCondition
+from .text_encoding import Krea2TextCondition
 
 
 KREA2_SAMPLER = "euler"

--- a/runtime/training/families/krea2/text_encoding.py
+++ b/runtime/training/families/krea2/text_encoding.py
@@ -25,7 +25,7 @@ from typing import Any, Callable, Iterable, Mapping, Sequence
 import torch
 from torch import Tensor
 
-from training.text_cache import TextCacheEntry, TextCacheStore
+from ...text_cache import TextCacheEntry, TextCacheStore
 
 
 logger = logging.getLogger(__name__)
@@ -364,14 +364,25 @@ class Krea2TextStack:
             self._validate_context(context, source="Qwen3-VL 输出")
         return contexts
 
-    def _encode_in_chunks(self, captions: Sequence[str]) -> dict[str, Tensor]:
+    def _encode_in_chunks(
+        self, captions: Sequence[str], *, log_progress: bool = False,
+    ) -> dict[str, Tensor]:
+        # log_progress 只在预缓存阶段开（对齐 VAE 缓存的"编码进度"口径）；
+        # 训练中 miss repair 走的也是本函数，那边一两条不刷屏。
         encoded: dict[str, Tensor] = {}
         unique = list(dict.fromkeys(str(caption) for caption in captions))
+        next_mark = 10
         for start in range(0, len(unique), self.cache_batch_size):
             chunk = unique[start:start + self.cache_batch_size]
             contexts = self._encode_many(chunk)
             for caption, context in zip(chunk, contexts):
                 encoded[caption] = context.detach().cpu().contiguous()
+            if log_progress:
+                done = len(encoded)
+                if done >= next_mark or done == len(unique):
+                    logger.info("  文本编码进度: %d/%d", done, len(unique))
+                    while next_mark <= done:
+                        next_mark += 10
         return encoded
 
     def _validate_context(self, context: object, *, source: str) -> Tensor:
@@ -417,11 +428,21 @@ class Krea2TextStack:
             if context is not None:
                 contexts[caption] = context
 
-        contexts.update(
-            self._encode_in_chunks(
-                [caption for caption in self._caption_entries if caption not in contexts],
-            )
-        )
+        to_encode = [
+            caption for caption in self._caption_entries if caption not in contexts
+        ]
+        if self._caption_entries:
+            if to_encode:
+                logger.info(
+                    "[text-cache] caption sidecar 命中 %d/%d，需编码 %d 条...",
+                    len(contexts), len(self._caption_entries), len(to_encode),
+                )
+            else:
+                logger.info(
+                    "[text-cache] caption sidecar 全部命中（%d 条），跳过编码",
+                    len(self._caption_entries),
+                )
+        contexts.update(self._encode_in_chunks(to_encode, log_progress=True))
         for caption, entries in missing_entries.items():
             for entry in entries:
                 self.store.write_caption(entry, self._payload(contexts[caption]))

--- a/runtime/training/families/latent_spaces.py
+++ b/runtime/training/families/latent_spaces.py
@@ -12,7 +12,9 @@ Qwen-Image VAE 复用它（`comfy/supported_models.py`
 
 from __future__ import annotations
 
-from training.families.spec import LatentSpec
+# 相对导入：studio server 经 `runtime.training.*` 命名间接 import 本模块（bucket
+# 分布预览），那边 sys.path 没有 runtime/，`training.*` 绝对导入会 ModuleNotFoundError。
+from .spec import LatentSpec
 
 # latent2rgb 快速预览的线性投影系数（"模糊但能看出图"）。取自 ComfyUI
 # comfy/latent_formats.py 的 `Wan21.latent_rgb_factors[_bias]`（GPL-3.0，

--- a/runtime/training/phases/dataset.py
+++ b/runtime/training/phases/dataset.py
@@ -160,11 +160,16 @@ def run(ctx: TrainingContext) -> None:
                 aspect_ratio_limit=ar_limit,
                 **native_kwargs,
             )
-            ctx.reg_dataset = reg_base
-            reg_weight = float(getattr(args, "reg_weight", 1.0) or 1.0)
-            cap_preview = f", caption=\"{reg_caption[:50]}{'...' if len(reg_caption) > 50 else ''}\"" if reg_caption else ""
-            weight_info = f", weight={reg_weight}" if reg_weight != 1.0 else ""
-            logger.info(f"正则数据集: {reg_data_dir} ({len(reg_base)} 样本, per-folder repeat{weight_info}){cap_preview}")
+            if len(reg_base) == 0:
+                # 空正则集不接线：包 CachedLatentDataset 会打出"所有 0 张图像已
+                # 缓存"迷惑日志，进 MergedDataset 也是纯空转。
+                logger.info(f"正则数据集为空（无有效图片），已跳过: {reg_data_dir}")
+            else:
+                ctx.reg_dataset = reg_base
+                reg_weight = float(getattr(args, "reg_weight", 1.0) or 1.0)
+                cap_preview = f", caption=\"{reg_caption[:50]}{'...' if len(reg_caption) > 50 else ''}\"" if reg_caption else ""
+                weight_info = f", weight={reg_weight}" if reg_weight != 1.0 else ""
+                logger.info(f"正则数据集: {reg_data_dir} ({len(reg_base)} 样本, per-folder repeat{weight_info}){cap_preview}")
 
     # 缓存 VAE latents（在 repeat 之前）
     ctx.use_cached = getattr(args, "cache_latents", False)
@@ -180,6 +185,7 @@ def run(ctx: TrainingContext) -> None:
             encode_tile_px=getattr(args, "cache_encode_tile_px", 1024),
             encode_tile_overlap=getattr(args, "cache_encode_tile_overlap", 128),
             encode_max_pixels=getattr(args, "cache_encode_max_pixels", 0),
+            label="训练集",
         )
     if ctx.reg_dataset is not None and ctx.use_cached:
         ctx.reg_dataset = CachedLatentDataset(
@@ -189,6 +195,7 @@ def run(ctx: TrainingContext) -> None:
             encode_tile_px=getattr(args, "cache_encode_tile_px", 1024),
             encode_tile_overlap=getattr(args, "cache_encode_tile_overlap", 128),
             encode_max_pixels=getattr(args, "cache_encode_max_pixels", 0),
+            label="正则集",
         )
 
     # repeat: 主数据集和正则数据集均通过文件夹名 Kohya 风格 repeat（如 5_concept），无需全局 repeat

--- a/tests/test_bucket_histogram.py
+++ b/tests/test_bucket_histogram.py
@@ -5,6 +5,8 @@
 """
 from __future__ import annotations
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -63,6 +65,29 @@ def test_only_captioned_images_counted(tmp_path: Path) -> None:
     _sq(tmp_path / "1_data", ["c"], caption=False)     # 无 caption
     out = compute_bucket_histogram(tmp_path, [1024], 2.0)
     assert sum(b["count"] for b in out[0]["buckets"]) == 2  # c 不计
+
+
+def test_dataset_importable_without_runtime_on_sys_path() -> None:
+    """studio server 的 sys.path 只有仓库根（没有 runtime/）——dataset.py 及其
+    导入链必须在 `runtime.training.*` 命名下可导入，否则 bucket-distribution
+    endpoint 500。conftest 会把 runtime/ 注入 sys.path，进程内测试测不出来，
+    必须开干净子进程。回归：多模型 PR-1 (#405) 引入的 `from training.*` 绝对
+    导入曾砸坏这条链（修复 = families 子树改相对导入）。"""
+    pytest.importorskip("torch")
+    repo_root = Path(__file__).resolve().parent.parent
+    code = (
+        "import sys; "
+        "sys.path[:] = [p for p in sys.path if 'runtime' not in p.lower()]; "
+        f"sys.path.insert(0, {str(repo_root)!r}); "
+        "from runtime.training.dataset import BucketManager, ImageDataset; "
+        "print('ok')"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, f"stderr:\n{proc.stderr}"
+    assert "ok" in proc.stdout
 
 
 def test_root_and_nested_images_counted(tmp_path: Path) -> None:


### PR DESCRIPTION
## 背景

krea2 A8 真卡端到端测试（项目 58 图 TXT caption 训练）抓出三个观测面问题：Train 页 ARB 桶分布面板不显示、trainer 日志出现「所有 0 张图像已缓存」迷惑输出、krea2 文本预缓存全程无进度。三者都源自同一轮 e2e 测试，一并修复。

## 改动概要

**1. 桶分布预览 500（功能回归，多模型 PR-1 #405 引入）**

`runtime/training/dataset.py` 被 studio server 以 `runtime.training.dataset` 复用（`compute_bucket_histogram`，桶算法不做第三份拷贝）。#405 加入的 `from training.families.anima import ANIMA_SPEC` 以 trainer 的 sys.path（`runtime/` 为根）为前提，server 进程只有仓库根在 sys.path，导入即 `ModuleNotFoundError` → `/bucket-distribution` 500 → 前端 `BucketPreview` 的 `.catch(() => setDist(null))` 静默吞掉，面板消失。

修复：把 studio 会触达的整条导入链改为相对导入（`dataset.py` + `families/__init__.py` + `families/anima/__init__.py` + `families/latent_spaces.py` + `families/krea2/{__init__,sampling,text_encoding}.py`），trainer（`training.*`）与 studio（`runtime.training.*`）两种命名下均可导入，且每个进程内模块身份单一。

回归测试：`test_dataset_importable_without_runtime_on_sys_path` 用**干净子进程**（sys.path 剔除 runtime/）导入验证——conftest 会把 `runtime/` 注入 sys.path，进程内测试测不出这类断裂，这正是本回归存活到现在的原因。

**2. 空正则集的 VAE 缓存迷惑日志**

配置了 reg 目录但 0 样本时，正则集仍被包进 `CachedLatentDataset` 并接入 `MergedDataset`，打出与主集无法区分的「检查 VAE latent 缓存... 所有 0 张图像已缓存」。改为：空正则集直接跳过接线（打「正则数据集为空，已跳过」）；`CachedLatentDataset` 新增 `label` 参数，VAE 缓存三条日志带（训练集）/（正则集）标注。

**3. krea2 文本预缓存无进度**

58 条 caption 编码约 7s，日志只有首尾两行，用户无从判断 text encode 是否发生、缓存落在哪。补：

- sidecar 命中统计：`[text-cache] caption sidecar 命中 M/N，需编码 K 条...` / 全部命中提示
- 编码进度：`文本编码进度: X/Y`（对齐 VAE 缓存的「编码进度」口径，每 10 条一报）
- 训练中 miss repair 走同一函数但不开进度日志，不刷屏

非改动说明：`train/.text-cache/` 是 D19 设计内的 sample/negative prompt 聚合缓存（无图可贴身）；图片 caption sidecar 本就随图落在 `train/{folder}/<图片名>.text.safetensors`，e2e 中 58/58 全部正常落盘。

## 测试方式

- `tests/test_bucket_histogram.py` 7 passed（含新回归测试）
- 文本缓存 / families：`test_krea2_text_encoding` `test_text_cache_phase` `test_text_cache` `test_model_families` `test_model_spec` `test_krea2_family_integration` `test_model_family_gating` 62 passed
- dataset / bucket 相关全量：`-k "dataset or bucket"` 81 passed
- 横切安全网：`test_route_snapshot.py` + `test_studio_configs.py` 33 passed
- 手测：对运行中 server 复打 `/api/projects/2/versions/87/bucket-distribution`，从 500 恢复为 58 图真实桶分布（12 桶）；trainer 两种命名导入冒烟通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)
