### PR TITLE
refactor(config): 刀 1 —— trainer 统一 TrainingConfig 加载路径 + 族矩阵单源

### DIFF
--- a/docs/design/config-pipeline-refactor.md
+++ b/docs/design/config-pipeline-refactor.md
@@ -1,0 +1,232 @@
+# 训练 config 管线重构(YAML 格式不变)
+
+状态:讨论中。已定决策见「决策记录」;未定项见「Open Questions」。
+触发:2026-07-17 krea2 训练 `shuffle_caption` 拒训 bug(见下)暴露的结构性同步成本。
+
+## 1. 背景:触发 bug 复盘
+
+fork anima 版本 → FamilySwitchDialog 切到 krea2 → 落盘裁剪把 `shuffle_caption` 键裁掉(show_when 为假,PR #366 语义)→ studio 侧 pydantic 读回时 `FAMILY_CONFIG_DEFAULTS` overlay 补 False,一切正常;但 trainer 走 argparse bridge 加载,缺键落回 schema 裸默认 True(anima 语义),第三层能力防线拒训。
+
+根因:**同一份 yaml 有两套「缺失键默认值」语义**——pydantic 路径(validator/overlay 全生效)与 argparse 路径(全不生效)。这是下述 A 类痛点的一个实例。
+
+## 2. 现状全景
+
+单一权威源 `TrainingConfig`(studio/domain/training.py,169 字段 / 17 validator)派生三个面:
+
+```
+TrainingConfig (pydantic, 单一权威源)
+ ├─ model_json_schema() ──→ GET /api/schema ──→ 前端 SchemaForm 泛型渲染
+ ├─ build_parser()      ──→ trainer CLI argparse(argparse_bridge.py)
+ └─ _tolerant_validate  ──→ 保存/preset 导入时校验 + 修复
+```
+
+写路径:前端完整 config → PUT → `_tolerant_validate`(17 validator + 迁移)→
+`prune_inactive_fields`(裁 show_when 假 + hidden 默认值)→ yaml 落盘。
+
+读路径(studio):yaml → pydantic(迁移 + 族 overlay + 校验)→ model_dump 补全默认 → 前端。
+
+读路径(trainer):yaml → `apply_yaml_config`(手工重跑 2 个迁移)→
+`merge_yaml_into_namespace`(「值==默认值」近似 CLI 显式性,**绕过全部 validator**)→
+argparse Namespace(训练进程的实际真相)→ 第三层能力校验。
+
+validator 构成:归一化 1 + 族 overlay 1 + 迁移 2 + 族门控 3 + 互斥 8 + 区间 2。
+
+## 3. 痛点分类(改一个东西要同步多处的结构性原因)
+
+| # | 痛点 | 实例 |
+|---|---|---|
+| A | **argparse Namespace 是第二个运行时真相**:merge 绕过 pydantic,每个 before-validator 都要在 runtime bootstrap 手工补调 | 迁移函数双调(bootstrap.py:98);族 overlay 漏调 → shuffle_caption bug;互斥/区间校验 runtime 侧不跑 |
+| B | **跨语言双实现**:show_when 求值器 + prune 前后端逐字镜像,靠注释纪律 + 平行测试 | `eval_show_when`↔`evalShowWhen`;`prune_inactive_fields`↔`pruneInactiveConfig`;`_js_str` 手工复刻 JS `String()` |
+| C | **跨进程三份矩阵**:FAMILY_CAPABILITIES / FAMILY_CONFIG_DEFAULTS / FAMILY_SAMPLING 在 studio/domain 与 runtime SPECS 各一份 | 靠 test_model_family_gating.py 单点锁死;加族/加能力位两边写 |
+| D | **元数据表达不了的逻辑逃逸成硬编码且已漂移** | SchemaForm `isAutoLrOptimizer` 缺 soap_sf(与后端 validator 名单不一致);disable_when 的「reset 到 disable_value」无后端对应物,tolerant 修复语义是 reset 到 default(learning_rate:disable_value=1.0 ≠ default=1e-4,两侧修复结果不同) |
+| E | **一条互斥规则写三处**:UI 灰显(disable_when 元数据)+ 后端 fail-fast(8 个同构 validator)+ 容错修复(InfoNoise 专用垫片) | 加一对互斥 = 三处开工 |
+
+## 4. 业界对照
+
+| 参考 | 对应痛点 | 核心做法 |
+|---|---|---|
+| jsonargparse / LightningCLI | A | yaml+CLI 合并后实例化类型对象、校验一次、运行时读对象;CLI 显式性用 `argparse.SUPPRESS` 精确探测 |
+| Kubernetes CRD + CEL | E | 校验规则声明进 schema(`x-kubernetes-validations`),规则=随 schema 传输的数据而非散落代码 |
+| VS Code settings when-clause | B/D | 统一表达式语言 + 单一求值器;设置 UI 全泛型渲染,零字段级硬编码 |
+| Hydra / OmegaConf | C | 族默认 = base + overlay 声明式 compose |
+
+本项目 `cap_gate()`「作者写时展开」已经是 K8s/VS Code 的思想,R2 是把它推广到互斥规则。
+
+## 5. 改造方案
+
+### R1. 收口运行时真相:trainer 过 TrainingConfig(根治 A)【已拍板,见 D1】
+
+`apply_yaml_config` 改为:
+
+```
+yaml → TrainingConfig(**yaml)   # 全部迁移/overlay/互斥/区间校验单点生效
+     → model_dump()
+     → 覆盖 CLI 显式项(SUPPRESS parser 产出的 sparse namespace)
+     → 再 validate 一次(CLI 覆盖也可能造出非法组合)
+     → 填 argparse.Namespace(下游零改动)
+```
+
+- CLI 显式性从「值==默认值」近似改为 `argparse.SUPPRESS`(parse 结果只含用户真正传的键),语义变精确。
+- runtime 三层能力防线退役为一层(pydantic 校验已含);bootstrap 手工迁移调用退役。
+- 行为变化:裸 CLI / 手写 yaml 的非法组合从「静默跑」变 fail-fast 拒训(与 Studio 写盘校验对齐)。**已确认接受。**
+- 依赖方向不变:runtime 本来就 import studio.schema。
+- yaml 格式零改动。
+
+### R2. 互斥/联动规则声明化(根治 D/E)【形态见 §6(v2 简化版),待拍板】
+
+### R3. 族矩阵单源(根治 C)【方向已认可,并入刀 1】
+
+capabilities / config_defaults / sampling 是纯数据;runtime→studio import 方向已存在,
+让 runtime SPECS 直接引用 `studio/domain/common.py` 的数据(loader/build 代码逻辑留 runtime),
+双份变单份,test_model_family_gating.py 的镜像锁死测试退役。
+
+### R4. YAML 预览改后端回执 + 删前端镜像(缓解 B)【已拍板,见 D3】
+
+现状:保存链路 = onChange → 600ms debounce → PUT 自动保存(改后**不变**)。
+预览抽屉独立于保存:前端把当前表单 state 实时过 `pruneInactiveConfig` + `configToYaml`
+两个镜像函数本地渲染 → 零滞后,但"与落盘一致"靠镜像纪律声称。
+
+改后:PUT 响应携带后端刚落盘的 yaml 文本,预览直接显示该回执。
+- 数据源从「前端模拟落盘」变「落盘回执」,物理一致,删 `pruneInactiveConfig` + `configToYaml` 两镜像及其测试。
+- 滞后 = debounce 窗口(≤600ms,自动保存本来就在跑,无额外请求)。
+- `evalShowWhen`(表单实时可见性)必须保留在前端;用共享 golden test vectors
+  (一份 JSON 用例,pytest 与 vitest 都加载断言)替代注释纪律。
+
+### R5. 杂项
+
+- Generate/RegAi 配置重复的路径/sampler Literal 抽公共基类。
+- 前端 `isAutoLrOptimizer`/automagic lr 改写等硬编码退役(随 R2 元数据派生)。
+
+### R6. 规则触发的「有损改值」走结构化确认弹窗(FamilySwitchDialog 泛化)【待拍板】
+
+现状不一致:model_family 切换有 modal 展示变更清单(from→to,用户确认才应用);
+其他联动(选 ppsf/automagic → learning_rate 被改写、disable_when takeover)是**静默改值 + 文本说明**。
+
+改后:规则声明化(R2)使「用户这次改动会连带改哪些字段」可计算——gate 字段变化时求值规则表,
+得到受影响字段清单(from → to + reason),复用 FamilySwitchDialog 的结构化 modal 范式:
+确认才应用,取消则回滚本次 gate 改动。FamilySwitchDialog 本身成为该机制的一个特例
+(族切换规则的确认弹窗),两套 UI 归一。
+
+**触发粒度(防弹窗疲劳)**:只在「有损」时弹——受影响字段当前值 ≠ 将写入值才列入清单,
+清单为空(受影响字段本来就在钉值上,如 loss_weighting 本就是 none)则静默应用,零打扰。
+与 switch_family 的 changes 清单只列真实变化字段同一语义。
+
+## 6. R2 规则声明(v2 简化版):升级现有 disable_when 为单源
+
+### 6.0 业界参考与取舍
+
+| 参考 | 形态 | 取舍 |
+|---|---|---|
+| **JSON Schema `if/then`**(draft-07+,标准) | `if:{properties:{infonoise_enabled:{const:true}}} then:{properties:{loss_weighting:{const:"none"}}}`;ajv/RJSF 生态直接消费 | 与本提案语义完全同构(pin=`then..const`,forbid=`then..not.const`)。**不直接采用**:项目已有 show_when 微文法 + 双端求值器,引入 if/then 会造成两套条件文法并存;pydantic 产出 JSON Schema 但不消费 if/then 做校验,后端仍要自写求值器,标准化收益落空 |
+| **Terraform provider schema** | `ConflictsWith/RequiredWith/ExactlyOneOf` 声明**挂在字段上**,大规模生态验证 | **采用其组织方式**:规则挂在字段元数据上,不建平行规则表 |
+| **Kubernetes CRD + CEL** | 校验表达式随 schema 传输 | 思想同源(规则=数据);CEL 太重不引入 |
+
+结论:**不引入新表、不引入新文法、不引入新概念**——现有 `disable_when`/`disable_value`/`disable_hint`
+本来就是 pin 规则的完整声明(条件/钉值/理由),只是今天**只有前端消费**。
+R2 v2 = 把这组既有元数据升级为「单源、双端强制」,并补一个对称的 option 级键承载 forbid。
+
+### 6.1 机制(零新概念)
+
+1. **pin 规则** = 字段上的 `disable_when` + `disable_value` + `disable_hint`(全部已存在):
+   - 前端:灰显 + takeover 写值(现状不变,但硬编码分支退役,全走元数据);
+   - **后端(新增消费)**:通用 model_validator——disable_when 命中且值 ≠ disable_value → raise,
+     文案 = 字段 + 钉值 + disable_hint;8 个手写互斥 validator 退役;
+   - **tolerant 修复(新增消费)**:违反时写 disable_value(修复语义与前端 takeover 对齐,
+     消除现状 reset-to-default 的不一致,如 learning_rate 1.0 vs 1e-4)。
+2. **forbid 规则** = 新元数据键 `option_disable_when: {值: when表达式}`(`option_show_when` 的姊妹):
+   - 前端:下拉中该选项**灰显 + hint**(D4 已拍板灰显不隐藏);
+   - 后端:同一 validator 消费,命中且等于禁值 → raise / tolerant 修复为 schema 默认。
+3. **fix=gate 策略**(InfoNoise 垫片泛化):极小全局集合 `TOLERANT_FIX_GATE_FIRST = {"infonoise_enabled"}`
+   ——tolerant 修复时,违反规则的 when 表达式含集合内开关则优先关开关(保住用户在目标字段的投入),
+   其余默认修目标字段。不做 per-rule 配置,YAGNI。
+
+### 6.2 现有 11 组规则逻辑 → 字段元数据(最终形态)
+
+写在各字段 `_meta(...)` 里(多 gate 钉同字段用 `||` 合并,现文法已支持):
+
+| 目标字段 | 新增/升级的元数据 | 替代的手写代码 |
+|---|---|---|
+| `lr_scheduler` | `disable_when="optimizer_type==automagic\|\|…prodigy\|\|…prodigy_plus_schedulefree\|\|…soap_sf", disable_value="none"`(已有,升级为双端强制) | `_validate_prodigy_scheduler` + 前端 `isAutoLrOptimizer` takeover 硬编码 |
+| `loss_weighting` | `disable_when="infonoise_enabled==true\|\|leap_enabled==true", disable_value="none"` | infonoise/leap × loss_weighting 两个 validator |
+| `timestep_schedule_shift` | `disable_when="infonoise_enabled==true", disable_value=1.0` | infonoise × schedule_shift validator |
+| `noise_enhancement_type` | `disable_when="infonoise_enabled==true", disable_value="none"` | infonoise × noise_enhancement validator |
+| `loss_type` | `option_disable_when={"huber": "infonoise_enabled==true\|\|leap_enabled==true"}` | infonoise/leap × huber 两个 validator |
+| `infonoise_enabled` | `disable_when="leap_enabled==true\|\|navit_packing==true", disable_value=False` | leap/navit × infonoise |
+| `leap_enabled` | `disable_when="navit_packing==true", disable_value=False` | navit × leap |
+| `sra_enabled` | `disable_when="navit_packing==true", disable_value=False` | navit × sra |
+| `lora_type` | `option_disable_when={"tlora": "navit_packing==true"}` | navit × tlora |
+| `cache_latents` | `disable_when="navit_packing==true", disable_value=True` | navit → cache_latents |
+| `navit_native_resolution` | `disable_when="navit_packing==false", disable_value=False` | navit_native_resolution 依赖校验 |
+| `attention_backend` | 已有 `disable_when="navit_packing==true", disable_value="xformers"`,升级为双端强制 | `_coerce_navit_attention_backend` before-validator |
+
+另:InfoNoise 专用 tolerant 垫片(presets/io.py)→ 由 `TOLERANT_FIX_GATE_FIRST` 通用化后删除。
+
+### 6.3 每条声明派生出什么(一处声明,五面生效)
+
+1. **后端校验**:通用 validator 消费 disable_when/option_disable_when(手写互斥 validator 退役)。
+2. **前端 UI**:灰显/takeover/hint——现有 SchemaForm 消费逻辑不变,新增 option 级灰显一处。
+3. **tolerant 修复**:写 disable_value(与前端 takeover 语义对齐)/ gate-first 集合。
+4. **R6 确认弹窗**:有损改值清单直接从同一份元数据求值生成。
+5. **runtime**:R1 后走同一 TrainingConfig,自动继承。
+
+### 6.4 保留手写的 validator(规则声明刻意不覆盖)
+
+| validator | 原因 |
+|---|---|
+| `_validate_detail_inv_t_range` / `_validate_sra_decay_range` / `_validate_infonoise_n_min_le_b` | 字段间区间比较(min≤max),3 个且语义各异,模板化收益低 |
+| navit_token_budget > 0 | 「必须显式设置非零」不是钉值/禁值 |
+| `_normalize_resolution` / 迁移 2 个 / 族 overlay / sampler grandfather coerce | 归一化/迁移类,本就不是规则 |
+
+判据:**bool/enum 门控 → 钉值/禁值**进表;涉及数值关系或改写逻辑的保留手写。
+
+## 7. PR 切分(合并后的两刀)
+
+| 刀 | 内容 | 前提 |
+|---|---|---|
+| **刀 1(后端收口)** | R1 + R3 + shuffle_caption bug 正式修复 + 回归测试(krea2 裁剪产物过 trainer 加载路径 → 零 violation);三层防线/双调迁移/镜像矩阵测试退役 | 已可动工 |
+| **刀 2(声明化 + 前端)** | R2 v2(disable_when 双端强制)+ R4 预览回执 + R6 确认弹窗 + R5 杂项 + 审计遗漏规则补录;golden vectors 锁 evalShowWhen | R2 v2 / R6 拍板 + 审计结果评审 |
+
+## 8. 决策记录
+
+- **D1(2026-07-17)**:R1 采纳,含行为严格化——裸 CLI/手写 yaml 的非法组合从静默跑变 fail-fast,与 Studio 写盘校验对齐。
+- **D2(2026-07-17)**:PR 切分从五刀合并为两刀(§7)。
+- **D3(2026-07-17)**:R4 采纳——预览改后端落盘回执,删 pruneInactiveConfig/configToYaml 前端镜像。
+- **D4(2026-07-17)**:forbid 规则前端形态 = 灰显选项(带 hint),不隐藏。
+- **D5(2026-07-17)**:R2 v2 采纳——不建规则表,升级现有 disable_when/disable_value/disable_hint 为双端强制,新增 option_disable_when 承载禁值;v1(独立 RULES 表)废弃。
+- **D6(2026-07-17)**:R6 采纳——规则触发的有损改值走结构化确认弹窗,「有损才弹、无损静默」;FamilySwitchDialog 并入同一机制。
+- **D7(2026-07-17)**:审计候选处置按 §10.1 表定案——#1/#6 补规则声明、#3 修 runtime 分派错位、#2 加 warning、#4 文档说明、#5 保留、#7 先数值复核再定;随刀 2 落地。
+
+## 9. Open Questions
+
+(当前无——D1-D7 已覆盖全部;#7 数值复核结果若确认漂移,补一条互斥即可,不阻塞。)
+
+## 10. 互斥覆盖审计结果(2026-07-17,runtime 全量对照)
+
+方法:深读 runtime/training/ 各机制实现里的 guard/skip/覆盖逻辑,对照配置层
+(11 个 validator + disable_when 元数据 + FAMILY_CAPABILITIES)。
+
+### 10.1 遗漏候选(待逐条拍板)
+
+| # | 组合 | runtime 证据 | 静默后果 | 处置建议 |
+|---|---|---|---|---|
+| 1 | **leap + sra** | loop.py:448 leap 步整段跳过 SRA;SRA MLP 仍建仍进优化器。leap_ratio=1.0 时 SRA 100% 零生效 | **高**:用户以为开了,实际不跑 | **补规则**:`sra_enabled` 加 `disable_when="leap_enabled==true\|\|navit_packing==true"`(与 navit 侧对称),leap validator 期加 sra 互斥 |
+| 2 | tlora + batch_size>1 | ortho/lycoris_adapter 取 batch 均值 t 生成单一 rank mask 广播,per-sample 机制退化为批均值 | 中:行为偏移非失效 | **warning 不拦**:bootstrap 期打印;强拦会误伤小 batch 用户 |
+| 3 | noise_offset>0 且 pyramid_noise_iters>0 | runtime 从不读 noise_enhancement_type,直接读两个原始值,各自独立生效可叠加;互斥只是 UI 显隐+prune 假象 | 中:裸 CLI/脏 yaml 双倍低频扰动 | **修错位**:runtime 改按 noise_enhancement_type 分派(根治「type 被 runtime 无视」);R1 后 pydantic 校验兜底 |
+| 4 | krea2 + infonoise(timestep_sampling 改离 krea2_shift 后) | timestep_samplers/__init__.py:42 只 fail-fast「仍是 krea2_shift」子集;改 logit_normal 再开 infonoise → krea2 静默失去校准 shift | 中:需用户显式两步操作 | **半拦**:krea2 的 timestep_sampling 纳入族白名单警告(同 sampler 白名单模式),或文档说明;倾向后者(A1「同代码不限制」先例) |
+| 5 | krea2 + timestep_shift_resolution_aware=true | loop.py:178 runtime 已 fail-fast raise | 低:崩但不静默 | **保留**(失败点偏晚但响) |
+| 6 | automagic v2 + grad_clip>0 | automagic.py:52 仅 warning,fused backward 下裁剪静默失效;grad_clip 默认 1.0 极易撞 | 中:默认值即触发,仅一行 log | **补规则**:`grad_clip_max_norm` 加 `disable_when="optimizer_type==automagic&&automagic_variant==v2", disable_value=0`(grad_accum/fp16 已 fail-fast 保留) |
+| 7 | infonoise + resolution_aware shift(多分辨率) | infonoise CDF 建在 shifted-t 上、采样值又被 shift 一次,refresh 可能沿复合方向漂移;单分辨率恒等无影响 | 低-中,**未数值验证** | **先复核**:确认漂移则按 schedule_shift 同款互斥;有界则文档说明 |
+
+### 10.2 已核实真兼容、不需拦(防重复怀疑)
+
+masked_loss×infonoise(loop.py:414 显式排除 mask 区不污染 CDF)、masked_loss×reg/loss_weighting、
+reg×infonoise(仅 main 集进 record)、reg×leap/navit(loss_weight 均生效)、
+loss_weighting/huber×navit(逐图 t 恰好匹配 per-sample SNR 语义,与 leap 不同,现状不拦正确)、
+noise_enhancement×leap、timestep 系×leap(已由 alt_description 披露 leap 恒用 U(0,1))、
+krea2×huber/loss_weighting/noise_enhancement/各 optimizer、sra×reg、eval×训练机制(正交)。
+
+### 10.3 附带发现(非配置问题,已单独开任务)
+
+navit_packing 路径 NameError 回归:loop.py:309 引用从未定义的 `t5_attn`
+(文本编码下沉 family 时 encode_text_for_batch 只 return cross,navit 分支未同步),
+navit_packing=True 首个 batch 即崩。已核实(grep 全文件唯一出现)。独立修复,不进本重构。

--- a/runtime/training/bootstrap.py
+++ b/runtime/training/bootstrap.py
@@ -80,23 +80,33 @@ def load_yaml_config(config_path):
 
 
 def apply_yaml_config(args, config):
-    """将 YAML 配置应用到 args；命令行显式参数优先于 YAML。
+    """将 YAML 与 CLI 显式参数合并，经 TrainingConfig 完整构造后返回新 args。
 
-    实现走 studio.argparse_bridge.merge_yaml_into_namespace —— 字段名 / 默认值
-    都从 studio.schema.TrainingConfig 这一份单一权威源派生，避免与 parse_args
-    脱节。未在 schema 中的 YAML 键会被忽略（拼写错误一目了然）。
+    config 管线刀 1（R1，docs/design/config-pipeline-refactor.md）：trainer 与
+    Studio 走同一条 pydantic 加载路径 —— 字段迁移 / FAMILY_CONFIG_DEFAULTS
+    族默认 overlay / 互斥与能力校验全部单点生效，本函数不再手工重放迁移
+    （旧 merge_yaml_into_namespace 绕过 validator 年代的产物）。
 
-    在 merge 前调用 save/noise 迁移兜底老 yaml；argparse_bridge 不走 pydantic validator，
-    schema 层的迁移逻辑无法生效，所以这里显式做一次。
+    命令行显式参数优先于 YAML：parse_args 以 suppress_defaults 构建 parser，
+    args 只含显式键，优先级是精确判定而非「值==默认值」近似。
+
+    校验失败逐条打印到 stderr 后 SystemExit(2) —— 与能力防线同款 fail-fast，
+    supervisor 截 stderr 尾部作为任务错误信息。
     """
-    from studio.infrastructure.argparse_bridge import merge_yaml_into_namespace
-    from studio.schema import (
-        TrainingConfig,
-        migrate_legacy_save_keys,
-        migrate_noise_enhancement_type,
-    )
-    config = migrate_noise_enhancement_type(migrate_legacy_save_keys(dict(config or {})))
-    return merge_yaml_into_namespace(args, config, TrainingConfig)
+    from pydantic import ValidationError
+
+    from studio.infrastructure.argparse_bridge import namespace_from_config
+    from studio.schema import TrainingConfig
+
+    try:
+        return namespace_from_config(args, dict(config or {}), TrainingConfig)
+    except ValidationError as exc:
+        errors = exc.errors()
+        print(f"配置校验失败（{len(errors)} 处）:", file=sys.stderr)
+        for err in errors:
+            loc = ".".join(str(p) for p in err["loc"]) or "config"
+            print(f"  {loc}: {err['msg']}", file=sys.stderr)
+        raise SystemExit(2) from exc
 
 
 def init_progress(show_progress, total_steps):

--- a/runtime/training/cli.py
+++ b/runtime/training/cli.py
@@ -19,11 +19,19 @@ def parse_args():
     """从 studio.schema.TrainingConfig 自动生成 parser；额外补 schema 之外的
     CLI-only 开关（auto-install / interactive / no-live-curve / 已弃用的
     --repeats 和 --reg-repeats）。
+
+    suppress_defaults=True（config 管线刀 1 / R1）：schema 字段不填 argparse
+    默认值，parse 产物只含用户显式传入的键。完整默认值由 apply_yaml_config
+    经 TrainingConfig 构造统一补齐（迁移 / 族默认 overlay / 校验单点生效），
+    CLI-only 开关保留普通默认、始终存在于 namespace。
     """
     from studio.infrastructure.argparse_bridge import build_parser
     from studio.schema import TrainingConfig
 
-    p = build_parser(TrainingConfig, prog="anima_train", description="Anima LoRA Trainer v2")
+    p = build_parser(
+        TrainingConfig, prog="anima_train",
+        description="Anima LoRA Trainer v2", suppress_defaults=True,
+    )
     # schema 之外的 CLI-only 开关
     p.add_argument("--auto-install", action="store_true", help="自动安装缺失依赖")
     p.add_argument("--interactive", action="store_true", help="交互模式，提示输入缺失参数")

--- a/runtime/training/families/anima/__init__.py
+++ b/runtime/training/families/anima/__init__.py
@@ -2,6 +2,16 @@
 
 from __future__ import annotations
 
+# 能力矩阵 / 族默认 / 采样白名单单源在 studio/domain/common.py（config 管线
+# 刀 1 / R3）：studio 不 import runtime（server sys.path 无 runtime/），反向
+# runtime → studio 是既有依赖方向（bootstrap 已 import studio.schema），
+# common.py 是零依赖纯数据叶子模块，server / 裸 CLI / tests 三场景都可达。
+from studio.domain.common import (
+    FAMILY_CAPABILITIES,
+    FAMILY_CONFIG_DEFAULTS,
+    FAMILY_SAMPLING,
+)
+
 # 相对导入：studio server 经 `runtime.training.dataset` 间接 import 本模块，
 # 那边 sys.path 没有 runtime/，`training.*` 绝对导入会 ModuleNotFoundError。
 from ..latent_spaces import WAN21_F8C16
@@ -28,20 +38,17 @@ ANIMA_SPEC = ModelSpec(
         fingerprint="anima-qwen3-0.6b-t5xxl",
     ),
     sampling=SamplingDefaults(
-        # 白名单与默认值对应 sampling.py Comfy KSampler parity 现状
-        samplers=("er_sde", "dpmpp_3m_sde"),
-        schedulers=("simple", "sgm_uniform"),
-        default_sampler="er_sde",
-        default_scheduler="simple",
+        # 白名单对应 sampling.py Comfy KSampler parity 现状；首项 = 族默认
+        samplers=FAMILY_SAMPLING["anima"]["samplers"],
+        schedulers=FAMILY_SAMPLING["anima"]["schedulers"],
+        default_sampler=FAMILY_SAMPLING["anima"]["samplers"][0],
+        default_scheduler=FAMILY_SAMPLING["anima"]["schedulers"][0],
         default_steps=25,
         default_cfg=4.0,
         shift_policy=ConstantShift(shift=3.0),
     ),
     # D5：Anima = 全量能力减 text_cache
-    capabilities=frozenset({
-        "navit", "sra", "leap", "compile_blocks",
-        "caption_tag_ops", "online_text", "masked_loss",
-    }),
+    capabilities=FAMILY_CAPABILITIES["anima"],
     lora=LoraOutputSpec(prefix="lora_unet", preset_name="anima_full"),
-    config_defaults={},
+    config_defaults=FAMILY_CONFIG_DEFAULTS["anima"],
 )

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -36,6 +36,12 @@ from ..spec import (
     SamplingDefaults,
     TextSpec,
 )
+# 单源数据（刀 1 / R3）：见 anima/__init__.py 同位注释的依赖方向说明
+from studio.domain.common import (
+    FAMILY_CAPABILITIES,
+    FAMILY_CONFIG_DEFAULTS,
+    FAMILY_SAMPLING,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -104,8 +110,11 @@ KREA2_SPEC = ModelSpec(
         fingerprint=KREA2_TEXT_FINGERPRINT,
     ),
     sampling=SamplingDefaults(
-        samplers=(KREA2_SAMPLER,),
-        schedulers=(KREA2_SCHEDULER,),
+        # 白名单单源 studio/domain/common.py FAMILY_SAMPLING（刀 1 / R3）；
+        # KREA2_SAMPLER 等常量仍归 sampling.py（生成侧 parity 共用），
+        # 与单源数据的一致性由 tests/test_model_family_gating.py 锁死
+        samplers=FAMILY_SAMPLING["krea2"]["samplers"],
+        schedulers=FAMILY_SAMPLING["krea2"]["schedulers"],
         default_sampler=KREA2_SAMPLER,
         default_scheduler=KREA2_SCHEDULER,
         default_steps=KREA2_RAW_STEPS,
@@ -116,21 +125,9 @@ KREA2_SPEC = ModelSpec(
         # 动态 mu 保留为 build_krea2_sigmas(dynamic_mu=True) 非默认路径。
         shift_policy=ConstantShift(shift=1.15),
     ),
-    capabilities=frozenset({"masked_loss", "text_cache"}),
+    capabilities=FAMILY_CAPABILITIES["krea2"],
     lora=LoraOutputSpec(prefix="lora_unet", preset_name="krea2_full"),
-    config_defaults={
-        "shuffle_caption": False,
-        "keep_tokens": 0,
-        "tag_dropout": 0.0,
-        "text_encoder_cache": True,
-        "attention_backend": "none",
-        "timestep_sampling": "krea2_shift",
-        "timestep_shift_resolution_aware": False,
-        "sample_sampler_name": KREA2_SAMPLER,
-        "sample_scheduler": KREA2_SCHEDULER,
-        "sample_infer_steps": KREA2_RAW_STEPS,
-        "sample_cfg_scale": KREA2_RAW_GUIDANCE,
-    },
+    config_defaults=FAMILY_CONFIG_DEFAULTS["krea2"],
 )
 
 

--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -127,14 +127,17 @@ def run(ctx: TrainingContext) -> None:
     _validate_schedulers()
     _validate_losses()
 
-    # 加载 YAML 配置文件
+    # 加载 YAML 配置文件 + TrainingConfig 归一（刀 1 / R1）。无 yaml 的纯 CLI
+    # 路径同样要走：parse_args 的 sparse namespace 缺 schema 默认值，由
+    # apply_yaml_config 经 pydantic 构造统一补齐（迁移 / 族 overlay / 校验一并生效）
+    config = {}
     if args.config:
         logger.info(f"加载配置文件: {args.config}")
         ctx.config_path = Path(args.config).resolve()
         ctx.config_dir = ctx.config_path.parent
         config = load_yaml_config(args.config)
-        ctx.args = apply_yaml_config(args, config)
-        args = ctx.args
+    ctx.args = apply_yaml_config(args, config)
+    args = ctx.args
 
     # bridge 已为 prefer_json bool 自动产生 --prefer-json / --no-prefer-json，
     # 此处无需再做兼容处理。
@@ -158,23 +161,11 @@ def run(ctx: TrainingContext) -> None:
 
     # 多模型 PR-2b：族解析 fail-fast（args 定稿后、任何权重加载前；未知
     # model_family 即死。pause snapshot 已 freeze args → 跨 pause 族一致性免费）
+    # 能力校验不再单独做（刀 1 / R1）：apply_yaml_config 的 TrainingConfig
+    # 构造已跑 _validate_family_capabilities，CLI 直达路径与 Studio 同一防线。
     from training.families import resolve_family
 
     ctx.family = resolve_family(args)
-    # 第三层能力防线（多模型 PR-3）：config 可绕过 studio 直达 CLI，这里用
-    # runtime SPECS 再校验一次。studio.domain 在裸 CLI 场景不一定可 import → 跳过
-    try:
-        from studio.domain.common import capability_violations
-
-        _bad = capability_violations(
-            ctx.family.spec.family_id, {k: getattr(args, k, None) for k in vars(args)}
-        )
-        if _bad:
-            raise SystemExit(
-                f"model_family='{ctx.family.spec.family_id}' 不支持这些已启用字段: {_bad}"
-            )
-    except ImportError:
-        pass
 
     # 触发词注入：caption 端 tag_worker 把 trigger 写为第一个 tag，这里同步
     # 注入 sample_prompt(s)，让采样图天然带 trigger。pause snapshot 已 freeze

--- a/studio/domain/common.py
+++ b/studio/domain/common.py
@@ -14,9 +14,10 @@ def _meta(group: str, control: str = "auto", **extra: Any) -> dict[str, Any]:
 
 
 # ─── 多模型能力矩阵（多模型 PR-3，04-synthesis D5/D11） ───────────────────
-# runtime training/families SPECS.capabilities 的镜像。studio/domain 不 import
-# runtime（trainer cli 反向 import 本模块，避免环 + server 启动不依赖 runtime
-# sys.path）；同步由 tests/test_model_family_gating.py 双向锁死。
+# 单一权威源（config 管线刀 1 / R3）：runtime training/families 的 SPECS 直接
+# 引用本表（依赖方向 runtime → studio，本模块是零依赖纯数据叶子）。studio/domain
+# 仍不 import runtime（server 启动不依赖 runtime sys.path）。
+# tests/test_model_family_gating.py 锁 SPECS 与本表的同一性（防再复制成镜像）。
 FAMILY_CAPABILITIES: dict[str, frozenset] = {
     "anima": frozenset({
         "navit", "sra", "leap", "compile_blocks",
@@ -25,8 +26,9 @@ FAMILY_CAPABILITIES: dict[str, frozenset] = {
     "krea2": frozenset({"masked_loss", "text_cache"}),
 }
 
-# ModelSpec.config_defaults 的 studio 镜像。server 不反向 import runtime；同步由
-# tests/test_model_family_gating.py 双向锁死。只在字段缺失时 overlay，显式配置不改写。
+# 族默认 overlay 的单一权威源（ModelSpec.config_defaults 直接引用本表，R3）。
+# 只在字段缺失时 overlay，显式配置不改写。消费方:pydantic before-validator
+# `_apply_family_config_defaults`（studio 与 trainer 现共用这一条加载路径，R1）。
 FAMILY_CONFIG_DEFAULTS: dict[str, dict[str, Any]] = {
     "anima": {},
     "krea2": {
@@ -48,9 +50,8 @@ FAMILY_CONFIG_DEFAULTS: dict[str, dict[str, Any]] = {
 MODEL_FAMILIES: tuple[str, ...] = tuple(FAMILY_CAPABILITIES)
 
 # ─── 采样端白名单（多模型 P4-2，A13） ─────────────────────────────────────
-# runtime SPECS[fam].sampling.samplers/schedulers 的镜像（首项 = 族默认值）。
-# 与能力矩阵同一纪律：studio 不 import runtime，同步由
-# tests/test_model_family_gating.py 双向锁死。
+# 单一权威源（首项 = 族默认值）：runtime SPECS[fam].sampling.samplers/schedulers
+# 直接引用本表（R3，同能力矩阵的依赖方向说明）。
 # 这两个字段是硬白名单——两族的 sample_image 都在入口对名单外的值 raise
 # （anima: families/anima/sampling.py Comfy parity 校验；krea2:
 # families/krea2/sampling.py 同款），所以跨族值在配置层就报错（fail-fast）。

--- a/studio/domain/config_prune.py
+++ b/studio/domain/config_prune.py
@@ -9,9 +9,12 @@
    trigger_word 等），默认值落盘纯属噪音；非默认值（裸 CLI 用户手写覆盖 /
    Tagging 页写入的 trigger_word）照常保留。
 
-runtime 侧的安全性：argparse parser 与默认值同样派生自 TrainingConfig
-（studio/infrastructure/argparse_bridge.py），yaml 缺失的键在
-merge_yaml_into_namespace 后落回同一份 schema 默认值，与显式写默认值等价。
+runtime 侧的安全性（config 管线刀 1 / R1 起）：trainer 加载 yaml 走与 Studio
+同一条 TrainingConfig 构造路径（argparse_bridge.namespace_from_config），缺失
+键经 pydantic 默认值 + FAMILY_CONFIG_DEFAULTS 族 overlay 补齐 —— 与保存端裁剪
+前的读回值逐字段一致。历史教训：旧 merge_yaml_into_namespace 用 argparse 裸
+默认补缺键、不走族 overlay，krea2 上被裁掉的 shuffle_caption 落回 anima 语义
+默认 True 而拒训；裁剪的安全性永远以「trainer 读回 == 保存端读回」为准。
 
 不裁 disable_when —— 命中的字段被前端 reset 到 disable_value，而
 disable_value 可能不等于字段默认值（如 Prodigy 时 lr_scheduler 被钉在

--- a/studio/infrastructure/argparse_bridge.py
+++ b/studio/infrastructure/argparse_bridge.py
@@ -76,8 +76,19 @@ def _flag_for(name: str, field: FieldInfo) -> str:
     return alias or "--" + name.replace("_", "-")
 
 
-def add_argument_for(parser: argparse.ArgumentParser, name: str, field: FieldInfo) -> None:
-    """把单个字段加到 parser。dest 始终等于字段名（即下划线形式）。"""
+def add_argument_for(
+    parser: argparse.ArgumentParser,
+    name: str,
+    field: FieldInfo,
+    *,
+    suppress_default: bool = False,
+) -> None:
+    """把单个字段加到 parser。dest 始终等于字段名（即下划线形式）。
+
+    suppress_default=True 时所有参数 default=argparse.SUPPRESS —— parse 产物
+    Namespace 只含用户显式传入的键（sparse），CLI 显式性由键的存在性精确判定，
+    供 namespace_from_config 做 CLI > YAML 合并。
+    """
     flag = _flag_for(name, field)
     annotation, is_optional = _unwrap_optional(field.annotation)
     default = _default_value(field)
@@ -90,15 +101,14 @@ def add_argument_for(parser: argparse.ArgumentParser, name: str, field: FieldInf
 
     # bool ----------------------------------------------------------------
     if annotation is bool:
-        # Optional[bool] 的默认值保留 None —— 表示「未指定」。
+        # Optional[bool] 的默认值保留 None —— 表示「未指定」；
         # 非 Optional 的 bool 则 fallback 到 False。
-        # 关键：merge_yaml_into_namespace 靠 `current == default` 判断
-        # CLI 有没有显式设值；如果这里把 None 转成 False，merge 会
-        # 误以为 CLI 显式传了 --no-xxx，YAML 值就永远合不进去。
         if is_optional:
             actual_default = default  # keep None
         else:
             actual_default = bool(default) if default is not None else False
+        if suppress_default:
+            actual_default = argparse.SUPPRESS
         # Python 3.13+ 的 argparse 拒绝把 --no-X 形式的 flag 传给
         # BooleanOptionalAction（会自动衍生 --no-no-X 与字段重名）。
         # 字段名以 no_ 开头时退化为一对互斥 store_true/store_false：
@@ -113,7 +123,13 @@ def add_argument_for(parser: argparse.ArgumentParser, name: str, field: FieldInf
                 default=actual_default,
                 help=help_text or None,
             )
-            parser.add_argument(positive, dest=name, action="store_false", help=None)
+            # 第二个同 dest action 的 default 必须与第一个一致：argparse 在
+            # parse 开始时按注册顺序 setattr default，非 SUPPRESS 的 None 会
+            # 把 sparse namespace 撑出一个假显式键。
+            parser.add_argument(
+                positive, dest=name, action="store_false",
+                default=actual_default, help=None,
+            )
         else:
             parser.add_argument(
                 flag,
@@ -134,7 +150,7 @@ def add_argument_for(parser: argparse.ArgumentParser, name: str, field: FieldInf
             dest=name,
             choices=choices,
             type=item_t,
-            default=default,
+            default=argparse.SUPPRESS if suppress_default else default,
             help=help_text or None,
         )
         return
@@ -147,17 +163,26 @@ def add_argument_for(parser: argparse.ArgumentParser, name: str, field: FieldInf
             dest=name,
             nargs="*",
             type=item_t,
-            default=default if default is not None else [],
+            default=argparse.SUPPRESS if suppress_default
+            else (default if default is not None else []),
             help=help_text or None,
         )
         return
 
     # int / float / str ---------------------------------------------------
     if annotation is int:
-        parser.add_argument(flag, dest=name, type=int, default=default, help=help_text or None)
+        parser.add_argument(
+            flag, dest=name, type=int,
+            default=argparse.SUPPRESS if suppress_default else default,
+            help=help_text or None,
+        )
         return
     if annotation is float:
-        parser.add_argument(flag, dest=name, type=float, default=default, help=help_text or None)
+        parser.add_argument(
+            flag, dest=name, type=float,
+            default=argparse.SUPPRESS if suppress_default else default,
+            help=help_text or None,
+        )
         return
 
     # 默认按字符串处理（包括 str、Optional[str]、未知类型）
@@ -165,7 +190,8 @@ def add_argument_for(parser: argparse.ArgumentParser, name: str, field: FieldInf
         flag,
         dest=name,
         type=str,
-        default=default if default is not None else ("" if not is_optional else None),
+        default=argparse.SUPPRESS if suppress_default
+        else (default if default is not None else ("" if not is_optional else None)),
         help=help_text or None,
     )
 
@@ -176,41 +202,59 @@ def build_parser(
     prog: str | None = None,
     description: str | None = None,
     add_config_arg: bool = True,
+    suppress_defaults: bool = False,
 ) -> argparse.ArgumentParser:
     """从 pydantic 模型生成完整 parser。
 
-    add_config_arg=True 时自动加上 `--config PATH`（指向 YAML 配置）。
+    add_config_arg=True 时自动加上 `--config PATH`（指向 YAML 配置；不参与
+    suppress —— 调用方在合并前就要读它）。
+    suppress_defaults=True 时 schema 字段全部 default=argparse.SUPPRESS，
+    parse 产物只含用户显式传入的键，配合 namespace_from_config 使用。
     """
     parser = argparse.ArgumentParser(prog=prog, description=description)
     if add_config_arg:
         parser.add_argument("--config", default="", help="YAML 配置文件路径")
     for name, field in model_cls.model_fields.items():
-        add_argument_for(parser, name, field)
+        add_argument_for(parser, name, field, suppress_default=suppress_defaults)
     return parser
 
 
 # ---------------------------------------------------------------------------
-# YAML → Namespace 合并（CLI 优先于 YAML）
+# YAML + CLI 显式值 → pydantic 校验 → 完整 Namespace
 # ---------------------------------------------------------------------------
 
 
-def merge_yaml_into_namespace(
+def namespace_from_config(
     args: argparse.Namespace,
     yaml_data: dict[str, Any],
     model_cls: type[BaseModel],
 ) -> argparse.Namespace:
-    """把 YAML 的字段写进 args，但仅当 args 当前值仍等于该字段的默认值时。
+    """合并 YAML 与 CLI 显式值，经 model_cls 完整构造后展开成 Namespace。
 
-    这与 anima_train.py 现有的「CLI 显式设置则保留」语义一致；CLI 的实际显式
-    设置无法直接探测，因此用「值 == 默认值」做近似。
+    取代旧 merge_yaml_into_namespace（「值==默认值」近似 CLI 显式性且绕过全部
+    validator——字段迁移 / FAMILY_CONFIG_DEFAULTS 族默认 overlay / 互斥与能力
+    校验在 trainer 路径全部失效，如 krea2 缺键 shuffle_caption 落回 anima 语义
+    默认 True 而拒训）。调用方的 parser 必须以 suppress_defaults=True 构建，
+    `args` 只含显式键，CLI > YAML 的优先级是精确判定。
+
+    合并语义：
+    - yaml_data 原样交给 pydantic —— 旧键由 before-validator 迁移，未知键按
+      模型的 extra 策略处理（TrainingConfig 为 ignore）
+    - args 中属于 schema 的键覆盖 YAML（CLI 显式优先）；合并结果整体过一次
+      模型构造，任何来源组合出的非法配置都在此 fail-fast
+    - args 中不属于 schema 的键（--interactive 等 CLI-only 开关）原样带回
+
+    Raises:
+        pydantic.ValidationError: 合并结果非法（互斥冲突 / 族能力越界等）。
     """
     fields = model_cls.model_fields
-    for key, value in yaml_data.items():
-        if key not in fields:
-            continue
-        default = _default_value(fields[key])
-        current = getattr(args, key, default)
-        # 只在 args 还是默认值时让 YAML 覆盖
-        if current == default:
-            setattr(args, key, value)
-    return args
+    explicit = vars(args)
+    merged = dict(yaml_data)
+    merged.update({k: v for k, v in explicit.items() if k in fields})
+    cfg = model_cls(**merged)
+    out = argparse.Namespace(
+        **{k: v for k, v in explicit.items() if k not in fields}
+    )
+    for key, value in cfg.model_dump(mode="python").items():
+        setattr(out, key, value)
+    return out

--- a/tests/test_anima_train_migration.py
+++ b/tests/test_anima_train_migration.py
@@ -100,39 +100,59 @@ def test_deprecated_repeats_flags_silently_accepted(at, monkeypatch: pytest.Monk
 
 
 def test_no_prefer_json_flips_default(at, monkeypatch: pytest.MonkeyPatch) -> None:
-    """bridge 自动从 prefer_json: bool=True 派生 --prefer-json / --no-prefer-json。"""
+    """bridge 自动从 prefer_json: bool=True 派生 --prefer-json / --no-prefer-json。
+
+    刀 1 / R1 起 parse_args 是 sparse namespace（只含显式键）；schema 默认值
+    由 apply_yaml_config 经 TrainingConfig 统一补齐。
+    """
     monkeypatch.setattr(sys, "argv", ["anima_train.py", "--no-prefer-json"])
     assert at.parse_args().prefer_json is False
     monkeypatch.setattr(sys, "argv", ["anima_train.py"])
-    assert at.parse_args().prefer_json is True
+    sparse = at.parse_args()
+    assert not hasattr(sparse, "prefer_json")  # 未显式传 → 不在 sparse namespace
+    assert at.apply_yaml_config(sparse, {}).prefer_json is True
 
 
 # ---------------------------------------------------------------------------
-# YAML 合并
+# YAML 合并（apply_yaml_config 返回归一后的新 namespace，不再原地改）
 # ---------------------------------------------------------------------------
 
 
 def test_apply_yaml_overrides_defaults(at, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", ["anima_train.py"])
-    args = at.parse_args()
-    yaml_data = {"epochs": 99, "lora_rank": 64}
-    at.apply_yaml_config(args, yaml_data)
+    args = at.apply_yaml_config(at.parse_args(), {"epochs": 99, "lora_rank": 64})
     assert args.epochs == 99
     assert args.lora_rank == 64
 
 
 def test_cli_wins_over_yaml(at, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", ["anima_train.py", "--epochs", "3"])
-    args = at.parse_args()
-    at.apply_yaml_config(args, {"epochs": 99})
+    args = at.apply_yaml_config(at.parse_args(), {"epochs": 99})
     assert args.epochs == 3
+
+
+def test_cli_explicit_default_wins_over_yaml(at, monkeypatch: pytest.MonkeyPatch) -> None:
+    """显式传等于 schema 默认的值也算显式（SUPPRESS 精确判定；旧「值==默认值」
+    近似的盲区，epochs 默认 10）。"""
+    monkeypatch.setattr(sys, "argv", ["anima_train.py", "--epochs", "10"])
+    args = at.apply_yaml_config(at.parse_args(), {"epochs": 99})
+    assert args.epochs == 10
 
 
 def test_unknown_yaml_keys_ignored(at, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(sys, "argv", ["anima_train.py"])
-    args = at.parse_args()
-    at.apply_yaml_config(args, {"this_key_doesnt_exist": 42})
+    args = at.apply_yaml_config(at.parse_args(), {"this_key_doesnt_exist": 42})
     assert not hasattr(args, "this_key_doesnt_exist")
+
+
+def test_invalid_yaml_combo_exits(at, monkeypatch: pytest.MonkeyPatch) -> None:
+    """互斥组合经统一加载路径 fail-fast（刀 1 前 trainer 静默放行）。"""
+    monkeypatch.setattr(sys, "argv", ["anima_train.py"])
+    with pytest.raises(SystemExit):
+        at.apply_yaml_config(
+            at.parse_args(),
+            {"infonoise_enabled": True, "loss_weighting": "min_snr"},
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_argparse_bridge.py
+++ b/tests/test_argparse_bridge.py
@@ -127,30 +127,91 @@ def test_cli_alias_overrides_default_flag() -> None:
 
 
 # ---------------------------------------------------------------------------
-# YAML 合并语义
+# YAML 合并语义（刀 1 / R1：suppress parser + namespace_from_config）
 # ---------------------------------------------------------------------------
 
 
-def test_yaml_overrides_when_value_is_default() -> None:
-    parser = bridge.build_parser(_Sample, add_config_arg=False)
-    args = parser.parse_args([])
-    # count 仍是默认 3，YAML 应当覆盖
-    bridge.merge_yaml_into_namespace(args, {"count": 99}, _Sample)
-    assert args.count == 99
+def _sparse(argv: list[str], model_cls=_Sample) -> "bridge.argparse.Namespace":
+    parser = bridge.build_parser(model_cls, add_config_arg=False, suppress_defaults=True)
+    return parser.parse_args(argv)
 
 
-def test_cli_wins_when_user_set_non_default() -> None:
-    parser = bridge.build_parser(_Sample, add_config_arg=False)
-    args = parser.parse_args(["--count", "7"])
-    bridge.merge_yaml_into_namespace(args, {"count": 99}, _Sample)
-    assert args.count == 7  # CLI 优先
+def test_suppress_parser_yields_only_explicit_keys() -> None:
+    """suppress_defaults=True 时 namespace 只含用户显式传入的键。"""
+    assert vars(_sparse([])) == {}
+    ns = _sparse(["--count", "7", "--no-enabled"])
+    assert vars(ns) == {"count": 7, "enabled": False}
+
+
+def test_yaml_fills_fields_cli_did_not_set() -> None:
+    args = _sparse([])
+    merged = bridge.namespace_from_config(args, {"count": 99}, _Sample)
+    assert merged.count == 99
+    # 未出现在 CLI / YAML 的字段落回 schema 默认
+    assert merged.name == "alpha" and merged.enabled is True
+
+
+def test_cli_wins_over_yaml() -> None:
+    args = _sparse(["--count", "7"])
+    merged = bridge.namespace_from_config(args, {"count": 99}, _Sample)
+    assert merged.count == 7  # CLI 优先
+
+
+def test_cli_explicit_default_value_still_wins() -> None:
+    """显式传「恰好等于默认值」的值也算显式 —— 旧「值==默认值」近似的盲区，
+    SUPPRESS 探测下 CLI 精确优先。"""
+    args = _sparse(["--count", "3"])  # 3 == schema 默认
+    merged = bridge.namespace_from_config(args, {"count": 99}, _Sample)
+    assert merged.count == 3
 
 
 def test_yaml_unknown_keys_ignored() -> None:
-    parser = bridge.build_parser(_Sample, add_config_arg=False)
-    args = parser.parse_args([])
-    bridge.merge_yaml_into_namespace(args, {"this_does_not_exist": 123}, _Sample)
-    assert not hasattr(args, "this_does_not_exist")
+    merged = bridge.namespace_from_config(
+        _sparse([]), {"this_does_not_exist": 123}, _Sample
+    )
+    assert not hasattr(merged, "this_does_not_exist")
+
+
+def test_non_schema_namespace_keys_pass_through() -> None:
+    """CLI-only 开关（--interactive 等非 schema 键）原样带回输出 namespace。"""
+    args = _sparse([])
+    args.interactive = True
+    args.monitor_state_file = None
+    merged = bridge.namespace_from_config(args, {"count": 5}, _Sample)
+    assert merged.interactive is True
+    assert merged.monitor_state_file is None
+    assert merged.count == 5
+
+
+def test_namespace_from_config_runs_validators() -> None:
+    """合并结果整体过 pydantic —— 互斥等非法组合 fail-fast，不再静默放行。"""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="loss_weighting"):
+        bridge.namespace_from_config(
+            _sparse([], TrainingConfig),
+            {"infonoise_enabled": True, "loss_weighting": "min_snr"},
+            TrainingConfig,
+        )
+
+
+def test_krea2_pruned_yaml_gets_family_defaults() -> None:
+    """shuffle_caption 拒训 bug 的回归测试（docs/design/config-pipeline-refactor.md §1）：
+
+    krea2 落盘 config 的 shuffle_caption 被 show_when 裁剪不落盘；trainer 加载
+    缺键必须走 FAMILY_CONFIG_DEFAULTS overlay 落回 False（krea2 语义），而不是
+    argparse 裸默认 True（anima 语义）——否则能力校验拒训。
+    """
+    from studio.domain.common import capability_violations
+    from studio.domain.config_prune import prune_inactive_fields
+
+    pruned = prune_inactive_fields(
+        TrainingConfig(model_family="krea2").model_dump(mode="python")
+    )
+    assert "shuffle_caption" not in pruned  # 前提：裁剪确实裁掉了它
+    merged = bridge.namespace_from_config(_sparse([], TrainingConfig), pruned, TrainingConfig)
+    assert merged.shuffle_caption is False
+    assert capability_violations("krea2", vars(merged)) == []
 
 
 # ---------------------------------------------------------------------------
@@ -269,15 +330,16 @@ def test_training_config_cli_cosine_with_warmup() -> None:
 
 def test_training_config_yaml_round_trip() -> None:
     """走完 CLI → YAML 合并这一条路径，确认 yaml_dict 字段都能被读进 args。"""
-    parser = bridge.build_parser(TrainingConfig)
-    args = parser.parse_args([])
-    yaml_data = {
-        "lora_rank": 16,
-        "epochs": 3,
-        "optimizer_type": "prodigy",
-        "prodigy_d_coef": 0.5,
-    }
-    bridge.merge_yaml_into_namespace(args, yaml_data, TrainingConfig)
+    args = bridge.namespace_from_config(
+        _sparse([], TrainingConfig),
+        {
+            "lora_rank": 16,
+            "epochs": 3,
+            "optimizer_type": "prodigy",
+            "prodigy_d_coef": 0.5,
+        },
+        TrainingConfig,
+    )
     assert args.lora_rank == 16
     assert args.epochs == 3
     assert args.optimizer_type == "prodigy"
@@ -313,17 +375,18 @@ def test_training_config_cli_ppsf() -> None:
 
 def test_training_config_yaml_ppsf() -> None:
     """PPSF 字段能通过 YAML 合并到 namespace。"""
-    parser = bridge.build_parser(TrainingConfig)
-    args = parser.parse_args([])
-    yaml_data = {
-        "optimizer_type": "prodigy_plus_schedulefree",
-        "ppsf_d_coef": 0.3,
-        "ppsf_beta1": 0.9,
-        "ppsf_beta2": 0.99,
-        "ppsf_prodigy_steps": 1000,
-        "ppsf_use_stableadamw": True,
-    }
-    bridge.merge_yaml_into_namespace(args, yaml_data, TrainingConfig)
+    args = bridge.namespace_from_config(
+        _sparse([], TrainingConfig),
+        {
+            "optimizer_type": "prodigy_plus_schedulefree",
+            "ppsf_d_coef": 0.3,
+            "ppsf_beta1": 0.9,
+            "ppsf_beta2": 0.99,
+            "ppsf_prodigy_steps": 1000,
+            "ppsf_use_stableadamw": True,
+        },
+        TrainingConfig,
+    )
     assert args.optimizer_type == "prodigy_plus_schedulefree"
     assert args.ppsf_d_coef == 0.3
     assert args.ppsf_beta1 == 0.9

--- a/tests/test_model_family_gating.py
+++ b/tests/test_model_family_gating.py
@@ -1,8 +1,8 @@
-"""model_family schema 门控三层防线 + studio↔runtime 能力矩阵镜像同步（多模型 PR-3）。
+"""model_family schema 门控防线 + studio↔runtime 族数据单源（多模型 PR-3 / 刀 1 R3）。
 
-studio/domain 刻意不 import runtime（trainer cli 反向依赖 + server sys.path），
-FAMILY_CAPABILITIES 是 runtime SPECS 的镜像——本文件是锁死两者同步的唯一机制，
-改任何一侧必须同时改另一侧。
+studio/domain/common.py 是能力矩阵 / 族默认 / 采样白名单的单一权威源，
+runtime SPECS 直接引用（依赖方向 runtime → studio）。本文件锁同一性——
+防止将来有人把引用又复制回字面量、退化成镜像。
 """
 
 from __future__ import annotations
@@ -27,28 +27,41 @@ from studio.domain.config_prune import eval_show_when
 from studio.schema import TrainingConfig
 
 
-def test_capability_matrix_mirrors_runtime_specs():
+def test_capability_matrix_single_source():
+    """SPECS 的 capabilities / config_defaults 必须是 studio 表的同一对象引用。"""
     from training.families import SPECS
 
     assert set(FAMILY_CAPABILITIES) == set(SPECS)
     for fid, spec in SPECS.items():
-        assert FAMILY_CAPABILITIES[fid] == spec.capabilities, (
-            f"studio 镜像与 runtime SPECS['{fid}'].capabilities 失同步"
+        assert spec.capabilities is FAMILY_CAPABILITIES[fid], (
+            f"SPECS['{fid}'].capabilities 不再引用 studio 单源——退化成镜像了"
         )
-        assert FAMILY_CONFIG_DEFAULTS[fid] == dict(spec.config_defaults)
+        assert spec.config_defaults is FAMILY_CONFIG_DEFAULTS[fid], fid
 
 
-def test_sampling_whitelist_mirrors_runtime_specs():
-    """FAMILY_SAMPLING 是 SPECS[fam].sampling 的镜像；首项 = 族默认值。"""
+def test_sampling_whitelist_single_source():
+    """SPECS 的 samplers/schedulers 引用 FAMILY_SAMPLING 单源；首项 = 族默认值。
+    default_sampler/default_scheduler 与 config_defaults 的 sample_* 仍是族内
+    常量（如 KREA2_SAMPLER），锁与单源的一致性。"""
     from training.families import SPECS
 
     assert set(FAMILY_SAMPLING) == set(SPECS)
     for fid, spec in SPECS.items():
-        mirror = FAMILY_SAMPLING[fid]
-        assert mirror["samplers"] == tuple(spec.sampling.samplers), fid
-        assert mirror["schedulers"] == tuple(spec.sampling.schedulers), fid
-        assert mirror["samplers"][0] == spec.sampling.default_sampler, fid
-        assert mirror["schedulers"][0] == spec.sampling.default_scheduler, fid
+        source = FAMILY_SAMPLING[fid]
+        assert spec.sampling.samplers is source["samplers"], fid
+        assert spec.sampling.schedulers is source["schedulers"], fid
+        assert source["samplers"][0] == spec.sampling.default_sampler, fid
+        assert source["schedulers"][0] == spec.sampling.default_scheduler, fid
+        # 族 config_defaults 声明的采样默认值（如 krea2）与 SamplingDefaults 一致
+        cd = spec.config_defaults
+        if "sample_sampler_name" in cd:
+            assert cd["sample_sampler_name"] == spec.sampling.default_sampler, fid
+        if "sample_scheduler" in cd:
+            assert cd["sample_scheduler"] == spec.sampling.default_scheduler, fid
+        if "sample_infer_steps" in cd:
+            assert cd["sample_infer_steps"] == spec.sampling.default_steps, fid
+        if "sample_cfg_scale" in cd:
+            assert cd["sample_cfg_scale"] == spec.sampling.default_cfg, fid
 
 
 def test_timestep_option_gate_targets_registered_strategy():


### PR DESCRIPTION
## 背景

krea2 训练 `shuffle_caption` 拒训 bug 暴露的结构性问题:同一份 config.yaml 有两套「缺失键默认值」语义——Studio 走 pydantic(迁移/族 overlay/校验全生效),trainer 走 argparse bridge(全不生效)。完整设计与决策记录见本 PR 内 `docs/design/config-pipeline-refactor.md`(D1-D7),本 PR 是两刀切分的刀 1。

## R1:trainer 统一走 TrainingConfig 加载路径

- `parse_args` 以 `suppress_defaults=True` 构建 parser:parse 产物只含用户显式传入的键,CLI 显式性由键存在性**精确判定**(取代旧「值==默认值」近似——显式传等于默认值的值现在也正确优先于 YAML)。
- `apply_yaml_config` 改走新的 `namespace_from_config`:YAML + CLI 显式值合并后**整体过 `TrainingConfig` 构造**——字段迁移、`FAMILY_CONFIG_DEFAULTS` 族默认 overlay、互斥与能力校验单点生效;校验失败逐条打印后 `SystemExit(2)`(supervisor 截 stderr 尾部可读)。
- 退役:`merge_yaml_into_namespace`、`apply_yaml_config` 里手工重放的两个迁移调用、runtime 第三层能力防线(统一路径已含 `_validate_family_capabilities`;`resolve_family` 仍负责未知族 fail-fast)。
- 修复 bug 本体:krea2 落盘 config 被 show_when 裁剪的 `shuffle_caption` 缺键,现在落回 krea2 语义 False 而非 argparse 裸默认 True。附回归测试(krea2 裁剪产物过加载路径零 violation)。

**行为变化(D1 已拍板)**:裸 CLI / 手写 yaml 的非法组合(互斥冲突、能力越界)从静默放行改为启动即报错,与 Studio 写盘校验对齐。

## R3:族矩阵单源化

`FAMILY_CAPABILITIES` / `FAMILY_CONFIG_DEFAULTS` / `FAMILY_SAMPLING` 从「studio 镜像 runtime SPECS + 测试双向锁死」改为单源:runtime `ANIMA_SPEC` / `KREA2_SPEC` 直接引用 `studio/domain/common.py`(runtime → studio 依赖方向已存在;common.py 是零依赖纯数据叶子,server / 裸 CLI / tests 三场景都可达)。镜像相等测试改为**同一性断言**,防退化回复制。

## 测试

- 新增:SUPPRESS sparse namespace 语义、CLI 显式默认值优先、CLI-only 键透传、非法组合 fail-fast、shuffle_caption 回归。
- 全量 `tests/` 3032 条本地全绿;端到端用真实 bug 现场 config 验证(缺键→False 可开训;显式 true→清晰报错退出)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)