### PR TITLE
feat(inference): fp8 merge 支持 LoHa + 解除 rs_lora 拒绝

### DIFF
--- a/runtime/training/families/krea2/lora_fp8_merge.py
+++ b/runtime/training/families/krea2/lora_fp8_merge.py
@@ -21,8 +21,9 @@ eager 路径，docs/design/krea2-fp8-inference.md §1.5）：
 - dequant 直落 fp16 域：QuantizedTensor.to(fp16) 只改 orig_dtype 标记
   （ck tensor/base.py _handle_to），dequantize 即 qdata.to(fp16)*scale.to(fp16)，
   无 bf16 中转；fp16 = comfy lora_compute_dtype（should_use_fp16 现代卡）
-- delta 域：comfy weight_adapter lokr/lora——因子 cast fp32 做 mm/kron，
-  ``weight += ((strength * alpha) * diff).type(fp16)``，加法在 fp16 域
+- delta 域：comfy weight_adapter lokr/lora/loha——因子 cast fp32 做
+  mm/kron/Hadamard，``weight += ((strength * alpha) * diff).type(fp16)``，
+  加法在 fp16 域
 - requantize：quant_ops._TensorCoreFP8LayoutBase.quantize 的
   scale="recalculate" + stochastic_rounding 分支
 - SR：comfy/float.py（Generator(device)+manual_seed → randint(0,256,uint8)）
@@ -201,6 +202,23 @@ def _apply_lora_delta(
         lora_diff = torch.mm(
             mat1.flatten(start_dim=1), mat2.flatten(start_dim=1),
         ).reshape(w16.shape)
+        w16 += ((strength * alpha) * lora_diff).type(w16.dtype)
+        return w16
+
+    if "hada_w1_a" in tensors:  # LoHa
+        if "hada_t1" in tensors or "hada_t2" in tensors:
+            raise ValueError(f"fp8 merge 不支持 LoHa tucker（t1/t2）形态：{source} 层 {layer}")
+        m1 = torch.mm(
+            tensors["hada_w1_a"].to(device=device, dtype=torch.float32),
+            tensors["hada_w1_b"].to(device=device, dtype=torch.float32),
+        )
+        m2 = torch.mm(
+            tensors["hada_w2_a"].to(device=device, dtype=torch.float32),
+            tensors["hada_w2_b"].to(device=device, dtype=torch.float32),
+        )
+        # dim 语义照 comfy weight_adapter/loha.py：divisor = w1_b 的 rank 维
+        alpha = float(tensors["alpha"]) / tensors["hada_w1_b"].shape[0] if "alpha" in tensors else 1.0
+        lora_diff = (m1 * m2).reshape(w16.shape)
         w16 += ((strength * alpha) * lora_diff).type(w16.dtype)
         return w16
 

--- a/studio/services/inference/core.py
+++ b/studio/services/inference/core.py
@@ -294,13 +294,17 @@ def apply_loras(
             algo = "lora"         # PEFT 双矩阵 = plain LoRA
 
         if fp8_merge:
-            # merge 是权重级线性操作，与 comfy 一致只认 alpha/dim 缩放——
-            # rs_lora（√rank 缩放）与 DoRA（非线性）在 merge 语义下无法
-            # 与训练语义对齐，提前拒绝
-            if meta.rs_lora or meta.weight_decompose:
+            # merge 是权重级线性操作，只认 per-layer alpha/dim 缩放。
+            # rs_lora 产物无需特判：lycoris 保存时把 √rank 校正烘进
+            # per-layer alpha 键（register_buffer("alpha", α·dim/√dim)，
+            # locon/loha/lokr 同款），标准 alpha/dim merge 得到的正是
+            # α/√rank——与 bf16 注入路径（建网 scale=α/√r）数值一致。
+            # DoRA（列范数归一化，非线性）merge 需要 comfy
+            # weight_decompose 语义，尚未实现，保持拒绝。
+            if meta.weight_decompose:
                 raise ValueError(
-                    f"fp8 量化底模不支持挂载 rs_lora / DoRA 训练的 LoRA："
-                    f"{Path(path).name}。请改用 bf16 版本底模。"
+                    f"fp8 量化底模不支持挂载 DoRA（weight_decompose）训练的 "
+                    f"LoRA：{Path(path).name}。请改用 bf16 版本底模。"
                 )
             merge_sources.append((sd_raw, float(spec.scale), Path(path).name))
             continue

--- a/tests/test_krea2_lora_fp8_merge.py
+++ b/tests/test_krea2_lora_fp8_merge.py
@@ -256,6 +256,68 @@ def test_merge_lokr_matches_comfy_kron_order():
     assert torch.equal(block.m.weight.detach(), expected.to(torch.bfloat16))
 
 
+def test_merge_loha_matches_comfy_hadamard():
+    model = _make_fp8_model()
+    block = model.blocks[0]
+    orig_m = block.m.weight.detach().clone()
+    torch.manual_seed(4)
+    w1a = torch.randn(4, 2, dtype=torch.float16)
+    w1b = torch.randn(2, 4, dtype=torch.float16)
+    w2a = torch.randn(4, 2, dtype=torch.float16)
+    w2b = torch.randn(2, 4, dtype=torch.float16)
+    sd = {
+        "lora_unet_blocks_0_m.hada_w1_a": w1a,
+        "lora_unet_blocks_0_m.hada_w1_b": w1b,
+        "lora_unet_blocks_0_m.hada_w2_a": w2a,
+        "lora_unet_blocks_0_m.hada_w2_b": w2b,
+        "lora_unet_blocks_0_m.alpha": torch.tensor(2.0),
+    }
+
+    merge_loras_into_fp8_model(model, [(sd, 0.5, "loha")])
+
+    diff = (torch.mm(w1a.float(), w1b.float())
+            * torch.mm(w2a.float(), w2b.float())).reshape(4, 4)
+    alpha = 2.0 / w1b.shape[0]  # divisor = w1_b 的 rank 维（comfy loha.py）
+    expected = orig_m.to(torch.float16) + ((0.5 * alpha) * diff).type(torch.float16)
+    assert torch.equal(block.m.weight.detach(), expected.to(torch.bfloat16))
+
+
+def test_merge_loha_no_alpha_means_scale_one():
+    model = _make_fp8_model()
+    block = model.blocks[0]
+    orig_m = block.m.weight.detach().clone()
+    torch.manual_seed(6)
+    sd = {
+        "lora_unet_blocks_0_m.hada_w1_a": torch.randn(4, 2, dtype=torch.float16),
+        "lora_unet_blocks_0_m.hada_w1_b": torch.randn(2, 4, dtype=torch.float16),
+        "lora_unet_blocks_0_m.hada_w2_a": torch.randn(4, 2, dtype=torch.float16),
+        "lora_unet_blocks_0_m.hada_w2_b": torch.randn(2, 4, dtype=torch.float16),
+    }
+
+    merge_loras_into_fp8_model(model, [(sd, 1.0, "loha")])
+
+    diff = (torch.mm(sd["lora_unet_blocks_0_m.hada_w1_a"].float(),
+                     sd["lora_unet_blocks_0_m.hada_w1_b"].float())
+            * torch.mm(sd["lora_unet_blocks_0_m.hada_w2_a"].float(),
+                       sd["lora_unet_blocks_0_m.hada_w2_b"].float())).reshape(4, 4)
+    expected = orig_m.to(torch.float16) + (1.0 * diff).type(torch.float16)
+    assert torch.equal(block.m.weight.detach(), expected.to(torch.bfloat16))
+
+
+def test_merge_rejects_loha_tucker():
+    model = _make_fp8_model()
+    sd = {
+        "lora_unet_blocks_0_q.hada_w1_a": torch.randn(2, 2),
+        "lora_unet_blocks_0_q.hada_w1_b": torch.randn(2, 2),
+        "lora_unet_blocks_0_q.hada_w2_a": torch.randn(2, 2),
+        "lora_unet_blocks_0_q.hada_w2_b": torch.randn(2, 2),
+        "lora_unet_blocks_0_q.hada_t1": torch.randn(2, 2, 1, 1),
+        "lora_unet_blocks_0_q.hada_t2": torch.randn(2, 2, 1, 1),
+    }
+    with pytest.raises(ValueError, match="t1/t2"):
+        merge_loras_into_fp8_model(model, [(sd, 1.0, "t")])
+
+
 def test_merge_rejects_dora_t2_unknown_and_all_miss():
     model = _make_fp8_model()
     dora = _plain_lora_sd(["blocks.0.q"])
@@ -320,7 +382,24 @@ def test_apply_loras_routes_fp8_model_to_merge(tmp_path):
     assert torch.equal(model.blocks[0].q.weight.view(torch.uint8), before)
 
 
-def test_apply_loras_fp8_rejects_rs_lora_and_dora_meta(tmp_path):
+def test_apply_loras_fp8_rejects_dora_meta(tmp_path):
+    from studio.services.inference.core import LoRASpec, apply_loras
+
+    model = _make_fp8_model()
+    path = _write_lora_file(
+        tmp_path, _plain_lora_sd(["blocks.0.q"]),
+        network_args={"algo": "lora", "weight_decompose": True},
+    )
+    with pytest.raises(ValueError, match="DoRA"):
+        apply_loras(
+            model, [LoRASpec(path=path, scale=1.0)], "cpu", torch.float32,
+            family_id="krea2",
+        )
+
+
+def test_apply_loras_fp8_accepts_rs_lora_meta(tmp_path):
+    """rs_lora 产物不再拒绝：lycoris 保存时已把 √rank 校正烘进 per-layer
+    alpha 键，merge 的标准 alpha/dim 公式数值自动正确。"""
     from studio.services.inference.core import LoRASpec, apply_loras
 
     model = _make_fp8_model()
@@ -328,11 +407,15 @@ def test_apply_loras_fp8_rejects_rs_lora_and_dora_meta(tmp_path):
         tmp_path, _plain_lora_sd(["blocks.0.q"]),
         network_args={"algo": "lora", "rs_lora": True},
     )
-    with pytest.raises(ValueError, match="rs_lora / DoRA"):
-        apply_loras(
-            model, [LoRASpec(path=path, scale=1.0)], "cpu", torch.float32,
-            family_id="krea2",
-        )
+    before = model.blocks[0].q.weight.detach().view(torch.uint8).clone()
+
+    adapters = apply_loras(
+        model, [LoRASpec(path=path, scale=1.0)], "cpu", torch.float32,
+        family_id="krea2",
+    )
+
+    assert isinstance(adapters[0], Fp8LoraMergeAdapter)
+    assert not torch.equal(model.blocks[0].q.weight.view(torch.uint8), before)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 改动

### LoHa × fp8 merge
`_apply_lora_delta` 加 LoHa 分支，公式对齐本地 oracle ComfyUI `comfy/weight_adapter/loha.py` 的 `calculate_weight`（Linear 非 tucker 路径）：

- `diff = (w1a@w1b) * (w2a@w2b)`，因子 cast fp32 做 mm/Hadamard
- alpha divisor = `hada_w1_b` 的 rank 维；无 alpha 键 = comfy 缩放 1.0 语义
- tucker（`hada_t1/t2`）形态显式拒绝（与 LoKr t2 / LoCon mid 同款处理）

此前 LoHa 是五个 lora_type 里唯一「训练得出来但 fp8 挂不上」的形态（落到无法识别报错）。

### rs_lora 解除 fp8 拒绝
原拒绝理由「√rank 缩放在 merge 语义下无法与训练对齐」经核对 lycoris 上游被证伪：lycoris 保存产物时把 √rank 校正**烘进 per-layer alpha 键**（`register_buffer("alpha", α·dim/√dim)`，locon/loha/lokr 三处同款）。标准 alpha/dim merge 拿到的正是 α/√r，与 bf16 注入路径（建网 scale=α/√r）数值一致，无需任何特判。这也是 rs_lora 产物在 comfy 生态一直可用的原因。

DoRA（列范数归一化，非线性）维持拒绝——merge 需要移植 comfy `weight_decompose` 语义并核对 strength≠1 时与 lycoris multiplier 的一致性，单独排期。

## 测试
- LoHa 数值对照（bf16 非量化层逐位）/ 无 alpha 缩放 1.0 / tucker 拒绝
- rs_lora metadata 从拒绝测试改为放行测试（走 merge 成功）
- DoRA 拒绝测试改用 weight_decompose metadata
- `test_krea2_lora_fp8_merge.py` 27 + `test_inference_core.py` 20 全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)