### PR TITLE
feat(generate): fp8 底模支持 XY 的 LoRA 强度轴（逐格重 merge）

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -498,13 +498,68 @@ CACHE = ModelCache()
 
 def _set_lora_multiplier(adapter: Any, scale: float) -> None:
     if adapter.network is None:
-        # 含 fp8 merge 句柄（network=None）：scale 已烘进权重，non-scale 轴
-        # 的逐格重置调用安全跳过（lora_scale 轴在 _run_xy 入口已拒绝）
+        # 含 fp8 merge 句柄（network=None）：scale 已烘进权重，逐格设值
+        # 安全跳过（fp8 的 lora_scale 轴由 _cell_lora_configs →
+        # CACHE.apply_loras 重 merge 生效）
         return
     adapter.network.multiplier = float(scale)
     for lora in getattr(adapter.network, "loras", []):
         if hasattr(lora, "multiplier"):
             lora.multiplier = float(scale)
+
+
+def _swap_ckpt_for_axis(spec: dict[str, Any], val: Any,
+                        lora_configs: list[dict[str, Any]]) -> None:
+    """axis=lora_ckpt 时把 lora_configs[lora_index].path 改成 val。"""
+    if spec.get("axis") != "lora_ckpt":
+        return
+    idx = int(spec.get("lora_index") or 0)
+    if 0 <= idx < len(lora_configs):
+        lora_configs[idx]["path"] = str(val)
+
+
+def _cell_lora_configs(
+    x_spec: dict[str, Any],
+    y_spec: dict[str, Any] | None,
+    xv: Any,
+    yv: Any,
+    base_paths: list[str],
+    base_scales: list[float],
+    *,
+    fp8_scale_axes: bool,
+) -> list[dict[str, Any]] | None:
+    """组装本格需要重挂载的 lora_configs；无需重挂载时返回 None。
+
+    - lora_ckpt 轴：按 lora_index 换单条 path（bf16/fp8 都走这里）。
+    - lora_scale 轴仅在 fp8 底模（``fp8_scale_axes=True``）时在这里生效：
+      merge 无常驻 network，改强度必须 detach 还原 + 重 merge——
+      CACHE.apply_loras 对 supports_hot_reload=False 的句柄自动走该路径
+      （lora_ckpt 轴同款），specs 相同的格子被去重零成本跳过。bf16 走
+      _apply_axis 的 multiplier 热换，不进这里。
+      全局轴语义：所有条目 scale=cell 值；x/y 都是 scale 轴时 y 后写赢，
+      与 _apply_axis 的 x→y 调用顺序一致。
+    """
+    x_axis = x_spec.get("axis")
+    y_axis = y_spec.get("axis") if y_spec is not None else None
+    needs = x_axis == "lora_ckpt" or y_axis == "lora_ckpt" or (
+        fp8_scale_axes and "lora_scale" in (x_axis, y_axis)
+    )
+    if not needs:
+        return None
+    configs = [
+        {"path": p, "scale": s} for p, s in zip(base_paths, base_scales)
+    ]
+    _swap_ckpt_for_axis(x_spec, xv, configs)
+    if y_spec is not None and yv is not None:
+        _swap_ckpt_for_axis(y_spec, yv, configs)
+    if fp8_scale_axes:
+        if x_axis == "lora_scale":
+            for lc in configs:
+                lc["scale"] = float(xv)
+        if y_axis == "lora_scale" and yv is not None:
+            for lc in configs:
+                lc["scale"] = float(yv)
+    return configs
 
 
 def _apply_axis(
@@ -837,21 +892,16 @@ def _run_xy(
     y_values = y_spec["values"] if y_spec else [None]
     distilled: bool = bool(cfg.get("distilled", False))
 
-    # fp8 底模的 LoRA 是 merge 进权重的（无常驻 network），lora_scale 轴的
-    # multiplier 原地设值会静默 no-op——每格出一样的图。逐格重 merge（13GB
-    # dequant/requant）当前不提供；lora_ckpt 轴走 CACHE.apply_loras 重注入
-    # （detach 还原 + 重 merge）不受影响。
-    if any(
-        spec is not None and spec.get("axis") == "lora_scale"
-        for spec in (x_spec, y_spec)
-    ):
+    # fp8 底模的 LoRA 是 merge 进权重的（无常驻 network），lora_scale 轴
+    # 不能 multiplier 热换——逐格走 detach 还原 + 重 merge
+    # （_cell_lora_configs 组装 → CACHE.apply_loras，lora_ckpt 轴同款）。
+    # 每个不同 scale 值一次全模型重 merge：scale 放 Y 轴时每行只 merge
+    # 一次（specs 去重），放 X 轴则每格一次。
+    fp8_model = False
+    if CACHE.model is not None:
         from training.families.krea2.quant_fp8 import model_has_fp8_layers
 
-        if CACHE.model is not None and model_has_fp8_layers(CACHE.model):
-            raise ValueError(
-                "fp8 量化底模不支持 XY 的 LoRA 强度轴（LoRA 已合并进权重，"
-                "逐格调整需重新合并）。请改用 bf16 版本底模跑该轴。"
-            )
+        fp8_model = model_has_fp8_layers(CACHE.model)
 
     if base_seed == 0:
         base_seed = random.randint(0, 2**31 - 1)
@@ -862,34 +912,22 @@ def _run_xy(
     total = len(x_values) * len(y_values)
     _emit_for(req_id, "started", task_id=task_id, total=total)
 
-    def _swap_ckpt_for_axis(spec: dict[str, Any], val: Any, lora_configs: list[dict[str, Any]]) -> None:
-        """axis=lora_ckpt 时把 lora_configs[lora_index].path 改成 val。"""
-        if spec.get("axis") != "lora_ckpt":
-            return
-        idx = int(spec.get("lora_index") or 0)
-        if 0 <= idx < len(lora_configs):
-            lora_configs[idx]["path"] = str(val)
-
     img_idx = 0
     image_done_count = 0
     image_errors: list[str] = []
     for yi, yv in enumerate(y_values):
         for xi, xv in enumerate(x_values):
             _raise_if_canceled(cancel_event)
-            # lora_ckpt 切换：mutate cfg.lora_configs 的 path 然后调
-            # CACHE.apply_loras —— commit 20 detach 路径会快速 reinject。
-            x_is_ckpt = x_spec.get("axis") == "lora_ckpt"
-            y_is_ckpt = y_spec is not None and y_spec.get("axis") == "lora_ckpt"
-            if x_is_ckpt or y_is_ckpt:
-                lora_configs = [
-                    {"path": p, "scale": s}
-                    for p, s in zip(base_lora_paths, base_scales)
-                ]
-                _swap_ckpt_for_axis(x_spec, xv, lora_configs)
-                if y_spec is not None and yv is not None:
-                    _swap_ckpt_for_axis(y_spec, yv, lora_configs)
+            # lora_ckpt 换文件 /（fp8 时）lora_scale 换强度：组装本格
+            # lora_configs 调 CACHE.apply_loras —— detach 还原 + 重挂载
+            # （bf16 reinject / fp8 重 merge）。base_paths/base_scales 是
+            # 循环外快照，格间互不污染。
+            lora_configs = _cell_lora_configs(
+                x_spec, y_spec, xv, yv, base_lora_paths, base_scales,
+                fp8_scale_axes=fp8_model,
+            )
+            if lora_configs is not None:
                 adapters = CACHE.apply_loras(lora_configs)
-                base_scales = [float(s.scale) for s in CACHE.last_lora_specs]
 
             for i, s in enumerate(base_scales):
                 if i < len(adapters):

--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -348,15 +348,17 @@ def _run_xy_matrix(
             "CLI runner anima_generate.py 不支持热切换 LoRA 文件"
         )
 
-    # fp8 底模的 LoRA 是 merge 进权重的（无常驻 network），lora_scale 轴的
-    # multiplier 原地设值会静默 no-op——每格出一样的图（daemon 侧同款拒绝）
+    # fp8 底模的 LoRA 是 merge 进权重的（无常驻 network），lora_scale 轴
+    # 需要逐格 detach + 重 merge——daemon 的 CACHE.apply_loras 路径已支持
+    # （_cell_lora_configs）；CLI runner 无缓存管理，与 lora_ckpt 轴同款
+    # 不接入。
     if x_spec.get("axis") == "lora_scale" or (y_spec and y_spec.get("axis") == "lora_scale"):
         from training.families.krea2.quant_fp8 import model_has_fp8_layers
 
         if model_has_fp8_layers(model):
-            raise ValueError(
-                "fp8 量化底模不支持 XY 的 LoRA 强度轴（LoRA 已合并进权重，"
-                "逐格调整需重新合并）。请改用 bf16 版本底模跑该轴。"
+            raise NotImplementedError(
+                "fp8 底模的 LoRA 强度轴需逐格重新合并，走 daemon path "
+                "(runtime/anima_daemon.py)；CLI runner 请改用 bf16 底模。"
             )
 
     if base_seed == 0:

--- a/tests/test_daemon_xy_fp8_scale.py
+++ b/tests/test_daemon_xy_fp8_scale.py
@@ -1,0 +1,106 @@
+"""daemon XY 的 fp8 lora_scale 轴：_cell_lora_configs 组装逻辑。
+
+fp8 底模的 LoRA 是 merge 进权重的，lora_scale 轴不能 multiplier 热换——
+逐格组装 lora_configs 走 CACHE.apply_loras（detach 还原 + 重 merge，
+lora_ckpt 轴同款路径）。bf16 底模的 scale 轴维持 _apply_axis 的
+multiplier 热换（返回 None 不重挂载）。
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# 同 test_anima_generate_xy.py：让 import anima_daemon 找到 runtime/ 邻居
+_REPO = Path(__file__).resolve().parent.parent
+for _p in (_REPO, _REPO / "runtime"):
+    s = str(_p)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+
+import anima_daemon  # noqa: E402
+
+_cell = anima_daemon._cell_lora_configs
+
+_PATHS = ["a.safetensors", "b.safetensors"]
+_SCALES = [0.8, 0.6]
+
+
+def test_bf16_scale_axis_returns_none() -> None:
+    """bf16（fp8_scale_axes=False）scale 轴走 multiplier 热换，不重挂载。"""
+    out = _cell(
+        {"axis": "lora_scale", "values": []}, None, 0.3, None,
+        _PATHS, _SCALES, fp8_scale_axes=False,
+    )
+    assert out is None
+
+
+def test_non_lora_axes_return_none() -> None:
+    out = _cell(
+        {"axis": "steps"}, {"axis": "cfg_scale"}, 20, 3.5,
+        _PATHS, _SCALES, fp8_scale_axes=True,
+    )
+    assert out is None
+
+
+def test_fp8_x_scale_sets_all_entries() -> None:
+    out = _cell(
+        {"axis": "lora_scale"}, {"axis": "steps"}, 0.3, 20,
+        _PATHS, _SCALES, fp8_scale_axes=True,
+    )
+    assert out == [
+        {"path": "a.safetensors", "scale": 0.3},
+        {"path": "b.safetensors", "scale": 0.3},
+    ]
+
+
+def test_fp8_y_scale_sets_all_entries() -> None:
+    out = _cell(
+        {"axis": "steps"}, {"axis": "lora_scale"}, 20, 0.9,
+        _PATHS, _SCALES, fp8_scale_axes=True,
+    )
+    assert all(lc["scale"] == 0.9 for lc in out)
+    assert [lc["path"] for lc in out] == _PATHS
+
+
+def test_fp8_both_scale_axes_y_wins() -> None:
+    """x/y 都是 scale 轴时 y 后写赢——与 _apply_axis 的 x→y 顺序一致。"""
+    out = _cell(
+        {"axis": "lora_scale"}, {"axis": "lora_scale"}, 0.3, 0.9,
+        _PATHS, _SCALES, fp8_scale_axes=True,
+    )
+    assert all(lc["scale"] == 0.9 for lc in out)
+
+
+def test_fp8_scale_with_ckpt_axis_combined() -> None:
+    """x=scale + y=ckpt：path 换（按 lora_index）+ scale=cell 值同时生效。"""
+    out = _cell(
+        {"axis": "lora_scale"},
+        {"axis": "lora_ckpt", "lora_index": 1},
+        0.5, "c.safetensors",
+        _PATHS, _SCALES, fp8_scale_axes=True,
+    )
+    assert out == [
+        {"path": "a.safetensors", "scale": 0.5},
+        {"path": "c.safetensors", "scale": 0.5},
+    ]
+
+
+def test_ckpt_axis_keeps_base_scales() -> None:
+    """ckpt 轴（bf16/fp8 通用）只换 path，scale 保持循环外快照。"""
+    out = _cell(
+        {"axis": "lora_ckpt", "lora_index": 0}, None, "c.safetensors", None,
+        _PATHS, _SCALES, fp8_scale_axes=False,
+    )
+    assert out == [
+        {"path": "c.safetensors", "scale": 0.8},
+        {"path": "b.safetensors", "scale": 0.6},
+    ]
+
+
+def test_single_axis_y_none() -> None:
+    """单轴（y_spec=None）时 yv=None 不参与。"""
+    out = _cell(
+        {"axis": "lora_scale"}, None, 0.4, None,
+        _PATHS, _SCALES, fp8_scale_axes=True,
+    )
+    assert all(lc["scale"] == 0.4 for lc in out)


### PR DESCRIPTION
## 背景

fp8 底模的 LoRA 是 merge 进权重的（无常驻 network），`lora_scale` 轴的 multiplier 热换无处可设，此前在 `_run_xy` 入口直接拒绝。而 `lora_ckpt` 轴早已支持 fp8——每格 mutate lora_configs 走 `CACHE.apply_loras`（对 `supports_hot_reload=False` 的 merge 句柄自动 detach 还原 + 重 merge）。本 PR 让 `lora_scale` 轴走完全同一条已验证路径。

## 改动

- **daemon `_run_xy`**：解除 fp8+lora_scale 拒绝。格内组装抽成纯函数 `_cell_lora_configs`：lora_ckpt 换 path（bf16/fp8 通用）+ fp8 时 lora_scale 轴全局覆盖 scale（所有条目=cell 值，与 bf16 multiplier 路径的全局轴语义一致；x/y 双 scale 轴 y 后写赢，对齐 `_apply_axis` 的 x→y 顺序）。无需重挂载的格子返回 None。
- **bf16 零倒退**：非 fp8 时 scale 轴照旧走 `_apply_axis` 的 multiplier 热换（`_cell_lora_configs` 返回 None）。
- **快照防污染**：删除格内 `base_scales` 从 `CACHE.last_lora_specs` 的刷新——fp8 scale 轴时 cell 值会污染下一格的组装基准（ckpt 场景该刷新本是恒等）。
- **CLI runner**：与 lora_ckpt 轴同款不接入（无缓存管理），拒绝从 ValueError 改为指路 daemon 的 NotImplementedError。

## 成本口径

每个不同 scale 值一次全模型重 merge（detach 回拷 CPU 备份 + 264 层 dequant/delta/requant/SR）。`CACHE.apply_loras` 的 specs 去重使相同值的格子零成本跳过：**scale 放 Y 轴每行只 merge 一次，放 X 轴则每格一次**。相对每格几十秒的采样时间可接受。

## 测试

`tests/test_daemon_xy_fp8_scale.py`（8 条）：bf16 返回 None / fp8 x 轴 / y 轴 / 双 scale 轴 y 赢 / scale+ckpt 组合 / ckpt 保持 base scale / 单轴 / 非 LoRA 轴。加上既有 XY 套件共 42 条全绿。

真卡验证建议：fp8 + 单 LoRA + x=lora_scale [0.0, 0.5, 1.0]——0.0 格应与无 LoRA 出图一致，三格图应有可见差异。

🤖 Generated with [Claude Code](https://claude.com/claude-code)