### PR TITLE
feat(train): krea2 fp8 底模训练支持（fp8_base）+ 下载中心官方 Raw fp8

### DIFF
--- a/docs/todo/krea2-vram-orchestration.md
+++ b/docs/todo/krea2-vram-orchestration.md
@@ -70,3 +70,23 @@ CPU → 采样。三个问题：
 
 daemon/family.sample_image 编排触点 + TE 初始 device + Krea2TextStack 在线
 LRU + 配置三件套（schema/Settings/i18n）+ 测试（判据分支/缓存命中/三档）。
+
+## 后续：TE（Qwen3-VL）fp8——生成侧专属（2026-07-17 拍板）
+
+TE 权重 fp8 存储（8.9GB → ~5GB），compute 维持 fp32（P-2 parity 不动）：
+
+- **收益面在生成侧**：32GB 同驻余量 +3.7GB（大分辨率更稳）；16GB 编排的
+  TE 让位/上卡搬运量近半——「内存吞吐压力」主要在这。encode 频率经在线
+  LRU 后本就低，吞吐无感。
+- **训练侧不引入**：两段式加载下 TE 只在 text cache 阶段上卡（DiT 未加载，
+  阶段峰值 ~9GB 远低于 DiT 阶段），fp8 省的显存不在训练峰值路径上；且
+  fp8 编码嵌入与 bf16 有微差，引入需给文本缓存指纹加 TE 精度维度——为
+  零收益付复杂度，不做。
+- **实现路径选 load-time rescale**（与 DiT 相反）：官方
+  `qwen3vl_4b_fp8_scaled.safetensors`（5.24GB）是 comfy 单文件布局，而
+  我们 TE loader 是 transformers HF 目录 `from_pretrained`（tokenizer 也
+  依赖该目录，comfy 单文件无 tokenizer）——接官方文件要写 comfy→HF 键
+  映射 + 混合加载，成本高。改为 HF bf16 目录照常加载后逐 Linear cast
+  fp8 + per-tensor scale，复用 `patch_fp8_linears` 机制（该函数本就族/
+  模型无关）。Embedding 表保持高精度不量化（comfy 同款范围）。
+- 时机：16GB 编排真机验证时一起做（收益最大场景），或作为独立小刀。

--- a/runtime/training/families/krea2/loader.py
+++ b/runtime/training/families/krea2/loader.py
@@ -43,9 +43,9 @@ _FLOAT_DTYPES = {
     "F32",
     "F64",
 }
-# fp8 是运行时量化技术（load-time 量化 + Linear forward patch + scale buffer），
-# 不是 checkpoint 交换格式——社区的「纯 fp8 cast」权重若静默 upcast 回 bf16，
-# 显存零收益还丢精度（A7'/C13）。显式报错并指路 bf16 版本。
+# fp8 权重原样常驻 + Linear forward 逐层 dequant（quant_fp8）。推理与训练
+# （fp8_base：底模 frozen，LoRA 参数全精度，kohya/musubi 生态标准做法）都
+# 支持——绝不静默 upcast 回 bf16（显存零收益丢精度，A7'/C13）。
 _FP8_DTYPES = {"F8_E4M3", "F8_E5M2"}
 
 
@@ -140,7 +140,8 @@ def _inspect(
         all_source_keys = list(handle.keys())
         prefix = _choose_prefix(all_source_keys, expected_keys)
         # fp8_scaled 的 per-layer scale 键：归一后形如 blocks.N.xxx.weight_scale。
-        # 只在 allow_fp8 时剥离；训练路径它们会照旧落进「多出」报错。
+        # 只在 allow_fp8 时剥离；显式 allow_fp8=False 的调用面它们照旧落进
+        # 「多出」报错。
         scale_to_source: dict[str, str] = {}
         source_keys = []
         for source_key in all_source_keys:
@@ -187,8 +188,7 @@ def _inspect(
         if fp8_keys and not allow_fp8:
             raise ValueError(
                 f"Krea2 checkpoint 含 fp8 参数（{len(fp8_keys)} 个，如 "
-                f"{fp8_keys[0]}）。fp8 权重仅推理（测试出图）支持；训练需要"
-                f"全精度梯度——请下载 bf16 版本权重（官方 Raw/Turbo 均为 bf16）。"
+                f"{fp8_keys[0]}），但调用方要求全精度权重。"
             )
         # fp8_scaled 一致性：有 scale 的层权重必须是 fp8；metadata 声明的层
         # 若既无 fp8 权重也无 scale 属异常文件
@@ -238,9 +238,30 @@ def inspect_krea2_checkpoint(
     *,
     config: Krea2Config = KREA2_CONFIG,
 ) -> Krea2CheckpointInfo:
-    """Validate keys and shapes from the safetensors header without reading payloads."""
-    info, _, _ = _inspect(path, config)
+    """Validate keys and shapes from the safetensors header without reading payloads.
+
+    bf16 与 fp8（scaled / 纯 cast）两种形态都是合法 checkpoint。
+    """
+    info, _, _ = _inspect(path, config, allow_fp8=True)
     return info
+
+
+def checkpoint_contains_fp8(path: str | Path) -> bool:
+    """轻量探测：safetensors header 里是否有 fp8 权重（不读 payload）。
+
+    供训练启动期防呆用（fp8 底模 + grad_checkpoint 关闭等组合要 fail-fast，
+    不能等 13GB 加载完才崩）。非 safetensors / 读失败返回 False——真正的
+    结构校验由 loader 兜底。
+    """
+    try:
+        checkpoint = _checkpoint_path(path)
+        with safe_open(str(checkpoint), framework="pt", device="cpu") as handle:
+            return any(
+                handle.get_slice(key).get_dtype() in _FP8_DTYPES
+                for key in handle.keys()
+            )
+    except Exception:
+        return False
 
 
 def load_krea2_model(
@@ -253,16 +274,19 @@ def load_krea2_model(
 ) -> SingleStreamDiT:
     """Strict-load a single-file Krea2 checkpoint into a frozen meta-created model.
 
-    ``purpose="generate"``（推理路径）允许 fp8 权重（纯 cast 与 fp8_scaled 两种
-    形态）：fp8 张量原样常驻显存，Linear 前向逐层 dequant 到 compute dtype
-    （ComfyUI parity，见 quant_fp8）。训练路径（默认）维持 bf16 全精度拒绝语义。
+    fp8 权重（纯 cast 与 fp8_scaled 两种形态）推理与训练都接受：fp8 张量
+    原样常驻显存，Linear 前向逐层 dequant 到 compute dtype（ComfyUI parity，
+    见 quant_fp8）。训练即 kohya/musubi 生态的 fp8_base 语义——底模 frozen
+    无梯度，LoRA 参数全精度；显存收益依赖 grad checkpointing（dequant 临时
+    权重随重算段释放），该约束由 trainer 启动期校验强制（phases/models）。
+    ``purpose`` 当前不影响加载行为，保留作调用面语义标注。
     """
     if dtype not in {torch.float16, torch.bfloat16, torch.float32, torch.float64}:
         raise ValueError(f"Krea2 loader 不支持 dtype={dtype}")
     target_device = torch.device(device)
     if target_device.type == "meta":
         raise ValueError("Krea2 loader 的目标 device 不能是 meta")
-    allow_fp8 = purpose != "train"
+    allow_fp8 = True
 
     model, expected_shapes = _expected_state(config)
     _, normalized_to_source, scale_to_source = _inspect(

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -142,11 +142,49 @@ def _defer_dit_for_text_cache(ctx: TrainingContext) -> bool:
     )
 
 
+def _validate_fp8_base(ctx: TrainingContext) -> None:
+    """fp8 底模（fp8_base 训练）的组合校验——fail-fast 于任何大加载之前。
+
+    探测只读 safetensors header（毫秒级），非 fp8 底模零开销直通。目前只有
+    krea2 loader 接受 fp8 checkpoint（Anima loader 自行拒绝），但探测本身
+    族无关。两条硬约束：
+
+    - grad_checkpoint 必须开：fp8 的显存收益依赖重算段释放逐层 dequant 的
+      临时权重；不开则 autograd 全量驻留 264 层 bf16 副本，占用反超 bf16。
+    - DoRA 不支持：lycoris weight_decompose 初始化读底模权重数值（范数），
+      fp8 直接 cast 缺 scale 校正，数值不正确（与推理/merge 拒绝口径一致）。
+    """
+    from training.families.krea2.loader import checkpoint_contains_fp8
+
+    args = ctx.args
+    if not checkpoint_contains_fp8(getattr(args, "transformer_path", "") or ""):
+        return
+    problems = []
+    if not bool(getattr(args, "grad_checkpoint", True)):
+        problems.append(
+            "grad_checkpoint=false：fp8 底模的逐层 dequant 临时权重会被 "
+            "autograd 全量驻留，显存占用反超 bf16。请开启梯度检查点。"
+        )
+    if bool(getattr(args, "lora_dora", False)):
+        problems.append(
+            "lora_dora=true：DoRA 初始化读取底模权重数值，fp8 存储下数值"
+            "不正确。请关闭 DoRA 或改用 bf16 底模。"
+        )
+    if problems:
+        raise RuntimeError(
+            "fp8 底模与当前配置不兼容：\n- " + "\n- ".join(problems)
+        )
+    logger.info(
+        "检测到 fp8 底模：以 fp8_base 语义训练（权重常驻 fp8，前向逐层 dequant）"
+    )
+
+
 def run(ctx: TrainingContext) -> None:
     """Resolve paths and load either the complete stack or the cache-first half."""
     if ctx.family is None:
         ctx.family = resolve_family(ctx.args)
     _resolve_paths(ctx)
+    _validate_fp8_base(ctx)
 
     if _defer_dit_for_text_cache(ctx):
         logger.info(

--- a/studio/services/models/downloader.py
+++ b/studio/services/models/downloader.py
@@ -118,7 +118,8 @@ def download_krea2_main(
         on_log(f"✗ 未知 Krea 2 variant {variant!r}")
         return False
     target = krea2_main_target(root, variant)
-    on_log(f"\n📥 Krea 2 [{variant}] (~26.3 GB) → {target}")
+    size_gb = float(info.get("size_estimate", 0)) / 1e9
+    on_log(f"\n📥 Krea 2 [{variant}] (~{size_gb:.1f} GB) → {target}")
     if _sources._source_for("training") == "modelscope":
         return _sources.download_flat_ms(
             str(info["ms_repo"]), str(info["ms_subpath"]), target, on_log=on_log,

--- a/studio/services/models/families/krea2.py
+++ b/studio/services/models/families/krea2.py
@@ -23,6 +23,19 @@ KREA2_VARIANTS: dict[str, dict[str, Any]] = {
         "purpose": "training",
         "size_estimate": 26_300_000_000,
     },
+    # Comfy-Org 官方量化管线的 fp8_scaled Raw：训练（fp8_base，权重显存
+    # 25.6→13.1GB，24GB 卡可训）与推理（fp8 出图链）双用途。purpose 维持
+    # training——is_distilled_path 按 purpose=inference 判 Turbo 蒸馏，
+    # 本文件是 Raw（非蒸馏）不能标 inference。
+    "raw_fp8": {
+        "repo": "Comfy-Org/Krea-2",
+        "subpath": "diffusion_models/krea2_raw_fp8_scaled.safetensors",
+        "ms_repo": "Comfy-Org/Krea-2",
+        "ms_subpath": "diffusion_models/krea2_raw_fp8_scaled.safetensors",
+        "filename": "krea2-raw-fp8-scaled.safetensors",
+        "purpose": "training",
+        "size_estimate": 13_100_000_000,
+    },
     "turbo": {
         "repo": "krea/Krea-2-Turbo",
         "subpath": "turbo.safetensors",
@@ -202,7 +215,10 @@ def catalog_sections(root: Path, models_cfg: Any) -> dict[str, Any]:
         "krea2_main": {
             "id": "krea2_main",
             "name": "Krea 2 主模型",
-            "description": "Raw 训练底模 / Turbo 推理底模（各约 26.3 GB）",
+            "description": (
+                "Raw 训练底模（bf16 26.3 GB；fp8 13.1 GB，训练/出图权重"
+                "显存减半）/ Turbo 推理底模（26.3 GB）"
+            ),
             "repo": "krea/Krea-2-{Raw,Turbo}",
             "variants": variants,
             "custom": custom_models,

--- a/tests/test_family_assets.py
+++ b/tests/test_family_assets.py
@@ -111,8 +111,10 @@ def test_krea2_catalog_sections_report_raw_turbo_and_text_encoder(tmp_path):
     sections = get_assets("krea2").catalog_sections(tmp_path, cfg)
     assert set(sections) == {"krea2_main", "krea2_text_encoder"}
     main = sections["krea2_main"]
-    assert [v["variant"] for v in main["variants"]] == ["raw", "turbo"]
-    assert [v["purpose"] for v in main["variants"]] == ["training", "inference"]
+    assert [v["variant"] for v in main["variants"]] == ["raw", "raw_fp8", "turbo"]
+    assert [v["purpose"] for v in main["variants"]] == [
+        "training", "training", "inference",
+    ]
     assert main["selected"] == str(custom)
     assert main["custom"] == [{
         "path": str(custom),

--- a/tests/test_generate_family.py
+++ b/tests/test_generate_family.py
@@ -43,6 +43,8 @@ def test_is_distilled_path_by_official_variant():
     krea2 = get_assets("krea2")
     assert krea2.is_distilled_path("G:/models/diffusion_models/krea2-turbo-bf16.safetensors")
     assert not krea2.is_distilled_path("G:/models/diffusion_models/krea2-raw-bf16.safetensors")
+    # fp8 Raw 是非蒸馏训练/推理底模——绝不能被 purpose 逻辑误判成 Turbo
+    assert not krea2.is_distilled_path("G:/models/diffusion_models/krea2-raw-fp8-scaled.safetensors")
     # custom 权重无 purpose 元数据 → 非蒸馏（A1：不加白名单，参数用户控制）
     assert not krea2.is_distilled_path("G:/models/my-community-turbo-mix.safetensors")
     assert not krea2.is_distilled_path("")

--- a/tests/test_krea2_loader.py
+++ b/tests/test_krea2_loader.py
@@ -157,6 +157,9 @@ def test_load_validates_header_before_reading_payload(
         def __exit__(self, *_args) -> None:
             return None
 
+        def metadata(self) -> None:
+            return None
+
         def keys(self):
             return expected.keys()
 
@@ -274,9 +277,9 @@ def test_load_rejects_meta_target_device(tmp_path: Path) -> None:
         )
 
 
-def test_inspect_rejects_fp8_checkpoint_with_actionable_error(tmp_path: Path) -> None:
-    """纯 fp8 cast 权重（社区推理格式）→ 显式报错，不静默 upcast 回 bf16
-    （显存零收益 + 丢精度，A7'/C13）。文案指路 bf16 版本。"""
+def test_inspect_accepts_fp8_checkpoint(tmp_path: Path) -> None:
+    """fp8（纯 cast）是合法 checkpoint 形态——inspect 校验通过（推理与
+    fp8_base 训练都支持，不再有全精度拒绝语义）。"""
     config = _tiny_config()
     state_dict = _state_dict(config)
     fp8_state = {
@@ -285,8 +288,8 @@ def test_inspect_rejects_fp8_checkpoint_with_actionable_error(tmp_path: Path) ->
     checkpoint = tmp_path / "fp8.safetensors"
     _write_checkpoint(checkpoint, fp8_state)
 
-    with pytest.raises(ValueError, match="fp8"):
-        inspect_krea2_checkpoint(checkpoint, config=config)
+    info = inspect_krea2_checkpoint(checkpoint, config=config)
+    assert info.key_count == len(state_dict)
 
 
 def _write_fp8_scaled_checkpoint(path: Path, state_dict, *, with_metadata=True):
@@ -369,12 +372,91 @@ def test_generate_purpose_loads_pure_fp8_cast(tmp_path: Path) -> None:
     torch.testing.assert_close(module(x), expected, rtol=0, atol=0)
 
 
-def test_train_purpose_still_rejects_fp8_scaled(tmp_path: Path) -> None:
-    """训练路径对两种 fp8 形态维持拒绝（梯度需要全精度）。"""
+def test_train_purpose_loads_fp8_scaled_frozen_with_dequant(tmp_path: Path) -> None:
+    """fp8_base 训练：purpose=train 接受 fp8_scaled，权重常驻 fp8 + dequant
+    前向 + 全模型 frozen（底模无梯度，LoRA 参数在 adapter 侧全精度）。"""
     from training.families.krea2.loader import load_krea2_model
 
     config = _tiny_config()
+    reference = _state_dict(config)
     checkpoint = tmp_path / "fp8_scaled.safetensors"
-    _write_fp8_scaled_checkpoint(checkpoint, _state_dict(config))
-    with pytest.raises(ValueError):
-        load_krea2_model(checkpoint, "cpu", torch.bfloat16, config=config)
+    layers = _write_fp8_scaled_checkpoint(checkpoint, reference)
+
+    model = load_krea2_model(checkpoint, "cpu", torch.bfloat16, config=config,
+                             purpose="train")
+    quantized = {
+        name for name, module in model.named_modules()
+        if isinstance(module, torch.nn.Linear)
+        and module.weight.dtype == torch.float8_e4m3fn
+    }
+    assert quantized == set(layers)
+    assert all(not p.requires_grad for p in model.parameters())
+
+
+def test_checkpoint_contains_fp8_probe(tmp_path: Path) -> None:
+    """header 级探测：bf16 → False；fp8 → True；坏路径 → False 不抛。"""
+    from training.families.krea2.loader import checkpoint_contains_fp8
+
+    config = _tiny_config()
+    reference = _state_dict(config)
+    bf16 = tmp_path / "bf16.safetensors"
+    _write_checkpoint(bf16, reference)
+    fp8 = tmp_path / "fp8.safetensors"
+    _write_fp8_scaled_checkpoint(fp8, reference)
+
+    assert checkpoint_contains_fp8(bf16) is False
+    assert checkpoint_contains_fp8(fp8) is True
+    assert checkpoint_contains_fp8(tmp_path / "missing.safetensors") is False
+
+
+# ---------------------------------------------------------------------------
+# 启动期防呆（phases/models._validate_fp8_base）
+# ---------------------------------------------------------------------------
+
+
+def _fp8_ctx(tmp_path: Path, **arg_overrides):
+    """duck-typed TrainingContext：_validate_fp8_base 只读 ctx.args。"""
+    from types import SimpleNamespace
+
+    checkpoint = tmp_path / "fp8_scaled.safetensors"
+    if not checkpoint.exists():
+        _write_fp8_scaled_checkpoint(checkpoint, _state_dict(_tiny_config()))
+    args = SimpleNamespace(
+        transformer_path=str(checkpoint),
+        grad_checkpoint=True,
+        lora_dora=False,
+    )
+    for key, value in arg_overrides.items():
+        setattr(args, key, value)
+    return SimpleNamespace(args=args)
+
+
+def test_validate_fp8_base_passes_with_checkpointing(tmp_path: Path) -> None:
+    from training.phases.models import _validate_fp8_base
+
+    _validate_fp8_base(_fp8_ctx(tmp_path))  # 不抛
+
+
+def test_validate_fp8_base_rejects_no_grad_checkpoint(tmp_path: Path) -> None:
+    """fp8 底模 + 关闭梯度检查点 → dequant 临时权重全量驻留，显存反超
+    bf16——启动期 fail-fast，不等 13GB 加载后才崩。"""
+    from training.phases.models import _validate_fp8_base
+
+    with pytest.raises(RuntimeError, match="grad_checkpoint"):
+        _validate_fp8_base(_fp8_ctx(tmp_path, grad_checkpoint=False))
+
+
+def test_validate_fp8_base_rejects_dora(tmp_path: Path) -> None:
+    from training.phases.models import _validate_fp8_base
+
+    with pytest.raises(RuntimeError, match="DoRA|lora_dora"):
+        _validate_fp8_base(_fp8_ctx(tmp_path, lora_dora=True))
+
+
+def test_validate_fp8_base_noop_for_bf16(tmp_path: Path) -> None:
+    from training.phases.models import _validate_fp8_base
+
+    bf16 = tmp_path / "bf16.safetensors"
+    _write_checkpoint(bf16, _state_dict(_tiny_config()))
+    ctx = _fp8_ctx(tmp_path, transformer_path=str(bf16), grad_checkpoint=False)
+    _validate_fp8_base(ctx)  # bf16 底模不受 fp8 约束


### PR DESCRIPTION
## 背景

krea2 bf16 训练权重常驻 25.6GB，32GB 卡余量≈0（Phase 0 实测口径）。显存优化方案讨论后拍板：**接入官方 Comfy-Org `krea2_raw_fp8_scaled.safetensors`（13.1GB）做 fp8_base 训练**——量化由官方管线完成（含层排除清单），不自写 rescale；block swap 留作 16GB 需求出现后的独立刀。

**权重显存 25.6GB → 13.1GB，训练峰值 ~17-18GB，训练下限 32GB → 24GB。**

## 改动

- **loader 训练路径放开 fp8**：`allow_fp8` 恒开，fp8 权重原样常驻 + Linear 逐层 dequant 前向（复用推理链 `patch_fp8_linears`，零新解析代码）。即 kohya/musubi 生态的 `fp8_base` 语义：底模 frozen 无梯度，LoRA 参数全精度。不加配置字段——用户选 fp8 文件当底模就是显式意图，按文件 dtype 分派。
- **启动期防呆**（`phases/models._validate_fp8_base`，header 毫秒级探测，任何大加载前 fail-fast）：
  - fp8 + `grad_checkpoint=false` → 拒：显存收益依赖重算段释放 dequant 临时权重，不开则 autograd 全量驻留 264 层 bf16 副本，占用反超 bf16
  - fp8 + `lora_dora` → 拒：DoRA init 读底模权重数值，fp8 下不正确（与推理/merge 拒绝口径一致）
- **下载中心**：krea2 catalog 加 `raw_fp8` variant（数据驱动，downloader/前端零改动；purpose=training——不能标 inference 否则被 `is_distilled_path` 误判 Turbo 蒸馏）。
- **docs**：TE（Qwen3-VL）fp8 计划记入 `docs/todo/krea2-vram-orchestration.md`——生成侧专属（训练侧零收益不引入），load-time rescale 路径，随 16GB 编排排期。

## LoRA 兼容性论证（代码核实，无需改动）

- lycoris `apply_to()` 保存的 `org_forward` 就是 patch 后的 dequant forward（patch 在 loader 内、inject 在 phase 后，顺序天然正确）；bypass / rebuild 两条 forward 路径都是 `org_forward(x) + delta(x)`，delta 由 LoRA 参数独立合成，不碰 org 权重数值 → lokr/lora/loha/tlora 全兼容
- ortho / tlora（默认 ortho 配方）：SVD 只用 U/V 基（丢奇异值），基对 per-tensor 标量 scale 不变；`basis_dtype` 白名单对 fp8 落 fp32 fallback → 无需修改
- per-block `torch.utils.checkpoint`（non-reentrant）已就位，是 dequant 临时权重不驻留的前提

## 测试

train 加载 fp8 + 全 frozen / header 探测三态 / 防呆四条（过、拒 no-ckpt、拒 DoRA、bf16 直通）/ catalog variant 断言 / is_distilled 非蒸馏。全量 3066 绿。

## 真卡验证建议

下载 raw_fp8 → 现有 A8 项目直接训一轮：加载期显存应 ~13GB（对照 bf16 ~26GB）、step 显存峰值 ~18GB、step 0 采样图正常（fp8 推理链）、loss 曲线与 bf16 底模训练大体一致（量化噪声内）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)