### PR TITLE
feat(train/eval/reg): 旁路出图与训练接入统一显存/内存编排

### DIFF
--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -258,6 +258,28 @@ def _rewrite_json_caption_for_prompt(caption_path: Path, excluded_tags: set[str]
     return prompt
 
 
+def _peek_prompt_for_image(train_img_path: Path, excluded_tags: set[str]) -> str | None:
+    """纯读派生 prompt（分批预编码用）——不拷贝、不改写任何文件。
+
+    与循环内 _copy_caption_for_reg + _rewrite_caption_for_prompt 的产物
+    逐字一致（同源文件同规则），保证出图时在线 LRU 精确命中。寻源失败 /
+    读取失败返回 None（该条回退循环内惰性编码）。
+    """
+    src = _caption_path_for_image(train_img_path)
+    if src is None:
+        return None
+    try:
+        if src.suffix == ".json":
+            raw = json.loads(src.read_text(encoding="utf-8"))
+            normalized = normalize_caption_json(raw if isinstance(raw, dict) else {})
+            return caption_json_to_text(
+                _filter_normalized_caption(normalized, excluded_tags)
+            )
+        return _build_prompt_from_caption(src, excluded_tags)
+    except Exception:
+        return None
+
+
 def _rewrite_caption_for_prompt(caption_path: Path, excluded_tags: set[str]) -> str:
     """Persist the reg sidecar caption that corresponds to the generated image."""
     if caption_path.suffix == ".json":
@@ -432,15 +454,13 @@ def main() -> None:
         t5_tokenizer_path = _T.resolve_path_best_effort(t5_tokenizer_path, bases)
 
     family = _T.resolve_family(cfg)  # D8'
-    logger.info("加载 Transformer...")
-    model = family.load_dit(
-        transformer_path, device, dtype,
-        attention_backend=("flash_attn" if use_flash else "none"), repo_root=repo_root,
-        purpose="generate",
-    )
-    if use_xformers:
-        _T.enable_xformers(model)
+    from training.sysmem import check_load_budget, gpu_free_bytes_global
 
+    check_load_budget(
+        True,
+        weight_paths=[transformer_path, vae_path, text_encoder_path],
+        stage="正则生成模型加载",
+    )
     logger.info("加载 VAE...")
     vae = family.load_vae(vae_path, device, dtype,
                           tiling=str(cfg.get("vae_tiling", "auto")))
@@ -454,6 +474,56 @@ def main() -> None:
         cache_enabled=False,
     )
 
+    # TE 先行 + 分批预编码（krea2）：reg 的 prompt 是每张图各不相同的
+    # caption（每条只用一次），LRU 容量（64）装不下全量——按批组织：
+    # 每批开头 TE 上卡编码 64 条 → 彻底释放 → 批内出图全 LRU 命中。
+    # 首批在 DiT 加载前编码（零同驻）；批 2+ 的 TE 上卡与 DiT 同驻瞬时，
+    # 显存不足时跳过预编码回退逐图惰性路径。anima 文本栈无 API 全程跳过。
+    _PRECACHE_BATCH = 64
+
+    def _precache_batch(batch: list[dict], first: bool) -> None:
+        precache = getattr(text_stack, "precache_online_prompts", None)
+        if not callable(precache):
+            return
+        if not first:
+            free = gpu_free_bytes_global()
+            # TE 上卡需求上界（bf16 ~11GB；fp8 更小）——不足时跳过，
+            # 由 sample_image 内部的逐图路径兜底
+            if free is not None and free < 12 * 1024**3:
+                logger.info("显存余量不足，本批跳过预编码（回退逐图编码）")
+                return
+        prompts = [
+            p for p in (
+                _peek_prompt_for_image(entry["img"], excluded_tags)
+                for entry in batch
+            ) if p
+        ]
+        if not prompts:
+            return
+        # negative 固定一条但会被满批 evict——每批都带上保持命中
+        prompts.append(str(negative_prompt or ""))
+        try:
+            encoded = precache(prompts)
+            release = getattr(text_stack, "release_model", None)
+            if callable(release):
+                release()
+            if encoded:
+                logger.info("本批预编码 %d 条 caption；TE 已释放", encoded)
+        except Exception:
+            logger.exception("批预编码失败；回退逐图惰性编码")
+
+    if to_generate:
+        _precache_batch(to_generate[:_PRECACHE_BATCH], first=True)
+
+    logger.info("加载 Transformer...")
+    model = family.load_dit(
+        transformer_path, device, dtype,
+        attention_backend=("flash_attn" if use_flash else "none"), repo_root=repo_root,
+        purpose="generate",
+    )
+    if use_xformers:
+        _T.enable_xformers(model)
+
     model.eval()
 
     if not incremental:
@@ -465,6 +535,10 @@ def main() -> None:
     actual_count = 0
 
     for idx, entry in enumerate(to_generate):
+        if idx and idx % _PRECACHE_BATCH == 0:
+            _precache_batch(
+                to_generate[idx:idx + _PRECACHE_BATCH], first=False,
+            )
         seed = (base_seed + idx) if base_seed != 0 else random.randint(0, 2**31 - 1)
         torch.manual_seed(seed)
         random.seed(seed)
@@ -509,6 +583,7 @@ def main() -> None:
                 scheduler=scheduler,
                 device=device,
                 dtype=dtype,
+                vram_policy="auto",
             )
             img.save(out_path)
             actual_count += 1

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -185,6 +185,8 @@ def _validate_fp8_base(ctx: TrainingContext) -> None:
 
 def run(ctx: TrainingContext) -> None:
     """Resolve paths and load either the complete stack or the cache-first half."""
+    from training.sysmem import check_load_budget
+
     if ctx.family is None:
         ctx.family = resolve_family(ctx.args)
     _resolve_paths(ctx)
@@ -194,12 +196,29 @@ def run(ctx: TrainingContext) -> None:
         logger.info(
             "文本缓存已开启：先加载 VAE/Qwen3-VL，缓存并释放 TE 后再加载 Transformer"
         )
+        # 分段预算：本段只加载 VAE + TE（DiT 由 finish 段单独预算）。
+        # 训练侧常开（多小时任务，中途换页卡死代价远高于一条报错）。
+        check_load_budget(
+            True,
+            weight_paths=[getattr(ctx.args, "vae_path", ""),
+                          getattr(ctx.args, "text_encoder_path", "")],
+            stage="训练模型加载（VAE/文本编码器）",
+        )
         _load_vae(ctx)
         _load_text(ctx)
         return
 
     # Preserve the historical Anima order. Storage-free Krea2 deliberately keeps
     # the DiT resident while its text encoder is loaded for per-batch encoding.
+    check_load_budget(
+        True,
+        weight_paths=[
+            getattr(ctx.args, "transformer_path", ""),
+            getattr(ctx.args, "vae_path", ""),
+            getattr(ctx.args, "text_encoder_path", ""),
+        ],
+        stage="训练模型加载",
+    )
     _load_dit(ctx)
     _load_vae(ctx)
     _load_text(ctx)
@@ -210,7 +229,14 @@ def finish(ctx: TrainingContext) -> None:
     """Load/inject a DiT deferred by cached text preparation; otherwise no-op."""
     if ctx.model is not None:
         return
+    from training.sysmem import check_load_budget
+
     logger.info("文本缓存完成且文本编码器已释放；继续加载 Transformer...")
+    check_load_budget(
+        True,
+        weight_paths=[getattr(ctx.args, "transformer_path", "")],
+        stage="训练模型加载（Transformer）",
+    )
     _load_dit(ctx)
     _inject_adapter(ctx)
 

--- a/studio/services/eval_samples.py
+++ b/studio/services/eval_samples.py
@@ -589,13 +589,14 @@ def _default_generator(
     progress("[eval-samples] loading base model")
     diffusion_root = _T.find_diffusion_pipe_root()
     family = _T.resolve_family(cfg)  # D8'
-    model = family.load_dit(
-        transformer_path, device, dtype,
-        attention_backend=("flash_attn" if use_flash else "none"), repo_root=diffusion_root,
-        purpose="generate",
+    items_for_precache = run.get("items") if isinstance(run.get("items"), list) else []
+    from training.sysmem import check_load_budget
+
+    check_load_budget(
+        True,
+        weight_paths=[transformer_path, vae_path, text_encoder_path],
+        stage="评估出图模型加载",
     )
-    if use_xformers:
-        _T.enable_xformers(model)
     vae = family.load_vae(vae_path, device, dtype)
     # 族 opaque 文本栈不拆包；eval prompt 是 ad-hoc 输入，关缓存
     text_stack = family.load_text(
@@ -604,6 +605,31 @@ def _default_generator(
         purpose="generate",
         cache_enabled=False,
     )
+    # TE 先行编排（krea2，daemon/CLI 同款）：items 的 prompt 集合封闭——
+    # DiT 加载前预编码全部并彻底释放 TE，任一时刻 GPU 只有一个大模型。
+    # anima 文本栈无此 API 自然跳过。
+    precache = getattr(text_stack, "precache_online_prompts", None)
+    if callable(precache):
+        try:
+            prompts_all = [
+                str(item.get("prompt") or "") for item in items_for_precache
+            ] + [str(negative_prompt or "")]
+            encoded = precache(prompts_all)
+            release = getattr(text_stack, "release_model", None)
+            if callable(release):
+                release()
+            if encoded:
+                progress(f"[eval-samples] precached {encoded} prompts; TE released")
+        except Exception:
+            logger.exception("eval prompt 预编码失败；退回逐图惰性编码")
+
+    model = family.load_dit(
+        transformer_path, device, dtype,
+        attention_backend=("flash_attn" if use_flash else "none"), repo_root=diffusion_root,
+        purpose="generate",
+    )
+    if use_xformers:
+        _T.enable_xformers(model)
 
     checkpoint = version_dir / run["checkpoint"]["path"]
     adapters = apply_loras(
@@ -644,6 +670,7 @@ def _default_generator(
                 device=device,
                 dtype=dtype,
                 seed=seed,
+                vram_policy="auto",
             )
             img.save(output)
             run = mark_item_done(version_dir, load_run(version_dir, run["run_id"], scoped_root) or run, idx, scoped_root)


### PR DESCRIPTION
## 背景（stacked on #437，先合 #437 再 retarget/合本 PR）

generate 侧的五件优化落地后盘点全链路：训练主链的分阶段编排本已在位（两段式加载正是 TE 先行的原型），**唯一 gap 是加载护栏**；真正的洼地是两个旁路出图链路（eval 出图 / 正则 AI 生成）——都是旧 generate 的全家桶复刻。

## 改动

### 训练加载护栏
`models.run`/`finish` 两个加载点前按**分段**文件实际大小预算 RAM + GPU free（NVML 全卡视角）：两段式族 run 段=[VAE, TE]、finish 段=[DiT]；全家桶族=三件总和。训练侧**常开无旋钮**——多小时任务中途换页卡死的代价远高于一条可操作报错（bf16 训练的 26GB mmap 瞬时峰值比 generate 的 fp8 更大，更需要）。

### eval 出图（训练后评估）
照 daemon/CLI 新时序重排：VAE → TE → 预编码全部 items prompt + negative → **彻底释放 TE** → DiT → LoRA → 循环。items 集合任务开始前封闭，LRU 容量内全命中。`sample_image` 接 `vram_policy=auto`（原来连参数都没传，走无条件 offload 老路径）。

### 正则 AI 生成（分批编排）
reg 的 prompt 是几百条各不相同的 caption（每条只用一次），LRU 容量 64 装不下全量——**分批预编码**：每批 64 条编码 → 释放 TE → 批内出图全命中，TE 往返摊销到每 64 图一次。关键实现：
- `_peek_prompt_for_image` 纯读派生 prompt（不拷贝不改写任何文件），与循环内 copy+rewrite 的产物**逐字一致**保证 LRU 精确命中；副作用顺序完全不变
- 首批在 DiT 加载前编码（零同驻）；批 2+ 的 TE 上卡与 DiT 同驻瞬时，显存余量 <12GB 时跳过预编码回退逐图惰性路径
- negative 固定一条但会被满批 evict——每批都带上

anima 族全程 duck-type 跳过（文本栈无 precache API），行为不变。

## 测试
全量 3106 绿。真机验证建议：krea2 项目跑一次「重建正则集」（日志应出现「本批预编码 N 条 caption；TE 已释放」按批出现）+ 一次训练后评估（「precached N prompts; TE released」，且 TE 不再逐图搬运）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)