### PR TITLE
fix(train): auto_sync 路径读取面跟随全局 selected + 删除按钮改 ghost

### DIFF
--- a/runtime/training/bootstrap.py
+++ b/runtime/training/bootstrap.py
@@ -116,8 +116,17 @@ def init_progress(show_progress, total_steps):
     - 关闭进度时返回 `(None, None, None)`
     - Rich 可用时返回 `(Progress 实例, task_id, "rich")`
     - Rich 缺失时返回 `("plain", None, None)`（main() 据此走纯文本进度）
+
+    非 tty（studio spawn 的 pipe）强制降级走 log_every 纯文本分支——
+    rich 在 pipe 下既刷屏又吃掉 step 行（log_every 是 elif），存量
+    config 固化的 ``no_progress: false``（老默认 + 字段现已 hidden）
+    曾让 task log 里一行 step 日志都没有。裸终端 CLI 不受影响。
     """
     if not show_progress:
+        return None, None, None
+    import sys as _sys
+
+    if not (hasattr(_sys.stdout, "isatty") and _sys.stdout.isatty()):
         return None, None, None
     try:
         from rich.progress import (

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -619,7 +619,15 @@ def run(ctx: TrainingContext) -> None:
                         if sra_align_loss_val is not None and sra_weighted_loss_val is not None
                         else f" denoise={denoise_loss_val:.6f}"
                     )
-                    print(f"epoch={epoch} step={ctx.global_step} loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} speed={steps_per_sec:.2f} it/s")
+                    # flush 必须开：studio spawn 的 stdout 是 pipe（全缓冲
+                    # 8KB），不 flush 时 step 行滞留缓冲——短训练/中止的
+                    # task log 里一行都看不到（曾被误判为 krea2 没打日志）
+                    print(
+                        f"epoch={epoch} step={ctx.global_step} "
+                        f"loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} "
+                        f"speed={steps_per_sec:.2f} it/s",
+                        flush=True,
+                    )
 
                 # 按 step 采样（轮换提示词）
                 if args.sample_steps > 0 and ctx.global_step % args.sample_steps == 0:

--- a/runtime/training/sample_runner.py
+++ b/runtime/training/sample_runner.py
@@ -82,6 +82,14 @@ def run_sample(
         clear_fn()
 
     was_training = bool(getattr(ctx.model, "training", True))
+    # 采样前归还训练积累的 allocator 碎片（多 bucket 形状的 reserved 段）。
+    # 采样分辨率 ≠ 训练 bucket 形状 → 采样激活是全新分配；不清理时
+    # 「训练 reserved + 采样新段」的瞬时提交可能顶穿 dedicated 上限，
+    # 触发 WDDM 把训练张量 demote 到共享内存（=系统 RAM）——之后每步
+    # 训练都走 PCIe，表现为采样后持续整机卡顿（显存/内存数字反而稳定）。
+    _log_vram_watermark("采样前")
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
     try:
         with optimizer_eval_mode(ctx.optimizer):
             ctx.model.eval()
@@ -118,3 +126,35 @@ def run_sample(
             ctx.model.train()
         else:
             ctx.model.eval()
+        # 归还采样期的新形状分配，训练继续时 allocator 干净
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+        _log_vram_watermark("采样后")
+
+
+def _log_vram_watermark(stage: str) -> None:
+    """采样前后水位一行日志：alloc/reserved（torch 视角）+ 全卡（NVML）。
+
+    reserved 与全卡的差额变化用于定位 WDDM demote（共享内存曲线跳升时
+    torch 侧数字反而稳定）。失败静默——日志不阻塞训练。"""
+    try:
+        if not torch.cuda.is_available():
+            return
+        alloc = torch.cuda.memory_allocated() / 1e9
+        reserved = torch.cuda.memory_reserved() / 1e9
+        line = f"[{stage}] 显存 alloc={alloc:.1f}GB reserved={reserved:.1f}GB"
+        try:
+            import pynvml
+
+            pynvml.nvmlInit()
+            try:
+                info = pynvml.nvmlDeviceGetMemoryInfo(
+                    pynvml.nvmlDeviceGetHandleByIndex(0))
+                line += f" 全卡={info.used / 1e9:.1f}GB"
+            finally:
+                pynvml.nvmlShutdown()
+        except Exception:
+            pass
+        logger.info(line)
+    except Exception:
+        pass

--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -819,6 +819,17 @@ def enqueue_version_training(
             code="version.config_missing", http_status=400,
         )
     cfg_path = version_config.version_config_path(project, ver)
+    # auto_sync_paths=ON：入队时把全局模型路径同步落盘——trainer 子进程
+    # 直接读 yaml（不经 studio 读取面的 overlay），全局 selected /
+    # selected_te 切换后训练必须用当前值（Train 页字段锁定并承诺
+    # 「自动 · 全局设置」）。OFF 时 read 不 overlay，写回幂等。
+    try:
+        synced = version_config.read_version_config(project, ver)
+        version_config.write_version_config(
+            project, ver, synced, force_project_overrides=True,
+        )
+    except version_config.VersionConfigError:
+        pass  # 坏 config 由下游校验报错，不在此处中断
     scheduled_at = body.scheduled_at if body else None
 
     with db.connection_for() as conn:

--- a/studio/services/version_config.py
+++ b/studio/services/version_config.py
@@ -133,7 +133,38 @@ def read_version_config_with_warnings(
             code="version.config_invalid",
         )
     cfg, dropped, defaulted = _tolerant_validate(raw)
-    return _absolutize_model_paths(cfg.model_dump(mode="python")), dropped, defaulted
+    # overlay 在 absolutize 之前——覆盖值与 yaml 值走同一套路径归一
+    data = apply_global_path_overlay(cfg.model_dump(mode="python"))
+    return _absolutize_model_paths(data), dropped, defaulted
+
+
+#: auto_sync_paths=ON 时由全局设置管理的 4 个模型路径字段（Train 页对应
+#: 字段锁定并标「自动 · 全局设置」——读取出口 overlay 让徽标语义成立：
+#: 全局 selected / selected_te 变化后，已有 version 的显示与派生链
+#: （训练入队 / reg / eval）即时跟随，而非停留在创建时的快照）
+GLOBAL_MODEL_PATH_FIELDS = (
+    "transformer_path", "vae_path", "text_encoder_path", "t5_tokenizer_path",
+)
+
+
+def apply_global_path_overlay(data: dict[str, Any]) -> dict[str, Any]:
+    """auto_sync_paths=ON 时用当前全局设置覆盖 4 个模型路径字段。
+
+    与 fork / save_preset / bundle 导入的「写入时覆盖」同一语义的读取面；
+    OFF（独立模型用户）原样返回。失败静默返回原值（读取不因 secrets /
+    catalog 异常而失败）。
+    """
+    try:
+        from . import models as model_downloader
+        from .presets import _auto_sync_paths
+
+        if not _auto_sync_paths():
+            return data
+        family = str(data.get("model_family") or "anima")
+        data.update(model_downloader.default_paths_for_new_version(family=family))
+    except Exception:
+        pass
+    return data
 
 
 def write_version_config(

--- a/studio/web/src/pages/tools/settings/modelCards.tsx
+++ b/studio/web/src/pages/tools/settings/modelCards.tsx
@@ -425,7 +425,7 @@ export function DownloadButton({ exists, status, busy, onClick, onDelete }: {
   }
   if (exists && onDelete) {
     return (
-      <button onClick={onDelete} className="btn btn-secondary btn-sm min-w-[5rem] justify-center text-err"
+      <button onClick={onDelete} className="btn btn-ghost btn-sm min-w-[5rem] justify-center"
         title={t('settings.deleteAssetTitle')}>
         🗑 {t('settings.deleteAsset')}
       </button>

--- a/tests/test_family_assets.py
+++ b/tests/test_family_assets.py
@@ -33,7 +33,13 @@ def test_anima_assets_surface():
     }
 
 
-def test_krea2_assets_surface_uses_shared_vae_and_isolated_text_dir():
+def test_krea2_assets_surface_uses_shared_vae_and_isolated_text_dir(monkeypatch):
+    # 隔离真实 secrets：断言硬编码官方文件名，开发机 selected 切 raw_fp8 会假红
+    from studio import secrets
+
+    monkeypatch.setattr(secrets, "load", lambda: secrets.Secrets(models={
+        "selected": {"anima": "1.0", "krea2": "raw"},
+    }))
     assets = get_assets("krea2")
     assert assets.family_id == "krea2"
     paths = assets.default_paths_for_new_version()

--- a/tests/test_family_switch.py
+++ b/tests/test_family_switch.py
@@ -9,6 +9,17 @@ from studio.schema import TrainingConfig
 from studio.services.models import default_paths_for_new_version
 
 
+@pytest.fixture(autouse=True)
+def _fixed_selected(monkeypatch):
+    """隔离真实 secrets：断言硬编码官方文件名（krea2-raw-bf16 等），开发机
+    selected 切成 raw_fp8 / custom 会让 default_paths 变值假红。"""
+    from studio import secrets
+
+    monkeypatch.setattr(secrets, "load", lambda: secrets.Secrets(models={
+        "selected": {"anima": "1.0", "krea2": "raw"},
+    }))
+
+
 def _paths(family: str) -> dict[str, str]:
     return default_paths_for_new_version(family=family)
 

--- a/tests/test_version_config.py
+++ b/tests/test_version_config.py
@@ -12,6 +12,17 @@ from studio.services.projects import projects, versions
 from studio.services import presets as preset_flow, version_config
 
 
+@pytest.fixture(autouse=True)
+def _fixed_selected(monkeypatch):
+    """隔离真实 secrets：多个断言硬编码官方文件名（krea2-raw-bf16 等），
+    开发机 selected 切成 raw_fp8 / custom 会让 default_paths 变值假红。"""
+    from studio import secrets
+
+    monkeypatch.setattr(secrets, "load", lambda: secrets.Secrets(models={
+        "selected": {"anima": "1.0", "krea2": "raw"},
+    }))
+
+
 @pytest.fixture
 def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     dbfile = tmp_path / "studio.db"


### PR DESCRIPTION
## 背景

fp8 训练真机实测（blinklikeer/k2v1，raw_fp8 + fp8 TE）暴露的四个问题，各一 commit：

## Commit 1：auto_sync 路径读取面跟随全局 selected + 删除按钮 ghost

Settings 选中 raw_fp8/TE fp8 后，已有 version 的训练配置仍显示/使用 bf16 路径——字段锁定且标「自动 · 全局设置」，但 auto_sync 只在 fork/save_preset/bundle 三处写入时覆盖，读取面停留在创建时快照；训练任务 config_path 直指 yaml，trainer 也用旧值。修：`read_version_config` 出口统一 overlay（family-aware，OFF 用户不受影响）+ 训练入队时 overlay 落盘。下载中心删除按钮 btn-secondary 红字 → btn-ghost。测试补 secrets 隔离（三处硬编码官方文件名的测试在开发机 selected 切 fp8 后假红）。

## Commit 2：中途采样前后 empty_cache + 显存水位日志

采样分辨率 ≠ 训练 bucket 形状，采样激活是全新分配——采样前归还训练 reserved 碎片、采样后归还采样段，防瞬时提交顶穿 dedicated 触发 WDDM demote；前后各一行水位日志（torch alloc/reserved + NVML 全卡）。

## Commit 3：step 日志 print 补 flush

log_every 分支的 print 不带 flush，studio spawn 的 stdout 是 pipe（全缓冲 8KB）——短训练/中止的 task log 里一行 step 都没有（task 1487 跑满一个 epoch 零 step 行实锤）。

## Commit 4：rich 进度条非 tty 强制降级

flush 修复后 step 行仍缺失的真根因：存量 config 固化 `no_progress: false`（老默认，字段现已 hidden 无法从 UI 改）→ 走 rich 分支 → log_every 纯文本分支是 elif 永不执行，且 rich 在 pipe 下刷屏。`init_progress` 加 tty 检测：非 tty 一律降级纯文本分支；裸终端 CLI 的 rich 不受影响，存量 config 零迁移。

## 真机实测闭环（10 分钟受控重训 + 密集采样）

- 加载链全部健康：fp8 指纹 text cache 复用、fp8 DiT/LoRA 注入、水位日志就位
- **峰值 25GB、0.13 it/s（12.9B fp8_base bs1 ga2 1024²）**、loss 正常、无泄漏无 demote
- 「整机卡顿」定性为非 bug：GPU 猝发满载（544W/100% 数秒交替）时 12.9B 长 kernel 挤压 DWM 桌面合成（WDDM 仅 kernel 边界抢占）——大模型与桌面共卡的固有现象；处置=HAGS 切换对照 / 桌面走核显

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 后续 commit（5-8）——本 PR 合并后追加，已移至 #441 承载

### Commit 5：底模 / TE 选择持久化进 prefs
原为刻意瞬态（每次进页面回到全局默认）——实测反馈切页面即被重置太烦。改进 prefs：null=跟随设置页 selected/selected_te（默认行为不变），显式覆盖跨页面/会话记住。

### Commit 6：显存策略文案对齐 TE 先行语义 + 下拉宽度统一
「自动」的名称与描述停留在旧按需判据语义（TE 先行后实际=预编码后固定释放）——改「默认（用后释放）」，三档 help 重写为真实行为；vramPolicy 下拉 max-w-40 → max-w-32 与同页一致。

### Commit 7：prompt token 计数角标 + 在线模式放开 512 截断
- `POST /api/generate/token_count`：按族选 tokenizer（与训练/推理同源），prompt 框右下角灰色「N tokens」角标（防抖 500ms，中性展示无警告）；`useAutoGrowTextarea` 高度 +1 行给角标留位（组件级）
- **在线模式放开 512 截断**：超长 prompt 完整进模型（varlen 链路无结构约束，512 只是官方训练口径），不再静默丢尾部；训练 cached 模式维持 512 定长（缓存指纹语义不变）

### Commit 8：route snapshot 补新端点

## 卡顿调查最终状态

- 训练侧：GPU 猝发满载（深度 CUDA 队列）+ 长 kernel 挤压 DWM——已定性
- 推理侧：受控实测 **97% 连续满载零猝发**（GPU 提交模式与 ComfyUI 无异）；用户卡顿表现为「光标流畅但应用 hover/点击卡」且任务管理器同卡 → 系统级 GPU 图形队列挤压，排除前端渲染主因
- 待办：用户本机 ComfyUI 同 fp8 文件对照（分流环境因素 vs 实现差异）

🤖 Generated with [Claude Code](https://claude.com/claude-code)