### PR TITLE
fix(train): prompt 文本聚合缓存移出数据集目录——落 task 档案根

### DIFF
--- a/docs/design/multi-model/04-synthesis.md
+++ b/docs/design/multi-model/04-synthesis.md
@@ -66,7 +66,7 @@ def convert_lora_state_dict(self, sd: dict[str, Tensor]) -> dict[str, Tensor]:
 | D16 | family 加载器必须对「checkpoint 与所选 family 不匹配」fail-fast 并给可操作文案（消费级用户拿 Anima 权重配 K2 版本的错误必然发生） | 02-P7 |
 | D17 | `latent_rgb_factors`（latent2rgb 预览投影系数）进 `LatentSpec`——`anima_daemon` 硬编码的 Wan21 系数收编，K2 同 latent 空间直接复用 | 02-P1(a) |
 | D18 | K2 v1 训练中预览用 Raw 权重 + CFG 采样（模型已在显存里）；Turbo 热切换（musubi `--turbo_dit` 模式）不进 v1，Turbo 作为 Generate 页可选底模留给 Phase 4 评估 | 02 §10.3-6 |
-| D19 | text cache 与 latent npz 缓存同域：放数据集 train/ 目录随图 sidecar。理由：caption 本身在 train/ 下、与 VAE 缓存一致、直接被既有项目导出 npz bundle 机制（PR #391）覆盖。同 caption 跨图重复存储的代价接受。失效判据仍按 D3/D12（文件内嵌 caption hash + TE 指纹，失配自动重编码）；非 caption prompt（sample/negative）的聚合缓存文件同放 train/ 下，命名与格式为 Phase 2 实现细节 | 用户裁定 2026-07-14（取代本文原「集中式内容寻址」倾向） |
+| D19 | text cache 与 latent npz 缓存同域：放数据集 train/ 目录随图 sidecar。理由：caption 本身在 train/ 下、与 VAE 缓存一致、直接被既有项目导出 npz bundle 机制（PR #391）覆盖。同 caption 跨图重复存储的代价接受。失效判据仍按 D3/D12（文件内嵌 caption hash + TE 指纹，失配自动重编码）；非 caption prompt（sample/negative）的聚合缓存文件**修订（2026-07-18）**：改放 task 档案根（`tasks/<id>/.text-cache/`，纯 CLI 退回 output_dir），不落 train/——放 train/ 会被数据集扫描当 concept 文件夹误触；bundle 不再打包聚合缓存 | 用户裁定 2026-07-14（取代本文原「集中式内容寻址」倾向）；聚合缓存位置 2026-07-18 修订 |
 
 ## 5. 更新后的 Phase 1 执行序列
 

--- a/runtime/training/README.md
+++ b/runtime/training/README.md
@@ -37,7 +37,7 @@ runtime/training/
 ├── state.py                ← save / load_training_state
 ├── snapshot.py             ← pause / resume 用的 state snapshot helpers（ADR 0006）
 ├── dataset.py              ← BucketManager + ImageDataset + 5 衍生类 + collate + navit sampler/collate
-├── text_cache.py           ← varlen 文本 sidecar / train/.text-cache prompt bundle 协议与原子 safetensors I/O
+├── text_cache.py           ← varlen 文本 sidecar / task 档案 .text-cache prompt bundle 协议与原子 safetensors I/O
 ├── sampling.py             ← 推理用 sample_image + sigma 调度（被 sister script 也用）
 ├── timestep_sampling.py    ← 训练 step 用 sample_t（logit_normal / uniform / mode）；
 │                            被 timestep_samplers/baseline.py 复用

--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -46,6 +46,10 @@ class TrainingContext:
     # 时 env 不存在 → None → state_dir() fallback 到 task_unknown 子目录。
     # 注意：跟 progress bar 的 task_id 字段（line ~80）是两回事，故意起不同名字。
     lora_task_id: Optional[int] = None
+    # task 档案根（studio_data/tasks/<id>/）。bootstrap 从 --monitor-state-file
+    # 上跳两层推出；纯 CLI 没传 → None。samples/ state/ 和 prompt 文本缓存
+    # （.text-cache/）都挂在这个根下。
+    task_archive_dir: Optional[Path] = None
     # ADR 0006 Addendum 2：auto_epoch_state.pt 落 task 档案（studio_data/tasks/
     # <id>/state/）。bootstrap 从 --monitor-state-file 推出档案根后填充（跟
     # sample_dir 同一约定）；纯 CLI 没传 → None → auto_state_dir() fallback

--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -218,12 +218,13 @@ def run(ctx: TrainingContext) -> None:
     # 没传 --monitor-state-file（纯 CLI 训练 / 兼容老版本注入路径）退回
     # output_dir/samples，samples.py 仍可在 monitor_dir 周围多候选搜回。
     _msf = getattr(args, "monitor_state_file", None)
-    ctx.sample_dir = (Path(_msf).parent.parent / "samples") if _msf else (ctx.output_dir / "samples")
+    ctx.task_archive_dir = Path(_msf).parent.parent if _msf else None
+    ctx.sample_dir = (ctx.task_archive_dir / "samples") if ctx.task_archive_dir else (ctx.output_dir / "samples")
     ctx.sample_dir.mkdir(parents=True, exist_ok=True)
     # ADR 0006 Addendum 2：auto_epoch_state.pt 同样归 task 档案 —— tasks/<id>/state/，
     # 跟 samples/ 同根。没传 --monitor-state-file（纯 CLI）→ None，
     # ctx.auto_state_dir() fallback 到 output_dir/state/task_<id>/（行为不变）。
-    ctx.task_archive_state_dir = (Path(_msf).parent.parent / "state") if _msf else None
+    ctx.task_archive_state_dir = (ctx.task_archive_dir / "state") if ctx.task_archive_dir else None
     # supervisor 启动训练时通过 env LORA_TASK_ID 注入 queue task id（ADR 0006）。
     # 用于 ctx.state_dir() 计算 per-task state 子目录；env 不存在时 fallback unknown。
     _env_tid = os.environ.get("LORA_TASK_ID")

--- a/runtime/training/phases/text_cache.py
+++ b/runtime/training/phases/text_cache.py
@@ -100,7 +100,10 @@ def run(ctx: TrainingContext) -> None:
     entries = _collect_entries(ctx)
     captions = [entry.caption for entry in entries]
     extras = _extra_prompts(ctx.args)
-    cache_root = Path(ctx.args.data_dir)
+    # prompt 聚合缓存归 task 档案（tasks/<id>/.text-cache/），不落数据集
+    # train/：放那里会被数据集扫描当成 concept 文件夹误触。纯 CLI（无 task
+    # 档案）退回 output_dir，同样在数据集扫描范围之外。
+    cache_root = ctx.task_archive_dir or ctx.output_dir
     logger.info(
         "[text-cache] 预缓存 %d 张图片 caption + %d 条采样/负面 prompt（varlen）",
         len(entries), len(extras),

--- a/runtime/training/text_cache.py
+++ b/runtime/training/text_cache.py
@@ -8,7 +8,9 @@
 - 图片 caption 缓存与图片同目录，使用 ``<完整图片名>.text.safetensors`` sidecar；
 - key 由最终 caption、TE 指纹和格式版本共同决定；
 - tensor 保留可变 token 长度，不 pad 到 512；
-- sample / negative prompt 聚合到数据集根目录的一个 safetensors 文件；
+- sample / negative prompt 聚合到 task 档案根（``tasks/<id>/.text-cache/``）的
+  一个 safetensors 文件——不落数据集 train/，避免被数据集扫描当 concept
+  文件夹误触（D19 修订）；
 - 写入使用 sibling tmp + ``os.replace``，训练中断不会留下半文件。
 """
 
@@ -77,8 +79,8 @@ def caption_sidecar_path(image_path) -> Path:
 def prompt_cache_path(root, text_fingerprint: str) -> Path:
     """sample/negative prompt 聚合缓存路径（按 TE 指纹隔离）。
 
-    聚合文件放进 ``train/.text-cache/``：仍与数据集同域，同时保持 bundle 的
-    ``train/{folder}/{file}`` 两层结构，导入时无需为根目录文件增加例外。
+    ``root`` 由调用方决定——训练里传 task 档案根（``tasks/<id>/``），聚合
+    文件落 ``<root>/.text-cache/``。
     """
 
     fp_short = hashlib.sha256(str(text_fingerprint).encode("utf-8")).hexdigest()[:12]

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -53,12 +53,11 @@ PRESETS_PREFIX = "presets/"
 CAPTION_EXTS = {".txt"}
 # VAE latent 缓存（CachedLatentDataset 的 {名}.npz / {名}.r{reso}.npz，紧挨图片）
 LATENT_CACHE_EXT = ".npz"
-# Phase 2 文本缓存：随图 sidecar + train/.text-cache/ 下的 prompt 聚合缓存。
+# Phase 2 文本缓存：随图 sidecar。prompt 聚合缓存归 task 档案
+# （tasks/<id>/.text-cache/），不在 version 树里，bundle 不打包。
 # 继续复用现有 train_latent_cache / reg_latent_cache bundle 选项：两者表达的
 # 是“携带可重建训练缓存”，不改变默认导出体积。
 TEXT_CACHE_SIDECAR_SUFFIX = ".text.safetensors"
-TEXT_CACHE_PROMPT_DIR = ".text-cache"
-TEXT_CACHE_EXT = ".safetensors"
 # 训练 mask sidecar（train/{folder}/{stem}.mask，与图同目录，详
 # services/preprocess/masks.py）。arcname 两段与图片同构。
 MASK_SUFFIX = ".mask"
@@ -400,12 +399,8 @@ def _collect_train(
             elif ext == LATENT_CACHE_EXT and include_latent_cache:
                 latent_cache_count += 1
                 payload.append((f, f"{TRAIN_PREFIX}{sub.name}/{f.name}"))
-            elif include_latent_cache and (
-                f.name.endswith(TEXT_CACHE_SIDECAR_SUFFIX)
-                or (
-                    sub.name == TEXT_CACHE_PROMPT_DIR
-                    and ext == TEXT_CACHE_EXT
-                )
+            elif include_latent_cache and f.name.endswith(
+                TEXT_CACHE_SIDECAR_SUFFIX
             ):
                 text_cache_count += 1
                 payload.append((f, f"{TRAIN_PREFIX}{sub.name}/{f.name}"))

--- a/tests/test_text_cache_phase.py
+++ b/tests/test_text_cache_phase.py
@@ -38,6 +38,13 @@ def _args(data_dir):
     )
 
 
+def _ctx(args, family, task_archive_dir=None, output_dir=None):
+    ctx = TrainingContext(args=args, family=family)
+    ctx.task_archive_dir = task_archive_dir
+    ctx.output_dir = output_dir
+    return ctx
+
+
 def test_cached_varlen_phase_collects_main_reg_and_deduplicates_fanout(tmp_path):
     image_a = tmp_path / "a.png"
     image_b = tmp_path / "reg" / "b.png"
@@ -53,7 +60,8 @@ def test_cached_varlen_phase_collects_main_reg_and_deduplicates_fanout(tmp_path)
         {str(image_b): "class caption"},
     )
     family = _Family("cached_varlen")
-    ctx = TrainingContext(args=_args(tmp_path), family=family)
+    task_dir = tmp_path / "tasks" / "7"
+    ctx = _ctx(_args(tmp_path), family, task_archive_dir=task_dir)
     ctx.base_dataset = main
     ctx.reg_dataset = reg
     ctx.text_stack = object()
@@ -66,9 +74,21 @@ def test_cached_varlen_phase_collects_main_reg_and_deduplicates_fanout(tmp_path)
     assert extras == ["trigger, portrait", "blurry"]
     assert [e.image_path for e in kwargs["cache_entries"]] == [image_a, image_b]
     assert kwargs["cache_entries"][0].cache_path.parent == image_a.parent
-    assert kwargs["cache_root"] == tmp_path
+    # prompt 聚合缓存根 = task 档案，不是数据集 train/（否则被数据集扫描误触）
+    assert kwargs["cache_root"] == task_dir
     assert kwargs["text"] is ctx.text_stack
     assert kwargs["device"] == "cuda"
+
+
+def test_prompt_cache_root_falls_back_to_output_dir_without_task_archive(tmp_path):
+    family = _Family("cached_varlen")
+    out_dir = tmp_path / "output"
+    ctx = _ctx(_args(tmp_path), family, output_dir=out_dir)
+    ctx.base_dataset = _Dataset([], {})
+
+    text_cache.run(ctx)
+
+    assert family.call[2]["cache_root"] == out_dir
 
 
 def test_online_strategy_is_noop_and_does_not_scan_dataset(tmp_path):
@@ -93,7 +113,7 @@ def test_sampling_default_and_empty_negative_are_cached(tmp_path):
     args.sample_prompts = []
     args.sample_negative_prompt = ""
     family = _Family("cached_varlen")
-    ctx = TrainingContext(args=args, family=family)
+    ctx = _ctx(args, family, output_dir=tmp_path / "output")
     ctx.base_dataset = _Dataset([], {})
 
     text_cache.run(ctx)

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -289,9 +289,6 @@ def test_export_bundle_training_caches_roundtrip(isolated, tmp_path: Path) -> No
     (train / "1_data" / "a.npz").write_bytes(b"fake-latent")
     (train / "1_data" / "a.r512.npz").write_bytes(b"fake-latent-512")
     (train / "1_data" / "a.png.text.safetensors").write_bytes(b"fake-text")
-    prompt_cache = train / ".text-cache" / "prompts.123456789abc.safetensors"
-    prompt_cache.parent.mkdir()
-    prompt_cache.write_bytes(b"fake-prompts")
     reg = train.parent / "reg" / "girl"
     reg.mkdir(parents=True)
     (reg / "r.png").write_bytes(_png(b"r"))
@@ -311,14 +308,13 @@ def test_export_bundle_training_caches_roundtrip(isolated, tmp_path: Path) -> No
     assert result["manifest"]["includes"]["train_latent_cache"] is True
     assert result["manifest"]["includes"]["reg_latent_cache"] is True
     assert result["manifest"]["stats"]["latent_cache_count"] == 3
-    assert result["manifest"]["stats"]["text_cache_count"] == 3
+    assert result["manifest"]["stats"]["text_cache_count"] == 2
     with zipfile.ZipFile(dest) as zf:
         names = set(zf.namelist())
     assert "train/1_data/a.npz" in names
     assert "train/1_data/a.r512.npz" in names
     assert "reg/girl/r.npz" in names
     assert "train/1_data/a.png.text.safetensors" in names
-    assert "train/.text-cache/prompts.123456789abc.safetensors" in names
     assert "reg/girl/r.png.text.safetensors" in names
 
     with db.connection_for(isolated["db"]) as conn:
@@ -334,11 +330,10 @@ def test_export_bundle_training_caches_roundtrip(isolated, tmp_path: Path) -> No
     reg_npz = new_dir / "reg" / "girl" / "r.npz"
     reg_img = new_dir / "reg" / "girl" / "r.png"
     text_cache = new_dir / "train" / "1_data" / "a.png.text.safetensors"
-    prompts = new_dir / "train" / ".text-cache" / "prompts.123456789abc.safetensors"
     reg_text_cache = new_dir / "reg" / "girl" / "r.png.text.safetensors"
     assert npz.exists() and (new_dir / "train" / "1_data" / "a.r512.npz").exists()
     assert reg_npz.exists()
-    assert text_cache.exists() and prompts.exists() and reg_text_cache.exists()
+    assert text_cache.exists() and reg_text_cache.exists()
     # zip 内 npz 按字典序先于图片落盘，没有 touch 修正会比图片旧
     assert npz.stat().st_mtime >= img.stat().st_mtime
     assert reg_npz.stat().st_mtime >= reg_img.stat().st_mtime


### PR DESCRIPTION
## 背景 / 动机

krea2 文本缓存（多模型 Phase 2，D19）把 sample/negative prompt 的 TE 编码聚合文件落在数据集 \`train/.text-cache/\`。数据集侧按「train/ 下的子目录 = concept 文件夹」扫描，这个目录会被当成空 concept 误触（Curation / 训练集统计等所有遍历 train/ 子目录的读取面）。

图片 caption 的缓存是随图 sidecar（\`<图片名>.text.safetensors\`），与 latent npz 同域，不受影响、保持原位。

## 改动概要

- **聚合缓存根改为 task 档案根**（\`tasks/<id>/.text-cache/\`），与 \`samples/\`、\`state/\` 同根，复用同一推导机制（\`--monitor-state-file\` 上跳两层）。\`TrainingContext\` 新增 \`task_archive_dir\` 字段，bootstrap 里 sample_dir / state 的推导顺带收口到它（行为不变）
- **纯 CLI**（无 task 档案）退回 \`output_dir/.text-cache/\`，同样在数据集扫描范围之外——不能退回 \`data_dir\`，否则 bug 复现
- **bundle 导出不再打包聚合缓存**（不在 version 树里了；导入后首次训练重编码，几条 prompt 开销可忽略）。sidecar 打包不变，导入侧通用两层放行无需改动
- 无兼容迁移：该布局未进 master，无存量数据
- 文档同步：04-synthesis D19 加修订注记 + runtime README 一行

取舍说明：聚合缓存随 task 走之后跨 task 不再复用，但 task 内（暂停/恢复、训练中缓存自修复 \`_repair_prompt_bundle\`）仍命中。

## 测试方式

- 新增回归测试：cache_root = task 档案根；无档案时 fallback 到 output_dir（\`test_text_cache_phase.py\`）
- \`test_train_io.py\` roundtrip 同步：聚合缓存不再出现在 bundle，sidecar 计数 3→2
- 本地：text_cache / train_io / krea2_text_encoding 相关 + 横切安全网（route_snapshot / studio_configs）82 项全绿

🤖 Generated with [Claude Code](https://claude.com/claude-code)