### PR TITLE
feat: lora_type 默认 lora + 下载中心删除接入全区

### DIFF
--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -244,8 +244,8 @@ class TrainingConfig(BaseModel):
 
     # ------------------------------------------------------------------- LoRA
     lora_type: Literal["lora", "lokr", "loha", "ortho", "tlora"] = Field(
-        "lokr",
-        description="适配器算法。lokr：Kronecker 分解，参数最省（默认）；lora：经典低秩，通用；loha：Hadamard 积，表达力较高但参数较多；ortho：正交参数化，可训练参数极少、防过拟合，适合小数据集人物/主体；tlora：噪声越高 rank 越小，专为单图/极少图主体定制防过拟合",
+        "lora",
+        description="适配器算法。lora：经典低秩，通用（默认）；lokr：Kronecker 分解，参数最省；loha：Hadamard 积，表达力较高但参数较多；ortho：正交参数化，可训练参数极少、防过拟合，适合小数据集人物/主体；tlora：噪声越高 rank 越小，专为单图/极少图主体定制防过拟合",
         json_schema_extra=_meta(
             "lora",
             # option 级禁值（forbid，R2 v2）：navit 是 B=1 打包序列 + 逐图 t，

--- a/studio/services/models/downloader.py
+++ b/studio/services/models/downloader.py
@@ -561,8 +561,9 @@ def delete_asset(model_id: str, variant: Optional[str] = None) -> None:
     """删除一个已下载资产（下载按钮的逆操作：用户先删除、再下载）。
 
     目标路径全部由服务端 target 函数解析——不接受任意路径；对应 key 的
-    下载进行中拒绝。覆盖 Settings 模型区的资产 id（主模型 variant / VAE /
-    文本编码器 / tokenizer）；打标、放大器等区暂不接入。文件被占用
+    下载进行中拒绝。覆盖下载中心全部资产 id：训练模型区（主模型 variant /
+    VAE / 文本编码器 / tokenizer）、打标（wd14 / cltagger）、eval 指标
+    （clip / dino / ccip）、放大器（预设 + 自定义文件名）。文件被占用
     （模型已加载 / 训练中）时 OSError 原样转可操作报错。
     """
     import shutil
@@ -592,6 +593,41 @@ def delete_asset(model_id: str, variant: Optional[str] = None) -> None:
         target = qwen3_vl_dir(root)
     elif model_id == "krea2_text_encoder_fp8":
         target = qwen3_vl_fp8_dir(root)
+    elif model_id == "wd14":
+        if not variant:
+            raise ValueError("wd14 需要 variant=model_id")
+        key = f"wd14:{variant}"
+        target = wd14_target_dir(root, variant)
+    elif model_id == "cltagger":
+        preset = CLTAGGER_VERSIONS.get(variant or "")
+        if preset is None:
+            raise ValueError(f"unknown cltagger variant {variant!r}")
+        key = f"cltagger:{variant}"
+        # 只删该版本子目录——v1/v2 同 repo 根下可并存多版本
+        target = cltagger_target_root(root, preset["model_id"]) / Path(
+            preset["model_path"]
+        ).parent
+    elif model_id in ("eval_clip", "eval_dino"):
+        if not variant:
+            raise ValueError(f"{model_id} 需要 variant=model_id")
+        kind = "clip" if model_id == "eval_clip" else "dino"
+        key = f"{model_id}:{variant}"
+        target = eval_model_target_dir(root, kind, variant)
+    elif model_id == "eval_ccip":
+        if not variant:
+            raise ValueError("eval_ccip 需要 variant=ccip 变体名")
+        key = f"eval_ccip:{variant}"
+        target = ccip_model_dir(root, variant)
+    elif model_id == "upscaler":
+        if not variant:
+            raise ValueError("upscaler 需要 variant=label")
+        # 预设 label 或自定义文件名；upscaler_target 自带路径穿越校验
+        key = (
+            f"upscaler:{variant}"
+            if variant in UPSCALER_VARIANTS
+            else f"upscaler:custom:{variant}"
+        )
+        target = upscaler_target(variant, root)
     else:
         raise ValueError(f"asset {model_id!r} does not support deletion")
 

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -393,7 +393,7 @@
       "caption_comfy_encoding": "Encode captions the ComfyUI way (same pipeline as test generation; recommended)",
       "cache_latents": "Cache VAE latents to speed up training",
       "vae_cache_batch_size": "VAE latent cache encoding batch size; 0 = follow training batch size, set to 1 if VRAM is tight",
-      "lora_type": "Adapter algorithm. lokr: Kronecker factorization, smallest parameter count (default); lora: classic low-rank, general purpose; loha: Hadamard product, higher expressiveness but more parameters; ortho: orthogonal parameterization, very few trainable parameters, resists overfitting, suited to small-dataset character/subject training; tlora: rank shrinks as noise increases, built to prevent overfitting in single-/few-image subject personalization",
+      "lora_type": "Adapter algorithm. lora: classic low-rank, general purpose (default); lokr: Kronecker factorization, smallest parameter count; loha: Hadamard product, higher expressiveness but more parameters; ortho: orthogonal parameterization, very few trainable parameters, resists overfitting, suited to small-dataset character/subject training; tlora: rank shrinks as noise increases, built to prevent overfitting in single-/few-image subject personalization",
       "lora_rank": "Rank: larger = more capacity but higher parameter/VRAM cost and overfit risk; smaller = leaner but underfits more easily. Common 8/16/32/64",
       "lora_alpha": "Alpha: LoRA scaling factor; larger = stronger LoRA effect. Usually equal to rank; when rs_lora is enabled, often set to √rank",
       "lokr_factor": "LoKr factorization factor: larger = stronger compression, fewer parameters; smaller = more parameters. Default 8 suits most cases",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1134,8 +1134,6 @@
     "downloadLogs": "Download logs ({{n}})",
     "partialFiles": "Partial ({{exists}}/{{total}})",
     "notDownloaded": "Not downloaded",
-    "redownloadTitle": "Already downloaded, click to redownload",
-    "redownload": "↻ Redownload",
     "downloadAction": "⤓ Download",
     "upscalersPreprocess": "Upscalers (preprocess)",
     "availableUpscalers": "Available upscalers",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -393,7 +393,7 @@
       "caption_comfy_encoding": "标签按 ComfyUI 方式编码（与测试出图同一链路，推荐开启）",
       "cache_latents": "缓存 VAE latent 加速训练",
       "vae_cache_batch_size": "VAE latent 缓存编码批次大小；0=跟随训练 batch size，显存不足时设为 1 逐张编码",
-      "lora_type": "适配器算法。lokr：Kronecker 分解，参数最省（默认）；lora：经典低秩，通用；loha：Hadamard 积，表达力较高但参数较多；ortho：正交参数化，可训练参数极少、防过拟合，适合小数据集人物/主体；tlora：噪声越高 rank 越小，专为单图/极少图主体定制防过拟合",
+      "lora_type": "适配器算法。lora：经典低秩，通用（默认）；lokr：Kronecker 分解，参数最省；loha：Hadamard 积，表达力较高但参数较多；ortho：正交参数化，可训练参数极少、防过拟合，适合小数据集人物/主体；tlora：噪声越高 rank 越小，专为单图/极少图主体定制防过拟合",
       "lora_rank": "rank：越大表达力越强，参数量与显存上升、易过拟合；越小越省但易欠拟合。常用 8/16/32/64",
       "lora_alpha": "alpha：LoRA 缩放系数，越大 LoRA 效果越强。通常等于 rank；启用 rs_lora 时常设为 √rank",
       "lokr_factor": "LoKr 矩阵分解因子：越大压缩越强、参数越少；越小参数越多。默认 8 适合大多数场景",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1134,8 +1134,6 @@
     "downloadLogs": "下载日志 ({{n}})",
     "partialFiles": "部分 ({{exists}}/{{total}})",
     "notDownloaded": "未下载",
-    "redownloadTitle": "已下载，点击重新下载",
-    "redownload": "↻ 重下",
     "downloadAction": "⤓ 下载",
     "upscalersPreprocess": "放大器（预处理）",
     "availableUpscalers": "可用放大器",

--- a/studio/web/src/lib/SettingsData.tsx
+++ b/studio/web/src/lib/SettingsData.tsx
@@ -19,6 +19,7 @@ import {
 } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, type ModelsCatalog, type Secrets, type SecretsPatch } from '../api/client'
+import { useDialog } from '../components/Dialog'
 import { useToast } from '../components/Toast'
 import { useEventStream } from './useEventStream'
 
@@ -60,6 +61,8 @@ interface SettingsData {
   reloadCatalog: () => Promise<ModelsCatalog | null>
   downloadBusy: Set<string>
   startDownload: (model_id: string, variant?: string) => Promise<void>
+  /** 下载的逆操作（confirm → DELETE → 刷 catalog），下载中心各区共用。 */
+  deleteAsset: (model_id: string, variant: string | undefined, name: string) => Promise<void>
   setDownloadSource: (type: string, source: string) => Promise<void>
 }
 
@@ -68,6 +71,7 @@ const Ctx = createContext<SettingsData | null>(null)
 export function SettingsDataProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation()
   const { toast } = useToast()
+  const dialog = useDialog()
   const [secrets, setSecrets] = useState<Secrets | null>(null)
   const [secretsError, setSecretsError] = useState<string | null>(null)
   const [catalog, setCatalog] = useState<ModelsCatalog | null>(null)
@@ -127,6 +131,19 @@ export function SettingsDataProvider({ children }: { children: ReactNode }) {
     }
   }, [reloadCatalog, t, toast])
 
+  // 删除已下载资产（下载的逆操作）：confirm → DELETE → 刷 catalog。
+  // 下载中心各区（训练模型 / 打标 / eval / 放大器）共用这一份流程。
+  const deleteAsset = useCallback(async (model_id: string, variant: string | undefined, name: string) => {
+    if (!(await dialog.confirm(t('settings.confirmDeleteAsset', { name }), { tone: 'danger' }))) return
+    try {
+      await api.deleteModelAsset(model_id, variant)
+      toast(t('settings.assetDeleted', { name }), 'success')
+      await reloadCatalog()
+    } catch (e) {
+      toast(String(e), 'error')
+    }
+  }, [dialog, reloadCatalog, t, toast])
+
   // 按类型选下载源：即时存（跟「下载」/ models.root 一样是立即动作，不进表单
   // draft）。刻意不 setSecrets —— 否则会让 SettingsPage 的 draft/server 失同步，
   // 表单 Save 时把这次改动 clobber 回去。dropdown 当前值读 catalog（reloadCatalog
@@ -183,7 +200,7 @@ export function SettingsDataProvider({ children }: { children: ReactNode }) {
     <Ctx.Provider value={{
       secrets, secretsError, setSecrets, commitSecrets, runSave, saveStatus,
       catalog, catalogError, reloadCatalog,
-      downloadBusy, startDownload, setDownloadSource,
+      downloadBusy, startDownload, deleteAsset, setDownloadSource,
     }}>
       {children}
     </Ctx.Provider>

--- a/studio/web/src/pages/tools/settings/modelCards.tsx
+++ b/studio/web/src/pages/tools/settings/modelCards.tsx
@@ -7,6 +7,7 @@ import {
   type ModelsCatalog,
 } from '../../../api/client'
 import { InfoButton } from '../../../components/InfoButton'
+import { useSettingsData } from '../../../lib/SettingsData'
 import { fmtBytes, MODEL_DESCRIPTION_KEYS, textInputClass, translatedCatalogText } from './constants'
 import { SettingsField, SettingsInput } from './fields'
 
@@ -169,6 +170,7 @@ export function WD14ModelCard({
   t: TFunction
 }) {
   const [advOpen, setAdvOpen] = useState(false)
+  const { deleteAsset } = useSettingsData()
   const wd14 = catalog?.wd14
   const wd14Description = translatedCatalogText(MODEL_DESCRIPTION_KEYS, 'wd14', wd14?.description, t)
   if (!wd14) {
@@ -205,6 +207,7 @@ export function WD14ModelCard({
               <DownloadButton
                 exists={v.exists} status={dl?.status} busy={busy.has(key)}
                 onClick={() => void start('wd14', v.model_id)}
+                onDelete={() => void deleteAsset('wd14', v.model_id, v.model_id)}
               />
             </li>
           )
@@ -239,6 +242,7 @@ export function EvalMetricModelCard({
   t: TFunction
 }) {
   const [advOpen, setAdvOpen] = useState(false)
+  const { deleteAsset } = useSettingsData()
   const em = catalog?.eval_metrics
   if (!em) {
     return <p className="text-fg-tertiary text-xs">{t('settings.loadingModelCatalog')}</p>
@@ -260,6 +264,7 @@ export function EvalMetricModelCard({
         <DownloadButton
           exists={exists} status={dl?.status} busy={busy.has(key)}
           onClick={() => void start(dlId, modelId)}
+          onDelete={() => void deleteAsset(dlId, modelId, modelId)}
         />
       </div>
       <button type="button" onClick={() => setAdvOpen(!advOpen)}
@@ -297,6 +302,7 @@ export function CLTaggerModelCard({
   t: TFunction
 }) {
   const [advOpen, setAdvOpen] = useState(false)
+  const { deleteAsset } = useSettingsData()
   const cl = catalog?.cltagger
   const clDescription = translatedCatalogText(MODEL_DESCRIPTION_KEYS, 'cltagger', cl?.description, t)
   if (!cl) {
@@ -343,6 +349,7 @@ export function CLTaggerModelCard({
               <DownloadButton
                 exists={v.exists} status={dl?.status} busy={busy.has(key)}
                 onClick={() => void start('cltagger', v.label)}
+                onDelete={() => void deleteAsset('cltagger', v.label, v.label)}
               />
             </li>
           )
@@ -412,29 +419,34 @@ export function StatusLabel({ bg, fg, text, pulse }: { bg: string; fg: string; t
   )
 }
 
+/** 已下载资产的「删除」按钮（下载的逆操作：用户先删再下载）。 */
+export function DeleteAssetButton({ onClick }: { onClick: () => void }) {
+  const { t } = useTranslation()
+  return (
+    <button onClick={onClick} className="btn btn-ghost btn-sm min-w-[5rem] justify-center"
+      title={t('settings.deleteAssetTitle')}>
+      🗑 {t('settings.deleteAsset')}
+    </button>
+  )
+}
+
 export function DownloadButton({ exists, status, busy, onClick, onDelete }: {
   exists: boolean; status?: ModelDownloadStatus['status']; busy: boolean; onClick: () => void
-  /** 提供时已下载状态的 action 变成「删除」（用户先删再下载）；未提供
-   *  保持「重下」（打标 / 放大器区尚未接删除 API）。 */
-  onDelete?: () => void
+  /** 已下载状态的 action：删除（用户先删再下载）。 */
+  onDelete: () => void
 }) {
   const { t } = useTranslation()
   const running = status === 'running' || busy
   if (running) {
     return <button disabled className="btn btn-secondary btn-sm min-w-[5rem] justify-center" style={{ opacity: 0.5 }}>...</button>
   }
-  if (exists && onDelete) {
-    return (
-      <button onClick={onDelete} className="btn btn-ghost btn-sm min-w-[5rem] justify-center"
-        title={t('settings.deleteAssetTitle')}>
-        🗑 {t('settings.deleteAsset')}
-      </button>
-    )
+  if (exists) {
+    return <DeleteAssetButton onClick={onDelete} />
   }
   return (
     <button onClick={onClick} className="btn btn-secondary btn-sm min-w-[5rem] justify-center"
-      title={exists ? t('settings.redownloadTitle') : t('common.download')}>
-      {exists ? t('settings.redownload') : t('settings.downloadAction')}
+      title={t('common.download')}>
+      {t('settings.downloadAction')}
     </button>
   )
 }

--- a/studio/web/src/pages/tools/settings/sections.tsx
+++ b/studio/web/src/pages/tools/settings/sections.tsx
@@ -23,7 +23,7 @@ import { applyDensity, applyTheme, getStoredDensity, getStoredTheme, setStoredDe
 import i18n, { getStoredLangWithDefault, setStoredLang } from '../../../i18n'
 import { MODEL_DESCRIPTION_KEYS, textInputClass, translatedCatalogText, UPSCALER_DESCRIPTION_KEYS, type Section } from './constants'
 import { Bool, SettingsField, SettingsInput, SettingsSection } from './fields'
-import { DownloadButton, ModelGroupCard, ModelStatusBadge, SourceSelect, StatusLabel } from './modelCards'
+import { DeleteAssetButton, DownloadButton, ModelGroupCard, ModelStatusBadge, SourceSelect, StatusLabel } from './modelCards'
 
 // ── 训练参数 Section ─────────────────────────────────────────────────
 //
@@ -109,7 +109,7 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
 }) {
   const { toast } = useToast()
   const dialog = useDialog()
-  const { runSave } = useSettingsData()
+  const { runSave, deleteAsset } = useSettingsData()
   const [selected, setSelected] = useState<Record<FamilyId, string>>({
     anima: '1.0', krea2: 'raw',
   })
@@ -162,18 +162,6 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
       toast(String(e), 'error')
     } finally {
       setAddingFamily(null)
-    }
-  }
-
-  // 删除已下载资产（下载的逆操作）：confirm → DELETE → 刷 catalog
-  const deleteAsset = async (modelId: string, variant: string | undefined, name: string) => {
-    if (!(await dialog.confirm(t('settings.confirmDeleteAsset', { name }), { tone: 'danger' }))) return
-    try {
-      await api.deleteModelAsset(modelId, variant)
-      toast(t('settings.assetDeleted', { name }), 'success')
-      await reloadCatalog()
-    } catch (e) {
-      toast(String(e), 'error')
     }
   }
 
@@ -341,7 +329,7 @@ export function ModelsSection({ catalog, busy, start, setSource, reloadCatalog, 
                           : <span className="text-err text-2xs">{t('settings.localModelMissing')}</span>}
                         <button
                           onClick={() => void removeCustom(section.family, section.fallbackSelected, c.path)}
-                          className="btn btn-secondary btn-sm shrink-0 min-w-[5rem] justify-center"
+                          className="btn btn-ghost btn-sm shrink-0 min-w-[5rem] justify-center"
                           title={t('settings.removeLocalModel')}
                         >🗑 {t('settings.removeLocalModelShort')}</button>
                       </li>
@@ -442,7 +430,7 @@ export function UpscalerSection({
   t: TFunction
 }) {
   const { toast } = useToast()
-  const { runSave } = useSettingsData()
+  const { runSave, deleteAsset } = useSettingsData()
   const [customSource, setCustomSource] = useState<'hf' | 'ms'>('hf')
   const [customRepo, setCustomRepo] = useState('')
   const [customFile, setCustomFile] = useState('')
@@ -541,13 +529,17 @@ export function UpscalerSection({
                       </span>
                     </div>
                     <ModelStatusBadge exists={v.exists} size={v.size} status={dl?.status} />
-                    {v.kind === 'preset' && (
+                    {v.kind === 'preset' ? (
                       <DownloadButton
                         exists={v.exists}
                         status={dl?.status}
                         busy={busy.has(`upscaler:${v.label}`)}
                         onClick={() => void start('upscaler', v.label)}
+                        onDelete={() => void deleteAsset('upscaler', v.label, v.label)}
                       />
+                    ) : (
+                      /* custom：扫盘发现的文件，只有删除（重下走下方自定义下载表单） */
+                      <DeleteAssetButton onClick={() => void deleteAsset('upscaler', v.filename, v.label)} />
                     )}
                   </li>
                 )

--- a/tests/test_argparse_bridge.py
+++ b/tests/test_argparse_bridge.py
@@ -227,7 +227,7 @@ def test_training_config_builds_without_collisions() -> None:
     assert hasattr(ns, "config")
     # 抽样字段都能解析出正确类型
     assert ns.lora_rank == 32
-    assert ns.lora_type == "lokr"
+    assert ns.lora_type == "lora"
     assert ns.cache_latents is True
     assert ns.vae_cache_batch_size == 0
     assert ns.sample_prompts == []

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -1231,9 +1231,76 @@ def test_delete_asset_removes_known_targets(tmp_path, monkeypatch):
 
     import pytest as _pytest
     with _pytest.raises(ValueError, match="deletion"):
-        m.delete_asset("wd14")
+        m.delete_asset("taeflux")
     with _pytest.raises(ValueError, match="variant"):
         m.delete_asset("krea2_main", "bogus")
+
+
+def test_delete_asset_tagger_eval_upscaler(tmp_path, monkeypatch):
+    """打标 / eval / 放大器区的删除：目录与文件两形态 + variant 必填校验。"""
+    from pathlib import Path
+
+    from studio.services import models as m
+    from studio.services.models import downloader as dl
+    from studio.services.models.paths import CLTAGGER_VERSIONS
+
+    monkeypatch.setattr(dl, "models_root", lambda: tmp_path)
+
+    # wd14：整目录（model_id 里的 / 会被 sanitize 成 _）
+    wd_dir = tmp_path / "wd14" / "SmilingWolf_wd-eva02-large-tagger-v3"
+    wd_dir.mkdir(parents=True)
+    (wd_dir / "model.onnx").write_bytes(b"w")
+    m.delete_asset("wd14", "SmilingWolf/wd-eva02-large-tagger-v3")
+    assert not wd_dir.exists()
+
+    # cltagger：只删该版本子目录，repo 根下其他版本保留
+    label, preset = next(iter(CLTAGGER_VERSIONS.items()))
+    repo_root = tmp_path / "cltagger" / preset["model_id"].replace("/", "_")
+    version_dir = repo_root / Path(preset["model_path"]).parent
+    version_dir.mkdir(parents=True)
+    (version_dir / "model.onnx").write_bytes(b"w")
+    (repo_root / "other_version").mkdir()
+    m.delete_asset("cltagger", label)
+    assert not version_dir.exists()
+    assert (repo_root / "other_version").exists()
+
+    # eval：clip / ccip 各一个目录
+    clip_dir = tmp_path / "eval" / "clip" / "openai_clip-vit-base-patch32"
+    clip_dir.mkdir(parents=True)
+    (clip_dir / "config.json").write_text("{}", encoding="utf-8")
+    m.delete_asset("eval_clip", "openai/clip-vit-base-patch32")
+    assert not clip_dir.exists()
+
+    ccip_dir = tmp_path / "eval" / "ccip" / "ccip-caformer-24-randaug-pruned"
+    ccip_dir.mkdir(parents=True)
+    (ccip_dir / "model_feat.onnx").write_bytes(b"w")
+    m.delete_asset("eval_ccip", "ccip-caformer-24-randaug-pruned")
+    assert not ccip_dir.exists()
+
+    # upscaler：预设 label → 预设 filename；自定义文件名直接删
+    from studio.services.models.paths import DEFAULT_UPSCALER, UPSCALER_VARIANTS
+
+    up_dir = tmp_path / "upscalers"
+    up_dir.mkdir()
+    preset_file = up_dir / UPSCALER_VARIANTS[DEFAULT_UPSCALER]["filename"]
+    preset_file.write_bytes(b"w")
+    m.delete_asset("upscaler", DEFAULT_UPSCALER)
+    assert not preset_file.exists()
+
+    custom_file = up_dir / "4x-MyCustom.pth"
+    custom_file.write_bytes(b"w")
+    m.delete_asset("upscaler", "4x-MyCustom.pth")
+    assert not custom_file.exists()
+
+    import pytest as _pytest
+    for mid in ("wd14", "eval_clip", "eval_dino", "eval_ccip", "upscaler"):
+        with _pytest.raises(ValueError, match="variant"):
+            m.delete_asset(mid)
+    with _pytest.raises(ValueError, match="cltagger"):
+        m.delete_asset("cltagger", "bogus")
+    # 自定义 label 的路径穿越保护由 upscaler_target 兜底
+    with _pytest.raises(ValueError):
+        m.delete_asset("upscaler", "..\\evil.pth")
 
 
 def test_delete_asset_rejects_running_download(tmp_path, monkeypatch):

--- a/tests/test_presets_io.py
+++ b/tests/test_presets_io.py
@@ -119,7 +119,7 @@ def test_parse_json_works_via_yaml_superset() -> None:
     import json
     raw = json.dumps(_payload()).encode("utf-8")
     config, suggested = presets_io.parse_preset_bytes(raw, "old.json")
-    assert config["lora_type"] == "lokr"
+    assert config["lora_type"] == "lora"
     assert suggested == "old"
 
 

--- a/tests/test_studio_configs.py
+++ b/tests/test_studio_configs.py
@@ -256,7 +256,7 @@ def test_yaml_on_disk_is_human_readable(client: TestClient, presets_dir: Path) -
     assert "transformer_path:" in text
     assert not text.startswith("{")
     parsed = yaml.safe_load(text)
-    assert parsed["lora_type"] == "lokr"
+    assert parsed["lora_type"] == "lora"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 改动一：训练 / 预设默认 LoRA 变种 lokr → lora

新项目与新预设的 `lora_type` 默认值改为经典 LoRA。schema 描述与 zh/en i18n 镜像同步（默认标注移到 lora）。预设默认值直接来自 `TrainingConfig()`，无独立预设文件需要改；family 切换（switch_family）不触碰 lora_type，两族生效一致。已存量配置不受影响（显式落盘值优先）。

## 改动二：下载中心「删除」接入全区 + 流程统一

#439 把已下载资产的「重下」改成「删除」，但只做了训练模型区。本次补齐：

**后端** `delete_asset` 新增分支（目标路径全部服务端解析，不接受任意路径）：
- `wd14`（整目录）
- `cltagger`（按版本子目录删——v1/v2 同 repo 根下多版本并存，只删所选版本）
- `eval_clip` / `eval_dino` / `eval_ccip`（整目录；用户填本地目录路径当 model_id 的场景天然安全——target 永远解析到 models_root 内，不存在则 no-op）
- `upscaler`（预设 label + 自定义文件名，路径穿越由 `upscaler_target` 现有校验兜底；running 检查按 `upscaler:custom:{filename}` 匹配自定义下载 key）

**前端统一抽象**：删除流程（confirm → DELETE → toast → 刷 catalog）此前是 `ModelsSection` 的局部函数，现收进 `SettingsData.deleteAsset` 供下载中心各区共用（`SettingsData` 本就是下载中心共享数据层，`startDownload` / `downloadBusy` / SSE 已在这里）。行级 UI 未强行合并成单一组件——各区行的选择语义 / 徽标差异大，共享件（`DownloadButton` / `DeleteAssetButton` / `ModelStatusBadge` / `ModelGroupCard`）已覆盖重复面。

**顺带**：
- custom 放大器行新增删除按钮（此前无任何 action，删除后经自定义下载表单重下）
- 本地模型「移除」按钮改 ghost 样式，与删除按钮一致
- `DownloadButton.onDelete` 收紧必填，删掉已无调用方的「重下」分支及 `settings.redownload*` i18n key

## 测试

- 关联：`test_model_downloader`（新增 tagger/eval/upscaler 删除用例）/ `test_argparse_bridge` / `test_presets_io` / `test_config_prune` / `test_config_rules` / `test_lokr_schema_extensions` 全绿
- 安全网：`test_route_snapshot` + `test_studio_configs` 全绿
- 前端：vitest 490 全绿 + `npm run build` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)