### PR TITLE
feat(models): 下载中心加官方 Turbo fp8 variant

### DIFF
--- a/studio/services/models/families/krea2.py
+++ b/studio/services/models/families/krea2.py
@@ -45,6 +45,18 @@ KREA2_VARIANTS: dict[str, dict[str, Any]] = {
         "purpose": "inference",
         "size_estimate": 26_300_000_000,
     },
+    # Comfy-Org 官方 fp8_scaled Turbo：TDM 蒸馏推理靶子的量化版（8 步 /
+    # 无 CFG，与 raw_fp8 同管线）。purpose=inference → is_distilled_path
+    # 判蒸馏，测试页选中自动应用蒸馏采样默认。
+    "turbo_fp8": {
+        "repo": "Comfy-Org/Krea-2",
+        "subpath": "diffusion_models/krea2_turbo_fp8_scaled.safetensors",
+        "ms_repo": "Comfy-Org/Krea-2",
+        "ms_subpath": "diffusion_models/krea2_turbo_fp8_scaled.safetensors",
+        "filename": "krea2-turbo-fp8-scaled.safetensors",
+        "purpose": "inference",
+        "size_estimate": 13_100_000_000,
+    },
 }
 LATEST_KREA2 = "raw"
 KREA2_LICENSE = "Krea 2 Community License"
@@ -255,8 +267,8 @@ def catalog_sections(root: Path, models_cfg: Any) -> dict[str, Any]:
             "id": "krea2_main",
             "name": "Krea 2 主模型",
             "description": (
-                "Raw 训练底模（bf16 26.3 GB；fp8 13.1 GB，训练/出图权重"
-                "显存减半）/ Turbo 推理底模（26.3 GB）"
+                "Raw 训练底模 / Turbo 推理底模，各有 bf16（26.3 GB）与"
+                "官方 fp8（13.1 GB，权重显存减半）两版"
             ),
             "repo": "krea/Krea-2-{Raw,Turbo}",
             "variants": variants,

--- a/tests/test_family_assets.py
+++ b/tests/test_family_assets.py
@@ -144,9 +144,11 @@ def test_krea2_catalog_sections_report_raw_turbo_and_text_encoder(tmp_path):
     )
     assert any(f["name"] == "config.json" for f in fp8_te["files"])
     main = sections["krea2_main"]
-    assert [v["variant"] for v in main["variants"]] == ["raw", "raw_fp8", "turbo"]
+    assert [v["variant"] for v in main["variants"]] == [
+        "raw", "raw_fp8", "turbo", "turbo_fp8",
+    ]
     assert [v["purpose"] for v in main["variants"]] == [
-        "training", "training", "inference",
+        "training", "training", "inference", "inference",
     ]
     assert main["selected"] == str(custom)
     assert main["custom"] == [{

--- a/tests/test_generate_family.py
+++ b/tests/test_generate_family.py
@@ -42,6 +42,8 @@ def test_is_distilled_path_by_official_variant():
     """Turbo 与 Raw 结构全等，loader 指纹无法区分——只能按 catalog 文件名判。"""
     krea2 = get_assets("krea2")
     assert krea2.is_distilled_path("G:/models/diffusion_models/krea2-turbo-bf16.safetensors")
+    # 官方 fp8 Turbo 同为蒸馏推理靶子——测试页选中自动应用 8 步/无 CFG
+    assert krea2.is_distilled_path("G:/models/diffusion_models/krea2-turbo-fp8-scaled.safetensors")
     assert not krea2.is_distilled_path("G:/models/diffusion_models/krea2-raw-bf16.safetensors")
     # fp8 Raw 是非蒸馏训练/推理底模——绝不能被 purpose 逻辑误判成 Turbo
     assert not krea2.is_distilled_path("G:/models/diffusion_models/krea2-raw-fp8-scaled.safetensors")


### PR DESCRIPTION
## 改动

下载中心 krea2 主模型卡新增 **turbo_fp8** variant——Comfy-Org 官方 `krea2_turbo_fp8_scaled.safetensors`（13.1GB，已核实存在，与 raw_fp8 同一量化管线）。

- `purpose=inference` → `is_distilled_path` 正确判蒸馏：测试页选中后自动应用 8 步 / 无 CFG 蒸馏采样默认（与 bf16 Turbo 同款行为）
- downloader / 前端 variant 渲染 / 删除 API 全数据驱动，加条目零额外改动
- 主模型卡 description 更新为「Raw / Turbo 各有 bf16 与官方 fp8 两版」
- 测试：variants/purposes 断言 + is_distilled turbo_fp8 用例

此前用户 fp8 推理测试用的是社区转传文件（custom 注册）；官方源进下载中心后可直接下载，variant 元数据（蒸馏检测）也就位。

🤖 Generated with [Claude Code](https://claude.com/claude-code)