### PR TITLE
refactor(sampling): krea2 调度器值 krea2_shift 改名 simple 对齐 ComfyUI 命名

### DIFF
--- a/runtime/training/families/krea2/sampling.py
+++ b/runtime/training/families/krea2/sampling.py
@@ -28,7 +28,10 @@ from .text_encoding import Krea2TextCondition
 
 
 KREA2_SAMPLER = "euler"
-KREA2_SCHEDULER = "krea2_shift"
+# scheduler 名对齐 ComfyUI（曾名 krea2_shift）：Comfy 的 simple 挂 Krea2
+# （ModelSamplingFlux shift=1.15）取出的 sigma 与 build_krea2_sigmas 恒等，
+# shift 属模型口径、不进 scheduler 命名——用户在 Comfy 复现时选 euler+simple。
+KREA2_SCHEDULER = "simple"
 KREA2_RAW_STEPS = 28
 KREA2_RAW_GUIDANCE = 4.5
 KREA2_TURBO_STEPS = 8
@@ -72,7 +75,7 @@ def resolve_sampling_settings(
     schedule = KREA2_SCHEDULER if scheduler is None else str(scheduler).lower().strip()
     if sampler != KREA2_SAMPLER or schedule != KREA2_SCHEDULER:
         raise ValueError(
-            "Krea2 仅支持 euler+krea2_shift，实际 "
+            "Krea2 仅支持 euler+simple，实际 "
             f"{sampler or '<empty>'}+{schedule or '<empty>'}"
         )
 

--- a/studio/api/schemas/generate.py
+++ b/studio/api/schemas/generate.py
@@ -16,7 +16,7 @@ class GenerateRequest(BaseModel):
     steps: int = 25
     cfg_scale: float = 4.0
     sampler_name: Literal["er_sde", "dpmpp_3m_sde", "euler"] = "er_sde"
-    scheduler: Literal["simple", "sgm_uniform", "krea2_shift"] = "simple"
+    scheduler: Literal["simple", "sgm_uniform"] = "simple"
     count: int = 1
     seed: int = 0
     lora_configs: list[LoraEntry] = []

--- a/studio/api/schemas/training.py
+++ b/studio/api/schemas/training.py
@@ -156,7 +156,7 @@ class RegAiRequest(BaseModel):
     steps: int = 25
     cfg_scale: float = 4.0
     # None = 未指定 → 端点按 version 的模型族解析默认（anima er_sde/simple，
-    # krea2 euler/krea2_shift）。显式给值则按族白名单严格校验
+    # krea2 euler/simple）。显式给值则按族白名单严格校验
     sampler_name: Optional[str] = None
     scheduler: Optional[str] = None
     seed: int = 0

--- a/studio/domain/common.py
+++ b/studio/domain/common.py
@@ -40,7 +40,7 @@ FAMILY_CONFIG_DEFAULTS: dict[str, dict[str, Any]] = {
         "timestep_sampling": "krea2_shift",
         "timestep_shift_resolution_aware": False,
         "sample_sampler_name": "euler",
-        "sample_scheduler": "krea2_shift",
+        "sample_scheduler": "simple",
         "sample_infer_steps": 28,
         "sample_cfg_scale": 4.5,
     },
@@ -61,8 +61,11 @@ FAMILY_SAMPLING: dict[str, dict[str, tuple[str, ...]]] = {
         "schedulers": ("simple", "sgm_uniform"),
     },
     "krea2": {
+        # scheduler 名对齐 ComfyUI：Comfy 的 simple 挂 Krea2（ModelSamplingFlux）
+        # 时取的就是本项目 krea2 sigma 口径——shift 属模型口径不属 scheduler 名
+        # （曾名 krea2_shift；存量值经 Literal-外归并落回 simple）。
         "samplers": ("euler",),
-        "schedulers": ("krea2_shift",),
+        "schedulers": ("simple",),
     },
 }
 

--- a/studio/domain/generate.py
+++ b/studio/domain/generate.py
@@ -70,7 +70,7 @@ class GenerateConfig(BaseModel):
     steps: int = Field(25, ge=1, le=150)
     cfg_scale: float = Field(4.0, ge=0.0, le=20.0)
     sampler_name: Literal["er_sde", "dpmpp_3m_sde", "euler"] = Field("er_sde")
-    scheduler: Literal["simple", "sgm_uniform", "krea2_shift"] = Field("simple")
+    scheduler: Literal["simple", "sgm_uniform"] = Field("simple")
     count: int = Field(1, ge=1, le=32, description="每个 prompt 生成张数")
     seed: int = Field(0, description="随机种子（0=随机）")
 

--- a/studio/domain/reg.py
+++ b/studio/domain/reg.py
@@ -50,7 +50,7 @@ class RegAiConfig(BaseModel):
     steps: int = Field(25, ge=1, le=150)
     cfg_scale: float = Field(4.0, ge=0.0, le=20.0)
     sampler_name: Literal["er_sde", "dpmpp_3m_sde", "euler"] = Field("er_sde")
-    scheduler: Literal["simple", "sgm_uniform", "krea2_shift"] = Field("simple")
+    scheduler: Literal["simple", "sgm_uniform"] = Field("simple")
     seed: int = Field(0, description="随机种子（0=随机）")
     incremental: bool = Field(
         False,

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -1192,10 +1192,10 @@ class TrainingConfig(BaseModel):
             "sample", option_show_when=sampling_option_gates("samplers"),
         ),
     )
-    sample_scheduler: Literal["simple", "sgm_uniform", "krea2_shift"] = Field(
+    sample_scheduler: Literal["simple", "sgm_uniform"] = Field(
         "simple",
-        description="调度器。simple / sgm_uniform 为 Anima 的 ComfyUI 切分；"
-                    "krea2_shift 为 Krea 2 的分辨率感知动态 shift 时刻表",
+        description="调度器。与 ComfyUI 同名同义；sigma 表由模型族决定"
+                    "（Krea 2 的 simple 含固定 shift=1.15 口径）",
         json_schema_extra=_meta(
             "sample", option_show_when=sampling_option_gates("schedulers"),
         ),

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -349,12 +349,11 @@
       "sampler": {
         "erSde": "ER SDE",
         "dpmpp3mSde": "DPM++ 3M SDE",
-        "euler": "Euler (FlowMatch)"
+        "euler": "Euler"
       },
       "scheduler": {
         "simple": "Simple",
-        "sgmUniform": "SGM Uniform",
-        "krea2Shift": "Krea2 Dynamic Shift"
+        "sgmUniform": "SGM Uniform"
       },
       "modelFamily": {
         "anima": "Anima",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -349,12 +349,11 @@
       "sampler": {
         "erSde": "ER SDE",
         "dpmpp3mSde": "DPM++ 3M SDE",
-        "euler": "Euler（FlowMatch）"
+        "euler": "Euler"
       },
       "scheduler": {
         "simple": "Simple",
-        "sgmUniform": "SGM Uniform",
-        "krea2Shift": "Krea2 动态 Shift"
+        "sgmUniform": "SGM Uniform"
       },
       "modelFamily": {
         "anima": "Anima",

--- a/studio/web/src/lib/schema.ts
+++ b/studio/web/src/lib/schema.ts
@@ -175,7 +175,6 @@ export const SCHEMA_ENUM_LABEL_KEYS: Record<string, Record<string, string>> = {
   sample_scheduler: {
     simple: 'schema.enums.scheduler.simple',
     sgm_uniform: 'schema.enums.scheduler.sgmUniform',
-    krea2_shift: 'schema.enums.scheduler.krea2Shift',
   },
 }
 

--- a/studio/web/src/pages/tools/generate/types.ts
+++ b/studio/web/src/pages/tools/generate/types.ts
@@ -30,7 +30,8 @@ export const SAMPLER_OPTIONS_BY_FAMILY = {
 
 export const SCHEDULER_OPTIONS_BY_FAMILY = {
   anima: ['simple', 'sgm_uniform'],
-  krea2: ['krea2_shift'],
+  // krea2 的 simple 含固定 shift 口径（曾名 krea2_shift，命名对齐 ComfyUI）
+  krea2: ['simple'],
 } as const satisfies Record<GenerateFamily, readonly string[]>
 
 /** 切族时应用的生成参数默认值（steps/cfg 对齐族 SamplingDefaults）。 */
@@ -47,6 +48,6 @@ export const SAMPLER_OPTIONS = ['er_sde', 'dpmpp_3m_sde', 'euler'] as const
 export type SamplerName = (typeof SAMPLER_OPTIONS)[number]
 export const DEFAULT_SAMPLER: SamplerName = 'er_sde'
 
-export const SCHEDULER_OPTIONS = ['simple', 'sgm_uniform', 'krea2_shift'] as const
+export const SCHEDULER_OPTIONS = ['simple', 'sgm_uniform'] as const
 export type SchedulerName = (typeof SCHEDULER_OPTIONS)[number]
 export const DEFAULT_SCHEDULER: SchedulerName = 'simple'

--- a/tests/test_comfy_parity_contract.py
+++ b/tests/test_comfy_parity_contract.py
@@ -92,7 +92,7 @@ def test_training_config_sampler_scheduler_are_enums() -> None:
         "er_sde", "dpmpp_3m_sde", "euler",
     }
     assert set(schema["properties"]["sample_scheduler"]["enum"]) == {
-        "simple", "sgm_uniform", "krea2_shift",
+        "simple", "sgm_uniform",
     }
 
 

--- a/tests/test_family_switch.py
+++ b/tests/test_family_switch.py
@@ -32,7 +32,7 @@ def test_switch_anima_to_krea2_rewrites_paths_and_flavor():
     assert new["transformer_path"].endswith("krea2-raw-bf16.safetensors")
     assert new["t5_tokenizer_path"] == ""
     assert new["sample_sampler_name"] == "euler"
-    assert new["sample_scheduler"] == "krea2_shift"
+    assert new["sample_scheduler"] == "simple"
     assert new["timestep_sampling"] == "krea2_shift"
     assert new["shuffle_caption"] is False
     # 目标族不支持的能力字段被关回，否则 validator 拒绝整份 config

--- a/tests/test_generate_family.py
+++ b/tests/test_generate_family.py
@@ -12,27 +12,28 @@ from studio.services.models.families import get_assets
 def test_generate_config_family_sampler_whitelist():
     """每任务临时 config 无 legacy 语料——越族 sampler 直接报错（422）。"""
     GenerateConfig(model_family="krea2", sampler_name="euler",
-                   scheduler="krea2_shift")
+                   scheduler="simple")
     with pytest.raises(ValueError, match="er_sde"):
         GenerateConfig(model_family="krea2", sampler_name="er_sde",
-                       scheduler="krea2_shift")
+                       scheduler="simple")
     with pytest.raises(ValueError, match="euler"):
         GenerateConfig(model_family="anima", sampler_name="euler")
-    with pytest.raises(ValueError, match="krea2_shift"):
-        GenerateConfig(model_family="anima", scheduler="krea2_shift")
+    with pytest.raises(ValueError, match="sgm_uniform"):
+        GenerateConfig(model_family="krea2", sampler_name="euler",
+                       scheduler="sgm_uniform")
 
 
 def test_reg_config_family_sampler_whitelist():
     RegAiConfig(model_family="krea2", sampler_name="euler",
-                scheduler="krea2_shift")
-    with pytest.raises(ValueError, match="simple"):
+                scheduler="simple")
+    with pytest.raises(ValueError, match="sgm_uniform"):
         RegAiConfig(model_family="krea2", sampler_name="euler",
-                    scheduler="simple")
+                    scheduler="sgm_uniform")
 
 
 def test_generate_config_carries_family_and_distilled_to_daemon():
     cfg = GenerateConfig(model_family="krea2", distilled=True,
-                         sampler_name="euler", scheduler="krea2_shift")
+                         sampler_name="euler", scheduler="simple")
     dumped = cfg.model_dump()
     assert dumped["model_family"] == "krea2"
     assert dumped["distilled"] is True

--- a/tests/test_model_family_gating.py
+++ b/tests/test_model_family_gating.py
@@ -121,7 +121,7 @@ def test_default_config_valid_and_yaml_roundtrip():
     assert krea2.attention_backend == "none"
     assert krea2.timestep_sampling == "krea2_shift"
     assert (krea2.sample_sampler_name, krea2.sample_scheduler) == (
-        "euler", "krea2_shift",
+        "euler", "simple",
     )
     assert (krea2.sample_infer_steps, krea2.sample_cfg_scale) == (28, 4.5)
 
@@ -174,8 +174,16 @@ def test_cross_family_sampler_asymmetric_grandfather():
     )
     with pytest.raises(ValueError, match="er_sde"):
         TrainingConfig(model_family="krea2", sample_sampler_name="er_sde")
-    with pytest.raises(ValueError, match="simple"):
-        TrainingConfig(model_family="krea2", sample_scheduler="simple")
+    with pytest.raises(ValueError, match="sgm_uniform"):
+        TrainingConfig(model_family="krea2", sample_scheduler="sgm_uniform")
+
+
+def test_krea2_shift_scheduler_value_renamed_to_simple():
+    """scheduler 值 krea2_shift → simple（命名对齐 ComfyUI）：改名前落盘的
+    krea2 config 经 Literal-外归并落回族默认 simple——语义等价（同一条 sigma
+    时刻表），不整份报废。"""
+    cfg = TrainingConfig(model_family="krea2", sample_scheduler="krea2_shift")
+    assert cfg.sample_scheduler == "simple"
 
 
 def test_legacy_garbage_sampler_still_migrates_to_family_default():
@@ -189,7 +197,7 @@ def test_legacy_garbage_sampler_still_migrates_to_family_default():
         sample_sampler_name="ancient_free_text", sample_scheduler="karras",
     )
     assert (krea2.sample_sampler_name, krea2.sample_scheduler) == (
-        "euler", "krea2_shift",
+        "euler", "simple",
     )
 
 

--- a/tests/test_version_config.py
+++ b/tests/test_version_config.py
@@ -353,7 +353,7 @@ def test_fork_krea2_preset_syncs_krea2_paths(env, monkeypatch) -> None:
     # krea2 preset 必须是自洽的族内值：shuffle_caption 关（anima-only 能力）、
     # sampler/scheduler 用族白名单值（跨族值在 P4-2 起报错而非静默改写）
     _seed_preset(env, "tpl", model_family="krea2", shuffle_caption=False,
-                 sample_sampler_name="euler", sample_scheduler="krea2_shift",
+                 sample_sampler_name="euler", sample_scheduler="simple",
                  transformer_path=_custom_path())
     cfg = preset_flow.fork_preset_for_version("tpl", p, v)
     assert cfg["model_family"] == "krea2"


### PR DESCRIPTION
## 动机

用户在测试页出完图去 ComfyUI 复现时，找不到「Krea2 动态 Shift」对应的组合。根因是命名切层不同：ComfyUI 把 shift 挂在模型注册上（Krea2 → `ModelSamplingFlux(shift=1.15)`），scheduler 下拉里显示的是通用名 `simple`；本程序此前把同一条 sigma 曲线显式命名成了 `krea2_shift`。两者数学恒等（`build_krea2_sigmas` 固定 mu=1.15 与 Comfy `flux_time_shift` 同一 Möbius 形式），但用户跨面对不上号。另外「动态」二字在默认口径改为固定 mu 后已名不副实。

本 PR 把 scheduler 值与 UI 标签统一改为 `simple`，采样器标签同步去掉「(FlowMatch)」尾注——用户在本程序看到的 **Euler + Simple** 与 ComfyUI 里挂 Krea2 模型时选的 **euler + simple** 逐字对应。

## 改动

- `FAMILY_SAMPLING["krea2"].schedulers` / `KREA2_SCHEDULER` → `"simple"`；`resolve_sampling_settings` 报错文案同步
- `sample_scheduler` / generate / reg 三份 config 的 Literal 收窄回 `["simple", "sgm_uniform"]`；`sgm_uniform` 经既有 `option_show_when` 推导自动只对 anima 展示，`simple` 两族共用不设门
- i18n 删除 `krea2Shift` 标签键；`euler` 标签「Euler（FlowMatch）」→「Euler」
- 前端 `SCHEDULER_OPTIONS(_BY_FAMILY)` 同步收窄

## 兼容

- 改名前落盘的 krea2 config（`sample_scheduler: krea2_shift`）落进 `_normalize_sampling` 的 Literal-外归并分支，自动迁回族默认 `simple`——语义等价（同一条时刻表），零额外迁移代码；补回归测试 `test_krea2_shift_scheduler_value_renamed_to_simple`
- 前端 localStorage prefs 与 PNG 快照导入走既有按族 coerce（非法值 → 族默认 = `simple`），同样自动迁移
- 训练端 `timestep_sampling="krea2_shift"`（kohya 系训练 t 采样策略，非 Comfy 概念）不在本次范围，维持原名
- krea2 未进过任何 release，不涉及 release notes

## 测试

- pytest 关联 9 个文件 122 passed（含 route/studio_configs 安全网快照）
- vitest 56 文件 496 passed；`tsc --noEmit` 干净

🤖 Generated with [Claude Code](https://claude.com/claude-code)