### PR TITLE
fix(train): NaViT 分支 t5_attn NameError —— 0.20.0 navit_packing 训练必崩

### DIFF
--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -62,12 +62,17 @@ class AnimaFamily:
         return None  # Anima 每步在线编码（spec.text.strategy="online"），无缓存
 
     def encode_text_for_batch(self, text, dit, captions, device, dtype, *,
-                              comfy_encoding: bool = True, kv_trim: bool = False):
+                              comfy_encoding: bool = True, kv_trim: bool = False,
+                              return_t5_attn: bool = False):
         """每步在线编码（自 loop.py 文本块下沉，行为零变化）。
 
         comfy_encoding=True（默认）：raw caption 进 Qwen；T5 整段字面 tokenize，
         与测试出图 / 训练预览 conditioning 同一链路。False = legacy A/B 路径。
         返回 cross —— 对循环 opaque（03 §2.7-4）。
+
+        return_t5_attn=True 时返回 (cross, t5_attn)：NaViT 打包需要逐图
+        attention mask 做 cross-attn padding 截断。navit 是 Anima 能力位（D5），
+        该 kwarg 为族私有、不进 protocol。
         """
         import torch
         import torch.nn.functional as F
@@ -106,6 +111,8 @@ class AnimaFamily:
                         _bucket = _b
                         break
                 cross = cross[:, :_bucket, :].contiguous()
+        if return_t5_attn:
+            return cross, t5_attn
         return cross
 
     # ── 训练前向 / 采样 ──────────────────────────────────────────────────

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -219,12 +219,24 @@ def run(ctx: TrainingContext) -> None:
 
             # 文本编码：整块下沉 family（cond 对循环 opaque，03 §2.7-4；
             # pad-to-512 / kv_trim / LLMAdapter 融合均为 Anima 私货）
-            cross = ctx.family.encode_text_for_batch(
-                ctx.text_stack, ctx.model, captions,
-                ctx.device, ctx.dtype,
+            _enc_kwargs = dict(
                 comfy_encoding=bool(getattr(args, "caption_comfy_encoding", True)),
                 kv_trim=bool(getattr(args, "kv_trim", False)),
             )
+            if navit_latents is not None:
+                # NaViT 打包需要逐图 attention mask 做 cross-attn padding 截断；
+                # navit 是 Anima 能力位（能力校验 fail-fast），族私有 kwarg 不进 protocol。
+                cross, t5_attn = ctx.family.encode_text_for_batch(
+                    ctx.text_stack, ctx.model, captions,
+                    ctx.device, ctx.dtype,
+                    return_t5_attn=True, **_enc_kwargs,
+                )
+            else:
+                cross = ctx.family.encode_text_for_batch(
+                    ctx.text_stack, ctx.model, captions,
+                    ctx.device, ctx.dtype,
+                    **_enc_kwargs,
+                )
 
             # Flow Matching：统一通过 timestep_sampler plugin 接口采样
             # （baseline = 4 种 mode；adaptive = InfoNoise 等；接口在 ADR 0003 plugin registry）

--- a/tests/test_navit_text_encode_regression.py
+++ b/tests/test_navit_text_encode_regression.py
@@ -1,0 +1,135 @@
+"""NaViT 文本编码回归（0.20.0 t5_attn NameError）。
+
+PR #407 把文本编码下沉 ``AnimaFamily.encode_text_for_batch``（只返回 opaque
+cross）后，loop.py 的 NaViT 分支仍引用旧局部变量 ``t5_attn`` → 所有
+``navit_packing=true`` 用户训练第一步 NameError 必崩。CI 无 GPU 跑不到该
+分支，故两层防线：
+
+1. ``encode_text_for_batch(return_t5_attn=True)`` 的族私有契约单测；
+2. ``symtable`` 静态扫描 runtime/training/ 全部函数作用域——引用了但在任何
+   作用域链上都无绑定的名字（即 pyflakes F821 类错误）直接测试失败。分支
+   门控代码路径不需要执行也能被抓住。
+"""
+from __future__ import annotations
+
+import builtins
+import symtable
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from training.families.anima.family import AnimaFamily
+
+
+# ── 1. return_t5_attn 契约 ──────────────────────────────────────────────
+
+
+def _stub_text_encoding(monkeypatch, attn: "torch.Tensor") -> None:
+    import training.families.anima.text_encoding as te
+
+    B, L = attn.shape
+    monkeypatch.setattr(
+        te, "encode_qwen", lambda model, tok, texts, device: (torch.zeros(B, 8, 4), None)
+    )
+    monkeypatch.setattr(
+        te,
+        "tokenize_t5_comfy_literal",
+        lambda tok, captions, max_length: (
+            torch.zeros(B, L, dtype=torch.long),
+            attn,
+            torch.ones(B, L),
+        ),
+    )
+
+
+def _stub_dit(max_len: int):
+    return SimpleNamespace(
+        preprocess_text_embeds=lambda qwen_emb, t5_ids, t5xxl_weights: torch.zeros(
+            t5_ids.shape[0], max_len, 4
+        )
+    )
+
+
+def test_encode_text_for_batch_returns_t5_attn_for_navit(monkeypatch) -> None:
+    family = AnimaFamily()
+    max_len = family.spec.text.max_seq_len
+    attn = torch.tensor([[1, 1, 1, 0], [1, 1, 0, 0]], dtype=torch.long)
+    _stub_text_encoding(monkeypatch, attn)
+
+    result = family.encode_text_for_batch(
+        (None, None, None), _stub_dit(max_len), ["a", "b"], "cpu", torch.float32,
+        return_t5_attn=True,
+    )
+    assert isinstance(result, tuple) and len(result) == 2
+    cross, t5_attn = result
+    assert cross.shape[1] == max_len
+    torch.testing.assert_close(t5_attn, attn)
+
+
+def test_encode_text_for_batch_default_stays_bare_cross(monkeypatch) -> None:
+    family = AnimaFamily()
+    max_len = family.spec.text.max_seq_len
+    _stub_text_encoding(monkeypatch, torch.ones(2, 4, dtype=torch.long))
+
+    cross = family.encode_text_for_batch(
+        (None, None, None), _stub_dit(max_len), ["a", "b"], "cpu", torch.float32,
+    )
+    assert isinstance(cross, torch.Tensor)
+
+
+# ── 2. symtable 未定义名静态扫描 ────────────────────────────────────────
+
+_TRAINING_ROOT = Path(__file__).resolve().parents[1] / "runtime" / "training"
+
+_MODULE_DUNDERS = {
+    "__name__", "__file__", "__doc__", "__package__", "__spec__",
+    "__loader__", "__builtins__", "__debug__", "__annotations__",
+    "__dict__", "__class__", "__module__", "__qualname__",
+}
+
+
+def _module_bindings(table: symtable.SymbolTable) -> set[str]:
+    names = {
+        sym.get_name()
+        for sym in table.get_symbols()
+        if sym.is_assigned() or sym.is_imported()
+    }
+    names |= {child.get_name() for child in table.get_children()}
+    return names
+
+
+def _walk_undefined(table: symtable.SymbolTable, module_names: set[str]) -> list[str]:
+    bad = []
+    if table.get_type() != "module":
+        for sym in table.get_symbols():
+            if not (sym.is_referenced() and sym.is_global()):
+                continue
+            name = sym.get_name()
+            if name in module_names or name in _MODULE_DUNDERS:
+                continue
+            if hasattr(builtins, name):
+                continue
+            bad.append(f"{table.get_name()}:{table.get_lineno()} 引用未定义名 {name!r}")
+    for child in table.get_children():
+        bad.extend(_walk_undefined(child, module_names))
+    return bad
+
+
+@pytest.mark.parametrize(
+    "py_file",
+    sorted(_TRAINING_ROOT.rglob("*.py")),
+    ids=lambda p: str(p.relative_to(_TRAINING_ROOT)),
+)
+def test_training_package_has_no_undefined_names(py_file: Path) -> None:
+    """函数作用域里 LOAD_GLOBAL 的名字必须解析到模块级绑定或 builtin。
+
+    抓的正是 0.20.0 ``t5_attn`` 这类"重构后残留引用、分支门控测试跑不到"
+    的 NameError。flow-insensitive（同 pyflakes）：模块级晚绑定不误报。
+    """
+    source = py_file.read_text(encoding="utf-8")
+    table = symtable.symtable(source, str(py_file), "exec")
+    bad = _walk_undefined(table, _module_bindings(table))
+    assert not bad, "\n".join(f"{py_file.name}: {b}" for b in bad)


### PR DESCRIPTION
## 问题

用户报告（0.20.0）：`navit_packing: true` 的训练第一步即崩：

```
File "runtime\training\loop.py", line 312, in run
    cross, t5_attn,
    ^^^^^^^
NameError: name 't5_attn' is not defined
```

## 根因

PR #407 把文本编码整块下沉 `AnimaFamily.encode_text_for_batch`（只返回 opaque `cross`），但 loop.py 的 NaViT 分支仍引用下沉前的局部变量 `t5_attn`。该分支需要逐图 attention mask 做 cross-attn padding 截断（`pack_cross_embeddings`）。CI 无 GPU 跑不到 NaViT 前向、又无 lint 门禁，静态可查的 NameError 一路逃逸到 release。

## 修复

- `AnimaFamily.encode_text_for_batch` 加族私有 kwarg `return_t5_attn=False`，True 时返回 `(cross, t5_attn)`。navit 是 Anima 能力位（`_validate_family_capabilities` fail-fast，CLI 直达同防线），krea2 永远收不到该 kwarg，protocol 不动、cond 对循环保持 opaque。
- loop.py NaViT 分支带 `return_t5_attn=True` 调用取回 mask；标准分支行为零变化。

## 回归测试（`tests/test_navit_text_encode_regression.py`）

1. `return_t5_attn` 契约单测（mock 编码栈，CPU 可跑）。
2. **symtable 静态扫描**：runtime/training/ 全部函数作用域，引用了但作用域链上无绑定的名字（pyflakes F821 类）直接失败——门控分支不需要执行也能抓住。已验证：对修复前的 loop.py 精确报出 `run:149 引用未定义名 't5_attn'`，对当前树 77 个文件零误报。

## 测试

- 新增回归 79 passed
- 存量关联（navit×3 / family gating / family switch / krea2 sampler / sra）67 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)