### PR TITLE
chore(ci): ruff F821 未定义名门禁 + 清存量违例

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-# 全量测试门禁 — PR 与 dev/master push 自动跑后端 pytest + 前端 vitest/lint/tsc。
+# 全量测试门禁 — PR 与 dev/master push 自动跑 Python lint(ruff F821) + 后端 pytest + 前端 vitest/lint/tsc。
 #
 # 定位（见 CONTRIBUTING「提交前自检」）：本地开发只跑相关测试，全量由本 workflow
 # 在机器时间兜底；release 前的全量人工自检照旧。
@@ -17,6 +17,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Python 静态门禁：ruff F821（未定义名）——专抓 CI 跑不到的分支里的
+  # 「重构残留引用」类 NameError（v0.20.1 教训）。规则范围见 ruff.toml。
+  lint-python:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff==0.15.22
+
+      - name: ruff check
+        run: ruff check .
+
   backend:
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,9 @@ python -m pytest tests/test_xxx.py -q
 # (2) 横切安全网（秒级，改后端必带——专抓"改 A 坏 B"）：
 python -m pytest tests/test_route_snapshot.py tests/test_studio_configs.py -q
 
+# (3) Python lint（CI 同款，秒级；ruff 用 pip install ruff 装一次）：
+python -m ruff check .
+
 # 改了前端：
 cd studio/web
 npx vitest run                 # 前端全量也只要 ~20s

--- a/modeling/anima/cosmos_predict2_modeling.py
+++ b/modeling/anima/cosmos_predict2_modeling.py
@@ -587,7 +587,9 @@ class Attention(nn.Module):
         self.output_dropout = nn.Dropout(dropout) if dropout > 1e-4 else nn.Identity()
 
         if self.backend == "transformer_engine":
-            self.attn_op = DotProductAttention(
+            # vendored 上游分支：transformer_engine 未 vendored（本应用只走 torch 后端），
+            # 走到这里会 NameError——保留上游结构不补 import
+            self.attn_op = DotProductAttention(  # noqa: F821
                 self.n_heads,
                 self.head_dim,
                 num_gqa_groups=self.n_heads,

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,12 @@
+# Python lint 门禁 —— 只做 F821（未定义名）。
+#
+# 定位（v0.20.1 教训）：t5_attn NameError 潜伏在 CI（无 GPU）跑不到的能力门控
+# 分支里一路发到 release——这类「重构残留引用」静态一扫就能抓。
+# 有意不开风格类规则：噪音大、价值靠 review 兜；本门禁只守正确性底线。
+# 与 tests/test_navit_text_encode_regression.py 的 symtable 扫描互补：
+# symtable 无 del+闭包误报（但只盖 runtime/training/），ruff 覆盖全仓库。
+
+extend-exclude = ["tmp", ".claude"]
+
+[lint]
+select = ["F821"]

--- a/runtime/training/families/anima/sampling.py
+++ b/runtime/training/families/anima/sampling.py
@@ -373,16 +373,19 @@ def sample_image(
                 # float32. For Anima multiplier=1.0, timestep == sigma.
                 x_model = x_in.to(device=x_in.device, dtype=dtype)
                 sigma_1d = sigma_in.reshape(1).to(device=x_in.device, dtype=torch.float32)
+                # noqa 说明：cross_cond / cross_uncond / pad_mask 在采样循环结束后
+                # 被 del 释放显存（见下方 VAE decode 前的清理）；本闭包只在循环内
+                # 调用，运行时引用有效。ruff F821 对 del+闭包流不敏感误报。
                 if float(cfg_scale) == 1.0:
                     return model(
                         x_model,
                         sigma_1d.expand(x_model.shape[0]),
-                        cross_cond,
-                        padding_mask=pad_mask.expand(x_model.shape[0], -1, -1, -1).contiguous(),
+                        cross_cond,  # noqa: F821
+                        padding_mask=pad_mask.expand(x_model.shape[0], -1, -1, -1).contiguous(),  # noqa: F821
                     )
                 x_batch = torch.cat([x_model, x_model], dim=0)
-                cross_batch = torch.cat([cross_uncond, cross_cond], dim=0)
-                pad_batch = pad_mask.expand(x_batch.shape[0], -1, -1, -1).contiguous()
+                cross_batch = torch.cat([cross_uncond, cross_cond], dim=0)  # noqa: F821
+                pad_batch = pad_mask.expand(x_batch.shape[0], -1, -1, -1).contiguous()  # noqa: F821
                 sigma_batch = sigma_1d.expand(x_batch.shape[0])
                 v_uncond, v_cond = model(
                     x_batch,

--- a/runtime/training/observability.py
+++ b/runtime/training/observability.py
@@ -14,7 +14,7 @@ import os
 import threading
 import time
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 
 logger = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ class WandBMonitor:
         self._upload_state_manual_policy = upload_state_manual_policy
         self._upload_state_auto_enabled = upload_state_auto
         self._upload_state_auto_policy = upload_state_auto_policy
-        self._last_artifact: dict[str, "Any"] = {}
+        self._last_artifact: dict[str, Any] = {}
 
     @property
     def enabled(self) -> bool:

--- a/studio/services/booru/downloader.py
+++ b/studio/services/booru/downloader.py
@@ -22,7 +22,7 @@ import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import requests
 

--- a/studio/services/eval_samples.py
+++ b/studio/services/eval_samples.py
@@ -12,6 +12,7 @@ without loading torch.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import shutil
@@ -22,6 +23,8 @@ from typing import Any, Callable
 from . import eval_validation
 from .projects import jobs as project_jobs
 from .projects import versions
+
+logger = logging.getLogger(__name__)
 
 EVAL_DIRNAME = "eval"
 # Reproducible default generation seed when sample_seed is 0 (=random for samples).

--- a/studio/workers/reg_build_worker.py
+++ b/studio/workers/reg_build_worker.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import traceback
 from pathlib import Path
 from typing import Any
 

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import threading
 import time
+from pathlib import Path
 
 import pytest
 


### PR DESCRIPTION
## 背景

v0.20.1 的 `t5_attn` NameError 潜伏在 CI（无 GPU）跑不到的能力门控分支里一路发到 release。这类「重构残留引用」是静态一扫就能抓的错，但仓库此前没有 Python lint 门禁。

## 改动

**门禁**（新增 `lint-python` job，~20s）：

- `ruff.toml`：只选 `F821`（未定义名）——有意不开风格类规则，只守正确性底线；与 `tests/test_navit_text_encode_regression.py` 的 symtable 扫描互补（symtable 无 del+闭包误报但只盖 `runtime/training/`，ruff 覆盖全仓库）
- `.github/workflows/test.yml`：独立 job 不等 torch 安装；ruff 版本钉死 0.15.22
- CONTRIBUTING 提交前自检加第 (3) 条

**存量 45 处违例清零**，其中两处是错误处理路径的真 bug（门禁头一天就抓到活的）：

- `studio/services/eval_samples.py`：`except` 分支里 `logger` 未定义——prompt 预编码失败时本应「记日志退回逐图惰性编码」，实际兜底代码自己 NameError
- `studio/workers/reg_build_worker.py` ×2：`traceback` 未 import——postprocess / auto-tag 失败时报错代码同款崩，「失败不算 fatal」的设计失效

其余为无运行时影响的清理：

- `tests/test_model_downloader.py`：34 处字符串注解 `"Path"` 缺 import
- `observability.py` / `booru/downloader.py`：`Any` 纯注解缺 import（PEP 526 局部注解不求值）
- `sampling.py` 4 处 `# noqa: F821`：`del`+闭包的 ruff 流不敏感误报（del 是 VAE decode 前显存清理，运行时引用有效），带注释说明
- `cosmos_predict2_modeling.py` 1 处 `# noqa: F821`：vendored 上游的 transformer_engine 分支，本应用不可达，保留上游结构不补 import

## 测试

- `ruff check .` 全仓归零
- 改动模块 import 冒烟通过
- 关联测试 + 横切安全网（model_downloader / navit 回归 / route_snapshot / studio_configs）168 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)