### PR TITLE
fix(web): AI生成正则集页面默认选择增量模式

### DIFF
--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -391,7 +391,7 @@ def main() -> None:
     sampler_name: str = cfg.get("sampler_name", "er_sde")
     scheduler: str = cfg.get("scheduler", "simple")
     base_seed: int = int(cfg.get("seed", 0))
-    incremental: bool = bool(cfg.get("incremental", False))
+    incremental: bool = bool(cfg.get("incremental", True))
     mixed_precision: str = cfg.get("mixed_precision", "bf16")
     backend: str = cfg.get("attention_backend", "flash_attn")
     use_flash = (backend == "flash_attn")

--- a/studio/api/schemas/training.py
+++ b/studio/api/schemas/training.py
@@ -160,7 +160,7 @@ class RegAiRequest(BaseModel):
     sampler_name: Optional[str] = None
     scheduler: Optional[str] = None
     seed: int = 0
-    incremental: bool = False
+    incremental: bool = True
     mixed_precision: str = "bf16"
 
 

--- a/studio/domain/reg.py
+++ b/studio/domain/reg.py
@@ -53,7 +53,7 @@ class RegAiConfig(BaseModel):
     scheduler: Literal["simple", "sgm_uniform"] = Field("simple")
     seed: int = Field(0, description="随机种子（0=随机）")
     incremental: bool = Field(
-        False,
+        True,
         description="补足模式：跳过 reg 子文件夹中已有以 train_stem 开头的图（重启续跑用）",
     )
     mixed_precision: str = Field("bf16")

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -114,7 +114,7 @@ export default function RegularizationPage() {
   const [aiCfg, setAiCfg] = useState(4.0)
   const [aiSeed, setAiSeed] = useState(0)
   const [aiIncremental, setAiIncremental] = useState(true)
-  // 本次先验生成临时选用的底模（null = 跟随设置页 selected_anima）。
+  // 本次先验生成临时选用的底模（null = 跟随设置页该族 selected）。
   const [aiBaseModel, setAiBaseModel] = useState<string | null>(null)
   // 先验生成的模型族跟随 version 训练配置（服务端权威解析；这里只为
   // BaseModelSelect 列对族的底模）。无 config / 读失败 → anima。

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -113,8 +113,8 @@ export default function RegularizationPage() {
   const [aiSteps, setAiSteps] = useState(25)
   const [aiCfg, setAiCfg] = useState(4.0)
   const [aiSeed, setAiSeed] = useState(0)
-  const [aiIncremental, setAiIncremental] = useState(false)
-  // 本次先验生成临时选用的底模（null = 跟随设置页该族 selected）。
+  const [aiIncremental, setAiIncremental] = useState(true)
+  // 本次先验生成临时选用的底模（null = 跟随设置页 selected_anima）。
   const [aiBaseModel, setAiBaseModel] = useState<string | null>(null)
   // 先验生成的模型族跟随 version 训练配置（服务端权威解析；这里只为
   // BaseModelSelect 列对族的底模）。无 config / 读失败 → anima。


### PR DESCRIPTION
AI生成正则集页面默认选择增量模式。

+ 为什么：这个页面在切换标签后会自动变回默认值，导致我在来回检查标签、删除出错的正则集图像并点击重新生成时误以“全量”模式开始，导致之前生成的图片被清空。因此做出了此修改，避免误操作导致大量时间浪费。
+ 做了什么：只改了前端页面的一处默认值和后端API的默认参数。其他都没动。
+ 测试：修改比较简单，只重启应用手动试了一下