### PR TITLE
fix(train,web): 修复 FP8 LoKr 训练崩溃与正则集界面回归

### DIFF
--- a/studio/web/src/pages/project/steps/Regularization.test.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { SourceSegmented } from './Regularization'
+
+describe('regularization source selector', () => {
+  it('uses the shared pill style and switches source', async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(<SourceSegmented source="ai" onChange={onChange} />)
+
+    const ai = screen.getByRole('radio', { name: /AI 先验/ })
+    const booru = screen.getByRole('radio', { name: /Booru 抓取/ })
+
+    expect(ai).toHaveClass('pill-radio', 'pill-radio-content', 'on')
+    expect(booru).toHaveClass('pill-radio', 'pill-radio-content')
+    expect(booru).not.toHaveClass('on')
+    expect(ai.querySelector('.pill-radio-dot')).not.toBeNull()
+    expect(booru.querySelector('.pill-radio-dot')).not.toBeNull()
+
+    await user.click(booru)
+    expect(onChange).toHaveBeenCalledWith('booru')
+  })
+})

--- a/studio/web/src/pages/project/steps/Regularization.test.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi } from 'vitest'
-import { SourceSegmented } from './Regularization'
+import { ExcludeTags, SourceSegmented } from './Regularization'
 
 describe('regularization source selector', () => {
   it('uses the shared pill style and switches source', async () => {
@@ -20,5 +20,26 @@ describe('regularization source selector', () => {
 
     await user.click(booru)
     expect(onChange).toHaveBeenCalledWith('booru')
+  })
+})
+
+describe('regularization exclusion chips', () => {
+  it('keeps a long natural-language tag inside a single-height chip', () => {
+    const longTag = 'a single girl with very long pale lavender hair faces toward the viewer while the background extends across the entire frame'
+    render(
+      <ExcludeTags
+        trainTags={[{ tag: longTag, count: 1 }]}
+        excluded={new Set()}
+        onToggle={vi.fn()}
+      />,
+    )
+
+    const text = screen.getByText(longTag)
+    const textContainer = text.parentElement
+    const chip = text.closest('button')
+
+    expect(chip).toHaveClass('h-6', 'max-w-full', 'overflow-hidden', 'whitespace-nowrap')
+    expect(textContainer).toHaveClass('min-w-0', 'truncate', 'text-left')
+    expect(textContainer).toHaveAttribute('title', longTag)
   })
 })

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -1275,7 +1275,7 @@ function CheckRow({
 }
 
 // 排除 tag — train 高频 tag 一栏列出 + 自定义排除一栏
-function ExcludeTags({
+export function ExcludeTags({
   trainTags, excluded, onToggle, modeHint,
 }: {
   trainTags: RegTagCount[]
@@ -1336,7 +1336,7 @@ function ExcludeTags({
                 key={info.tag}
                 onClick={() => onToggle(info.tag)}
                 className={
-                  'inline-flex items-center gap-1.5 h-6 px-2.5 rounded-md font-mono text-xs cursor-pointer transition-colors border ' +
+                  'inline-flex items-center gap-1.5 h-6 max-w-full overflow-hidden whitespace-nowrap px-2.5 rounded-md font-mono text-xs cursor-pointer transition-colors border ' +
                   (on
                     ? 'text-accent-hover'
                     : 'bg-sunken text-fg-secondary hover:text-fg-primary')
@@ -1348,11 +1348,16 @@ function ExcludeTags({
                 }
                 title={on ? t('reg.excludeUnclick') : t('reg.excludeClick')}
               >
-                <span className={on ? 'text-accent' : 'text-fg-tertiary'}>
+                <span className={`shrink-0 ${on ? 'text-accent' : 'text-fg-tertiary'}`}>
                   {on ? '✕' : '+'}
                 </span>
-                <TranslatedTag tag={info.tag.replace(/_/g, ' ')} />
-                <span className="text-fg-disabled text-2xs">×{info.count}</span>
+                <span
+                  className="min-w-0 truncate text-left"
+                  title={info.tag.replace(/_/g, ' ')}
+                >
+                  <TranslatedTag tag={info.tag.replace(/_/g, ' ')} />
+                </span>
+                <span className="shrink-0 text-fg-disabled text-2xs">×{info.count}</span>
               </button>
             )
           })}
@@ -1367,17 +1372,22 @@ function ExcludeTags({
           {customTags.map((tag) => (
             <span
               key={tag}
-              className="inline-flex items-center gap-1.5 h-6 px-2.5 rounded-md font-mono text-xs border"
+              className="inline-flex items-center gap-1.5 h-6 max-w-full overflow-hidden whitespace-nowrap px-2.5 rounded-md font-mono text-xs border"
               style={{
                 background: 'var(--warn-soft)',
                 borderColor: 'rgba(224,162,58,0.4)',
                 color: 'var(--warn)',
               }}
             >
-              <TranslatedTag tag={tag.replace(/_/g, ' ')} />
+              <span
+                className="min-w-0 truncate text-left"
+                title={tag.replace(/_/g, ' ')}
+              >
+                <TranslatedTag tag={tag.replace(/_/g, ' ')} />
+              </span>
               <button
                 onClick={() => onToggle(tag)}
-                className="bg-transparent border-none cursor-pointer p-0 text-warn opacity-80"
+                className="shrink-0 bg-transparent border-none cursor-pointer p-0 text-warn opacity-80"
                 aria-label={t('reg.excludeCustomRemoveAria', { tag })}
               >
                 ×

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -774,10 +774,10 @@ function RegTab({
   )
 }
 
-// 来源选择：container 卡片包住 + pill radio 切换，复用设置页「系统 / 版本 /
-// 更新通道」的 vs-channel-radio 样式（圆点 + accent 选中态），视觉与之一致。
+// 来源选择：container 卡片包住 + pill radio 切换，复用 tokens.css 的通用
+// pill-radio 样式（圆点 + accent 选中态），视觉与设置页更新通道一致。
 // 说明文字在控件下方随选择切换。
-function SourceSegmented({
+export function SourceSegmented({
   source, onChange,
 }: {
   source: 'ai' | 'booru'
@@ -810,8 +810,8 @@ function SourceSegmented({
   )
 }
 
-// 单个来源 pill：沿用 version-section.css 的 vs-channel-radio（全局 CSS，index.css
-// 已 import）。主名 + 浅色副标题小字（基底模型生成 / 简易·快）。
+// 单个来源 pill：沿用 tokens.css 的通用 pill-radio。主名 + 浅色副标题小字
+//（基底模型生成 / 简易·快）。
 function SourceRadio({
   on, onClick, label, sub,
 }: {
@@ -826,9 +826,9 @@ function SourceRadio({
       role="radio"
       aria-checked={on}
       onClick={onClick}
-      className={`vs-channel-radio${on ? ' on' : ''}`}
+      className={`pill-radio pill-radio-content${on ? ' on' : ''}`}
     >
-      <span className="vs-channel-dot" />
+      <span className="pill-radio-dot" />
       <span>{label}</span>
       <span className="text-2xs opacity-70">· {sub}</span>
     </button>

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -312,6 +312,17 @@ select option:checked {
 .pill-radio.on .pill-radio-dot {
   background: currentColor;
 }
+/* 带主/副标题的胶囊按内容撑开；圆点回到正常文档流，避免 120px 等宽
+ * 版本在窄卡片内把来源名称拆成两行。普通设置项仍保持等宽居中。 */
+.pill-radio.pill-radio-content {
+  width: auto;
+  gap: 5px;
+  padding: 4px 10px;
+}
+.pill-radio-content .pill-radio-dot {
+  position: static;
+  transform: none;
+}
 
 .input {
   background: var(--bg-surface);

--- a/tests/test_lycoris_bypass.py
+++ b/tests/test_lycoris_bypass.py
@@ -19,6 +19,8 @@ import torch.nn as nn
 
 from utils.lycoris_adapter import AnimaLycorisAdapter
 from training.families.anima.preset import ANIMA_PRESET
+from training.families.krea2.preset import KREA2_PRESET
+from training.families.krea2.quant_fp8 import patch_fp8_linears
 
 pytest.importorskip("lycoris")
 
@@ -165,6 +167,34 @@ def test_adapter_lokr_keeps_rebuild() -> None:
     modes = _bypass_modes(adapter)
     assert modes
     assert not any(modes), f"lokr 应保持 rebuild，但 bypass_mode={modes}"
+
+
+def test_adapter_lokr_fp8_base_forces_bypass_and_trains() -> None:
+    """Monkeypatched FP8 nn.Linear uses bypass and full-precision LoKr params."""
+    torch.manual_seed(0)
+    model = MockDiT(d=16)
+    scales = {}
+    for name, module in model.named_modules():
+        if isinstance(module, nn.Linear):
+            module.weight.requires_grad_(False)
+            module.weight.data = module.weight.data.to(torch.float8_e4m3fn)
+            scales[name] = torch.tensor(0.5)
+    patch_fp8_linears(model, scales)
+
+    adapter = AnimaLycorisAdapter(
+        preset=KREA2_PRESET, algo="lokr", rank=4, alpha=4, factor=4,
+    )
+    adapter.inject(model)
+
+    modes = _bypass_modes(adapter)
+    assert modes and all(modes)
+    params = adapter.get_params()
+    assert params and all(p.dtype == torch.float32 for p in params)
+
+    output = model.q_proj(torch.randn(2, 3, 16))
+    output.square().mean().backward()
+    grads = [p.grad for p in params if p.grad is not None]
+    assert grads and all(torch.isfinite(g).all() for g in grads)
 
 
 def test_adapter_loha_keeps_rebuild() -> None:

--- a/tests/test_lycoris_tlora.py
+++ b/tests/test_lycoris_tlora.py
@@ -253,19 +253,19 @@ def test_run_sample_no_clear_method_does_not_crash() -> None:
 
 # ── test 4: bypass_mode invariant ──────────────────────────────────────────
 #
-# 设计 invariant：AnimaLycorisAdapter.inject() 里 line 111-112 只在
-#   self.algo == "lora" and not self.weight_decompose
-# 时设置 bypass_mode=True；algo == "tlora" 永远不进此分支，必走 rebuild
-# (make_weight) 路径，让 _install_tlora_masks 的 mask patch 真正生效。
+# 设计 invariant：AnimaLycorisAdapter.inject() 只允许两条 bypass 路径：
+#   1. self.algo == "lora" and not self.weight_decompose
+#   2. self.algo == "lokr" and has_fp8_base
+# algo == "tlora" 永远不进这两条分支，必走 rebuild (make_weight) 路径，
+# 让 _install_tlora_masks 的 mask patch 真正生效。
 #
 # 这里不依赖完整 inject (lycoris preset 与本机版本不兼容)，直接 inspect
 # AnimaLycorisAdapter.inject 源码确认 tlora 不会被设 bypass_mode=True。
 
 
 def test_tlora_inject_never_sets_bypass_mode() -> None:
-    """inject() 里给 lycoris 的 extra dict 设 bypass_mode=True 这件事只在
-    algo='lora' 分支发生；algo='tlora' 不进，必走 make_weight rebuild 路径让
-    _install_tlora_masks 的 mask patch 生效。
+    """inject() 只允许 LoRA 或 FP8 LoKr 设置 bypass_mode=True；
+    algo='tlora' 不进，必走 make_weight rebuild 路径让 mask patch 生效。
 
     防止后续维护误把 tlora 也加进 bypass 路径让 mask 静默失效。"""
     import re
@@ -279,15 +279,18 @@ def test_tlora_inject_never_sets_bypass_mode() -> None:
         "源码结构变了，需重写本 invariant 测试或重新评估 bypass_mode 默认行为。"
     )
     for m in matches:
-        # 该赋值之前 ~250 字符内必须出现 'self.algo == "lora"' 守卫（带或不带空格）
-        # 且必须不在跟 'tlora' 相关的条件里
+        # 该赋值之前 ~250 字符内必须出现两个受支持守卫之一，且不能提到 tlora。
+        # FP8 LoKr 必须同时检查 has_fp8_base，避免普通 LoKr 被误切到 bypass。
         ctx_start = max(0, m.start() - 250)
         ctx = src[ctx_start:m.start()]
         has_lora_guard = bool(re.search(r'self\.algo\s*==\s*["\']lora["\']', ctx))
+        has_fp8_lokr_guard = bool(re.search(
+            r'self\.algo\s*==\s*["\']lokr["\']\s+and\s+has_fp8_base', ctx,
+        ))
         mentions_tlora_nearby = "tlora" in ctx.lower()
-        assert has_lora_guard and not mentions_tlora_nearby, (
+        assert (has_lora_guard or has_fp8_lokr_guard) and not mentions_tlora_nearby, (
             f"extra['bypass_mode'] 赋值 (位置 {m.start()}) 上方 250 字符内未见到"
-            f" `self.algo == 'lora'` 独立守卫；可能让 tlora 也走 bypass 路径让"
-            f" make_weight mask patch 静默失效。"
+            f" LoRA 或 FP8 LoKr 的独立守卫；可能让 tlora / 普通 LoKr 误走"
+            f" bypass，让 make_weight 路径静默失效。"
             f" 上下文：\n{ctx[-200:]}"
         )

--- a/utils/lycoris_adapter.py
+++ b/utils/lycoris_adapter.py
@@ -28,6 +28,9 @@ from utils.lycoris_patch import apply_lokr_device_patch
 
 logger = logging.getLogger(__name__)
 
+_FP8_DTYPES = frozenset({torch.float8_e4m3fn, torch.float8_e5m2})
+_ADAPTER_DTYPES = frozenset({torch.float16, torch.bfloat16, torch.float32, torch.float64})
+
 # lycoris-lora 3.4.0 LokrModule.get_weight rank_dropout device bug 一次性修复。
 # 模块级调用：任何路径走到 lycoris_adapter（CLI 训练 / Studio worker / 测试）
 # 都会先 patch 一次。返回值供测试断言；正常 import 路径下结果落到 logger。
@@ -125,6 +128,21 @@ class LycorisAdapter:
         if self.algo == "lora" and not self.weight_decompose:
             extra["bypass_mode"] = True
 
+        # Krea2 FP8 checkpoints keep frozen Linear weights in float8 and
+        # monkeypatch Linear.forward to dequantize them to the input dtype.
+        # LyCORIS only recognizes dedicated quantized Linear subclasses, so a
+        # monkeypatched nn.Linear is otherwise mistaken for a regular layer and
+        # LoKr takes the rebuild path. That path casts the dense LoKr delta to
+        # the raw base-weight dtype; torch has no float8 mul/add kernels for it.
+        # Bypass preserves the patched base forward and computes LoKr separately.
+        has_fp8_base = any(
+            isinstance(module, nn.Linear) and module.weight.dtype in _FP8_DTYPES
+            for module in model.modules()
+        )
+        if self.algo == "lokr" and has_fp8_base:
+            extra["bypass_mode"] = True
+            logger.info("FP8 base detected: forcing LoKr bypass forward")
+
         self.network = LycorisNetwork(
             model,
             multiplier=1.0,
@@ -149,9 +167,17 @@ class LycorisAdapter:
         # 转成 fp32，以贴近 ComfyUI LoRA patch 的中间精度。
         try:
             ref = next(model.parameters())
-            self.network.to(device=ref.device, dtype=ref.dtype)
         except StopIteration:
-            pass
+            ref = None
+        if ref is not None:
+            # The first parameter may itself be FP8. Adapter parameters must
+            # stay in a trainable compute dtype; prefer the model's first
+            # non-FP8 floating dtype and fall back to fp32 for an all-FP8 model.
+            adapter_dtype = next(
+                (p.dtype for p in model.parameters() if p.dtype in _ADAPTER_DTYPES),
+                torch.float32,
+            )
+            self.network.to(device=ref.device, dtype=adapter_dtype)
 
         # LycorisNetwork 是独立 nn.Module，不在 model 子树里；model.eval()/.train() 不会
         # 级联到 lycoris 模块（self.training 永远 True）。这导致 sample 时仍进 rank_dropout


### PR DESCRIPTION
## 背景

v0.20.x 已发布版本有三项实际回归：

1. Krea 2 官方 FP8 底模搭配 LoKr 时，训练任务在第一步报 `"mul_cuda" not implemented for 'Float8_e4m3fn'` 并退出（训练 task 1520）。
2. v0.20.0 的共享样式迁移后，正则集「AI 先验 / Booru 抓取」来源切换丢失边框、圆点和选中态。
3. 排除 train top tag 中的长自然语言句子会换成多行，文本溢出固定高度 chip 并覆盖后续内容。

## 为什么走 Hotfix

- FP8 + LoKr 是已发布的 Krea 2 训练组合，当前完全无法开训，属于核心流程阻断。
- 两项正则集问题都是已发布页面的直接可见回归。
- 这些修复需要尽快进入 stable，不应等待或捎带 dev 上尚未发布的功能；因此按 CONTRIBUTING 的 Hotfix 加急路径从 `master` 切分支，PR base 也保持 `master`。

本 PR 只包含修复与回归测试。合并后再按 Hotfix 步骤直接在 `master` bump PATCH、发布并同步回 `dev`。

## 根因

### FP8 + LoKr

Krea 2 FP8 loader 保留 `nn.Linear` 的 FP8 冻结权重，并 monkeypatch `forward` 在计算时反量化。LyCORIS 只识别专用量化 Linear 子类，因此把该模块误判为普通 Linear，LoKr 进入 rebuild 路径后直接对 FP8 权重执行乘法，触发 CUDA 不支持的 FP8 `mul`。

### 正则集来源切换

v0.20.0 的共享样式迁移删除了 `.vs-channel-radio` / `.vs-channel-dot`，改用 `.pill-radio` / `.pill-radio-dot`；`Regularization.tsx` 没有同步迁移，功能仍可点击但样式全部失效。

### 长自然语言 chip

chip 外层固定为单行高度，但文本仍允许正常换行且 `overflow: visible`。超长 tag 的文本节点会远高于按钮盒，并绘制到后续行上。

## 改动

- 检测到 FP8 Linear 时强制 LoKr 使用 bypass forward，保留底模的反量化路径。
- LoKr 参数选择可训练的非 FP8 compute dtype；全 FP8 模型回退到 FP32。
- 增加 FP8 LoKr forward / backward 回归测试。
- 正则集来源切换迁移到共享 pill 样式，并增加内容宽度修饰，保持名称单行。
- train tag 与自定义排除 tag 限制在容器宽度内；只截断文本，保留 `+ / ✕`、计数和删除按钮。
- 截断内容可悬停查看完整 tag。
- 增加来源切换样式/交互和长 chip 回归测试。

## 测试

- Python 关联测试：**54 passed**
- 目标 Ruff：**通过**
- Regularization Vitest：**2 passed**
- 前端 ESLint：**0 errors**（另有 `PreprocessInpaint.tsx` 的 2 条既存 warning）
- TypeScript `tsc -b`：**通过**
- Vite production build：**通过**（仅既存 chunk-size warning）

## UI 手测

在 `/projects/32/v/88/reg` 实页验证：

- 来源切换恢复胶囊边框、圆点和选中态；切换 Booru 后 checked state、样式与说明文案同步更新。
- 990 字符自然语言 tag 修复前文本节点高 252px、溢出 22.5px chip；修复后文本保持 18px 单行、chip 高度 22.5px，并以省略号截断。

## 已知基线

当前 `master` 的全仓 `ruff check .` 有 305 个本 PR 之外的既存错误。本 Hotfix 不夹带无关格式化修改。
