### PR TITLE
feat(generate): 落盘测试图写 Civitai/A1111 兼容 metadata

### DIFF
--- a/docs/user-guide/getting-started.en.md
+++ b/docs/user-guide/getting-started.en.md
@@ -93,6 +93,12 @@ View tasks on the **Queue** page; open **task detail** for logs / monitoring / o
 
 After training, the sidebar **Test** page runs single-image / XY matrix / inference daemon for LoRA evaluation. Prompts can be pulled directly from the training set, eliminating round trips to ComfyUI.
 
+When Settings → Testing → Save test images is enabled, newly saved single images and
+XY cell PNGs include A1111 / Civitai-compatible metadata: the effective prompt,
+sampling parameters, base model, VAE, LoRA weights, and resource SHA256 hashes. An
+XY composite represents multiple parameter sets, so its full external metadata is
+kept on the individual cell PNGs while the composite retains Studio's structured data.
+
 The LoRA weights produced are already in `lora_unet_*` format and can be **dropped directly into ComfyUI** without any conversion.
 
 ## Next

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -93,6 +93,11 @@ python tools/download_models.py --modelscope      # 走魔搭社区
 
 训完后侧栏 **测试**：跑单图 / XY 矩阵 / 推理 daemon 评测 LoRA，prompt 可从训练集直接拉，不用切 ComfyUI 反复测。
 
+开启 Settings → Testing → 保存测试图片后，新落盘的单图与 XY cell PNG 会携带
+A1111 / Civitai 兼容 metadata，包括实际 prompt、采样参数、底模、VAE、LoRA
+权重与资源 SHA256。XY 合成图包含多组参数，因此只保留 Studio 的结构化参数；
+完整的外部兼容 metadata 写在每个 cell 原图中。
+
 输出的 LoRA 权重已经是 `lora_unet_*` 格式，**直接拖进 ComfyUI 即可**，不需要任何转换。
 
 ## 进一步

--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -17,6 +17,7 @@ task 结束 supervisor 仍调 cleanup_generate_tempdir 清掉空目录。server 
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import io
 import json
@@ -48,6 +49,10 @@ from ...domain.errors import (
 from ...domain.comfy_parity import force_comfy_parity_runtime_config
 from ...infrastructure.event_bus import bus
 from ...infrastructure.paths import STUDIO_DATA
+from ...services.generation_metadata import (
+    build_external_metadata,
+    write_manifest as write_generation_metadata_manifest,
+)
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -278,6 +283,24 @@ def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
         if body.params_snapshot:
             cfg_dict["_anima_params_snapshot_"] = body.params_snapshot
 
+        # Civitai/A1111 资源身份不能塞进可移植的 anima_params（其中禁止绝对
+        # 路径），单独写 task 私有档案。task 结束只清 anima_gen_<id> 临时目录，
+        # tasks/<id>/ 档案会保留到用户删任务；落盘接口凭 task_id 读取并算 hash。
+        try:
+            write_generation_metadata_manifest(
+                task_id,
+                prompts=list(body.prompts),
+                model_family=body.model_family,
+                model_path=str(model_paths.get("transformer_path") or ""),
+                vae_path=str(model_paths.get("vae_path") or "") or None,
+                text_encoder=body.text_encoder,
+                loras=[lc.model_dump() for lc in body.lora_configs],
+                xy_matrix=body.xy_matrix.model_dump() if body.xy_matrix else None,
+            )
+        except (OSError, TypeError, ValueError):
+            # metadata 是附加能力，档案写入失败不能让已经校验通过的生成任务失败。
+            logger.warning("write generation metadata manifest failed", exc_info=True)
+
         cfg_path = tempdir / "config.json"
         cfg_path.write_text(
             json.dumps(cfg_dict, indent=2, ensure_ascii=False), encoding="utf-8"
@@ -475,7 +498,9 @@ def get_generate_sample(task_id: int, filename: str) -> Any:
 SCHEMA_VERSION = 2
 
 
-def _format_a1111_parameters(params: dict[str, Any]) -> str:
+def _format_a1111_parameters(
+    params: dict[str, Any], external: dict[str, Any] | None = None
+) -> str:
     """组装 a1111 兼容的 `parameters` tEXt 块（ComfyUI / WebUI / Civitai 等通用）。
 
     格式：
@@ -484,11 +509,16 @@ def _format_a1111_parameters(params: dict[str, Any]) -> str:
         Steps: N, Sampler: ..., Schedule type: ..., CFG scale: N, Seed: N, Size: WxH
 
     LoRA 用 <lora:basename-without-ext:scale> 语法（a1111/ComfyUI 标准）。
-    xy_draft / dataset_pick 不入此块（a1111 没标准字段；用 anima_params 取）。
+    xy_draft / dataset_pick 的 UI 上下文不入此块（a1111 没标准字段）；但实际送给
+    daemon 的合并 prompt 会从 task 私有档案写进第一行。
     """
+    external = external or {}
     prompts = params.get("prompts") or [""]
-    prompt = prompts[0] if isinstance(prompts, list) else str(prompts)
-    loras = params.get("loras") or []
+    prompt = external.get("prompt")
+    if prompt is None:
+        prompt = prompts[0] if isinstance(prompts, list) else str(prompts)
+    prompt = str(prompt)
+    loras = external.get("loras") or params.get("loras") or []
     lora_tags: list[str] = []
     for lo in loras:
         if not isinstance(lo, dict):
@@ -512,10 +542,54 @@ def _format_a1111_parameters(params: dict[str, Any]) -> str:
         f"Seed: {params.get('seed', '')}",
         f"Size: {width}x{height}",
     ]
+    model_family = external.get("model_family") or params.get("model_family")
+    if model_family:
+        parts.append(f"Model family: {model_family}")
+    text_encoder = external.get("text_encoder") or params.get("text_encoder")
+    if text_encoder:
+        parts.append(f"Text encoder: {text_encoder}")
+
+    hashes: dict[str, str] = {}
+    model = external.get("model")
+    if isinstance(model, dict) and model.get("name"):
+        parts.append(f"Model: {model['name']}")
+        if model.get("hash"):
+            model_hash = str(model["hash"])
+            parts.append(f"Model hash: {model_hash}")
+            hashes["model"] = model_hash
+    vae = external.get("vae")
+    if isinstance(vae, dict) and vae.get("name"):
+        parts.append(f"VAE: {vae['name']}")
+        if vae.get("hash"):
+            vae_hash = str(vae["hash"])
+            parts.append(f"VAE hash: {vae_hash}")
+            hashes["vae"] = vae_hash
+
+    lora_hashes: list[str] = []
+    for lo in loras:
+        if not isinstance(lo, dict) or not lo.get("hash"):
+            continue
+        name = str(lo.get("name") or "").rsplit(".", 1)[0]
+        if not name:
+            continue
+        digest = str(lo["hash"])
+        lora_hashes.append(f"{name}: {digest}")
+        hashes[f"lora:{name}"] = digest
+    if lora_hashes:
+        parts.append(f'Lora hashes: "{", ".join(lora_hashes)}"')
+    if hashes:
+        parts.append(f"Hashes: {json.dumps(hashes, separators=(',', ':'))}")
+    parts.append("Software: AnimaLoraStudio")
     return f"{prompt}\nNegative prompt: {neg}\n{', '.join(parts)}"
 
 
-def _inject_png_metadata(raw: bytes, params: dict[str, Any], *, mode: str) -> bytes:
+def _inject_png_metadata(
+    raw: bytes,
+    params: dict[str, Any],
+    *,
+    mode: str,
+    external: dict[str, Any] | None = None,
+) -> bytes:
     """注入 PNG tEXt 块到图：
        - `anima_params` —— 结构化 JSON，**zTXt 压缩**（决策 #17），本程序回填用
        - `parameters`   —— a1111 兼容文本（决策 #7：xy **不写**，矩阵图单图拖
@@ -531,7 +605,7 @@ def _inject_png_metadata(raw: bytes, params: dict[str, Any], *, mode: str) -> by
         # 压缩后通常 1-2KB，a1111 不识别 anima_params 反正会跳过
         info.add_text("anima_params", json.dumps(params, ensure_ascii=False), zip=True)
         if mode == "single":
-            info.add_text("parameters", _format_a1111_parameters(params))
+            info.add_text("parameters", _format_a1111_parameters(params, external))
         out = io.BytesIO()
         img.save(out, format="PNG", pnginfo=info)
         return out.getvalue()
@@ -694,12 +768,35 @@ def _decode_params_field(raw: str, field: str) -> dict[str, Any]:
     return decoded
 
 
+def _build_external_metadata_safe(
+    task_id: int | None,
+    params: dict[str, Any],
+    *,
+    source_filename: str,
+) -> dict[str, Any]:
+    """资源 metadata 是 best-effort；失败时仍允许按旧格式保存 PNG。"""
+    try:
+        return build_external_metadata(
+            task_id,
+            params,
+            source_filename=source_filename,
+        )
+    except Exception:
+        logger.warning(
+            "build Civitai resource metadata failed for task %s",
+            task_id,
+            exc_info=True,
+        )
+        return {}
+
+
 @router.post("/api/generate/save")
 async def save_test_image(
     mode: str = Form(...),
     image: UploadFile = File(...),
     params: str = Form(""),
     task_id: Optional[int] = Form(None),
+    source_filename: str = Form(""),
     cells: list[UploadFile] = File(default=[]),
     cells_manifest: str = Form(""),
 ) -> dict[str, Any]:
@@ -710,8 +807,9 @@ async def save_test_image(
 
     **xy mode** → `studio_data/test/<YYYY-MM-DD>/xy/xy plot <N>/{xy plot.png, cell x<i> y<j>.png ...}`
     - `image` = composite 大图（导出 + 缩略图来源），按 mode='xy' 注 anima_params，不写 a1111
-    - `cells` = 每格原图 N 张；`cells_manifest` = JSON 数组 [{xi:int, yi:int, params:dict}]，
-      与 `cells` 同序；每 cell 按 mode='single' 注 anima_params + a1111
+    - `cells` = 每格原图 N 张；`cells_manifest` = JSON 数组
+      [{xi:int, yi:int, params:dict, source_filename:str}]，与 `cells` 同序；每 cell
+      按 mode='single' 注 anima_params + a1111
     - 校验：len(cells)==len(manifest)，无重复 (xi,yi)
     - atomic：先写 sibling `.xy plot <N>.tmp/`，全部 cell 落盘后 `os.replace` 成正式名；
       任一步失败 → `shutil.rmtree(tmp)` 抛 500
@@ -743,7 +841,13 @@ async def save_test_image(
         if params:
             decoded = _decode_params_field(params, "params")
             enriched = _enrich_params_server_side(decoded, task_id=task_id, mode=mode)
-            raw = _inject_png_metadata(raw, enriched, mode=mode)
+            external = await asyncio.to_thread(
+                _build_external_metadata_safe,
+                task_id,
+                enriched,
+                source_filename=source_filename,
+            )
+            raw = _inject_png_metadata(raw, enriched, mode=mode, external=external)
 
         target_dir = TEST_IMAGES_DIR / date.today().isoformat() / mode
         target_dir.mkdir(parents=True, exist_ok=True)
@@ -769,7 +873,7 @@ async def save_test_image(
 
     # 校验 manifest 条目 + 收集 (xi, yi) 防重
     seen_xy: set[tuple[int, int]] = set()
-    cell_specs: list[tuple[int, int, dict[str, Any]]] = []
+    cell_specs: list[tuple[int, int, dict[str, Any], str]] = []
     for i, entry in enumerate(manifest):
         if not isinstance(entry, dict):
             raise HTTPException(400, f"cells_manifest[{i}]: must be an object")
@@ -786,7 +890,8 @@ async def save_test_image(
         cell_params = entry.get("params")
         if cell_params is not None and not isinstance(cell_params, dict):
             raise HTTPException(400, f"cells_manifest[{i}].params: must be a JSON object")
-        cell_specs.append((xi, yi, cell_params or {}))
+        cell_source_filename = str(entry.get("source_filename") or "")
+        cell_specs.append((xi, yi, cell_params or {}, cell_source_filename))
 
     # composite 注入 anima_params（mode='xy'，不写 a1111）
     composite_bytes = raw
@@ -820,11 +925,21 @@ async def save_test_image(
         _atomic_write_png(tmp_dir / _XY_COMPOSITE_NAME, composite_bytes)
         # cells
         cell_paths: list[Path] = []
-        for (xi, yi, cell_params), cb in zip(cell_specs, cell_bytes_list):
+        for (xi, yi, cell_params, cell_source_filename), cb in zip(
+            cell_specs, cell_bytes_list
+        ):
             cell_payload = cb
             if cell_params:
                 enriched_cell = _enrich_params_server_side(cell_params, task_id=task_id, mode="single")
-                cell_payload = _inject_png_metadata(cell_payload, enriched_cell, mode="single")
+                external = await asyncio.to_thread(
+                    _build_external_metadata_safe,
+                    task_id,
+                    enriched_cell,
+                    source_filename=cell_source_filename,
+                )
+                cell_payload = _inject_png_metadata(
+                    cell_payload, enriched_cell, mode="single", external=external,
+                )
             cell_path = tmp_dir / f"cell x{xi} y{yi}.png"
             _atomic_write_png(cell_path, cell_payload)
             cell_paths.append(cell_path)

--- a/studio/services/generation_metadata.py
+++ b/studio/services/generation_metadata.py
@@ -1,0 +1,257 @@
+"""测试出图的外部生态 metadata 资源解析与文件哈希缓存。
+
+PNG 内的 ``anima_params`` 是可移植的 UI 快照，刻意不含绝对路径；Civitai
+要可靠识别底模 / LoRA 却需要文件 hash。两份数据不能混在一起，因此 enqueue
+时把实际推理资源写进 task 私有档案，本模块在落盘 PNG 时读取档案并生成只供
+``parameters`` 文本块使用的外部 metadata。绝对路径永不写入 PNG。
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import threading
+from pathlib import Path
+from typing import Any
+
+from ..infrastructure.paths import STUDIO_DATA, task_dir
+
+logger = logging.getLogger(__name__)
+
+MANIFEST_FILENAME = "generate-metadata.json"
+HASH_CACHE_PATH = STUDIO_DATA / ".cache" / "resource-hashes.json"
+_PROMPT_INDEX_RE = re.compile(r"_p(\d+)(?:_|\.)")
+_HASH_LOCK = threading.Lock()
+_HASH_CACHE: dict[str, dict[str, Any]] | None = None
+
+
+def manifest_path(task_id: int) -> Path:
+    return task_dir(task_id) / MANIFEST_FILENAME
+
+
+def write_manifest(
+    task_id: int,
+    *,
+    prompts: list[str],
+    model_family: str,
+    model_path: str,
+    vae_path: str | None,
+    text_encoder: str | None,
+    loras: list[dict[str, Any]],
+    xy_matrix: dict[str, Any] | None,
+) -> None:
+    """原子写 task 私有资源清单；清单与 task 档案同生命周期。"""
+    path = manifest_path(task_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema_version": 1,
+        "prompts": list(prompts),
+        "model_family": model_family,
+        "model_path": model_path,
+        "vae_path": vae_path,
+        "text_encoder": text_encoder,
+        "loras": loras,
+        "xy_matrix": xy_matrix,
+    }
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def read_manifest(task_id: int | None) -> dict[str, Any] | None:
+    if task_id is None:
+        return None
+    try:
+        value = json.loads(manifest_path(task_id).read_text(encoding="utf-8"))
+        return value if isinstance(value, dict) else None
+    except (OSError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def _load_hash_cache() -> dict[str, dict[str, Any]]:
+    global _HASH_CACHE
+    if _HASH_CACHE is not None:
+        return _HASH_CACHE
+    try:
+        value = json.loads(HASH_CACHE_PATH.read_text(encoding="utf-8"))
+        _HASH_CACHE = value if isinstance(value, dict) else {}
+    except (OSError, json.JSONDecodeError):
+        _HASH_CACHE = {}
+    return _HASH_CACHE
+
+
+def _write_hash_cache(cache: dict[str, dict[str, Any]]) -> None:
+    HASH_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = HASH_CACHE_PATH.with_suffix(HASH_CACHE_PATH.suffix + ".tmp")
+    tmp.write_text(json.dumps(cache, ensure_ascii=False, indent=2), encoding="utf-8")
+    os.replace(tmp, HASH_CACHE_PATH)
+
+
+def file_sha256(path_value: str | Path) -> str | None:
+    """返回完整文件 SHA256；按 resolved path + size + mtime_ns 持久缓存。
+
+    锁覆盖 hash 过程，避免 single 多图并发保存时重复顺序读取 13–26GB 底模。
+    文件在读取过程中发生变化则不缓存也不返回，防止写入错误身份。
+    """
+    path = Path(path_value).expanduser()
+    try:
+        path = path.resolve(strict=True)
+        before = path.stat()
+        if not path.is_file():
+            return None
+    except OSError:
+        return None
+
+    key = str(path)
+    with _HASH_LOCK:
+        cache = _load_hash_cache()
+        entry = cache.get(key)
+        if (
+            isinstance(entry, dict)
+            and entry.get("size") == before.st_size
+            and entry.get("mtime_ns") == before.st_mtime_ns
+            and isinstance(entry.get("sha256"), str)
+        ):
+            return str(entry["sha256"])
+
+        digest = hashlib.sha256()
+        try:
+            with path.open("rb") as f:
+                while chunk := f.read(8 * 1024 * 1024):
+                    digest.update(chunk)
+            after = path.stat()
+        except OSError:
+            return None
+        if (after.st_size, after.st_mtime_ns) != (before.st_size, before.st_mtime_ns):
+            logger.warning("resource changed while hashing; skip metadata hash: %s", path)
+            return None
+
+        result = digest.hexdigest()
+        cache[key] = {
+            "size": before.st_size,
+            "mtime_ns": before.st_mtime_ns,
+            "sha256": result,
+        }
+        try:
+            _write_hash_cache(cache)
+        except OSError:
+            logger.warning("write generation resource hash cache failed", exc_info=True)
+        return result
+
+
+def _effective_prompt_from_snapshot(params: dict[str, Any]) -> str:
+    """兼容无 task manifest 的旧客户端：按前端提交规则合并 picker tags。"""
+    raw_prompts = params.get("prompts") or [""]
+    prompts = [str(x).strip() for x in raw_prompts if str(x).strip()]
+    pick = params.get("dataset_pick")
+    tags = pick.get("tags") if isinstance(pick, dict) else None
+    suffix = ", ".join(str(x) for x in tags if str(x).strip()) if isinstance(tags, list) else ""
+    if prompts:
+        return f"{prompts[0]}, {suffix}" if suffix else prompts[0]
+    return suffix
+
+
+def _select_prompt(manifest: dict[str, Any] | None, params: dict[str, Any], source_filename: str) -> str:
+    prompts = manifest.get("prompts") if manifest else None
+    if isinstance(prompts, list) and prompts:
+        match = _PROMPT_INDEX_RE.search(source_filename)
+        index = int(match.group(1)) if match else 0
+        if 0 <= index < len(prompts):
+            return str(prompts[index])
+        return str(prompts[0])
+    return _effective_prompt_from_snapshot(params)
+
+
+def _apply_xy_resource_axis(
+    loras: list[dict[str, Any]], axis: dict[str, Any] | None, value_index: int
+) -> None:
+    if not isinstance(axis, dict):
+        return
+    values = axis.get("values")
+    if not isinstance(values, list) or not (0 <= value_index < len(values)):
+        return
+    value = values[value_index]
+    kind = axis.get("axis")
+    if kind == "lora_scale":
+        try:
+            scale = float(value)
+        except (TypeError, ValueError):
+            return
+        for lora in loras:
+            lora["scale"] = scale
+    elif kind == "lora_ckpt":
+        index = axis.get("lora_index")
+        if isinstance(index, int) and 0 <= index < len(loras):
+            loras[index]["path"] = str(value)
+
+
+def build_external_metadata(
+    task_id: int | None,
+    params: dict[str, Any],
+    *,
+    source_filename: str = "",
+) -> dict[str, Any]:
+    """构造 Civitai/A1111 metadata 视图；返回值不含任何绝对路径。"""
+    manifest = read_manifest(task_id)
+    result: dict[str, Any] = {
+        "prompt": _select_prompt(manifest, params, source_filename),
+        "model_family": str((manifest or {}).get("model_family") or params.get("model_family") or ""),
+        "text_encoder": (manifest or {}).get("text_encoder") or params.get("text_encoder"),
+        "loras": [],
+    }
+    if not manifest:
+        snapshot_loras = params.get("loras")
+        if isinstance(snapshot_loras, list):
+            result["loras"] = [dict(x) for x in snapshot_loras if isinstance(x, dict)]
+        return result
+
+    model_path = Path(str(manifest.get("model_path") or ""))
+    if model_path.name:
+        result["model"] = {
+            "name": model_path.stem,
+            "hash": file_sha256(model_path),
+        }
+    vae_path = Path(str(manifest.get("vae_path") or ""))
+    if vae_path.name:
+        result["vae"] = {
+            "name": vae_path.stem,
+            "hash": file_sha256(vae_path),
+        }
+
+    loras = [dict(x) for x in manifest.get("loras", []) if isinstance(x, dict)]
+    origin = params.get("xy_origin")
+    matrix = manifest.get("xy_matrix")
+    if isinstance(origin, dict) and isinstance(matrix, dict):
+        try:
+            xi = int(origin.get("xi", 0))
+            yi = int(origin.get("yi", 0))
+        except (TypeError, ValueError):
+            xi = yi = 0
+        _apply_xy_resource_axis(loras, matrix.get("x"), xi)
+        if matrix.get("y") is not None:
+            _apply_xy_resource_axis(loras, matrix.get("y"), yi)
+
+    external_loras: list[dict[str, Any]] = []
+    for lora in loras:
+        path = Path(str(lora.get("path") or ""))
+        if not path.name:
+            continue
+        try:
+            scale = float(lora.get("scale", 1.0))
+        except (TypeError, ValueError):
+            scale = 1.0
+        external_loras.append({
+            "name": path.stem,
+            "scale": scale,
+            "hash": file_sha256(path),
+        })
+    result["loras"] = external_loras
+    return result
+
+
+def _reset_hash_cache_for_tests() -> None:
+    global _HASH_CACHE
+    with _HASH_LOCK:
+        _HASH_CACHE = None

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -660,7 +660,10 @@ export default function GeneratePage() {
       // 跟 dispatch 一起送 snapshot 给 server：image_done 时塞进加密 cache
       // payload header（save=false）+ list_index 时返还回填用。落盘 save=true
       // 分支仍用各自 saveSingleSamples/saveXYMatrix 自己构造；两边字段对齐。
-      const snapshotLoras: SnapshotLora[] = loras.map((l) => ({
+      // snapshot 记录实际送进 daemon 的 LoRA，而不是 sidebar 原始桶。XY 构建会
+      // 丢弃未被轴引用的孤儿 anchor；继续从 loras 取会让 PNG 声称用了实际未
+      // 加载的资源，也会把错误 hash 交给 Civitai。
+      const snapshotLoras: SnapshotLora[] = loraConfigs.map((l) => ({
         name: loraBasename(l.path),
         scale: l.scale,
         project_id: l.project_id ?? null,

--- a/studio/web/src/pages/tools/generate/saveTestImages.test.ts
+++ b/studio/web/src/pages/tools/generate/saveTestImages.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GenerateParamsSnapshot } from './paramsSnapshot'
+import { saveSingleSamples } from './saveTestImages'
+
+const snapshot: GenerateParamsSnapshot = {
+  schema_version: 1,
+  mode: 'single',
+  prompts: ['raw prompt'],
+  negative_prompt: '',
+  width: 1024,
+  height: 1024,
+  steps: 25,
+  cfg_scale: 4,
+  count: 1,
+  seed: 7,
+  loras: [],
+}
+
+describe('saveSingleSamples metadata identity', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('sends the daemon source filename so the server selects the actual prompt index', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        blob: async () => new Blob(['png'], { type: 'image/png' }),
+      })
+      .mockImplementationOnce(async (_url: string, init: RequestInit) => {
+        const form = init.body as FormData
+        expect(form.get('source_filename')).toBe('gen_0001_p1_c0_s7.png')
+        expect(form.get('task_id')).toBe('42')
+        return {
+          ok: true,
+          json: async () => ({ path: 'saved.png', index: 1, filename: 'saved.png' }),
+        }
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(saveSingleSamples(
+      42,
+      ['gen_0001_p1_c0_s7.png'],
+      snapshot,
+    )).resolves.toEqual(['saved.png'])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/studio/web/src/pages/tools/generate/saveTestImages.ts
+++ b/studio/web/src/pages/tools/generate/saveTestImages.ts
@@ -47,6 +47,9 @@ export async function saveSingleSamples(
       fd.append('mode', 'single')
       fd.append('image', blob, 'single.png')
       fd.append('params', JSON.stringify(params))
+      // server 由 daemon 文件名里的 _pN_ 选择这张图实际对应的 prompt；POST
+      // upload filename 固定 single.png，若不单独传会让多 prompt 全写第一条。
+      fd.append('source_filename', fn)
       // 0.17 item3：带上 task_id，server enrich 进 PNG anima_params，`?task=` 深链
       // 回看才能按 task_id 命中该磁盘条目（此前漏发 → 落盘图都无 task_id → 回看失败）。
       fd.append('task_id', String(taskId))
@@ -73,7 +76,13 @@ export async function saveXYMatrix(
     const yLoraIndex = xySnapshot.xy_draft?.y?.loraIndex ?? null
 
     // 1) 拉所有 cell PNG bytes + 构 per-cell single-snapshot
-    type CellEntry = { xi: number; yi: number; blob: Blob; params: GenerateParamsSnapshot }
+    type CellEntry = {
+      xi: number
+      yi: number
+      blob: Blob
+      sourceFilename: string
+      params: GenerateParamsSnapshot
+    }
     const cellEntries: CellEntry[] = []
     for (const s of samples) {
       const fn = s.path.split(/[\\/]/).pop()
@@ -88,7 +97,9 @@ export async function saveXYMatrix(
           x: { axis: xAxis, loraIndex: xLoraIndex, value: xv },
           y: yAxis ? { axis: yAxis, loraIndex: yLoraIndex, value: yv ?? '' } : null,
         })
-        cellEntries.push({ xi: s.xy.xi, yi: s.xy.yi, blob, params: cellParams })
+        cellEntries.push({
+          xi: s.xy.xi, yi: s.xy.yi, blob, sourceFilename: fn, params: cellParams,
+        })
       } catch {
         // 单 cell 拉失败跳过；server 会按 manifest 校验，缺 cell 就不发送
       }
@@ -104,7 +115,9 @@ export async function saveXYMatrix(
     fd.append('image', composite, 'xy plot.png')
     fd.append('params', JSON.stringify(xySnapshot))
     fd.append('task_id', String(taskId))  // 0.17 item3：同 single，供 ?task= 深链回看命中
-    const manifest = cellEntries.map(({ xi, yi, params }) => ({ xi, yi, params }))
+    const manifest = cellEntries.map(({ xi, yi, sourceFilename, params }) => ({
+      xi, yi, source_filename: sourceFilename, params,
+    }))
     fd.append('cells_manifest', JSON.stringify(manifest))
     for (const { xi, yi, blob } of cellEntries) {
       fd.append('cells', blob, `cell x${xi} y${yi}.png`)

--- a/tests/test_generate_save_metadata.py
+++ b/tests/test_generate_save_metadata.py
@@ -3,7 +3,9 @@ GET /api/generate/disk/history 扫 PNG metadata、GET /api/generate/disk/image/*
 静态返回的覆盖测试。"""
 from __future__ import annotations
 
+import hashlib
 import json
+import re
 from io import BytesIO
 from pathlib import Path
 
@@ -43,9 +45,15 @@ def _params(**overrides) -> dict:
 @pytest.fixture
 def client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient, Path]:
     from studio.api.routers import generate as _gen
+    from studio.services import generation_metadata as _meta
 
     test_dir = tmp_path / "test"
     monkeypatch.setattr(_gen, "TEST_IMAGES_DIR", test_dir)
+    monkeypatch.setattr(
+        _meta, "manifest_path", lambda task_id: tmp_path / "tasks" / str(task_id) / _meta.MANIFEST_FILENAME,
+    )
+    monkeypatch.setattr(_meta, "HASH_CACHE_PATH", tmp_path / ".cache" / "resource-hashes.json")
+    _meta._reset_hash_cache_for_tests()
 
     class _FakeGenCfg:
         save_test_images = True
@@ -147,6 +155,168 @@ def test_save_writes_a1111_parameters_text_block(client) -> None:
     assert "CFG scale: 7.0" in a1111
     assert "Seed: 42" in a1111
     assert "Size: 1024x1024" in a1111
+
+
+def test_save_a1111_uses_effective_dataset_prompt_without_manifest(client) -> None:
+    """旧客户端/无 task 档案也不能把 dataset picker 实际 prompt 写成空。"""
+    tc, _ = client
+    p = _params(
+        prompts=[],
+        dataset_pick={"tags": ["trigger", "orange hair", "flower crown"]},
+    )
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(p)},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 200
+    a1111 = _open_png_text(Path(r.json()["path"]))["parameters"]
+    assert a1111.splitlines()[0] == "trigger, orange hair, flower crown"
+
+
+def test_save_writes_civitai_resource_hashes_from_private_task_manifest(
+    client, tmp_path: Path,
+) -> None:
+    """实际 prompt + model/VAE/LoRA SHA256 写 parameters，绝对路径不进 PNG。"""
+    from studio.services import generation_metadata as meta
+
+    tc, _ = client
+    model = tmp_path / "models" / "krea2-turbo.safetensors"
+    vae = tmp_path / "models" / "qwen-vae.safetensors"
+    lora = tmp_path / "loras" / "artist-style.safetensors"
+    for path, payload in ((model, b"model"), (vae, b"vae"), (lora, b"lora")):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(payload)
+
+    task_id = 123
+    meta.write_manifest(
+        task_id,
+        prompts=["first prompt", "actual second prompt"],
+        model_family="krea2",
+        model_path=str(model),
+        vae_path=str(vae),
+        text_encoder="fp8",
+        loras=[{"path": str(lora), "scale": 0.75}],
+        xy_matrix=None,
+    )
+    p = _params(
+        prompts=["UI raw prompt"],
+        model_family="krea2",
+        text_encoder="fp8",
+        loras=[{"name": lora.name, "scale": 0.75}],
+    )
+    r = tc.post(
+        "/api/generate/save",
+        data={
+            "mode": "single",
+            "params": json.dumps(p),
+            "task_id": str(task_id),
+            "source_filename": "gen_0001_p1_c0_s7.png",
+        },
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 200, r.text
+    text = _open_png_text(Path(r.json()["path"]))
+    a1111 = text["parameters"]
+    assert a1111.splitlines()[0] == "actual second prompt <lora:artist-style:0.75>"
+    assert "Model: krea2-turbo" in a1111
+    assert f"Model hash: {hashlib.sha256(b'model').hexdigest()}" in a1111
+    assert "VAE: qwen-vae" in a1111
+    assert f"VAE hash: {hashlib.sha256(b'vae').hexdigest()}" in a1111
+    assert f"artist-style: {hashlib.sha256(b'lora').hexdigest()}" in a1111
+    assert '"lora:artist-style"' in a1111
+    assert "Model family: krea2" in a1111
+    assert "Text encoder: fp8" in a1111
+    assert "Software: AnimaLoraStudio" in a1111
+    match = re.search(r", Hashes: (\{.*?\})(?:,|$)", a1111)
+    assert match is not None
+    assert json.loads(match.group(1)) == {
+        "model": hashlib.sha256(b"model").hexdigest(),
+        "vae": hashlib.sha256(b"vae").hexdigest(),
+        "lora:artist-style": hashlib.sha256(b"lora").hexdigest(),
+    }
+    assert str(tmp_path) not in a1111
+    assert str(tmp_path) not in text["anima_params"]
+
+
+def test_resource_metadata_failure_does_not_block_png_save(
+    client, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from studio.api.routers import generate as generate_router
+
+    tc, _ = client
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("hash backend unavailable")
+
+    monkeypatch.setattr(generate_router, "build_external_metadata", fail)
+    r = tc.post(
+        "/api/generate/save",
+        data={"mode": "single", "params": json.dumps(_params())},
+        files={"image": ("a.png", _png_bytes(), "image/png")},
+    )
+    assert r.status_code == 200, r.text
+    assert "parameters" in _open_png_text(Path(r.json()["path"]))
+
+
+def test_resource_hash_cache_reuses_and_invalidates_by_stat(
+    client, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from studio.services import generation_metadata as meta
+
+    path = tmp_path / "resource.safetensors"
+    path.write_bytes(b"v1")
+    first = meta.file_sha256(path)
+    assert first == hashlib.sha256(b"v1").hexdigest()
+
+    def should_not_open(*args, **kwargs):
+        raise AssertionError("cache hit unexpectedly reopened the resource")
+
+    original_open = Path.open
+    monkeypatch.setattr(Path, "open", should_not_open)
+    assert meta.file_sha256(path) == first
+    monkeypatch.setattr(Path, "open", original_open)
+
+    path.write_bytes(b"version two")
+    second = meta.file_sha256(path)
+    assert second == hashlib.sha256(b"version two").hexdigest()
+    assert second != first
+
+
+def test_xy_cell_external_metadata_tracks_checkpoint_and_scale(
+    client, tmp_path: Path,
+) -> None:
+    from studio.services import generation_metadata as meta
+
+    first = tmp_path / "lora-a.safetensors"
+    second = tmp_path / "lora-b.safetensors"
+    first.write_bytes(b"a")
+    second.write_bytes(b"b")
+    meta.write_manifest(
+        456,
+        prompts=["xy prompt"],
+        model_family="anima",
+        model_path="",
+        vae_path=None,
+        text_encoder=None,
+        loras=[{"path": str(first), "scale": 1.0}],
+        xy_matrix={
+            "x": {"axis": "lora_ckpt", "values": [str(first), str(second)], "lora_index": 0},
+            "y": {"axis": "lora_scale", "values": [0.4, 0.8], "lora_index": None},
+        },
+    )
+    params = _params(
+        mode="single",
+        xy_origin={"xi": 1, "yi": 0},
+        loras=[{"name": second.name, "scale": 0.4}],
+    )
+    external = meta.build_external_metadata(456, params)
+    assert external["prompt"] == "xy prompt"
+    assert external["loras"] == [{
+        "name": "lora-b",
+        "scale": 0.4,
+        "hash": hashlib.sha256(b"b").hexdigest(),
+    }]
 
 
 def test_save_does_not_write_sidecar(client) -> None:


### PR DESCRIPTION
## 背景 / 动机

测试出图落盘的 PNG 只带 Studio 内部的 `anima_params`（可移植 UI 快照，刻意无绝对路径）。把图拖进 Civitai / A1111 / ComfyUI 时读不到底模、VAE、LoRA 身份，也无法按 hash 匹配资源。此外现有 metadata 有两个会让外部生态读错的 bug。

## 改动概要

**新功能：Civitai/A1111 兼容 metadata**
- enqueue 时写一份 task 私有档案 `generate-metadata.json`，记录实际推理资源的真实路径（model / vae / lora）。它与 task 档案同生命周期，不进临时目录。
- 落盘时新模块 `studio/services/generation_metadata.py` 读档案，算资源 SHA256，把 `Model / Model hash / VAE / VAE hash / Lora hashes / Hashes / Software` 注进 a1111 `parameters` 块。
- **绝对路径永不写进 PNG**：资源身份与可移植 `anima_params` 分离，只有 basename + hash 进图。
- 资源 hash 按 resolved path + size + mtime_ns 持久缓存（`.cache/resource-hashes.json`）并加线程锁，避免单次多图并发保存时重复顺序读 13–26GB 底模；读取过程中文件变化则不缓存、不写错身份。
- XY 合成图只保留 Studio 结构化参数；完整外部 metadata 写在每个 cell 原图（一张合成图代表多组参数，无法用单一 a1111 块表达）。

**顺带修两个 metadata bug**
- a1111 `parameters` 之前恒取 `prompts[0]`：多 prompt / dataset picker 出的图会写错或写空 prompt。改为按 daemon 文件名 `_pN_` 索引选实际 prompt；无 task 档案的旧客户端回退合并 picker tags。
- 前端 snapshot 的 LoRA 取自 sidebar 原始桶 `loras`：XY 构建会丢弃未被轴引用的孤儿 anchor，导致 PNG 声称用了实际没加载的资源、把错 hash 交给 Civitai。改取实际下发给 daemon 的 `loraConfigs`。

## 测试方式

- 新增/扩展后端回归 `tests/test_generate_save_metadata.py`（无 manifest 回退 prompt、私有档案资源 hash、失败不阻断落盘、hash 缓存按 stat 失效、XY cell 资源轴追踪等）
- 新增前端回归 `saveTestImages.test.ts`（source_filename 随上传下发，server 才能选对 prompt 索引）
- 本地：`test_generate_save_metadata` + 安全网 `route_snapshot` / `studio_configs` 77 passed；ruff 干净；vitest 1 passed；eslint / tsc 干净

## 外部代码

未移植或复制外部仓库代码。metadata 字段名沿用 A1111 / Civitai 既有公开约定（`Model hash` / `Lora hashes` / `Hashes`）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)