### PR TITLE
fix(web): 统一各步骤页图片列表排序为 booru id 序

### DIFF
--- a/studio/web/src/lib/imageSort.test.ts
+++ b/studio/web/src/lib/imageSort.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { compareImageName, compareImagePath, numericIdKey } from './imageSort'
+
+describe('numericIdKey', () => {
+  it('纯数字 stem 取数值', () => {
+    expect(numericIdKey('9.jpg')).toBe(9)
+    expect(numericIdKey('10.png')).toBe(10)
+    expect(numericIdKey('0001.webp')).toBe(1)
+  })
+
+  it('非纯数字 stem 落到 +∞', () => {
+    expect(numericIdKey('IMG_9.jpg')).toBe(Number.POSITIVE_INFINITY)
+    expect(numericIdKey('9_c0.jpg')).toBe(Number.POSITIVE_INFINITY)
+    expect(numericIdKey('cover.png')).toBe(Number.POSITIVE_INFINITY)
+  })
+})
+
+describe('compareImageName', () => {
+  it('booru id 按数值排，不是字典序', () => {
+    const names = ['10.jpg', '9.jpg', '100.jpg', '2.jpg']
+    expect([...names].sort(compareImageName)).toEqual([
+      '2.jpg', '9.jpg', '10.jpg', '100.jpg',
+    ])
+  })
+
+  it('非数字名排在数字名之后，彼此按字典序', () => {
+    const names = ['cover.png', '3.jpg', 'aaa.png', '12.jpg']
+    expect([...names].sort(compareImageName)).toEqual([
+      '3.jpg', '12.jpg', 'aaa.png', 'cover.png',
+    ])
+  })
+
+  it('两个非数字名不产生 NaN（Infinity - Infinity 陷阱）', () => {
+    expect(compareImageName('b.png', 'a.png')).toBeGreaterThan(0)
+    expect(compareImageName('a.png', 'a.png')).toBe(0)
+  })
+
+  it('扩展名不同但 id 相同时按全名比', () => {
+    expect(compareImageName('7.jpg', '7.png')).toBeLessThan(0)
+  })
+})
+
+describe('compareImagePath', () => {
+  it('先按目录字典序，同目录内按 id', () => {
+    const paths = ['5_b/10.jpg', '1_a/9.jpg', '5_b/9.jpg', '1_a/10.jpg']
+    expect([...paths].sort(compareImagePath)).toEqual([
+      '1_a/9.jpg', '1_a/10.jpg', '5_b/9.jpg', '5_b/10.jpg',
+    ])
+  })
+
+  it('无目录的名字视作根目录，排在有目录的之前', () => {
+    const paths = ['1_a/9.jpg', '10.jpg', '9.jpg']
+    expect([...paths].sort(compareImagePath)).toEqual([
+      '9.jpg', '10.jpg', '1_a/9.jpg',
+    ])
+  })
+
+  it('嵌套目录按完整前缀比', () => {
+    expect(compareImagePath('a/b/1.jpg', 'a/c/1.jpg')).toBeLessThan(0)
+  })
+})

--- a/studio/web/src/lib/imageSort.ts
+++ b/studio/web/src/lib/imageSort.ts
@@ -1,0 +1,33 @@
+/**
+ * 图片列表统一排序。
+ *
+ * 各步骤页（概览 / 数据集 / 预处理 / 标签编辑 / 训练集筛选 / 正则集）显示的
+ * 是同一批图，顺序必须一致。后端各端点返回的是路径字典序，对 booru 下载的
+ * 纯数字文件名会把 `10.jpg` 排在 `9.jpg` 前面 —— 与用户认知的 id 顺序不符。
+ * 所以顺序统一在渲染层由这里决定：文件名去后缀是纯数字时按数值排（booru id），
+ * 其余按字典序落在数字之后。
+ */
+
+/** 排序键：纯数字 stem → 该数值；其余 → +∞（落到数字之后，再按名字比）。 */
+export function numericIdKey(name: string): number {
+  const stem = name.replace(/\.[^.]+$/, '')
+  return /^\d+$/.test(stem) ? Number(stem) : Number.POSITIVE_INFINITY
+}
+
+/** 比较单个文件名（不含目录）。 */
+export function compareImageName(a: string, b: string): number {
+  const ka = numericIdKey(a)
+  const kb = numericIdKey(b)
+  // 两侧都非数字时 ka === kb === +∞，走 localeCompare，不会算出 NaN
+  return ka === kb ? a.localeCompare(b) : ka - kb
+}
+
+/** 比较 `folder/name` 形式的相对路径：先按目录字典序，同目录内按文件名。 */
+export function compareImagePath(a: string, b: string): number {
+  const ia = a.lastIndexOf('/')
+  const ib = b.lastIndexOf('/')
+  const da = ia >= 0 ? a.slice(0, ia) : ''
+  const db = ib >= 0 ? b.slice(0, ib) : ''
+  if (da !== db) return da.localeCompare(db)
+  return compareImageName(ia >= 0 ? a.slice(ia + 1) : a, ib >= 0 ? b.slice(ib + 1) : b)
+}

--- a/studio/web/src/pages/project/Overview.tsx
+++ b/studio/web/src/pages/project/Overview.tsx
@@ -30,6 +30,7 @@ import ImageGrid, { type ImageGridItem } from '../../components/ImageGrid'
 import ImagePreviewModal from '../../components/ImagePreviewModal'
 import { OutputsTab } from '../QueueDetail'
 import { arBucket } from '../../lib/aspectRatio'
+import { compareImageName } from '../../lib/imageSort'
 import { computePixelHist } from '../../lib/pixelBins'
 import { useProjectCtx } from '../../context/ProjectContext'
 import { useEventStream } from '../../lib/useEventStream'
@@ -761,7 +762,9 @@ function TrainSetCard({ project, version }: { project: ProjectDetail; version: V
     const out: Array<ImageGridItem & { folder: string; pureName: string }> = []
     const list = selectedFolder === 'all' ? view.folders : [selectedFolder]
     for (const folder of list) {
-      const arr = view.right[folder] ?? []
+      const arr = [...(view.right[folder] ?? [])].sort((a, b) =>
+        compareImageName(a.name, b.name)
+      )
       for (const it of arr) {
         out.push({
           name: `${folder}/${it.name}`,

--- a/studio/web/src/pages/project/steps/Curation.tsx
+++ b/studio/web/src/pages/project/steps/Curation.tsx
@@ -16,6 +16,7 @@ import PaneResizer from '../../../components/PaneResizer'
 import StepShell from '../../../components/StepShell'
 import { useDialog } from '../../../components/Dialog'
 import { useToast } from '../../../components/Toast'
+import { compareImageName } from '../../../lib/imageSort'
 import { useEventStream } from '../../../lib/useEventStream'
 import { useLocalStorageState } from '../../../lib/useLocalStorageState'
 
@@ -35,18 +36,11 @@ const DEFAULT_SORT: SortMode = 'id-asc'
 type Bucket = 'train' | 'validation'
 const BUCKET_STORAGE_KEY = 'curation:bucket'
 
-function numericIdKey(name: string): number {
-  const stem = name.replace(/\.[^.]+$/, '')
-  return /^\d+$/.test(stem) ? Number(stem) : Number.POSITIVE_INFINITY
-}
-
 function compareItems(a: CurationItem, b: CurationItem, mode: SortMode): number {
   switch (mode) {
     case 'id-asc':
     case 'id-desc': {
-      const ka = numericIdKey(a.name)
-      const kb = numericIdKey(b.name)
-      const d = ka === kb ? a.name.localeCompare(b.name) : ka - kb
+      const d = compareImageName(a.name, b.name)
       return mode === 'id-asc' ? d : -d
     }
     case 'name-asc':

--- a/studio/web/src/pages/project/steps/Download.tsx
+++ b/studio/web/src/pages/project/steps/Download.tsx
@@ -16,6 +16,7 @@ import StepShell from '../../../components/StepShell'
 import UploadProgressBar from '../../../components/UploadProgressBar'
 import { useDialog } from '../../../components/Dialog'
 import { useToast } from '../../../components/Toast'
+import { compareImageName } from '../../../lib/imageSort'
 import { useEventStream } from '../../../lib/useEventStream'
 import { useUploadProgress } from '../../../lib/useUploadProgress'
 
@@ -73,7 +74,7 @@ export default function DownloadPage() {
   const refreshFiles = useCallback(async () => {
     try {
       const r = await api.listFiles(project.id)
-      setFiles(r.items)
+      setFiles([...r.items].sort((a, b) => compareImageName(a.name, b.name)))
     } catch {
       /* ignore */
     }

--- a/studio/web/src/pages/project/steps/Preprocess.tsx
+++ b/studio/web/src/pages/project/steps/Preprocess.tsx
@@ -9,6 +9,7 @@ import {
   type Version,
 } from '../../../api/client'
 import { parseFolderMeta } from '../../../lib/folderMeta'
+import { compareImagePath } from '../../../lib/imageSort'
 import ImageGrid, { applySelection } from '../../../components/ImageGrid'
 import ImagePreviewModal from '../../../components/ImagePreviewModal'
 import PreprocessToolsBar from '../../../components/preprocess/PreprocessToolsBar'
@@ -206,7 +207,7 @@ export default function PreprocessPage() {
         mtime: img.mtime,
       })
     }
-    out.sort((a, b) => a.name.localeCompare(b.name))
+    out.sort((a, b) => compareImagePath(a.name, b.name))
     return out
   }, [files])
 

--- a/studio/web/src/pages/project/steps/PreprocessCrop.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessCrop.tsx
@@ -17,6 +17,7 @@ import { useToast } from '../../../components/Toast'
 import { useEventStream } from '../../../lib/useEventStream'
 import { arBucket, arLabel } from '../../../lib/aspectRatio'
 import { clusterByAspectRatio } from '../../../lib/cropClustering'
+import { compareImagePath } from '../../../lib/imageSort'
 
 interface Ctx {
   project: ProjectDetail
@@ -73,7 +74,7 @@ export default function PreprocessCropPage() {
     if (!vid) return
     try {
       const r = await api.listCropWorkspaceTrain(project.id, vid)
-      setImages(r.images)
+      setImages([...r.images].sort((a, b) => compareImagePath(a.name, b.name)))
     } catch {
       /* ignore */
     } finally {

--- a/studio/web/src/pages/project/steps/PreprocessInpaint.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessInpaint.tsx
@@ -18,6 +18,7 @@ import InpaintCanvas, {
 import PreprocessToolsBar from '../../../components/preprocess/PreprocessToolsBar'
 import StepShell from '../../../components/StepShell'
 import { useToast } from '../../../components/Toast'
+import { compareImagePath } from '../../../lib/imageSort'
 import { useLocalStorageState } from '../../../lib/useLocalStorageState'
 
 interface Ctx {
@@ -67,7 +68,7 @@ export default function PreprocessInpaintPage() {
     if (!vid) return
     try {
       const r = await api.listCropWorkspaceTrain(project.id, vid)
-      setImages(r.images)
+      setImages([...r.images].sort((a, b) => compareImagePath(a.name, b.name)))
     } catch {
       /* ignore */
     } finally {

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -23,6 +23,7 @@ import { TagSuggestList } from '../../../components/tagSuggest/TagSuggestList'
 import { useTagSuggest } from '../../../components/tagSuggest/useTagSuggest'
 import { useDialog } from '../../../components/Dialog'
 import { useToast } from '../../../components/Toast'
+import { compareImagePath } from '../../../lib/imageSort'
 import { useEventStream } from '../../../lib/useEventStream'
 import { useLatestJobReplay } from '../../../lib/useLatestJobReplay'
 
@@ -155,7 +156,9 @@ export default function RegularizationPage() {
     if (!vid) return
     try {
       const s = await api.getRegStatus(project.id, vid)
-      setReg(s)
+      // 在源头排序：预览 modal 的 onPick(idx) 直接索引 reg.files，
+      // 缩略图网格也从 reg.files 顺序派生，两者必须同序。
+      setReg({ ...s, files: [...s.files].sort(compareImagePath) })
     } catch (e) {
       toast(t('reg.loadFailed', { error: String(e) }), 'error')
     }

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -17,6 +17,7 @@ import TagEditor from '../../../components/TagEditor'
 import TagStatsPanel from '../../../components/TagStatsPanel'
 import { useToast } from '../../../components/Toast'
 import ZoomableImage from '../../../components/ZoomableImage'
+import { compareImagePath } from '../../../lib/imageSort'
 import { useEventStream } from '../../../lib/useEventStream'
 import { useLocalStorageState } from '../../../lib/useLocalStorageState'
 
@@ -78,7 +79,10 @@ export default function TagEditPage() {
       const c = new Map<string, string[]>()
       const m = new Map<string, CaptionMeta>()
       const ks: string[] = []
-      for (const it of r.items) {
+      const sorted = [...r.items].sort((a, b) =>
+        compareImagePath(keyOf(a.folder, a.name), keyOf(b.folder, b.name))
+      )
+      for (const it of sorted) {
         const k = keyOf(it.folder, it.name)
         c.set(k, it.tags)
         m.set(k, { folder: it.folder, name: it.name, format: it.format })


### PR DESCRIPTION
## 背景 / 动机

各步骤页显示的是同一批图，但顺序此前由各自的数据源决定：

| 页面 | 此前顺序来源 |
|---|---|
| 训练集筛选 | 前端 `compareItems`，有排序选择器，默认 `id-asc`（**数值序**） |
| 概览 | `curation_view` 的 `sorted(key=name)` |
| 数据集 | `/files` 的 `sorted(pdir.iterdir())` |
| 预处理 / 裁剪 / 涂抹 | 前端 `name.localeCompare` / 后端原顺序 |
| 标签编辑 | `_imgs_in` 的 `sorted()` |
| 正则集 | `/reg` 的 `sorted(rdir.rglob("*"))` |

除训练集筛选页外全是路径字典序，对 booru 下载的纯数字文件名会把 `10.jpg`
排在 `9.jpg` 前面。结果是同一批图在训练集筛选页和其他页顺序对不上，图越多
（跨了位数）错位越明显。

排序选择器只在训练集筛选页有；给其余页都加选择器会挤占本就紧的页面头部，
所以这里只统一默认顺序，不铺 UI。

## 改动概要

新增 `studio/web/src/lib/imageSort.ts`：

- `numericIdKey(name)` — 从训练集筛选页原样提出，语义不变（纯数字 stem 取
  数值，其余 `+∞`）
- `compareImageName(a, b)` — 单文件名比较
- `compareImagePath(a, b)` — `folder/name` 相对路径：先目录字典序，同目录内
  按文件名

各页在渲染层统一调用，**后端返回顺序和 API 契约不动**：

- 训练集筛选 — 删本地 `numericIdKey`，`id-asc/desc` 改调公共比较器
- 概览 — `view.right[folder]` 排序副本后入网格
- 数据集 — `setFiles` 时排
- 预处理 — `localeCompare` → `compareImagePath`
- 裁剪 / 涂抹 — `setImages` 时排（同属预处理步、同批图，一并跟上）
- 标签编辑 — `listCaptionsFull` 结果按 `folder/name` 排
- 正则集 — 在 `setReg` 源头排 `files`

正则集特意排在 `setReg` 而不是网格的 `useMemo`：预览 modal 的 `onPick(idx)`
直接索引 `reg.files`，网格又从 `reg.files` 派生，只排一边会点开错图。代码里
留了注释说明。

## 测试方式

新增 `imageSort.test.ts` 9 条：`10 vs 9` 数值序、非数字名排在数字之后、
`Infinity - Infinity = NaN` 陷阱、同 id 不同扩展名、跨目录路径比较。

```
npx vitest run          # 60 files / 515 tests 全绿
npm run lint            # 0 error（仅 PreprocessInpaint 既有的 2 条 exhaustive-deps warning）
npx tsc --noEmit        # 干净
```

未改后端，无 pytest 相关面。

## 截图

纯排序改动，页面布局 / 元素没有变化，故未附截图。
