### PR TITLE
test(krea2): 补 DiT batch 不变量回归测试

### DIFF
--- a/tests/test_krea2_modeling.py
+++ b/tests/test_krea2_modeling.py
@@ -100,6 +100,31 @@ def test_tiny_forward_preserves_5d_shape_and_crops_patch_padding() -> None:
     assert torch.isfinite(output).all()
 
 
+def test_batched_forward_matches_per_sample_forward() -> None:
+    """Modulation is broadcast per sample, never across the token axis.
+
+    ``tproj`` emits (B, 1, 6*features); a missing token axis would broadcast
+    (B, features) against (B, L, features) and silently pass only when B == 1.
+    """
+    torch.manual_seed(11)
+    model = SingleStreamDiT(_tiny_config()).eval()
+    x, timesteps, context, mask = _tiny_inputs()
+    with torch.no_grad():
+        batched = model(x, timesteps, context, mask)
+        per_sample = torch.cat(
+            [
+                model(
+                    x[i : i + 1],
+                    timesteps[i : i + 1],
+                    context[i : i + 1],
+                    mask[i : i + 1],
+                )
+                for i in range(x.shape[0])
+            ]
+        )
+    torch.testing.assert_close(batched, per_sample, rtol=1e-5, atol=1e-5)
+
+
 def test_flattened_and_layered_text_context_are_equivalent() -> None:
     model = SingleStreamDiT(_tiny_config()).eval()
     x, timesteps, context, mask = _tiny_inputs()


### PR DESCRIPTION
## 背景 / 动机

排查一份 batch>1 崩溃报告时，怀疑 `SingleStreamBlock` 的 modulation 广播错了：`(vec + lin).chunk(6, dim=-1)` 得到的若是 `(B, features)`，与 `(B, L, features)` 右对齐会变成 `(1, B, features)`，只有 B == 1 才碰巧成立。

**核对结论：代码没有问题，batch>1 一直是好的。** 所需的 token 轴已经存在，只是插在 `_timestep_embedding` 内部：

```python
angles = (t.float() * 1e3)[:, None, None] * freqs   # -> (B, 1, tdim)
```

于是 `time` 是 `(B, 1, features)`、`time_mod = tproj(time)` 是 `(B, 1, 6*features)`，chunk 后 `(B, 1, features)` 与 `(B, L, features)` 正确广播。

ComfyUI parity 也核对过，`comfy/ldm/krea2/model.py` 是等价写法，只是把 unsqueeze 放在了外面：

```python
t = self.tmlp(timestep_embedding(timesteps, self.tdim).unsqueeze(1).to(img.dtype))
```

两边落到 block 的 vec 同为 `(B, 1, 6F)`；block 的契约就是 3D vec，Comfy 收到 2D 一样会崩。**本 PR 不含任何生产代码改动。**

## 改动概要

只加一条测试 `test_batched_forward_matches_per_sample_forward`：batched 前向必须逐样本等于单样本前向。

补它的理由与上面那次误判无关，独立成立——这个 token 轴离使用点隔了 `tmlp` / `tproj` / `chunk` 三层，读代码时不易串起来（这次的误判本身就是佐证）。一旦被当作冗余「清理」掉，B == 1 全绿、B > 1 才崩，是只在多 batch 下暴露的静默契约。本文件现有前向测试虽然都用 `batch=2`，但没有一条断言 batch 内各样本互不串味。

## 测试方式

- `tests/test_krea2_modeling.py` — 18 passed
- 相关面 `test_krea2_loader` / `test_krea2_family_integration` / `test_krea2_sampling` — 53 passed
- 横切安全网 `test_route_snapshot` / `test_studio_configs` — 33 passed
- `ruff check` + `ruff format --check` 干净

**变异验证**（确认断言有牙齿）：把 `[:, None, None]` 临时改成 `[:, None]`，本文件 6 条测试转红，含新增这条；源文件已还原，未纳入本 PR。

排查期另做过的等价性实测（未纳入 PR，仅记录）：tiny config 下 B=1/2/3 的 4D、5D、attention_mask、梯度检查点、非方形与奇数尺寸 padding 路径全部正常，batched 与 per-sample `max abs diff` 为 3.6e-07（fp32 噪声级）。

CI 会跑全量兜底。
