### PR TITLE
fix(train): block swap 反向未换回权重导致梯度静默错乱

### DIFF
--- a/docs/design/block-swap.md
+++ b/docs/design/block-swap.md
@@ -576,11 +576,8 @@ fp8 那条只要**顺序对**就正确：loader 落 CPU pinned → `apply_loras`
 注册 forward pre/post hook**（`PinnedBlockSwap.attach()`），更好：
 
 - **完全不改 `modeling/krea2/`** —— 那里对 ComfyUI 有逐字 parity 要求（§7.1）。
-- **反向自动成立**：开 gradient checkpointing 后，反向阶段会重算前向，即再次调用
-  block 的 forward → pre-hook 随之触发，按逆序换回权重。§2.4 说的「重算与反向在同
-  一驻留窗口内完成」在这里是自然结果，**不需要为反向单独编排时序**。
-  该结论由 `tests/test_block_swap.py::test_attach_with_gradient_checkpointing_backward`
-  实测钉死（与全常驻的梯度逐位一致），不是推断。
+- ~~**反向自动成立**：checkpoint 重算会触发 forward hook，逆序换入自动成立~~
+  —— **这条是错的，已于 §9.10 更正**。反向必须自己挂钩子取回权重。
 - Anima 接线因此也只是「构造 + attach」，连它的手工展开循环都不必改。
 
 ### 9.4 实施中实测抓出的三个坑（都已有回归测试）
@@ -659,3 +656,50 @@ block 的不止 `ctx.model` —— LyCORIS injector 持 `org_module`、optimizer
 hook 闭包也可能持有。真机实测只丢 swap 对象归还 **0 字节**，丢 model 之后才归还。
 与其到处找持有者，不如让组件自己把参数指走。`close()` 之后仍需
 `release_pinned_host_cache()` 才真正还给操作系统（§9.7 的另一层）。
+
+### 9.10 反向必须单独挂钩子（推翻 §9.3 的错误论断）
+
+**症状**：用户开 block swap + PPSF 训练，Prodigy 的 `d` 估计大幅跳升、学习率失控、
+训练失败。
+
+**根因**：`attach()` 起初只挂前向 pre/post 钩子，基于一个错误论断——「开 gradient
+checkpointing 后反向会重算前向，forward hook 随之触发，逆序换入自动成立」。实测两处
+都不成立：
+
+1. **重算不触发 forward_hook**：实测 checkpoint 下 pre-hook 触发 2N 次，而 post-hook
+   只有 N 次（重算只走 pre）。
+2. **更关键**：重算之后本 block 的**反向**仍要读权重，而前向 post 已经放开了槽位 ——
+   下一次换入直接覆盖正在被反向读的权重。
+
+后果是**静默的**：不报错、不 NaN，梯度只是数值不对。定量（RTX 5090，真实 6144-dim
+block）：
+
+| | 噪声底 | swap 偏差 | 倍数 |
+|---|---|---|---|
+| 修复前 · checkpoint | 4.4e-3 | **1.31** | **298×** |
+| 修复前 · 无 checkpoint | 2.2e-3 | 1.48 | 675× |
+| 修复后 · checkpoint | 4.4e-3 | 4.7e-3 | 1× |
+| 修复后 · 无 checkpoint | 3.5e-3 | 4.7e-3 | 1.4× |
+
+**PPSF 是报警器不是肇事者**：固定 lr 的 AdamW 会带着被污染的梯度闷头训完、产出一个
+质量下降但看不出异常的 LoRA；Prodigy 系靠梯度一致性估计 `d`，梯度一乱 `d` 立刻炸。
+**用 AdamW + block swap 训过的 LoRA 都应视为受影响。**
+
+**修法**：四个钩子缺一不可 —— 前向 pre 取回 / post 放开、**反向 pre 再取回 / post
+放开**。开 checkpoint 时反向 pre 通常命中紧邻重算刚放好的权重，零额外传输；不开
+checkpoint 时它是唯一的换回时机。
+
+### 9.11 这个 bug 为什么能溜过全部既有测试
+
+`test_block_swap.py` 里那条 checkpoint 反向测试**在 bug 存在时照样全绿**。原因：
+
+- 小张量（16–32 dim）、`_Tiny` block **没有 attention**，计算快到竞态窗口不显形；
+- 它用 `assert_close` 逐位比 —— 而真实尺寸下 SDPA 反向在 CUDA/bf16 上**本就非确定**
+  （同权重跑两遍梯度差约 5e-3），逐位比在真实尺寸上根本没法用。
+
+教训两条，已固化进 `tests/test_block_swap_grad_fidelity.py`：
+
+1. **验证并发/竞态必须用真实尺寸**。小 case 的绿灯是假信心。
+2. **非确定性环境里要先测噪声底再做判据**。第一次排查时我直接拿「梯度不逐位相等」
+   当证据，其实无 swap 跑两遍也不相等 —— 缺对照组的测量会同时制造假阳性（当时）
+   和假阴性（原单测）。判据应是「与对照组自身重复性同量级」。

--- a/runtime/training/block_swap.py
+++ b/runtime/training/block_swap.py
@@ -287,15 +287,25 @@ class PinnedBlockSwap:
         return ptrs
 
     def attach(self) -> None:
-        """给每个换出 block 注册 forward pre/post hook，接管换入换出。
+        """给每个换出 block 注册前向 + 反向钩子，接管换入换出。
 
         这是**推荐的接线方式**：完全从外部生效，不需要改模型的 forward 循环
         （krea2 的循环在 parity 敏感的 ``modeling/`` 内，不宜改动，doc §7.1）。
 
-        反向为什么也自动成立：开 gradient checkpointing 后，反向阶段会**重算
-        前向**，即再次调用该 block 的 forward —— pre-hook 随之触发，按反向的
-        逆序把权重换回来。所以不需要为反向单独编排时序（doc §2.4 说的「重算与
-        反向在同一驻留窗口内完成」在这里是自然结果）。
+        **四个钩子缺一不可**（前向 pre/post + 反向 pre/post）：
+
+        - 前向 pre 取回权重、post 放开槽位；
+        - **反向 pre 必须再取一次** —— 前向 post 已经放开了槽位（不放开的话前向
+          期间没有任何 done 事件、双缓冲失去保护），到本 block 反向时槽里装的
+          早已是别的层。
+
+        曾经以为「开 gradient checkpointing 后反向重算会触发 forward hook，逆序
+        换入自动成立」，**那是错的**：重算的 forward_hook 根本不触发（实测
+        checkpoint 下 pre 触发 2N 次而 post 只 N 次），且重算之后本 block 的反向
+        仍要读权重。少了反向钩子，梯度会**静默**算错 —— 不报错、不 NaN，只是数值
+        不对，真机实测偏差达非确定性噪声底的 300 倍，PPSF 的 d 估计随即炸掉。
+        回归见 ``tests/test_block_swap_grad_fidelity.py``（必须用真实尺寸 +
+        噪声底校准，小张量测试对此完全不敏感）。
 
         幂等：重复调用不会重复注册。
         """
@@ -306,17 +316,28 @@ class PinnedBlockSwap:
             block = self.blocks[absolute]
 
             def pre_hook(_module, _args, idx=absolute):
-                # 前向：算 idx 时预取 idx+1；反向重算时该预取落空（越界或已在位），
-                # 由 _fetch 的边界与命中检查静默吸收
                 self.ensure_resident(idx, prefetch_next=idx + 1)
 
             def post_hook(_module, _args, output, idx=absolute):
                 self.release(idx)
                 return output
 
+            def backward_pre_hook(_module, _gout, idx=absolute):
+                # **反向必须自己把权重取回来。** 前向结束就放开了槽位，到本 block
+                # 反向时槽里装的早已是别的层 —— 少了这一步梯度会**静默**算错
+                # （不报错、不 NaN，只是数值不对；真机实测偏差达噪声底 300 倍，
+                # PPSF 的 d 估计直接炸掉）。开 checkpoint 时紧邻的重算刚把权重
+                # 放好，这里命中直接返回、零额外传输。
+                self.ensure_resident(idx, prefetch_next=idx - 1)
+
+            def backward_hook(_module, _gin, _gout, idx=absolute):
+                self.release(idx)
+
             self._handles.append(block.register_forward_pre_hook(pre_hook))
             self._handles.append(block.register_forward_hook(post_hook))
-        logger.info("block swap 已挂载：%d 个 block 的前向钩子", self.num_swap)
+            self._handles.append(block.register_full_backward_pre_hook(backward_pre_hook))
+            self._handles.append(block.register_full_backward_hook(backward_hook))
+        logger.info("block swap 已挂载：%d 个 block 的前向/反向钩子", self.num_swap)
 
     def detach(self) -> None:
         """移除 attach 注册的钩子（权重不还原，需要时自行 ensure_resident）。"""

--- a/tests/test_block_swap.py
+++ b/tests/test_block_swap.py
@@ -353,8 +353,9 @@ def test_detach_removes_hooks():
     swap = PinnedBlockSwap(blocks, num_swap=2, device=device)
     swap.attach()
     swap.attach()  # 幂等
-    n_handles = len(swap._handles)
-    assert n_handles == 2 * 2  # 每个换出 block 2 个钩子
+    # 每个换出 block 4 个钩子：前向 pre/post + 反向 pre/post。反向那两个不能省，
+    # 少了梯度会静默算错（见 test_block_swap_grad_fidelity.py）
+    assert len(swap._handles) == 2 * 4
     swap.detach()
     assert swap._handles == []
 

--- a/tests/test_block_swap_grad_fidelity.py
+++ b/tests/test_block_swap_grad_fidelity.py
@@ -1,0 +1,126 @@
+"""block swap 的梯度保真度（真实尺寸 + 噪声底校准）。
+
+**为什么单独一个文件、且必须用真实尺寸**：`test_block_swap.py` 里那条小张量的
+checkpoint 反向测试，在权重换入换出存在竞态时**照样全绿** —— 小 block 没有
+attention、计算快到竞态窗口不显形。真机 6144-dim × 28 层才暴露：梯度偏差达噪声
+底的 300 倍，PPSF 的 `d` 估计直接炸掉（用户真机报告）。
+
+**为什么不能用 assert_close 逐位比**：SDPA 反向在 CUDA/bf16 上非确定 —— 同一份
+权重跑两遍梯度就差约 5e-3。所以判据是「与**对照组自身的重复性**同量级」：
+先测两次无 swap 的差（噪声底），再要求 swap 的差不超过它的若干倍。
+
+历史读数（RTX 5090，8 层 × features 6144）：
+    修复前 checkpoint  噪声底 4.4e-3  swap 差 1.31    → 298× ❌
+    修复后 checkpoint  噪声底 4.4e-3  swap 差 4.7e-3  →   1× ✅
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+from torch import nn
+from torch.utils.checkpoint import checkpoint
+
+_ROOT = Path(__file__).resolve().parent.parent
+for _p in (_ROOT, _ROOT / "runtime"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="block swap 是 CUDA-only 机制"
+)
+
+_LAYERS = 6
+_SWAP = 4
+_SEQ = 512 + 128
+#: swap 的梯度偏差相对噪声底的容忍倍数。真实 bug 是 300× 量级，噪声本身在
+#: 1–2× 抖动，10× 给足余量又能牢牢抓住回归。
+_TOLERANCE = 10.0
+
+
+def _make_model(device, dtype):
+    """真实尺寸的 krea2 block（含 attention —— 竞态要靠它才显形）+ 模拟 LoRA。"""
+    from modeling.krea2 import KREA2_CONFIG
+    from modeling.krea2.krea2_modeling import SingleStreamBlock
+
+    cfg = KREA2_CONFIG
+    torch.manual_seed(0)
+    blocks = nn.ModuleList([
+        SingleStreamBlock(
+            cfg.features, cfg.heads, cfg.multiplier, cfg.bias, cfg.kvheads,
+        )
+        for _ in range(_LAYERS)
+    ]).to(device, dtype)
+    blocks.requires_grad_(False)          # 底模 frozen
+    torch.manual_seed(1)
+    for b in blocks:                      # LoRA 式可训练参数（常驻，不参与 swap）
+        b.lora = nn.Parameter(torch.ones(cfg.features, device=device, dtype=dtype) * 0.01)
+    return blocks, cfg
+
+
+def _inputs(cfg, device, dtype):
+    from modeling.krea2.krea2_modeling import PositionalEncoding
+
+    head = cfg.features // cfg.heads
+    axes = (head - 12 * (head // 16), 6 * (head // 16), 6 * (head // 16))
+    freqs = PositionalEncoding(axes, theta=cfg.theta)(
+        torch.zeros(1, _SEQ, 3, device=device)
+    )
+    torch.manual_seed(9)
+    x = torch.randn(1, _SEQ, cfg.features, device=device, dtype=dtype)
+    vec = torch.randn(1, 6 * cfg.features, device=device, dtype=dtype)
+    return x, vec, freqs
+
+
+def _grads(blocks, inputs, *, use_checkpoint: bool):
+    x, vec, freqs = inputs
+    h = x
+    for b in blocks:
+        def fwd(t, blk=b):
+            return blk(t, vec, freqs) * blk.lora
+        h = checkpoint(fwd, h, use_reentrant=False) if use_checkpoint else fwd(h)
+    h.sum().backward()
+    return [b.lora.grad.clone() for b in blocks]
+
+
+def _max_rel(a_list, b_list) -> float:
+    return max(
+        ((a.float() - b.float()).abs().max()
+         / max(b.float().abs().max().item(), 1e-9)).item()
+        for a, b in zip(a_list, b_list)
+    )
+
+
+@pytest.mark.parametrize("use_checkpoint", [True, False])
+def test_swap_gradients_stay_within_nondeterminism_noise(use_checkpoint):
+    """swap 的梯度偏差必须与「无 swap 跑两遍」同量级。
+
+    回归的是：前向结束就放开槽位、而反向仍要读那批权重 → 下一次换入把正在被
+    读的权重覆盖掉 → 梯度静默错乱（不报错、不 NaN，只是数值不对）。
+    """
+    from training.block_swap import PinnedBlockSwap
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+
+    blocks_a, cfg = _make_model(device, dtype)
+    inputs = _inputs(cfg, device, dtype)
+    grads_a = _grads(blocks_a, inputs, use_checkpoint=use_checkpoint)
+
+    blocks_b, _ = _make_model(device, dtype)
+    grads_b = _grads(blocks_b, inputs, use_checkpoint=use_checkpoint)
+    noise = _max_rel(grads_a, grads_b)      # 同一份权重跑两遍的固有抖动
+
+    blocks_swap, _ = _make_model(device, dtype)
+    swap = PinnedBlockSwap(blocks_swap, num_swap=_SWAP, device=device)
+    swap.attach()
+    grads_swap = _grads(blocks_swap, inputs, use_checkpoint=use_checkpoint)
+    observed = _max_rel(grads_swap, grads_a)
+
+    assert observed <= max(noise, 1e-4) * _TOLERANCE, (
+        f"block swap 的梯度偏差 {observed:.2e} 超过噪声底 {noise:.2e} 的 "
+        f"{_TOLERANCE}× —— 权重在反向期间被换入覆盖了"
+    )


### PR DESCRIPTION
## 为什么不能等下次 release

**v0.21.0 已发布，且带着这个 bug。** 任何在 v0.21.0 里开了 `blocks_to_swap` 的用户，
训练**正在静默产出被污染的梯度** —— 不报错、不 NaN，只是数值不对。

| | |
|---|---|
| 触发条件 | `blocks_to_swap > 0`（训练侧；开/不开 gradient checkpointing 都中招） |
| 梯度偏差 | 非确定性噪声底的 **~300 倍** |
| 用户可见症状 | 配 PPSF / Prodigy 时 `d` 估计跳升、lr 失控、训练失败；配 AdamW 则**无任何异常表现**，只是产出的 LoRA 质量下降 |
| 波及范围 | v0.21.0 中开过 block swap 训练的 LoRA 都应视为受影响、建议重训 |
| 推理侧 | **不受影响**（只有前向，无反向） |

「静默」是这里最危险的部分：多数用户用 AdamW，不会察觉。

## 根因

`PinnedBlockSwap.attach()` 起初只挂前向 pre/post 钩子，依据一个**错误论断**——
「开 gradient checkpointing 后反向会重算前向，forward hook 随之触发，逆序换入自动
成立」。实测两处都不成立：

1. **重算不触发 `forward_hook`**：checkpoint 下 pre-hook 触发 2N 次，post-hook 只 N 次。
2. **更关键**：重算之后本 block 的**反向**仍要读权重，而前向 post 已经放开了槽位 ——
   下一次换入直接覆盖正在被反向读的权重。

不开 checkpointing 时更直接：反向根本不会重跑前向，权重压根没被换回来。

## 修法

四个钩子缺一不可 —— 前向 pre 取回 / post 放开、**反向 pre 再取回 / post 放开**。
开 checkpoint 时反向 pre 命中紧邻重算刚放好的权重，零额外传输；不开 checkpoint 时
它是唯一的换回时机。

## 定量验证（RTX 5090，真实 6144-dim block）

判据不能用逐位比 —— SDPA 反向在 CUDA/bf16 上**本就非确定**（同权重跑两遍梯度差约
5e-3）。所以先测噪声底，再要求 swap 的偏差与之同量级：

| | 噪声底 | swap 偏差 | 倍数 |
|---|---|---|---|
| 修复前 · checkpoint | 4.4e-3 | **1.31** | **298×** |
| 修复前 · 无 checkpoint | 2.2e-3 | 1.48 | 675× |
| 修复后 · checkpoint | 4.4e-3 | 4.7e-3 | **1×** |
| 修复后 · 无 checkpoint | 3.5e-3 | 4.7e-3 | 1.4× |

## 测试方式

新增 `tests/test_block_swap_grad_fidelity.py`（真实尺寸 + 噪声底校准），已验证
**退回修复前该测试必红**。

既有的小张量 checkpoint 反向测试在 bug 存在时**照样全绿** —— `_Tiny` block 没有
attention、计算快到竞态窗口不显形。教训写进 doc §9.11：验证竞态必须用真实尺寸，
非确定性环境里要先测噪声底再定判据。

- `ruff check .` 全绿
- 有 GPU：27 passed；**无 GPU（`CUDA_VISIBLE_DEVICES=""` 模拟 CI）**：76 passed
  （含横切安全网 `test_route_snapshot` + `test_studio_configs`）

## 合并后待办

1. bump PATCH → v0.21.1（`studio/__init__.py` + `package.json` + release post + README）
2. 打 tag + 发 GitHub Release，**release notes 建议点名**：开过 block swap 训练的
   LoRA 需重训
3. **必须 sync 回 dev**（CONTRIBUTING §Hotfix 第 5 步），否则下次 release 会回归
