### PR TITLE
fix(train): 收敛 LoKr/LoHa normal dropout 告警刷屏

### DIFF
--- a/tests/test_lycoris_dropout_spam.py
+++ b/tests/test_lycoris_dropout_spam.py
@@ -1,0 +1,115 @@
+"""LoKr/LoHa normal-dropout 告警刷屏收敛（utils.lycoris_adapter）。
+
+lycoris 的 LokrModule/LohaModule 在 `dropout>0` 时**每个模块实例**都 print 一行
+"[WARN]LoHa/LoKr haven't implemented normal dropout yet."，280 层就是 280 行。
+注入期把 stdout 按行过滤：含 marker 的整行吞掉并计数，其余原样透传，退出时汇总成
+一条 logger 记录。
+
+覆盖：整行丢弃 + 计数、非 marker 行原样透传、跨 write 的半行、无换行尾巴的 flush、
+上下文退出（含异常）后 sys.stdout 复原、属性透传。
+"""
+from __future__ import annotations
+
+import io
+import sys
+
+import pytest
+
+from utils.lycoris_adapter import (
+    _LOKR_DROPOUT_MARKER,
+    _LineFilteredStdout,
+    _suppress_lokr_dropout_spam,
+)
+
+SPAM = f"[WARN]LoHa/LoKr {_LOKR_DROPOUT_MARKER}"
+
+
+def test_drops_marker_lines_and_counts_them() -> None:
+    sink = io.StringIO()
+    flt = _LineFilteredStdout(sink, _LOKR_DROPOUT_MARKER)
+
+    for _ in range(280):
+        flt.write(SPAM + "\n")
+
+    assert flt.dropped == 280
+    assert sink.getvalue() == ""
+
+
+def test_passes_other_lines_through_unchanged() -> None:
+    sink = io.StringIO()
+    flt = _LineFilteredStdout(sink, _LOKR_DROPOUT_MARKER)
+
+    flt.write("training step 1\n")
+    flt.write(SPAM + "\n")
+    flt.write("training step 2\n")
+
+    assert flt.dropped == 1
+    assert sink.getvalue() == "training step 1\ntraining step 2\n"
+
+
+def test_filters_across_write_boundaries() -> None:
+    """print 不保证一行一次 write —— 半行也要按行判定，不能漏过 marker。"""
+    sink = io.StringIO()
+    flt = _LineFilteredStdout(sink, _LOKR_DROPOUT_MARKER)
+
+    head, tail = SPAM[:10], SPAM[10:]
+    flt.write(head)
+    flt.write(tail + "\nkeep me\n")
+
+    assert flt.dropped == 1
+    assert sink.getvalue() == "keep me\n"
+
+
+def test_write_returns_input_length() -> None:
+    """IO 协议：write 返回写入的字符数，调用方（print）据此判断。"""
+    flt = _LineFilteredStdout(io.StringIO(), _LOKR_DROPOUT_MARKER)
+    assert flt.write(SPAM + "\n") == len(SPAM) + 1
+    assert flt.write("plain\n") == 6
+
+
+def test_flush_handles_trailing_partial_line() -> None:
+    """最后一行没有换行时，flush 也要按 marker 判定，不能把它当普通输出漏出去。"""
+    sink = io.StringIO()
+    flt = _LineFilteredStdout(sink, _LOKR_DROPOUT_MARKER)
+    flt.write(SPAM)  # 无换行
+    flt.flush()
+
+    assert flt.dropped == 1
+    assert sink.getvalue() == ""
+
+    sink2 = io.StringIO()
+    flt2 = _LineFilteredStdout(sink2, _LOKR_DROPOUT_MARKER)
+    flt2.write("half line")  # 无换行、非 marker
+    flt2.flush()
+
+    assert flt2.dropped == 0
+    assert sink2.getvalue() == "half line"
+
+
+def test_forwards_unknown_attributes_to_wrapped() -> None:
+    """encoding / isatty 等由被包装对象提供 —— 训练进程里 stdout 是真 TextIO。"""
+    flt = _LineFilteredStdout(sys.__stdout__, _LOKR_DROPOUT_MARKER)
+    assert flt.encoding == sys.__stdout__.encoding
+    assert flt.isatty() == sys.__stdout__.isatty()
+
+
+def test_context_restores_stdout_and_reports_count(capsys) -> None:
+    original = sys.stdout
+    with _suppress_lokr_dropout_spam() as flt:
+        assert sys.stdout is not original
+        print(SPAM)
+        print(SPAM)
+        print("real output")
+    assert sys.stdout is original
+    assert flt.dropped == 2
+    assert capsys.readouterr().out == "real output\n"
+
+
+def test_context_restores_stdout_on_exception() -> None:
+    """注入抛错时也必须把 stdout 换回去，否则后续输出全走过滤器。"""
+    original = sys.stdout
+    with pytest.raises(RuntimeError):
+        with _suppress_lokr_dropout_spam():
+            print(SPAM)
+            raise RuntimeError("injection blew up")
+    assert sys.stdout is original

--- a/utils/lycoris_adapter.py
+++ b/utils/lycoris_adapter.py
@@ -16,6 +16,8 @@ import json
 import logging
 import math
 import re
+import sys
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Optional
 
@@ -35,6 +37,57 @@ _ADAPTER_DTYPES = frozenset({torch.float16, torch.bfloat16, torch.float32, torch
 # 模块级调用：任何路径走到 lycoris_adapter（CLI 训练 / Studio worker / 测试）
 # 都会先 patch 一次。返回值供测试断言；正常 import 路径下结果落到 logger。
 _LOKR_PATCH_STATUS = apply_lokr_device_patch()
+
+# lycoris 的 LokrModule/LohaModule 在 dropout>0 时，每个模块实例都会 print 一行
+#   "[WARN]LoHa/LoKr haven't implemented normal dropout yet."
+# 280 层就刷 280 行。行为上等于静默忽略 normal dropout（rank/module dropout 不受影响）。
+# 注入期临时按行过滤 stdout，把这些行吞掉并计数，最后汇总成一条 logger 记录。
+_LOKR_DROPOUT_MARKER = "haven't implemented normal dropout yet"
+
+
+class _LineFilteredStdout:
+    """按行包装 stdout，丢弃含 marker 的整行并计数；其余原样透传。"""
+
+    def __init__(self, wrapped: Any, marker: str) -> None:
+        self._wrapped = wrapped
+        self._marker = marker
+        self._buf = ""
+        self.dropped = 0
+
+    def write(self, s: str) -> int:
+        self._buf += s
+        while "\n" in self._buf:
+            line, self._buf = self._buf.split("\n", 1)
+            if self._marker in line:
+                self.dropped += 1
+            else:
+                self._wrapped.write(line + "\n")
+        return len(s)
+
+    def flush(self) -> None:
+        if self._buf:
+            if self._marker in self._buf:
+                self.dropped += 1
+            else:
+                self._wrapped.write(self._buf)
+            self._buf = ""
+        self._wrapped.flush()
+
+    def __getattr__(self, name: str) -> Any:  # encoding/fileno/isatty 等透传
+        return getattr(self._wrapped, name)
+
+
+@contextmanager
+def _suppress_lokr_dropout_spam():
+    """注入期临时收敛 lycoris 的 normal-dropout print 刷屏。"""
+    original = sys.stdout
+    flt = _LineFilteredStdout(original, _LOKR_DROPOUT_MARKER)
+    sys.stdout = flt
+    try:
+        yield flt
+    finally:
+        flt.flush()
+        sys.stdout = original
 
 
 class LycorisAdapter:
@@ -143,18 +196,27 @@ class LycorisAdapter:
             extra["bypass_mode"] = True
             logger.info("FP8 base detected: forcing LoKr bypass forward")
 
-        self.network = LycorisNetwork(
-            model,
-            multiplier=1.0,
-            lora_dim=self.rank,
-            alpha=self.alpha,
-            dropout=self.dropout,
-            rank_dropout=self.rank_dropout,
-            module_dropout=self.module_dropout,
-            network_module=net_module,
-            **extra,
-        )
-        self.network.apply_to()
+        with _suppress_lokr_dropout_spam() as _dropout_filter:
+            self.network = LycorisNetwork(
+                model,
+                multiplier=1.0,
+                lora_dim=self.rank,
+                alpha=self.alpha,
+                dropout=self.dropout,
+                rank_dropout=self.rank_dropout,
+                module_dropout=self.module_dropout,
+                network_module=net_module,
+                **extra,
+            )
+            self.network.apply_to()
+
+        if _dropout_filter.dropped:
+            logger.info(
+                "LoKr/LoHa 不支持 normal dropout（lora_dropout=%s），已静默忽略；"
+                "上游逐层告警 %d 条已收敛。rank_dropout/module_dropout 不受影响。",
+                self.dropout,
+                _dropout_filter.dropped,
+            )
 
         if self.lora_reg_dims:
             _apply_reg_dims_(self.network, self.lora_reg_dims)


### PR DESCRIPTION
## 问题

用 LoKr / LoHa 且 `lora_dropout > 0` 时，训练日志开头会被这行刷屏：

```
[WARN]LoHa/LoKr haven't implemented normal dropout yet.
[WARN]LoHa/LoKr haven't implemented normal dropout yet.
... ×280
```

lycoris 的 `LokrModule` / `LohaModule` 构造时每个模块实例都 `print` 一次，28 层 × 10 个投影就是 280 行。

## 改动

注入期（`LycorisNetwork(...)` + `apply_to()`）临时按行过滤 `sys.stdout`：含该 marker 的整行吞掉并计数，其余原样透传。退出上下文时汇总成一条 `logger.info`，带被吞行数和当前 `lora_dropout` 值。

**行为不变** —— 上游本来就是静默忽略 normal dropout，`rank_dropout` / `module_dropout` 不受影响。这里只是把 280 行降成 1 行，并让用户知道这个参数没生效。

## 两个实现细节

- **按行过滤而不是整段丢弃**：`print` 不保证一行一次 `write`，半行也要按行判定，否则跨 write 边界的 marker 会漏过去。
- **上下文退出走 `finally`**：注入抛错时 `sys.stdout` 也会换回去，不会让后续所有输出都留在过滤器里。

## 测试

新增 `tests/test_lycoris_dropout_spam.py`（8 个用例）：整行丢弃 + 计数、非 marker 行原样透传、跨 write 的半行、无换行尾巴的 flush、`write` 返回值符合 IO 协议、属性透传、上下文退出（含异常路径）后 `sys.stdout` 复原。

```
8 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
