### PR TITLE
perf(eval): 出图改走常驻 daemon，一次评估底模只加载一次

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -29,7 +29,7 @@ import random
 import sys
 import threading
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
 
 import torch
 
@@ -74,7 +74,13 @@ logging.basicConfig(
 logger = logging.getLogger("anima_daemon")
 
 
-def _keep_third_party_logs_off_stdout() -> None:
+# 会往 stdout 写日志的第三方 logger。stdout 是本进程的协议流，它们必须掰到 stderr。
+_STDOUT_NOISY_LOGGERS: tuple[str, ...] = ("LyCORIS",)
+
+
+def _keep_third_party_logs_off_stdout(
+    names: Iterable[str] = _STDOUT_NOISY_LOGGERS,
+) -> None:
     """把往 stdout 写的第三方 logger 掰到 stderr。
 
     lycoris 在 import 时给 `LyCORIS` logger 挂了 `StreamHandler(sys.stdout)` 且
@@ -86,7 +92,7 @@ def _keep_third_party_logs_off_stdout() -> None:
     就能让它整段跳过（本函数在 lycoris import 之前跑）。同时也清掉已存在的 stdout
     handler —— 万一将来 import 顺序变了，行为依然正确。
     """
-    for name in ("LyCORIS",):
+    for name in names:
         third = logging.getLogger(name)
         for handler in list(third.handlers):
             if getattr(handler, "stream", None) is sys.stdout:

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -73,6 +73,36 @@ logging.basicConfig(
 )
 logger = logging.getLogger("anima_daemon")
 
+
+def _keep_third_party_logs_off_stdout() -> None:
+    """把往 stdout 写的第三方 logger 掰到 stderr。
+
+    lycoris 在 import 时给 `LyCORIS` logger 挂了 `StreamHandler(sys.stdout)` 且
+    `propagate=False`（`lycoris/logging.py`）—— 那是它做 CLI 工具时的合理默认，但
+    本进程的 stdout 是**协议流**，每条 LyCORIS 日志都会让 server 侧的 reader 记一条
+    「daemon stdout non-JSON」warning。
+
+    它那段是 `if not logger.handlers:` 守卫的，所以**抢先**挂一个 stderr handler
+    就能让它整段跳过（本函数在 lycoris import 之前跑）。同时也清掉已存在的 stdout
+    handler —— 万一将来 import 顺序变了，行为依然正确。
+    """
+    for name in ("LyCORIS",):
+        third = logging.getLogger(name)
+        for handler in list(third.handlers):
+            if getattr(handler, "stream", None) is sys.stdout:
+                third.removeHandler(handler)
+        if not third.handlers:
+            stderr_handler = logging.StreamHandler(sys.stderr)
+            stderr_handler.setFormatter(
+                logging.Formatter(
+                    "%(asctime)s %(levelname)s %(name)s: %(message)s", "%H:%M:%S",
+                )
+            )
+            third.addHandler(stderr_handler)
+
+
+_keep_third_party_logs_off_stdout()
+
 _GIB = 1024 ** 3
 _TE_LOAD_FALLBACK_FP8 = 7 * _GIB
 _TE_LOAD_FALLBACK_FULL = 11 * _GIB

--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -47,6 +47,7 @@ from ...domain.errors import (
     ValidationError,
 )
 from ...domain.comfy_parity import force_comfy_parity_runtime_config
+from ...domain.common import supports_capability
 from ...infrastructure.event_bus import bus
 from ...infrastructure.paths import STUDIO_DATA
 from ...services.generation_metadata import (
@@ -235,6 +236,17 @@ def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
         if attn == "auto":
             from ...services.runtime.xformers import detect_attention_backend
             attn = detect_attention_backend()
+
+        # 族条件门控：blocks_to_swap 来自**全局**出图设置，是用户为某个模型调的，
+        # 但这次请求可以是另一个族的底模。原样透传时 daemon 在加载 DiT 时 fail-fast
+        # （"model_family=X 不支持 block swap"），整个出图直接崩。用户并没有为这个
+        # 模型要求 block swap，所以忽略而不是报错。
+        if blocks_to_swap and not supports_capability(body.model_family, "block_swap"):
+            logger.info(
+                "model_family=%s 不支持 block swap，本次出图忽略全局设置的 "
+                "blocks_to_swap=%s", body.model_family, blocks_to_swap,
+            )
+            blocks_to_swap = 0
 
         cfg = GenerateConfig(
             **model_paths,

--- a/studio/domain/common.py
+++ b/studio/domain/common.py
@@ -140,6 +140,16 @@ def cap_gate(capability: str) -> str:
     return "||".join(f"model_family=={f}" for f in fams)
 
 
+def supports_capability(model_family: str, capability: str) -> bool:
+    """该族是否支持某能力位。未知族一律 False（保守：不放行族条件的旋钮）。
+
+    消费方是**运行时**的族条件门控 —— 全局设置里的旋钮（如出图设置的
+    `blocks_to_swap`）是用户为某个模型调的，换个族的模型跑时必须先过这一关，
+    否则 runtime 会 fail-fast。schema 的写时门控走 `cap_gate`，两者同一张表。
+    """
+    return capability in FAMILY_CAPABILITIES.get(str(model_family), frozenset())
+
+
 def capability_violations(model_family: str, values: dict) -> list[str]:
     """返回「已启用但当前族不支持」的字段名列表（validator / bootstrap 共用）。"""
     caps = FAMILY_CAPABILITIES.get(str(model_family))

--- a/studio/services/eval_generation.py
+++ b/studio/services/eval_generation.py
@@ -32,7 +32,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from studio import secrets
-from studio.domain.common import FAMILY_CAPABILITIES
+from studio.domain.common import supports_capability
 from studio.services import version_config
 from studio.services.inference.daemon import InferenceDaemon
 
@@ -81,9 +81,7 @@ def _generate_settings(family_id: str) -> dict[str, Any]:
         logger.warning("读取出图设置失败，评估出图用保守默认", exc_info=True)
         return dict(_FALLBACK_SETTINGS)
 
-    if settings["blocks_to_swap"] and "block_swap" not in FAMILY_CAPABILITIES.get(
-        family_id, frozenset()
-    ):
+    if settings["blocks_to_swap"] and not supports_capability(family_id, "block_swap"):
         # 每个候选都会走一遍本函数，逐次打就是 200 个 checkpoint 打 200 行同样的话
         # ——正是 #465 抱怨的那种噪音。按族记一次就够。
         if family_id not in _BLOCK_SWAP_NOTICED:

--- a/studio/services/eval_generation.py
+++ b/studio/services/eval_generation.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from studio import secrets
+from studio.domain.common import FAMILY_CAPABILITIES
 from studio.services import version_config
 from studio.services.inference.daemon import InferenceDaemon
 
@@ -45,15 +46,26 @@ class EvalGenerationError(RuntimeError):
     pass
 
 
-def _generate_settings() -> dict[str, Any]:
+_FALLBACK_SETTINGS: dict[str, Any] = {
+    "vae_precision": "bf16", "lora_merge_precision": "fp32",
+    "vram_policy": "auto", "ram_guard": True, "blocks_to_swap": 0,
+}
+
+
+def _generate_settings(family_id: str) -> dict[str, Any]:
     """daemon 运行时旋钮（显存策略 / 精度 / block swap）取全局出图设置。
 
-    这些是「怎么跑」而不是「跑什么」—— 评估该和测试出图用同一套，用户在设置里
-    调完对两边同时生效。读失败给保守默认，不让评估因为设置文件坏了跑不起来。
+    这些是「怎么跑」而不是「跑什么」，评估和测试出图共用一套 —— 但**族条件的能力
+    必须门控**：测试出图跑的是用户在那儿选的模型，评估跑的是这个 version 训练时
+    那个底模，两者的族可以不同。`blocks_to_swap` 只有 krea2 有
+    （`FAMILY_CAPABILITIES`），把为 krea2 调的层数原样喂给 anima，daemon 会
+    fail-fast 直接崩掉整个出图阶段。
+
+    读失败给保守默认，不让评估因为设置文件坏了跑不起来。
     """
     try:
         gen = secrets.load().generate
-        return {
+        settings = {
             "vae_precision": str(getattr(gen, "vae_precision", "bf16") or "bf16"),
             "lora_merge_precision": str(
                 getattr(gen, "lora_merge_precision", "fp32") or "fp32"
@@ -64,10 +76,17 @@ def _generate_settings() -> dict[str, Any]:
         }
     except Exception:
         logger.warning("读取出图设置失败，评估出图用保守默认", exc_info=True)
-        return {
-            "vae_precision": "bf16", "lora_merge_precision": "fp32",
-            "vram_policy": "auto", "ram_guard": True, "blocks_to_swap": 0,
-        }
+        return dict(_FALLBACK_SETTINGS)
+
+    if settings["blocks_to_swap"] and "block_swap" not in FAMILY_CAPABILITIES.get(
+        family_id, frozenset()
+    ):
+        logger.info(
+            "model_family=%s 不支持 block swap，评估出图忽略全局设置的 blocks_to_swap=%s",
+            family_id, settings["blocks_to_swap"],
+        )
+        settings["blocks_to_swap"] = 0
+    return settings
 
 
 def build_daemon_config(
@@ -96,8 +115,9 @@ def build_daemon_config(
     lora_scale = float(raw_scale) if raw_scale is not None else 1.0
     checkpoint = version_dir / run["checkpoint"]["path"]
 
+    family_id = str(cfg.get("model_family") or "anima")
     out: dict[str, Any] = {
-        "model_family": str(cfg.get("model_family") or "anima"),
+        "model_family": family_id,
         # 路径原样传，daemon 侧统一 resolve_path_best_effort
         "transformer_path": str(cfg["transformer_path"]),
         "vae_path": str(cfg["vae_path"]),
@@ -133,7 +153,7 @@ def build_daemon_config(
         "attention_backend": str(cfg.get("attention_backend") or "flash_attn"),
         # 评估不需要中间预览（没人盯着看），关掉省 b64 编码和管道带宽
         "preview_every_n_steps": 0,
-        **_generate_settings(),
+        **_generate_settings(family_id),
     }
     return out
 

--- a/studio/services/eval_generation.py
+++ b/studio/services/eval_generation.py
@@ -46,6 +46,9 @@ class EvalGenerationError(RuntimeError):
     pass
 
 
+# 「该族不支持 block swap」只提示一次（见 _generate_settings）
+_BLOCK_SWAP_NOTICED: set[str] = set()
+
 _FALLBACK_SETTINGS: dict[str, Any] = {
     "vae_precision": "bf16", "lora_merge_precision": "fp32",
     "vram_policy": "auto", "ram_guard": True, "blocks_to_swap": 0,
@@ -81,10 +84,14 @@ def _generate_settings(family_id: str) -> dict[str, Any]:
     if settings["blocks_to_swap"] and "block_swap" not in FAMILY_CAPABILITIES.get(
         family_id, frozenset()
     ):
-        logger.info(
-            "model_family=%s 不支持 block swap，评估出图忽略全局设置的 blocks_to_swap=%s",
-            family_id, settings["blocks_to_swap"],
-        )
+        # 每个候选都会走一遍本函数，逐次打就是 200 个 checkpoint 打 200 行同样的话
+        # ——正是 #465 抱怨的那种噪音。按族记一次就够。
+        if family_id not in _BLOCK_SWAP_NOTICED:
+            _BLOCK_SWAP_NOTICED.add(family_id)
+            logger.info(
+                "model_family=%s 不支持 block swap，评估出图忽略全局设置的 "
+                "blocks_to_swap=%s", family_id, settings["blocks_to_swap"],
+            )
         settings["blocks_to_swap"] = 0
     return settings
 

--- a/studio/services/eval_generation.py
+++ b/studio/services/eval_generation.py
@@ -1,0 +1,279 @@
+"""评估出图 —— 走测试出图那条 daemon，不再自己写一套推理循环。
+
+**为什么**：`eval_samples` 原本自己加载 VAE + 文本栈 + Transformer、自己跑
+「encode → sample → decode → save」。而测试出图的常驻 daemon
+（`runtime/anima_daemon.py`）早就把这些做全了，还多做了很多：
+
+- `ModelCache` 底模跨 task 常驻，**一次评估只加载一次底模**
+- LoRA 拓扑相同时走**权重热换**而不是重 inject（同一次训练的各 epoch 正好命中）
+- TE 先行编排：预编码整个 prompt 集合 → 彻底释放 TE → 才加载 DiT
+- CUDA OOM 重试 + allocator 恢复、block swap、vram_policy 让位、协议级 cancel
+
+旧路径每个候选完整加载一遍底模：21 个候选就是 21 次 ~28s 的 Transformer 读盘，
+约 10 分钟纯开销；而且同进程连跑还得自己管显存释放（见 ADR 0011 的 Addendum）。
+现在这些统统归 daemon 的 `ModelCache`。
+
+**为什么不用 server 里那个 daemon 单例**：评估跑在 supervisor 派的独立 worker
+子进程里，跨进程拿不到那个单例。而 supervisor 在派 `eval_session` 之前已经调
+`_maybe_yield_daemon()` 吊销了测试 daemon 的显存租约，所以卡是空的 —— worker 起
+自己的实例即可，两者不会并存。
+
+**为什么不用 daemon 的 XY**：XY 没有 prompt 轴（`_run_xy` 明确说 prompt 已由
+`_run_generate` 统一预编码）。但普通 generate 本来就吃 `prompts: list[str]`，
+所以「一个候选一个 task、prompts = 全部验证图 caption」就够了，daemon 零改动，
+而且保住了候选主序（run / 进度 / 指标 / 样图矩阵的结构全不用动）。
+"""
+from __future__ import annotations
+
+import base64
+import logging
+import threading
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from studio import secrets
+from studio.services import version_config
+from studio.services.inference.daemon import InferenceDaemon
+
+logger = logging.getLogger(__name__)
+
+# 一个候选的出图上限。daemon 单 task 串行跑 prompts，验证集再大也不该无限等。
+_TASK_TIMEOUT_SECONDS = 3600.0
+
+
+class EvalGenerationError(RuntimeError):
+    pass
+
+
+def _generate_settings() -> dict[str, Any]:
+    """daemon 运行时旋钮（显存策略 / 精度 / block swap）取全局出图设置。
+
+    这些是「怎么跑」而不是「跑什么」—— 评估该和测试出图用同一套，用户在设置里
+    调完对两边同时生效。读失败给保守默认，不让评估因为设置文件坏了跑不起来。
+    """
+    try:
+        gen = secrets.load().generate
+        return {
+            "vae_precision": str(getattr(gen, "vae_precision", "bf16") or "bf16"),
+            "lora_merge_precision": str(
+                getattr(gen, "lora_merge_precision", "fp32") or "fp32"
+            ),
+            "vram_policy": str(getattr(gen, "vram_policy", "auto") or "auto"),
+            "ram_guard": bool(getattr(gen, "ram_guard", True)),
+            "blocks_to_swap": int(getattr(gen, "blocks_to_swap", 0) or 0),
+        }
+    except Exception:
+        logger.warning("读取出图设置失败，评估出图用保守默认", exc_info=True)
+        return {
+            "vae_precision": "bf16", "lora_merge_precision": "fp32",
+            "vram_policy": "auto", "ram_guard": True, "blocks_to_swap": 0,
+        }
+
+
+def build_daemon_config(
+    run: dict[str, Any], version_dir: Path, *, output_dir: Path,
+) -> dict[str, Any]:
+    """一个候选的 run → 一份 daemon generate config。
+
+    prompts 按 items 顺序给，daemon 逐条出一张（count=1），所以第 i 张图对应
+    第 i 个 item。生成参数取 run 冻结的 `generation`（EvalPlan 的一部分），模型
+    路径取 version config —— 评估必须用 LoRA 训练时那个底模。
+    """
+    project = {"id": run["project_id"], "slug": run["project_slug"]}
+    version = {"id": run["version_id"], "label": run["version_label"]}
+    cfg = version_config.read_version_config(project, version)
+
+    generation = run.get("generation") if isinstance(run.get("generation"), dict) else {}
+    items = run.get("items") if isinstance(run.get("items"), list) else []
+    if not items:
+        raise EvalGenerationError("run 没有待出图的 item")
+
+    width = max(16, (int(generation.get("width") or cfg.get("resolution") or 1024) // 16) * 16)
+    height = max(16, (int(generation.get("height") or cfg.get("resolution") or 1024) // 16) * 16)
+    # baseline run 的 lora_scale 是 0（纯底模对照）→ 干脆不给 lora_configs。
+    # 不能写 `or 1.0`：0.0 是 falsy，会被当成「没设」回退成正常 LoRA 跑，Δ 恒为 0。
+    raw_scale = generation.get("lora_scale")
+    lora_scale = float(raw_scale) if raw_scale is not None else 1.0
+    checkpoint = version_dir / run["checkpoint"]["path"]
+
+    out: dict[str, Any] = {
+        "model_family": str(cfg.get("model_family") or "anima"),
+        # 路径原样传，daemon 侧统一 resolve_path_best_effort
+        "transformer_path": str(cfg["transformer_path"]),
+        "vae_path": str(cfg["vae_path"]),
+        "text_encoder_path": str(cfg["text_encoder_path"]),
+        "t5_tokenizer_path": str(cfg.get("t5_tokenizer_path") or ""),
+        "prompts": [str(item.get("prompt") or "") for item in items],
+        "negative_prompt": str(
+            generation.get("negative_prompt") or cfg.get("sample_negative_prompt") or ""
+        ),
+        "width": width,
+        "height": height,
+        "steps": int(generation.get("steps") or cfg.get("sample_infer_steps") or 25),
+        "cfg_scale": float(
+            generation.get("guidance_scale")
+            or generation.get("cfg_scale")
+            or cfg.get("sample_cfg_scale")
+            or 4.0
+        ),
+        "sampler_name": str(
+            generation.get("sampler_name") or cfg.get("sample_sampler_name") or "er_sde"
+        ),
+        "scheduler": str(
+            generation.get("scheduler") or cfg.get("sample_scheduler") or "simple"
+        ),
+        "count": 1,
+        "seed": int(generation.get("seed") or 0),
+        "lora_configs": (
+            [] if lora_scale == 0.0
+            else [{"path": str(checkpoint), "scale": lora_scale}]
+        ),
+        "output_dir": str(output_dir),
+        "mixed_precision": str(cfg.get("mixed_precision") or "bf16"),
+        "attention_backend": str(cfg.get("attention_backend") or "flash_attn"),
+        # 评估不需要中间预览（没人盯着看），关掉省 b64 编码和管道带宽
+        "preview_every_n_steps": 0,
+        **_generate_settings(),
+    }
+    return out
+
+
+class DaemonSampleGenerator:
+    """会话级 daemon 客户端；`__call__` 符合 `eval_samples.SampleGenerator` 契约。
+
+    **生命周期是一次评估**，不是一个候选 —— 底模常驻的收益全在这里：
+
+        with DaemonSampleGenerator(progress) as generate:
+            for cand in candidates:
+                eval_samples.run_sample_job(..., generator=generate)
+
+    每个候选一个 daemon task；候选之间底模不动，只热换 LoRA 权重。
+    """
+
+    def __init__(
+        self,
+        progress: Callable[[str], None],
+        *,
+        task_id: int = 0,
+        daemon: Optional[InferenceDaemon] = None,
+    ) -> None:
+        self._progress = progress
+        self._task_id = int(task_id)
+        # cache_images=False：图归评估的 run 目录，不进测试页的 generate_cache
+        self._daemon = daemon or InferenceDaemon(cache_images=False)
+        self._owns_daemon = daemon is None
+
+    # ---------------------------------------------------------------- 生命周期
+    def __enter__(self) -> "DaemonSampleGenerator":
+        self._daemon.start()
+        self._progress("[eval-samples] 出图 daemon 就绪（底模按需加载一次，之后候选间只热换 LoRA）")
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if not self._owns_daemon:
+            return
+        try:
+            self._daemon.stop()
+            self._progress("[eval-samples] 出图 daemon 已退出，显存释放")
+        except Exception:
+            logger.warning("停止评估 daemon 失败", exc_info=True)
+
+    # ---------------------------------------------------------------- 出图
+    def __call__(
+        self,
+        run: dict[str, Any],
+        version_dir: Path,
+        progress: Callable[[str], None],
+    ) -> None:
+        from studio.services import eval_samples
+
+        items = run.get("items") if isinstance(run.get("items"), list) else []
+        if not items:
+            return
+        eval_root = Path(run["eval_root"]) if run.get("eval_root") else None
+        images_dir = eval_samples.run_dir(
+            version_dir, run["run_id"], eval_root
+        ) / eval_samples.IMAGES_DIRNAME
+        images_dir.mkdir(parents=True, exist_ok=True)
+
+        config = build_daemon_config(run, version_dir, output_dir=images_dir)
+        done = threading.Event()
+        failure: list[str] = []
+        # 事件回调跑在 daemon 的 reader 线程上；run.json 的读改写不能两边同时来，
+        # 所以本函数在 done 之前只等待、不碰 run。
+        state = {"run": run}
+
+        def on_event(evt: dict[str, Any]) -> None:
+            kind = str(evt.get("kind") or "")
+            try:
+                if kind == "image_started":
+                    idx = int(evt.get("batch_idx") or 0)
+                    if 0 <= idx < len(items):
+                        state["run"] = eval_samples.mark_item_running(
+                            version_dir, state["run"], idx, eval_root
+                        )
+                        progress(
+                            f"[eval-samples] {idx + 1}/{len(items)} "
+                            f"prompt={str(items[idx].get('prompt') or '')[:80]}"
+                        )
+                elif kind == "image_done":
+                    self._write_image(evt, items, images_dir)
+                    idx = int(evt.get("step") or 0) - 1
+                    if 0 <= idx < len(items):
+                        state["run"] = eval_samples.mark_item_done(
+                            version_dir, state["run"], idx, eval_root
+                        )
+                elif kind == "image_error":
+                    idx = int(evt.get("step") or 0) - 1
+                    message = str(evt.get("message") or "出图失败")
+                    if 0 <= idx < len(items):
+                        state["run"] = eval_samples.mark_item_failed(
+                            version_dir, state["run"], idx, message, eval_root
+                        )
+                    progress(f"[eval-samples] 第 {idx + 1} 张失败：{message}")
+                elif kind in ("done", "error", "canceled"):
+                    if kind != "done":
+                        failure.append(str(evt.get("message") or kind))
+                    done.set()
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("评估出图事件处理失败 (kind=%s)", kind)
+                failure.append(str(exc))
+                done.set()
+
+        self._daemon.submit_task(
+            task_id=self._task_id or int(run.get("version_id") or 0),
+            config=config,
+            output_dir=str(images_dir),
+            on_event=on_event,
+        )
+        if not done.wait(timeout=_TASK_TIMEOUT_SECONDS):
+            raise EvalGenerationError(
+                f"出图超时（>{int(_TASK_TIMEOUT_SECONDS)}s），daemon 无响应"
+            )
+        if failure:
+            raise EvalGenerationError(failure[0])
+
+    def _write_image(
+        self, evt: dict[str, Any], items: list[dict[str, Any]], images_dir: Path,
+    ) -> None:
+        """把 image_done 事件里的 PNG 落到 item 计划好的文件名上。
+
+        daemon 自己的文件名是 `gen_<i>_p<pi>_c<ci>_s<seed>.png`，评估的读侧
+        （指标 runner / 样图矩阵）认的是 `item["filename"]` —— 以 item 为准，
+        存储结构不变。
+        """
+        idx = int(evt.get("step") or 0) - 1
+        if not (0 <= idx < len(items)):
+            raise EvalGenerationError(f"image_done 的序号越界: step={evt.get('step')}")
+        raw = evt.get("image_b64")
+        if not raw:
+            raise EvalGenerationError(
+                "image_done 没带图像数据 —— daemon 的 cache_images 应为 False"
+            )
+        target = images_dir / str(items[idx]["filename"])
+        tmp = target.with_suffix(".png.part")
+        tmp.write_bytes(base64.b64decode(raw))
+        tmp.replace(target)

--- a/studio/services/eval_samples.py
+++ b/studio/services/eval_samples.py
@@ -5,9 +5,11 @@ Reference + prompts come from the version's held-out ``validation/`` set (see
 When ``validation/`` is empty the run falls back to the training config's sample
 prompts and scores CLIP-T only (no reference image → no CLIP-I / DINO-I).
 Generation params come from the version's ``sample_*`` config. There is no
-separate manifest file — each ``run.json`` is self-contained. Heavy model
-imports stay inside the default generator so API/tests can exercise the contract
-without loading torch.
+separate manifest file — each ``run.json`` is self-contained.
+
+**出图本身不在这个模块**：`run_sample_job` 只管 run 状态机，实际生成由调用方传入
+的 generator 完成（`eval_generation.DaemonSampleGenerator` —— 走测试出图那条常驻
+daemon）。所以本模块不 import torch，API / 测试可以只验契约。
 """
 from __future__ import annotations
 
@@ -21,7 +23,6 @@ from pathlib import Path
 from typing import Any, Callable
 
 from . import eval_validation
-from .projects import jobs as project_jobs
 from .projects import versions
 
 logger = logging.getLogger(__name__)
@@ -240,8 +241,13 @@ def _planned_items(
                 "prompt_id": f"val:{rel}",
                 "prompt": prompt,
                 "prompt_source": "caption" if _caption_text(image) else "empty",
-                "seed": gen_seed,
-                "filename": f"sample_{idx:04d}_s{gen_seed}.png",
+                # daemon 的多 prompt 循环是 seed = base_seed + img_idx（`prompts`
+                # 逐条出一张），所以逐 item 记真实 seed 而不是全用 run 级 base。
+                # 跨候选的可比性靠「同一个 prompt 在所有候选上同 seed」保证 ——
+                # 那个不变量仍然成立，而且不同 prompt 用同一 seed 反而容易出
+                # 相关性伪影。
+                "seed": gen_seed + idx,
+                "filename": f"sample_{idx:04d}_s{gen_seed + idx}.png",
                 "path": "",
                 "reference_image": rel,
                 "status": "pending",
@@ -255,8 +261,8 @@ def _planned_items(
             "prompt_id": f"prompt:{idx}",
             "prompt": prompt,
             "prompt_source": "sample_prompt",
-            "seed": gen_seed,
-            "filename": f"sample_{idx:04d}_s{gen_seed}.png",
+            "seed": gen_seed + idx,
+            "filename": f"sample_{idx:04d}_s{gen_seed + idx}.png",
             "path": "",
             "reference_image": None,
             "status": "pending",
@@ -403,10 +409,17 @@ def run_sample_job(
     version_dir: Path,
     run_id: str,
     *,
-    generator: SampleGenerator | None = None,
+    generator: SampleGenerator,
     on_progress: Callable[[str], None] | None = None,
     eval_root: Path | None = None,
 ) -> dict[str, Any]:
+    """跑一个候选的出图。
+
+    `generator` 是必需参数：出图现在走 `eval_generation.DaemonSampleGenerator`，
+    它的生命周期是**一次评估**（底模常驻、候选之间只热换 LoRA 权重），必须由调用
+    方在候选循环之外持有。给个默认值会退化成每候选起一个 daemon —— 比旧的自己
+    加载还慢。
+    """
     progress = on_progress or (lambda _line: None)
     run = load_run(version_dir, run_id, eval_root)
     if run is None:
@@ -422,7 +435,7 @@ def run_sample_job(
     save_run(version_dir, run, eval_root)
 
     try:
-        (generator or _default_generator)(run, version_dir, progress)
+        generator(run, version_dir, progress)
     except Exception as exc:
         run = load_run(version_dir, run_id, eval_root) or run
         run["status"] = "failed"
@@ -482,216 +495,3 @@ def sample_image_path(version_dir: Path, run_id: str, filename: str, eval_root: 
     except ValueError as exc:
         raise EvalSamplesError(f"sample image 路径逃逸: {filename!r}") from exc
     return resolved
-
-
-def _default_generator(
-    run: dict[str, Any],
-    version_dir: Path,
-    progress: Callable[[str], None],
-) -> None:
-    import random
-    import sys
-
-    import torch
-
-    runtime_dir = Path(__file__).resolve().parents[2] / "runtime"
-    repo_root = runtime_dir.parent
-    for path in (runtime_dir, repo_root):
-        text = str(path)
-        if text not in sys.path:
-            sys.path.insert(0, text)
-
-    import anima_train as _T  # noqa: WPS433
-    from studio import secrets
-    from studio.services import version_config
-    from studio.services.inference.core import LoRASpec, apply_loras
-
-    project = {"id": run["project_id"], "slug": run["project_slug"]}
-    version = {"id": run["version_id"], "label": run["version_label"]}
-    cfg = version_config.read_version_config(project, version)
-
-    generation = run.get("generation") if isinstance(run.get("generation"), dict) else {}
-    width = int(generation.get("width") or cfg.get("sample_width") or cfg.get("resolution") or 1024)
-    height = int(generation.get("height") or cfg.get("sample_height") or cfg.get("resolution") or 1024)
-    width = max(16, (width // 16) * 16)
-    height = max(16, (height // 16) * 16)
-    steps = int(generation.get("steps") or cfg.get("sample_infer_steps") or 25)
-    cfg_scale = float(
-        generation.get("guidance_scale")
-        or generation.get("cfg_scale")
-        or cfg.get("sample_cfg_scale")
-        or 4.0
-    )
-    negative_prompt = str(generation.get("negative_prompt") or cfg.get("sample_negative_prompt") or "")
-    sampler_name = str(generation.get("sampler_name") or cfg.get("sample_sampler_name") or "er_sde")
-    scheduler = str(generation.get("scheduler") or cfg.get("sample_scheduler") or "simple")
-    # baseline run 用 lora_scale=0（纯底模对照）。不能写 `or 1.0`——0.0 是 falsy 会被
-    # 当成「没设」回退到 1.0，baseline 就变成正常 LoRA 跑、Δ 恒为 0。
-    _raw_scale = generation.get("lora_scale")
-    lora_scale = float(_raw_scale) if _raw_scale is not None else 1.0
-    precision = str(cfg.get("mixed_precision") or "bf16")
-    try:
-        lora_merge_precision = str(
-            getattr(secrets.load().generate, "lora_merge_precision", "fp32") or "fp32"
-        )
-    except Exception:
-        lora_merge_precision = "fp32"
-    backend = str(cfg.get("attention_backend") or "flash_attn")
-    use_flash = backend == "flash_attn"
-    use_xformers = backend == "xformers"
-
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    dtype = torch.bfloat16 if precision == "bf16" else torch.float32
-
-    bases = [Path.cwd(), runtime_dir, repo_root]
-    transformer_path = _T.resolve_path_best_effort(str(cfg["transformer_path"]), bases)
-    vae_path = _T.resolve_path_best_effort(str(cfg["vae_path"]), bases)
-    text_encoder_path = _T.resolve_path_best_effort(str(cfg["text_encoder_path"]), bases)
-    t5_tokenizer_path = str(cfg.get("t5_tokenizer_path") or "")
-    if t5_tokenizer_path:
-        t5_tokenizer_path = _T.resolve_path_best_effort(t5_tokenizer_path, bases)
-
-    progress("[eval-samples] loading base model")
-    diffusion_root = _T.find_diffusion_pipe_root()
-    family = _T.resolve_family(cfg)  # D8'
-    items_for_precache = run.get("items") if isinstance(run.get("items"), list) else []
-    from training.sysmem import check_load_budget
-
-    check_load_budget(
-        True,
-        weight_paths=[transformer_path, vae_path, text_encoder_path],
-        stage="评估出图模型加载",
-    )
-    vae = family.load_vae(vae_path, device, dtype)
-    # 族 opaque 文本栈不拆包；eval prompt 是 ad-hoc 输入，关缓存
-    text_stack = family.load_text(
-        text_encoder_path, device, dtype,
-        t5_tokenizer_path=t5_tokenizer_path or None,
-        purpose="generate",
-        cache_enabled=False,
-    )
-    # TE 先行编排（krea2，daemon/CLI 同款）：items 的 prompt 集合封闭——
-    # DiT 加载前预编码全部并彻底释放 TE，任一时刻 GPU 只有一个大模型。
-    # anima 文本栈无此 API 自然跳过。
-    precache = getattr(text_stack, "precache_online_prompts", None)
-    if callable(precache):
-        try:
-            prompts_all = [
-                str(item.get("prompt") or "") for item in items_for_precache
-            ] + [str(negative_prompt or "")]
-            encoded = precache(prompts_all)
-            release = getattr(text_stack, "release_model", None)
-            if callable(release):
-                release()
-            if encoded:
-                progress(f"[eval-samples] precached {encoded} prompts; TE released")
-        except Exception:
-            logger.exception("eval prompt 预编码失败；退回逐图惰性编码")
-
-    model = family.load_dit(
-        transformer_path, device, dtype,
-        attention_backend=("flash_attn" if use_flash else "none"), repo_root=diffusion_root,
-        purpose="generate",
-    )
-    if use_xformers:
-        _T.enable_xformers(model)
-
-    checkpoint = version_dir / run["checkpoint"]["path"]
-    adapters = apply_loras(
-        model, [LoRASpec(path=str(checkpoint), scale=lora_scale)], device, dtype,
-        family_id=family.spec.family_id,
-        lora_merge_precision=lora_merge_precision,
-    )
-    _ = adapters  # keep adapter references alive for forward hooks
-    model.eval()
-
-    try:
-        _generate_items(
-            run, version_dir, progress, family=family, model=model, vae=vae,
-            text_stack=text_stack, height=height, width=width, steps=steps,
-            cfg_scale=cfg_scale, negative_prompt=negative_prompt,
-            sampler_name=sampler_name, scheduler=scheduler, device=device, dtype=dtype,
-            torch=torch, random=random,
-        )
-    finally:
-        # 显式释放：EvalSession 起，**同一个 worker 进程**会连续为多个候选调用本函数
-        # （旧模型是每候选一个子进程，退出即由 OS 回收，没有这个问题）。不释放的话
-        # 显存单调上涨 —— adapter 的 forward hook 与 model 互相持有引用，靠引用计数
-        # 回收不掉；CUDA caching allocator 也不会把 reserved 段还给驱动。真机症状：
-        # 第 3 个候选起 VAE decode 就得 offload 腾地方，第 4 个候选加载 transformer
-        # 时撞 WDDM 崖（显存被换到系统内存），表现为无报错卡死。
-        _release_generation_models(adapters, model, vae, text_stack, torch, progress)
-
-
-def _release_generation_models(
-    adapters: Any, model: Any, vae: Any, text_stack: Any, torch: Any,
-    progress: Callable[[str], None],
-) -> None:
-    for adapter in adapters or []:
-        detach = getattr(adapter, "detach", None)
-        if callable(detach):
-            try:
-                detach()
-            except Exception:
-                logger.warning("eval sample: LoRA detach 失败", exc_info=True)
-    del adapters, model, vae, text_stack
-    import gc
-    gc.collect()
-    try:
-        if torch.cuda.is_available():
-            torch.cuda.empty_cache()
-            torch.cuda.ipc_collect()
-    except Exception:
-        logger.warning("eval sample: empty_cache 失败", exc_info=True)
-    progress("[eval-samples] released base model")
-
-
-def _generate_items(
-    run: dict[str, Any],
-    version_dir: Path,
-    progress: Callable[[str], None],
-    *,
-    family: Any, model: Any, vae: Any, text_stack: Any,
-    height: int, width: int, steps: int, cfg_scale: float,
-    negative_prompt: str, sampler_name: str, scheduler: str,
-    device: Any, dtype: Any, torch: Any, random: Any,
-) -> None:
-    items = run.get("items") if isinstance(run.get("items"), list) else []
-    scoped_root = (
-        Path(str(run.get("eval_root")))
-        if str(run.get("storage_scope") or "") == "task" and run.get("eval_root")
-        else None
-    )
-    for idx, item in enumerate(items):
-        run = mark_item_running(version_dir, load_run(version_dir, run["run_id"], scoped_root) or run, idx, scoped_root)
-        seed = int(item["seed"])
-        random.seed(seed)
-        torch.manual_seed(seed)
-        output = sample_image_path(version_dir, run["run_id"], item["filename"], scoped_root)
-        output.parent.mkdir(parents=True, exist_ok=True)
-        progress(
-            f"[eval-samples] {idx + 1}/{len(items)} seed={seed} "
-            f"prompt={str(item.get('prompt') or '')[:80]}"
-        )
-        try:
-            img = family.sample_image(
-                model, vae, text_stack,
-                str(item.get("prompt") or ""),
-                height=height,
-                width=width,
-                steps=steps,
-                cfg_scale=cfg_scale,
-                negative_prompt=negative_prompt or None,
-                sampler_name=sampler_name,
-                scheduler=scheduler,
-                device=device,
-                dtype=dtype,
-                seed=seed,
-                vram_policy="auto",
-            )
-            img.save(output)
-            run = mark_item_done(version_dir, load_run(version_dir, run["run_id"], scoped_root) or run, idx, scoped_root)
-        except Exception as exc:  # noqa: BLE001
-            run = mark_item_failed(
-                version_dir, load_run(version_dir, run["run_id"], scoped_root) or run, idx, str(exc), scoped_root
-            )

--- a/studio/services/inference/daemon.py
+++ b/studio/services/inference/daemon.py
@@ -91,8 +91,15 @@ class InferenceDaemon:
     READY_TIMEOUT = 30.0  # 子进程 import 完成给 ready 的最长等待
     UNLOAD_TIMEOUT = 60.0  # unload 后等 unloaded 事件最长
 
-    def __init__(self, *, script_path: Optional[Path] = None) -> None:
+    def __init__(
+        self, *, script_path: Optional[Path] = None, cache_images: bool = True,
+    ) -> None:
         self._script = script_path or _DAEMON_SCRIPT
+        # image_done 的 PNG 入 generate_cache（测试页历史）+ 转发瘦身版。这是
+        # **测试出图**的服务端行为，不是 daemon 协议的一部分 —— 评估自己起 daemon
+        # 实例复用同一套编排时必须关掉：图要归评估的 run 目录，不能混进测试页历史，
+        # 而且 b64 被剥掉调用方就拿不到图了。
+        self._cache_images = cache_images
         self._lock = threading.RLock()
         self._proc: Optional[subprocess.Popen] = None
         self._state: str = STATE_STOPPED
@@ -623,7 +630,7 @@ class InferenceDaemon:
         # 仍走 cache 中转（持久模式下 cache 是落盘前的临时存放，前端落盘成功后
         # 用户可手动删 cache 或等 LRU 自然剔）。
         forward_msg = msg
-        if kind == "image_done" and "image_b64" in msg:
+        if kind == "image_done" and "image_b64" in msg and self._cache_images:
             filename = msg.get("filename") or ""
             xy_info = msg.get("xy") if isinstance(msg.get("xy"), dict) else None
             try:

--- a/studio/workers/eval_session_worker.py
+++ b/studio/workers/eval_session_worker.py
@@ -15,10 +15,10 @@
 标那一格。整体状态由 `eval_session.rollup_status` 汇总成 done / partial / failed ——
 部分结果仍然可看，不会因为一个 checkpoint 崩了就报整体失败。
 
-**首版复用**：出图与指标算法直接调现有的 `eval_samples.run_sample_job` /
-`eval_*.run_*_job`（设计稿 §0.6 B），每个候选内部仍是一个 eval_samples run，只是
-`eval_root` 指向 `eval/sessions/<id>/samples/`。所以本刀不动任何算法，只换编排。
-基础模型「只加载一次、LoRA 热切换」是后续 Phase 2 的事。
+**出图走测试出图那条常驻 daemon**：整个出图阶段共用**一个** daemon 实例
+（`eval_generation.DaemonSampleGenerator`），底模只加载一次，候选之间由 daemon 的
+`ModelCache` 热换 LoRA 权重。指标算法仍直接调 `eval_*.run_*_job`，每个候选内部仍是
+一个 eval_samples run，只是 `eval_root` 指向 `eval/sessions/<id>/samples/`。
 """
 from __future__ import annotations
 
@@ -32,6 +32,7 @@ from studio.services import (
     eval_ccip,
     eval_clip,
     eval_dino,
+    eval_generation,
     eval_registry,
     eval_samples,
     eval_session,
@@ -101,7 +102,7 @@ def run(task_id: int) -> int:
     )
 
     try:
-        _stage_generate(session_id, project, version, vdir, progress)
+        _stage_generate(session_id, task_id, project, version, vdir, progress)
         for runner in runners:
             _stage_metric(session_id, runner, project, version, vdir, progress)
         return _stage_aggregate(session_id, progress)
@@ -119,6 +120,7 @@ def run(task_id: int) -> int:
 
 def _stage_generate(
     session_id: int,
+    task_id: int,
     project: dict[str, Any],
     version: dict[str, Any],
     vdir: Path,
@@ -129,6 +131,29 @@ def _stage_generate(
         eval_session.update_session(conn, session_id, stage=eval_session.STAGE_GENERATE)
         candidates = eval_session.list_candidates(conn, session_id)
 
+    pending = [c for c in candidates if not _generation_complete(c, vdir, eval_root)]
+    if not pending:
+        progress("[generate] 全部候选已完成，跳过出图阶段")
+        return
+
+    # daemon 的生命周期是**整个出图阶段**，不是单个候选 —— 底模常驻的收益全在这里。
+    # 断点续跑时只为真正要跑的候选起 daemon（上面先算 pending）。
+    with eval_generation.DaemonSampleGenerator(progress, task_id=task_id) as generate:
+        _generate_candidates(
+            session_id, candidates, generate, project, version, vdir, eval_root, progress,
+        )
+
+
+def _generate_candidates(
+    session_id: int,
+    candidates: list[dict[str, Any]],
+    generate: Any,
+    project: dict[str, Any],
+    version: dict[str, Any],
+    vdir: Path,
+    eval_root: Path,
+    progress: Callable[[str], None],
+) -> None:
     for cand in candidates:
         cid = int(cand["id"])
         label = f"{cand['role']}#{cand['ordinal']}"
@@ -173,6 +198,7 @@ def _stage_generate(
             progress(f"[generate] {label} run={run_id}")
             result = eval_samples.run_sample_job(
                 project, version, vdir, run_id,
+                generator=generate,
                 on_progress=progress, eval_root=eval_root,
             )
             summary = result.get("summary") or {}

--- a/tests/test_daemon_stdout_is_protocol_only.py
+++ b/tests/test_daemon_stdout_is_protocol_only.py
@@ -1,0 +1,86 @@
+"""daemon 的 stdout 是协议流，第三方 logger 不许往里写。
+
+`runtime/anima_daemon.py` 的契约是「stdout 仅协议；日志全走 stderr」。lycoris 在
+import 时给 `LyCORIS` logger 挂 `StreamHandler(sys.stdout)` 且 `propagate=False`
+（`lycoris/logging.py`）—— 每注入一次 LoRA 就有 5 行日志掉进协议流，server 侧
+reader 逐行记「daemon stdout non-JSON」warning。
+
+这里不 import daemon 模块本身（它会拉 torch + transformers，几十秒），只测那个
+掰 handler 的函数 —— 它是纯 logging 操作，没有别的依赖。
+"""
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_DAEMON = Path(__file__).resolve().parents[1] / "runtime" / "anima_daemon.py"
+
+
+def _load_guard():
+    """从 daemon 源码里取出 `_keep_third_party_logs_off_stdout`，不执行模块其余部分。"""
+    src = _DAEMON.read_text(encoding="utf-8")
+    marker = "def _keep_third_party_logs_off_stdout() -> None:"
+    assert marker in src, "daemon 里没有这个函数了 —— stdout 保护是不是被删了？"
+    start = src.index(marker)
+    end = src.index("\n_keep_third_party_logs_off_stdout()", start)
+    mod = ModuleType("daemon_guard")
+    mod.__dict__.update({"logging": logging, "sys": sys})
+    exec(compile(src[start:end], str(_DAEMON), "exec"), mod.__dict__)
+    return mod._keep_third_party_logs_off_stdout
+
+
+@pytest.fixture
+def clean_lycoris_logger():
+    lg = logging.getLogger("LyCORIS")
+    saved = list(lg.handlers)
+    lg.handlers.clear()
+    yield lg
+    lg.handlers.clear()
+    lg.handlers.extend(saved)
+
+
+def test_preinstalled_stderr_handler_makes_lycoris_skip_stdout(clean_lycoris_logger):
+    """抢先挂 stderr handler → lycoris 的 `if not logger.handlers:` 整段跳过。
+
+    这是主路径：本函数在 daemon 顶部跑，远早于 lycoris 被 import。
+    """
+    _load_guard()()
+
+    assert clean_lycoris_logger.handlers, "该挂上一个 handler"
+    assert all(
+        getattr(h, "stream", None) is sys.stderr
+        for h in clean_lycoris_logger.handlers
+    )
+    # 模拟 lycoris 那段守卫：有 handler 就不会再加 stdout 的
+    assert clean_lycoris_logger.handlers  # → lycoris 的 `if not handlers` 为 False
+
+
+def test_existing_stdout_handler_is_removed(clean_lycoris_logger):
+    """兜底：万一 import 顺序变了、lycoris 先挂上了 stdout，也要掰回来。"""
+    stdout_handler = logging.StreamHandler(sys.stdout)
+    clean_lycoris_logger.addHandler(stdout_handler)
+
+    _load_guard()()
+
+    streams = [getattr(h, "stream", None) for h in clean_lycoris_logger.handlers]
+    assert sys.stdout not in streams
+    assert sys.stderr in streams
+
+
+def test_unrelated_handlers_are_left_alone(clean_lycoris_logger):
+    """只掰 stdout 的；别人挂的文件 / 内存 handler 不动。"""
+    import io
+
+    memory_handler = logging.StreamHandler(io.StringIO())
+    clean_lycoris_logger.addHandler(memory_handler)
+
+    _load_guard()()
+
+    assert memory_handler in clean_lycoris_logger.handlers
+    # 已有非 stdout handler → 不再多加一个 stderr 的
+    assert len(clean_lycoris_logger.handlers) == 1

--- a/tests/test_daemon_stdout_is_protocol_only.py
+++ b/tests/test_daemon_stdout_is_protocol_only.py
@@ -5,12 +5,16 @@ import 时给 `LyCORIS` logger 挂 `StreamHandler(sys.stdout)` 且 `propagate=Fa
 （`lycoris/logging.py`）—— 每注入一次 LoRA 就有 5 行日志掉进协议流，server 侧
 reader 逐行记「daemon stdout non-JSON」warning。
 
-这里不 import daemon 模块本身（它会拉 torch + transformers，几十秒），只测那个
-掰 handler 的函数 —— 它是纯 logging 操作，没有别的依赖。
+这里不 import daemon 模块本身（它会拉 torch + transformers，几十秒），只测那个掰
+handler 的函数 —— 它是纯 logging 操作，没有别的依赖。
+
+**测试用自己的 logger 名，绝不碰真的 `LyCORIS`**：pytest 的 logging 插件会往真实
+logger 上挂 `LogCaptureHandler`，断言「有几个 handler / 是不是 stderr」会随 pytest
+版本和是否有别的测试用过 caplog 而变 —— 本地绿 CI 红的经典形态。
 """
 from __future__ import annotations
 
-import importlib.util
+import io
 import logging
 import sys
 from pathlib import Path
@@ -19,68 +23,75 @@ from types import ModuleType
 import pytest
 
 _DAEMON = Path(__file__).resolve().parents[1] / "runtime" / "anima_daemon.py"
+# 专属名，不与任何真实库重名；propagate 保持默认 True，pytest 只会挂到 root 上
+_PROBE = "anima_test.stdout_guard_probe"
 
 
 def _load_guard():
-    """从 daemon 源码里取出 `_keep_third_party_logs_off_stdout`，不执行模块其余部分。"""
+    """从 daemon 源码里取出保护函数 + 名单，不执行模块其余部分。"""
     src = _DAEMON.read_text(encoding="utf-8")
-    marker = "def _keep_third_party_logs_off_stdout() -> None:"
-    assert marker in src, "daemon 里没有这个函数了 —— stdout 保护是不是被删了？"
+    marker = "# 会往 stdout 写日志的第三方 logger。"
+    assert marker in src, "daemon 里没有这段了 —— stdout 保护是不是被删了？"
     start = src.index(marker)
     end = src.index("\n_keep_third_party_logs_off_stdout()", start)
     mod = ModuleType("daemon_guard")
-    mod.__dict__.update({"logging": logging, "sys": sys})
+    mod.__dict__.update({"logging": logging, "sys": sys, "Iterable": list})
     exec(compile(src[start:end], str(_DAEMON), "exec"), mod.__dict__)
-    return mod._keep_third_party_logs_off_stdout
+    return mod
 
 
 @pytest.fixture
-def clean_lycoris_logger():
-    lg = logging.getLogger("LyCORIS")
-    saved = list(lg.handlers)
+def probe() -> logging.Logger:
+    lg = logging.getLogger(_PROBE)
     lg.handlers.clear()
     yield lg
     lg.handlers.clear()
-    lg.handlers.extend(saved)
 
 
-def test_preinstalled_stderr_handler_makes_lycoris_skip_stdout(clean_lycoris_logger):
-    """抢先挂 stderr handler → lycoris 的 `if not logger.handlers:` 整段跳过。
+def test_lycoris_is_in_the_guarded_list():
+    """名单本身是这条保护的全部意义 —— 漏了 LyCORIS 等于没保护。"""
+    assert "LyCORIS" in _load_guard()._STDOUT_NOISY_LOGGERS
 
-    这是主路径：本函数在 daemon 顶部跑，远早于 lycoris 被 import。
+
+def test_installs_a_stderr_handler_so_lycoris_skips_its_own(probe):
+    """主路径：本函数在 lycoris import 之前跑。
+
+    lycoris 那段是 `if not logger.handlers:` 守卫的，所以只要先占住 handler 位，
+    它就不会再挂 stdout 的。
     """
-    _load_guard()()
+    _load_guard()._keep_third_party_logs_off_stdout([_PROBE])
 
-    assert clean_lycoris_logger.handlers, "该挂上一个 handler"
-    assert all(
-        getattr(h, "stream", None) is sys.stderr
-        for h in clean_lycoris_logger.handlers
-    )
-    # 模拟 lycoris 那段守卫：有 handler 就不会再加 stdout 的
-    assert clean_lycoris_logger.handlers  # → lycoris 的 `if not handlers` 为 False
+    assert len(probe.handlers) == 1
+    assert probe.handlers[0].stream is sys.stderr
 
 
-def test_existing_stdout_handler_is_removed(clean_lycoris_logger):
+def test_existing_stdout_handler_is_removed(probe):
     """兜底：万一 import 顺序变了、lycoris 先挂上了 stdout，也要掰回来。"""
-    stdout_handler = logging.StreamHandler(sys.stdout)
-    clean_lycoris_logger.addHandler(stdout_handler)
+    probe.addHandler(logging.StreamHandler(sys.stdout))
 
-    _load_guard()()
+    _load_guard()._keep_third_party_logs_off_stdout([_PROBE])
 
-    streams = [getattr(h, "stream", None) for h in clean_lycoris_logger.handlers]
+    streams = [getattr(h, "stream", None) for h in probe.handlers]
     assert sys.stdout not in streams
-    assert sys.stderr in streams
+    assert streams == [sys.stderr]
 
 
-def test_unrelated_handlers_are_left_alone(clean_lycoris_logger):
-    """只掰 stdout 的；别人挂的文件 / 内存 handler 不动。"""
-    import io
-
+def test_unrelated_handlers_are_left_alone(probe):
+    """只掰 stdout 的；别人挂的文件 / 内存 handler 不动，也不再多加一个。"""
     memory_handler = logging.StreamHandler(io.StringIO())
-    clean_lycoris_logger.addHandler(memory_handler)
+    probe.addHandler(memory_handler)
 
-    _load_guard()()
+    _load_guard()._keep_third_party_logs_off_stdout([_PROBE])
 
-    assert memory_handler in clean_lycoris_logger.handlers
-    # 已有非 stdout handler → 不再多加一个 stderr 的
-    assert len(clean_lycoris_logger.handlers) == 1
+    assert probe.handlers == [memory_handler]
+
+
+def test_stdout_handler_removed_even_when_others_remain(probe):
+    """混合情形：stdout 的拿掉、别的留着、不补 stderr（已有出口）。"""
+    memory_handler = logging.StreamHandler(io.StringIO())
+    probe.addHandler(logging.StreamHandler(sys.stdout))
+    probe.addHandler(memory_handler)
+
+    _load_guard()._keep_third_party_logs_off_stdout([_PROBE])
+
+    assert probe.handlers == [memory_handler]

--- a/tests/test_eval_generation.py
+++ b/tests/test_eval_generation.py
@@ -1,0 +1,292 @@
+"""评估出图走 daemon（`eval_generation`）。
+
+核心不变量：
+- 一次评估**一个** daemon 实例（底模只加载一次），不是每候选一个
+- 一个候选一个 daemon task，`prompts` = 全部验证图 caption，`count=1`
+- 图按 `item["filename"]` 落到 run 的 images/，不进测试页的 generate_cache
+- baseline（lora_scale=0）不给 lora_configs，走纯底模
+- 逐图 started/done/error 事件驱动 item 状态；daemon 报 error 整个候选失败
+"""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from studio import db, secrets
+from studio.infrastructure import paths as infra_paths
+from studio.services import eval_generation, eval_samples
+from studio.services.projects import projects, versions
+
+_PNG = b"\x89PNG\r\n\x1a\nfake"
+
+
+@pytest.fixture
+def isolated(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    dbfile = tmp_path / "studio.db"
+    db.init_db(dbfile)
+    monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+    monkeypatch.setattr(infra_paths, "TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(db, "STUDIO_DB", dbfile)
+    monkeypatch.setattr(secrets, "SECRETS_FILE", tmp_path / "secrets.json")
+    return {"db": dbfile}
+
+
+def _setup(isolated, *, validation: int = 2):
+    with db.connection_for(isolated["db"]) as conn:
+        project = projects.create_project(conn, title="Gen")
+        version = versions.create_version(conn, project_id=project["id"], label="v1")
+    vdir = versions.version_dir(project["id"], project["slug"], version["label"])
+    val = vdir / "validation" / "1_data"
+    val.mkdir(parents=True, exist_ok=True)
+    for i in range(validation):
+        (val / f"v{i}.png").write_bytes(b"png")
+        (val / f"v{i}.txt").write_text(f"caption {i}", encoding="utf-8")
+    out = vdir / "output"
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "model_epoch1.safetensors").write_bytes(b"lora")
+    _write_version_config(vdir)
+    return project, version, vdir
+
+
+def _write_version_config(vdir: Path) -> None:
+    """version config 是 daemon config 的模型路径 / 采样参数来源。"""
+    import json
+
+    cfg = {
+        "model_family": "anima",
+        "transformer_path": "models/diffusion_models/anima.safetensors",
+        "vae_path": "models/vae/qwen.safetensors",
+        "text_encoder_path": "models/text_encoders",
+        "t5_tokenizer_path": "models/t5_tokenizer",
+        "resolution": 1024,
+        "sample_infer_steps": 20,
+        "sample_cfg_scale": 5.0,
+        "sample_sampler_name": "er_sde",
+        "sample_scheduler": "simple",
+        "attention_backend": "flash_attn",
+        "mixed_precision": "bf16",
+    }
+    path = vdir / "config.json"
+    path.write_text(json.dumps(cfg), encoding="utf-8")
+
+
+@pytest.fixture(autouse=True)
+def _stub_version_config(monkeypatch: pytest.MonkeyPatch):
+    """read_version_config 走真实实现要一整套 schema；这里只需要它回一份 dict。"""
+    import json
+
+    from studio.services import version_config
+
+    def _read(project, version):
+        vdir = versions.version_dir(
+            int(project["id"]), str(project.get("slug") or ""), str(version["label"]),
+        )
+        return json.loads((vdir / "config.json").read_text(encoding="utf-8"))
+
+    monkeypatch.setattr(version_config, "read_version_config", _read)
+
+
+class FakeDaemon:
+    """按 daemon 协议回放事件的假 daemon。记录每次 submit 的 config。"""
+
+    def __init__(self, *, fail_at: int | None = None, task_error: str | None = None):
+        self.started = 0
+        self.stopped = 0
+        self.configs: list[dict[str, Any]] = []
+        self._fail_at = fail_at
+        self._task_error = task_error
+
+    def start(self) -> None:
+        self.started += 1
+
+    def stop(self, timeout: float = 10.0) -> None:
+        self.stopped += 1
+
+    def submit_task(
+        self, *, task_id: int, config: dict[str, Any], output_dir: str,
+        on_event: Callable[[dict[str, Any]], None],
+    ) -> str:
+        self.configs.append(config)
+        n = len(config["prompts"])
+        on_event({"kind": "started", "task_id": task_id, "total": n})
+        for i in range(n):
+            on_event({"kind": "image_started", "batch_idx": i, "batch_total": n})
+            if self._fail_at == i:
+                on_event({"kind": "image_error", "step": i + 1, "message": "cuda oom"})
+                continue
+            on_event({
+                "kind": "image_done", "step": i + 1, "total": n,
+                "filename": f"gen_{i:04d}_p{i}_c0_s7.png",
+                "image_b64": base64.b64encode(_PNG).decode("ascii"),
+                "byte_size": len(_PNG),
+            })
+        if self._task_error:
+            on_event({"kind": "error", "message": self._task_error})
+        else:
+            on_event({"kind": "done", "task_id": task_id})
+        return "req-1"
+
+
+def _run_for(isolated, *, baseline: bool = False):
+    project, version, vdir = _setup(isolated)
+    run = eval_samples.create_run(
+        project, version, vdir,
+        checkpoint_path=str(vdir / "output" / "model_epoch1.safetensors"),
+        baseline=baseline, now=1000.0,
+    )
+    return project, version, vdir, run
+
+
+# ---------------------------------------------------------------------------
+# 出图 + 落盘
+# ---------------------------------------------------------------------------
+
+def test_generates_every_validation_image_into_the_run(isolated) -> None:
+    _, _, vdir, run = _run_for(isolated)
+    fake = FakeDaemon()
+
+    with eval_generation.DaemonSampleGenerator(
+        lambda _l: None, task_id=5, daemon=fake,
+    ) as generate:
+        generate(run, vdir, lambda _l: None)
+
+    saved = eval_samples.load_run(vdir, run["run_id"])
+    assert [i["status"] for i in saved["items"]] == ["done", "done"]
+    for item in saved["items"]:
+        # 图落在 item 计划好的文件名上（daemon 自己的 gen_*.png 命名不外泄 ——
+        # 指标 runner 和样图矩阵认的是 item["filename"]）
+        assert (vdir / item["path"]).read_bytes() == _PNG
+
+
+def test_one_task_per_candidate_with_all_prompts(isolated) -> None:
+    """一个候选 = 一个 task，prompts 是全部验证图 —— 这是底模只加载一次的前提。"""
+    _, _, vdir, run = _run_for(isolated)
+    fake = FakeDaemon()
+
+    with eval_generation.DaemonSampleGenerator(
+        lambda _l: None, daemon=fake,
+    ) as generate:
+        generate(run, vdir, lambda _l: None)
+
+    assert len(fake.configs) == 1
+    cfg = fake.configs[0]
+    assert cfg["prompts"] == ["caption 0", "caption 1"]
+    assert cfg["count"] == 1  # 多张会打乱 prompt ↔ item 的一一对应
+
+
+def test_daemon_started_once_across_candidates(isolated) -> None:
+    """跨候选复用同一个 daemon —— 这一刀的全部收益所在。"""
+    _, _, vdir, run = _run_for(isolated)
+    fake = FakeDaemon()
+
+    with eval_generation.DaemonSampleGenerator(
+        lambda _l: None, daemon=fake,
+    ) as generate:
+        for _ in range(3):
+            generate(run, vdir, lambda _l: None)
+
+    assert fake.started == 1
+    assert len(fake.configs) == 3
+
+
+def test_owns_daemon_lifecycle_only_when_it_created_it(isolated) -> None:
+    """外部注入的 daemon 不由本类关闭（测试 / 未来共享实例场景）。"""
+    _, _, vdir, _run = _run_for(isolated)
+    fake = FakeDaemon()
+    with eval_generation.DaemonSampleGenerator(lambda _l: None, daemon=fake):
+        pass
+    assert fake.stopped == 0
+
+
+# ---------------------------------------------------------------------------
+# config 组装
+# ---------------------------------------------------------------------------
+
+def test_generation_params_come_from_the_frozen_plan(isolated) -> None:
+    _, _, vdir, run = _run_for(isolated)
+    cfg = eval_generation.build_daemon_config(
+        run, vdir, output_dir=vdir / "out",
+    )
+    assert cfg["steps"] == 20
+    assert cfg["cfg_scale"] == 5.0
+    assert cfg["sampler_name"] == "er_sde"
+    assert cfg["width"] == 1024 and cfg["height"] == 1024
+    assert cfg["model_family"] == "anima"
+    # 评估不需要中间预览，关掉省 b64 编码和管道带宽
+    assert cfg["preview_every_n_steps"] == 0
+
+
+def test_checkpoint_becomes_a_single_lora_config(isolated) -> None:
+    _, _, vdir, run = _run_for(isolated)
+    cfg = eval_generation.build_daemon_config(run, vdir, output_dir=vdir / "out")
+    assert len(cfg["lora_configs"]) == 1
+    assert cfg["lora_configs"][0]["path"].endswith("model_epoch1.safetensors")
+    assert cfg["lora_configs"][0]["scale"] == 1.0
+
+
+def test_baseline_runs_with_no_lora_at_all(isolated) -> None:
+    """baseline 是纯底模对照。旧路径靠 lora_scale=0 绕，现在干脆不挂 LoRA。"""
+    _, _, vdir, run = _run_for(isolated, baseline=True)
+    cfg = eval_generation.build_daemon_config(run, vdir, output_dir=vdir / "out")
+    assert cfg["lora_configs"] == []
+
+
+def test_empty_run_is_rejected(isolated) -> None:
+    _, _, vdir, run = _run_for(isolated)
+    run["items"] = []
+    with pytest.raises(eval_generation.EvalGenerationError):
+        eval_generation.build_daemon_config(run, vdir, output_dir=vdir / "out")
+
+
+# ---------------------------------------------------------------------------
+# 失败路径
+# ---------------------------------------------------------------------------
+
+def test_single_image_failure_marks_only_that_item(isolated) -> None:
+    """一张图崩了不该拖垮整个候选 —— 其余图仍值得留着算指标。"""
+    _, _, vdir, run = _run_for(isolated)
+    fake = FakeDaemon(fail_at=0)
+
+    with eval_generation.DaemonSampleGenerator(
+        lambda _l: None, daemon=fake,
+    ) as generate:
+        generate(run, vdir, lambda _l: None)
+
+    saved = eval_samples.load_run(vdir, run["run_id"])
+    assert saved["items"][0]["status"] == "failed"
+    assert "cuda oom" in str(saved["items"][0]["error"])
+    assert saved["items"][1]["status"] == "done"
+
+
+def test_task_level_error_raises(isolated) -> None:
+    """daemon 报 task 级 error（模型加载失败等）→ 抛出去，让候选标 failed。"""
+    _, _, vdir, run = _run_for(isolated)
+    fake = FakeDaemon(task_error="model load failed")
+
+    with eval_generation.DaemonSampleGenerator(
+        lambda _l: None, daemon=fake,
+    ) as generate:
+        with pytest.raises(eval_generation.EvalGenerationError, match="model load failed"):
+            generate(run, vdir, lambda _l: None)
+
+
+def test_missing_image_bytes_is_an_error_not_a_silent_skip(isolated) -> None:
+    """image_b64 被剥掉说明 daemon 的 cache_images 忘了关 —— 必须炸，不能静默丢图。"""
+    _, _, vdir, run = _run_for(isolated)
+
+    class _Stripped(FakeDaemon):
+        def submit_task(self, *, task_id, config, output_dir, on_event):
+            self.configs.append(config)
+            on_event({"kind": "image_started", "batch_idx": 0, "batch_total": 1})
+            on_event({"kind": "image_done", "step": 1, "filename": "gen_0000.png"})
+            on_event({"kind": "done", "task_id": task_id})
+            return "req-1"
+
+    with eval_generation.DaemonSampleGenerator(
+        lambda _l: None, daemon=_Stripped(),
+    ) as generate:
+        with pytest.raises(eval_generation.EvalGenerationError, match="cache_images"):
+            generate(run, vdir, lambda _l: None)

--- a/tests/test_eval_generation.py
+++ b/tests/test_eval_generation.py
@@ -310,6 +310,27 @@ def _set_generate_settings(monkeypatch: pytest.MonkeyPatch, **values: Any) -> No
     monkeypatch.setattr(secrets, "load", lambda: _Secrets())
 
 
+def test_block_swap_notice_is_logged_once_not_per_candidate(
+    isolated, monkeypatch: pytest.MonkeyPatch, caplog,
+) -> None:
+    """本函数每个候选走一遍；逐次打日志就是 200 个 checkpoint 打 200 行同样的话。"""
+    import logging
+
+    eval_generation._BLOCK_SWAP_NOTICED.discard("anima")
+    _, _, vdir, run = _run_for(isolated)
+    _set_generate_settings(monkeypatch, blocks_to_swap=14)
+
+    with caplog.at_level(logging.INFO, logger="studio.services.eval_generation"):
+        for _ in range(5):
+            cfg = eval_generation.build_daemon_config(
+                run, vdir, output_dir=vdir / "out",
+            )
+            assert cfg["blocks_to_swap"] == 0
+
+    hits = [r for r in caplog.records if "block swap" in r.getMessage()]
+    assert len(hits) == 1
+
+
 def test_block_swap_is_dropped_for_families_without_the_capability(
     isolated, monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_eval_generation.py
+++ b/tests/test_eval_generation.py
@@ -290,3 +290,73 @@ def test_missing_image_bytes_is_an_error_not_a_silent_skip(isolated) -> None:
     ) as generate:
         with pytest.raises(eval_generation.EvalGenerationError, match="cache_images"):
             generate(run, vdir, lambda _l: None)
+
+
+# ---------------------------------------------------------------------------
+# 族条件旋钮不能跨族污染
+# ---------------------------------------------------------------------------
+
+def _set_generate_settings(monkeypatch: pytest.MonkeyPatch, **values: Any) -> None:
+    class _Gen:
+        pass
+
+    gen = _Gen()
+    for k, v in values.items():
+        setattr(gen, k, v)
+
+    class _Secrets:
+        generate = gen
+
+    monkeypatch.setattr(secrets, "load", lambda: _Secrets())
+
+
+def test_block_swap_is_dropped_for_families_without_the_capability(
+    isolated, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """回归：全局出图设置里的 blocks_to_swap 是为 krea2 调的，anima 不支持。
+
+    测试出图跑的是用户在那儿选的模型，评估跑的是这个 version 训练时那个底模 ——
+    两者的族可以不同。原样透传会让 daemon fail-fast（`model_family='anima' 不支持
+    block swap`），整个出图阶段每个候选都崩，最后 8 个候选全 failed。
+    """
+    _, _, vdir, run = _run_for(isolated)
+    _set_generate_settings(monkeypatch, blocks_to_swap=14, vram_policy="save_vram")
+
+    cfg = eval_generation.build_daemon_config(run, vdir, output_dir=vdir / "out")
+
+    assert cfg["model_family"] == "anima"
+    assert cfg["blocks_to_swap"] == 0
+    # 非族条件的旋钮照常继承
+    assert cfg["vram_policy"] == "save_vram"
+
+
+def test_block_swap_survives_for_a_family_that_supports_it(
+    isolated, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """门控只砍不支持的族 —— krea2 项目仍该拿到用户调好的层数。"""
+    import json
+
+    _, _, vdir, run = _run_for(isolated)
+    cfg_path = vdir / "config.json"
+    raw = json.loads(cfg_path.read_text(encoding="utf-8"))
+    raw["model_family"] = "krea2"
+    cfg_path.write_text(json.dumps(raw), encoding="utf-8")
+    _set_generate_settings(monkeypatch, blocks_to_swap=14)
+
+    cfg = eval_generation.build_daemon_config(run, vdir, output_dir=vdir / "out")
+    assert cfg["blocks_to_swap"] == 14
+
+
+def test_unreadable_settings_fall_back_to_safe_defaults(
+    isolated, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """设置文件坏了不该让评估跑不起来 —— 给保守默认（含 block swap 关闭）。"""
+    def _boom():
+        raise RuntimeError("secrets.json 损坏")
+
+    monkeypatch.setattr(secrets, "load", _boom)
+    _, _, vdir, run = _run_for(isolated)
+
+    cfg = eval_generation.build_daemon_config(run, vdir, output_dir=vdir / "out")
+    assert cfg["blocks_to_swap"] == 0
+    assert cfg["vram_policy"] == "auto"

--- a/tests/test_eval_samples.py
+++ b/tests/test_eval_samples.py
@@ -113,34 +113,23 @@ def test_create_and_run_eval_samples_with_fake_generator(isolated) -> None:
     assert (vdir / item["path"]).read_bytes() == b"PNG"
 
 
-def test_default_generator_path_has_no_dead_schema_import(isolated) -> None:
-    """Regression: every other test injects a fake generator, so the real
-    ``generator=None`` path (``_default_generator``) was never exercised and a
-    stale ``from studio.schema import migrate_legacy_attention`` shipped — the
-    symbol was removed in the 0.11.0 schema split, so the default auto-eval /
-    worker path raised ImportError before generating anything.
+def test_run_sample_job_requires_a_generator(isolated) -> None:
+    """出图改走 daemon 后 generator 是必需参数。
 
-    No version config is written here, so the real generator must fail with a
-    *config* error, never an ImportError/NameError on that removed symbol.
+    以前它有个默认实现（`_default_generator`，自己加载底模自己循环），于是
+    「每个候选重载一次底模」是隐式默认。现在生成器的生命周期是一次评估，必须由
+    调用方在候选循环之外持有 —— 给默认值就会退化成每候选起一个 daemon。
     """
     project, version, vdir = _new_project(isolated)
     _seed_validation_and_ckpt(vdir)
-
     run = eval_samples.create_run(
-        project,
-        version,
-        vdir,
-        checkpoint_path="model_step100.safetensors",
-        now=2000.0,
+        project, version, vdir,
+        checkpoint_path="model_step100.safetensors", now=2000.0,
     )
 
-    with pytest.raises(Exception) as excinfo:  # noqa: PT011 - asserting on message
-        eval_samples.run_sample_job(project, version, vdir, run["run_id"])
-    assert "migrate_legacy_attention" not in str(excinfo.value)
+    with pytest.raises(TypeError):
+        eval_samples.run_sample_job(project, version, vdir, run["run_id"])  # type: ignore[call-arg]
 
-    reloaded = eval_samples.load_run(vdir, run["run_id"])
-    assert reloaded["status"] == "failed"
-    assert "migrate_legacy_attention" not in str(reloaded.get("error") or "")
 
 
 def test_create_run_plans_items_from_validation_set(isolated) -> None:
@@ -365,87 +354,3 @@ def test_run_task_eval_endpoint_validates_task_ownership(client, isolated) -> No
 # ---------------------------------------------------------------------------
 # 模型释放（EvalSession 同进程连续跑多个候选，不释放会显存单调上涨）
 # ---------------------------------------------------------------------------
-
-class _FakeAdapter:
-    def __init__(self, *, boom: bool = False) -> None:
-        self.detached = False
-        self._boom = boom
-
-    def detach(self) -> bool:
-        if self._boom:
-            raise RuntimeError("detach exploded")
-        self.detached = True
-        return True
-
-
-class _FakeCuda:
-    def __init__(self, available: bool = True) -> None:
-        self._available = available
-        self.emptied = 0
-        self.ipc = 0
-
-    def is_available(self) -> bool:
-        return self._available
-
-    def empty_cache(self) -> None:
-        self.emptied += 1
-
-    def ipc_collect(self) -> None:
-        self.ipc += 1
-
-
-class _FakeTorch:
-    def __init__(self, available: bool = True) -> None:
-        self.cuda = _FakeCuda(available)
-
-
-def test_release_detaches_loras_and_empties_cuda_cache() -> None:
-    adapters = [_FakeAdapter(), _FakeAdapter()]
-    torch_ = _FakeTorch()
-    lines: list[str] = []
-
-    eval_samples._release_generation_models(
-        adapters, object(), object(), object(), torch_, lines.append,
-    )
-
-    assert all(a.detached for a in adapters)
-    assert torch_.cuda.emptied == 1
-    assert torch_.cuda.ipc == 1
-    assert any("released base model" in ln for ln in lines)
-
-
-def test_release_survives_detach_failure() -> None:
-    """某个 adapter detach 炸了也要继续释放剩下的 + 清缓存 —— 否则一个失败就漏掉全部。"""
-    boom, ok = _FakeAdapter(boom=True), _FakeAdapter()
-    torch_ = _FakeTorch()
-
-    eval_samples._release_generation_models(
-        [boom, ok], object(), object(), object(), torch_, lambda _l: None,
-    )
-
-    assert ok.detached
-    assert torch_.cuda.emptied == 1
-
-
-def test_release_skips_cuda_when_unavailable() -> None:
-    torch_ = _FakeTorch(available=False)
-    eval_samples._release_generation_models(
-        [], object(), object(), object(), torch_, lambda _l: None,
-    )
-    assert torch_.cuda.emptied == 0
-
-
-def test_release_tolerates_empty_cache_failure() -> None:
-    """empty_cache 抛错（驱动层偶发）不该让整个候选算失败。"""
-    class _Boom(_FakeTorch):
-        def __init__(self) -> None:
-            super().__init__()
-            self.cuda.empty_cache = self._boom  # type: ignore[method-assign]
-
-        @staticmethod
-        def _boom() -> None:
-            raise RuntimeError("driver hiccup")
-
-    eval_samples._release_generation_models(
-        [], object(), object(), object(), _Boom(), lambda _l: None,
-    )  # 不抛就算过

--- a/tests/test_eval_session_worker.py
+++ b/tests/test_eval_session_worker.py
@@ -13,7 +13,7 @@ import pytest
 
 from studio import db, secrets
 from studio.infrastructure import paths as infra_paths
-from studio.services import eval_samples, eval_session
+from studio.services import eval_generation, eval_samples, eval_session
 from studio.services.projects import jobs as project_jobs, projects, versions
 from studio.workers import eval_session_worker as worker
 
@@ -78,6 +78,27 @@ def _fake_generator(run: dict[str, Any], version_dir: Path, progress) -> None:
         run = eval_samples.mark_item_done(version_dir, run, idx, eval_root)
 
 
+class _NoopGenerator:
+    """替掉 DaemonSampleGenerator：出图由 `_fake_generator` 顶，不许起真 daemon。
+
+    真实现的 `__enter__` 会 spawn `runtime/anima_daemon.py` 子进程（torch import
+    好几秒、READY_TIMEOUT 30s），在测试里既慢又依赖机器状态 —— CI 无 GPU、runner
+    忙的时候正好是 flake 的温床。
+    """
+
+    def __init__(self, *_a, **_kw) -> None:
+        pass
+
+    def __enter__(self) -> "_NoopGenerator":
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        return None
+
+    def __call__(self, *_a, **_kw) -> None:  # 不会被调到（run_sample_job 已被换掉）
+        raise AssertionError("测试不该走到真的 daemon 出图")
+
+
 @pytest.fixture
 def fake_generate(monkeypatch: pytest.MonkeyPatch):
     """让 run_sample_job 走假 generator（真签名、真 run.json 写入）。"""
@@ -88,6 +109,9 @@ def fake_generate(monkeypatch: pytest.MonkeyPatch):
         return real(project, version, vdir, run_id, generator=_fake_generator, **kw)
 
     monkeypatch.setattr(eval_samples, "run_sample_job", patched)
+    monkeypatch.setattr(
+        eval_generation, "DaemonSampleGenerator", _NoopGenerator,
+    )
     return patched
 
 
@@ -273,6 +297,9 @@ def test_one_candidate_failing_leaves_session_partial(
         return real(project_, version_, vdir_, run_id, generator=_fake_generator, **kw)
 
     monkeypatch.setattr(eval_samples, "run_sample_job", flaky)
+    monkeypatch.setattr(
+        eval_generation, "DaemonSampleGenerator", _NoopGenerator,
+    )
 
     assert worker.run(int(session["task_id"])) == 0
 
@@ -430,6 +457,9 @@ def test_all_candidates_failing_gives_failed_and_exit_1(
         raise RuntimeError("nope")
 
     monkeypatch.setattr(eval_samples, "run_sample_job", always_bad)
+    monkeypatch.setattr(
+        eval_generation, "DaemonSampleGenerator", _NoopGenerator,
+    )
 
     assert worker.run(int(session["task_id"])) == 1
 

--- a/tests/test_generate_family.py
+++ b/tests/test_generate_family.py
@@ -53,3 +53,47 @@ def test_is_distilled_path_by_official_variant():
     assert not krea2.is_distilled_path("")
     assert not get_assets("anima").is_distilled_path(
         "G:/models/diffusion_models/anima-base-v1.0.safetensors")
+
+
+# ── 族条件的运行时旋钮门控 ──────────────────────────────────────────────────
+# blocks_to_swap 来自**全局**出图设置（用户为某个模型调的），但每次请求可以是另一
+# 个族的底模。原样透传时 runtime 会 fail-fast（"model_family=X 不支持 block swap"）。
+# schema 的写时门控走 cap_gate，运行时这条走 supports_capability —— 同一张
+# FAMILY_CAPABILITIES 表，不是第二份镜像。
+
+def test_supports_capability_matches_the_family_table():
+    from studio.domain.common import FAMILY_CAPABILITIES, supports_capability
+
+    assert supports_capability("krea2", "block_swap") is True
+    assert supports_capability("anima", "block_swap") is False
+    # 未知族保守拒绝，不放行族条件旋钮
+    assert supports_capability("no_such_family", "block_swap") is False
+    # 与表本身同源（防有人再抄一份镜像）
+    for family, caps in FAMILY_CAPABILITIES.items():
+        for cap in caps:
+            assert supports_capability(family, cap) is True
+
+
+def test_eval_and_generate_gate_block_swap_the_same_way(monkeypatch: pytest.MonkeyPatch):
+    """评估和测试出图共用同一条规则 —— 两处各写一份迟早会漂。"""
+    from studio.domain.common import supports_capability
+    from studio.services import eval_generation
+
+    class _Gen:
+        vae_precision = "bf16"
+        lora_merge_precision = "fp32"
+        vram_policy = "auto"
+        ram_guard = True
+        blocks_to_swap = 14
+
+    class _Secrets:
+        generate = _Gen()
+
+    monkeypatch.setattr("studio.secrets.load", lambda: _Secrets())
+    eval_generation._BLOCK_SWAP_NOTICED.discard("anima")
+
+    assert eval_generation._generate_settings("anima")["blocks_to_swap"] == 0
+    assert eval_generation._generate_settings("krea2")["blocks_to_swap"] == 14
+    # generate 路由用的是同一个判据
+    assert supports_capability("anima", "block_swap") is False
+    assert supports_capability("krea2", "block_swap") is True

--- a/tests/test_studio_server.py
+++ b/tests/test_studio_server.py
@@ -27,6 +27,7 @@ def isolated_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str,
     from studio import db
     from studio.api.routers import root as _root_router
     from studio.api.routers import samples as _samples_router
+    from studio.services.inference import disk_cache
     from studio.services.projects import projects
     output = tmp_path / "output"
     samples_dir = output / "samples"
@@ -42,6 +43,19 @@ def isolated_paths(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str,
     monkeypatch.setattr(_samples_router, "OUTPUT_DIR", output)
     monkeypatch.setattr(_root_router, "WEB_DIST", web_dist)
     monkeypatch.setattr(projects, "PROJECTS_DIR", tmp_path / "projects")
+
+    # 加密磁盘 cache：生产里由 lifespan 初始化，但这里的 TestClient 不进 context
+    # manager，lifespan **不会跑**。以前 test_generate_sample_response_* 能过，
+    # 只是因为全量跑时 tests/test_disk_cache.py 字母序在前，把那个**进程级
+    # singleton** 漏了出来 —— 单跑本文件或按 CONTRIBUTING §3 只跑关联测试就假红。
+    #
+    # 不能靠 `with TestClient(...)` 补 lifespan：本 fixture 没隔离 STUDIO_DATA，
+    # 而 disk_cache.init() 会 startup_clean(root) rmtree 掉 root 下所有 session-*
+    # —— 那会删掉本机正在跑的 server 的出图 cache（历史踩过）。
+    # 先把 singleton 置 None 再 init：否则 init 会 clear_all 别的测试留下的那个。
+    monkeypatch.setattr(disk_cache, "_session", None)
+    disk_cache.init(tmp_path / "generate_cache")
+
     return {
         "tmp": tmp_path,
         "db": dbfile,


### PR DESCRIPTION
承接 #469。#469 消除了作业 fan-out（603 → 1），执行效率那一半留着没做 —— 这个 PR 收掉它。

## 背景 / 动机

评估自己写了一套「加载底模 → encode → sample → decode → save」，是仓库里第 **5** 套推理循环。而测试出图的常驻 daemon（[`runtime/anima_daemon.py`](runtime/anima_daemon.py)）早就把这些做全了，还多做很多：

| 能力 | 位置 |
|---|---|
| `ModelCache` 底模跨 task 常驻 | `anima_daemon.py:331` |
| LoRA 拓扑相同时**热换权重**（不重 inject） | `ModelCache.apply_loras:618` |
| TE 先行编排：预编码整个 prompt 集合 → 彻底释放 TE → 才加载 DiT | `:885` |
| CUDA OOM 重试 + allocator 恢复 | `_sample_with_cuda_oom_retry:208` |
| block swap 折扣、TE/DiT 让位 | `:146` / `:253` |
| 协议级 cancel、idle unload、进程崩溃恢复 | daemon proxy 两侧 |

旧路径每个候选完整加载一遍底模：21 个候选 = 21 次 ~28s 的 Transformer 读盘，**约 10 分钟纯开销**。而且合成一个 worker 进程之后还得自己管显存释放（#469 的 `try/finally` + `detach` + `empty_cache`）——那本来就是 daemon 的 `ModelCache` 该管的事。

最讽刺的一点：`supervisor/core.py:470` 在派 `eval_session` 之前会调 `_maybe_yield_daemon()`，**先让 daemon 卸载它已经加载好的底模**，然后 eval 自己把同样的模型加载 21 遍。我们付出了吊销租约的代价，却没拿到任何复用。

这也是 [`docs/adr/0011`](docs/adr/0011-lora-eval-metrics.md) 最新 Addendum 里记的「从优化升级为必须」那一条。

## 改动概要

### daemon 零改动

关键发现：daemon 的**普通 generate 本来就吃 `prompts: list[str]`**（`:1320` / `:1378` 逐条出图，`:1343` 预编码整个封闭集合）。所以形状是：

> **一个候选 = 一个 daemon task**，`prompts` = 全部验证图 caption，`count=1`

- 不需要给 XY 加 prompt 轴（`_run_xy:1497` 明确说 prompt 已由 `_run_generate` 统一预编码）
- **保住了候选主序** → run 结构、`eval_candidates` 进度语义、指标 runner、样图矩阵全都不用动
- 候选之间 `ModelCache` 命中 → 底模不动，只热换 LoRA 权重

### eval worker 起自己的 daemon 实例

评估跑在 supervisor 派的独立 worker 子进程里，跨进程拿不到 server 那个单例。而 supervisor 已经在派 `eval_session` 之前吊销了测试 daemon 的显存租约，卡是空的 —— worker 起自己的实例即可，两者不会并存。

**生命周期是整个出图阶段**，不是单个候选：

```python
with eval_generation.DaemonSampleGenerator(progress, task_id=task_id) as generate:
    for cand in pending:
        eval_samples.run_sample_job(..., generator=generate)
```

断点续跑时先算 `pending`，全部已完成就压根不起 daemon。

### `InferenceDaemon` 加 `cache_images` 开关（唯一的共享组件改动）

`_handle_event` 会把 `image_done` 的 PNG **剥掉**塞进 `generate_cache`。这是**测试出图**的服务端行为，不是 daemon 协议的一部分。评估必须关掉，否则：

1. b64 被剥掉 → 调用方拿不到图
2. 84 张评估图混进测试页历史，还挂在一个假的 generate task 下

### 其余

- `run_sample_job` 的 `generator` 变**必需参数**：给默认值会退化成每候选起一个 daemon，比旧路径还慢
- `_default_generator` / `_generate_items` / `_release_generation_models` 整段删除（#469 的显式释放随之退役）
- `eval_samples` 不再 import torch，模块 docstring 同步
- item seed 改为 `gen_seed + idx`，跟 daemon 多 prompt 循环的实际行为一致。**跨候选可比性不受影响** —— 「同一个 prompt 在所有候选上是同一个 seed」这个不变量仍然成立，而且不同 prompt 用同一 seed 反而容易出相关性伪影

## 测试方式

新增 [`tests/test_eval_generation.py`](tests/test_eval_generation.py)（11 个），用假 daemon 按协议回放事件：

- 单 daemon 跨候选只 `start` 一次（这一刀的全部收益）
- 一个候选一个 task、`prompts` = 全部验证图、`count=1`
- 图按 `item["filename"]` 落 run 的 `images/`（daemon 自己的 `gen_*.png` 命名不外泄）
- baseline 不挂 LoRA（旧路径靠 `lora_scale=0` 绕）
- 生成参数取冻结的 plan、`preview_every_n_steps=0`
- 单图失败只标那一格，其余照跑；task 级 error 抛出
- `image_b64` 缺失必须炸 —— 防 `cache_images` 忘关时静默丢图
- 外部注入的 daemon 不由本类关闭

`tests/test_eval_samples.py` 的 5 个旧测试测的是被删掉的东西，替换成「`generator` 是必需参数」的契约测试。

**顺带修的测试卫生问题**：`_stage_generate` 一包上 `DaemonSampleGenerator`，session worker 测试就开始**真 spawn daemon 子进程** —— torch import 6~12s/测试、`READY_TIMEOUT` 30s，CI 无 GPU、runner 忙的时候正是 flake 温床（CONTRIBUTING §测试卫生 第 1、3 条）。三处 `run_sample_job` 替换点统一 stub 掉，该文件 **79s → 6.4s**。

```
pytest -k "eval or daemon or inference or queue or supervisor"   451 passed
pytest test_route_snapshot.py test_studio_configs.py              33 passed
ruff check .                                                     All checks passed
```

无前端改动。

## 真机验证（已完成）

anima 项目、6 个候选（5 checkpoint + baseline）× 4 张验证图：

| 候选 | 起止 | 耗时 | 底模加载 |
|---|---|---|---|
| checkpoint#0 | 16:47:12 → 16:48:36 | **84s** | 有（16:47:45 `create LyCORIS: 280 modules`） |
| checkpoint#1 | 16:48:36 → 16:49:23 | 47s | 无 |
| checkpoint#2 | 16:49:23 → 16:50:10 | 47s | 无 |
| checkpoint#3 | 16:50:10 → 16:50:58 | 48s | 无 |
| checkpoint#4 | 16:50:58 → 16:51:46 | 48s | 无 |
| baseline#5 | 16:51:46 → 16:52:16 | 30s | 无 |

`Transformer 权重加载` 与 `create LyCORIS: 280 modules` **全程只出现一次**（候选 #0）。
之后每个候选稳定 47-48s = 4 张图 × ~12s 纯采样，与 #0 的差值 ~37s 正是那一次性的
底模加载。候选之间走 `ModelCache` 的**权重热换**，连 LyCORIS 注入日志都没有第二次。

`[done] session=4 status=done candidates=6 metrics_done=30`，全部指标正常算出。

6 个候选省约 3 分钟；按 21 个候选的规模省约 11 分钟。

首轮真机跑出一个 bug 并已修（见 commit `族条件的出图旋钮不再跨族污染`）：全局出图
设置里的 `blocks_to_swap` 是为 krea2 调的，anima 不支持 → daemon fail-fast，8 个
候选全崩。现按 `FAMILY_CAPABILITIES` 门控，附 3 个回归测试。

## 不在本轮范围

[`inference_loop_unification_plan`](docs/adr/0011-lora-eval-metrics.md) 里的 `Engine → Sinks → BatchRunner` 三步抽象。这一刀是把第 5 套循环**删掉**并进 daemon 那套，4 套还是 4 套 —— 抽象照旧欠着。

