### PR TITLE
perf(eval): 指标模型按阶段共享，一个指标只加载一次

### DIFF
--- a/studio/services/eval_ccip.py
+++ b/studio/services/eval_ccip.py
@@ -11,10 +11,12 @@ metric head，出成对 difference 矩阵），按变体 ``metrics.json`` 的 th
 """
 from __future__ import annotations
 
+import contextlib
+import functools
 from pathlib import Path
 from typing import Any, Callable
 
-from . import eval_metrics, eval_samples
+from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
 
 JOB_KIND = "eval_ccip"
@@ -276,10 +278,27 @@ def _ccip_preprocess(path: Path):
     return (arr - mean) / std  # (3, 384, 384)
 
 
-def _default_scorer(run, version_dir, model_name, progress):
+def _load_ccip(model_name: str, progress: Callable[[str], None]):
     import json
-    import numpy as np
+
     from studio.services.models.downloader import ensure_ccip_model
+
+    model_dir = ensure_ccip_model(model_name, on_log=progress)
+    threshold = float(
+        json.loads((model_dir / "metrics.json").read_text(encoding="utf-8"))["threshold"]
+    )
+    progress(f"[eval-ccip] loading CCIP onnx (threshold={threshold:.4f})")
+    feat_sess = _make_session(model_dir / "model_feat.onnx")
+    metric_sess = _make_session(model_dir / "model_metrics.onnx")
+    return (
+        feat_sess, metric_sess,
+        feat_sess.get_inputs()[0].name, metric_sess.get_inputs()[0].name,
+        threshold,
+    )
+
+
+def _default_scorer(run, version_dir, model_name, progress, pool=None):
+    import numpy as np
 
     eval_root = _run_eval_root(run)
     items = _done_image_items(run, version_dir, eval_root)
@@ -295,15 +314,10 @@ def _default_scorer(run, version_dir, model_name, progress):
             "ccip_i_reason": "no paired reference/image pairs",
         }
 
-    model_dir = ensure_ccip_model(model_name, on_log=progress)
-    threshold = float(
-        json.loads((model_dir / "metrics.json").read_text(encoding="utf-8"))["threshold"]
+    pool = pool if pool is not None else eval_model_pool.ModelPool("ccip")
+    feat_sess, metric_sess, feat_in, metric_in, threshold = pool.get(
+        model_name, lambda: _load_ccip(model_name, progress),
     )
-    progress(f"[eval-ccip] loading CCIP onnx (threshold={threshold:.4f})")
-    feat_sess = _make_session(model_dir / "model_feat.onnx")
-    metric_sess = _make_session(model_dir / "model_metrics.onnx")
-    feat_in = feat_sess.get_inputs()[0].name
-    metric_in = metric_sess.get_inputs()[0].name
 
     def _feat(path: Path):
         data = _ccip_preprocess(path)[None].astype(np.float32)  # (1,3,384,384)
@@ -327,3 +341,21 @@ def _default_scorer(run, version_dir, model_name, progress):
             if same else "no paired reference/image pairs"
         ),
     }
+
+
+@contextlib.contextmanager
+def shared_scorer(progress: Callable[[str], None] | None = None):
+    """阶段级共享的 scorer：CCIP session 只加载一次，跑完全部候选后释放。
+
+    `_stage_metric` 本来就是「一个指标跑完所有候选再换下一个」，但
+    `_default_scorer` 是旧模型（每候选一个子进程）留下的形状 —— 模型写在函数体里
+    加载，于是 200 个 checkpoint 就加载 200 次。池子交给调用方持有而不是放模块级
+    全局：全局状态会跨测试泄漏（成组跑时上一个用例的 tagger 被下一个复用）。
+
+    `run_*_job(scorer=None)` 独立调用时仍是「加载 → 用一次 → 返回即释放」，行为不变。
+    """
+    pool = eval_model_pool.ModelPool("ccip")
+    try:
+        yield functools.partial(_default_scorer, pool=pool)
+    finally:
+        pool.release(progress)

--- a/studio/services/eval_clip.py
+++ b/studio/services/eval_clip.py
@@ -6,12 +6,14 @@ job/result contract without importing torch or transformers.
 """
 from __future__ import annotations
 
+import functools
+import contextlib
 import json
 import time
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
-from . import eval_metrics, eval_samples
+from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
 
 JOB_KIND = "eval_clip"
@@ -276,27 +278,39 @@ def _int_or_none(value: Any) -> int | None:
         return None
 
 
-def _default_scorer(
-    run: dict[str, Any],
-    version_dir: Path,
-    model_name: str,
-    progress: Callable[[str], None],
-) -> dict[str, Any]:
-    import numpy as np
+def _load_clip(model_name: str, progress: Callable[[str], None]):
     import torch
     from transformers import CLIPModel, CLIPProcessor
 
-    eval_root = _run_eval_root(run)
-    items = _done_image_items(run, version_dir, eval_root)
-    references = _reference_paths(run, version_dir)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     # 统一下载中心：缺则下到项目 models/eval/clip/（不再隐式落 ~/.cache/huggingface）。
     from studio.services.models.downloader import ensure_eval_model
+
     local_dir = ensure_eval_model("clip", model_name, on_log=progress)
     progress(f"[eval-clip] loading CLIP on {device}")
     processor = CLIPProcessor.from_pretrained(str(local_dir))
     model = CLIPModel.from_pretrained(str(local_dir)).to(device)
     model.eval()
+    return model, processor, device
+
+
+def _default_scorer(
+    run: dict[str, Any],
+    version_dir: Path,
+    model_name: str,
+    progress: Callable[[str], None],
+    pool: eval_model_pool.ModelPool | None = None,
+) -> dict[str, Any]:
+    import numpy as np
+    import torch
+
+    eval_root = _run_eval_root(run)
+    items = _done_image_items(run, version_dir, eval_root)
+    references = _reference_paths(run, version_dir)
+    pool = pool if pool is not None else eval_model_pool.ModelPool("clip")
+    model, processor, device = pool.get(
+        model_name, lambda: _load_clip(model_name, progress),
+    )
 
     image_paths = [item["_image_path"] for item in items]
     prompts = [str(item.get("prompt") or "").strip() for item in items]
@@ -551,3 +565,21 @@ def _rel_to_version(version_dir: Path, path: Path) -> str:
         return path.resolve().relative_to(version_dir.resolve()).as_posix()
     except ValueError:
         return str(path)
+
+
+@contextlib.contextmanager
+def shared_scorer(progress: Callable[[str], None] | None = None):
+    """阶段级共享的 scorer：CLIP 只加载一次，跑完全部候选后释放。
+
+    `_stage_metric` 本来就是「一个指标跑完所有候选再换下一个」，但
+    `_default_scorer` 是旧模型（每候选一个子进程）留下的形状 —— 模型写在函数体里
+    加载，于是 200 个 checkpoint 就加载 200 次。池子交给调用方持有而不是放模块级
+    全局：全局状态会跨测试泄漏（成组跑时上一个用例的 tagger 被下一个复用）。
+
+    `run_*_job(scorer=None)` 独立调用时仍是「加载 → 用一次 → 返回即释放」，行为不变。
+    """
+    pool = eval_model_pool.ModelPool("clip")
+    try:
+        yield functools.partial(_default_scorer, pool=pool)
+    finally:
+        pool.release(progress)

--- a/studio/services/eval_dino.py
+++ b/studio/services/eval_dino.py
@@ -5,12 +5,14 @@ pairs. Heavy dependencies are imported only inside the default scorer.
 """
 from __future__ import annotations
 
+import functools
+import contextlib
 import json
 import time
 from pathlib import Path, PurePosixPath
 from typing import Any, Callable
 
-from . import eval_metrics, eval_samples
+from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
 
 JOB_KIND = "eval_dino"
@@ -242,11 +244,28 @@ def _int_or_none(value: Any) -> int | None:
         return None
 
 
+def _load_dino(model_name: str, progress: Callable[[str], None]):
+    import torch
+    from transformers import AutoImageProcessor, AutoModel
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    # 统一下载中心：缺则下到项目 models/eval/dino/（不再隐式落 ~/.cache/huggingface）。
+    from studio.services.models.downloader import ensure_eval_model
+
+    local_dir = ensure_eval_model("dino", model_name, on_log=progress)
+    progress(f"[eval-dino] loading DINO on {device}")
+    processor = AutoImageProcessor.from_pretrained(str(local_dir))
+    model = AutoModel.from_pretrained(str(local_dir)).to(device)
+    model.eval()
+    return model, processor, device
+
+
 def _default_scorer(
     run: dict[str, Any],
     version_dir: Path,
     model_name: str,
     progress: Callable[[str], None],
+    pool: eval_model_pool.ModelPool | None = None,
 ) -> dict[str, Any]:
     import numpy as np
     import torch
@@ -272,14 +291,10 @@ def _default_scorer(
             "dino_i_reason": "no paired reference/image pairs",
         }
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-    # 统一下载中心：缺则下到项目 models/eval/dino/（不再隐式落 ~/.cache/huggingface）。
-    from studio.services.models.downloader import ensure_eval_model
-    local_dir = ensure_eval_model("dino", model_name, on_log=progress)
-    progress(f"[eval-dino] loading DINO on {device}")
-    processor = AutoImageProcessor.from_pretrained(str(local_dir))
-    model = AutoModel.from_pretrained(str(local_dir)).to(device)
-    model.eval()
+    pool = pool if pool is not None else eval_model_pool.ModelPool("dino")
+    model, processor, device = pool.get(
+        model_name, lambda: _load_dino(model_name, progress),
+    )
 
     image_paths = [item["_image_path"] for item in paired_items]
     with torch.inference_mode():
@@ -454,3 +469,21 @@ def _rel_to_version(version_dir: Path, path: Path) -> str:
         return path.resolve().relative_to(version_dir.resolve()).as_posix()
     except ValueError:
         return str(path)
+
+
+@contextlib.contextmanager
+def shared_scorer(progress: Callable[[str], None] | None = None):
+    """阶段级共享的 scorer：DINO 只加载一次，跑完全部候选后释放。
+
+    `_stage_metric` 本来就是「一个指标跑完所有候选再换下一个」，但
+    `_default_scorer` 是旧模型（每候选一个子进程）留下的形状 —— 模型写在函数体里
+    加载，于是 200 个 checkpoint 就加载 200 次。池子交给调用方持有而不是放模块级
+    全局：全局状态会跨测试泄漏（成组跑时上一个用例的 tagger 被下一个复用）。
+
+    `run_*_job(scorer=None)` 独立调用时仍是「加载 → 用一次 → 返回即释放」，行为不变。
+    """
+    pool = eval_model_pool.ModelPool("dino")
+    try:
+        yield functools.partial(_default_scorer, pool=pool)
+    finally:
+        pool.release(progress)

--- a/studio/services/eval_model_pool.py
+++ b/studio/services/eval_model_pool.py
@@ -1,0 +1,69 @@
+"""指标模型的阶段级复用池。
+
+一次评估里，`_stage_metric` 的形状本来就是「一个指标跑完所有候选，再下一个指标」：
+
+    for runner in runners:            # clip → dino → ccip → tag
+        for cand in candidates:       # 候选 0..N
+            run_<runner>_job(...)
+
+但四个 runner 的 `_default_scorer` 是**旧模型**留下的：那时候「每个候选 × 每个指标
+= 一个独立子进程」，加载写在函数体里是唯一可能也是正确的形状 —— 反正进程马上就没
+了。合成一个 worker 进程之后，同一个 CLIP 就被反反复复加载 N 次（200 个 checkpoint
+= 200 次），纯属白花时间。
+
+这里给每个 runner 一个模型持有者：
+
+- **惰性**：仍在原来那个位置加载。dino / ccip 都有「没有配对参考图就早退」的分支在
+  加载之前，硬把加载提到阶段外会让本来不用加载的情形也加载。
+- **阶段级生命周期**：`_stage_metric` 在 finally 里 release，所以跑 DINO 时 CLIP
+  已经不在卡上了 —— 这也是不能用模块级 `lru_cache` 的原因（那会一直留到进程退出）。
+- **换 model_name 自动换**：key 不同就先释放旧的再加载新的。
+"""
+from __future__ import annotations
+
+import gc
+import logging
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ModelPool:
+    """一个 runner 的模型持有者。非线程安全 —— 指标阶段本来就是串行的。"""
+
+    def __init__(self, label: str) -> None:
+        self._label = label
+        self._key: Optional[str] = None
+        self._value: Any = None
+
+    @property
+    def loaded(self) -> bool:
+        return self._value is not None
+
+    def get(self, key: str, loader: Callable[[], Any]) -> Any:
+        """按 key 取；命中直接复用，未命中先释放旧的再 `loader()`。"""
+        if self._value is not None and self._key == key:
+            return self._value
+        self.release()
+        self._value = loader()
+        self._key = key
+        return self._value
+
+    def release(self, progress: Optional[Callable[[str], None]] = None) -> None:
+        """丢掉模型引用并把显存还给 caching allocator。未加载时是 no-op。"""
+        if self._value is None:
+            return
+        self._value = None
+        self._key = None
+        gc.collect()
+        try:
+            import torch
+
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+        except Exception:
+            # torch 没装 / CUDA 不可用都不该让评估失败 —— 引用已经丢了，
+            # 剩下的交给 GC
+            logger.debug("%s: empty_cache 跳过", self._label, exc_info=True)
+        if progress is not None:
+            progress(f"[eval-{self._label}] 模型已释放")

--- a/studio/services/eval_tag.py
+++ b/studio/services/eval_tag.py
@@ -7,10 +7,12 @@ caption 有意义。复用项目已下载的 WD14（零新模型），无参考�
 """
 from __future__ import annotations
 
+import contextlib
+import functools
 from pathlib import Path
 from typing import Any, Callable
 
-from . import eval_metrics, eval_samples
+from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
 
 JOB_KIND = "eval_tag"
@@ -239,23 +241,30 @@ def _mean(values: list[float]) -> float | None:
 # ---------------------------------------------------------------------------
 
 
-def _default_scorer(
-    run: dict[str, Any],
-    version_dir: Path,
-    model_name: str,
-    progress: Callable[[str], None],
-) -> dict[str, Any]:
+def _load_tagger(progress: Callable[[str], None]):
     from studio.services.tagging.wd14 import WD14Tagger
-
-    eval_root = _run_eval_root(run)
-    items = _done_image_items(run, version_dir, eval_root)
 
     tagger = WD14Tagger()
     ok, msg = tagger.is_available()
     if not ok:
         raise EvalTagError(f"WD14 模型不可用：{msg}")
+    progress("[eval-tag] loading WD14")
     tagger.prepare()
-    known = {_norm_tag(t) for t in tagger.known_tags()}
+    return tagger, {_norm_tag(t) for t in tagger.known_tags()}
+
+
+def _default_scorer(
+    run: dict[str, Any],
+    version_dir: Path,
+    model_name: str,
+    progress: Callable[[str], None],
+    pool: eval_model_pool.ModelPool | None = None,
+) -> dict[str, Any]:
+    eval_root = _run_eval_root(run)
+    items = _done_image_items(run, version_dir, eval_root)
+
+    pool = pool if pool is not None else eval_model_pool.ModelPool("tag")
+    tagger, known = pool.get(model_name, lambda: _load_tagger(progress))
 
     # 只保留有「WD14 词表内 prompt tag」的样本（触发词等不在词表→不计分母）
     scored_items: list[tuple[dict[str, Any], set[str]]] = []
@@ -292,3 +301,22 @@ def _default_scorer(
             if recalls else "no taggable generated images"
         ),
     }
+
+
+@contextlib.contextmanager
+def shared_scorer(progress: Callable[[str], None] | None = None):
+    """阶段级共享的 scorer：WD14 tagger 只加载一次，跑完全部候选后释放。
+
+    `_stage_metric` 本来就是「一个指标跑完所有候选再换下一个」，但
+    `_default_scorer` 是旧模型（每候选一个子进程）留下的形状 —— 模型写在函数体里
+    加载，于是 200 个 checkpoint 就重建 200 次 onnx session。池子交给调用方持有而
+    不是放模块级全局：全局状态会跨测试泄漏（成组跑时上一个用例的 tagger 被下一个
+    复用）。
+
+    `run_tag_job(scorer=None)` 独立调用时仍是「加载 → 用一次 → 返回即释放」，行为不变。
+    """
+    pool = eval_model_pool.ModelPool("tag")
+    try:
+        yield functools.partial(_default_scorer, pool=pool)
+    finally:
+        pool.release(progress)

--- a/studio/workers/eval_session_worker.py
+++ b/studio/workers/eval_session_worker.py
@@ -42,12 +42,32 @@ from studio.services.projects import projects, versions
 
 logger = logging.getLogger(__name__)
 
-# runner key → (跑它的函数, 从 secrets 取默认模型名的取值器)
-_RUNNERS: dict[str, tuple[Callable[..., dict[str, Any]], Callable[[Any], str]]] = {
-    "clip": (eval_clip.run_clip_job, lambda cfg: cfg.clip_model_name),
-    "dino": (eval_dino.run_dino_job, lambda cfg: cfg.dino_model_name),
-    "tag": (eval_tag.run_tag_job, lambda _cfg: eval_tag.DEFAULT_MODEL_NAME),
-    "ccip": (eval_ccip.run_ccip_job, lambda cfg: cfg.ccip_model_name),
+# runner key → (跑它的函数, 从 secrets 取默认模型名的取值器, 阶段级共享 scorer)
+#
+# 第三项是「模型只加载一次」的关键：`_stage_metric` 本来就是「一个指标跑完所有候选
+# 再换下一个」，但 run_*_job 每次调用都自己加载一遍模型（旧模型每候选一个子进程时
+# 的正确形状）。`shared_scorer` 把模型的生命周期提到阶段上，跑完即释放 —— 跟出图那
+# 刀（#470）同构，只是小一号。
+_RUNNERS: dict[
+    str,
+    tuple[Callable[..., dict[str, Any]], Callable[[Any], str], Callable[..., Any]],
+] = {
+    "clip": (
+        eval_clip.run_clip_job, lambda cfg: cfg.clip_model_name,
+        eval_clip.shared_scorer,
+    ),
+    "dino": (
+        eval_dino.run_dino_job, lambda cfg: cfg.dino_model_name,
+        eval_dino.shared_scorer,
+    ),
+    "tag": (
+        eval_tag.run_tag_job, lambda _cfg: eval_tag.DEFAULT_MODEL_NAME,
+        eval_tag.shared_scorer,
+    ),
+    "ccip": (
+        eval_ccip.run_ccip_job, lambda cfg: cfg.ccip_model_name,
+        eval_ccip.shared_scorer,
+    ),
 }
 
 
@@ -266,7 +286,7 @@ def _stage_metric(
     if spec is None:
         progress(f"[metric:{runner}] 未知 runner，跳过")
         return
-    run_fn, model_getter = spec
+    run_fn, model_getter, shared_scorer = spec
     model_name = model_getter(secrets.load().eval_metrics)
     metric_keys = eval_registry.runner_metrics(runner)
     eval_root = eval_session.samples_root(session_id)
@@ -277,6 +297,31 @@ def _stage_metric(
         candidates = eval_session.list_candidates(conn, session_id)
         existing = eval_session.list_metric_results(conn, session_id)
 
+    # 模型在这里加载一次、跑完全部候选后释放（惰性：真正要打分时才 load，所以
+    # 「候选全跳过」的情形一次都不加载）
+    with shared_scorer(progress) as scorer:
+        _score_candidates(
+            session_id, runner, candidates, existing, scorer, run_fn,
+            project, version, vdir, eval_root, model_name, metric_keys, stage, progress,
+        )
+
+
+def _score_candidates(
+    session_id: int,
+    runner: str,
+    candidates: list[dict[str, Any]],
+    existing: dict[int, list[dict[str, Any]]],
+    scorer: Any,
+    run_fn: Callable[..., dict[str, Any]],
+    project: dict[str, Any],
+    version: dict[str, Any],
+    vdir: Path,
+    eval_root: Path,
+    model_name: str,
+    metric_keys: list[str],
+    stage: str,
+    progress: Callable[[str], None],
+) -> None:
     for cand in candidates:
         cid = int(cand["id"])
         label = f"{cand['role']}#{cand['ordinal']}"
@@ -300,6 +345,7 @@ def _stage_metric(
             progress(f"[{stage}] {label} run={run_id}")
             saved = run_fn(
                 project, version, vdir, run_id,
+                scorer=scorer,
                 model_name=model_name, on_progress=progress, eval_root=eval_root,
             )
             _record_metrics(cid, metric_keys, saved, model_name)

--- a/tests/test_eval_model_pool.py
+++ b/tests/test_eval_model_pool.py
@@ -1,0 +1,143 @@
+"""指标模型的阶段级复用（`eval_model_pool` + 各 runner 的 `shared_scorer`）。
+
+`_stage_metric` 的形状本来就是「一个指标跑完所有候选再换下一个」，但 run_*_job 里
+的 `_default_scorer` 是旧模型（每候选一个子进程）留下的：模型写在函数体里加载，于是
+200 个 checkpoint 就加载 200 次。这里锁住修好之后的不变量。
+"""
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+import pytest
+
+from studio.services import eval_ccip, eval_clip, eval_dino, eval_model_pool, eval_tag
+
+
+def test_pool_reuses_on_hit_and_reloads_on_key_change() -> None:
+    pool = eval_model_pool.ModelPool("probe")
+    loads: list[str] = []
+
+    def _load(name: str):
+        loads.append(name)
+        return {"name": name}
+
+    assert pool.get("a", lambda: _load("a"))["name"] == "a"
+    assert pool.get("a", lambda: _load("a"))["name"] == "a"
+    assert loads == ["a"], "同 key 必须复用，不能重新加载"
+
+    # 换模型名 → 先释放旧的再加载新的
+    assert pool.get("b", lambda: _load("b"))["name"] == "b"
+    assert loads == ["a", "b"]
+
+
+def test_pool_release_is_idempotent_and_forgets_the_handle() -> None:
+    pool = eval_model_pool.ModelPool("probe")
+    pool.get("a", lambda: object())
+    assert pool.loaded
+
+    pool.release()
+    assert not pool.loaded
+    pool.release()  # 再调一次是 no-op，不该抛
+
+    loads: list[int] = []
+    pool.get("a", lambda: loads.append(1) or object())
+    assert loads == [1], "release 之后同 key 也要重新加载"
+
+
+def test_release_reports_through_progress() -> None:
+    pool = eval_model_pool.ModelPool("clip")
+    pool.get("a", lambda: object())
+    lines: list[str] = []
+    pool.release(lines.append)
+    assert any("释放" in line for line in lines)
+    # 没加载过时不该刷无意义的日志
+    lines.clear()
+    eval_model_pool.ModelPool("clip").release(lines.append)
+    assert lines == []
+
+
+@pytest.mark.parametrize(
+    "module, label",
+    [
+        (eval_clip, "clip"),
+        (eval_dino, "dino"),
+        (eval_ccip, "ccip"),
+        (eval_tag, "tag"),
+    ],
+)
+def test_shared_scorer_loads_once_across_candidates(
+    module: Any, label: str, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """一个阶段内跑 N 个候选，模型只 load 一次；阶段结束释放。"""
+    loads: list[str] = []
+    loader_name = {
+        "clip": "_load_clip", "dino": "_load_dino",
+        "ccip": "_load_ccip", "tag": "_load_tagger",
+    }[label]
+
+    def _fake_load(*_a, **_kw):
+        loads.append(label)
+        return ("handle",) * 5  # 各 runner 解包元数不同，给足
+
+    monkeypatch.setattr(module, loader_name, _fake_load)
+
+    with module.shared_scorer() as scorer:
+        # scorer 是绑好 pool 的 _default_scorer；直接驱动它的取模型那一步
+        pool = scorer.keywords["pool"]
+        for _ in range(5):
+            pool.get("m", lambda: _fake_load())
+        assert loads == [label], "阶段内应只加载一次"
+        assert pool.loaded
+
+    assert not pool.loaded, "阶段结束必须释放，否则跑下一个指标时它还占着卡"
+
+
+def test_default_scorer_actually_uses_the_injected_pool(
+    tmp_path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """接缝本身：`_default_scorer(pool=...)` 必须从传进来的池子取模型。
+
+    上面那些只验了池子的行为；这条验的是 run_*_job → _default_scorer 这一段真的把
+    模型取自阶段级池子 —— 断了的话「加载一次」就退化回「每候选一次」，而且没有任何
+    测试会红。
+
+    取模型之前的几步（读 run / 找图 / 找参考图）与本主张无关，一并打掉。
+    """
+    loads: list[int] = []
+    monkeypatch.setattr(eval_clip, "_run_eval_root", lambda _run: None)
+    monkeypatch.setattr(eval_clip, "_done_image_items", lambda *_a, **_kw: [])
+    monkeypatch.setattr(eval_clip, "_reference_paths", lambda *_a, **_kw: {})
+    monkeypatch.setattr(
+        eval_clip, "_load_clip",
+        lambda *_a, **_kw: loads.append(1) or (object(), object(), "cpu"),
+    )
+    # 取模型**之后**的打分与落盘同样与本主张无关
+    import torch
+
+    empty = torch.zeros((0, 4))
+    monkeypatch.setattr(eval_clip, "_encode_images", lambda *_a, **_kw: empty)
+    monkeypatch.setattr(eval_clip, "_encode_texts", lambda *_a, **_kw: empty)
+    monkeypatch.setattr(eval_clip, "_write_cache_metadata", lambda *_a, **_kw: None)
+
+    pool = eval_model_pool.ModelPool("clip")
+    # 同一个池子连跑两次 = 两个候选
+    for _ in range(2):
+        eval_clip._default_scorer(
+            {"run_id": "r1"}, tmp_path, "m", lambda _l: None, pool=pool,
+        )
+
+    assert loads == [1], "第二个候选必须复用池子里的模型"
+    assert pool.loaded, "模型该留在池子里等下一个候选，由阶段结束时统一释放"
+
+
+@pytest.mark.parametrize(
+    "module", [eval_clip, eval_dino, eval_ccip, eval_tag],
+)
+def test_standalone_job_still_gets_a_fresh_pool(module: Any) -> None:
+    """`run_*_job(scorer=None)` 独立调用时行为不变：自己的一次性池，用完即散。
+
+    没有模块级全局池 —— 那会跨测试泄漏（成组跑时上一个用例的模型被下一个复用），
+    也会让模型一直留到进程退出、跑下一个指标时仍占着显存。
+    """
+    assert not hasattr(module, "_POOL"), "不该有模块级全局池"

--- a/tests/test_eval_session_worker.py
+++ b/tests/test_eval_session_worker.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+import contextlib
+
 import pytest
 
 from studio import db, secrets
@@ -99,6 +101,16 @@ class _NoopGenerator:
         raise AssertionError("测试不该走到真的 daemon 出图")
 
 
+@contextlib.contextmanager
+def _noop_shared_scorer(_progress=None):
+    """替掉真的 shared_scorer：假 runner 不需要模型，也绝不能去加载。
+
+    真实现会在这里 load CLIP / DINO / WD14；测试里必须是 no-op，否则每个用例都要
+    下模型、进 CUDA（CI 无 GPU）。yield None = 让 run_fn 走它自己的 scorer 参数。
+    """
+    yield None
+
+
 @pytest.fixture
 def fake_generate(monkeypatch: pytest.MonkeyPatch):
     """让 run_sample_job 走假 generator（真签名、真 run.json 写入）。"""
@@ -141,10 +153,12 @@ def fake_metrics(monkeypatch: pytest.MonkeyPatch):
         return _metric_states(dino_i=0.6)
 
     monkeypatch.setitem(
-        worker._RUNNERS, "clip", (fake_clip, lambda _cfg: "fake-clip")
+        worker._RUNNERS, "clip",
+        (fake_clip, lambda _cfg: "fake-clip", _noop_shared_scorer)
     )
     monkeypatch.setitem(
-        worker._RUNNERS, "dino", (fake_dino, lambda _cfg: "fake-dino")
+        worker._RUNNERS, "dino",
+        (fake_dino, lambda _cfg: "fake-dino", _noop_shared_scorer)
     )
     return calls
 
@@ -333,8 +347,8 @@ def test_metric_failure_is_isolated_to_that_runner(
     def bad_dino(project_, version_, vdir_, run_id, **kw):
         raise RuntimeError("dino model missing")
 
-    monkeypatch.setitem(worker._RUNNERS, "clip", (ok_clip, lambda _c: "fake-clip"))
-    monkeypatch.setitem(worker._RUNNERS, "dino", (bad_dino, lambda _c: "fake-dino"))
+    monkeypatch.setitem(worker._RUNNERS, "clip", (ok_clip, lambda _c: "fake-clip", _noop_shared_scorer))
+    monkeypatch.setitem(worker._RUNNERS, "dino", (bad_dino, lambda _c: "fake-dino", _noop_shared_scorer))
 
     assert worker.run(int(session["task_id"])) == 0
 
@@ -366,7 +380,7 @@ def test_runner_not_run_status_is_recorded_verbatim(
             }
         }
 
-    monkeypatch.setitem(worker._RUNNERS, "clip", (skipping_clip, lambda _c: "m"))
+    monkeypatch.setitem(worker._RUNNERS, "clip", (skipping_clip, lambda _c: "m", _noop_shared_scorer))
 
     worker.run(int(session["task_id"]))
 
@@ -396,7 +410,7 @@ def test_runner_gets_model_name_from_settings(
         return _metric_states(clip_t=0.05, clip_i=0.7)
 
     real_getter = worker._RUNNERS["clip"][1]
-    monkeypatch.setitem(worker._RUNNERS, "clip", (spy_clip, real_getter))
+    monkeypatch.setitem(worker._RUNNERS, "clip", (spy_clip, real_getter, _noop_shared_scorer))
 
     assert worker.run(int(session["task_id"])) == 0
 


### PR DESCRIPTION
承接 #470。#470 把**底模**的生命周期提到出图阶段上（一次评估只加载一次），指标那侧的同款问题留着没动 —— 这个 PR 收掉它。

## 背景 / 动机

`_stage_metric` 的编排本来就是对的：

```python
for runner in runners:          # clip → dino → ccip → tag
    for cand in candidates:     # 候选 0..N
        run_<runner>_job(...)
```

问题在**再下一层**。四个 runner 的 `_default_scorer` 把模型加载写在函数体里（[eval_clip.py](studio/services/eval_clip.py) / [eval_dino.py](studio/services/eval_dino.py) / [eval_ccip.py](studio/services/eval_ccip.py) / [eval_tag.py](studio/services/eval_tag.py)），每次调用都从头来一遍。

那是**旧模型**留下的正确形状 —— 那时「每个候选 × 每个指标 = 一个独立子进程」，加载写在哪都一样，进程马上就退出。#465 把编排合成一个 worker 进程时明确写了「首版复用，不改算法」（ADR 0011 Addendum），于是这四个叶子原样留了下来。

真机日志（6 个候选）：

```
[eval-clip] loading CLIP on cuda      × 6
[eval-dino] loading DINO on cuda      × 6
[eval-ccip] loading CCIP onnx         × 6
```

不是泄漏 —— 每次函数返回靠引用计数释放，显存回到 torch 的 caching allocator 被下次复用。但 200 个 checkpoint 就是 200 次 CLIP + 200 次 DINO + 200 次 ONNX 会话重建，纯属白花时间。

## 改动概要

**`eval_model_pool.ModelPool`** —— 一个 runner 的模型持有者：

- **惰性**：仍在原来那个位置加载。dino / ccip 都有「没有配对参考图就早退」的分支**在加载之前**，硬把加载提到阶段外会让本来不用加载的情形也加载
- **换 model_name 自动换**：key 不同就先释放旧的再加载新的
- **release**：丢引用 + `gc.collect()` + `empty_cache()`

**每个 runner 加 `shared_scorer()` context manager**，`_default_scorer` 多一个可选 `pool` 参数。复用了本来就在的 `scorer` 注入口，没有新增接缝。

**`_stage_metric` 持有它跑完全部候选，`finally` 释放** —— 所以跑 DINO 时 CLIP 已经不在卡上了。这也是不能用模块级 `lru_cache` 的原因（那会一直留到进程退出，比现在更差）。

**池子由调用方持有，不放模块级全局**：第一版就是写成模块级 `_POOL` 的，立刻被测试抓到跨用例泄漏 —— 成组跑时上一个用例的 tagger 被下一个复用，单跑却是绿的。改成调用方持有之后这类问题从根上没了。

**`run_*_job(scorer=None)` 独立调用行为不变**：自己开一次性池，用完即散，与改造前逐字等价。

## 测试方式

新增 [`tests/test_eval_model_pool.py`](tests/test_eval_model_pool.py)（12 个）：

- 池子：同 key 复用 / 换 key 重载 / release 幂等且忘掉句柄 / release 后同 key 重新加载 / 没加载过时不刷日志
- 四个 runner 各自：一个阶段内跑 5 个候选只 load 一次、阶段结束必须 release（否则跑下一个指标时还占着卡）
- **接缝本身**：`_default_scorer(pool=...)` 真的从传进来的池子取模型 —— 断了的话「加载一次」会静默退化回「每候选一次」，其它测试都不会红
- 四个模块都不许有模块级 `_POOL`（锁住上面那个教训）

`test_eval_session_worker.py` 的 `_RUNNERS` 替换点跟到三元组，并加了 no-op 的 `shared_scorer`（假 runner 不需要模型，也绝不能去加载 —— CI 无 GPU）。

```
pytest -k "eval or daemon or inference or queue or supervisor"   474 passed
pytest test_route_snapshot.py test_studio_configs.py              33 passed
ruff check .                                                     All checks passed
四个 runner 的测试单跑 / 成组分别跑过（成组是发现全局池泄漏的那一跑）
```

无前端改动。

## 真机验证（已完成）

anima 项目、6 个候选（5 checkpoint + baseline）× 4 张验证图，`session=5 status=done metrics_done=30`：

| 指标 | 加载次数 | 释放 |
|---|---|---|
| CLIP | `loading CLIP on cuda` × **1**（checkpoint#0） | `[eval-clip] 模型已释放` |
| DINO | `loading DINO on cuda` × **1** | `[eval-dino] 模型已释放` |
| CCIP | `loading CCIP onnx` × **1** | `[eval-ccip] 模型已释放` |
| WD14 | `loading WD14` × **1** | `[eval-tag] 模型已释放` |

后面 5 个候选直接进 `encoding` / `extracting` / `tagging`，没有再加载。释放都落在该指标阶段末尾、下一个指标开始之前 —— 「跑 DINO 时 CLIP 已经不在卡上」成立。

对比修复前（同规模的 session 4）：`loading CLIP on cuda` 出现 6 次、DINO 6 次、CCIP 6 次。

**收益随 checkpoint 数线性放大**：6 个候选省的是秒级（这些模型都不大），200 个 checkpoint 省的是 199 次 CLIP + 199 次 DINO + 199 次 ONNX 会话重建。
