### PR TITLE
fix(ui): 将 attention backend 的 none 显示为 SDPA

### DIFF
--- a/docs/user-guide/training-tips.md
+++ b/docs/user-guide/training-tips.md
@@ -281,7 +281,7 @@ LoRA 参数全精度——kohya / musubi 生态的 `fp8_base` 语义）：
 | `sample_sampler_name` / `sample_scheduler` | `euler` / `simple` | 与 ComfyUI 里挂 Krea 2 模型时选的 **euler + simple** 逐字对应 |
 | `sample_infer_steps` / `sample_cfg_scale` | 28 / 4.5 | Raw 官方口径 |
 | `text_encoder_cache` | `true` | 训练开始先把全部 caption 预编码成缓存、随即释放 Qwen3-VL（省约 9 GB 显存）；关闭则 TE 常驻在线编码（适合大显存、小磁盘的云端） |
-| `attention_backend` | `none`（PyTorch SDPA） | Krea 2 加载器固定 SDPA |
+| `attention_backend` | SDPA（配置值为 `none`） | Krea 2 加载器固定 SDPA |
 | `shuffle_caption` / `keep_tokens` / `tag_dropout` | 关闭 | tag 生态操作对自然语言 caption 不适用 |
 
 **能力差异**：NaViT 打包、SRA、LeapAlign、compile_blocks 为仅 Anima 功能（Krea 2 下自动隐藏）；

--- a/studio/domain/generate.py
+++ b/studio/domain/generate.py
@@ -105,7 +105,7 @@ class GenerateConfig(BaseModel):
     )
     attention_backend: AttentionBackend = Field(
         "flash_attn",
-        description="Attention backend：none（SDPA）/ xformers / flash_attn",
+        description="Attention backend：SDPA / xFormers / Flash Attention",
     )
     blocks_to_swap: int = Field(
         0, ge=0,

--- a/studio/domain/reg.py
+++ b/studio/domain/reg.py
@@ -59,7 +59,7 @@ class RegAiConfig(BaseModel):
     mixed_precision: str = Field("bf16")
     attention_backend: AttentionBackend = Field(
         "flash_attn",
-        description="Attention backend：none（SDPA）/ xformers / flash_attn",
+        description="Attention backend：SDPA / xFormers / Flash Attention",
     )
 
     @model_validator(mode="after")

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -923,7 +923,7 @@ class TrainingConfig(BaseModel):
 
     attention_backend: AttentionBackend = Field(
         "flash_attn",
-        description="Attention 后端。none = PyTorch SDPA 默认；xformers 显存更省；flash_attn 最快（需 Ampere+ GPU 支持）",
+        description="Attention 后端。SDPA 由 PyTorch 自动选择可用实现；xFormers 显存更省；Flash Attention 最快（需 Ampere+ GPU 支持）",
         json_schema_extra=_meta(
             "system",
             disable_when="navit_packing==true",

--- a/studio/web/src/components/Field.test.tsx
+++ b/studio/web/src/components/Field.test.tsx
@@ -209,6 +209,35 @@ describe('Field number input (PP10.3)', () => {
   })
 })
 
+describe('Field attention backend select', () => {
+  it('shows SDPA while preserving the compatible none value', async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    const prop: SchemaProperty = {
+      type: 'string',
+      enum: ['none', 'xformers', 'flash_attn'],
+      default: 'none',
+      group: 'misc',
+      control: 'select',
+      description: '',
+    }
+
+    render(
+      <Field
+        name="attention_backend"
+        prop={prop}
+        value="xformers"
+        onChange={onChange}
+      />,
+    )
+
+    const option = screen.getByRole('option', { name: 'SDPA' })
+    expect(option).toHaveValue('none')
+    await user.selectOptions(screen.getByRole('combobox'), option)
+    expect(onChange).toHaveBeenCalledWith('none')
+  })
+})
+
 const stringListProp: SchemaProperty = {
   type: 'array',
   items: { type: 'string' },

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -349,7 +349,7 @@
         "no": "No mixed precision"
       },
       "attentionBackend": {
-        "none": "PyTorch SDPA",
+        "none": "SDPA",
         "xformers": "xFormers",
         "flashAttn": "Flash Attention"
       },
@@ -491,7 +491,7 @@
       "leap_traj_sim_min": "[LeapAlign] Lower bound τ for trajectory similarity weighting: prevents nearly-identical jump pairs from being over-amplified by 1/d. Smaller = more aggressive. Typical 0.05-0.2",
       "grad_clip_max_norm": "Max gradient norm: when the step's total gradient norm exceeds this value, rescale it down to this value to prevent a single outlier step from blowing up the model. Default 1.0 fits most cases; lower to 0.5 if bf16+DoRA/LoKr is unstable; 0 disables.",
       "mixed_precision": "Training precision. bf16 recommended (same dynamic range as fp32, stable); fp16 has the same memory footprint but smaller dynamic range and is prone to gradient overflow; no = fp32, most stable but doubles VRAM",
-      "attention_backend": "Attention backend. none = PyTorch SDPA (default fallback); xformers saves more VRAM; flash_attn is fastest (requires Ampere+ GPU)",
+      "attention_backend": "Attention backend. SDPA lets PyTorch automatically select an available implementation; xFormers saves more VRAM; Flash Attention is fastest (requires Ampere+ GPU)",
       "num_workers": "Data loading worker threads; larger = faster loading but more RAM usage. Must be 0 on Windows",
       "output_dir": "Output directory",
       "output_name": "Output filename prefix",
@@ -1226,7 +1226,7 @@
     "install": "Install",
     "confirmInstallXformers": "xformers will be installed with pip using the PyTorch index URL matching the current torch+cu.\nInstallation can take several to tens of minutes; restart Studio after installation. Continue?",
     "xformersSubtitle": "attention acceleration (mutually exclusive with Flash Attention)",
-    "xformersHelp1": "xformers and Flash Attention are <strong>mutually exclusive</strong>; each training / generation task chooses one <code>attention_backend</code> value (none / xformers / flash_attn).",
+    "xformersHelp1": "xFormers and Flash Attention are <strong>mutually exclusive</strong>; each training / generation task chooses one <code>attention_backend</code> value (SDPA / xFormers / Flash Attention).",
     "xformersHelp2": "xformers is more broadly compatible (sm_70+), while flash_attn is faster (sm_80+ Ampere and newer).",
     "xformersHelp3": "Install failures usually mean upstream PyPI / PyTorch index has no wheel for this torch+cu combination (common for 5090 / new GPUs). The button toast shows the tail of stderr; use it to downgrade torch or wait for upstream coverage.",
     "reinstallAutoMatchPlain": "Reinstall (auto match)",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -349,7 +349,7 @@
         "no": "不使用"
       },
       "attentionBackend": {
-        "none": "PyTorch SDPA",
+        "none": "SDPA",
         "xformers": "xFormers",
         "flashAttn": "Flash Attention"
       },
@@ -491,7 +491,7 @@
       "leap_traj_sim_min": "【LeapAlign】轨迹相似度加权下限 τ：防止近乎相同的跳跃对被 1/d 过度放大。越小越激进。典型 0.05-0.2",
       "grad_clip_max_norm": "梯度范数上限：本步所有可训练参数的梯度总范数超过该值时按比例缩到该值，防止单步极端梯度把模型推飞。默认 1.0 适合绝大多数场景；bf16+DoRA/LoKr 不稳可降到 0.5；0=禁用。",
       "mixed_precision": "训练精度。bf16 推荐（与 fp32 同动态范围、稳定）；fp16 同显存但动态范围小、梯度易溢出；no 用 fp32 最稳但显存翻倍",
-      "attention_backend": "Attention 后端。none = PyTorch SDPA 默认；xformers 显存更省；flash_attn 最快（需 Ampere+ GPU 支持）",
+      "attention_backend": "Attention 后端。SDPA 由 PyTorch 自动选择可用实现；xFormers 显存更省；Flash Attention 最快（需 Ampere+ GPU 支持）",
       "num_workers": "数据加载并行线程数；越大加载越快但内存占用上升。Windows 必须填 0",
       "output_dir": "输出目录",
       "output_name": "输出文件名前缀",
@@ -1226,7 +1226,7 @@
     "install": "安装",
     "confirmInstallXformers": "将 pip install xformers，按当前 torch+cu 选 PyTorch index URL。\n装包几分钟到十几分钟，装完后必须重启 Studio。继续？",
     "xformersSubtitle": "attention 加速（与 Flash Attention 二选一）",
-    "xformersHelp1": "xformers 与 Flash Attention <strong>互斥</strong>，每个训练 / 出图任务的 <code>attention_backend</code> 字段三选一（无 / xformers / flash_attn）。",
+    "xformersHelp1": "xFormers 与 Flash Attention <strong>互斥</strong>，每个训练 / 出图任务的 <code>attention_backend</code> 字段三选一（SDPA / xFormers / Flash Attention）。",
     "xformersHelp2": "xformers 泛用性更广（支持 sm_70+），flash_attn 性能更高（sm_80+ Ampere 起）。",
     "xformersHelp3": "装失败多数是上游 PyPI / PyTorch index 没出对应 torch+cu 组合的 wheel（5090 / 新 GPU 常见）。失败时按钮 toast 会显示 stderr 末尾，可根据提示降 torch 版本或等上游覆盖。",
     "reinstallAutoMatchPlain": "重装（自动匹配）",


### PR DESCRIPTION
## 背景

关联 #467。

`attention_backend: none` 实际走的是 PyTorch SDPA，但 UI 直接暴露内部枚举值容易让用户误以为没有启用 attention backend。根因是内部兼容值 `none` 与用户可见语义混在了一起。

## 改动概要

- 中英文 UI 将 `none` 选项显示为 `SDPA`
- 帮助说明明确 SDPA 由 PyTorch 自动选择可用实现
- 同步训练、生成、正则配置的 schema 描述以及用户指南
- 添加回归测试，锁定“显示 `SDPA`、提交值仍为 `none`”

## 用户 / 开发者影响

- 用户不再看到容易误解的 `none` 选项
- 内部枚举、YAML 值和运行时路径均未改变，现有配置及 preset 保持兼容
- 本 PR 不增加或强制 memory-efficient attention 路径；相关策略留待出现明确 user case 后单独评估

## 测试

- `npx vitest run`：64 files / 554 tests passed
- `npm run lint` 等价检查：0 errors（2 个与本 PR 无关的既有 Hooks warnings）
- `npx tsc --noEmit`：passed
- 前端生产构建：passed
- `python -m ruff check .`：passed
- `python -m pytest tests/test_route_snapshot.py tests/test_studio_configs.py -q`：33 passed
- 本地 Studio 预设页视觉校验：`Attention Backend` 显示为 `SDPA`，说明文字正确，底层值仍为 `none`

## 截图

<!-- visual-verification-screenshot -->
