### PR TITLE
fix(generate): 双开 server 不再删活实例的出图 cache（单实例锁 + put 自愈）

### DIFF
--- a/studio/api/lifespan.py
+++ b/studio/api/lifespan.py
@@ -111,6 +111,23 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
     # 装 shutdown 取消 SSE 连接时的 CancelledError 日志过滤器（详见 class docstring）
     _install_uvicorn_cancelled_asgi_filter()
 
+    # 单实例锁：必须在一切破坏性启动副作用（db migration、startup_clean rmtree
+    # 活 session 目录……）之前。uvicorn 先跑 lifespan 后 bind 端口 —— 双开时
+    # 注定 bind 失败的实例没有这把锁会先把活 server 的 cache 目录清掉再死
+    # （2026-07-28 丢图 root cause）。锁随进程退出自动释放，无 stale 问题。
+    from ..infrastructure.paths import STUDIO_DATA
+    from ..infrastructure.single_instance import LOCK_FILENAME, SingleInstanceLock
+    instance_lock = SingleInstanceLock(STUDIO_DATA / LOCK_FILENAME)
+    if not instance_lock.acquire():
+        logger.error(
+            "another Studio server is already running for %s; "
+            "refusing to start (close the other instance first)", STUDIO_DATA,
+        )
+        raise RuntimeError(
+            f"another Studio server is already running for {STUDIO_DATA}; "
+            "close the other instance first"
+        )
+
     # PR-5：从 server.py 顶层搬来的 import-time 副作用 —— 现在跟随 app 启动
     # 才落盘，便于测试 / 工具 import 而不写文件系统。
     ensure_dirs()
@@ -121,7 +138,6 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
     from ..services.inference import disk_cache as generate_cache
     from ..services import models as _md
     from ..services import system_stats
-    from ..infrastructure.paths import STUDIO_DATA
     cleanup_stale_generate_tempdirs()
 
     # 加密磁盘 cache 初始化：startup_clean 清掉残留 session-* 目录（上次 SIGKILL
@@ -232,3 +248,5 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
         # shutdown 清整个 session 目录 + 进程退出 aes_key 一起没（即便 rmtree
         # 失败，残留文件无 key 也是乱字节，下次启动 startup_clean 兜底）
         generate_cache.clear_all()
+        # 最后放单实例锁（启动中途 raise 不经这里没关系：锁随进程退出自动释放）
+        instance_lock.release()

--- a/studio/infrastructure/single_instance.py
+++ b/studio/infrastructure/single_instance.py
@@ -1,0 +1,85 @@
+"""studio_data 单实例锁 —— 防第二个 server 进程对同一份数据执行破坏性启动清理。
+
+背景（2026-07-28 定案的丢图 root cause）：uvicorn 是**先跑完 lifespan、之后才
+bind 端口**。用户双开 `python -m studio` 时，注定 bind 失败的那个实例在死掉之前
+已经把 lifespan 里的破坏性清理跑了一遍 —— `disk_cache.startup_clean` 会 rmtree
+掉活 server 正在用的 cache session 目录，从那一刻起活 server 每张出图都丢。
+db migration 等其余启动副作用同样不该在两个进程间并发。
+
+所以独占的单位是 **studio_data 目录**（真正要保护的资源），不是端口：lifespan
+一进来就抢 `studio_data/.server.lock`，抢不到立刻 raise，让第二个实例在执行任何
+破坏性操作**之前**退出。
+
+机制：OS 级文件区域锁（Windows `msvcrt.locking` / POSIX `fcntl.flock`），随进程
+退出（含 SIGKILL / 断电）自动释放，没有 stale lock 问题 —— 这是不用「写 pid 进
+lock 文件再判活」方案的原因。lock 文件本身 0 字节、不删除（Windows 上删除与
+下次 open 有竞态，留着无害）。
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import IO, Optional
+
+logger = logging.getLogger(__name__)
+
+LOCK_FILENAME = ".server.lock"
+
+
+class SingleInstanceLock:
+    """一个 lock 文件的独占句柄。acquire 失败 = 别的进程正持有。
+
+    单次使用：acquire() → （进程生命周期）→ release()。release 后可以再
+    acquire（测试用）；同一实例重复 acquire 而不 release 是使用错误。
+    """
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self._handle: Optional[IO[bytes]] = None
+
+    def acquire(self) -> bool:
+        """非阻塞抢锁。True=拿到；False=已被其他进程（或其他句柄）持有。"""
+        if self._handle is not None:
+            raise RuntimeError("lock already acquired by this instance")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        # "a+b" 不截断已有文件；并发 open 同一路径是安全的，独占靠区域锁
+        handle = open(self.path, "a+b")
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                # 锁首字节。文件是 0 字节也允许（Windows 区域锁可超出 EOF）
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            handle.close()
+            return False
+        self._handle = handle
+        return True
+
+    def release(self) -> None:
+        """释放并关闭句柄。未持有时 no-op（shutdown 路径容错）。"""
+        handle = self._handle
+        if handle is None:
+            return
+        self._handle = None
+        try:
+            if os.name == "nt":
+                import msvcrt
+
+                handle.seek(0)
+                msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+            else:
+                import fcntl
+
+                fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            # close() 也会随句柄释放锁；这里失败不影响正确性
+            logger.warning("unlock failed for %s", self.path, exc_info=True)
+        finally:
+            handle.close()

--- a/studio/services/inference/disk_cache.py
+++ b/studio/services/inference/disk_cache.py
@@ -132,6 +132,10 @@ class SessionCache:
 
         file_id = uuid.uuid4().hex
         file_path = self.session_dir / f"{file_id}.bin"
+        # 自愈：session 目录可能被外部整个删掉（另一进程的 startup_clean /
+        # 手删）。没有这行，目录一旦消失，之后每张图都 FileNotFoundError 丢弃，
+        # 直到 clear_all / 重启才恢复 —— 正是「出图完成后图消失」的放大器。
+        self.session_dir.mkdir(parents=True, exist_ok=True)
         # 原子写：写 tmp + rename。session 目录是独占的，不存在并发写同名情况
         tmp = file_path.with_suffix(".bin.tmp")
         tmp.write_bytes(blob)

--- a/tests/test_disk_cache.py
+++ b/tests/test_disk_cache.py
@@ -13,6 +13,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 from pathlib import Path
 
 import pytest
@@ -68,6 +69,21 @@ def test_put_writes_different_ciphertext_each_time(cache: disk_cache.SessionCach
     cache.put(1, "x.png", png, {}, mode="single")
     blob2 = next(iter(cache._index.values())).file_path.read_bytes()
     assert blob1 != blob2
+
+
+def test_put_recreates_session_dir_if_deleted(cache: disk_cache.SessionCache) -> None:
+    """session 目录被外部 rmtree（另一进程 startup_clean / 手删）后 put 自愈。
+
+    2026-07-28 丢图 root cause 回归：没有自愈时目录一旦消失，每张
+    cache_image 都 FileNotFoundError 丢弃，直到 clear_all / 重启。
+    """
+    cache.put(1, "a.png", _png_bytes(b"a"), {}, mode="single")
+    shutil.rmtree(cache.session_dir)
+    cache.put(1, "b.png", _png_bytes(b"b"), {}, mode="single")
+    assert cache.get_image(1, "b.png") == _png_bytes(b"b")
+    # 旧 entry 文件已随目录消失：get 返 None 并剔出 index（既有语义不变）
+    assert cache.get_image(1, "a.png") is None
+    assert cache.total_count() == 1
 
 
 def test_overwrite_same_key_deletes_old_file(cache: disk_cache.SessionCache) -> None:

--- a/tests/test_logging_bootstrap.py
+++ b/tests/test_logging_bootstrap.py
@@ -40,6 +40,15 @@ def test_webui_lifespan_calls_setup_logging(tmp_path: Path,
     monkeypatch.setenv("ANIMA_LOG_DIR", str(tmp_path))
     from fastapi.testclient import TestClient
     from studio import server
+    from studio.infrastructure import paths
+
+    # 隔离 STUDIO_DATA：lifespan 会拿单实例锁 + disk_cache.init（其
+    # startup_clean 会 rmtree root 下所有 session-*）。不隔离的话：
+    # (a) 本机 dev server 在跑时锁被占，本测试假红；
+    # (b) 更糟 —— 老版本没锁时曾把活 server 的出图 cache 目录整个删掉。
+    # lifespan 内部是函数级 `from ..infrastructure.paths import STUDIO_DATA`，
+    # setattr 模块属性即可生效。
+    monkeypatch.setattr(paths, "STUDIO_DATA", tmp_path / "studio_data")
 
     # 触发 lifespan
     with TestClient(server.app) as client:

--- a/tests/test_single_instance.py
+++ b/tests/test_single_instance.py
@@ -1,0 +1,76 @@
+"""studio_data 单实例锁 (`studio.infrastructure.single_instance`) 单测。
+
+覆盖：
+  - 抢锁 / 第二个句柄抢不到 / release 后可再抢
+  - lock 文件父目录不存在时自动创建
+  - release 幂等（未持有时 no-op）
+  - lifespan 集成：锁被占时 startup 直接 raise，不执行任何破坏性清理
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from studio.infrastructure.single_instance import LOCK_FILENAME, SingleInstanceLock
+
+
+def test_acquire_blocks_second_handle(tmp_path: Path) -> None:
+    lock_path = tmp_path / LOCK_FILENAME
+    first = SingleInstanceLock(lock_path)
+    second = SingleInstanceLock(lock_path)
+    assert first.acquire()
+    # OS 区域锁按句柄独占：同进程第二个句柄同样抢不到（等价于第二个进程）
+    assert not second.acquire()
+    first.release()
+    assert second.acquire()
+    second.release()
+
+
+def test_acquire_creates_parent_dir(tmp_path: Path) -> None:
+    lock = SingleInstanceLock(tmp_path / "not_yet" / "deeper" / LOCK_FILENAME)
+    assert lock.acquire()
+    assert lock.path.exists()
+    lock.release()
+
+
+def test_release_without_acquire_is_noop(tmp_path: Path) -> None:
+    SingleInstanceLock(tmp_path / LOCK_FILENAME).release()  # 不抛即过
+
+
+def test_double_acquire_same_instance_raises(tmp_path: Path) -> None:
+    lock = SingleInstanceLock(tmp_path / LOCK_FILENAME)
+    assert lock.acquire()
+    try:
+        with pytest.raises(RuntimeError, match="already acquired"):
+            lock.acquire()
+    finally:
+        lock.release()
+
+
+def test_lifespan_refuses_when_lock_held(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """双开保护：锁被占时 lifespan 在执行任何破坏性副作用之前 raise。
+
+    锁检查位于 ensure_dirs / db.init_db / disk_cache.init（含 startup_clean
+    rmtree）之前 —— 用「studio_data 里除了 lock 文件外什么都没被创建」验证
+    「没执行到后续启动步骤」。
+    """
+    from fastapi.testclient import TestClient
+    from studio import server
+    from studio.infrastructure import paths
+
+    studio_data = tmp_path / "studio_data"
+    monkeypatch.setattr(paths, "STUDIO_DATA", studio_data)
+
+    holder = SingleInstanceLock(studio_data / LOCK_FILENAME)
+    assert holder.acquire()
+    try:
+        with pytest.raises(RuntimeError, match="already running"):
+            with TestClient(server.app):
+                pass
+        # 只有 lock 文件本身，没有 .cache/ logs/ 等后续启动产物
+        assert [p.name for p in studio_data.iterdir()] == [LOCK_FILENAME]
+    finally:
+        holder.release()


### PR DESCRIPTION
## 问题

「图片生成完成后从右栏 image list 消失，预览框显示 cache 暂未就绪」的 root cause 修复。

完整证据链（2026-07-28 studio.log）：

1. uvicorn 是**先跑完 lifespan、之后才 bind 端口**。双开 `python -m studio` 时，注定 bind 失败的实例在报 `winerror 10048` 退出**之前**，已经把 lifespan 里的 `disk_cache.startup_clean` 跑了一遍 —— 它无差别 rmtree root 下所有 `session-*` 目录，包括活 server 正在用的那个。
2. 活 server 的 `SessionCache.put()` 写盘前不重建目录 → 从那一刻起每张出图 `cache_image` 都 `FileNotFoundError`（日志特征：`cache_image failed for gen_*.png`，ENOENT on `.bin.tmp`）。图既进不了 index（右栏无 entry）也取不到（404 → 前端提示粘死），直到重启才恢复。

## 改动

- **`studio/infrastructure/single_instance.py`（新）**：`studio_data/.server.lock` 单实例锁。OS 级文件区域锁（Windows `msvcrt.locking` / POSIX `fcntl.flock`），随进程退出（含 SIGKILL / 断电）自动释放，无 stale lock 问题。独占单位是 **studio_data 目录**（真正要保护的资源），不是端口。
- **`lifespan.py`**：进入 lifespan 先抢锁，抢不到立刻 raise —— 第二个实例在执行任何破坏性副作用（db migration / `startup_clean`）之前退出。shutdown 时释放。
- **`disk_cache.py put()`**：写 tmp 前 `mkdir(parents=True, exist_ok=True)` 自愈 —— 目录被外删后下一张图立即恢复，不再整段丢图。
- **`tests/test_logging_bootstrap.py`**：真 lifespan 测试隔离 `STUDIO_DATA`。此前它跑真 `startup_clean`，是历史上「跑 pytest 删活 server cache」的触发点；加锁后不隔离还会在 dev server 运行期间假红。

## 测试

- 新增 `tests/test_single_instance.py`：抢锁互斥 / release 后可再抢 / 父目录自动创建 / release 幂等 / **lifespan 集成**（锁被占时 startup raise，且 studio_data 里除 lock 文件外无任何启动产物 = 破坏性清理确实没执行）。
- `tests/test_disk_cache.py` 新增 put 自愈回归（外部 rmtree session 目录后 put/get 正常）。
- `pytest tests/test_disk_cache.py tests/test_single_instance.py tests/test_logging_bootstrap.py tests/test_studio_server.py` → 93 passed。

🤖 Generated with [Claude Code](https://claude.com/claude-code)