### PR TITLE
fix(generate): LoRA picker 下拉不再被父级重渲染打回已存槽值

### DIFF
--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.test.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.test.tsx
@@ -464,4 +464,48 @@ describe('InlineLoraPicker — controlled sync (Step 6 / 决策 #8)', () => {
     // 没有受控 value 时仍能看到 projects[0] 的 ckpts（fallback 行为）
     await waitFor(() => expect(screen.getByText('step 2000')).toBeInTheDocument())
   })
+
+  it('父级重渲染（value 同内容新对象）不打回用户正在切换的项目下拉', async () => {
+    // 回归：SidebarLoras 每次渲染都新建 value 字面量。sync effect 若依赖对象
+    // 本身，任何父级重渲染都会把 pid 打回槽里已存值 —— 用户刚在下拉切到别的
+    // 项目，1-2s 内被刷回（catalog 懒加载返回 / SSE setState 都会触发）。
+    const catalog = catalogFrom(sample, ckptsV3)
+    const onChange = vi.fn()
+    const onClose = vi.fn()
+    const savedValue = (): PickedLora => ({
+      path: '/loras/cute_chibi/v3/final.safetensors',
+      projectId: 1, versionId: 11,
+    })
+    const { rerender } = render(
+      <InlineLoraPicker
+        mode="single"
+        catalog={catalog}
+        value={savedValue()}
+        weight={1.0}
+        onChange={onChange}
+        onClose={onClose}
+      />
+    )
+    const projectSelect = () => screen.getAllByRole('combobox')[0] as HTMLSelectElement
+    await waitFor(() => expect(projectSelect().value).toBe('1'))
+
+    // 用户在下拉切到项目 2（还没点 ckpt chip，槽值不变）
+    fireEvent.change(projectSelect(), { target: { value: '2' } })
+    expect(projectSelect().value).toBe('2')
+
+    // 父级因无关原因重渲染：value 内容相同但对象是新建的
+    rerender(
+      <InlineLoraPicker
+        mode="single"
+        catalog={catalog}
+        value={savedValue()}
+        weight={1.0}
+        onChange={onChange}
+        onClose={onClose}
+      />
+    )
+    // 下拉必须停在用户选的项目 2，不被打回槽里的项目 1
+    await waitFor(() => expect(projectSelect().value).toBe('2'))
+    expect(projectSelect().value).toBe('2')
+  })
 })

--- a/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
+++ b/studio/web/src/pages/tools/generate/InlineLoraPicker.tsx
@@ -119,12 +119,20 @@ export default function InlineLoraPicker(props: Props) {
   // 旧值（之前靠父级 bump urlConsumedKey 强制 remount 兜底，Step 6 砍掉）。
   // setPid 函数式更新 + 值未变跳过自动免无限循环。
   // value=null 时不 sync（保留 fallback：未选 LoRA 时给用户看 projects[0] ckpts）
+  //
+  // deps 必须用**原始值**（path/projectId/versionId），不能用 singleValue 对象：
+  // SidebarLoras 每次渲染都新建 value 字面量，对象做 dep 会让任何父级重渲染
+  // （catalog 懒加载返回 / SSE 驱动的 setState…）都重跑本 effect，把用户正在
+  // 下拉里切换的 pid/vid 打回槽里已存值 —— 表现为「刚切到别的项目，1-2s 内
+  // 被刷回进入页面时的状态」。原始值 deps 下只有槽值真正变化才重新锚定。
   const singleValue = isSingle ? props.value : null
+  const singleValuePath = singleValue?.path ?? null
+  const singleValuePid = singleValue?.projectId ?? null
+  const singleValueVid = singleValue?.versionId ?? null
   useEffect(() => {
-    if (!isSingle || singleValue == null) return
-    const next = singleValue.projectId
-    setPid((cur) => (cur === next ? cur : next))
-  }, [isSingle, singleValue])
+    if (!isSingle || singleValuePath == null) return
+    setPid((cur) => (cur === singleValuePid ? cur : singleValuePid))
+  }, [isSingle, singleValuePath, singleValuePid])
 
   // multi mode：当 caller 给 initialPid（XY 历史回填），pid 跟着 prop 走
   useEffect(() => {
@@ -150,11 +158,11 @@ export default function InlineLoraPicker(props: Props) {
 
   const [vid, setVid] = useState<number | null>(initialVid)
   // 同 pid：single 模式下 value 非 null 时 vid 跟 props.value.versionId 同步
+  //（deps 同上，用原始值防父级重渲染打回用户的下拉切换）
   useEffect(() => {
-    if (!isSingle || singleValue == null) return
-    const next = singleValue.versionId
-    setVid((cur) => (cur === next ? cur : next))
-  }, [isSingle, singleValue])
+    if (!isSingle || singleValuePath == null) return
+    setVid((cur) => (cur === singleValueVid ? cur : singleValueVid))
+  }, [isSingle, singleValuePath, singleValueVid])
 
   // multi mode：受控 vid（同 multiInitialPid 一对儿）
   useEffect(() => {


### PR DESCRIPTION
## 问题

测试页 LoRA 选择器：进页面后在下拉里切到别的项目/版本，1-2s 内被刷回进入页面时的状态。

根因：single 模式的 pid/vid 同步 effect（为历史回填 / `?lora=` 深链服务）把 `props.value` **对象**放进了 deps，而 `SidebarLoras` 每次渲染都新建 value 字面量。于是任何父级重渲染都会重跑 effect，把用户正在切换的下拉打回槽里已存值 —— 而用户切换动作自己触发的 versions/ckpts 懒加载一返回就会引发这样一次重渲染，形成「切完 1-2s 必被打回」的确定性复现（槽里有已存 LoRA 时必现；空槽因 value=null 跳过同步不受影响）。

## 改动

`InlineLoraPicker.tsx` 两个同步 effect 的 deps 改为原始值（`path` / `projectId` / `versionId`）：只有槽值真正变化（点 ckpt chip / 历史回填 / 深链）才重新锚定下拉，用户的浏览操作不再被覆盖。行为语义不变（value=null 不同步、外部文件 LoRA 的 projectId=null 同步为「选项目…」均与之前一致）。

## 测试

- `InlineLoraPicker.test.tsx` 新增回归：用户在下拉切到项目 2 → 父级用**同内容新对象**的 value 重渲染 → 下拉必须停在 2（旧代码会被打回 1）。
- `npx tsc --noEmit` / `npx eslint`（两个改动文件）/ `vitest run InlineLoraPicker.test.tsx`（26 passed）+ `Generate.test.tsx`（14 passed）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)