### PR TITLE
fix(tagger): 可用性检查带上本次覆盖并跟配置回流重查

### DIFF
--- a/studio/api/routers/tagger.py
+++ b/studio/api/routers/tagger.py
@@ -5,6 +5,7 @@
 """
 from __future__ import annotations
 
+import json
 from typing import Any
 
 from fastapi import APIRouter
@@ -16,14 +17,32 @@ router = APIRouter()
 
 
 @router.get("/api/tagger/{name}/check")
-def check_tagger(name: str) -> dict[str, Any]:
+def check_tagger(name: str, overrides: str | None = None) -> dict[str, Any]:
+    """`overrides` 是 JSON dict（与 startTag 的 `<name>_overrides` 同构）。
+
+    check 必须与本次打标同口径：页面上的模型版本 / 预设选择是本次覆盖，
+    不落盘；不带 overrides 检查全局默认，会把选了已下载模型的用户误判为
+    「需下载」并锁死开始按钮（issue #477）。
+    """
     if name not in VALID_TAGGER_NAMES:
         raise ValidationError(
             f'Unknown tagger: "{name}"',
             code="tag.tagger_invalid", details={"name": name}, http_status=400,
         )
+    parsed: dict[str, Any] | None = None
+    if overrides:
+        try:
+            parsed = json.loads(overrides)
+        except json.JSONDecodeError:
+            parsed = None
+        if not isinstance(parsed, dict):
+            raise ValidationError(
+                "overrides must be a JSON object",
+                code="tag.tagger_overrides_invalid",
+                details={"field": "overrides"}, http_status=400,
+            )
     try:
-        t = get_tagger(name)
+        t = get_tagger(name, parsed)
     except Exception as exc:  # noqa: BLE001
         return {"name": name, "ok": False, "msg": str(exc)}
     ok, msg = t.is_available()

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -2554,8 +2554,14 @@ export const api = {
     ),
 
   // Tagging (PP4) --------------------------------------------------------
-  checkTagger: (name: TaggerName) =>
-    req<TaggerStatus>(`/api/tagger/${name}/check`),
+  // overrides 与 startTag 的 `<name>_overrides` 同构：check 必须按本次打标
+  // 实际生效的配置检查，否则页面覆盖（模型版本 / 预设）不被感知（issue #477）。
+  checkTagger: (name: TaggerName, overrides?: Record<string, unknown>) =>
+    req<TaggerStatus>(
+      `/api/tagger/${name}/check${
+        overrides ? `?overrides=${encodeURIComponent(JSON.stringify(overrides))}` : ''
+      }`,
+    ),
   startTag: (
     pid: number,
     vid: number,

--- a/studio/web/src/pages/project/steps/Tagging.test.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { availabilityOverrides } from './Tagging'
+
+// issue #477：可用性检查必须带上页面的模型版本覆盖，helper 负责挑出
+// 「与全局默认不同、且影响可用性」的字段。
+describe('availabilityOverrides', () => {
+  const defaults = {
+    model_id: 'cella110n/cl_tagger',
+    model_path: 'cl_tagger_1_02/model.onnx',
+    tag_mapping_path: 'cl_tagger_1_02/tag_mapping.json',
+    threshold_general: 0.35,
+  }
+
+  it('form / defaults 未加载时不产生覆盖', () => {
+    expect(availabilityOverrides(null, defaults, ['model_id'])).toBeUndefined()
+    expect(availabilityOverrides(defaults, null, ['model_id'])).toBeUndefined()
+  })
+
+  it('与默认一致时不产生覆盖', () => {
+    expect(availabilityOverrides({ ...defaults }, defaults, ['model_id', 'model_path'])).toBeUndefined()
+  })
+
+  it('只挑列出的且不同的字段（改版本 → 三元组里变了的进覆盖，阈值不进）', () => {
+    const form = {
+      ...defaults,
+      model_id: 'cella110n/cl_tagger_v2',
+      model_path: 'v2_01a/model.onnx',
+      tag_mapping_path: 'v2_01a/model_vocabulary.json',
+      threshold_general: 0.5,
+    }
+    expect(
+      availabilityOverrides(form, defaults, ['model_id', 'model_path', 'tag_mapping_path']),
+    ).toEqual({
+      model_id: 'cella110n/cl_tagger_v2',
+      model_path: 'v2_01a/model.onnx',
+      tag_mapping_path: 'v2_01a/model_vocabulary.json',
+    })
+  })
+})

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -78,6 +78,17 @@ function fromCLTaggerConfig(cfg: CLTaggerConfig): CLTaggerForm {
   }
 }
 
+// form 与全局默认不同的字段挑出来作 check override（判据与 buildXXXOverrides
+// 一致，但只取 keys 列出的影响可用性的字段）。form / defaults 未加载 → 不覆盖。
+export function availabilityOverrides<T extends object>(
+  form: T | null, defaults: T | null, keys: (keyof T)[],
+): Partial<T> | undefined {
+  if (!form || !defaults) return undefined
+  const out: Partial<T> = {}
+  for (const k of keys) if (form[k] !== defaults[k]) out[k] = form[k]
+  return Object.keys(out).length ? out : undefined
+}
+
 export default function TaggingPage() {
   const { t } = useTranslation()
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
@@ -150,15 +161,38 @@ export default function TaggingPage() {
     })
   }, [llmDefaults])
 
+  // 可用性检查跟着「本次打标实际生效的配置」走（issue #477）：模型版本 / 预设
+  // 选择属于本次覆盖，不带上会按全局默认误报「需下载 / 未配置」并锁死开始按钮。
+  // 只挑影响可用性的字段——阈值 / 附加标签类别不参与，避免输入过程反复请求。
+  const availabilityKey = JSON.stringify([
+    tagger,
+    tagger === 'wd14'
+      ? availabilityOverrides(wd14Form, wd14Defaults, ['model_id'])
+      : tagger === 'cltagger'
+        ? availabilityOverrides(cltaggerForm, cltaggerDefaults, [
+            'model_id', 'model_path', 'tag_mapping_path',
+          ])
+        : tagger === 'llm' && llmPresetId && llmDefaults && llmPresetId !== llmDefaults.current_preset
+          ? { current_preset: llmPresetId }
+          : undefined,
+  ])
+  // secrets / catalog 进依赖：预设编辑器与设置抽屉保存（instant-apply 回流）、
+  // 模型下载完成（model_download_changed → reloadCatalog）都要触发重查。
   useEffect(() => {
+    const [name, overrides] = JSON.parse(availabilityKey) as [
+      TaggerName,
+      Record<string, unknown> | null,
+    ]
+    let stale = false
     setTaggerStatus(null)
     void api
-      .checkTagger(tagger)
-      .then(setTaggerStatus)
-      .catch((e) =>
-        setTaggerStatus({ name: tagger, ok: false, msg: String(e), requires_service: false })
-      )
-  }, [tagger])
+      .checkTagger(name, overrides ?? undefined)
+      .then((s) => { if (!stale) setTaggerStatus(s) })
+      .catch((e) => {
+        if (!stale) setTaggerStatus({ name, ok: false, msg: String(e), requires_service: false })
+      })
+    return () => { stale = true }
+  }, [availabilityKey, secrets, catalog])
 
   // 刷新 / 进入页面时回放最近一次打标 job：锁回 id + 回放历史日志。
   useEffect(() => {

--- a/tests/test_cltagger_tagger.py
+++ b/tests/test_cltagger_tagger.py
@@ -111,6 +111,40 @@ def test_v2_missing_external_data_reports_not_ready(isolated_secrets: Path) -> N
     assert available is False
 
 
+def test_is_available_with_overrides_checks_overridden_model(isolated_secrets: Path) -> None:
+    """override 选中的版本已就绪、全局默认未下载 → is_available 按 override 判可用。
+
+    issue #477 的复刻：页面高级参数里选了已下载的 v2，可用性检查却按全局默认
+    cl_tagger_1_02 报「需下载」，开始按钮被锁死。
+    """
+    base = model_downloader.cltagger_target_root(
+        model_downloader.models_root(),
+        "cella110n/cl_tagger_v2",
+    )
+    version_dir = base / "v2_01a"
+    version_dir.mkdir(parents=True, exist_ok=True)
+    (version_dir / "model.onnx").write_bytes(b"fake-onnx")
+    (version_dir / "model.onnx.data").write_bytes(b"fake-weights")
+    (version_dir / "model_metadata.json").write_text("{}", encoding="utf-8")
+    (version_dir / "model_vocabulary.json").write_text(
+        json.dumps({"idx_to_tag": {"0": "1girl"}}),
+        encoding="utf-8",
+    )
+    # 全局 secrets 保持默认（cl_tagger_1_02，未下载）——不带 overrides 时不可用
+    ok_default, msg_default = cltagger_tagger.CLTagger().is_available()
+    assert ok_default is False
+    assert "需下载模型" in msg_default
+
+    t = cltagger_tagger.CLTagger(overrides={
+        "model_id": "cella110n/cl_tagger_v2",
+        "model_path": "v2_01a/model.onnx",
+        "tag_mapping_path": "v2_01a/model_vocabulary.json",
+    })
+    ok, msg = t.is_available()
+    assert ok is True
+    assert "v2_01a" in msg
+
+
 def test_is_available_does_not_download_when_model_missing(
     isolated_secrets: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_tag_endpoints.py
+++ b/tests/test_tag_endpoints.py
@@ -67,9 +67,36 @@ def test_check_wd14(client: TestClient, env, monkeypatch: pytest.MonkeyPatch) ->
     # 模块级 binding 在 server 命名空间，需要在那打补丁。
     # PR-6 commit 1：/api/tagger/{name}/check 搬到 api/routers/tagger.py
     from studio.api.routers import tagger as _tagger_router
-    monkeypatch.setattr(_tagger_router, "get_tagger", lambda name: fake)
+    monkeypatch.setattr(_tagger_router, "get_tagger", lambda name, overrides=None: fake)
     r = client.get("/api/tagger/wd14/check").json()
     assert r == {"name": "wd14", "ok": True, "msg": "ready", "requires_service": False}
+
+
+def test_check_passes_overrides(client: TestClient, env, monkeypatch: pytest.MonkeyPatch) -> None:
+    """check 带 overrides → 解析成 dict 传给 get_tagger（issue #477：check 必须
+    按本次打标实际生效的配置检查，否则页面选的模型版本 / 预设不被感知）。"""
+    import json as _json
+    fake = MagicMock()
+    fake.is_available.return_value = (True, "ready")
+    fake.requires_service = False
+    seen: dict = {}
+    from studio.api.routers import tagger as _tagger_router
+
+    def _get_tagger(name, overrides=None):
+        seen["name"], seen["overrides"] = name, overrides
+        return fake
+
+    monkeypatch.setattr(_tagger_router, "get_tagger", _get_tagger)
+    ov = {"model_id": "cella110n/cl_tagger_v2", "model_path": "v2_01a/model.onnx"}
+    r = client.get("/api/tagger/cltagger/check", params={"overrides": _json.dumps(ov)})
+    assert r.json()["ok"] is True
+    assert seen == {"name": "cltagger", "overrides": ov}
+
+
+def test_check_overrides_invalid_400(client: TestClient) -> None:
+    """overrides 不是合法 JSON dict → 400（不能静默吞掉按全局默认检查）。"""
+    assert client.get("/api/tagger/wd14/check", params={"overrides": "not-json"}).status_code == 400
+    assert client.get("/api/tagger/wd14/check", params={"overrides": "[1, 2]"}).status_code == 400
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #477

## 背景

打标页的可用性检查（打标器下拉旁的红绿徽章 + 「开始打标」按钮的禁用条件）只查全局 secrets 默认配置，且只在切换打标器时查一次。issue #477 的两个症状同源：

- **CLTagger**：高级参数里选了已下载的 `cl_tagger_v2_v2_01a`（本次覆盖，不落盘），check 仍按全局默认 `cl_tagger_1_02`（未下载）报「需下载模型」，开始按钮被锁死。
- **LLM**：面板上选的预设 ≠ 全局默认预设时，check 查的是后者，用户给选中预设填了 base_url 也报「未配置 base_url」；且预设编辑器保存后 check 不重跑（依赖数组只有 tagger）。

## 改动

- `GET /api/tagger/{name}/check` 新增可选 `overrides` query 参数（JSON dict，与 `startTag` 的 `<name>_overrides` 同构），透传给 `get_tagger(name, overrides)`——工厂本就支持，此前仅 check 端点没传。非法 JSON / 非 dict → 400。
- 前端 `checkTagger` 带上影响可用性的本次覆盖：wd14 `model_id`、cltagger `model_id / model_path / tag_mapping_path`、llm `current_preset`。阈值等不影响可用性的字段不参与，避免输入过程反复请求。
- 检查 effect 的依赖从 `[tagger]` 扩为「tagger + 覆盖值序列化 key + secrets + catalog」：改选版本 / 预设立即重查；预设编辑器与设置抽屉保存（instant-apply 回流）后重查；模型下载完成（`model_download_changed` → reloadCatalog）后重查。加 stale flag 防连续检查的竞态。

## 测试

- `tests/test_cltagger_tagger.py`：issue 场景复刻——全局默认未下载 + override 指向已就绪 v2 → `is_available` 按 override 判可用。
- `tests/test_tag_endpoints.py`：check 端点把 overrides 解析传给 `get_tagger`；非法 overrides → 400。
- `Tagging.test.tsx`：`availabilityOverrides` helper 只挑列出的且与默认不同的字段。
- 本地：相关 pytest + 横切安全网（route snapshot / studio configs）82 passed；vitest 全量 558 passed；ruff / eslint / tsc / `npm run build` 全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
