### PR TITLE
fix(settings): 内存/显存水位保护默认全面改关

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -388,7 +388,7 @@ class ModelCache:
         self.lora_merge_precision: str = "fp32"
         self.text_encoder_backend: Optional[str] = None
         self.t5_tokenizer_backend: Optional[str] = None
-        self.ram_guard: bool = True
+        self.ram_guard: bool = False
         #: TE 先行栈的身份键（family_id, text_encoder_path）——ensure_text_ready
         #: 据此复用/重建；_load 据此避免重复加载
         self._text_ready_key: Optional[tuple] = None
@@ -486,7 +486,7 @@ class ModelCache:
         if t5_tokenizer_path:
             t5_tokenizer_path = _T.resolve_path_best_effort(t5_tokenizer_path, bases)
 
-        self.ram_guard = bool(cfg.get("ram_guard", True))
+        self.ram_guard = bool(cfg.get("ram_guard", False))
 
         # 比较是否需要 reload（换族 = 换整套模型栈，全重载）
         needs_reload = (

--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -226,7 +226,7 @@ def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
                 getattr(gen_cfg, "lora_merge_precision", "fp32") or "fp32"
             )
             vram_policy = str(getattr(gen_cfg, "vram_policy", "auto") or "auto")
-            ram_guard = bool(getattr(gen_cfg, "ram_guard", True))
+            ram_guard = bool(getattr(gen_cfg, "ram_guard", False))
             blocks_to_swap = int(getattr(gen_cfg, "blocks_to_swap", 0) or 0)
         except Exception:
             attn_default = "auto"
@@ -234,7 +234,7 @@ def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
             vae_precision = "bf16"
             lora_merge_precision = "fp32"
             vram_policy = "auto"
-            ram_guard = True
+            ram_guard = False
             blocks_to_swap = 0
         attn = body.attention_backend or attn_default
         if attn == "auto":

--- a/studio/domain/generate.py
+++ b/studio/domain/generate.py
@@ -123,7 +123,7 @@ class GenerateConfig(BaseModel):
                     "performance=全部常驻显存，峰值最高、零搬运",
     )
     ram_guard: bool = Field(
-        True,
+        False,
         description="内存/显存水位保护：加载大模型前按权重文件实际大小预算系统内存与 GPU 空闲显存，"
                     "任一不足时中止并报错（含其他进程占用显存的情形）；"
                     "关闭后资源不足时加载会继续，可能触发整机换页卡顿",

--- a/studio/infrastructure/secrets.py
+++ b/studio/infrastructure/secrets.py
@@ -493,13 +493,14 @@ class TrainingConfig(BaseModel):
 
     - `ram_guard`：训练 / AI 先验（正则生成）的内存/显存水位保护。语义同
       `generate.ram_guard`：加载大模型前按权重文件实际大小预算系统内存与
-      GPU 空闲显存，任一不足时中止并报可操作错误；默认开，关闭后资源不足
-      时继续加载，可能触发整机换页卡顿。经环境变量 ``LORA_RAM_GUARD``
+      GPU 空闲显存，任一不足时中止并报可操作错误。**v0.23.1 起默认关**
+      （按文件大小的估算偏保守，误拒率高）；关闭时资源不足会继续加载，
+      可能触发整机换页卡顿。经环境变量 ``LORA_RAM_GUARD``
       注入训练子进程（supervisor `_popen`）。block swap 的 pinned 内存护栏
       **不受此开关影响**——锁定内存不可换页、占满会硬卡整机，且有独立
       出路（调小 blocks_to_swap）。
     """
-    ram_guard: bool = True
+    ram_guard: bool = False
 
 
 class ModelsConfig(BaseModel):
@@ -600,8 +601,9 @@ class GenerateConfig(BaseModel):
       低，每图多几秒搬运）；`'performance'` 全部常驻显存（峰值最高、零搬运）。
     - `ram_guard`：内存/显存水位保护。加载大模型前按权重文件实际大小
       预算系统内存与 GPU 空闲显存，任一不足时中止并报可操作错误
-      （默认开；显存检查可拦多进程叠加）；关闭后资源不足时继续加载，
-      可能触发整机换页卡顿。
+      （开启时显存检查可拦多进程叠加）。**v0.23.1 起默认关**（按文件
+      大小的估算偏保守，误拒率高）；关闭时资源不足会继续加载，可能
+      触发整机换页卡顿。
     - `task_timeout_minutes`：出图任务超时兜底。任务开始后超 N 分钟未
       完成 → 强制终止 daemon 进程（卡死场景协议级取消无效，只能进程级
       kill；下次任务自动重启）。0（默认）= 关闭。
@@ -613,7 +615,7 @@ class GenerateConfig(BaseModel):
     idle_timeout_minutes: int = 10
     save_test_images: bool = False
     vram_policy: str = "auto"
-    ram_guard: bool = True
+    ram_guard: bool = False
     #: 换出到内存的 DiT 层数（0=关闭，krea2 生效）。与 vram_policy 分工不同：
     #: 前者管模型之间谁让位，本项管单个 DiT 内部——单个模型自己就装不下显存时
     #: 唯一的办法。见 docs/design/block-swap.md。
@@ -639,6 +641,12 @@ class SystemConfig(BaseModel):
     update_channel: str = "stable"  # "stable" / "dev"
     show_dev_channel: bool = False  # deprecated, 仅作迁移源
     enable_automagic_v2: bool = False  # 实验性：文件级开关，UI 不暴露
+    # v0.23.1 「ram_guard 默认改关」一次性迁移哨兵（_migrate_legacy_schema
+    # 第 10 步）。判据是**盘上键缺失**（只有 v0.23.1 之前写的旧盘没有此键）
+    # → 丢弃盘上的 generate/training ram_guard 旧值让新默认（关）生效；
+    # 新代码落的盘总带此键（save 全量 dump），显式开启的值不会被丢弃。
+    # 默认 True：新装无旧值可迁，「迁移已完成」天然成立。
+    ram_guard_default_off: bool = True
 
 
 class ProxyConfig(BaseModel):
@@ -1058,6 +1066,20 @@ def _migrate_legacy_schema(raw: dict[str, Any]) -> dict[str, Any]:
         # 新字段已显式设过 → 不覆盖（幂等）
         if "update_channel" not in sys_raw and sys_raw.get("show_dev_channel") is True:
             sys_raw["update_channel"] = "dev"
+
+    # 10. ram_guard 默认改关（v0.23.1 hotfix）：save() 全量落盘使「用户显式
+    #     开启」与「旧默认 true 被动落盘」不可分辨（同第 8 步先例），故对
+    #     旧盘一次性丢弃 ram_guard 值，让所有用户回到新默认（关）。判据是
+    #     哨兵**键缺失**（不能看值：v0.23.1+ 代码落的盘总带此键，值即真源；
+    #     用「值为假」判会把新装用户首次显式开启的值也丢掉）。哨兵在下次
+    #     save() 才落盘，落盘前重复丢弃是幂等的（丢的仍是旧盘值）。
+    sys_raw_rg = raw.setdefault("system", {})
+    if isinstance(sys_raw_rg, dict) and "ram_guard_default_off" not in sys_raw_rg:
+        for section in ("generate", "training"):
+            sec_raw = raw.get(section)
+            if isinstance(sec_raw, dict):
+                sec_raw.pop("ram_guard", None)
+        sys_raw_rg["ram_guard_default_off"] = True
 
     # 8. R-1 资源档位（0.17）：queue.allow_gpu_during_train 废弃。语义变化
     #    （老开关连 eval_samples 等底模级任务一起放行，是 OOM 隐患；新开关

--- a/studio/services/eval_generation.py
+++ b/studio/services/eval_generation.py
@@ -51,7 +51,7 @@ _BLOCK_SWAP_NOTICED: set[str] = set()
 
 _FALLBACK_SETTINGS: dict[str, Any] = {
     "vae_precision": "bf16", "lora_merge_precision": "fp32",
-    "vram_policy": "auto", "ram_guard": True, "blocks_to_swap": 0,
+    "vram_policy": "auto", "ram_guard": False, "blocks_to_swap": 0,
 }
 
 
@@ -74,7 +74,7 @@ def _generate_settings(family_id: str) -> dict[str, Any]:
                 getattr(gen, "lora_merge_precision", "fp32") or "fp32"
             ),
             "vram_policy": str(getattr(gen, "vram_policy", "auto") or "auto"),
-            "ram_guard": bool(getattr(gen, "ram_guard", True)),
+            "ram_guard": bool(getattr(gen, "ram_guard", False)),
             "blocks_to_swap": int(getattr(gen, "blocks_to_swap", 0) or 0),
         }
     except Exception:

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -1279,9 +1279,10 @@ class Supervisor:
         # （Windows 无官方 triton wheel），被失败摘要误当失败原因；本 app 的
         # xformers 路径不用 triton kernel，无条件短路。
         _xformers_svc.disable_triton_probe(env)
-        # 训练侧内存/显存水位保护开关（Settings → 训练 → 训练参数）。runtime
-        # 侧默认开，只有关闭时才需要显式传；训练与正则 AI 子进程读它，
-        # generate daemon 走自己的 cfg.ram_guard 不受影响。
+        # 训练侧内存/显存水位保护开关（Settings → 训练 → 训练参数，v0.23.1
+        # 起默认关）。runtime 侧 env 缺省=开（CLI 直跑的安全兜底），只有
+        # 关闭时才需要显式传；训练与正则 AI 子进程读它，generate daemon
+        # 走自己的 cfg.ram_guard 不受影响。
         try:
             if not _secrets.load().training.ram_guard:
                 env.setdefault("LORA_RAM_GUARD", "0")

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -655,7 +655,7 @@ export interface TagDictionaryPayload {
 
 export interface TrainingSecretsConfig {
   /** 训练/AI 先验的内存/显存水位保护（语义同 generate.ram_guard，只管训练侧
-   * 子进程；supervisor 经 LORA_RAM_GUARD 环境变量注入，默认开）。 */
+   * 子进程；supervisor 经 LORA_RAM_GUARD 环境变量注入，v0.23.1 起默认关）。 */
   ram_guard: boolean
 }
 

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1100,7 +1100,7 @@
     "autoSyncPathsOn": "On · fork auto-syncs global",
     "autoSyncPathsOff": "Off · fork respects preset values",
     "trainRamGuardLabel": "RAM/VRAM guard",
-    "trainRamGuardHelp": "Before training or AI prior (regularization) generation loads large models, budget system RAM and free VRAM against the actual weight file sizes, aborting with an error if either falls short to avoid system-wide paging freezes (on by default). When off, loading continues even with insufficient resources. The test-generation counterpart has its own toggle under VRAM policy.",
+    "trainRamGuardHelp": "Before training or AI prior (regularization) generation loads large models, budget system RAM and free VRAM against the actual weight file sizes, aborting with an error if either falls short to avoid system-wide paging freezes (off by default; the file-size-based estimate is conservative and can wrongly report insufficient memory). When off, loading continues even with insufficient resources. The test-generation counterpart has its own toggle under VRAM policy.",
     "trainRamGuardOn": "On · check memory before loading",
     "trainRamGuardOff": "Off · load even when memory is low",
     "defaultTransformerHelp": "The selected version becomes the default transformer for <strong>new versions</strong>.",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1100,7 +1100,7 @@
     "autoSyncPathsOn": "已开启 · fork 自动同步全局",
     "autoSyncPathsOff": "已关闭 · fork 尊重预设值",
     "trainRamGuardLabel": "内存/显存水位保护",
-    "trainRamGuardHelp": "训练与 AI 先验（正则生成）加载大模型前，按权重文件实际大小预算系统内存与 GPU 空闲显存，任一不足时中止并报错，避免整机换页卡死（默认开启）。关闭后资源不足时仍继续加载。测试出图的同名保护在「显存策略」里单独开关。",
+    "trainRamGuardHelp": "训练与 AI 先验（正则生成）加载大模型前，按权重文件实际大小预算系统内存与 GPU 空闲显存，任一不足时中止并报错，避免整机换页卡死（默认关闭；按文件大小的估算偏保守，可能误报内存不足）。关闭时资源不足仍继续加载。测试出图的同名保护在「显存策略」里单独开关。",
     "trainRamGuardOn": "已开启 · 加载前检查内存水位",
     "trainRamGuardOff": "已关闭 · 资源不足时仍继续加载",
     "defaultTransformerHelp": "选中的版本会作为<strong>新建 version</strong> 的默认 transformer。",

--- a/studio/web/src/pages/tools/settings/constants.ts
+++ b/studio/web/src/pages/tools/settings/constants.ts
@@ -241,8 +241,8 @@ export const EMPTY: Secrets = {
   },
   models: { root: null, selected: { anima: '1.0', krea2: 'raw' }, selected_anima: '1.0', custom_anima_paths: [], selected_upscaler: '4x-AnimeSharp', auto_sync_paths: true },
   queue: { light_tasks_during_train: true },
-  generate: { preview_every_n_steps: 3, attention_backend: 'auto', vae_precision: 'bf16', lora_merge_precision: 'fp32', idle_timeout_minutes: 10, save_test_images: false, vram_policy: 'auto', ram_guard: true, blocks_to_swap: 0, task_timeout_minutes: 0 },
-  training: { ram_guard: true },
+  generate: { preview_every_n_steps: 3, attention_backend: 'auto', vae_precision: 'bf16', lora_merge_precision: 'fp32', idle_timeout_minutes: 10, save_test_images: false, vram_policy: 'auto', ram_guard: false, blocks_to_swap: 0, task_timeout_minutes: 0 },
+  training: { ram_guard: false },
   system: { update_channel: 'stable', show_dev_channel: false },
   proxy: {
     enabled: false,

--- a/studio/web/src/pages/tools/settings/sections.tsx
+++ b/studio/web/src/pages/tools/settings/sections.tsx
@@ -37,13 +37,13 @@ export function TrainingParamsSection() {
   const { runSave } = useSettingsData()
   const [autoSyncPaths, setAutoSyncPaths] = useState<boolean>(true)
   const [savingAutoSync, setSavingAutoSync] = useState(false)
-  const [trainRamGuard, setTrainRamGuard] = useState<boolean>(true)
+  const [trainRamGuard, setTrainRamGuard] = useState<boolean>(false)
   const [savingRamGuard, setSavingRamGuard] = useState(false)
 
   useEffect(() => {
     void api.getSecrets().then((sec) => {
       setAutoSyncPaths(sec.models?.auto_sync_paths ?? true)
-      setTrainRamGuard(sec.training?.ram_guard ?? true)
+      setTrainRamGuard(sec.training?.ram_guard ?? false)
     }).catch(() => { /* 显示用，拉不到不阻塞 */ })
   }, [])
 
@@ -1383,7 +1383,7 @@ export function VramPolicySection({
         helpTooltip={<p>{t('settings.vramPolicy.ramGuardHelp')}</p>}
       >
         <Bool
-          value={draft.generate.ram_guard ?? true}
+          value={draft.generate.ram_guard ?? false}
           onChange={(v) => update('generate', 'ram_guard', v)}
         />
       </SettingsField>

--- a/tests/test_secrets.py
+++ b/tests/test_secrets.py
@@ -575,22 +575,61 @@ def test_has_gelbooru_credentials(secrets_file: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_training_ram_guard_defaults_on(secrets_file: Path) -> None:
-    """训练侧水位保护默认开；老 secrets.json 没有 training 字段也用默认值。"""
-    assert secrets.load().training.ram_guard is True
+def test_ram_guard_defaults_off(secrets_file: Path) -> None:
+    """水位保护 v0.23.1 起默认关（训练侧 + 推理侧）；老 secrets.json 没有
+    对应字段也用默认值。"""
+    s = secrets.load()
+    assert s.training.ram_guard is False
+    assert s.generate.ram_guard is False
     secrets_file.write_text(
         json.dumps({"gelbooru": {"user_id": "alice"}}),
         encoding="utf-8",
     )
-    assert secrets.load().training.ram_guard is True
+    s = secrets.load()
+    assert s.training.ram_guard is False
+    assert s.generate.ram_guard is False
 
 
 def test_training_ram_guard_round_trip(secrets_file: Path) -> None:
-    """update + load 持久化（Settings → 训练 → 训练参数 切 toggle）。"""
-    secrets.update({"training": {"ram_guard": False}})
-    assert secrets.load().training.ram_guard is False
+    """update + load 持久化（Settings → 训练 → 训练参数 切 toggle）。
+    显式开启落盘时迁移哨兵一并落盘，之后 load 不得再丢弃显式值。"""
     secrets.update({"training": {"ram_guard": True}})
     assert secrets.load().training.ram_guard is True
+    # 幂等：哨兵已落盘，重复 load 不回退
+    assert secrets.load().training.ram_guard is True
+    secrets.update({"training": {"ram_guard": False}})
+    assert secrets.load().training.ram_guard is False
+
+
+def test_ram_guard_legacy_true_discarded_once(secrets_file: Path) -> None:
+    """v0.23.1 一次性迁移：旧盘的 ram_guard=true（旧默认被动落盘，与显式
+    开启不可分辨）在无哨兵时被丢弃 → 所有用户回到新默认（关）。"""
+    secrets_file.write_text(
+        json.dumps({
+            "generate": {"ram_guard": True},
+            "training": {"ram_guard": True},
+        }),
+        encoding="utf-8",
+    )
+    s = secrets.load()
+    assert s.generate.ram_guard is False
+    assert s.training.ram_guard is False
+    assert s.system.ram_guard_default_off is True
+
+
+def test_ram_guard_kept_when_sentinel_present(secrets_file: Path) -> None:
+    """哨兵已置位（迁移后用户显式开启）→ 盘上的 true 保留，不再丢弃。"""
+    secrets_file.write_text(
+        json.dumps({
+            "generate": {"ram_guard": True},
+            "training": {"ram_guard": True},
+            "system": {"ram_guard_default_off": True},
+        }),
+        encoding="utf-8",
+    )
+    s = secrets.load()
+    assert s.generate.ram_guard is True
+    assert s.training.ram_guard is True
 
 
 def test_system_defaults_update_channel_stable(secrets_file: Path) -> None:

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -366,11 +366,12 @@ def test_popen_injects_wandb_env(env, tmp_path, monkeypatch: pytest.MonkeyPatch)
 
 
 def test_popen_injects_ram_guard_off(env, tmp_path, monkeypatch) -> None:
-    """training.ram_guard=False → 子进程 env 带 LORA_RAM_GUARD=0（训练/正则
-    AI 据此跳过水位护栏）；默认开时不注入（runtime 侧缺省即开）。"""
+    """training.ram_guard=False（v0.23.1 起即默认值）→ 子进程 env 带
+    LORA_RAM_GUARD=0（训练/正则 AI 据此跳过水位护栏）；显式开启时不注入
+    （runtime 侧 env 缺省=开，CLI 直跑的安全兜底）。"""
     monkeypatch.delenv("LORA_RAM_GUARD", raising=False)
     cfg = secrets.Secrets()
-    cfg.training.ram_guard = False
+    assert cfg.training.ram_guard is False  # 默认即关 → 无需显式设值
     monkeypatch.setattr("studio.supervisor._secrets.load", lambda: cfg)
     captured: dict[str, Any] = {}
 


### PR DESCRIPTION
## 背景 / 为什么走 hotfix

内存/显存水位保护按权重文件大小估算内存预算，估算偏保守、误判「内存不足」拒绝启动的场景多（#480 给训练侧加开关正是为此开的口子）。maintainer 决定该功能全面改为默认关闭：需要护栏的用户显式开启，而不是所有用户默认被拦。误拒直接阻断训练/出图主流程，不等下次 release，走 hotfix（base = master）。

## 改动概要

- **默认值翻转（两侧）**：`generate.ram_guard` 与 `training.ram_guard` 默认 `True → False`。AI 先验（正则生成）随训练侧开关；block swap 的 pinned 内存护栏不属于此开关辖区，保持常开（#480 的边界不变）。
- **一次性迁移（关键）**：`save()` 全量落盘使「用户显式开启」与「旧默认 true 被动落盘」不可分辨（同 `allow_gpu_during_train` 先例）——只翻默认值对存量用户无效。`_migrate_legacy_schema` 第 10 步按 `system.ram_guard_default_off` 哨兵**键缺失**判定旧盘，一次性丢弃盘上 ram_guard 旧值，所有用户回到新默认（关）。
  - 判据必须是「键缺失」而不是「值为假」：新代码落的盘总带此键；用值判会把新装用户首次显式开启的值也丢掉（初版实现踩到，被新增的 round-trip 测试抓出后改正）。
  - 哨兵默认 `True`（新装无旧值可迁）；迁移后用户显式开启的值正常保留。
- **消费点 fallback 对齐**：`routers/generate.py`、`eval_generation.py`、`anima_daemon.py`（daemon 侧初始值 + `cfg.get` 缺省）、`domain/generate.py` schema 默认，全部 `True → False`。
- **supervisor 注入逻辑不变**：仍是「关闭时注入 `LORA_RAM_GUARD=0`」；secrets 默认关 → Studio 拉起的训练默认注入。runtime env 缺省仍为开（CLI 直跑不经 supervisor 的安全兜底，#480 的有意设计，本 PR 不动）。
- **前端**：`constants.ts` 默认镜像、`sections.tsx` 两处 `?? true → ?? false`、`client.ts` 注释、zh/en 的 `trainRamGuardHelp` tooltip「默认开启 → 默认关闭」（推理侧 tooltip 未写默认值，不动）。

## 测试方式

- `tests/test_secrets.py`：默认值断言改双侧 `False`；新增 `test_ram_guard_legacy_true_discarded_once`（旧盘 true 无哨兵 → 丢弃回 False）、`test_ram_guard_kept_when_sentinel_present`（哨兵在 → 显式 true 保留）；round-trip 改为「显式开启 → 落盘 → 重复 load 不回退」。
- `tests/test_supervisor.py`：注入测试改用默认值直接验证（默认即关 → 注入 `LORA_RAM_GUARD=0`；显式开 → 不注入）。
- 本地：关联 pytest + 横切安全网（route snapshot / studio configs）124 + supervisor 17 全过；ruff 干净；vitest 558 全过；tsc 干净；eslint 0 errors（2 warnings 为 PreprocessInpaint.tsx 既有问题）；`npm run build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
