### PR TITLE
fix(train): 非有限 loss 跳过不再丢弃累积组内梯度、不再冻结 global_step

### DIFF
--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -516,22 +516,31 @@ def run(ctx: TrainingContext) -> None:
                 if reg is not None:
                     loss = loss + reg
 
-            # NaN 检测：forward 出 NaN 时跳过本 micro-batch
-            if not torch.isfinite(loss):
-                logger.warning(f"step {ctx.global_step} micro-batch {batch_idx}: loss={loss.item():.4g}，跳过")
-                ctx.optimizer.zero_grad()
-                continue
-
             # 反向传播。尾组（len % grad_accum）不满时按实际 micro-batch 数归一，
             # 且 epoch 末批不满也 step —— 修尾批丢弃 + 跨 epoch 梯度泄漏（见 _accumulation_step）。
             group_size, is_group_end = _accumulation_step(batch_idx, dl_len, args.grad_accum)
-            loss = loss / group_size
-            if ctx.scaler is not None:
-                ctx.scaler.scale(loss).backward()
+
+            # NaN 检测：forward 出 NaN 时只跳过本 micro-batch 的 backward。
+            # 不 zero_grad —— 同一累积组内其它 micro-batch 已积累的正常梯度要保留；
+            # 也不跳过组尾结算 —— 否则组尾撞上 NaN 时整组梯度作废且 global_step 冻结。
+            loss_is_finite = bool(torch.isfinite(loss))
+            if not loss_is_finite:
+                logger.warning(
+                    f"step {ctx.global_step} micro-batch {batch_idx}: loss={loss.item():.4g}，跳过 backward"
+                )
             else:
-                loss.backward()
+                loss = loss / group_size
+                if ctx.scaler is not None:
+                    ctx.scaler.scale(loss).backward()
+                else:
+                    loss.backward()
 
             if is_group_end:
+                # 组内所有 micro-batch 都被跳过 → 无梯度可结算：不 step、不推进
+                # global_step（无梯度的 step 会污染 Prodigy 的 k / scheduler 进度；
+                # fp16 下 GradScaler 对空梯度组 step 会直接 assert 崩）。
+                if not any(p.grad is not None for p in ctx.trainable_params):
+                    continue
                 if ctx.scaler is not None:
                     ctx.scaler.unscale_(ctx.optimizer)
                 # NaN 梯度检测：跳过本次 update，清零继续
@@ -561,120 +570,123 @@ def run(ctx: TrainingContext) -> None:
                 # 自适应采样器：刷新采样分布；baseline 是 no-op
                 ctx.timestep_sampler.maybe_refresh(ctx.global_step)
 
-                # 记录 loss 历史
-                loss_val = float(loss.item() * group_size)
-                denoise_loss_val = (
-                    float(denoise_loss_log.item())
-                    if denoise_loss_log is not None else loss_val
-                )
-                sra_align_loss_val = (
-                    float(sra_align_loss_log.item())
-                    if sra_align_loss_log is not None else None
-                )
-                sra_weighted_loss_val = (
-                    float(sra_weighted_loss_log.item())
-                    if sra_weighted_loss_log is not None else None
-                )
-                epoch_loss_sum += loss_val
-                epoch_step_count += 1
-                if args.loss_curve_steps and len(ctx.loss_history) < args.loss_curve_steps:
-                    ctx.loss_history.append(loss_val)
+                # 组尾 micro-batch 非有限时跳过本 step 的记录/监控（loss_val 是 NaN，
+                # 写进 monitor JSON / wandb 会污染曲线）；step 结算本身已完成。
+                if loss_is_finite:
+                    # 记录 loss 历史
+                    loss_val = float(loss.item() * group_size)
+                    denoise_loss_val = (
+                        float(denoise_loss_log.item())
+                        if denoise_loss_log is not None else loss_val
+                    )
+                    sra_align_loss_val = (
+                        float(sra_align_loss_log.item())
+                        if sra_align_loss_log is not None else None
+                    )
+                    sra_weighted_loss_val = (
+                        float(sra_weighted_loss_log.item())
+                        if sra_weighted_loss_log is not None else None
+                    )
+                    epoch_loss_sum += loss_val
+                    epoch_step_count += 1
+                    if args.loss_curve_steps and len(ctx.loss_history) < args.loss_curve_steps:
+                        ctx.loss_history.append(loss_val)
 
-                # 更新进度显示
-                now = time.perf_counter()
-                optimizer_metrics = get_optimizer_monitor_metrics(ctx.optimizer)
-                lr = optimizer_metrics["lr"]
+                    # 更新进度显示
+                    now = time.perf_counter()
+                    optimizer_metrics = get_optimizer_monitor_metrics(ctx.optimizer)
+                    lr = optimizer_metrics["lr"]
 
-                # 更新训练监控面板
-                if ctx.monitor_server:
-                    try:
-                        from train_monitor import update_monitor
-                        monitor_metrics = dict(optimizer_metrics)
-                        monitor_metrics["denoise_loss"] = denoise_loss_val
-                        if sra_align_loss_val is not None:
-                            monitor_metrics["sra_align_loss"] = sra_align_loss_val
-                        if sra_weighted_loss_val is not None:
-                            monitor_metrics["sra_weighted_loss"] = sra_weighted_loss_val
-                        if sra_effective_weight_log is not None:
-                            monitor_metrics["sra_effective_weight"] = float(sra_effective_weight_log)
-                        update_monitor(
-                            loss=loss_val, lr=lr, epoch=epoch + 1,
-                            total_epochs=int(args.epochs or 0),
-                            step=ctx.global_step,
-                            total_steps=ctx.total_steps_display or ctx.total_steps,
-                            speed=ctx.speed_ema or 0,
-                            optimizer_metrics=monitor_metrics,
+                    # 更新训练监控面板
+                    if ctx.monitor_server:
+                        try:
+                            from train_monitor import update_monitor
+                            monitor_metrics = dict(optimizer_metrics)
+                            monitor_metrics["denoise_loss"] = denoise_loss_val
+                            if sra_align_loss_val is not None:
+                                monitor_metrics["sra_align_loss"] = sra_align_loss_val
+                            if sra_weighted_loss_val is not None:
+                                monitor_metrics["sra_weighted_loss"] = sra_weighted_loss_val
+                            if sra_effective_weight_log is not None:
+                                monitor_metrics["sra_effective_weight"] = float(sra_effective_weight_log)
+                            update_monitor(
+                                loss=loss_val, lr=lr, epoch=epoch + 1,
+                                total_epochs=int(args.epochs or 0),
+                                step=ctx.global_step,
+                                total_steps=ctx.total_steps_display or ctx.total_steps,
+                                speed=ctx.speed_ema or 0,
+                                optimizer_metrics=monitor_metrics,
+                            )
+                        except Exception:
+                            pass
+                    dt_step = now - step_start_time
+                    steps_per_sec = (1.0 / dt_step) if dt_step > 0 else 0.0
+                    ctx.speed_ema = steps_per_sec if ctx.speed_ema is None else (0.9 * ctx.speed_ema + 0.1 * steps_per_sec)
+                    log_payload: dict[str, Any] = {
+                        "train/loss": loss_val,
+                        "train/denoise_loss": denoise_loss_val,
+                        "train/lr": float(lr),
+                        "train/speed_it_s": float(ctx.speed_ema or 0),
+                    }
+                    if sra_align_loss_val is not None:
+                        log_payload["train/sra_align_loss"] = sra_align_loss_val
+                    if sra_weighted_loss_val is not None:
+                        log_payload["train/sra_weighted_loss"] = sra_weighted_loss_val
+                    if sra_effective_weight_log is not None:
+                        log_payload["train/sra_effective_weight"] = float(sra_effective_weight_log)
+                    if "d" in optimizer_metrics:
+                        log_payload["train/optimizer_d"] = float(optimizer_metrics["d"])
+                    if "base_lr" in optimizer_metrics:
+                        log_payload["train/base_lr"] = float(optimizer_metrics["base_lr"])
+                    if "effective_lr" in optimizer_metrics:
+                        log_payload["train/effective_lr"] = float(optimizer_metrics["effective_lr"])
+                    # 自适应采样器可观测性（P1-1）：CDF 是否就绪 + 退化次数
+                    if (
+                        ctx.global_step % args.log_every == 0
+                        and ctx.timestep_sampler.status().get("kind") == "infonoise"
+                    ):
+                        status = ctx.timestep_sampler.status()
+                        log_payload["infonoise/cdf_ready"] = float(status["cdf_ready"])
+                        log_payload["infonoise/refresh_degraded_count"] = status["refresh_degraded_count"]
+                    ctx.wandb_monitor.log(log_payload, step=ctx.global_step)
+
+                    if ctx.use_rich:
+                        desc = f"epoch {epoch+1}/{args.epochs} step {ctx.global_step}/{ctx.total_steps_display or ctx.total_steps or '?'}"
+                        ctx.progress.update(
+                            ctx.task_id, advance=1, description=desc,
+                            loss=loss_val, lr=float(lr), speed=float(ctx.speed_ema or 0),
                         )
-                    except Exception:
-                        pass
-                dt_step = now - step_start_time
-                steps_per_sec = (1.0 / dt_step) if dt_step > 0 else 0.0
-                ctx.speed_ema = steps_per_sec if ctx.speed_ema is None else (0.9 * ctx.speed_ema + 0.1 * steps_per_sec)
-                log_payload: dict[str, Any] = {
-                    "train/loss": loss_val,
-                    "train/denoise_loss": denoise_loss_val,
-                    "train/lr": float(lr),
-                    "train/speed_it_s": float(ctx.speed_ema or 0),
-                }
-                if sra_align_loss_val is not None:
-                    log_payload["train/sra_align_loss"] = sra_align_loss_val
-                if sra_weighted_loss_val is not None:
-                    log_payload["train/sra_weighted_loss"] = sra_weighted_loss_val
-                if sra_effective_weight_log is not None:
-                    log_payload["train/sra_effective_weight"] = float(sra_effective_weight_log)
-                if "d" in optimizer_metrics:
-                    log_payload["train/optimizer_d"] = float(optimizer_metrics["d"])
-                if "base_lr" in optimizer_metrics:
-                    log_payload["train/base_lr"] = float(optimizer_metrics["base_lr"])
-                if "effective_lr" in optimizer_metrics:
-                    log_payload["train/effective_lr"] = float(optimizer_metrics["effective_lr"])
-                # 自适应采样器可观测性（P1-1）：CDF 是否就绪 + 退化次数
-                if (
-                    ctx.global_step % args.log_every == 0
-                    and ctx.timestep_sampler.status().get("kind") == "infonoise"
-                ):
-                    status = ctx.timestep_sampler.status()
-                    log_payload["infonoise/cdf_ready"] = float(status["cdf_ready"])
-                    log_payload["infonoise/refresh_degraded_count"] = status["refresh_degraded_count"]
-                ctx.wandb_monitor.log(log_payload, step=ctx.global_step)
-
-                if ctx.use_rich:
-                    desc = f"epoch {epoch+1}/{args.epochs} step {ctx.global_step}/{ctx.total_steps_display or ctx.total_steps or '?'}"
-                    ctx.progress.update(
-                        ctx.task_id, advance=1, description=desc,
-                        loss=loss_val, lr=float(lr), speed=float(ctx.speed_ema or 0),
-                    )
-                    if ctx.live and args.loss_curve_steps > 0 and not args.no_live_curve:
-                        panel = render_curve_panel(ctx.loss_history, width=min(60, args.loss_curve_steps), height=10)
-                        if panel is not None:
-                            from rich.console import Group
-                            ctx.live.update(Group(ctx.progress, panel))
-                elif ctx.use_plain:
-                    sra_suffix = (
-                        f" denoise={denoise_loss_val:.6f}"
-                        f" sra={sra_align_loss_val:.6f}"
-                        f" sra_w={sra_weighted_loss_val:.6f}"
-                        if sra_align_loss_val is not None and sra_weighted_loss_val is not None
-                        else f" denoise={denoise_loss_val:.6f}"
-                    )
-                    print(f"epoch {epoch+1}/{args.epochs} step {ctx.global_step} loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} speed={ctx.speed_ema:.2f} it/s", end="\r", flush=True)
-                elif args.log_every and ctx.global_step % args.log_every == 0:
-                    sra_suffix = (
-                        f" denoise={denoise_loss_val:.6f}"
-                        f" sra={sra_align_loss_val:.6f}"
-                        f" sra_w={sra_weighted_loss_val:.6f}"
-                        if sra_align_loss_val is not None and sra_weighted_loss_val is not None
-                        else f" denoise={denoise_loss_val:.6f}"
-                    )
-                    # flush 必须开：studio spawn 的 stdout 是 pipe（全缓冲
-                    # 8KB），不 flush 时 step 行滞留缓冲——短训练/中止的
-                    # task log 里一行都看不到（曾被误判为 krea2 没打日志）
-                    print(
-                        f"epoch={epoch} step={ctx.global_step} "
-                        f"loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} "
-                        f"speed={steps_per_sec:.2f} it/s",
-                        flush=True,
-                    )
+                        if ctx.live and args.loss_curve_steps > 0 and not args.no_live_curve:
+                            panel = render_curve_panel(ctx.loss_history, width=min(60, args.loss_curve_steps), height=10)
+                            if panel is not None:
+                                from rich.console import Group
+                                ctx.live.update(Group(ctx.progress, panel))
+                    elif ctx.use_plain:
+                        sra_suffix = (
+                            f" denoise={denoise_loss_val:.6f}"
+                            f" sra={sra_align_loss_val:.6f}"
+                            f" sra_w={sra_weighted_loss_val:.6f}"
+                            if sra_align_loss_val is not None and sra_weighted_loss_val is not None
+                            else f" denoise={denoise_loss_val:.6f}"
+                        )
+                        print(f"epoch {epoch+1}/{args.epochs} step {ctx.global_step} loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} speed={ctx.speed_ema:.2f} it/s", end="\r", flush=True)
+                    elif args.log_every and ctx.global_step % args.log_every == 0:
+                        sra_suffix = (
+                            f" denoise={denoise_loss_val:.6f}"
+                            f" sra={sra_align_loss_val:.6f}"
+                            f" sra_w={sra_weighted_loss_val:.6f}"
+                            if sra_align_loss_val is not None and sra_weighted_loss_val is not None
+                            else f" denoise={denoise_loss_val:.6f}"
+                        )
+                        # flush 必须开：studio spawn 的 stdout 是 pipe（全缓冲
+                        # 8KB），不 flush 时 step 行滞留缓冲——短训练/中止的
+                        # task log 里一行都看不到（曾被误判为 krea2 没打日志）
+                        print(
+                            f"epoch={epoch} step={ctx.global_step} "
+                            f"loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} "
+                            f"speed={steps_per_sec:.2f} it/s",
+                            flush=True,
+                        )
 
                 # 按 step 采样（轮换提示词）
                 if args.sample_steps > 0 and ctx.global_step % args.sample_steps == 0:

--- a/tests/test_loop_nonfinite_loss.py
+++ b/tests/test_loop_nonfinite_loss.py
@@ -1,0 +1,199 @@
+"""非有限 loss micro-batch 的累积组语义（runtime/training/loop.py）。
+
+回归背景（task 1848/1853 事故）：旧实现对 loss=NaN 的 micro-batch 做
+`zero_grad() + continue`——
+1. 把同一累积组内其它正常 micro-batch 已积累的梯度一并清掉；
+2. 跳过组尾结算，组尾撞上 NaN 时 global_step 冻结，权重坏死后训练
+   以「空转」跑完所有 epoch 并以 exit 0 伪装成功。
+
+新语义：非有限 loss 只跳过本 micro-batch 的 backward，组内其它梯度保留、
+组尾照常结算；组内全部被跳过（无任何梯度）时不 step、不推进 global_step。
+
+harness：为 loop.run() 搭最小 fake（CPU、标准 rectified-flow 路径、真 SGD），
+NaN 注入走真实事故同路径——latents 含 NaN → forward → loss NaN。
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+pytest.importorskip("torch")
+import torch  # noqa: E402
+import torch.nn as nn  # noqa: E402
+
+from runtime.training import loop as loop_mod  # noqa: E402
+from runtime.training.context import TrainingContext  # noqa: E402
+
+
+class _ScalarGainModel(nn.Module):
+    """pred = 输入 × 标量参数：梯度直达唯一参数，更新与否一眼可判。"""
+
+    def __init__(self):
+        super().__init__()
+        self.w = nn.Parameter(torch.tensor(1.0))
+
+    def forward(self, x):
+        return x * self.w
+
+
+class _FakeFamily:
+    spec = types.SimpleNamespace(family_id="fake")
+
+    def encode_text_for_batch(self, text_stack, model, captions, device, dtype, **kw):
+        return torch.zeros(len(captions), 1, 8)
+
+    def forward_train(self, model, noisy, t, cross, use_checkpoint=False):
+        return model(noisy)
+
+
+class _FakeTimestepSampler:
+    def sample(self, bs, device):
+        return torch.full((bs,), 0.5)
+
+    def record(self, t, mse):
+        pass
+
+    def maybe_refresh(self, step):
+        pass
+
+    def status(self):
+        return {"kind": "fake"}
+
+
+class _FakeInjector:
+    def on_step_begin(self, step_ctx):
+        pass
+
+    def regularization_loss(self, step_ctx):
+        return None
+
+    def save(self, path):
+        pass
+
+
+class _FakeLoss:
+    def compute(self, pred, target, t):
+        return (pred - target) ** 2
+
+
+class _FakeWandb:
+    def log(self, *a, **k):
+        pass
+
+    def upload_model(self, *a, **k):
+        pass
+
+    def upload_state_auto(self, *a, **k):
+        pass
+
+    def upload_state_manual(self, *a, **k):
+        pass
+
+    def finish(self):
+        pass
+
+
+def _make_args(**over):
+    d = dict(
+        epochs=1,
+        grad_accum=2,
+        grad_checkpoint=False,
+        max_steps=0,
+        sample_steps=0,
+        sample_every=0,
+        save_every_epochs=0,
+        save_every_steps=0,
+        save_state_every_epochs=0,
+        save_state_every_steps=0,
+        log_every=10,  # 0 会在既有 infonoise 可观测性分支里除零（真实默认 10）
+        loss_curve_steps=100,
+        output_name="t",
+        navit_packing=False,
+        leap_enabled=False,
+        masked_loss=False,
+        loss_weighting="none",
+        noise_enhancement_type="none",
+        timestep_shift_resolution_aware=False,
+        caption_comfy_encoding=True,
+        kv_trim=False,
+    )
+    d.update(over)
+    return types.SimpleNamespace(**d)
+
+
+def _batch(nan: bool = False):
+    lat = torch.randn(1, 4, 1, 8, 8)
+    if nan:
+        lat[...] = float("nan")
+    return {"captions": ["c"], "latents": lat}
+
+
+def _make_ctx(tmp_path, batches, monkeypatch, **args_over):
+    # epoch 末的周期 IO（auto_epoch_state 写盘 + event）与本测试无关，打掉
+    monkeypatch.setattr(loop_mod, "save_training_state", lambda *a, **k: None)
+    monkeypatch.setattr(loop_mod, "write_config_snapshot", lambda *a, **k: None)
+    monkeypatch.setattr(loop_mod, "emit_event", lambda *a, **k: None)
+
+    ctx = TrainingContext(args=_make_args(**args_over))
+    model = _ScalarGainModel()
+    ctx.family = _FakeFamily()
+    ctx.device = "cpu"
+    ctx.dtype = torch.float32
+    ctx.use_cached = True
+    ctx.dataloader = batches
+    ctx.model = model
+    ctx.optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+    ctx.optimizer_type = "sgd"
+    ctx.trainable_params = list(model.parameters())
+    ctx.timestep_sampler = _FakeTimestepSampler()
+    ctx.injector = _FakeInjector()
+    ctx.loss_fn = _FakeLoss()
+    ctx.wandb_monitor = _FakeWandb()
+    ctx.output_dir = tmp_path / "out"
+    ctx.output_dir.mkdir(parents=True, exist_ok=True)
+    ctx.sample_dir = tmp_path / "samples"
+    ctx.grad_clip = 0.0
+    ctx.total_steps = 10
+    return ctx
+
+
+def test_baseline_two_finite_microbatches_step_once(tmp_path, monkeypatch):
+    # harness 自检：正常两 micro-batch（ga=2）→ 恰好 1 次 step，参数被更新
+    ctx = _make_ctx(tmp_path, [_batch(), _batch()], monkeypatch)
+    loop_mod.run(ctx)
+    assert ctx.global_step == 1
+    assert float(ctx.model.w.detach()) != 1.0
+    assert len(ctx.loss_history) == 1
+    assert all(v == v for v in ctx.loss_history)  # 无 NaN
+
+
+def test_nan_tail_microbatch_still_steps_with_kept_grads(tmp_path, monkeypatch):
+    # [好, NaN]（ga=2）：旧实现组尾 NaN → zero_grad + continue → 好梯度作废、
+    # global_step 冻结。新语义：好 micro-batch 的梯度保留，组尾照常 step。
+    ctx = _make_ctx(tmp_path, [_batch(), _batch(nan=True)], monkeypatch)
+    loop_mod.run(ctx)
+    assert ctx.global_step == 1
+    assert float(ctx.model.w.detach()) != 1.0
+    # 组尾 micro-batch 非有限 → 本 step 跳过 loss 记录，不得混入 NaN
+    assert all(v == v for v in ctx.loss_history)
+
+
+def test_nan_head_microbatch_group_still_steps(tmp_path, monkeypatch):
+    # [NaN, 好]：NaN 在组头不得影响随后的正常 micro-batch 结算
+    ctx = _make_ctx(tmp_path, [_batch(nan=True), _batch()], monkeypatch)
+    loop_mod.run(ctx)
+    assert ctx.global_step == 1
+    assert float(ctx.model.w.detach()) != 1.0
+    assert len(ctx.loss_history) == 1
+    assert all(v == v for v in ctx.loss_history)
+
+
+def test_all_nan_group_does_not_step(tmp_path, monkeypatch):
+    # 组内全 NaN → 无梯度可结算：不 step、global_step 不推进、参数不动
+    # （空梯度 step 会污染 Prodigy 的 k / scheduler 进度，fp16 下 GradScaler 直接崩）
+    ctx = _make_ctx(tmp_path, [_batch(nan=True), _batch(nan=True)], monkeypatch)
+    loop_mod.run(ctx)
+    assert ctx.global_step == 0
+    assert float(ctx.model.w.detach()) == 1.0
+    assert ctx.loss_history == []


### PR DESCRIPTION
## 背景

task 1848/1853 事故调查（两个训练数值崩溃后以 exit 0「完成」）暴露了 `loop.py` 非有限 loss 处理的两个缺陷。本 PR 修其中的累积组语义（fail-fast 另开 PR 处理）：

旧实现对 loss=NaN 的 micro-batch 做 `zero_grad() + continue`：

1. **丢好梯度**：同一累积组内其它正常 micro-batch 已经 backward 积累的梯度被一并清掉；
2. **冻结 global_step**：`continue` 跳过组尾结算，组尾撞上 NaN 时整组作废且 global_step 不推进。权重坏死（全 NaN）后 step 永远停在原地，epoch 以 ~10× 速度空转跑完，任务标 done / exit 0——1848 卡在 step 204 空转 38 个 epoch，1853 卡在 step 42 空转 30 个 epoch。

## 改动

- 非有限 loss 只跳过**本 micro-batch 的 backward**：不 `zero_grad`（保留组内其它梯度）、不跳过组尾结算；
- 组尾结算前检查组内是否有任何梯度：**全组被跳过时不 step、不推进 global_step**（空梯度 step 会污染 Prodigy 的 `k` / scheduler 进度；fp16 下 GradScaler 对空梯度组 step 会 assert 崩）；
- 组尾 micro-batch 非有限时跳过该 step 的 loss 记录/监控写入（`loss_val` 是 NaN，写进 monitor JSON / wandb 会污染曲线；step 结算本身照常完成）。diff 里记录/监控块的大段变化是包进 `if loss_is_finite:` 的缩进，逻辑未动。

## 测试

新增 `tests/test_loop_nonfinite_loss.py`：为 `loop.run()` 搭最小 CPU harness（标准 rectified-flow 路径 + 真 SGD），NaN 注入走真实事故同路径（latents 含 NaN → forward → loss NaN）：

- 基线：两个正常 micro-batch（ga=2）→ 恰好 1 次 step（harness 自检）
- `[好, NaN]`：组尾 NaN 仍用保留的好梯度 step、global_step 推进、loss 历史无 NaN —— **旧代码此用例红**（已验证：stash 掉修复后该用例 FAILED）
- `[NaN, 好]`：组头 NaN 不影响后续结算
- `[NaN, NaN]`：全 NaN 组不 step、参数不动

本地已跑：新测试 4 passed；`test_route_snapshot` + `test_studio_configs` 安全网、`test_grad_accum_tail` / `test_masked_loss` / `test_sra_align` / `test_display_total_steps` 共 67 passed；ruff 无违例。

🤖 Generated with [Claude Code](https://claude.com/claude-code)