### PR TITLE
fix(setup): transformers floor 抬到 >=4.57.0 — 老 venv 缺 Qwen3VL 致 Krea2 训练崩

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,12 @@
 torch>=2.0.0
 torchvision>=0.15.0
 diffusers>=0.32.0
-transformers>=4.35.0
+# >=4.57.0：Krea2 文本编码器用 Qwen3VLForConditionalGeneration（4.57.0 引入）。
+# 自更新的 pip install -r 不带 --upgrade（仅补缺），floor 不抬上去，v0.20 之前
+# 装机的老 venv 永远停在旧版，Krea2 全链路在 TE 加载即崩（#485）。抬 floor 后
+# pip 连带升 huggingface_hub→1.x / tokenizers→0.22+ / safetensors→0.8+，torch
+# 不在 transformers 硬依赖里、不受影响。
+transformers>=4.57.0
 sentencepiece>=0.1.99
 protobuf>=3.20.0
 accelerate>=0.24.0


### PR DESCRIPTION
## 背景 / 动机

#485：用户报告 Krea2 训练启动即崩 `RuntimeError: 当前 transformers 不含 Qwen3VLForConditionalGeneration`，而 Anima 训练正常。

根因是依赖钉版遗漏：Krea2（v0.20.0）的文本编码器需要 `Qwen3VLForConditionalGeneration`（transformers **4.57.0** 引入），但 `requirements.txt` 一直停在 `transformers>=4.35.0`，没随 Krea2 上线抬高。自更新的 `pip install -r` 特意不带 `--upgrade`（仅补缺），floor 已满足就永不升级——于是 **v0.20 之前装机、之后原地升级上来的老 venv 永远停在旧版 transformers**，Krea2 的训练 / 评估 / 测试出图在 TE 加载处全挂。Anima 不受影响（TE 是 Qwen3-0.6B + T5，老版本就支持），与用户「Anima 还能正常训练」的观察吻合。新装机不受影响（pip 直接解析到最新版）。

## 改动概要

- `requirements.txt`：`transformers>=4.35.0` → `transformers>=4.57.0`（附注释说明缘由）。

一行钉版即是完整修复：hash 变化天然触发 updater 的 marker-stale 路径 → `pip install -r` → pip 发现 floor 不满足 → 升级。老用户随下次更新自动痊愈，零手动操作。

**牵连面已查清（无钉子）**：

| 项 | 结论 |
|---|---|
| Python | pip 实际解析到 5.15.0，要求 >=3.10——与项目一贯要求一致（README / studio.bat / studio.sh 均有 3.10+ gate）；万一有 3.9 用户，pip 自动退到 4.57.x（支持 3.9，同样含 Qwen3VL） |
| torch | **不在 transformers 硬依赖里**（在 extras），已核对 5.8.0 / 5.15.0 两版 metadata——不会把用户的 CUDA torch 顶成 PyPI CPU 轮子 |
| huggingface_hub | 连带升到 1.5+；代码库已兼容 1.x（#387 httpx 链路，`httpx[socks]` 已在 requirements） |
| tokenizers | 连带升到 0.22+；老版对 hf_hub 的 `<1.0` 上限随升级一起消失，不卡解析 |
| safetensors / regex / typer | 连带升 / 新增装，均在现有 floor 允许范围内，纯 Python 无风险 |
| 反向依赖 | venv 全扫描：无包对 transformers 加上限（peft 裸依赖、diffusers 不依赖它、modelscope 对 hf_hub 零约束） |

本机 dev venv（transformers 5.8.0 + 全家桶）全绿，是现成的兼容性证明。

## 测试方式

- `pytest tests/test_check_requirements_changed.py tests/test_route_snapshot.py tests/test_studio_configs.py -q` → 43 passed
- `ruff check .` → 通过
- 依赖影响为静态钉版分析（PyPI metadata + venv 反向依赖扫描），无代码行为变化

Fixes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)
