### PR TITLE
fix: 移除 caption / prompt 的 512 token 截断——上游的 512 是 pad 下限不是上限

### DIFF
--- a/docs/user-guide/caption-format.md
+++ b/docs/user-guide/caption-format.md
@@ -1,8 +1,8 @@
 # JSON Caption 格式规范
 
 > **适用范围**：分类 JSON caption（fixed / character / series / artist + 分类 shuffle）服务
-> Anima 的 booru tag 生态。Krea 2 用自然语言长 caption（LLM 打标器输出，训练侧截断 512
-> token），一般直接用 TXT / 扁平文本即可，不需要本格式的分类结构。
+> Anima 的 booru tag 生态。Krea 2 用自然语言长 caption（LLM 打标器输出，长度不设上限），
+> 一般直接用 TXT / 扁平文本即可，不需要本格式的分类结构。
 
 AnimaLoraStudio 支持结构化的 JSON 标签文件，相比传统 TXT 文件有以下优势：
 

--- a/docs/user-guide/training-tips.md
+++ b/docs/user-guide/training-tips.md
@@ -293,7 +293,9 @@ Krea 2 走 Qwen3-VL 自然语言 caption，不是 booru tag 生态：
 
 - 打标推荐用 **LLM 打标器**（长自然语言描述）；WD14 tag 链路机制上可用但非推荐
 - 触发词照常有效（自动注入 caption；采样 prompt 需自己写进去）
-- 训练侧 caption 截断到 **512 token**（官方训练口径）；测试出图的在线编码不截断
+- caption 长度不设上限，训练与出图都不截断。超过 512 token 的部分照常参与训练，
+  代价是文本缓存和显存跟着涨（缓存约 31MB / 512 token；DiT 的注意力序列 =
+  caption token 数 + 图像 token 数，1024×1024 图的图像侧是 4096）
 
 ### Block 交换（换出到内存的层数）
 

--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -104,28 +104,34 @@ class AnimaFamily:
         )
 
         qwen_model, qwen_tok, t5_tok = text
-        max_len = self.spec.text.max_seq_len
+        # pad 下限，不是 caption 长度上限——两条 tokenize 路径都不截断
+        # （ComfyUI Qwen3Tokenizer/T5XXLTokenizer 是 max_length=99999999）
+        pad_floor = self.spec.text.max_seq_len
         with torch.no_grad():
             if comfy_encoding:
                 qwen_texts = [str(c) for c in captions]
                 qwen_emb, _ = encode_qwen(qwen_model, qwen_tok, qwen_texts, device)
-                t5_ids, t5_attn, t5_w = tokenize_t5_comfy_literal(t5_tok, captions, max_length=max_len)
+                t5_ids, t5_attn, t5_w = tokenize_t5_comfy_literal(t5_tok, captions)
             else:
                 qwen_texts = [_build_qwen_text_from_prompt(c) for c in captions]
                 qwen_emb, _ = encode_qwen(qwen_model, qwen_tok, qwen_texts, device)
-                t5_ids, t5_attn, t5_w = tokenize_t5_weighted(t5_tok, captions, max_length=max_len)
+                t5_ids, t5_attn, t5_w = tokenize_t5_weighted(t5_tok, captions)
             t5_ids = t5_ids.to(device)
             t5_attn = t5_attn.to(device)
             t5_w = t5_w.to(device, dtype=torch.float32)
             # t5_w 在 preprocess_text_embeds 内乘到 LLMAdapter 输出上（ComfyUI 对齐）
             cross = dit.preprocess_text_embeds(qwen_emb, t5_ids, t5xxl_weights=t5_w)
-            if cross.shape[1] < max_len:
-                cross = F.pad(cross, (0, 0, 0, max_len - cross.shape[1]))
+            # 只补不足（ComfyUI comfy/ldm/anima/model.py:204-205 同款 floor pad）；
+            # 超过 pad_floor 的 caption 原样保留
+            if cross.shape[1] < pad_floor:
+                cross = F.pad(cross, (0, 0, 0, pad_floor - cross.shape[1]))
             if kv_trim:
-                # KV trim：padding 截到最近有效 token bucket（64/128/256/512）
+                # KV trim：padding 截到最近有效 token bucket（64/128/256/512）。
+                # 上限是 cross 实际宽度而非 pad_floor——超长 caption 下用
+                # pad_floor 兜底会把尾巴又砍掉一次。
                 _actual = int(t5_attn.sum(dim=-1).max().item())
-                _bucket = max_len
-                for _b in (64, 128, 256, max_len):
+                _bucket = cross.shape[1]
+                for _b in (64, 128, 256, pad_floor):
                     if _b >= _actual:
                         _bucket = _b
                         break

--- a/runtime/training/families/anima/navit.py
+++ b/runtime/training/families/anima/navit.py
@@ -26,11 +26,12 @@ def pack_cross_embeddings(
     """把 per-image text embedding 拼成一条序列，供 block-diagonal cross-attn。
 
     Args:
-        cross: ``[G, L, D]`` — per-image text embedding（L=512 padded）。
+        cross: ``[G, L, D]`` — per-image text embedding（L=max(512, 最长 caption)，
+            512 是 pad 下限而非上限）。
         t5_attn: ``[G, L]`` — per-image attention mask（1=有效 token）。
             仅 ``navit_text_trim_padding=True`` 时使用。
         navit_text_trim_padding: True 时按每图有效 token 数截断 padding（cross-attn
-            提速、不注意 padding 位）；False 时每图带完整 512-pad（与标准路径行为一致）。
+            提速、不注意 padding 位）；False 时每图带完整 L-pad（与标准路径行为一致）。
 
     Returns:
         (cross_packed ``[1, ΣL, D]``, text_seqlens ``[G]``)

--- a/runtime/training/families/anima/sampling.py
+++ b/runtime/training/families/anima/sampling.py
@@ -315,7 +315,6 @@ def sample_image(
             qwen_text, t5_ids, t5_attn, t5_w = build_comfy_anima_conditioning_inputs(
                 t5_tokenizer,
                 prompt_text,
-                max_length=512,
             )
             qwen_embeds, qwen_attn = encode_qwen(
                 qwen_model,
@@ -330,6 +329,8 @@ def sample_image(
             t5_attn = t5_attn.to(device)
             t5_w = t5_w.to(device, dtype=dtype)
             cross = model.preprocess_text_embeds(qwen_embeds, t5_ids, t5xxl_weights=t5_w)
+            # 只补不足（ComfyUI comfy/ldm/anima/model.py:204-205）；超过 512 的
+            # prompt 原样保留——上游 tokenizer 同样无长度上限
             if cross.shape[1] < 512:
                 cross = F.pad(cross, (0, 0, 0, 512 - cross.shape[1]))
             return cross

--- a/runtime/training/families/anima/text_encoding.py
+++ b/runtime/training/families/anima/text_encoding.py
@@ -24,8 +24,8 @@ import torch
 logger = logging.getLogger(__name__)
 
 
-def encode_qwen(model, tokenizer, texts, device, max_length=512, preserve_empty_text: bool = False):
-    """Qwen 文本编码。"""
+def encode_qwen(model, tokenizer, texts, device, preserve_empty_text: bool = False):
+    """Qwen 文本编码（不截断）。"""
     # Qwen3 tokenizer 对空字符串可能返回 0 tokens（会导致模型内部 reshape 失败）
     # ComfyUI 的 AnimaTokenizer 设置了 min_length=1，这里做同等兜底。
     if isinstance(texts, str):
@@ -35,12 +35,13 @@ def encode_qwen(model, tokenizer, texts, device, max_length=512, preserve_empty_
     else:
         texts = [(" " if (t is None or str(t).strip() == "") else str(t)) for t in texts]
 
+    # 不设长度上限：ComfyUI 的 Qwen3Tokenizer 是 max_length=99999999 +
+    # pad_to_max_length=False（comfy/text_encoders/anima.py），512 在上游是
+    # cross embedding 的 pad 下限而非 token 上限。
     inputs = tokenizer(
         texts,
         return_tensors="pt",
         padding=True,
-        truncation=True,
-        max_length=max_length,
         add_special_tokens=False,
     )
     uses_comfy_masking = bool(getattr(model, "uses_comfy_clip_masking", False))
@@ -230,12 +231,17 @@ def _tokenizer_input_ids_without_eos(tokenizer, text: str, eos_id: int) -> list[
     return out
 
 
-def build_comfy_anima_conditioning_inputs(t5_tokenizer, prompt: str, max_length=512):
+def build_comfy_anima_conditioning_inputs(t5_tokenizer, prompt: str):
     """Build generate-time Anima text inputs using Comfy-compatible tokenization.
 
     Comfy's Anima tokenizer keeps Qwen text raw while using SDTokenizer-style
     weighted parsing for T5. This helper intentionally does not replace the
     legacy training tokenization helpers.
+
+    No length cap: Comfy's T5XXLTokenizer runs at ``max_length=99999999`` with
+    ``pad_to_max_length=False``, and the 512 in ``comfy/ldm/anima/model.py``
+    (``preprocess_text_embeds``) is a pad floor applied after the adapter, not
+    a token ceiling.
     """
     qwen_text = "" if prompt is None else str(prompt)
 
@@ -252,21 +258,14 @@ def build_comfy_anima_conditioning_inputs(t5_tokenizer, prompt: str, max_length=
     ids.append(int(eos_id))
     weights.append(1.0)
 
-    if max_length and len(ids) > int(max_length):
-        keep = max(1, int(max_length))
-        ids = ids[:keep]
-        weights = weights[:keep]
-        ids[-1] = int(eos_id)
-        weights[-1] = 1.0
-
     t5_ids = torch.tensor([ids], dtype=torch.long)
     t5_weights = torch.tensor([weights], dtype=torch.float32)
     t5_attn = torch.ones_like(t5_ids, dtype=torch.long)
     return qwen_text, t5_ids, t5_attn, t5_weights
 
 
-def tokenize_t5_comfy_literal(tokenizer, texts, max_length=512):
-    """Comfy-style 字面 T5 tokenization（训练 caption 用，批量版）。
+def tokenize_t5_comfy_literal(tokenizer, texts):
+    """Comfy-style 字面 T5 tokenization（训练 caption 用，批量版，不截断）。
 
     与 build_comfy_anima_conditioning_inputs 的差异：caption 是数据不是 prompt，
     整段按字面文本分词——不做权重语法解析、不清洗。booru tag 的括号
@@ -287,9 +286,6 @@ def tokenize_t5_comfy_literal(tokenizer, texts, max_length=512):
     for text in texts:
         ids = _tokenizer_input_ids_without_eos(tokenizer, str(text), int(eos_id))
         ids.append(int(eos_id))
-        if max_length and len(ids) > int(max_length):
-            ids = ids[: int(max_length)]
-            ids[-1] = int(eos_id)
         seqs.append(ids)
 
     max_len = max((len(s) for s in seqs), default=1)
@@ -329,9 +325,10 @@ def apply_t5_token_weights(cross: torch.Tensor, token_weights: torch.Tensor | No
     return cross * weights.unsqueeze(-1)
 
 
-def tokenize_t5_weighted(tokenizer, texts, max_length=512):
+def tokenize_t5_weighted(tokenizer, texts):
     """
     参考 ComfyUI 的 anima-kai：按逗号切分 tag，逐 tag 分词，并为每个 token 附带权重。
+    不截断（ComfyUI tokenizer 无长度上限）。
     返回：input_ids, attention_mask(1=有效), token_weights
     """
     if isinstance(texts, str):
@@ -358,11 +355,6 @@ def tokenize_t5_weighted(tokenizer, texts, max_length=512):
         # 末尾补一个 eos（ComfyUI 也是最后加一个终止 token）
         ids.append(int(eos_id))
         ws.append(1.0)
-
-        # 截断到 max_length（保留最后一个 eos）
-        if max_length and len(ids) > max_length:
-            ids = ids[: max_length - 1] + [int(eos_id)]
-            ws = ws[: max_length - 1] + [1.0]
 
         all_ids.append(torch.tensor(ids, dtype=torch.long))
         all_w.append(torch.tensor(ws, dtype=torch.float32))

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -109,6 +109,8 @@ KREA2_SPEC = ModelSpec(
     latent=WAN21_F8C16,
     text=TextSpec(
         strategy="cached_varlen",
+        # caption padding 的定长下限，不是长度上限——训练与在线两条路径都不
+        # 截断（KREA2_MAX_LENGTH 注释）。K2 无消费者，仅作声明。
         max_seq_len=512,
         fingerprint=KREA2_TEXT_FINGERPRINT,
     ),

--- a/runtime/training/families/krea2/text_encoding.py
+++ b/runtime/training/families/krea2/text_encoding.py
@@ -31,6 +31,8 @@ from ...text_cache import TextCacheEntry, TextCacheStore
 logger = logging.getLogger(__name__)
 
 KREA2_TEXT_FINGERPRINT = "qwen3-vl-4b-instruct-krea2-12x2560-v1"
+#: 训练 caption 的 padding 定长下限——不是长度上限（两条路径都不截断）。
+#: 保留这个定长是文本缓存兼容性依据，见 Krea2TextStack._pad_to_floor。
 KREA2_MAX_LENGTH = 512
 KREA2_SELECTED_LAYERS = (2, 5, 8, 11, 14, 17, 20, 23, 26, 29, 32, 35)
 KREA2_TEXT_WIDTH = 2560
@@ -463,6 +465,30 @@ class Krea2TextStack:
         if self.device.type == "cuda" and torch.cuda.is_available():
             torch.cuda.empty_cache()
 
+    def _pad_to_floor(self, encoded: Mapping[str, Tensor]) -> dict[str, Tensor]:
+        """把 caption 段右 pad 到 max_length 定长下限（不足才补，超出原样）。
+
+        等价于旧的 ``padding="max_length"``——定长以内逐位一致，是文本缓存
+        跨版本兼容的依据。批内出现超长样本时 ``padding="longest"`` 已把同批
+        短样本 pad 到那个更长的宽度，短样本的 suffix 位置随之后移：同一
+        caption 换一种分批组合会编出略有差异的嵌入。缓存只写一次，训练中不
+        会自相矛盾；cache_batch_size=1（现状）下该分支根本不触发。
+        """
+        input_ids = encoded["input_ids"]
+        floor = self.max_length + _PREFIX_TOKENS - _SUFFIX_TOKENS
+        deficit = floor - input_ids.shape[1]
+        if deficit <= 0:
+            return {"input_ids": input_ids, "attention_mask": encoded["attention_mask"]}
+        pad_id = getattr(self.tokenizer, "pad_token_id", None)
+        return {
+            "input_ids": torch.nn.functional.pad(
+                input_ids, (0, deficit), value=int(pad_id) if pad_id is not None else 0,
+            ),
+            "attention_mask": torch.nn.functional.pad(
+                encoded["attention_mask"], (0, deficit), value=0,
+            ),
+        }
+
     def _tokenize(self, captions: Sequence[str]) -> tuple[Tensor, Tensor]:
         text = [_PROMPT_PREFIX + str(caption) for caption in captions]
         suffix = [_PROMPT_SUFFIX] * len(text)
@@ -480,16 +506,25 @@ class Krea2TextStack:
                 return_tensors="pt",
             )
         else:
-            # 训练 cached 模式维持官方训练口径 512 定长（缓存指纹语义不变）
+            # 训练 cached 模式同样不截断（与在线模式口径一致）：DiT 侧文本
+            # 位置编码恒为零（krea2_modeling text_pos），文本长度对 DiT 无
+            # 结构约束；TE 是 Qwen3-VL，512 远在其上下文之内。代价是显存与
+            # 缓存体积随长度线性涨（一条 512 token ≈31MB），由用户掌握。
+            #
+            # 短 caption 仍 pad 到 max_length 定长是缓存兼容性要求：这是
+            # interior padding（pad 在 caption 与 suffix 之间），suffix 的
+            # RoPE 绝对位置因此恒定在定长之后。改成「只 pad 到批内最长」会
+            # 让 ≤max_length 的 caption 嵌入数值改变，已有 sidecar 全量失效。
+            # 保留定长下限 → 定长以内逐位不变 → 指纹无需变更。
             encoded = self.tokenizer(
                 text,
-                truncation=True,
+                truncation=False,
                 return_length=False,
                 return_overflowing_tokens=False,
-                padding="max_length",
-                max_length=self.max_length + _PREFIX_TOKENS - _SUFFIX_TOKENS,
+                padding="longest",
                 return_tensors="pt",
             )
+            encoded = self._pad_to_floor(encoded)
         suffix_encoded = self.tokenizer(suffix, return_tensors="pt")
         input_ids = torch.cat(
             [encoded["input_ids"], suffix_encoded["input_ids"]], dim=1,

--- a/tests/test_comfy_anima_text_encoding.py
+++ b/tests/test_comfy_anima_text_encoding.py
@@ -665,7 +665,7 @@ def test_tokenize_t5_comfy_literal_keeps_parentheses_literal_weight_one() -> Non
     from training.families.anima.text_encoding import tokenize_t5_comfy_literal
 
     caption = "ganyu (genshin impact), 1girl"
-    ids, attn, w = tokenize_t5_comfy_literal(FakeTokenizer(), [caption], max_length=512)
+    ids, attn, w = tokenize_t5_comfy_literal(FakeTokenizer(), [caption])
 
     valid = attn[0].bool()
     valid_ids = ids[0][valid].tolist()
@@ -681,7 +681,7 @@ def test_tokenize_t5_comfy_literal_differs_from_prompt_weight_parsing() -> None:
     from training.families.anima.text_encoding import tokenize_t5_comfy_literal
 
     caption = "ganyu (genshin impact)"
-    ids, attn, _w = tokenize_t5_comfy_literal(FakeTokenizer(), [caption], max_length=512)
+    ids, attn, _w = tokenize_t5_comfy_literal(FakeTokenizer(), [caption])
     valid_ids = ids[0][attn[0].bool()].tolist()
 
     # prompt 权重解析会吃掉括号并给 1.1 倍权重——caption 路径必须不同
@@ -691,10 +691,36 @@ def test_tokenize_t5_comfy_literal_differs_from_prompt_weight_parsing() -> None:
     assert valid_ids != parsed_ids
 
 
+def test_tokenize_t5_comfy_literal_does_not_truncate_beyond_512() -> None:
+    """ComfyUI 的 T5XXLTokenizer 是 max_length=99999999——caption 不设上限。"""
+    from training.families.anima.text_encoding import tokenize_t5_comfy_literal
+
+    caption = "a" * 700
+    ids, attn, _w = tokenize_t5_comfy_literal(FakeTokenizer(), [caption])
+
+    # 700 个字符 token + 1 个 eos，全部有效（旧口径砍到 512）
+    assert ids.shape[1] == 701
+    assert int(attn[0].sum()) == 701
+    assert ids[0][-1].item() == FakeTokenizer.eos_token_id
+
+
+def test_comfy_conditioning_inputs_do_not_truncate_beyond_512() -> None:
+    """出图路径同理：512 是 cross 的 pad 下限，不是 prompt token 上限。"""
+    prompt = "b" * 700
+    _qwen_text, t5_ids, t5_attn, t5_weights = build_comfy_anima_conditioning_inputs(
+        FakeTokenizer(), prompt,
+    )
+
+    assert t5_ids.shape[1] == 701
+    assert int(t5_attn[0].sum()) == 701
+    assert t5_weights.shape[1] == 701
+    assert t5_ids[0][-1].item() == FakeTokenizer.eos_token_id
+
+
 def test_tokenize_t5_comfy_literal_batch_padding_conventions() -> None:
     from training.families.anima.text_encoding import tokenize_t5_comfy_literal
 
-    ids, attn, w = tokenize_t5_comfy_literal(FakeTokenizer(), ["1girl", "a"], max_length=512)
+    ids, attn, w = tokenize_t5_comfy_literal(FakeTokenizer(), ["1girl", "a"])
 
     assert ids.shape == attn.shape == w.shape
     assert ids.shape[0] == 2

--- a/tests/test_krea2_text_encoding.py
+++ b/tests/test_krea2_text_encoding.py
@@ -177,7 +177,46 @@ def test_cached_mode_precaches_reuses_and_releases_model(tmp_path):
     )
 
     assert not second.is_model_loaded
-    assert condition.attention_mask.sum(dim=1).tolist() == [6, 7, 8]
+    # "sample"（34+6=40 token）超过定长 37：不再被砍到 37，6 个 caption token
+    # 全部保留 + 5 个 suffix = 11（旧截断口径是 3+5=8）
+    assert condition.attention_mask.sum(dim=1).tolist() == [6, 7, 11]
+
+
+def test_cached_mode_keeps_padding_floor_for_short_captions(tmp_path):
+    """短 caption 仍 pad 到定长 → suffix 位置不变 → 已有文本缓存继续有效。"""
+    loader = _Loader()
+    stack = _stack(tmp_path, loader, cache_enabled=True)
+    entry = TextCacheEntry.for_image(tmp_path / "image.png", "ab")
+
+    stack.prepare_text_cache(["ab"], [], cache_entries=[entry], cache_root=tmp_path)
+    context = stack.store.read_caption(entry)["context"]
+
+    # 定长 = max_length(8) + prefix(34) - suffix(5) = 37：caption 占 34/35，
+    # 36 是 interior pad（被 mask 掉），suffix 落在 37..41。跳过 136 正是定长
+    # padding 的指纹——改成「只 pad 到批内最长」会变成连续的 134..140，已有
+    # sidecar 就会全量失效。
+    assert context.shape == (7, 2, 4)
+    assert context[:, 0, 0].tolist() == [
+        134.0, 135.0, 137.0, 138.0, 139.0, 140.0, 141.0,
+    ]
+
+
+def test_cached_mode_no_longer_truncates_long_captions(tmp_path):
+    """超过定长的 caption 完整进模型（旧口径砍到 max_length）。"""
+    loader = _Loader()
+    stack = _stack(tmp_path, loader, cache_enabled=True)
+    long_caption = "x" * 20  # 34 + 20 = 54 token，远超定长 37
+    entry = TextCacheEntry.for_image(tmp_path / "long.png", long_caption)
+
+    stack.prepare_text_cache(
+        [long_caption], [], cache_entries=[entry], cache_root=tmp_path,
+    )
+    context = stack.store.read_caption(entry)["context"]
+
+    # 20 个 caption token + 5 个 suffix；宽度已超定长 → 无 interior pad，
+    # 位置连续（在线模式同款口径）
+    assert context.shape == (25, 2, 4)
+    assert context[:, 0, 0].tolist() == [float(134 + index) for index in range(25)]
 
 
 def test_invalid_sidecar_is_reencoded_and_released(tmp_path):

--- a/tests/test_navit_text_encode_regression.py
+++ b/tests/test_navit_text_encode_regression.py
@@ -37,7 +37,7 @@ def _stub_text_encoding(monkeypatch, attn: "torch.Tensor") -> None:
     monkeypatch.setattr(
         te,
         "tokenize_t5_comfy_literal",
-        lambda tok, captions, max_length: (
+        lambda tok, captions: (
             torch.zeros(B, L, dtype=torch.long),
             attn,
             torch.ones(B, L),
@@ -67,6 +67,35 @@ def test_encode_text_for_batch_returns_t5_attn_for_navit(monkeypatch) -> None:
     cross, t5_attn = result
     assert cross.shape[1] == max_len
     torch.testing.assert_close(t5_attn, attn)
+
+
+def test_encode_text_for_batch_pads_short_cross_to_floor(monkeypatch) -> None:
+    """512 是 pad 下限（ComfyUI model.py:204-205）——短 caption 照旧补齐。"""
+    family = AnimaFamily()
+    pad_floor = family.spec.text.max_seq_len
+    _stub_text_encoding(monkeypatch, torch.ones(1, 8, dtype=torch.long))
+
+    cross = family.encode_text_for_batch(
+        (None, None, None), _stub_dit(8), ["a"], "cpu", torch.float32,
+    )
+    assert cross.shape[1] == pad_floor
+
+
+def test_kv_trim_does_not_re_truncate_long_captions(monkeypatch) -> None:
+    """kv_trim 的 bucket 上限是 cross 实际宽度，不是 pad 下限。
+
+    旧实现 bucket 兜底取 512：超长 caption 走完 64/128/256/512 都不命中，
+    就被 cross[:, :512] 又砍掉一次尾巴。
+    """
+    family = AnimaFamily()
+    long_len = family.spec.text.max_seq_len + 128
+    _stub_text_encoding(monkeypatch, torch.ones(1, long_len, dtype=torch.long))
+
+    cross = family.encode_text_for_batch(
+        (None, None, None), _stub_dit(long_len), ["x"], "cpu", torch.float32,
+        kv_trim=True,
+    )
+    assert cross.shape[1] == long_len
 
 
 def test_encode_text_for_batch_default_stays_bare_cross(monkeypatch) -> None:


### PR DESCRIPTION
## 背景 / 动机

用户反馈：同一条长 prompt 在 ComfyUI 里正常生效，在本仓训练 Krea 2 时却像被砍过。查上游源码确认——**512 在 ComfyUI 里是 pad 下限，不是 token 上限**：

- [`comfy/text_encoders/anima.py:11,16`](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/text_encoders/anima.py) — `Qwen3Tokenizer` 与 `T5XXLTokenizer` 都是 `max_length=99999999, pad_to_max_length=False, min_length=1`。SDTokenizer 的分块阈值因此永不触发（也正是 `encode_token_weights` 取 `["t5xxl"][0]` 安全的前提）
- [`comfy/ldm/anima/model.py:204-205`](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/ldm/anima/model.py) — `if out.shape[1] < 512: pad(...)`，**只补不足，不砍超出**

本仓把它读成了上限：Krea 2 训练路径截断 caption，Anima 四个 tokenize 入口各截一刀。用户在 ComfyUI 写的长 caption 到这边被静默丢尾。

DiT 侧本来就没有长度约束：`krea2_modeling.py:489` 的 `text_pos` 恒为零向量，文本 token 在 DiT 里不带位置编码，长度纯粹是序列维；Anima 的 LLMAdapter 是 `nn.Embedding` + 按 `arange(seq_len)` 动态生成的 RoPE，同样无上限。

## 改动概要

**Krea 2**（`families/krea2/text_encoding.py`）

- 训练 cached 路径 `truncation=False`，与在线路径统一
- **保留** `padding="max_length"` 的 512 定长。那是 interior padding，suffix 的 RoPE 绝对位置因此恒定在定长之后；改成只 pad 到批内最长会让 ≤512 的 caption 嵌入数值改变、**已有 sidecar 全量失效**。保留定长 → 定长以内逐位不变 → **文本缓存指纹无需变更，用户现有缓存继续有效**
- 抽出 `_pad_to_floor`，并在 docstring 写明批内混长度时短样本 suffix 位置会随批浮动（`cache_batch_size=1` 是现状，该分支不触发）

**Anima**（`families/anima/`）

- 删四处上游没有的截断：`encode_qwen` / `tokenize_t5_comfy_literal` / `tokenize_t5_weighted` / `build_comfy_anima_conditioning_inputs`（三个函数的 `max_length` 参数一并去掉，它只做截断）
- 两处 floor pad 保留（`family.py` / `sampling.py`），那部分与上游一致
- **修一个连带的二次截断**：`kv_trim` 的 bucket 兜底取 pad 下限，超长 caption 走完 64/128/256/512 都不命中，就被 `cross[:, :512]` 又砍一次。上限改取 `cross.shape[1]`

**行为影响**：≤512 token 的路径**逐位不变**，两族都是纯增量。超过 512 的 caption / prompt 从「静默砍尾」变成「完整生效」。代价随长度线性涨、不加保护：Krea 2 文本缓存约 31MB / 512 token，DiT 注意力序列 = text_len + image_len（1024×1024 图的图像侧是 4096）。

## 测试方式

新增 6 个 regression test：

| 测试 | 锁住的行为 |
|---|---|
| `test_cached_mode_no_longer_truncates_long_captions` | Krea 2 训练不再截断 |
| `test_cached_mode_keeps_padding_floor_for_short_captions` | 定长 padding 保留（缓存兼容的直接断言：位置序列跳过 interior pad 位） |
| `test_tokenize_t5_comfy_literal_does_not_truncate_beyond_512` | Anima caption 路径不截断 |
| `test_comfy_conditioning_inputs_do_not_truncate_beyond_512` | Anima 出图路径不截断 |
| `test_encode_text_for_batch_pads_short_cross_to_floor` | floor pad 保留 |
| `test_kv_trim_does_not_re_truncate_long_captions` | kv_trim 不二次砍尾 |

`test_cached_mode_precaches_reuses_and_releases_model` 的断言从 `[6, 7, 8]` 改成 `[6, 7, 11]` —— 那条 caption 原本正好被砍到 8，现在完整保留，是行为翻转的直接证据。

本地跑过（`venv` Python 3.13）：

- 关联：`test_krea2_text_encoding` / `test_krea2_te_fp8` / `test_comfy_anima_text_encoding` / `test_navit_text_encode_regression` / `test_comfyui_t2i_parity` — 134 passed
- 扩面：`-k "anima or navit or krea2 or text_cache or comfy or families or family"` — 502 passed；`-k "loop or sample or generate or dataset"` — 303 passed
- 横切安全网：`test_route_snapshot` + `test_studio_configs` — 33 passed
- `ruff check .` — All checks passed

**待真机验证**：本机无 GPU，超长 caption 的 Krea 2 训练与 Anima 出图需要在有卡的机器上跑一次确认。

## 外部代码声明

未复制任何上游代码——只对照 ComfyUI 源码（GPL-3.0）核对了长度口径，判据写进注释与本描述。`krea2/text_encoding.py`（musubi-tuner，Apache-2.0）与 `modeling/anima/anima_modeling.py`（ComfyUI，GPL-3.0）的既有来源声明和 `THIRD_PARTY_NOTICES.md` 条目均未变动。

## 文档

`docs/user-guide/training-tips.md` 与 `caption-format.md` 里「训练侧截断 512」的说法已同步。`docs/announcements/2026-07-18-krea2-guide.md` 作为 point-in-time 公告保留原状。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
