### PR TITLE
refactor(schema): Block 交换说明改为按族给可填范围与每层占用

### DIFF
--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -167,12 +167,9 @@ class TrainingConfig(BaseModel):
     # 换出多少层对产出的 LoRA 逐位无影响（纯资源旋钮，同 vae_tiling / cache_latents）
     blocks_to_swap: int = Field(
         0, ge=0,
-        description="Block 交换：换出到内存的 DiT 层数（0=关闭）。被换出的层权重常驻"
-                    "内存，算到该层才搬进显存，用时间换显存，不影响训练结果。"
-                    "每层省多少取决于模型：Krea 2 约 0.4GB（fp8 底模）/ 0.8GB（bf16 底模）每层，"
-                    "Anima 约 0.13GB 每层；1024 分辨率下 Krea 2 换出全部 28 层 fp8 实测约慢 4%。"
-                    "超过模型总层数的值按全部换出处理。"
-                    "需要等量的可用内存，且这部分内存会被锁定、其他程序无法使用",
+        description="Block 交换：换出到内存的 DiT 层数（0=关闭；Anima 接受 0-28，每层约 0.13GB；"
+                    "Krea 2 接受 0-28，每层约 0.4GB fp8 底模 / 0.8GB bf16 底模）。"
+                    "数值越大，显存占用越少、内存占用越大",
         json_schema_extra=_meta(
             "system",
             show_when=cap_gate("block_swap"),


### PR DESCRIPTION
## 背景

训练页「Block 交换」的字段说明把四件事挤在一段小字里：机制（换出层怎么工作）、每层省多少、1024² 下的实测速度代价、pinned 内存会被锁定。用户在这个输入框前最需要的信息——**这个数字能填到多少**——反而只能从「超过模型总层数的值按全部换出处理」倒推。

## 改动

```
- Block 交换：换出到内存的 DiT 层数（0=关闭）。被换出的层权重常驻内存，算到该层才搬进
- 显存，用时间换显存，不影响训练结果。每层省多少取决于模型：Krea 2 约 0.4GB（fp8 底模）
- / 0.8GB（bf16 底模）每层，Anima 约 0.13GB 每层；1024 分辨率下 Krea 2 换出全部 28 层
- fp8 实测约慢 4%。超过模型总层数的值按全部换出处理。需要等量的可用内存，且这部分内存
- 会被锁定、其他程序无法使用
+ Block 交换：换出到内存的 DiT 层数（0=关闭；Anima 接受 0-28，每层约 0.13GB；Krea 2
+ 接受 0-28，每层约 0.4GB fp8 底模 / 0.8GB bf16 底模）。数值越大，显存占用越少、内存
+ 占用越大
```

页面上留「能填什么数字 + 是什么 + 选大选小的影响」，机制与实测细节留在文档（README 硬件要求段、`docs/user-guide/training-tips.md` 的 Block 交换节）。

纯文案改动，无行为变化。

## 数字核实

范围与每层占用直接读本地权重的 safetensors header（只读 header，不读 payload）：

| 模型 | block 数 | 单层 | block 合计 | 非 block（不参与换出） |
|---|---|---|---|---|
| `anima-base-v1.0`（bf16） | 28 | 末 22 层 0.129 GiB / 前 6 层 0.160 GiB | 3.80 GiB | 0.098 GiB |
| `krea2-raw-fp8-scaled` | 28 | 0.404 GiB | 11.32 GiB | 0.92 GiB |
| `krea2-raw-bf16` | 28 | 0.809 GiB | 22.65 GiB | 1.83 GiB |

两点顺带确认：

- **两族都能填到 28**，没有必须驻留的层。`PinnedBlockSwap.__init__` 只在 `num_swap > total` 时报错，`== total` 合法；28 层全换出是 #463 / #490 真机实测过的配置。填 27 和 28 只差一层权重的常驻显存，没有阶跃。
- **去掉了「Anima 大版本 36 层」的括注**。代码保留对 36 层的兼容（`swapped_param_ratio_from_header` 从 header 数层，不写死），但项目发布的 Anima 基模只有 28 层版，这个括注对用户是噪音；超界仍由 `min(blocks_to_swap, len(blocks))` clamp 兜底。

## 测试

- `tests/test_route_snapshot.py tests/test_studio_configs.py` — 33 passed
- `ruff check .` — All checks passed
- 无测试断言这段文案（`tests/` 下无对应字符串）
