### PR TITLE
fix(generate): XY 换 LoRA 三份模型同驻 OOM + 失败后「释放缓存」空转

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -825,19 +825,15 @@ class ModelCache:
     def unload(self, *, keep_text: bool = False) -> None:
         """卸载模型栈。``keep_text``：保留 TE 先行栈（含预编码 LRU）——
         ensure_loaded 的重载路径用，避免刚编码完的结果被清掉。"""
-        had_text = self.text_stack is not None
         if not keep_text:
             self.text_stack = None
             self._text_ready_key = None
         if not self.loaded:
-            if had_text and not keep_text:
-                try:
-                    import gc
-                    gc.collect()
-                    if torch.cuda.is_available():
-                        torch.cuda.empty_cache()
-                except Exception:
-                    pass
+            # 模型未加载 ≠ 显存干净：加载中途 OOM 后 self.model 仍是 None，
+            # 但异常 traceback 的循环引用钉着半上卡的 state_dict（refcount
+            # 收不掉）——手动「释放缓存」落到这个分支时必须无条件清扫，
+            # 否则按钮空转（实测 20GB 纹丝不动）。
+            _reclaim_cuda_leftovers()
             return
         logger.info("unloading model")
         # 埋点必须在**丢引用之前**取基线，否则丢引用那一步的回收量测不到
@@ -920,6 +916,29 @@ def _release_pinned_host_cache() -> None:
     from training.block_swap import release_pinned_host_cache
 
     release_pinned_host_cache()
+
+
+def _reclaim_cuda_leftovers() -> None:
+    """回收不再被业务引用持有、但还占着显存/pinned 内存的残骸。
+
+    异常（尤其加载/采样中途的 OOM）traceback 与 frame 互相引用，钉住
+    frame locals 里的大张量，必须 gc 才收得掉；empty_cache 再把空闲
+    block 还给驱动。pinned host cache 同理显式归还（无 cache 时 no-op）。
+    模型本体不受影响——只清「已无主」的部分。"""
+    try:
+        import gc
+        gc.collect()
+        if torch.cuda.is_available():
+            try:
+                # cuBLAS workspace 会钉住所在 segment（见 unload 内注释），
+                # 先清再 empty_cache 才能整段归还
+                torch._C._cuda_clearCublasWorkspaces()
+            except Exception:
+                pass
+            torch.cuda.empty_cache()
+        _release_pinned_host_cache()
+    except Exception:
+        logger.exception("CUDA leftovers reclaim failed")
 
 
 CACHE = ModelCache()
@@ -1664,6 +1683,7 @@ def _run_generate_worker(
     output_dir: Path,
     cancel_event: threading.Event,
 ) -> None:
+    failed = False
     try:
         _run_generate(req_id, task_id, cfg, output_dir, cancel_event)
         _emit_for(req_id, "done", task_id=task_id)
@@ -1673,7 +1693,12 @@ def _run_generate_worker(
     except Exception as e:
         logger.exception("generate failed")
         _emit_for(req_id, "error", task_id=task_id, message=str(e))
+        failed = True
     finally:
+        if failed:
+            # 必须在 except 块结束（异常对象被隐式 del）之后清扫，traceback
+            # 钉住的 frame locals（如 OOM 时半上卡的 state_dict）才收得掉
+            _reclaim_cuda_leftovers()
         _pop_cancel(req_id)
         with _ACTIVE_WORKER_LOCK:
             global _ACTIVE_WORKER

--- a/runtime/training/families/krea2/lora_fp8_merge.py
+++ b/runtime/training/families/krea2/lora_fp8_merge.py
@@ -302,7 +302,11 @@ class Fp8LoraMergeAdapter:
 
     def detach(self) -> bool:
         if not self._can_restore:
-            # 没留备份：告诉调用方「还不了」，由它重载模型保证干净状态
+            # 没留备份：告诉调用方「还不了」，由它重载模型保证干净状态。
+            # 模型引用必须一并丢掉——这个句柄还被 _run_generate/_run_xy 的
+            # 局部 adapters 变量持着，不置空则重载兜底期间旧模型整份钉在
+            # 显存里（XY 逐格换 LoRA 时最多三份模型同驻，直接 OOM）
+            self._model = None
             return False
         if not self._backup:
             return True
@@ -313,6 +317,7 @@ class Fp8LoraMergeAdapter:
             if scale_cpu is not None:
                 module.weight_scale.copy_(scale_cpu.to(module.weight_scale.device))
         self._backup = {}
+        self._model = None
         return True
 
 
@@ -436,8 +441,9 @@ def merge_loras_into_fp8_model(
             torch.cuda.empty_cache()
 
     logger.info(
-        "Krea2 fp8 merge：%d 份 LoRA 烘进 %d 个 Linear（delta=%s；chunk_rows=%s；含备份，可 detach 还原）",
+        "Krea2 fp8 merge：%d 份 LoRA 烘进 %d 个 Linear（delta=%s；chunk_rows=%s；%s）",
         len(sources), len(per_layer), str(compute_dtype).removeprefix("torch."),
         normalized_chunk_rows or "off",
+        "含备份，可 detach 还原" if keep_backup else "无备份，换 LoRA 走重载兜底",
     )
     return Fp8LoraMergeAdapter(model, backup, can_restore=keep_backup)

--- a/tests/test_block_swap_fp8_merge.py
+++ b/tests/test_block_swap_fp8_merge.py
@@ -121,11 +121,16 @@ def test_keep_backup_false_skips_the_second_full_copy():
     a_kept = merge_loras_into_fp8_model(kept, [(lora, 1.0, "t")], keep_backup=True)
     assert a_kept._backup, "默认应留备份"
     assert a_kept.detach() is True, "有备份 → 能就地还原"
+    assert a_kept._model is None, "还原完成后句柄不应再钉着模型"
 
     lean = _build_fp8_blocks(device)
     a_lean = merge_loras_into_fp8_model(lean, [(lora, 1.0, "t")], keep_backup=False)
     assert not a_lean._backup, "关掉后不应有任何备份张量"
     assert a_lean.detach() is False, "无备份 → 必须返回 False 触发重载兜底"
+    # 兜底=调用方卸载重载整个模型,此时句柄还被 _run_generate/_run_xy 的
+    # 局部 adapters 持着——不丢模型引用,重载期间旧模型整份钉在显存里
+    # (XY 逐格换 LoRA 时最多三份模型同驻,实测 32GB 卡第 3 格 OOM)
+    assert a_lean._model is None, "detach 失败路径必须丢模型引用"
 
 
 def test_keep_backup_false_still_merges_identically():

--- a/tests/test_block_swap_pinned_release.py
+++ b/tests/test_block_swap_pinned_release.py
@@ -105,3 +105,43 @@ def test_release_helper_is_silent_when_api_missing(monkeypatch):
 
     monkeypatch.setattr(torch._C, "_host_emptyCache", _boom, raising=False)
     d._release_pinned_host_cache()  # 不应抛出
+
+
+def test_unload_reclaims_leftovers_even_when_model_absent(monkeypatch):
+    """**回归**：模型未加载 ≠ 显存干净。加载中途 OOM 后 model 仍是 None，
+    但异常 traceback 的循环引用钉着半上卡的 state_dict（refcount 收不掉）——
+    手动「释放缓存」落到早退分支时必须无条件清扫，否则按钮空转
+    （真机实测 20GB 纹丝不动，daemon 却汇报「已卸载」）。"""
+    d = _daemon()
+    calls = []
+    monkeypatch.setattr(d, "_reclaim_cuda_leftovers", lambda: calls.append(1))
+
+    cache = d.ModelCache()
+    assert not cache.loaded
+    cache.unload()
+
+    assert calls, "早退分支必须清扫（gc + empty_cache + pinned 归还）"
+
+
+def test_generate_worker_reclaims_leftovers_on_failure(monkeypatch):
+    """任务失败后 worker 必须清扫一次 —— OOM 残骸不该留到下次成功 load。
+    清扫必须发生在 except 块结束（异常对象被隐式 del）之后，traceback
+    钉住的 frame locals 才收得掉；这里只测接线（有没有调 + 失败才调）。"""
+    from pathlib import Path as _P
+
+    d = _daemon()
+    calls = []
+    monkeypatch.setattr(d, "_reclaim_cuda_leftovers", lambda: calls.append(1))
+    monkeypatch.setattr(d, "_emit_for", lambda *a, **k: None)
+
+    def _boom(*a, **k):
+        raise RuntimeError("synthetic failure")
+
+    monkeypatch.setattr(d, "_run_generate", _boom)
+    d._run_generate_worker("req-x", 1, {}, _P("."), __import__("threading").Event())
+    assert calls, "失败路径必须清扫"
+
+    calls.clear()
+    monkeypatch.setattr(d, "_run_generate", lambda *a, **k: None)
+    d._run_generate_worker("req-y", 2, {}, _P("."), __import__("threading").Event())
+    assert not calls, "成功路径不清扫（别把有用的 allocator cache 也倒掉）"


### PR DESCRIPTION
## 症状

XY 图(krea2 fp8 + block swap,X 轴=lora_ckpt)第 3 格必报 CUDA OOM(`18.89 GiB is allocated by PyTorch`);之后点「释放缓存」,daemon 汇报已卸载、UI 显示成功,但进程实际仍钉着 20.1GB 专用显存。

## 根因

**三份模型同驻**:fp8 底模的 LoRA 是 merge 进权重的,开 block swap 时刻意不留 12GB CPU 还原备份(`keep_merge_backup=False`),换 LoRA 走「detach 失败 → 全量卸载重载」兜底。但 `Fp8LoraMergeAdapter._model` 持有整个模型,且该句柄被 `_run_generate:1398` 与 `_run_xy:1564` 的**局部 `adapters` 变量**持有——`CACHE.unload()` 只清 CACHE 自身引用。逐格换 LoRA 时:格 1 句柄钉到任务结束、格 2 句柄要等 `apply_loras` 返回才被重新赋值放掉(而重载恰在 `apply_loras` 内部)、格 3 正在加载 → 3 × ~6GB,32GB 卡第 3 格 OOM。

**「释放缓存」空转**:OOM 抛在 `_load()` 内部,`self.model` 仍是 None → `unload()` 早退分支直接 return,gc/empty_cache 都不跑;而 OOM 残骸(异常 traceback 循环引用钉住的半上卡 state_dict)恰恰只有 gc 才收得掉。

## 修复

- `Fp8LoraMergeAdapter.detach()` 两条路径(无备份返回 False / 有备份还原成功)均置空 `_model`——兜底重载期间旧模型立即可回收,三同驻消失
- 新增 `_reclaim_cuda_leftovers()`(gc + cuBLAS workspace 清理 + empty_cache + pinned 归还):`unload()` 早退分支无条件调用;`_run_generate_worker` 失败路径在 except 块结束(异常对象隐式 del)后调用
- fp8 merge 完成日志按 `keep_backup` 实际值打,不再无条件写「含备份,可 detach 还原」

## 验证

- 新增 3 条测试:detach 两路径丢模型引用、unload 早退分支清扫接线、worker 失败才清扫(成功不清);关联 7 个测试文件 97 passed
- 真机复现原任务(4 格 lora_ckpt 轴 XY,与 OOM 任务同参数):4 格全部走 detach-failed 全量重载路径,全部出图,任务 done;此前第 3 格 100% OOM
- 「释放缓存」验证:杀旧 daemon 后 22.9GB → 2.4GB;新 daemon 任务结束后 15.9GB 为模型正常常驻

🤖 Generated with [Claude Code](https://claude.com/claude-code)
