### PR TITLE
feat(anima): 底模层数从 checkpoint header 推断（支持 Anima-2.9B 等插层扩展版）

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -187,7 +187,7 @@ def _swap_discount_ratio(
     比例而非字节：fp8 与 bf16 的文件大小差一倍，按字节折扣会在 fp8 场景把护栏
     折扣穿（训练侧同款，见 training/sysmem.check_load_budget）。
     族不支持 / 查询失败返回 0，护栏退化成保守。
-    transformer_path：anima 靠它区分 28/36 层版本；krea2 结构唯一、忽略。
+    transformer_path：anima 层数由文件决定（28/36/40…）靠它数；krea2 结构唯一、忽略。
     """
     if blocks_to_swap <= 0:
         return 0.0
@@ -626,7 +626,7 @@ class ModelCache:
             from training.block_swap import PinnedBlockSwap
 
             # clamp 到总层数：全局设置值跨族/跨版本共享（krea2 28 层、anima
-            # 28/36 层），超界按全量换出处理而非 fail（训练侧同口径）
+            # 层数由 checkpoint 决定），超界按全量换出处理而非 fail（训练侧同口径）
             self.block_swap = PinnedBlockSwap(
                 model.blocks, min(blocks_to_swap, len(model.blocks)), device,
             )

--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -38,8 +38,9 @@ class AnimaFamily:
                             checkpoint_path: str | None = None) -> float:
         """换出层占全模型参数的比例（显存预算折扣用，krea2 同款语义）。
 
-        Anima 的层数由 checkpoint 决定（2B=28 层 / 14B=36 层），不能像 krea2
-        那样按固定 config 数 meta 参数 —— 从 safetensors header 数 numel，
+        Anima 的层数由 checkpoint 决定（官方 2B=28 层 / 14B=36 层 / 第三方
+        插层扩展版更多），不能像 krea2 那样按固定 config 数 meta 参数 —— 从
+        safetensors header 数 numel（studio.services.inference.checkpoint_arch），
         天然版本无关。未给路径 / 读失败返回 0：护栏退化为保守（按完整模型
         预算显存，不会误放行）。
         """

--- a/runtime/training/families/anima/loader.py
+++ b/runtime/training/families/anima/loader.py
@@ -11,6 +11,10 @@ import logging
 import re
 from pathlib import Path
 
+from studio.services.inference.checkpoint_arch import (
+    AnimaCheckpointArch,
+    inspect_anima_checkpoint,
+)
 from training.model_loading import (
     _load_safetensors_state_dict,
     _load_weights_best_effort,
@@ -18,40 +22,59 @@ from training.model_loading import (
 
 logger = logging.getLogger(__name__)
 
-#: checkpoint 键里的 block 归属（键可能带 model./module. 等前缀，
-#: _load_weights_best_effort 加载时才剥——这里按子串匹配，前缀无关）
-_BLOCK_KEY_RE = re.compile(r"(?:^|\.)blocks\.(\d+)\.")
+#: checkpoint 里随模型一起存下来的 RoPE 派生缓冲（第三方训练器会把
+#: ``pos_embedder.seq / dim_spatial_range / dim_temporal_range`` 存进文件）。
+#: 它们不是权重，形状与值都由本地建模配置决定（seq 长度 = max_img_h // patch），
+#: 与写文件那边的配置无关；留在 state dict 里会因形状不同让 load_state_dict
+#: 直接 raise（strict=False 只管缺/多 key，不管 shape）。加载前一律剥掉。
+_DERIVED_BUFFER_RE = re.compile(r"(?:^|\.)pos_embedder\.")
 
 
 def swapped_param_ratio_from_header(checkpoint_path, blocks_to_swap: int) -> float:
     """换出层占全模型参数的比例，从 safetensors header 数 numel（不读 payload）。
 
     krea2 用固定 config 数 meta 模型参数；Anima 的层数由 checkpoint 决定
-    （2B=28 层 / 14B=36 层），header 才是版本真相，且数参数天然 dtype 无关
-    （显存折扣必须按比例乘文件实际大小，见 krea2 loader 同名函数的说明）。
+    （官方 2B=28 层 / 14B=36 层 / 第三方插层扩展版更多），header 才是版本真相，
+    且数参数天然 dtype 无关（显存折扣必须按比例乘文件实际大小，见 krea2 loader
+    同名函数的说明）。
     """
-    from safetensors import safe_open
-
     if blocks_to_swap <= 0:
         return 0.0
-    per_block: dict[int, int] = {}
-    total = 0
-    with safe_open(str(checkpoint_path), framework="pt", device="cpu") as f:
-        for key in f.keys():
-            numel = 1
-            for dim in f.get_slice(key).get_shape():
-                numel *= dim
-            total += numel
-            m = _BLOCK_KEY_RE.search(key)
-            if m:
-                idx = int(m.group(1))
-                per_block[idx] = per_block.get(idx, 0) + numel
-    if not per_block or total <= 0:
-        return 0.0
-    num_blocks = max(per_block) + 1
-    first = max(num_blocks - blocks_to_swap, 0)
-    swapped = sum(n for i, n in per_block.items() if i >= first)
-    return swapped / total
+    return inspect_anima_checkpoint(checkpoint_path).swapped_param_ratio(blocks_to_swap)
+
+
+def arch_to_config(arch: AnimaCheckpointArch) -> dict:
+    """底模架构 → ``Anima(**config)`` 构造参数（纯函数，可单测）。
+
+    层数 / 通道数 / 输入通道来自 header；其余是 Anima 族固定的建模常量。
+    """
+    if arch.num_heads is None:
+        raise RuntimeError(f"未知的 model_channels={arch.model_channels}")
+    return dict(
+        max_img_h=1024, max_img_w=1024, max_frames=128,
+        in_channels=arch.in_channels, out_channels=16,
+        patch_spatial=2, patch_temporal=1,
+        concat_padding_mask=True,
+        model_channels=arch.model_channels,
+        num_blocks=arch.num_blocks, num_heads=arch.num_heads,
+        crossattn_emb_channels=1024,
+        pos_emb_cls="rope3d", pos_emb_learnable=True,
+        pos_emb_interpolation="crop",
+        use_adaln_lora=True, adaln_lora_dim=256,
+        rope_h_extrapolation_ratio=4.0 if arch.in_channels == 16 else 3.0,
+        rope_w_extrapolation_ratio=4.0 if arch.in_channels == 16 else 3.0,
+        rope_t_extrapolation_ratio=1.0,
+    )
+
+
+def drop_derived_buffers(sd: dict) -> dict:
+    """剥掉 checkpoint 里的 RoPE 派生缓冲（见 ``_DERIVED_BUFFER_RE``）。返回新 dict。"""
+    dropped = [k for k in sd if _DERIVED_BUFFER_RE.search(k)]
+    if not dropped:
+        return sd
+    logger.info("忽略 checkpoint 里的 %d 个 RoPE 派生缓冲（本地按配置重算）: %s",
+                len(dropped), ", ".join(dropped[:4]))
+    return {k: v for k, v in sd.items() if k not in set(dropped)}
 
 
 def place_model_for_block_swap(model, device, dtype, blocks_to_swap: int) -> int:
@@ -63,7 +86,7 @@ def place_model_for_block_swap(model, device, dtype, blocks_to_swap: int) -> int
     只 pin、不重复拷贝）。
 
     返回实际换出层数（clamp 到总层数——blocks_to_swap 是全局设置，用户可能
-    按 36 层版调的值喂给 28 层版，超界按全量换出处理）。
+    按层数更多的版本调的值喂给层数少的版本，超界按全量换出处理）。
     """
     import torch
 
@@ -109,8 +132,6 @@ def load_anima_model(transformer_path, device, dtype, repo_root, *,
     时由 caller 传入），让 caller 完全决定 attention 实现 —— PR #17 那版默认
     fn(True) 强制开 flash_attn 不让用户关，与 cfg.attention_backend 解耦不彻底。
     """
-    from safetensors import safe_open
-
     # repo_root 参数保留但已不使用（sister 契约签名「可加不可减不可改」）：模型
     # 代码随仓库发布，走正常 import —— 单一模块身份，exec-load 已退役（多模型
     # PR-2a），attention backend 开关不再需要跨模块别名广播。
@@ -143,43 +164,12 @@ def load_anima_model(transformer_path, device, dtype, repo_root, *,
         logger.info("flash_attn 关闭（attention_backend=%s 或包未安装）",
                     "flash_attn" if flash_attn else "non-flash")
 
-    # 从 checkpoint 推断配置
-    with safe_open(transformer_path, framework="pt", device="cpu") as f:
-        for k in f.keys():
-            if k.endswith("x_embedder.proj.1.weight"):
-                w = f.get_tensor(k)
-                break
-
-    in_channels = (w.shape[1] // 4) - 1  # concat_padding_mask=True
-    model_channels = w.shape[0]
-
-    if model_channels == 2048:
-        num_blocks, num_heads = 28, 16
-    elif model_channels == 5120:
-        num_blocks, num_heads = 36, 40
-    else:
-        raise RuntimeError(f"未知的 model_channels={model_channels}")
-
-    config = dict(
-        max_img_h=1024, max_img_w=1024, max_frames=128,
-        in_channels=in_channels, out_channels=16,
-        patch_spatial=2, patch_temporal=1,
-        concat_padding_mask=True,
-        model_channels=model_channels,
-        num_blocks=num_blocks, num_heads=num_heads,
-        crossattn_emb_channels=1024,
-        pos_emb_cls="rope3d", pos_emb_learnable=True,
-        pos_emb_interpolation="crop",
-        use_adaln_lora=True, adaln_lora_dim=256,
-        rope_h_extrapolation_ratio=4.0 if in_channels == 16 else 3.0,
-        rope_w_extrapolation_ratio=4.0 if in_channels == 16 else 3.0,
-        rope_t_extrapolation_ratio=1.0,
-    )
-
-    model = Anima(**config)
+    # 从 checkpoint header 推断架构（层数由文件决定，不查表）
+    arch = inspect_anima_checkpoint(transformer_path)
+    model = Anima(**arch_to_config(arch))
 
     # 加载权重
-    sd = _load_safetensors_state_dict(Path(transformer_path))
+    sd = drop_derived_buffers(_load_safetensors_state_dict(Path(transformer_path)))
     info = _load_weights_best_effort(model, sd, label="Transformer")
 
     # 如果 checkpoint 中完全没有 llm_adapter 权重，随机初始化会把 cross-attn 条件搞乱，直接禁用更安全
@@ -196,7 +186,9 @@ def load_anima_model(transformer_path, device, dtype, repo_root, *,
         model = model.to(device=device, dtype=dtype)
     model.requires_grad_(False)
 
-    logger.info(f"Anima 模型加载完成: {model_channels}ch, {num_blocks} blocks")
+    # 公开架构事实：LoRA 元数据 / 出图侧兼容判定按它取层数，不再各自数一遍
+    model.checkpoint_arch = arch
+    logger.info(f"Anima 模型加载完成: {arch.model_channels}ch, {arch.num_blocks} blocks")
     return model
 
 

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -160,7 +160,7 @@ class Krea2Family:
         刻意是比例不是字节数 —— fp8 与 bf16 的文件大小差一倍，按字节折扣会在
         fp8 场景把护栏折扣穿。
 
-        ``checkpoint_path`` 是跨族协议参数（anima 靠它区分 28/36 层版本）；
+        ``checkpoint_path`` 是跨族协议参数（anima 层数由 checkpoint 决定，靠它数）；
         krea2 结构唯一（KREA2_CONFIG），不需要。
         """
         del checkpoint_path

--- a/runtime/training/model_loading.py
+++ b/runtime/training/model_loading.py
@@ -258,6 +258,18 @@ def _load_weights_best_effort(model: torch.nn.Module, sd: dict, label: str) -> d
             f"关键参数缺失: {preview_missing or 'N/A'}。\n"
             f"这通常表示你选错了 .safetensors（不是完整 transformer/vae 权重），或 checkpoint key 前缀不匹配。"
         )
+    # 反向同样致命：checkpoint 里有关键层而模型没有 —— 典型是层数比模型多
+    # （建模时层数推断错），静默丢层后模型仍能"跑"，只是全是垃圾。这里必须
+    # 硬报错而不是只 log（此前 unexpected 只打一行 info）。
+    critical_unexpected = [k for k in unexpected if k.startswith(critical_prefixes)]
+    if critical_unexpected:
+        preview_unexpected = ", ".join(critical_unexpected[:8])
+        raise RuntimeError(
+            f"{label} checkpoint 含有模型里不存在的关键参数（{len(critical_unexpected)} 个，"
+            f"remap={remap_name}）: {preview_unexpected}。\n"
+            f"checkpoint 的层数/结构与建出的模型不一致——多半是模型层数推断错了，"
+            f"或这不是当前模型族的权重。"
+        )
     return {
         "remap": remap_name,
         "coverage": coverage,

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -63,7 +63,7 @@ def _swap_vram_discount(ctx: TrainingContext) -> float:
     if ratio_fn is None:
         return 0.0
     try:
-        # checkpoint_path：anima 靠它区分 28/36 层版本；krea2 结构唯一、忽略
+        # checkpoint_path：anima 层数由文件决定（28/36/40…）靠它数；krea2 结构唯一、忽略
         return float(ratio_fn(
             blocks_to_swap,
             checkpoint_path=str(getattr(ctx.args, "transformer_path", "") or ""),
@@ -160,7 +160,7 @@ def _setup_block_swap(ctx: TrainingContext) -> None:
     from training.block_swap import PinnedBlockSwap
 
     # clamp 到总层数：blocks_to_swap 是跨族/跨版本共享的设置值（krea2 28 层、
-    # anima 28/36 层），超界按全量换出处理而非 fail（loader 侧同口径）
+    # anima 层数由 checkpoint 决定），超界按全量换出处理而非 fail（loader 侧同口径）
     ctx.block_swap = PinnedBlockSwap(
         ctx.model.blocks, min(blocks_to_swap, len(ctx.model.blocks)), ctx.device,
     )

--- a/studio/domain/training.py
+++ b/studio/domain/training.py
@@ -167,8 +167,8 @@ class TrainingConfig(BaseModel):
     # 换出多少层对产出的 LoRA 逐位无影响（纯资源旋钮，同 vae_tiling / cache_latents）
     blocks_to_swap: int = Field(
         0, ge=0,
-        description="Block 交换：换出到内存的 DiT 层数（0=关闭；Anima 接受 0-28，每层约 0.13GB；"
-                    "Krea 2 接受 0-28，每层约 0.4GB fp8 底模 / 0.8GB bf16 底模）。"
+        description="Block 交换：换出到内存的 DiT 层数（0=关闭；超过底模层数按全部换出；"
+                    "Anima 每层约 0.13GB，Krea 2 每层约 0.4GB fp8 底模 / 0.8GB bf16 底模）。"
                     "数值越大，显存占用越少、内存占用越大",
         json_schema_extra=_meta(
             "system",

--- a/studio/services/inference/checkpoint_arch.py
+++ b/studio/services/inference/checkpoint_arch.py
@@ -1,0 +1,182 @@
+"""Anima 族底模 checkpoint 架构探测 —— 只读 safetensors header，不碰 payload。
+
+Anima 的层数由 checkpoint 决定（官方 2B=28 层、14B=36 层、第三方插层扩展版
+如 Anima-2.9B=40 层……），代码里**不允许再出现任何写死的层数**：loader 建模型、
+block swap 算换出比例、LoRA 元数据记底模架构、studio 目录行展示层数，全部
+从这里的 :class:`AnimaCheckpointArch` 取值（单一真相）。
+
+放在 studio/services/inference/ 而不是 runtime/：与 ``core.py``（LoRA 元数据 /
+apply）同款定位 —— 被 runtime 训练/出图进程与 studio 服务端两边共用，依赖方向
+runtime → studio 已是既有约定；且 studio 服务端列目录时不能为此 import torch
+（``runtime.training.families`` 包顶层会拉起 torch），本模块只用标准库。
+
+header 解析自己做（8 字节小端长度 + JSON），不走 ``safetensors.safe_open``：
+后者 ``framework="pt"`` 会 import torch。
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import struct
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+#: model_channels → 注意力头数。这是本模块唯一允许的「查表」——头数不出现在
+#: 权重形状里（q_proj 是 [C, C]），只能靠通道数对应；层数一律数出来。
+HEADS_BY_MODEL_CHANNELS: dict[int, int] = {2048: 16, 5120: 40}
+
+#: DiT block 键（键可能带 net. / model. / module. 等前缀，按子串匹配）。
+#: llm_adapter 自己也有 ``blocks.N``（6 层小 transformer），必须排除，否则会
+#: 把 adapter 参数算进 DiT block 0-5、层数推断也可能被污染。
+_BLOCK_KEY_RE = re.compile(r"(?:^|\.)blocks\.(\d+)\.")
+_ADAPTER_MARK = "llm_adapter."
+_X_EMBEDDER_SUFFIX = "x_embedder.proj.1.weight"
+
+#: safetensors header 长度上限：真实 checkpoint 的 header 在几十 KB ~ 几百 KB，
+#: 超过这个数基本是读到了别的文件 / 损坏文件，直接拒绝而不是分配巨量内存。
+_MAX_HEADER_BYTES = 256 * 1024 * 1024
+
+
+class CheckpointInspectError(ValueError):
+    """checkpoint 不是（可识别的）Anima 族 transformer 权重。"""
+
+
+def read_safetensors_header(path: str | os.PathLike[str]) -> dict[str, Any]:
+    """读 safetensors 文件头（含 ``__metadata__``），不读任何张量数据。
+
+    格式：前 8 字节 = 小端 uint64 header 长度 N，随后 N 字节 UTF-8 JSON。
+    """
+    with open(path, "rb") as f:
+        head = f.read(8)
+        if len(head) < 8:
+            raise CheckpointInspectError(f"不是 safetensors 文件（不足 8 字节）: {path}")
+        (n,) = struct.unpack("<Q", head)
+        if n <= 0 or n > _MAX_HEADER_BYTES:
+            raise CheckpointInspectError(f"safetensors header 长度异常（{n}）: {path}")
+        raw = f.read(n)
+    if len(raw) != n:
+        raise CheckpointInspectError(f"safetensors header 被截断: {path}")
+    try:
+        header = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, ValueError) as exc:
+        raise CheckpointInspectError(f"safetensors header 不是合法 JSON: {path}") from exc
+    if not isinstance(header, dict):
+        raise CheckpointInspectError(f"safetensors header 结构异常: {path}")
+    return header
+
+
+def _numel(shape: Any) -> int:
+    n = 1
+    for d in shape or ():
+        n *= int(d)
+    return n
+
+
+@dataclass(frozen=True)
+class AnimaCheckpointArch:
+    """从 header 推断出的 Anima 底模架构。
+
+    只含「决定怎么建模型 / LoRA 能否互换 / 资源量级」的事实；不含任何人类命名
+    （2B / 2.9B 之类只在下载目录的 label 里）。
+    """
+
+    #: ``x_embedder.proj.1.weight.shape[0]``
+    model_channels: int
+    #: ``x_embedder.proj.1.weight.shape[1] // 4 - 1``（concat_padding_mask=True）
+    in_channels: int
+    #: DiT block 数 = ``blocks.N`` 最大下标 + 1（不含 llm_adapter.blocks）
+    num_blocks: int
+    #: 按 :data:`HEADS_BY_MODEL_CHANNELS` 查表；未知通道数为 None（由建模方决定报错）
+    num_heads: int | None
+    has_llm_adapter: bool
+    #: header 数出的全模型参数量（dtype 无关）
+    param_count: int
+    #: 每个 DiT block 的参数量，下标 = block 序号
+    block_param_counts: tuple[int, ...]
+    file_bytes: int
+
+    @property
+    def dit_param_count(self) -> int:
+        return sum(self.block_param_counts)
+
+    def swapped_param_ratio(self, blocks_to_swap: int) -> float:
+        """换出末尾 ``blocks_to_swap`` 层占全模型参数的比例（超界按全部换出）。
+
+        显存折扣必须按比例乘文件实际大小（dtype 无关），见 krea2 loader 同名函数说明。
+        """
+        n = min(int(blocks_to_swap), self.num_blocks)
+        if n <= 0 or self.param_count <= 0:
+            return 0.0
+        return sum(self.block_param_counts[self.num_blocks - n:]) / self.param_count
+
+    def as_dict(self) -> dict[str, Any]:
+        """给 API / 元数据用的扁平字典（不含 per-block 明细）。"""
+        return {
+            "model_channels": self.model_channels,
+            "in_channels": self.in_channels,
+            "num_blocks": self.num_blocks,
+            "num_heads": self.num_heads,
+            "has_llm_adapter": self.has_llm_adapter,
+            "param_count": self.param_count,
+            "file_bytes": self.file_bytes,
+        }
+
+
+def arch_from_header(header: dict[str, Any], *, file_bytes: int = 0) -> AnimaCheckpointArch:
+    """纯函数：safetensors header（tensor 名 → {dtype, shape, data_offsets}）→ 架构。"""
+    x_key = next((k for k in header if k != "__metadata__" and k.endswith(_X_EMBEDDER_SUFFIX)), None)
+    if x_key is None:
+        raise CheckpointInspectError(
+            "不是 Anima / Cosmos-Predict2 transformer 权重（缺 x_embedder.proj.1.weight）"
+        )
+    x_shape = header[x_key].get("shape") or []
+    if len(x_shape) != 2:
+        raise CheckpointInspectError(f"x_embedder.proj.1.weight 形状异常: {x_shape}")
+    model_channels = int(x_shape[0])
+    in_channels = int(x_shape[1]) // 4 - 1
+
+    per_block: dict[int, int] = {}
+    total = 0
+    has_adapter = False
+    for key, ent in header.items():
+        if key == "__metadata__" or not isinstance(ent, dict):
+            continue
+        numel = _numel(ent.get("shape"))
+        total += numel
+        if _ADAPTER_MARK in key:
+            has_adapter = True
+            continue
+        m = _BLOCK_KEY_RE.search(key)
+        if m:
+            idx = int(m.group(1))
+            per_block[idx] = per_block.get(idx, 0) + numel
+    if not per_block:
+        raise CheckpointInspectError("权重里没有任何 blocks.N.* 张量")
+    num_blocks = max(per_block) + 1
+    missing = [i for i in range(num_blocks) if i not in per_block]
+    if missing:
+        raise CheckpointInspectError(f"DiT block 下标不连续，缺 {missing[:8]}（共 {len(missing)} 层）")
+
+    return AnimaCheckpointArch(
+        model_channels=model_channels,
+        in_channels=in_channels,
+        num_blocks=num_blocks,
+        num_heads=HEADS_BY_MODEL_CHANNELS.get(model_channels),
+        has_llm_adapter=has_adapter,
+        param_count=total,
+        block_param_counts=tuple(per_block[i] for i in range(num_blocks)),
+        file_bytes=int(file_bytes),
+    )
+
+
+def inspect_anima_checkpoint(path: str | os.PathLike[str]) -> AnimaCheckpointArch:
+    """读文件头并推断架构（毫秒级；不读 payload、不 import torch）。"""
+    p = Path(path)
+    header = read_safetensors_header(p)
+    try:
+        file_bytes = p.stat().st_size
+    except OSError:
+        file_bytes = 0
+    return arch_from_header(header, file_bytes=file_bytes)

--- a/tests/test_anima_checkpoint_arch.py
+++ b/tests/test_anima_checkpoint_arch.py
@@ -1,0 +1,199 @@
+"""Anima 底模架构探测（studio.services.inference.checkpoint_arch）+ loader 接线。
+
+背景：第三方插层扩展版（Anima-2.9B = 40 层）进不来的两处根因 ——
+① loader 按 model_channels 查表把层数写死 28（多出的层进 unexpected 只 log，静默丢层）；
+② 文件里带 RoPE 派生缓冲 pos_embedder.seq [256]，与本地 [512] 形状不同，
+   load_state_dict(strict=False) 对 shape 不匹配照样 raise。
+修法：层数从 header 数；加载前剥派生缓冲；unexpected 关键层硬报错。
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from pathlib import Path
+
+import pytest
+import torch
+
+from studio.services.inference.checkpoint_arch import (
+    AnimaCheckpointArch,
+    CheckpointInspectError,
+    arch_from_header,
+    inspect_anima_checkpoint,
+    read_safetensors_header,
+)
+
+
+# ── 造 header / 造文件 ────────────────────────────────────────────────────
+
+def _anima_like_header(*, num_blocks: int, model_channels: int = 2048,
+                       prefix: str = "net.", adapter_blocks: int = 6,
+                       with_pos_embedder: bool = False) -> dict:
+    """键形态贴近真实 checkpoint 的 header（形状缩小，只关心 numel 相对关系）。
+
+    每个 DiT block 一个 [8, 8] 张量（64 参数）；llm_adapter 6 个 block 各一个 [4, 4]
+    （16 参数）——它们也叫 blocks.N，探测器必须排除。
+    """
+    h: dict = {
+        f"{prefix}x_embedder.proj.1.weight": {"dtype": "BF16", "shape": [model_channels, 68], "data_offsets": [0, 0]},
+        f"{prefix}final_layer.linear.weight": {"dtype": "BF16", "shape": [4, 4], "data_offsets": [0, 0]},
+    }
+    for i in range(num_blocks):
+        h[f"{prefix}blocks.{i}.self_attn.q_proj.weight"] = {"dtype": "BF16", "shape": [8, 8], "data_offsets": [0, 0]}
+    for i in range(adapter_blocks):
+        h[f"{prefix}llm_adapter.blocks.{i}.self_attn.q_proj.weight"] = {"dtype": "BF16", "shape": [4, 4], "data_offsets": [0, 0]}
+    if with_pos_embedder:
+        h[f"{prefix}pos_embedder.seq"] = {"dtype": "BF16", "shape": [256], "data_offsets": [0, 0]}
+        h[f"{prefix}pos_embedder.dim_spatial_range"] = {"dtype": "BF16", "shape": [21], "data_offsets": [0, 0]}
+    return h
+
+
+def _write_safetensors_with_header(path: Path, header: dict) -> None:
+    """只写 header（payload 空）——探测器不读 payload，够用。"""
+    raw = json.dumps(header).encode("utf-8")
+    path.write_bytes(struct.pack("<Q", len(raw)) + raw)
+
+
+# ── arch_from_header：纯函数 ──────────────────────────────────────────────
+
+def test_num_blocks_counted_from_header_not_table():
+    """40 层第三方版：层数 = blocks.N 最大下标 + 1，与 model_channels 无关。"""
+    arch = arch_from_header(_anima_like_header(num_blocks=40))
+    assert arch.num_blocks == 40
+    assert arch.model_channels == 2048
+    assert arch.num_heads == 16
+    assert arch.in_channels == 16
+    assert arch.has_llm_adapter is True
+    # 官方 28 层同一条路
+    assert arch_from_header(_anima_like_header(num_blocks=28)).num_blocks == 28
+    # 14B：通道 5120 → 40 头，层数仍数出来
+    big = arch_from_header(_anima_like_header(num_blocks=36, model_channels=5120))
+    assert (big.num_blocks, big.num_heads) == (36, 40)
+
+
+def test_llm_adapter_blocks_excluded_from_dit_block_counts():
+    """llm_adapter.blocks.0-5 不能算进 DiT block 0-5（旧 _BLOCK_KEY_RE 的 bug）。"""
+    arch = arch_from_header(_anima_like_header(num_blocks=4, adapter_blocks=6))
+    assert arch.num_blocks == 4  # 不会被 adapter 的 6 层污染成 6
+    assert arch.block_param_counts == (64, 64, 64, 64)  # 每层只有自己的 64，不含 adapter 的 16
+    # 但 adapter 参数计入总量：x_embedder 2048*68 + final 16 + 4*64 + 6*16
+    assert arch.param_count == 2048 * 68 + 16 + 4 * 64 + 6 * 16
+
+
+def test_swapped_param_ratio_from_arch():
+    arch = arch_from_header(_anima_like_header(num_blocks=4, adapter_blocks=0, model_channels=2048))
+    total = 2048 * 68 + 16 + 4 * 64
+    assert arch.swapped_param_ratio(2) == pytest.approx(128 / total)
+    assert arch.swapped_param_ratio(4) == pytest.approx(256 / total)
+    assert arch.swapped_param_ratio(99) == pytest.approx(256 / total)  # 超界 clamp
+    assert arch.swapped_param_ratio(0) == 0.0
+
+
+def test_unknown_channels_keeps_heads_none_and_rejects_non_anima():
+    """未知通道数：探测不报错（block swap 比例仍可算），建模时才 raise。"""
+    arch = arch_from_header(_anima_like_header(num_blocks=4, model_channels=4))
+    assert arch.num_heads is None
+    from training.families.anima.loader import arch_to_config
+
+    with pytest.raises(RuntimeError, match="未知的 model_channels"):
+        arch_to_config(arch)
+    # 缺 x_embedder → 不是 Anima 权重
+    with pytest.raises(CheckpointInspectError, match="x_embedder"):
+        arch_from_header({"blocks.0.w": {"dtype": "BF16", "shape": [1], "data_offsets": [0, 0]}})
+    # block 下标断档 → 报错而不是静默建一个层数错的模型
+    h = _anima_like_header(num_blocks=4)
+    del h["net.blocks.2.self_attn.q_proj.weight"]
+    with pytest.raises(CheckpointInspectError, match="不连续"):
+        arch_from_header(h)
+
+
+def test_arch_to_config_feeds_num_blocks_through():
+    from training.families.anima.loader import arch_to_config
+
+    cfg = arch_to_config(arch_from_header(_anima_like_header(num_blocks=40)))
+    assert cfg["num_blocks"] == 40
+    assert cfg["num_heads"] == 16
+    assert cfg["model_channels"] == 2048
+    assert cfg["in_channels"] == 16
+    assert cfg["rope_h_extrapolation_ratio"] == 4.0
+
+
+# ── 文件级：header 直读、前缀无关、__metadata__ 忽略 ───────────────────────
+
+def test_inspect_reads_header_only_and_is_prefix_agnostic(tmp_path):
+    h = _anima_like_header(num_blocks=40, prefix="model.", with_pos_embedder=True)
+    h["__metadata__"] = {"format": "pt"}
+    p = tmp_path / "third_party.safetensors"
+    _write_safetensors_with_header(p, h)
+    arch = inspect_anima_checkpoint(p)
+    assert isinstance(arch, AnimaCheckpointArch)
+    assert arch.num_blocks == 40
+    assert arch.file_bytes == p.stat().st_size
+    assert read_safetensors_header(p)["__metadata__"] == {"format": "pt"}
+
+
+def test_inspect_rejects_garbage(tmp_path):
+    bad = tmp_path / "garbage.safetensors"
+    bad.write_bytes(b"garbage")
+    with pytest.raises(CheckpointInspectError):
+        inspect_anima_checkpoint(bad)
+
+
+def test_real_safetensors_file_roundtrip(tmp_path):
+    """用 safetensors 真写一个文件（有 payload），探测结果与张量一致。"""
+    from safetensors.torch import save_file
+
+    tensors = {"net.x_embedder.proj.1.weight": torch.zeros(2048, 68)}
+    for i in range(3):
+        tensors[f"net.blocks.{i}.mlp.layer1.weight"] = torch.zeros(8, 8)
+    p = tmp_path / "real.safetensors"
+    save_file(tensors, str(p))
+    arch = inspect_anima_checkpoint(p)
+    assert arch.num_blocks == 3
+    assert arch.has_llm_adapter is False
+    assert arch.param_count == 2048 * 68 + 3 * 64
+
+
+# ── loader 接线：派生缓冲剥离 + unexpected 关键层硬报错 ───────────────────
+
+def test_drop_derived_buffers_strips_pos_embedder_only():
+    from training.families.anima.loader import drop_derived_buffers
+
+    sd = {
+        "net.pos_embedder.seq": torch.zeros(256),
+        "net.pos_embedder.dim_spatial_range": torch.zeros(21),
+        "net.blocks.0.self_attn.q_proj.weight": torch.zeros(2, 2),
+        "net.x_embedder.proj.1.weight": torch.zeros(2, 2),
+    }
+    out = drop_derived_buffers(sd)
+    assert set(out) == {"net.blocks.0.self_attn.q_proj.weight", "net.x_embedder.proj.1.weight"}
+    # 没有派生缓冲时原样返回（不复制多 GB 的 dict）
+    assert drop_derived_buffers(out) is out
+
+
+class _TinyDiT(torch.nn.Module):
+    def __init__(self, num_blocks: int) -> None:
+        super().__init__()
+        self.x_embedder = torch.nn.Linear(4, 4)
+        self.blocks = torch.nn.ModuleList([torch.nn.Linear(4, 4) for _ in range(num_blocks)])
+        self.final_layer = torch.nn.Linear(4, 4)
+
+
+def test_load_weights_rejects_checkpoint_with_more_blocks_than_model():
+    """40 层权重灌 28 层模型：此前 coverage=100%、missing=0 → 只 log 一行放行
+    （静默丢层）。现在关键前缀的 unexpected 必须硬报错。"""
+    from training.model_loading import _load_weights_best_effort
+
+    model = _TinyDiT(num_blocks=2)
+    sd = _TinyDiT(num_blocks=3).state_dict()  # 多一层 blocks.2.*
+    with pytest.raises(RuntimeError, match="不存在的关键参数"):
+        _load_weights_best_effort(model, sd, label="Transformer")
+    # 层数一致 → 正常
+    info = _load_weights_best_effort(model, _TinyDiT(num_blocks=2).state_dict(), label="Transformer")
+    assert info["coverage"] == pytest.approx(1.0)
+    # 非关键的多余键（如剥漏的杂项）仍只记录不报错
+    sd_ok = _TinyDiT(num_blocks=2).state_dict()
+    sd_ok["some_extra.weight"] = torch.zeros(1)
+    info = _load_weights_best_effort(model, sd_ok, label="Transformer")
+    assert info["unexpected"] == ["some_extra.weight"]


### PR DESCRIPTION
## 背景

第三方 [Gazingstars123/Anima-2.9B](https://huggingface.co/Gazingstars123/Anima-2.9B) 把 Anima 的 28 层 DiT 插层扩到 40 层（其余结构、TE、VAE、key 布局全同）。现状下这个文件进不来：

1. `families/anima/loader.py` 按 `model_channels` 查表把层数写死 28 → 建成 28 层模型，多出的 12 层进 `unexpected` 只 log 一行就放行，**静默丢层**后训练/出图全是垃圾。
2. 文件带 RoPE 派生缓冲 `pos_embedder.seq [256]`，本地 `VideoRopePosition3DEmb` 是 persistent buffer 长 512 → `load_state_dict(strict=False)` 对 shape 不匹配照样 raise，**硬崩**。

这是「Anima-2.9B 完全兼容」的第一刀（加载可用）；后续 PR-2 LoRA 兼容契约、PR-3 目录/展示。

## 改动

- 新增 `studio/services/inference/checkpoint_arch.py`：只读 safetensors header（标准库解析，不 import torch）→ `AnimaCheckpointArch`（通道/层数/头数/参数量/逐层参数/文件大小），层数的**单一真相**。放这里与 `core.py` 同款定位：runtime 与 studio 服务端共用、依赖方向 runtime→studio 是既有约定，且服务端列目录时不能为此拉起 torch。
- loader：层数取 arch（`num_heads` 仍是唯一允许的按通道查表）；`arch_to_config` 纯函数；加载前 `drop_derived_buffers` 剥 `pos_embedder.*`；`swapped_param_ratio_from_header` 改走 arch，顺手修旧正则把 `llm_adapter.blocks.0-5` 算进 DiT block 0-5 的比例误差；`model.checkpoint_arch` 公开给后续 LoRA 元数据。
- `model_loading._load_weights_best_effort`：`unexpected` 里出现 `blocks./x_embedder./final_layer.` 前缀 → 硬报错（与现有「关键层 missing → 报错」对称）。
- `blocks_to_swap` schema 说明与若干注释去掉「Anima 接受 0-28」「28/36 层」这类写死层数的表述。
- 架构本体 `modeling/anima/*`、block swap 机制、LoRA preset 零改动（本来就按 `len(model.blocks)` / header 动态取值）。

## 测试

- 新增 `tests/test_anima_checkpoint_arch.py`（12 个）：40/28/36 层推断、adapter 排除、换出比例、未知通道/非 Anima/下标断档拒绝、header 直读前缀无关、真 safetensors 往返、派生缓冲剥离、unexpected 关键层硬报错。
- 本地：`test_anima_checkpoint_arch` + `test_block_swap_anima` + 关联安全网（model_families / anima_preset / custom_model / comfy_qwen_loading / vae_tiled_decode / lycoris_resume 等）全绿。
- **真机未验**（本机无 GPU）：2.9B 加载出图对照 Comfy、40 层 block swap 峰值需用户本地跑。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
