### PR TITLE
feat(lora): LoRA ↔ 底模层数兼容契约（写元数据 / 键扫描兜底 / 一处判定，三处消费）

### DIFF
--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -29,7 +29,7 @@ import random
 import sys
 import threading
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from typing import Any, Callable, Iterable, Optional
 
 import torch
 
@@ -49,6 +49,7 @@ from studio.services.inference.core import (  # noqa: E402
     DeferredVAE,
     LoRAMeta,
     LoRASpec,
+    _check_lora_compat_or_raise,
     apply_loras,
     read_lora_meta,
     release_vae_after_decode,
@@ -132,6 +133,15 @@ def _emit_evt(kind: str, **extra: Any) -> None:
 
 def _emit_for(req_id: str, kind: str, **extra: Any) -> None:
     _emit({"id": req_id, "kind": kind, **extra})
+
+
+def _warning_emitter(req_id: str) -> Callable[[str], None]:
+    """task 级 warning 事件（非致命提示，如 LoRA 与底模可能不匹配）→ supervisor
+    转 SSE generate_warning → 前端 toast。日志由调用方（core._warn）另打。"""
+    def _emit_warning(message: str) -> None:
+        _emit_for(req_id, "warning", message=str(message))
+
+    return _emit_warning
 
 
 # ---------------------------------------------------------------------------
@@ -664,8 +674,16 @@ class ModelCache:
 
         trim_working_set()
 
-    def apply_loras(self, lora_configs: list[dict[str, Any]]) -> list[Any]:
-        """按 lora_configs inject adapters；同结构 checkpoint 切换时只热换权重。"""
+    def apply_loras(
+        self,
+        lora_configs: list[dict[str, Any]],
+        on_warning: Callable[[str], None] | None = None,
+    ) -> list[Any]:
+        """按 lora_configs inject adapters；同结构 checkpoint 切换时只热换权重。
+
+        on_warning：LoRA 与底模「可能不匹配」（lora_compat warn 档）时回调，
+        _run_generate / _run_xy 接成 warning 事件推给前端；确定不匹配直接 raise。
+        """
         self._move_runtime_to_device()
         if self.block_swap is not None:
             # 关键顺序（doc §9.6）：fp8 底模的 LoRA 走**权重 merge**，而跑过前向后
@@ -717,6 +735,10 @@ class ModelCache:
             and all(getattr(a, "supports_hot_reload", True) for a in self.adapters)
         )
         if can_hot_reload:
+            # 热换不经 core.apply_loras：兼容判定（同族不同层数）必须在这里补上，
+            # 否则同拓扑的 28 层 LoRA 换 40 层 LoRA 会绕过检查静默错位。
+            for spec, meta in zip(specs, current_metas):
+                _check_lora_compat_or_raise(meta, self.model, Path(spec.path).name, on_warning)
             try:
                 for adapter, spec in zip(self.adapters, specs):
                     _reload_adapter_weights(adapter, spec, self.device, self.lora_dtype)
@@ -781,6 +803,7 @@ class ModelCache:
             # 开了 block swap = 用户内存本就紧张：不留那份与整个模型等大的 CPU
             # 备份（krea2 fp8 实测 12.23GB），换 LoRA 改走「重载模型」兜底
             keep_merge_backup=self.block_swap is None,
+            on_warning=on_warning,
         )
         self.last_lora_specs = specs
         self.last_lora_metas = current_metas
@@ -1414,7 +1437,9 @@ def _run_generate(
     )
     _finish_initial_te_peak_calibration(initial_te_measurement)
     CACHE.ensure_loaded(cfg)
-    adapters = CACHE.apply_loras(cfg.get("lora_configs", []))
+    adapters = CACHE.apply_loras(
+        cfg.get("lora_configs", []), on_warning=_warning_emitter(req_id),
+    )
 
     # 进度推送：永远建 callback 推 preview_step（含 step/total）；
     # preview_every_n_steps>0 时附 image_b64 中间预览图（commit 14）。
@@ -1580,7 +1605,7 @@ def _run_xy(
                 fp8_scale_axes=fp8_model,
             )
             if lora_configs is not None:
-                adapters = CACHE.apply_loras(lora_configs)
+                adapters = CACHE.apply_loras(lora_configs, on_warning=_warning_emitter(req_id))
 
             for i, s in enumerate(base_scales):
                 if i < len(adapters):

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -30,6 +30,7 @@ from training.snapshot import (
 )
 from training.state import save_training_state
 from training.timestep_sampling import apply_resolution_shift, latent_token_counts
+from studio.services.inference.lora_compat import model_num_blocks
 from utils.optimizer_utils import get_optimizer_monitor_metrics, optimizer_eval_mode
 
 
@@ -733,6 +734,7 @@ def run(ctx: TrainingContext) -> None:
                             sra_aligner=ctx.sra_aligner,
                             scaler=ctx.scaler,
                             model_family=ctx.family.spec.family_id,
+                            base_num_blocks=model_num_blocks(ctx.model),
                         )
                         # 同时保存 LoRA 权重
                         lora_path = ctx.output_dir / f"{args.output_name}_step{ctx.global_step}.safetensors"
@@ -800,6 +802,7 @@ def run(ctx: TrainingContext) -> None:
                         sra_aligner=ctx.sra_aligner,
                         scaler=ctx.scaler,
                         model_family=ctx.family.spec.family_id,
+                        base_num_blocks=model_num_blocks(ctx.model),
                     )
                     lora_path = ctx.output_dir / f"{args.output_name}_epoch{ctx.current_epoch}.safetensors"
                     if not lora_path.exists():
@@ -833,6 +836,7 @@ def run(ctx: TrainingContext) -> None:
                     sra_aligner=ctx.sra_aligner,
                     scaler=ctx.scaler,
                     model_family=ctx.family.spec.family_id,
+                    base_num_blocks=model_num_blocks(ctx.model),
                 )
             ctx.wandb_monitor.upload_state_auto(auto_state_path)
             # 更新 ctx 字段供 handle_interrupt emit pause_state 用

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -10,6 +10,11 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from studio.services.inference.lora_compat import (
+    base_arch_network_args_from_model,
+    check_lora_compat,
+    model_num_blocks,
+)
 from training.context import TrainingContext
 from training.families import resolve_family
 from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC
@@ -174,16 +179,18 @@ def _inject_adapter(ctx: TrainingContext) -> None:
     from training.adapters import build_adapter
 
     ctx.injector = build_adapter(args, preset=ctx.family.lora_preset())
-    ctx.injector.metadata_extra = ctx.family.lora_metadata()
+    # LoRA 元数据 = 族标记（D13）+ 底模架构（lora_compat 契约：层数/通道/文件名，
+    # 同族不同层数的 LoRA 靠它分辨）
+    ctx.injector.metadata_extra = {
+        **ctx.family.lora_metadata(),
+        **base_arch_network_args_from_model(
+            ctx.model, getattr(args, "transformer_path", "") or "",
+        ),
+    }
     ctx.injector.inject(ctx.model)
 
     if getattr(args, "resume_lora", "") and Path(args.resume_lora).exists():
-        lora_family = _read_lora_family(args.resume_lora)
-        if lora_family != ctx.family.spec.family_id:
-            raise RuntimeError(
-                f"resume_lora 跨模型族被拒绝：{args.resume_lora} 属于 '{lora_family}'，"
-                f"当前 model_family='{ctx.family.spec.family_id}'"
-            )
+        _check_resume_lora_compat(ctx, args.resume_lora)
         ctx.injector.load(args.resume_lora)
         logger.info("将从已有 LoRA 继续训练: %s", args.resume_lora)
 
@@ -325,16 +332,25 @@ def finish(ctx: TrainingContext) -> None:
     _log_train_start_vram(ctx)
 
 
-def _read_lora_family(path) -> str:
-    """Read artifact family; legacy unmarked safetensors grandfather to Anima."""
-    import json
+def _check_resume_lora_compat(ctx: TrainingContext, path) -> None:
+    """resume_lora 的族 + 底模架构校验（与出图侧 apply_loras 同一契约）。
 
-    from safetensors import safe_open
+    族：无标记的存量文件 grandfather 为 anima。架构：元数据确证 / 键必然越界
+    → 拒绝；键扫描只是下界的存量文件 → 警告放行（可能是老 28 层 LoRA，也可能
+    只挂部分层——静默错位比崩溃更糟，但没有证据时不拦）。
+    """
+    from studio.services.inference.core import read_lora_meta
 
-    try:
-        with safe_open(str(path), framework="pt", device="cpu") as handle:
-            meta = handle.metadata() or {}
-        args = json.loads(meta.get("ss_network_args") or "{}")
-        return str(args.get("model_family") or "anima")
-    except Exception:
-        return "anima"
+    meta = read_lora_meta(str(path))
+    if meta.model_family != ctx.family.spec.family_id:
+        raise RuntimeError(
+            f"resume_lora 跨模型族被拒绝：{path} 属于 '{meta.model_family}'，"
+            f"当前 model_family='{ctx.family.spec.family_id}'"
+        )
+    verdict = check_lora_compat(
+        meta.base_arch, model_num_blocks(ctx.model), lora_name=Path(str(path)).name,
+    )
+    if verdict.level == "reject":
+        raise RuntimeError(f"resume_lora 与当前底模层数不匹配：{verdict.reason}")
+    if verdict.level == "warn":
+        logger.warning("resume_lora：%s", verdict.reason)

--- a/runtime/training/phases/resume.py
+++ b/runtime/training/phases/resume.py
@@ -11,6 +11,7 @@ import signal
 import time
 from pathlib import Path
 
+from studio.services.inference.lora_compat import model_num_blocks
 from training.bootstrap import init_progress
 from training.context import TrainingContext
 from training.observability import render_curve_panel
@@ -66,6 +67,7 @@ def run(ctx: TrainingContext) -> None:
             sra_aligner=ctx.sra_aligner,
             scaler=ctx.scaler,
             expected_family=ctx.family.spec.family_id,
+            expected_num_blocks=model_num_blocks(ctx.model),
         )
         ctx.emit(f"从断点恢复训练: epoch={ctx.start_epoch}, step={ctx.global_step}")
 

--- a/runtime/training/state.py
+++ b/runtime/training/state.py
@@ -25,12 +25,16 @@ def save_training_state(
     path, injector, optimizer, epoch, global_step,
     loss_history=None, rng_state=None, monitor_state=None,
     scheduler=None, timestep_sampler=None, sra_aligner=None,
-    scaler=None, model_family=None,
+    scaler=None, model_family=None, base_num_blocks=None,
 ):
     """保存完整训练状态，支持断点续训。
 
     timestep_sampler（ADR 0006 Addendum 1）：自适应采样器（InfoNoise）的 EMA / CDF / FIFO buffer。
     无状态采样器（baseline）的 state_dict() 是 {}，跳过不存，避免 ckpt 文件无谓增大。
+
+    base_num_blocks：底模 DiT 层数（lora_compat 契约）。同族不同层数的底模之间
+    resume，LoRA 网络形状对不上、optimizer param group 也对不上——load 侧按它
+    fail-fast 并说人话，而不是崩在 torch 的 param group 报错上。
     """
     state = {
         "lora_state_dict": injector.state_dict(),
@@ -47,6 +51,8 @@ def save_training_state(
         # 多模型 D13：族标记；load 侧跨族 fail-fast（strict=False 会静默冷启动）
         "model_family": str(model_family or "anima"),
     }
+    if base_num_blocks is not None:
+        state["base_num_blocks"] = int(base_num_blocks)
     if scheduler is not None:
         state["scheduler_state_dict"] = scheduler.state_dict()
     if sra_aligner is not None and hasattr(sra_aligner, "state_dict"):
@@ -82,11 +88,14 @@ def save_training_state(
     logger.info(f"训练状态已保存: {path} (epoch={epoch}, step={global_step})")
 
 
-def load_training_state(path, injector, optimizer, scheduler=None, timestep_sampler=None, sra_aligner=None, scaler=None, expected_family=None):
+def load_training_state(path, injector, optimizer, scheduler=None, timestep_sampler=None, sra_aligner=None, scaler=None, expected_family=None, expected_num_blocks=None):
     """加载训练状态，返回 (epoch, global_step, loss_history, monitor_state)。
 
     timestep_sampler（ADR 0006 Addendum 1）：如 ckpt 含 timestep_sampler_state 且 sampler
     实现了 load_state_dict，把 EMA / CDF / FIFO 灌回去；否则保持冷启动（warning 提示）。
+
+    expected_num_blocks：当前底模层数；恢复点记了 base_num_blocks 且不等 → 拒绝
+    （同族不同层数底模之间的 resume 一定错）。老恢复点没记 → 不判。
     """
     logger.info(f"加载训练状态: {path}")
     state = torch.load(path, map_location="cpu", weights_only=False)
@@ -98,6 +107,17 @@ def load_training_state(path, injector, optimizer, scheduler=None, timestep_samp
             f"跨模型族 resume 被拒绝：恢复点属于 '{saved_family}'，"
             f"当前 model_family='{expected_family}'。"
             f"（strict=False 加载会静默变成全 missing 冷启动，比崩溃更糟）"
+        )
+    saved_blocks = state.get("base_num_blocks")
+    if (
+        expected_num_blocks is not None
+        and saved_blocks is not None
+        and int(saved_blocks) != int(expected_num_blocks)
+    ):
+        raise RuntimeError(
+            f"resume 与当前底模层数不匹配：恢复点训练自 {int(saved_blocks)} 层底模，"
+            f"当前底模 {int(expected_num_blocks)} 层，层与层对不上。"
+            f"请换回原底模，或新开版本从头训练。"
         )
 
     # 加载 LoRA 权重（lycoris-lora backend）— 一次性导入 state_dict

--- a/studio/services/inference/core.py
+++ b/studio/services/inference/core.py
@@ -27,7 +27,14 @@ import shutil
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Optional, Sequence
+from typing import Any, Callable, Optional, Sequence
+
+from .lora_compat import (
+    LoraBaseArch,
+    check_lora_compat,
+    lora_base_arch,
+    model_num_blocks,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +164,9 @@ class LoRAMeta:
     #: musubi / comfy 系）不带我们的标记——grandfather 值只用于展示，
     #: 跨族硬拒绝只对显式标记生效，无标记靠注入/merge 的键匹配兜底。
     family_explicit: bool = False
+    #: 训练底模的架构（层数等）：元数据优先、键扫描兜底（lora_compat 契约）。
+    #: 同族不同层数（Anima 28 层 vs 第三方 40 层）靠它分辨——族标记分不出。
+    base_arch: LoraBaseArch = field(default_factory=lambda: LoraBaseArch(None, "unknown"))
 
 
 def read_lora_meta(path: str) -> LoRAMeta:
@@ -174,6 +184,7 @@ def read_lora_meta(path: str) -> LoRAMeta:
     try:
         with safe_open(str(path), framework="pt", device="cpu") as f:
             meta = f.metadata() or {}
+            keys = list(f.keys())
     except Exception as e:
         logger.warning(f"读 LoRA metadata 失败 {path}: {e}; 用默认参数")
         return LoRAMeta(_DEFAULT_RANK, _DEFAULT_ALPHA, _DEFAULT_ALGO, _DEFAULT_FACTOR)
@@ -235,6 +246,7 @@ def read_lora_meta(path: str) -> LoRAMeta:
         lora_reg_dims=lora_reg_dims,
         model_family=str(ss_args.get("model_family") or "anima"),
         family_explicit=bool(ss_args.get("model_family")),
+        base_arch=lora_base_arch(ss_args, keys),
     )
 
 
@@ -304,6 +316,32 @@ def _normalize_peft_lora_sd(
     return normalized, max_rank, reg_dims
 
 
+def _warn(on_warning: Optional[Callable[[str], None]], message: str) -> None:
+    logger.warning(message)
+    if on_warning is not None:
+        try:
+            on_warning(message)
+        except Exception:  # noqa: BLE001 — 通知失败不能影响出图
+            logger.exception("on_warning callback failed")
+
+
+def _check_lora_compat_or_raise(
+    meta: LoRAMeta,
+    model: Any,
+    lora_name: str,
+    on_warning: Optional[Callable[[str], None]] = None,
+) -> None:
+    """lora_compat 契约的出图侧消费：reject → ValueError；warn → 回调 + 日志。
+
+    daemon 热换权重路径（同拓扑 LoRA 换文件、不经 apply_loras）也调它。
+    """
+    verdict = check_lora_compat(meta.base_arch, model_num_blocks(model), lora_name=lora_name)
+    if verdict.level == "reject":
+        raise ValueError(f"LoRA 与当前底模层数不匹配：{verdict.reason}。请换用在同一底模上训练的 LoRA，或切换底模。")
+    if verdict.level == "warn":
+        _warn(on_warning, verdict.reason)
+
+
 def apply_loras(
     model: Any,
     specs: Sequence[LoRASpec],
@@ -313,6 +351,7 @@ def apply_loras(
     lora_merge_precision: str = "fp32",
     lora_merge_chunk_rows: int = 1024,
     keep_merge_backup: bool = True,
+    on_warning: Optional[Callable[[str], None]] = None,
 ) -> list[Any]:
     """对每个 LoRA 单独 inject 一份 AnimaLycorisAdapter；forward 时 hook 累加 delta。
 
@@ -320,6 +359,10 @@ def apply_loras(
     权重 merge；其 delta 临时精度由 lora_merge_precision 控制（fp32/bf16）。
     普通 Linear LoRA 默认按 1024 输出行分块，避免物化整层 dense delta；
     LoHa/LoKr 暂时保留原算法。
+
+    on_warning：LoRA 与底模「可能不匹配」（lora_compat warn 档）时的回调，
+    调用方把它接到 UI（daemon 发 warning 事件）；None 时只进日志。reject 档
+    直接 raise ValueError（与跨族拒绝同级）。
 
     multiplier 字段控制每份 LoRA 贡献权重（用户传的 scale）：
       - LycorisNetwork.multiplier 是 forward 内取的全局倍率
@@ -363,6 +406,10 @@ def apply_loras(
                 f"'{meta.model_family}'，当前底模族为 '{family_id}'。"
                 f"请换用同族 LoRA 或切换底模。"
             )
+        # 同族不同层数（Anima 28 层 vs 第三方 40 层）：族标记分不出，按
+        # lora_compat 契约判——元数据确证 / 键必然越界 → 拒绝；键扫描只是
+        # 下界的存量文件 → 警告放行（可能是老 LoRA，也可能只挂部分层）。
+        _check_lora_compat_or_raise(meta, model, Path(path).name, on_warning)
         sd_raw: dict = {}
         with safe_open(str(path), framework="pt", device="cpu") as f:
             for k in f.keys():
@@ -427,6 +474,13 @@ def apply_loras(
             raise ValueError(
                 f"LoRA 与当前底模不匹配：{Path(path).name} 的键全部无法对应"
                 f"（可能属于其他模型族，或是本路径尚不支持的键格式）。"
+            )
+        if unexpected:
+            # 部分键没被吃掉：与 fp8 merge 路径（lora_fp8_merge）同口径升为 warning，
+            # 不再只是一行 info（此前 28 层 LoRA 挂 40 层底模就是这样静默过去的）
+            _warn(
+                on_warning,
+                f"{Path(path).name} 有 {unexpected}/{len(sd)} 个权重键在当前底模上找不到对应层，已忽略",
             )
         logger.info(
             f"已加载 LoRA: {Path(path).name} "

--- a/studio/services/inference/lora_compat.py
+++ b/studio/services/inference/lora_compat.py
@@ -1,0 +1,258 @@
+"""LoRA ↔ 底模兼容契约：写（元数据）/ 读（元数据优先、键扫描兜底）/ 判（一个纯函数）。
+
+背景：同族底模可以有不同层数（Anima 官方 28 层、第三方插层扩展版 40 层……）。
+LoRA 按模块名 ``blocks.N.xxx`` 套用，28 层底模上训的 LoRA 挂到 40 层底模，
+``blocks.0..27`` 全按名字对上、``blocks.28..39`` 缺 —— 不报错不警告，出的图是
+错位的垃圾。族标记（``model_family``）分不出这个差别，所以再加一层「底模架构」
+契约：
+
+- **写**：训练保存 LoRA 时把底模的层数 / 通道 / 文件名写进 ``ss_network_args``
+  （:func:`base_arch_network_args`）；三处写盘（lycoris / ortho / lora_merge）
+  共用 :func:`build_lora_metadata` 拼顶层 metadata。
+- **读**：:func:`lora_num_blocks_from_keys` 从 LoRA 键名数 ``blocks.N`` 最大下标
+  +1，给没有元数据的存量 / 外部文件兜底（注意只是**下界**——只挂部分层的 LoRA
+  也会小于底模层数）。
+- **判**：:func:`check_lora_compat` 是唯一的判定函数，出图 apply / 训练 resume_lora
+  / 恢复点 / 前端预检全部消费它的结论，不各自再算一遍：
+
+  | 情形 | 结论 |
+  |---|---|
+  | 元数据有层数且 ≠ 底模层数 | reject（一定错，与「跨族拒绝」同级） |
+  | 无元数据，键最大下标 ≥ 底模层数 | reject（键必然 unexpected，一定错） |
+  | 无元数据，键最大下标 +1 < 底模层数 | warn（可能是老 28 层 LoRA，也可能只挂部分层） |
+  | 其余 | ok |
+
+与 ``core.py`` / ``checkpoint_arch.py`` 同款定位：runtime 与 studio 服务端共用，只用标准库。
+"""
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, Literal, Optional
+
+#: ``ss_network_args`` 里的底模架构键（写读两侧唯一出处）
+KEY_BASE_NUM_BLOCKS = "base_num_blocks"
+KEY_BASE_MODEL_CHANNELS = "base_model_channels"
+KEY_BASE_MODEL_FILE = "base_model_file"
+
+#: LoRA 键里的 block 下标：kohya 键把模块路径的 ``.`` 换成 ``_``
+#: （``lora_unet_blocks_12_self_attn_q_proj.lora_down.weight``），PEFT / 外部键
+#: 保留 ``.``（``diffusion_model.blocks.12.self_attn.q_proj.lora_A.weight``）。
+_LORA_BLOCK_RE = re.compile(r"(?:^|[._])blocks[._](\d+)[._]")
+_ADAPTER_MARK = "llm_adapter"
+
+ArchSource = Literal["metadata", "keys", "unknown"]
+CompatLevel = Literal["ok", "warn", "reject"]
+
+
+# ── 写 ──────────────────────────────────────────────────────────────────────
+
+def base_arch_network_args(
+    *,
+    num_blocks: Optional[int],
+    model_channels: Optional[int] = None,
+    base_model_file: Optional[str] = None,
+) -> dict[str, Any]:
+    """底模架构 → 要并进 ``ss_network_args`` 的键。None 的项不写。"""
+    out: dict[str, Any] = {}
+    if num_blocks is not None:
+        out[KEY_BASE_NUM_BLOCKS] = int(num_blocks)
+    if model_channels is not None:
+        out[KEY_BASE_MODEL_CHANNELS] = int(model_channels)
+    if base_model_file:
+        out[KEY_BASE_MODEL_FILE] = str(base_model_file)
+    return out
+
+
+def base_arch_network_args_from_model(model: Any, transformer_path: Any = None) -> dict[str, Any]:
+    """从已加载的 DiT 取架构事实（``len(model.blocks)`` / ``model_channels``）。
+
+    loader 会在模型上挂 ``checkpoint_arch``（Anima）；没有的族（krea2）退回
+    数 ``model.blocks``。``transformer_path`` 只取文件名做溯源展示。
+    """
+    num_blocks = model_num_blocks(model)
+    model_channels: Optional[int] = None
+    arch = getattr(model, "checkpoint_arch", None)
+    if arch is not None:
+        model_channels = _positive_int(getattr(arch, "model_channels", None))
+    if model_channels is None:
+        model_channels = _positive_int(getattr(model, "model_channels", None))
+    base_file = None
+    if transformer_path:
+        base_file = str(transformer_path).replace("\\", "/").rsplit("/", 1)[-1]
+    return base_arch_network_args(
+        num_blocks=num_blocks, model_channels=model_channels, base_model_file=base_file,
+    )
+
+
+def build_lora_metadata(
+    *,
+    rank: Any,
+    alpha: Any,
+    network_args: dict[str, Any],
+    extra: Optional[dict[str, str]] = None,
+) -> dict[str, str]:
+    """LoRA safetensors 顶层 metadata（kohya / ComfyUI 兼容形态）。
+
+    三处写盘共用：``ss_network_dim/alpha/module`` + ``ss_network_args``（JSON）。
+    ``extra`` 是额外的顶层键（如 lora_merge 的 provenance）。
+    """
+    meta = {
+        "ss_network_dim": str(rank),
+        "ss_network_alpha": str(alpha),
+        "ss_network_module": "lycoris.kohya",
+        "ss_network_args": json.dumps(network_args),
+    }
+    if extra:
+        meta.update({str(k): str(v) for k, v in extra.items()})
+    return meta
+
+
+# ── 读 ──────────────────────────────────────────────────────────────────────
+
+def lora_num_blocks_from_keys(keys: Iterable[str]) -> Optional[int]:
+    """LoRA 键名里 ``blocks.N`` 最大下标 +1；没有 block 键返回 None。
+
+    只是下界：LoRA 若只挂了部分层（自定义 target / reg_dims 之类），数出来会
+    小于真实底模层数。llm_adapter 的 blocks 排除。
+    """
+    top = -1
+    for k in keys:
+        if _ADAPTER_MARK in k:
+            continue
+        m = _LORA_BLOCK_RE.search(k)
+        if m:
+            top = max(top, int(m.group(1)))
+    return top + 1 if top >= 0 else None
+
+
+@dataclass(frozen=True)
+class LoraBaseArch:
+    """一份 LoRA 声明 / 推断出的底模架构。"""
+
+    num_blocks: Optional[int]
+    source: ArchSource
+    model_channels: Optional[int] = None
+    base_model_file: Optional[str] = None
+
+    @property
+    def explicit(self) -> bool:
+        return self.source == "metadata"
+
+
+def read_lora_base_arch(path: Any) -> LoraBaseArch:
+    """只读 header 取 LoRA 的底模架构（studio 列表用：不 import torch、毫秒级）。
+
+    读失败 / 不是 safetensors → unknown（列表不因单个坏文件失败）。
+    """
+    from .checkpoint_arch import read_safetensors_header
+
+    try:
+        header = read_safetensors_header(path)
+    except Exception:  # noqa: BLE001
+        return LoraBaseArch(num_blocks=None, source="unknown")
+    meta = header.get("__metadata__") or {}
+    try:
+        ss_args = json.loads(meta.get("ss_network_args") or "{}") if isinstance(meta, dict) else {}
+        if not isinstance(ss_args, dict):
+            ss_args = {}
+    except (TypeError, ValueError):
+        ss_args = {}
+    return lora_base_arch(ss_args, (k for k in header if k != "__metadata__"))
+
+
+def lora_base_arch(network_args: dict[str, Any], keys: Iterable[str] = ()) -> LoraBaseArch:
+    """元数据优先（``ss_network_args``），否则扫键兜底。"""
+    raw = network_args.get(KEY_BASE_NUM_BLOCKS)
+    if raw is not None:
+        try:
+            nb = int(raw)
+        except (TypeError, ValueError):
+            nb = None
+        if nb is not None and nb > 0:
+            mc_raw = network_args.get(KEY_BASE_MODEL_CHANNELS)
+            try:
+                mc = int(mc_raw) if mc_raw is not None else None
+            except (TypeError, ValueError):
+                mc = None
+            bf = network_args.get(KEY_BASE_MODEL_FILE)
+            return LoraBaseArch(
+                num_blocks=nb, source="metadata", model_channels=mc,
+                base_model_file=str(bf) if bf else None,
+            )
+    nb = lora_num_blocks_from_keys(keys)
+    if nb is not None:
+        return LoraBaseArch(num_blocks=nb, source="keys")
+    return LoraBaseArch(num_blocks=None, source="unknown")
+
+
+# ── 判 ──────────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class CompatVerdict:
+    level: CompatLevel
+    #: 事实句（用户可读，中文），ok 时为空串
+    reason: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.level == "ok"
+
+
+def check_lora_compat(
+    lora: LoraBaseArch,
+    model_num_blocks: Optional[int],
+    *,
+    lora_name: str = "LoRA",
+) -> CompatVerdict:
+    """LoRA 声明/推断的底模层数 vs 当前底模层数（见模块 docstring 的规则表）。
+
+    ``model_num_blocks`` 为 None（底模层数未知）时不判，返回 ok。
+    """
+    if model_num_blocks is None or lora.num_blocks is None:
+        return CompatVerdict("ok")
+    if lora.source == "metadata":
+        if lora.num_blocks != model_num_blocks:
+            return CompatVerdict(
+                "reject",
+                f"{lora_name} 训练自 {lora.num_blocks} 层底模，当前底模 {model_num_blocks} 层，"
+                f"层与层对不上，不能挂载",
+            )
+        return CompatVerdict("ok")
+    # 无元数据：键扫描只是下界
+    if lora.num_blocks > model_num_blocks:
+        return CompatVerdict(
+            "reject",
+            f"{lora_name} 含 blocks.{lora.num_blocks - 1} 的权重，当前底模只有 {model_num_blocks} 层，"
+            f"层与层对不上，不能挂载",
+        )
+    if lora.num_blocks < model_num_blocks:
+        return CompatVerdict(
+            "warn",
+            f"{lora_name} 只覆盖前 {lora.num_blocks} 层（无底模层数元数据），当前底模 {model_num_blocks} 层："
+            f"若它训练自层数更少的底模，挂上去层与层对不上",
+        )
+    return CompatVerdict("ok")
+
+
+def _positive_int(v: Any) -> Optional[int]:
+    return v if isinstance(v, int) and not isinstance(v, bool) and v > 0 else None
+
+
+def model_num_blocks(model: Any) -> Optional[int]:
+    """当前已加载底模的 DiT 层数（Anima loader 挂的 ``checkpoint_arch`` 优先，否则数 ``blocks``）。
+
+    只认真正的正整数（替身 / mock 对象一律 None → 不判）。
+    """
+    arch = getattr(model, "checkpoint_arch", None)
+    nb = _positive_int(getattr(arch, "num_blocks", None)) if arch is not None else None
+    if nb is not None:
+        return nb
+    blocks = getattr(model, "blocks", None)
+    if blocks is None:
+        return None
+    try:
+        return _positive_int(len(blocks))
+    except TypeError:
+        return None

--- a/studio/services/projects/versions.py
+++ b/studio/services/projects/versions.py
@@ -9,6 +9,7 @@ high-lr 这种语义名），同 project 内唯一，且不可改（路径锚点
 """
 from __future__ import annotations
 
+import functools
 import json
 import re
 import shutil
@@ -19,6 +20,13 @@ from typing import Any, Optional
 
 from . import projects
 from ...services.dataset.scan import IMAGE_EXTS
+from ...services.inference.lora_compat import LoraBaseArch, read_lora_base_arch
+
+
+@functools.lru_cache(maxsize=4096)
+def _lora_base_arch_cached(path: str, size: int, mtime: float) -> LoraBaseArch:
+    """LoRA header 只读一次（按 path+size+mtime 失效）；训练中 ckpt 列表会反复拉。"""
+    return read_lora_base_arch(path)
 
 # ADR-0007 §11.3-B：versions 状态机用 status + phase 两个正交字段。
 # 老 stage 已在 PR-5 移除（PR-5 commit 2 删 VALID_STAGES / advance_stage）。
@@ -239,12 +247,20 @@ def list_lora_ckpts(vdir: Path) -> list[dict[str, Any]]:
                 kind = "final"
                 label = "final"
         try:
-            mtime = f.stat().st_mtime
+            st = f.stat()
+            mtime = st.st_mtime
+            size = st.st_size
         except OSError:
             mtime = 0.0
+            size = -1
+        arch = _lora_base_arch_cached(str(f), size, mtime)
         items.append({
             "kind": kind, "value": value, "label": label,
             "path": str(f), "mtime": mtime,
+            # lora_compat 契约：训练底模层数（元数据 / 键扫描下界 / 未知），前端
+            # 据此标记「28 层 / 40 层」并与当前底模比对
+            "base_num_blocks": arch.num_blocks,
+            "base_arch_source": arch.source,
         })
 
     # 排序：final 顶部；step/epoch 按 value 降序；other 按 label 自然序升序

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -1072,6 +1072,14 @@ class Supervisor:
                 "name": event.get("name"),
             })
             return
+        if kind == "warning":
+            # 非致命提示（如 LoRA 与底模层数可能不匹配）→ 前端 toast；任务继续跑
+            self._on_event({
+                "type": "generate_warning",
+                "task_id": tid,
+                "message": str(event.get("message") or ""),
+            })
+            return
         if kind == "preview_step":
             # commit 14：中间步进度 + 可选预览。step/total 永远有，image_b64
             # 取决于 settings.preview_every_n_steps + TAEFlux 是否可用

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1620,6 +1620,10 @@ export interface LoraCkpt {
   path: string
   /** 文件 mtime 时间戳 */
   mtime: number
+  /** 训练底模的 DiT 层数（lora_compat 契约）：元数据 / 键扫描下界 / 未知(null)。
+   *  同族不同层数（Anima 28 层 vs 第三方 40 层）的 LoRA 靠它分辨。 */
+  base_num_blocks?: number | null
+  base_arch_source?: 'metadata' | 'keys' | 'unknown'
 }
 
 /** Phase 2 commit 14 — TAEFlux 模型状态（GET /api/generate/taeflux/status）。 */

--- a/studio/web/src/components/Toast.tsx
+++ b/studio/web/src/components/Toast.tsx
@@ -7,7 +7,7 @@ import {
   type ReactNode,
 } from 'react'
 
-type Kind = 'info' | 'success' | 'error'
+type Kind = 'info' | 'success' | 'warning' | 'error'
 
 interface ToastItem {
   id: number
@@ -29,7 +29,7 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     setItems((arr) => [...arr, { id, kind, message }])
     window.setTimeout(() => {
       setItems((arr) => arr.filter((t) => t.id !== id))
-    }, kind === 'error' ? 6000 : 3000)
+    }, kind === 'error' || kind === 'warning' ? 6000 : 3000)
   }, [])
 
   return (
@@ -43,6 +43,8 @@ export function ToastProvider({ children }: { children: ReactNode }) {
               'px-4 py-2 rounded-lg shadow-lg text-sm border ' +
               (t.kind === 'error'
                 ? 'bg-err-soft border-err text-err'
+                : t.kind === 'warning'
+                ? 'bg-warn-soft border-warn text-warn'
                 : t.kind === 'success'
                 ? 'bg-ok-soft border-ok text-ok'
                 : 'bg-elevated border-subtle text-fg-primary')

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -472,6 +472,11 @@ export default function GeneratePage() {
         void historyRef.current.refresh()
       }, 300)
     }
+    if (evt.type === 'generate_warning' && typeof evt.message === 'string' && evt.message) {
+      // daemon 侧非致命提示（如 LoRA 与底模层数可能不匹配）：不管当前显示哪个任务都提示，
+      // 因为它是用户刚提交的那次出图的事，图照出但可能不对
+      toast(evt.message, 'warning')
+    }
     const tid = taskIdRef.current
     if (tid == null) return
     if (evt.type === 'task_state_changed' && evt.task_id === tid) {

--- a/tests/test_anima_daemon_comfy_parity_runtime.py
+++ b/tests/test_anima_daemon_comfy_parity_runtime.py
@@ -124,7 +124,7 @@ def test_daemon_worker_reports_error_when_all_images_fail(monkeypatch, tmp_path)
         def ensure_text_ready(self, _cfg):
             return None
 
-        def apply_loras(self, _lora_configs):
+        def apply_loras(self, _lora_configs, on_warning=None):
             return []
 
     events: list[dict] = []
@@ -177,7 +177,7 @@ def test_daemon_restores_runtime_to_device_after_successful_generate(monkeypatch
         def ensure_text_ready(self, _cfg):
             events.append("ensure_text_ready")
 
-        def apply_loras(self, _lora_configs):
+        def apply_loras(self, _lora_configs, on_warning=None):
             events.append("apply_loras")
             return []
 

--- a/tests/test_inference_core.py
+++ b/tests/test_inference_core.py
@@ -385,7 +385,7 @@ def test_model_cache_moves_offloaded_model_before_injecting_lora(tmp_path: Path,
 
     def fake_apply_loras(
         model, specs, device, dtype, family_id="anima", lora_merge_precision="fp32",
-        keep_merge_backup=True,
+        keep_merge_backup=True, on_warning=None,
     ):
         events.append("apply_loras")
         assert "model.to:cuda" in events
@@ -454,7 +454,7 @@ def test_model_cache_remerges_fp8_lora_when_merge_precision_changes(
 
     def fake_apply_loras(
         model, specs, device, dtype, family_id="anima", lora_merge_precision="fp32",
-        keep_merge_backup=True,
+        keep_merge_backup=True, on_warning=None,
     ):
         calls.append(lora_merge_precision)
         handle = MagicMock()

--- a/tests/test_lora_compat.py
+++ b/tests/test_lora_compat.py
@@ -1,0 +1,273 @@
+"""LoRA ↔ 底模兼容契约（studio.services.inference.lora_compat）+ 三处消费。
+
+同族不同层数（Anima 28 层 vs 第三方插层扩展 40 层）的 LoRA 按 blocks.N 名字
+套用会静默错位；族标记分不出。契约 = 写（元数据）/ 读（键扫描兜底）/ 判（一个
+纯函数），出图 apply、训练 resume_lora、恢复点三处消费同一判定。
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+from safetensors.torch import save_file
+
+from studio.services.inference.lora_compat import (
+    KEY_BASE_MODEL_CHANNELS,
+    KEY_BASE_MODEL_FILE,
+    KEY_BASE_NUM_BLOCKS,
+    LoraBaseArch,
+    base_arch_network_args,
+    base_arch_network_args_from_model,
+    build_lora_metadata,
+    check_lora_compat,
+    lora_base_arch,
+    lora_num_blocks_from_keys,
+    model_num_blocks,
+    read_lora_base_arch,
+)
+
+
+# ── 写 ──────────────────────────────────────────────────────────────────────
+
+def test_base_arch_network_args_from_model_prefers_checkpoint_arch():
+    model = SimpleNamespace(
+        checkpoint_arch=SimpleNamespace(num_blocks=40, model_channels=2048),
+        blocks=[object()] * 3,  # 与 arch 不一致时以 arch 为准（arch 是 header 真相）
+    )
+    args = base_arch_network_args_from_model(model, r"C:\models\Anima-2.9B-preview-v1.safetensors")
+    assert args == {
+        KEY_BASE_NUM_BLOCKS: 40,
+        KEY_BASE_MODEL_CHANNELS: 2048,
+        KEY_BASE_MODEL_FILE: "Anima-2.9B-preview-v1.safetensors",
+    }
+
+
+def test_base_arch_network_args_from_model_falls_back_to_blocks():
+    """没有 checkpoint_arch 的族（krea2）：数 model.blocks；没有 blocks → 不写层数。"""
+    model = SimpleNamespace(blocks=torch.nn.ModuleList([torch.nn.Linear(2, 2) for _ in range(28)]))
+    args = base_arch_network_args_from_model(model)
+    assert args == {KEY_BASE_NUM_BLOCKS: 28}
+    assert base_arch_network_args_from_model(object()) == {}
+    assert base_arch_network_args(num_blocks=None) == {}
+
+
+def test_build_lora_metadata_shape():
+    meta = build_lora_metadata(
+        rank=16, alpha=8.0, network_args={"algo": "lokr", KEY_BASE_NUM_BLOCKS: 40},
+        extra={"anima_merge_sources": "[]"},
+    )
+    assert meta["ss_network_dim"] == "16"
+    assert meta["ss_network_alpha"] == "8.0"
+    assert meta["ss_network_module"] == "lycoris.kohya"
+    assert json.loads(meta["ss_network_args"]) == {"algo": "lokr", KEY_BASE_NUM_BLOCKS: 40}
+    assert meta["anima_merge_sources"] == "[]"
+    assert all(isinstance(v, str) for v in meta.values())  # safetensors metadata 只收 str
+
+
+# ── 读 ──────────────────────────────────────────────────────────────────────
+
+def test_lora_num_blocks_from_keys_kohya_and_peft_and_adapter_exclusion():
+    kohya = [
+        "lora_unet_blocks_0_self_attn_q_proj.lokr_w1",
+        "lora_unet_blocks_27_mlp_layer2.lokr_w2_a",
+        "lora_unet_blocks_27_mlp_layer2.alpha",
+    ]
+    assert lora_num_blocks_from_keys(kohya) == 28
+    peft = ["diffusion_model.blocks.39.self_attn.q_proj.lora_A.weight"]
+    assert lora_num_blocks_from_keys(peft) == 40
+    # llm_adapter 自己的 blocks 不算
+    assert lora_num_blocks_from_keys(["lora_unet_llm_adapter_blocks_5_mlp_0.lora_down.weight"]) is None
+    assert lora_num_blocks_from_keys(["lora_unet_final_layer_linear.lora_down.weight"]) is None
+    assert lora_num_blocks_from_keys([]) is None
+
+
+def test_lora_base_arch_metadata_wins_over_keys():
+    args = {KEY_BASE_NUM_BLOCKS: 40, KEY_BASE_MODEL_CHANNELS: 2048, KEY_BASE_MODEL_FILE: "x.safetensors"}
+    keys = ["lora_unet_blocks_3_self_attn_q_proj.lokr_w1"]  # 键只到 block 3
+    arch = lora_base_arch(args, keys)
+    assert arch == LoraBaseArch(40, "metadata", 2048, "x.safetensors")
+    assert arch.explicit
+    # 无元数据 → 键扫描（下界）
+    assert lora_base_arch({}, keys) == LoraBaseArch(4, "keys")
+    # 都没有 → unknown
+    assert lora_base_arch({}, []) == LoraBaseArch(None, "unknown")
+    # 元数据坏值 → 退回键
+    assert lora_base_arch({KEY_BASE_NUM_BLOCKS: "abc"}, keys).source == "keys"
+
+
+def test_read_lora_base_arch_header_only(tmp_path):
+    p = tmp_path / "lora.safetensors"
+    save_file(
+        {"lora_unet_blocks_27_self_attn_q_proj.lokr_w1": torch.zeros(2, 2)},
+        str(p),
+        metadata={"ss_network_args": json.dumps({"algo": "lokr", KEY_BASE_NUM_BLOCKS: 28})},
+    )
+    assert read_lora_base_arch(p) == LoraBaseArch(28, "metadata")
+    # 存量文件（无契约键）→ 键扫描
+    q = tmp_path / "legacy.safetensors"
+    save_file({"lora_unet_blocks_27_self_attn_q_proj.lokr_w1": torch.zeros(2, 2)}, str(q))
+    assert read_lora_base_arch(q) == LoraBaseArch(28, "keys")
+    # 坏文件 → unknown，不抛
+    bad = tmp_path / "bad.safetensors"
+    bad.write_bytes(b"nope")
+    assert read_lora_base_arch(bad).source == "unknown"
+
+
+def test_model_num_blocks_only_trusts_real_ints():
+    from unittest.mock import MagicMock
+
+    assert model_num_blocks(SimpleNamespace(checkpoint_arch=SimpleNamespace(num_blocks=40))) == 40
+    assert model_num_blocks(SimpleNamespace(blocks=[1, 2, 3])) == 3
+    assert model_num_blocks(object()) is None
+    assert model_num_blocks(MagicMock()) is None  # 替身对象不判
+
+
+# ── 判 ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize(
+    "lora, model_blocks, level",
+    [
+        (LoraBaseArch(28, "metadata"), 40, "reject"),   # 元数据确证不等
+        (LoraBaseArch(40, "metadata"), 28, "reject"),
+        (LoraBaseArch(40, "metadata"), 40, "ok"),
+        (LoraBaseArch(40, "keys"), 28, "reject"),       # 键必然越界
+        (LoraBaseArch(28, "keys"), 40, "warn"),         # 键只是下界：可能老 LoRA / 部分层
+        (LoraBaseArch(28, "keys"), 28, "ok"),
+        (LoraBaseArch(None, "unknown"), 40, "ok"),      # 一无所知不判
+        (LoraBaseArch(28, "metadata"), None, "ok"),     # 底模层数未知不判
+    ],
+)
+def test_check_lora_compat_rules(lora, model_blocks, level):
+    verdict = check_lora_compat(lora, model_blocks, lora_name="x.safetensors")
+    assert verdict.level == level
+    if level != "ok":
+        assert "x.safetensors" in verdict.reason and "层" in verdict.reason
+
+
+# ── 三处消费 ─────────────────────────────────────────────────────────────────
+
+class _TinyDiT(torch.nn.Module):
+    def __init__(self, num_blocks: int) -> None:
+        super().__init__()
+        self.blocks = torch.nn.ModuleList([torch.nn.Linear(4, 4) for _ in range(num_blocks)])
+
+
+def _write_lora(path: Path, *, num_blocks_meta=None, key_block: int = 0) -> Path:
+    args = {"algo": "lokr", "factor": 8, "model_family": "anima"}
+    if num_blocks_meta is not None:
+        args[KEY_BASE_NUM_BLOCKS] = num_blocks_meta
+    save_file(
+        {f"lora_unet_blocks_{key_block}_self_attn_q_proj.lokr_w1": torch.zeros(2, 2)},
+        str(path),
+        metadata={"ss_network_dim": "8", "ss_network_alpha": "8", "ss_network_args": json.dumps(args)},
+    )
+    return path
+
+
+def test_apply_loras_rejects_metadata_mismatch_and_warns_on_key_lower_bound(tmp_path):
+    """出图侧：28 层 LoRA（元数据确证）挂 40 层底模 → 拒绝；无元数据只到 block 27
+    的存量文件 → 警告回调（放行）。"""
+    from studio.services.inference.core import LoRASpec, apply_loras
+
+    model = _TinyDiT(40)
+    p_reject = _write_lora(tmp_path / "old28.safetensors", num_blocks_meta=28)
+    with pytest.raises(ValueError, match="层数不匹配"):
+        apply_loras(model, [LoRASpec(path=str(p_reject))], "cpu", torch.float32, family_id="anima")
+
+    p_warn = _write_lora(tmp_path / "legacy.safetensors", key_block=27)
+    warnings: list[str] = []
+    # 走到 inject 前就该 warn；用 fake adapter 截住后续（不依赖 lycoris）
+    import sys
+    import types
+    from unittest.mock import MagicMock, patch
+
+    def _fake_adapter(*a, **k):
+        m = MagicMock()
+        m.network = MagicMock()
+        m.network.loras = []
+        m.load_state_dict.return_value = MagicMock(missing_keys=[], unexpected_keys=[])
+        return m
+
+    fake_mod = types.ModuleType("utils.lycoris_adapter")
+    fake_mod.AnimaLycorisAdapter = _fake_adapter  # type: ignore[attr-defined]
+    with patch.dict(sys.modules, {"utils.lycoris_adapter": fake_mod}):
+        apply_loras(
+            model, [LoRASpec(path=str(p_warn))], "cpu", torch.float32,
+            family_id="anima", on_warning=warnings.append,
+        )
+    assert len(warnings) == 1 and "28" in warnings[0] and "40" in warnings[0]
+
+
+def test_resume_lora_check_rejects_and_warns(tmp_path):
+    from training.phases.models import _check_resume_lora_compat
+
+    ctx = SimpleNamespace(
+        model=_TinyDiT(40),
+        family=SimpleNamespace(spec=SimpleNamespace(family_id="anima")),
+    )
+    with pytest.raises(RuntimeError, match="层数不匹配"):
+        _check_resume_lora_compat(ctx, _write_lora(tmp_path / "old28.safetensors", num_blocks_meta=28))
+    # 同层数放行
+    _check_resume_lora_compat(ctx, _write_lora(tmp_path / "ok40.safetensors", num_blocks_meta=40))
+    # 跨族仍拒绝
+    k2 = tmp_path / "k2.safetensors"
+    save_file({"x": torch.zeros(1)}, str(k2), metadata={
+        "ss_network_args": json.dumps({"algo": "lokr", "model_family": "krea2"}),
+    })
+    with pytest.raises(RuntimeError, match="跨模型族"):
+        _check_resume_lora_compat(ctx, k2)
+
+
+def test_training_state_records_and_checks_base_num_blocks(tmp_path):
+    from training.state import load_training_state, save_training_state
+
+    class _Inj:
+        def state_dict(self):
+            return {"w": torch.zeros(1)}
+
+        def load_state_dict(self, sd, strict=False):
+            return SimpleNamespace(missing_keys=[], unexpected_keys=[])
+
+    p = torch.nn.Parameter(torch.zeros(1))
+    opt = torch.optim.SGD([p], lr=0.1)
+    path = tmp_path / "state.pt"
+    save_training_state(path, _Inj(), opt, epoch=1, global_step=10, base_num_blocks=28)
+    # 同层数放行；不给 expected 也放行（老调用方）；不等 → 拒绝且说人话
+    load_training_state(path, _Inj(), opt, expected_num_blocks=28)
+    load_training_state(path, _Inj(), opt)
+    with pytest.raises(RuntimeError, match="层数不匹配"):
+        load_training_state(path, _Inj(), opt, expected_num_blocks=40)
+    # 老恢复点（没记层数）→ 不判
+    save_training_state(path, _Inj(), opt, epoch=1, global_step=10)
+    load_training_state(path, _Inj(), opt, expected_num_blocks=40)
+
+
+def test_lycoris_adapter_save_writes_base_arch_via_metadata_extra(tmp_path):
+    """真 AnimaLycorisAdapter：metadata_extra 里的契约键随 ss_network_args 落盘。"""
+    pytest.importorskip("lycoris")
+    from studio.services.inference.core import read_lora_meta
+    from utils.lycoris_adapter import AnimaLycorisAdapter
+
+    class _M(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.blocks = torch.nn.ModuleList([torch.nn.Module() for _ in range(2)])
+            for b in self.blocks:
+                b.self_attn = torch.nn.Module()
+                b.self_attn.q_proj = torch.nn.Linear(8, 8)
+
+    model = _M()
+    adapter = AnimaLycorisAdapter(
+        preset={"target_name": ["*q_proj"], "exclude_name": [], "use_fnmatch": True, "lora_prefix": "lora_unet"},
+        algo="lora", rank=2, alpha=2.0,
+    )
+    adapter.metadata_extra = {"model_family": "anima", **base_arch_network_args_from_model(model, "base.safetensors")}
+    adapter.inject(model)
+    out = tmp_path / "out.safetensors"
+    adapter.save(out)
+    meta = read_lora_meta(str(out))
+    assert meta.base_arch == LoraBaseArch(2, "metadata", None, "base.safetensors")

--- a/tools/lora_merge.py
+++ b/tools/lora_merge.py
@@ -42,6 +42,35 @@ sys.path.insert(0, str(REPO_ROOT))
 import torch  # noqa: E402
 
 from studio.services.inference.core import LoRAMeta, read_lora_meta  # noqa: E402
+from studio.services.inference.lora_compat import (  # noqa: E402
+    base_arch_network_args,
+    build_lora_metadata,
+)
+
+
+def _inherit_base_arch(sources: list[tuple[Path, float]], metas: list[LoRAMeta]) -> dict:
+    """merge 产物的族 / 底模架构键：各源一致才继承，冲突拒绝。
+
+    族：显式标记的源之间必须一致（无标记源 grandfather 为 anima，不参与比对）。
+    层数：元数据确证的源之间必须一致；只有键扫描（下界）的源不写层数。
+    """
+    families = {m.model_family for m in metas if m.family_explicit}
+    if len(families) > 1:
+        raise SystemExit(f"源 LoRA 分属不同模型族 {sorted(families)}，不能 merge")
+    out: dict = {}
+    if families:
+        out["model_family"] = families.pop()
+    explicit = [(p, m.base_arch) for (p, _), m in zip(sources, metas) if m.base_arch.explicit]
+    blocks = {a.num_blocks for _, a in explicit}
+    if len(blocks) > 1:
+        detail = ", ".join(f"{p.name}={a.num_blocks} 层" for p, a in explicit)
+        raise SystemExit(f"源 LoRA 训练自不同层数的底模（{detail}），层与层对不上，不能 merge")
+    if explicit:
+        _, arch = explicit[0]
+        out.update(base_arch_network_args(
+            num_blocks=arch.num_blocks, model_channels=arch.model_channels,
+        ))
+    return out
 
 
 def _load_layers(path: Path) -> dict[str, dict[str, torch.Tensor]]:
@@ -183,14 +212,14 @@ def merge(
     }
     if reg_dims:
         network_args["lora_reg_dims"] = reg_dims
+    # 族 + 底模架构（lora_compat 契约）从源继承：各源一致才写；不一致直接拒绝
+    # ——不同层数底模上训的 LoRA 层与层对不上，merge 出来也是错的。
+    network_args.update(_inherit_base_arch(sources, metas))
     provenance = [{"file": p.name, "weight": w} for p, w in sources]
-    metadata = {
-        "ss_network_dim": str(max_rank),
-        "ss_network_alpha": str(float(max_rank)),
-        "ss_network_module": "lycoris.kohya",
-        "ss_network_args": json.dumps(network_args),
-        "anima_merge_sources": json.dumps(provenance, ensure_ascii=False),
-    }
+    metadata = build_lora_metadata(
+        rank=max_rank, alpha=float(max_rank), network_args=network_args,
+        extra={"anima_merge_sources": json.dumps(provenance, ensure_ascii=False)},
+    )
     from safetensors.torch import save_file
 
     out_path.parent.mkdir(parents=True, exist_ok=True)

--- a/utils/lycoris_adapter.py
+++ b/utils/lycoris_adapter.py
@@ -12,7 +12,6 @@ Copyright (c) 2026 Seunghyun Ji，见 THIRD_PARTY_NOTICES.md）；mask 注入机
 """
 from __future__ import annotations
 
-import json
 import logging
 import math
 import re
@@ -26,6 +25,7 @@ import torch.nn as nn
 from safetensors.torch import save_file
 from safetensors import safe_open
 
+from studio.services.inference.lora_compat import build_lora_metadata
 from utils.lycoris_patch import apply_lokr_device_patch
 
 logger = logging.getLogger(__name__)
@@ -467,15 +467,10 @@ class LycorisAdapter:
         }
         if self.lora_reg_dims:
             ss_args["lora_reg_dims"] = self.lora_reg_dims
-        # 多模型 D13：族标记（phases/models 注入 family.lora_metadata()）；
-        # 无标记的存量产物读取侧 grandfather 为 anima
+        # 多模型 D13：族标记 + 底模架构（phases/models 注入 family.lora_metadata()
+        # 与 lora_compat 契约键）；无标记的存量产物读取侧 grandfather 为 anima
         ss_args.update(getattr(self, "metadata_extra", None) or {})
-        meta = {
-            "ss_network_dim": str(self.rank),
-            "ss_network_alpha": str(self.alpha),
-            "ss_network_module": "lycoris.kohya",
-            "ss_network_args": json.dumps(ss_args),
-        }
+        meta = build_lora_metadata(rank=self.rank, alpha=self.alpha, network_args=ss_args)
         save_file(sd, str(path), metadata=meta)
         logger.info(f"LoRA 保存到: {path}")
 

--- a/utils/ortho_adapter.py
+++ b/utils/ortho_adapter.py
@@ -24,7 +24,6 @@ Provenance:
 """
 from __future__ import annotations
 
-import json
 import logging
 from fnmatch import fnmatch
 from pathlib import Path
@@ -37,6 +36,7 @@ import torch.nn.functional as F
 from safetensors import safe_open
 from safetensors.torch import save_file
 
+from studio.services.inference.lora_compat import build_lora_metadata
 
 logger = logging.getLogger(__name__)
 
@@ -377,12 +377,7 @@ class OrthoLoRAAdapter:
             "rs_lora": False,
         }
         ss_args.update(getattr(self, "metadata_extra", None) or {})
-        meta = {
-            "ss_network_dim": str(self.rank),
-            "ss_network_alpha": str(self.alpha),
-            "ss_network_module": "lycoris.kohya",
-            "ss_network_args": json.dumps(ss_args),
-        }
+        meta = build_lora_metadata(rank=self.rank, alpha=self.alpha, network_args=ss_args)
         save_file(sd, str(path), metadata=meta)
         logger.info("OrthoLoRA 保存到: %s (baked as plain LoRA)", path)
 


### PR DESCRIPTION
> 叠在 #502（PR-1，`feat/anima-checkpoint-arch`）之上；#502 合入 dev 后本 PR 会自动 retarget 到 dev（或我 rebase）。这是「Anima-2.9B 完全兼容」的第二刀。

## 背景

同族底模可以有不同层数（Anima 官方 28 层、第三方插层扩展版 40 层）。LoRA 按 `blocks.N` 名字套用：28 层 LoRA 挂 40 层底模，`blocks.0..27` 全对上、`28..39` 缺 → 此前 `apply_loras` 的门槛是 `unexpected >= len(sd)` 才报错（all-or-nothing），**不报错不警告**，出的图是错位的垃圾；族标记 `model_family` 分不出这个差别；训练侧 `resume_lora` 同样只查族；恢复点没有底模指纹（换底模续训崩在 torch 的 param group 报错上）。

## 契约（`studio/services/inference/lora_compat.py`，只用标准库）

- **写**：训练保存 LoRA 时把底模 `base_num_blocks / base_model_channels / base_model_file` 写进 `ss_network_args`（`phases/models.py` 注入，取自 PR-1 的 `model.checkpoint_arch`，无 arch 的族退回数 `model.blocks`）；lycoris / ortho / lora_merge 三处写盘共用 `build_lora_metadata`。
- **读**：`lora_base_arch`——元数据优先，否则扫键 `blocks.N` 最大下标 +1 兜底（**只是下界**：只挂部分层的 LoRA 也会小于底模层数）；`read_lora_base_arch` 只读 header 给 studio 列表用。
- **判**：`check_lora_compat` 是唯一判定函数：

  | 情形 | 结论 |
  |---|---|
  | 元数据有层数且 ≠ 底模层数 | **reject**（与跨族拒绝同级） |
  | 无元数据，键最大下标 ≥ 底模层数 | **reject**（键必然 unexpected） |
  | 无元数据，键最大下标 +1 < 底模层数 | **warn**（可能是老 28 层 LoRA，也可能只挂部分层） |
  | 其余 / 一方层数未知 | ok |

## 消费

- 出图 `core.apply_loras`：reject → `ValueError`；warn → `on_warning` 回调；部分键没被吃掉从 info 升 warning（与 fp8 merge 路径同口径）。daemon **热换权重路径**（同拓扑换文件、不经 apply_loras）补同一判定。
- daemon 新增 task 级 `warning` 事件 → supervisor `generate_warning` SSE → 前端 toast（`Toast` 加 `warning` 档，6s）。
- 训练 `resume_lora`：`_check_resume_lora_compat`（族 + 层数）替代只查族的 `_read_lora_family`。
- 恢复点 `state.py`：save 记 `base_num_blocks`，load 侧 `expected_num_blocks` 不等 → 拒绝并说人话；老恢复点没记 → 不判。
- LoRA 列表行（`list_lora_ckpts`）带 `base_num_blocks` / `base_arch_source`（按 path+size+mtime 缓存，只读 header）；前端 `LoraCkpt` 类型同步。**展示（chip 上标「28 层 / 40 层」+ 与当前底模不匹配的标记）放 PR-3**——需要底模行的 arch 数据一起到位。
- `lora_merge`：族与层数从源继承、冲突拒绝；顺手补上此前缺失的 `model_family`。

## 测试

- 新增 `tests/test_lora_compat.py`（19 个）：写/读/判纯函数、header 直读、apply_loras reject+warn、resume_lora 校验、恢复点记/判层数、真 AnimaLycorisAdapter 落盘契约键。
- 两个测试替身签名加 `on_warning=None`（`test_inference_core` / `test_anima_daemon_comfy_parity_runtime`）。
- 本地：inference_core / lycoris_resume / model_families / lora_merge / ortho / krea2+anima preset / state 系 / daemon 系 / lora_ckpt_scan / eval 系全绿；`tsc --noEmit` + vitest（components / generate）全绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
