### PR TITLE
feat(logging): 日志目标态刀 1——记录不过滤 / 一个格式 / 一个 env（含设计稿 + ADR 0009 Addendum）

### DIFF
--- a/docs/adr/0009-logging-error-system.md
+++ b/docs/adr/0009-logging-error-system.md
@@ -1,6 +1,6 @@
 # 0009 — 统一日志 + 错误体系（0.12.0）
 
-**状态**：Accepted
+**状态**：Accepted + Addendum 1 2026-08-19（日志目标态刀 1：记录不过滤 / 一个格式 / 一个 env，见末尾「增量更新」）
 **日期**：2026-05-28
 **决策者**：@WalkingMeatAxolotl（三方 agent review：架构师 / 审计员 / 迁移策略师，各两轮）
 **落地**：PR #155 (PR-1 后端基础设施) / PR #156 (PR-2 错误体系) / PR #TBD (PR-3 前端 + CLI 收尾)
@@ -372,3 +372,30 @@ A agent 首轮主张。否决理由：当前 ~200 LOC 单文件完全 hold；6 �
   - `studio/domain/errors.py` — 错误体系入口
   - `studio/api/exception_handlers.py` — 3 个 handler 注册点
   - `studio/api/middleware/trace.py` — trace_id 入口
+
+## 增量更新
+
+### 2026-08-19 — Addendum 1: 日志目标态刀 1（记录不过滤 / 一个格式 / 一个 env）
+
+**影响范围**：改「决策」中 `setup_logging` 的级别语义、「实施 lessons」第 6 条的 `_say` 实现、「不在范围」里的 `jobs/<id>.log` GC 与「演进双写」条目。设计全文见 `docs/design/logging-target-state.md`（含四项拍板 D1-D4、五条不变量、四刀分工）；本 Addendum 只记录对本 ADR 结论有改动的部分。
+
+**起因**：issue #505 的切桶释放日志无处可去 → 全仓盘点发现 8 处 `logger.debug` 在任何配置下不可见（只有 webui 读 `ANIMA_LOG_LEVEL`，cli / worker / runtime 四入口硬编码 INFO）、run.log 是无级别的裸字节流（logger 行 + 裸 print + 协议行混流）、`[Debug]` 前缀的采样日志反而每次无条件刷屏。
+
+**拍板与推论**（D1-D4 原文在设计稿 §2）：
+
+| 决策 | 对本 ADR 的改动 |
+|---|---|
+| D1 调试开关进 UI；全局管默认、视图独立、**显示过滤而非不记录** | `setup_logging` 的级别模型改为：自家命名空间（`OWN_LOGGER_NAMESPACES`：studio / training / utils / runtime / modeling / anima_*）恒 DEBUG；root 保持 INFO 防第三方 debug 洪水；file handler 不设级别；console handler 级别 = 参数 > `ANIMA_LOG_LEVEL` > INFO。**`ANIMA_LOG_LEVEL` 从「进程日志级别」退化为「终端可读性」旋钮**，在 `setup_logging` 内部读，所有入口共用；supervisor / daemon spawn 注入 `ANIMA_LOG_LEVEL=DEBUG`（子进程 stderr 即 run.log，记录面必须 DEBUG） |
+| D2 子进程 / daemon 不落 studio.log | 「不在范围 → 演进双写」条目**作废**：worker 与 runtime 脚本永远 `file=False`，各写各的面，排障靠诊断包（刀 4）拼；`setup_logging(extra_handlers=…)` 死参数删除 |
+| D3 训练进度行算日志 | pipe 模式下 `log_every` 进度行走 `training.progress` logger、`ctx.emit` 走 `training.emit`；tty 交互（rich / plain `\r`）不变 |
+| D4 run.log 不做 GC | 「不在范围 → `jobs/<id>.log` GC 超 7 天」条目**作废**；run.log 随任务删除 |
+
+**行契约**（跨进程，改即 breaking）：所有进程的 stderr / run.log 行都是 `HumanConsoleFormatter`：`%(asctime)s.%(msecs)03d %(levelname)-5s %(name)s: %(message)s`；解析正则 `LOG_LINE_RE` 导出在 `studio/infrastructure/logging.py`，不匹配行头的行是上一条记录的续行。四个 runtime 入口（anima_train / daemon / generate / reg_ai）弃各自 `basicConfig` 改调 `setup_logging(process, file=False, console=True)`，process 名 / trace_id 取 supervisor 注入的 env（`_spawn_job` 与 daemon spawn 补齐注入，之前只有 `_spawn_task` 有）。`console="auto"` 在 pipe 下不再输出 JSON（与 studio.log 重复）。
+
+**裸 print 白名单**（`tests/test_print_whitelist.py` AST 扫描锁死）：stdout 协议行（`__EVENT__:` / daemon line-JSON）、tty 交互（rich/plain 进度行、`input()` 配套提示、独立 CLI 工具 `__main__` 结果输出）、CLI 启动 banner。其余 runtime 35 处 / studio 41 处 print 已收编为 logger；`[Debug]` / `[WARN]` / `[OK]` 冒充级别的前缀清掉（`[Debug]` 11 条→ debug）；`anima_generate` / `anima_reg_ai` 的 `logger.error(str(e))` → `logger.exception`。
+
+**`_say` 改动**（覆盖实施 lessons 第 6 条）：`studio/cli.py::_say(msg, level)` 改为 `logging.getLogger("studio.cli")` 的薄包装，`level` 真起作用；`--verbose` 不做，走 `ANIMA_LOG_LEVEL`。第 6 条描述的「`_say` 内部用字符串拼接避免正则误伤」不再适用。
+
+**噪音表**：`_NOISY_LOGGERS` 扩到 transformers / diffusers / accelerate / peft / wandb / spandrel / multipart / charset_normalizer / numba / fsspec / watchfiles；`uvicorn.access` 压到 WARNING（uvicorn / uvicorn.error 的启动信息保留 INFO）。
+
+**后续刀**（见设计稿 §6）：刀 2 读取面（`/api/logs` 分页 + SSE seq 统一 + error_msg 取 ERROR 块）→ 刀 3 前端统一 LogView + 全局/视图调试开关（后端字段 `system.log_debug_default`）→ 刀 4 诊断包。

--- a/docs/design/logging-target-state.md
+++ b/docs/design/logging-target-state.md
@@ -1,6 +1,6 @@
 # 日志体系目标态：统一行契约 + 显示级过滤
 
-状态：四项关键决策已拍板（2026-08-19），待实施。分刀见 §6。
+状态：四项关键决策已拍板（2026-08-19）；**刀 1 已实施**（分支 feat/logging-unify，见 ADR 0009 Addendum 1）。分刀见 §6。
 触发：issue #505 的切桶释放日志无处可去 → 全仓盘点发现 8 处 `logger.debug` 在任何配置下都不可见、run.log 是无级别的裸字节流、前端 6 套日志视图零级别解析。盘点原稿在 `tmp/logging-inventory.md`（本地）。
 上游：ADR 0009（logging/error system）定的 studio 侧骨架（`setup_logging` / JSON line / trace_id / 错误 envelope）不推翻，本文只补它没覆盖的子进程与显示面，并把跨进程的行契约定下来。
 
@@ -50,7 +50,7 @@
 | anima_daemon | stderr → server ring buffer（2000 行不变） | DEBUG（daemon spawn 同样注入） | 同上；LyCORIS 掰 stderr 逻辑保留 | 即 ring |
 | anima_generate / 手跑 anima_train | 终端 | `ANIMA_LOG_LEVEL` 默认 INFO | 同上 | 终端 |
 
-规则一句话：**被 studio 拉起 → 记 DEBUG；人手拉起 → 默认 INFO；`ANIMA_LOG_LEVEL` 两边都能覆盖。** 只有这一个 env，`setup_logging` 内部读它（现在只有 webui 入口在外面读），四个 runtime 入口不再各自 `basicConfig`，改调同一个轻量 bootstrap（`setup_logging(process, file=False, console=True)` 或等价的 runtime 版，取决于 import 成本——见 §7）。
+规则一句话：**被 studio 拉起 → 记 DEBUG；人手拉起 → 默认 INFO；`ANIMA_LOG_LEVEL` 两边都能覆盖。** 只有这一个 env，`setup_logging` 内部读它（现在只有 webui 入口在外面读），四个 runtime 入口不再各自 `basicConfig`，改调 `setup_logging(process, file=False, console=True)`（runtime 本就 import studio.*，无额外成本；open question 1 已定）。
 
 trace / process 注入补齐：`_spawn_job`、daemon spawn 与 `_spawn_task` 一样注入 `ANIMA_TRACE_ID` / `ANIMA_PROCESS_NAME`。
 
@@ -67,7 +67,7 @@ Traceback (most recent call last):
 - 多行记录（traceback、rich 曲线面板）：续行无前缀；解析器把不匹配行头的行归入上一条记录、继承其级别。
 - 训练 pipe 模式：`log_every` 进度行、`ctx.emit` 消息全部 `logger.info`；tty 模式不变（rich Progress / plain `\r`）。`ctx.emit` 的三路分流保留，只把最后的 `print` 分支换成 logger。
 - 裸 print 合法白名单：`__EVENT__:` 协议行（`snapshot.emit_event`、`preprocess_worker`）、daemon `_emit*` line-JSON、rich/plain tty 进度、`api/main.py` banner。其余 print → logger（runtime 35 处 / studio 41 处，清单见盘点稿 §1）。
-- 严重度只由级别表达：`[Debug]`（sampling.py 11 处）→ `logger.debug` 去前缀；`[WARN]` → `logger.warning`；`[OK]` print → `logger.info`。主题 tag（`[显存]` `[navit]` `[text-cache]` `[masked-loss]` …）保留，同主题同级别。
+- 严重度只由级别表达：`[Debug]`（sampling.py 11 处）→ `logger.debug` 去前缀；`[WARN]` → `logger.warning`；`[OK]` print → `logger.info`。主题 tag（`[显存]` `[navit]` `[text-cache]` `[masked-loss]` …）保留；级别按事件本身定，tag 不携带级别语义。
 - `error_msg` 回写：从 run.log 尾部取**最后一个 ERROR 级记录块**（含续行），找不到再退回现在的 Traceback/末 12 行策略。
 
 ### 3.3 显示面
@@ -160,6 +160,6 @@ studio.log 查看 UI；子进程写 studio.log（D2）；run.log GC（D4）；�
 
 ## 7. Open questions（实施时定，不阻塞开工）
 
-- runtime 入口复用 `studio.infrastructure.logging.setup_logging` 还是抄一份轻量版：前者少一份 formatter 定义，但 runtime 进程要 import `studio.*`（现在只 import `studio.paths` 等少数）；后者多一处同步点。倾向前者，import 成本实测后定。
-- 进度行的 logger 名用 `training.loop` 还是单独 `training.progress`（方便前端将来单独折叠进度行）：倾向 `training.progress`。
+- ~~runtime 入口复用 `setup_logging` 还是轻量版~~：已定复用（刀 1）。
+- ~~进度行 logger 名~~：已定 `training.progress`，`ctx.emit` 非 tty 出口 `training.emit`（刀 1）。
 - 视图开关的默认值在「全局开关变化时」是否同步已打开的视图：倾向不同步（不持久化 + 挂载取值，语义最简单）。

--- a/docs/design/logging-target-state.md
+++ b/docs/design/logging-target-state.md
@@ -1,0 +1,164 @@
+# 日志体系目标态：统一行契约 + 显示级过滤
+
+状态：四项关键决策已拍板（2026-08-19），待实施。分刀见 §6。
+触发：issue #505 的切桶释放日志无处可去 → 全仓盘点发现 8 处 `logger.debug` 在任何配置下都不可见、run.log 是无级别的裸字节流、前端 6 套日志视图零级别解析。盘点原稿在 `tmp/logging-inventory.md`（本地）。
+上游：ADR 0009（logging/error system）定的 studio 侧骨架（`setup_logging` / JSON line / trace_id / 错误 envelope）不推翻，本文只补它没覆盖的子进程与显示面，并把跨进程的行契约定下来。
+
+## 1. 用户场景
+
+**普通用户（webui）**
+- 打开任一任务的日志：每行有时间、级别、来源；报错行红、警告行黄，一眼看到「哪一步开始不对」；默认不显示调试行，报错后**在同一个视图里打开「调试」开关**就能看到调试行，不用重跑。
+- 任务失败：红框里是最后一个 ERROR/Traceback 块，不是文件尾巴碰运气。
+- 日志抽屉和日志 tab 是同一个东西：同样的着色、过滤、复制、下载、自动滚动开关；长任务不卡页面；刷新/断线不丢行。
+- 报 issue：一个按钮导出诊断包（该任务 run.log + 时间窗内 studio.log + 版本/GPU/env 摘要）。
+
+**终端用户 / 纯 CLI**
+- 控制台里看到的与 run.log 同一套格式；不再一半 `[studio]` print、一半 logger、一半 JSON。
+- 直接跑 `runtime/anima_train.py` 仍是交互式进度条；pipe 模式自动切成逐行日志。
+
+**开发者 / 排障**
+- 拿到诊断包就够：run.log 每行可定位模块；trace_id 从 toast → API → studio.log → 子进程 run.log 贯通。
+- 加一条 `logger.debug` 时知道它一定会被记录、用户一开开关就能看到。
+
+## 2. 决策记录
+
+| # | 问题 | 决策 | 推论 |
+|---|---|---|---|
+| D1 | 调试日志开关放哪 | **进 UI 设置**：全局开关只负责「默认值」；每个日志视图有**独立开关**（不持久化，初值取全局）；调试行靠**显示过滤**隐藏而不是不记录 | ⇒ 供 UI 展示的记录面（run.log / daemon ring）**始终记到 DEBUG**；级别开关是显示端的事，不是生成端的事 |
+| D2 | 子进程 / daemon 日志要不要落 studio.log | **不落**；各进程写各自的面，排障靠诊断包拼 | studio.log 仍只属 webui 进程；不引入跨进程写同一文件 |
+| D3 | 训练进度行（step/loss/speed）算不算日志 | **算**：pipe 模式下走 logger，与其它行同契约 | 「一个格式」不变量没有例外；tty 交互模式仍用 rich/plain 进度条 |
+| D4 | run.log 保留策略 | **不做 GC**；随任务删除 | ADR 0009「7 天 GC」条目作废 |
+
+由此推出的五条不变量（也是各刀的验收标准）：
+
+1. **一个格式**：所有进程落到任何日志面的行都是同一契约（§3.2）；结构化面（studio.log）是它的 JSON 版。裸 `print` 只剩三类合法用途：stdout 协议行（`__EVENT__:` / daemon line-JSON）、tty 交互进度、CLI 启动 banner。
+2. **记录不过滤，显示才过滤**：面向 UI 的记录面永远 DEBUG；`ANIMA_LOG_LEVEL` 只管终端可读性（开发者旋钮，不进 UI）。
+3. **级别是级别、tag 是主题**：`[Debug]` / `[WARN]` / `[OK]` 这类冒充级别的前缀清掉；方括号只保留主题 tag，同主题同级别。
+4. **一个日志组件**：前端所有「看一段任务/进程日志」的地方用同一组件 + 同一数据 hook；数据契约「seq 单调 + 可从 seq/offset 续拉」。
+5. **debug 有去处**：没有任何 `logger.debug` 是「写了永远看不到」。
+
+## 3. 目标态
+
+### 3.1 记录面：级别与落点
+
+| 进程 | 落点 | 我方 logger 级别 | 第三方 logger | 终端 stderr |
+|---|---|---|---|---|
+| webui | `studio.log`（JSON line，50MB×5 不变） | DEBUG | `_NOISY_LOGGERS` → WARNING（列表扩到 transformers / diffusers / accelerate / peft / wandb / spandrel / matplotlib.font_manager） | console handler 级别 = `ANIMA_LOG_LEVEL`（默认 INFO）；tty → Human，pipe → 同 Human（**不再输出 JSON**，与文件重复无意义） |
+| cli | 无文件 | — | 同上 | 同上 |
+| worker 子进程 | 自身 stderr = `tasks/<id>/run.log`（OS 合流不变） | DEBUG（supervisor spawn 注入 `ANIMA_LOG_LEVEL=DEBUG`，`setdefault` 外部可覆盖） | 同上 + 现有 `TRANSFORMERS_VERBOSITY=error` 等 env 保留 | 即 run.log |
+| anima_train / anima_reg_ai | 同上 | 同上 | 同上 | 同上 |
+| anima_daemon | stderr → server ring buffer（2000 行不变） | DEBUG（daemon spawn 同样注入） | 同上；LyCORIS 掰 stderr 逻辑保留 | 即 ring |
+| anima_generate / 手跑 anima_train | 终端 | `ANIMA_LOG_LEVEL` 默认 INFO | 同上 | 终端 |
+
+规则一句话：**被 studio 拉起 → 记 DEBUG；人手拉起 → 默认 INFO；`ANIMA_LOG_LEVEL` 两边都能覆盖。** 只有这一个 env，`setup_logging` 内部读它（现在只有 webui 入口在外面读），四个 runtime 入口不再各自 `basicConfig`，改调同一个轻量 bootstrap（`setup_logging(process, file=False, console=True)` 或等价的 runtime 版，取决于 import 成本——见 §7）。
+
+trace / process 注入补齐：`_spawn_job`、daemon spawn 与 `_spawn_task` 一样注入 `ANIMA_TRACE_ID` / `ANIMA_PROCESS_NAME`。
+
+### 3.2 行契约
+
+```
+2026-08-19 14:03:22.417 INFO  training.loop: epoch=0 step=50 loss=0.031 lr=1.0e-4 speed=0.78 it/s
+2026-08-19 14:03:23.001 ERROR training.phases.finalize: block swap 释放失败
+Traceback (most recent call last):
+  ...
+```
+
+- 格式即现有 studio Human formatter：`%(asctime)s.%(msecs)03d %(levelname)-5s %(name)s: %(message)s`，datefmt `%Y-%m-%d %H:%M:%S`。runtime 四入口改用同一 formatter；`anima_train` 的 logger 名从 `__name__`（跑成 `__main__`）改固定 `anima_train`。
+- 多行记录（traceback、rich 曲线面板）：续行无前缀；解析器把不匹配行头的行归入上一条记录、继承其级别。
+- 训练 pipe 模式：`log_every` 进度行、`ctx.emit` 消息全部 `logger.info`；tty 模式不变（rich Progress / plain `\r`）。`ctx.emit` 的三路分流保留，只把最后的 `print` 分支换成 logger。
+- 裸 print 合法白名单：`__EVENT__:` 协议行（`snapshot.emit_event`、`preprocess_worker`）、daemon `_emit*` line-JSON、rich/plain tty 进度、`api/main.py` banner。其余 print → logger（runtime 35 处 / studio 41 处，清单见盘点稿 §1）。
+- 严重度只由级别表达：`[Debug]`（sampling.py 11 处）→ `logger.debug` 去前缀；`[WARN]` → `logger.warning`；`[OK]` print → `logger.info`。主题 tag（`[显存]` `[navit]` `[text-cache]` `[masked-loss]` …）保留，同主题同级别。
+- `error_msg` 回写：从 run.log 尾部取**最后一个 ERROR 级记录块**（含续行），找不到再退回现在的 Traceback/末 12 行策略。
+
+### 3.3 显示面
+
+**全局开关**：设置页「日志」组一项「默认显示调试日志」（布尔，默认关）。只影响显示默认值，前端 localStorage 持久化即可（先例：tag autocomplete 全局开关 `autocompleteToggle.ts`），后端不加字段。
+
+**视图开关**：每个日志视图头部一个「调试」toggle，不持久化，挂载时取全局开关值；开 = 显示 DEBUG 及以上，关 = 显示 INFO 及以上。WARNING/ERROR 永远显示且着色（黄/红），DEBUG 行显示时用弱化色。
+
+**统一组件** `LogView`（一个 presentational 组件 + 一个 `useLogSource` 数据 hook）：
+
+| 能力 | 规格 |
+|---|---|
+| 解析 | 按 §3.2 行头正则切记录；续行并入 |
+| 过滤 | 视图开关（级别阈值）；不做关键字搜索（非目标） |
+| 着色 | ERROR 红 / WARNING 黄 / INFO 默认 / DEBUG 弱化；单一 token 集，不再四套颜色 |
+| 尾部加载 | 初次只拉尾 N 条（默认 500），顶部「加载更早」按 offset 往前翻；客户端上限 5000 记录 |
+| 增量 | SSE 按 seq 追加；`onOpen` 重连时用最后 seq/offset 补拉 |
+| 操作 | 自动滚动开关、复制、下载（原始 run.log） |
+| 状态 | 等待日志 / 已结束 / 断线重连中 |
+
+替换关系：`TaskLogDrawer` 内容区、`QueueDetail` LogTab、`DaemonLogDrawer` 内容区、`useEvalLogSource` 全部改用 `LogView`；QueueDetail 同页两次 `getLog` 合成一次。设置页下载日志 / 更新日志 / onboarding 安装日志三个小面复用 `LogView` 只读模式（无 SSE、无分页）。抽屉的开合状态机、StepShell 的 `logSources` 挂载方式不变。
+
+其它显示修正：DaemonLogDrawer 渲染 `ts`；PreprocessDuplicates 的 per-line `status` 映射到级别；`PauseProgressModal` 深链改 `navigate('/queue/<id>#log')`；error toast 末尾接上已写好的 `formatErrorTraceSuffix`。
+
+### 3.4 读取面：API 与 SSE
+
+| 端点 / 事件 | 现状 | 目标 |
+|---|---|---|
+| `GET /api/logs/{task_id}` | 全文 `{content,size}` | `?tail=N`（默认 500 行）/ `?before=<offset>&limit=N`；返回 `{lines: [{offset,text}], start_offset, end_offset, size}`；服务端仍剥 `__EVENT__:` 行；不再一次性读整文件 |
+| `GET /api/logs/{task_id}/raw` | 无 | 原始文件下载（诊断包 / 下载按钮用） |
+| SSE `task_log_appended` / `job_log_appended` | 两种形状（LogTailer 带 seq、daemon 回写不带） | 统一 `{type, task_id|job_id, seq, offset, text}`；daemon 回写路径补 seq/offset |
+| SSE `daemon_log_line` | `{ts, seq, line}` | 不变 |
+| `GET /api/generate/daemon/logs` | `since_seq` / `limit` | 不变（已是目标形状） |
+| `event_malformed` | task 路径 emit、job 路径不 emit、前端不消费 | job 路径补 emit；前端 LogView 收到后插一条 WARNING 伪记录「事件解析失败」 |
+| `_on_task_log` / `_on_line` | try 块包住 `_on_event` | 只包解析，广播移出 try |
+
+### 3.5 CLI / 终端
+
+- `_say(msg, level)` 改成 `logging.getLogger("studio.cli")` 的薄包装，`level` 真起作用（info/warning/error 走对应级别，Human formatter 出前缀）；14 处裸 print 与 `pending_install` 的 10 处 `[studio]` print 收编。`--verbose` 不做，走 `ANIMA_LOG_LEVEL`。
+- webui console handler 不再在 pipe 下输出 JSON（与 studio.log 重复）。
+- uvicorn access log 降到 WARNING（业务日志不与 access 抢 50MB 配额；需要时 `ANIMA_LOG_LEVEL=DEBUG` 打开）。
+
+### 3.6 诊断包
+
+设置页 / 失败任务详情各一个入口：`GET /api/diagnostics/bundle?task_id=…` → zip：该任务 `run.log`、以任务起止时间为窗的 `studio.log` 片段、`GET /api/system/env` 已有的版本/GPU/依赖摘要、任务 config 快照。不含 secrets（wandb key 等走现有脱敏）。
+
+### 3.7 非目标
+
+studio.log 查看 UI；子进程写 studio.log（D2）；run.log GC（D4）；按模块配级别；日志关键字搜索；日志上报/远端；wandb 通道。
+
+## 4. 现状 → 目标 变化清单（按代码位置）
+
+**后端**
+- `studio/infrastructure/logging.py`：`setup_logging` 内读 `ANIMA_LOG_LEVEL`（参数仍可显式覆盖）；file handler 与 console handler 分级（file DEBUG、console = env）；`_NOISY_LOGGERS` 扩表；console `auto` 在 pipe 下改 Human；uvicorn 三 logger 设 WARNING；删死参数 `extra_handlers`。
+- `runtime/anima_train.py:50` / `anima_daemon.py:68` / `anima_generate.py:53` / `anima_reg_ai.py:61`：`basicConfig` → 共用 bootstrap；`anima_train` logger 固定名。
+- `studio/supervisor/core.py:1267-1318`（`_spawn_task` env）与 `:866-906`（`_spawn_job`）、`services/inference/daemon.py:274-317`：注入 `ANIMA_LOG_LEVEL=DEBUG`（setdefault）+ trace/process。
+- `runtime/training/loop.py:733,745`（进度行）、`context.py:147-159`（emit print 分支）→ logger；`bootstrap.py:38-108`、`training/cli.py:90,99`、`utils/optimizer_utils.py` 15 处、`utils/caption_utils.py` 6 处 → logger。
+- `runtime/training/families/anima/sampling.py` 11 处 `[Debug]` → debug；`utils/lycoris_adapter.py:42`、`optimizer_utils.py:1337` `[WARN]` → warning。
+- `anima_generate.py:282,472`、`anima_reg_ai.py:599` `logger.error(str(e))` → `logger.exception`。
+- workers 5 处 `progress()`/`log()` 闭包与 8 处 `[error]` print → logger（进度闭包保留函数形状，内部换 logger.info）。
+- `studio/cli.py:67-80` `_say` 接 logger；14 处裸 print 收编；`services/runtime/pending_install.py:74-95` 收编。
+- `studio/api/routers/logs.py`：分页 + raw；`supervisor/core.py:74-101` `_tail_log_for_error_msg` 改按 ERROR 块；`core.py:1108-1133` daemon 回写补 seq/offset；`core.py:922-950` job 路径补 `event_malformed`；两处 try 范围收窄。
+- 新增 `studio/api/routers/diagnostics.py`（诊断包）。
+
+**前端**
+- 新增 `components/LogView.tsx` + `lib/useLogSource.ts`；`TaskLogDrawer` / `QueueDetail` LogTab / `DaemonLogDrawer` / `useEvalLogSource` 改用；三个小面复用只读模式。
+- 设置页「日志」组：全局开关（localStorage）。
+- `PauseProgressModal.tsx:124` 深链；`api/client.ts` error toast 接 trace suffix；删 `Toast.tsx:66,75` 死导出；孤儿 i18n `duplicates.logTitle` / `reg.aiLogTitle` / `reg.tabConfig` 清理。
+- i18n：`logView.*`（调试开关、加载更早、下载、断线重连、事件解析失败）；`settings.log.*`。
+
+**文档**
+- ADR 0009 加 Addendum：记录 D1-D4、行契约、`ANIMA_LOG_LEVEL` 语义变化（生成端 → 终端可读性）、GC 条目作废、`extra_handlers` 删除。
+- user-guide：「查看日志 / 调试开关 / 导出诊断包」一节。
+
+## 5. 与 PR #506 的关系
+
+#506 的切桶释放日志已按本文规格写成 `logger.debug`（同主题 `[显存]` tag，级别待 sysmem.py 一侧对齐）；刀 1 合入后它在 run.log 里可见，刀 3 合入后用户在视图里打开「调试」即可看到。
+
+## 6. 分刀与验收
+
+依赖链：刀 1 → 刀 2 → 刀 3；刀 4 独立。每刀独立可合，无临时脚手架。
+
+| 刀 | 内容 | 验收 |
+|---|---|---|
+| 1 后端一致性 | §3.1 全部 + §3.2 生成端全部 + §3.5 | 单测：`setup_logging` 读 env、file/console 分级；四入口输出行匹配契约正则；spawn env 含 `ANIMA_LOG_LEVEL=DEBUG` 与 trace；runtime/ 与 studio/ 下 print 只剩白名单（AST 扫描测试锁死）。人工：跑一次训练，run.log 每行有 ts/level/name，debug 行在场 |
+| 2 读取面 | §3.4 + error_msg | 单测：分页边界（空文件 / 单行 / 跨 offset）、`__EVENT__` 剥离、SSE 形状统一、error_msg 取 ERROR 块；前端 client 类型同步 |
+| 3 前端 | §3.3 全部 + 深链 / toast trace / 死代码 / i18n | vitest：解析器（行头/续行/多行 traceback）、过滤阈值、着色 token、断线补拉、开关初值取全局；三处旧组件删除；真机验一次训练日志 + daemon 日志 |
+| 4 诊断包 | §3.6 | 单测：zip 内容清单、时间窗切片、脱敏；真机导一次 |
+
+## 7. Open questions（实施时定，不阻塞开工）
+
+- runtime 入口复用 `studio.infrastructure.logging.setup_logging` 还是抄一份轻量版：前者少一份 formatter 定义，但 runtime 进程要 import `studio.*`（现在只 import `studio.paths` 等少数）；后者多一处同步点。倾向前者，import 成本实测后定。
+- 进度行的 logger 名用 `training.loop` 还是单独 `training.progress`（方便前端将来单独折叠进度行）：倾向 `training.progress`。
+- 视图开关的默认值在「全局开关变化时」是否同步已打开的视图：倾向不同步（不持久化 + 挂载取值，语义最简单）。

--- a/docs/design/logging-target-state.md
+++ b/docs/design/logging-target-state.md
@@ -72,7 +72,7 @@ Traceback (most recent call last):
 
 ### 3.3 显示面
 
-**全局开关**：设置页「日志」组一项「默认显示调试日志」（布尔，默认关）。只影响显示默认值，前端 localStorage 持久化即可（先例：tag autocomplete 全局开关 `autocompleteToggle.ts`），后端不加字段。
+**全局开关**：设置页一项「默认显示调试日志」（布尔，默认关），**后端字段** `Secrets.system.log_debug_default`（与设置页其它项一样走 secrets 落盘 + 现有 settings API / instant-apply），换浏览器不丢。它只影响显示默认值，不影响记录（记录恒 DEBUG，见 §3.1）。
 
 **视图开关**：每个日志视图头部一个「调试」toggle，不持久化，挂载时取全局开关值；开 = 显示 DEBUG 及以上，关 = 显示 INFO 及以上。WARNING/ERROR 永远显示且着色（黄/红），DEBUG 行显示时用弱化色。
 
@@ -130,11 +130,12 @@ studio.log 查看 UI；子进程写 studio.log（D2）；run.log GC（D4）；�
 - workers 5 处 `progress()`/`log()` 闭包与 8 处 `[error]` print → logger（进度闭包保留函数形状，内部换 logger.info）。
 - `studio/cli.py:67-80` `_say` 接 logger；14 处裸 print 收编；`services/runtime/pending_install.py:74-95` 收编。
 - `studio/api/routers/logs.py`：分页 + raw；`supervisor/core.py:74-101` `_tail_log_for_error_msg` 改按 ERROR 块；`core.py:1108-1133` daemon 回写补 seq/offset；`core.py:922-950` job 路径补 `event_malformed`；两处 try 范围收窄。
+- `studio/infrastructure/secrets.py` `SystemConfig` 加 `log_debug_default: bool = False`；settings 端点/前端 client 类型同步。
 - 新增 `studio/api/routers/diagnostics.py`（诊断包）。
 
 **前端**
 - 新增 `components/LogView.tsx` + `lib/useLogSource.ts`；`TaskLogDrawer` / `QueueDetail` LogTab / `DaemonLogDrawer` / `useEvalLogSource` 改用；三个小面复用只读模式。
-- 设置页「日志」组：全局开关（localStorage）。
+- 设置页：全局开关「默认显示调试日志」读写 `system.log_debug_default`。
 - `PauseProgressModal.tsx:124` 深链；`api/client.ts` error toast 接 trace suffix；删 `Toast.tsx:66,75` 死导出；孤儿 i18n `duplicates.logTitle` / `reg.aiLogTitle` / `reg.tabConfig` 清理。
 - i18n：`logView.*`（调试开关、加载更早、下载、断线重连、事件解析失败）；`settings.log.*`。
 

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -25,6 +25,7 @@ import base64
 import io
 import json
 import logging
+import os
 import random
 import sys
 import threading
@@ -64,13 +65,10 @@ try:
 except Exception:
     pass
 
-# 日志走 stderr，stdout 留给协议
-logging.basicConfig(
-    level=logging.INFO,
-    stream=sys.stderr,
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    datefmt="%H:%M:%S",
-)
+# 日志走 stderr（setup_logging 的 console handler 即 stderr），stdout 留给协议
+from studio.infrastructure.logging import PROCESS_ENV, setup_logging  # noqa: E402
+
+setup_logging(os.environ.get(PROCESS_ENV) or "anima_daemon", file=False, console=True)
 logger = logging.getLogger("anima_daemon")
 
 

--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import random
 import sys
 from pathlib import Path
@@ -50,11 +51,9 @@ from studio.services.inference.core import (  # noqa: E402
     release_vae_after_decode,
 )
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    datefmt="%H:%M:%S",
-)
+from studio.infrastructure.logging import PROCESS_ENV, setup_logging  # noqa: E402
+
+setup_logging(os.environ.get(PROCESS_ENV) or "anima_generate", file=False, console=True)
 logger = logging.getLogger("anima_generate")
 
 

--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -278,7 +278,7 @@ def main() -> None:
                 if _update_monitor:
                     _update_monitor(sample_path=str(out_path), step=img_idx + 1)
             except Exception as e:
-                logger.error(f"生成失败 [{img_idx + 1}/{total}]: {e}")
+                logger.exception(f"生成失败 [{img_idx + 1}/{total}]: {e}")
 
             img_idx += 1
 
@@ -468,7 +468,7 @@ def _run_xy_matrix(
                         xy={"xi": xi, "yi": yi, "xv": xv, "yv": yv},
                     )
             except Exception as e:
-                logger.error(f"XY [{xi},{yi}] 失败: {e}")
+                logger.exception(f"XY [{xi},{yi}] 失败: {e}")
 
             img_idx += 1
 

--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -595,7 +595,7 @@ def main() -> None:
             if _update_monitor:
                 _update_monitor(sample_path=str(out_path), step=idx + 1)
         except Exception as e:
-            logger.error(f"  生成失败: {e}")
+            logger.exception(f"  生成失败: {e}")
             if not out_path.exists():
                 caption_path.unlink(missing_ok=True)
 

--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import random
 import shutil
 import sys
@@ -58,11 +59,9 @@ from studio.services.tagging.caption_format import (  # noqa: E402
     normalize_caption_json,
 )
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
-    datefmt="%H:%M:%S",
-)
+from studio.infrastructure.logging import PROCESS_ENV, setup_logging  # noqa: E402
+
+setup_logging(os.environ.get(PROCESS_ENV) or "anima_reg_ai", file=False, console=True)
 logger = logging.getLogger("anima_reg_ai")
 
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif"}

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -37,18 +37,19 @@ for _p in (_REPO_ROOT, _REPO_ROOT / "runtime"):
     if _ps not in sys.path:
         sys.path.insert(0, _ps)
 
-# Windows 控制台默认 cp936，logging / print 写中文会 UnicodeEncodeError，
-# 默认 handler 的 errors='backslashreplace' 会把中文转成 \uXXXX 形式 ——
-# 这就是 task log 里看到的「检查 VAE」之类乱码的来源。
-# 强制 stdout/stderr UTF-8 + replace 让中文 / emoji 永远直出。
-for _stream in (sys.stdout, sys.stderr):
-    try:
-        _stream.reconfigure(encoding="utf-8", errors="replace")
-    except (AttributeError, OSError):
-        pass
+# 统一日志 bootstrap（docs/design/logging-target-state.md）：与 studio / worker
+# 同一 formatter；console 级别读 ANIMA_LOG_LEVEL（supervisor spawn 注入 DEBUG，
+# 人手跑默认 INFO）；内含 Windows 控制台 UTF-8 兜底（cp936 下中文变 \uXXXX 的
+# 老问题）。process 名 / trace_id 优先取 supervisor 注入的 env（与 worker 一致），
+# 人手跑退回脚本名。sister script（daemon / generate / reg_ai）import 本模块后
+# 再各自调一次，process 名不同则替换成自己的一套 handler。
+from studio.infrastructure.logging import (  # noqa: E402
+    PROCESS_ENV, TRACE_ENV, bind_trace_id, new_trace_id, setup_logging,
+)
 
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
-logger = logging.getLogger(__name__)
+setup_logging(os.environ.get(PROCESS_ENV) or "anima_train", file=False, console=True)
+bind_trace_id(os.environ.get(TRACE_ENV) or new_trace_id())
+logger = logging.getLogger("anima_train")
 
 
 # ─── Re-exports for sister script / tests (ADR 0003 PR-A) ────────────────────

--- a/runtime/training/bootstrap.py
+++ b/runtime/training/bootstrap.py
@@ -10,9 +10,12 @@
 
 from __future__ import annotations
 
+import logging
 import subprocess
 import sys
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def ensure_dependencies(auto_install: bool = False) -> None:
@@ -35,16 +38,18 @@ def ensure_dependencies(auto_install: bool = False) -> None:
     if not missing:
         return
     missing_list = ", ".join(sorted(set(missing)))
-    print(f"Missing dependencies: {missing_list}")
     if not auto_install:
-        print(f"Install them with:\n  {sys.executable} -m pip install {missing_list}")
+        logger.error(
+            f"Missing dependencies: {missing_list}. Install them with:\n"
+            f"  {sys.executable} -m pip install {missing_list}"
+        )
         raise SystemExit(1)
+    logger.info(f"Missing dependencies: {missing_list}; installing...")
     cmd = [sys.executable, "-m", "pip", "install", *sorted(set(missing))]
-    print("Installing missing dependencies...")
     try:
         subprocess.run(cmd, check=False)
     except Exception as exc:
-        print(f"Auto-install failed: {exc}")
+        logger.error(f"Auto-install failed: {exc}")
         raise SystemExit(1)
     still_missing = []
     for module_name, pip_name in required.items():
@@ -54,7 +59,7 @@ def ensure_dependencies(auto_install: bool = False) -> None:
             still_missing.append(pip_name)
     if still_missing:
         still_list = ", ".join(sorted(set(still_missing)))
-        print(f"Still missing: {still_list}")
+        logger.error(f"Still missing after install: {still_list}")
         raise SystemExit(1)
 
 
@@ -63,7 +68,7 @@ def load_yaml_config(config_path):
     try:
         import yaml
     except ImportError:
-        print("PyYAML not installed. Install with: pip install pyyaml")
+        logger.error("PyYAML not installed. Install with: pip install pyyaml")
         raise SystemExit(1)
 
     config_path = Path(config_path)
@@ -90,8 +95,8 @@ def apply_yaml_config(args, config):
     命令行显式参数优先于 YAML：parse_args 以 suppress_defaults 构建 parser，
     args 只含显式键，优先级是精确判定而非「值==默认值」近似。
 
-    校验失败逐条打印到 stderr 后 SystemExit(2) —— 与能力防线同款 fail-fast，
-    supervisor 截 stderr 尾部作为任务错误信息。
+    校验失败以一条 ERROR 记录（逐条错误作续行）落日志后 SystemExit(2) ——
+    与能力防线同款 fail-fast，supervisor 从 run.log 尾部取错误块作为任务错误信息。
     """
     from pydantic import ValidationError
 
@@ -102,10 +107,11 @@ def apply_yaml_config(args, config):
         return namespace_from_config(args, dict(config or {}), TrainingConfig)
     except ValidationError as exc:
         errors = exc.errors()
-        print(f"配置校验失败（{len(errors)} 处）:", file=sys.stderr)
+        lines = [f"配置校验失败（{len(errors)} 处）:"]
         for err in errors:
             loc = ".".join(str(p) for p in err["loc"]) or "config"
-            print(f"  {loc}: {err['msg']}", file=sys.stderr)
+            lines.append(f"  {loc}: {err['msg']}")
+        logger.error("\n".join(lines))
         raise SystemExit(2) from exc
 
 

--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -23,6 +24,9 @@ import torch
 
 if TYPE_CHECKING:
     from training.losses.protocol import LossProtocol
+
+# ctx.emit 在非 tty 下的出口：采样 / 保存 / resume / 暂停等 user-facing 提示
+_emit_logger = logging.getLogger("training.emit")
 
 
 @dataclass
@@ -147,16 +151,19 @@ class TrainingContext:
     def emit(self, msg: str) -> None:
         """打印一条 user-facing 消息，按当前进度显示模式分流。
 
-        移植自原 main() 内 emit 闭包；行为完全一致。
+        tty 交互（rich live / progress / plain）三路不变；非 tty（studio spawn 的
+        pipe）走 logger，与 run.log 其它行同契约（设计 D3：进度/提示也是日志）。
         """
         if self.use_plain:
-            print()
+            print()  # 冲掉 loop 的 `\r` 进度行（tty 交互）
         if self.live:
             self.live.console.print(msg)
         elif self.use_rich:
             self.progress.console.print(msg)
-        else:
+        elif self.use_plain:
             print(msg)
+        else:
+            _emit_logger.info(msg)
 
     def get_next_sample_prompt(self) -> str:
         """取下一个采样提示词（轮换；sample_prompts 为空则返回默认）。"""

--- a/runtime/training/families/anima/sampling.py
+++ b/runtime/training/families/anima/sampling.py
@@ -296,13 +296,13 @@ def sample_image(
 
     sampler_name, scheduler = _resolve_parity_sampler_scheduler(sampler_name, scheduler)
 
-    logger.info(f"[Debug] Sampling start. Prompt: {prompt[:50]}...")
+    logger.debug(f"Sampling start. Prompt: {prompt[:50]}...")
 
     # Check VAE scale
     if isinstance(vae.scale, list) and len(vae.scale) == 2:
         m, s = vae.scale
-        logger.info(f"[Debug] VAE scale: mean_shape={m.shape}, std_inv_shape={s.shape}")
-        logger.info(f"[Debug] VAE scale values: mean={m.mean().item():.4f}, std_inv={s.mean().item():.4f}")
+        logger.debug(f"VAE scale: mean_shape={m.shape}, std_inv_shape={s.shape}")
+        logger.debug(f"VAE scale values: mean={m.mean().item():.4f}, std_inv={s.mean().item():.4f}")
 
     # 对齐 ComfyUI：负面提示词没有隐式默认，None 即空。
     negative_prompt = "" if negative_prompt is None else str(negative_prompt)
@@ -323,7 +323,7 @@ def sample_image(
                 device,
                 preserve_empty_text=True,
             )
-            logger.info(f"[Debug] Qwen embeds: {qwen_embeds.shape}, mean={qwen_embeds.mean().item():.4f}")
+            logger.debug(f"Qwen embeds: {qwen_embeds.shape}, mean={qwen_embeds.mean().item():.4f}")
             qwen_embeds = qwen_embeds.to(device=device, dtype=dtype)
             t5_ids = t5_ids.to(device)
             t5_attn = t5_attn.to(device)
@@ -342,7 +342,7 @@ def sample_image(
         cross_uncond = build_cross(negative_prompt)
 
     except Exception as e:
-        logger.error(f"[Debug] Encoding failed: {e}")
+        logger.error(f"文本编码失败: {e}")
         raise e
 
     # sigmas（对齐 ComfyUI supported_models.Anima: shift=3.0, multiplier=1.0）
@@ -364,7 +364,7 @@ def sample_image(
     # 初始化噪声（ComfyUI CONST.noise_scaling: x = sigma*noise + (1-sigma)*latent_image；txt2img latent_image=0）
     empty_latent = _prepare_comfy_ksampler_txt2img_latent(height, width, device="cpu")
     x = _prepare_comfy_t2i_noise(tuple(empty_latent.shape), sigmas, device=device, seed=seed)
-    logger.info(f"[Debug] Latents init: {x.shape}, mean={x.mean().item():.4f}, std={x.std().item():.4f}")
+    logger.debug(f"Latents init: {x.shape}, mean={x.mean().item():.4f}, std={x.std().item():.4f}")
 
     pad_mask = torch.zeros(1, 1, lat_h, lat_w, device=device, dtype=dtype)
     device_type = "cuda" if str(device).startswith("cuda") else "cpu"
@@ -423,7 +423,7 @@ def sample_image(
         return x_in - sigma_5d * v.float()
 
     sampler_name_l = str(sampler_name).lower().strip()
-    logger.info(f"[Debug] Sampler={sampler_name_l}, Scheduler={scheduler}, steps={steps}, cfg={cfg_scale}")
+    logger.debug(f"Sampler={sampler_name_l}, Scheduler={scheduler}, steps={steps}, cfg={cfg_scale}")
 
     # PR-C：通过 inference_samplers plugin registry 派发；白名单已在入口校验
     from training.inference_samplers import build_inference_sampler
@@ -456,7 +456,7 @@ def sample_image(
     if phase_callback:
         phase_callback("vae")
     latents = x.to(device=device, dtype=dtype)
-    logger.info(f"[Debug] Final latents: mean={latents.mean().item():.4f}, std={latents.std().item():.4f}")
+    logger.debug(f"Final latents: mean={latents.mean().item():.4f}, std={latents.std().item():.4f}")
     del denoise_fn, x, cross_cond, cross_uncond, pad_mask, sigmas, empty_latent
     offloaded_modules: list[tuple[object, torch.device]] = []
     try:
@@ -467,7 +467,7 @@ def sample_image(
         # VAEWrapper.should_offload_for_whole_decode。
         _should_offload = getattr(vae, "should_offload_for_whole_decode", None)
         if device_type == "cuda" and callable(_should_offload) and _should_offload(latents):
-            logger.info("[Debug] VAE decode: 显存紧张且峰值在崖下，offload 非活跃模块以整图 decode")
+            logger.info("[显存] VAE decode：显存紧张且峰值在崖下，offload 非活跃模块以整图 decode")
             offloaded_modules = _offload_modules_for_vae_decode(
                 *_decode_offload_targets(model, qwen_model)
             )
@@ -484,11 +484,11 @@ def sample_image(
         if device_type == "cuda" and torch.cuda.is_available():
             torch.cuda.empty_cache()
     except Exception as e:
-        logger.error(f"[Debug] VAE decode failed: {e}")
+        logger.error(f"VAE decode 失败: {e}")
         raise
     finally:
         if offloaded_modules:
-            logger.info("[Debug] VAE decode: restoring offloaded modules after cleanup")
+            logger.debug("VAE decode: restoring offloaded modules after cleanup")
             _restore_offloaded_modules(offloaded_modules)
 
     model.train()

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -34,6 +34,9 @@ from utils.optimizer_utils import get_optimizer_monitor_metrics, optimizer_eval_
 
 
 logger = logging.getLogger(__name__)
+# 训练进度行（step/loss/lr/speed）专用 logger：与本模块其它日志分名，方便
+# 显示端按名折叠/过滤高频行（docs/design/logging-target-state.md §7 open question 2）。
+_progress_logger = logging.getLogger("training.progress")
 
 
 def _resolve_sra_weight(args: Any) -> float:
@@ -739,14 +742,12 @@ def run(ctx: TrainingContext) -> None:
                             if sra_align_loss_val is not None and sra_weighted_loss_val is not None
                             else f" denoise={denoise_loss_val:.6f}"
                         )
-                        # flush 必须开：studio spawn 的 stdout 是 pipe（全缓冲
-                        # 8KB），不 flush 时 step 行滞留缓冲——短训练/中止的
-                        # task log 里一行都看不到（曾被误判为 krea2 没打日志）
-                        print(
-                            f"epoch={epoch} step={ctx.global_step} "
-                            f"loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} "
-                            f"speed={steps_per_sec:.2f} it/s",
-                            flush=True,
+                        # pipe 模式（studio spawn）：进度行也是日志（设计 D3），走
+                        # 独立 logger 名 training.progress，与其它行同契约、前端可
+                        # 单独折叠。StreamHandler 每条 flush，不会滞留 8KB 缓冲。
+                        _progress_logger.info(
+                            "epoch=%d step=%d loss=%.6f%s lr=%.2e speed=%.2f it/s",
+                            epoch, ctx.global_step, loss_val, sra_suffix, lr, steps_per_sec,
                         )
 
                 # 按 step 采样（轮换提示词）

--- a/studio/api/lifespan.py
+++ b/studio/api/lifespan.py
@@ -104,7 +104,7 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
     # PR-1 C4: 统一日志体系入口 (ADR-0009)。第一行调，让 ensure_dirs / db.init_db
     # 自己 emit 的 log 也能进 studio.log。setup_logging 自身 mkdir LOGS_DIR
     # 不需要等 ensure_dirs。env ANIMA_LOGGING_NO_BOOTSTRAP=1 时 noop（测试态）。
-    setup_logging("webui", level=os.environ.get("ANIMA_LOG_LEVEL", "INFO"))
+    setup_logging("webui")  # console 级别读 ANIMA_LOG_LEVEL（setup_logging 内部）
 
     # 装 Windows ProactorEventLoop 的 ConnectionResetError 过滤器（详见 helper docstring）
     _install_proactor_disconnect_filter(asyncio.get_running_loop())

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import logging
 import os
 import shutil
 import signal
@@ -64,20 +65,30 @@ _NPM_MIRROR = "https://mirrors.cloud.tencent.com/npm/"
 _PIP_MIRROR = "https://mirrors.cloud.tencent.com/pypi/simple/"
 
 
-def _say(msg: str, level: str = "info") -> None:
-    """统一 CLI 用户输出入口（ADR-0009 PR-3 C4）。
+_log = logging.getLogger("studio.cli")
 
-    保 print 路径（ADR-0009 round 2 §1.3 决策 — CLI 5s 短命周期落盘价值低；
-    用户终端看 `[studio] ...` 比 logger 默认 format 清爽；capsys 测试 UX 优先）。
-    本 wrapper 给未来加 verbose 控制 / 着色留单一入口；现在等价于带前缀的 print。
+
+def _say(msg: str, level: str = "info") -> None:
+    """统一 CLI 用户输出入口 —— `studio.cli` logger 的薄包装。
+
+    行契约见 docs/design/logging-target-state.md §3.2 / §3.5：CLI 不再自己
+    print，全部走 logger；`setup_logging("cli:<cmd>")` 装的 Human formatter 出
+    `ts LEVEL studio.cli: msg` 前缀，级别由 `level` 真实表达（不再手写
+    `[studio] ` / `警告：` 之类冒充级别的前缀）。终端可见级别由 ANIMA_LOG_LEVEL
+    控（默认 INFO）。多行消息（安装提示 / 重装命令）作为一条记录，续行无前缀。
 
     level:
-      - "info" / "success" → stdout，`[studio] ` 前缀
-      - "warning" / "error" → stderr，`[studio] ` 前缀
+      - "info" / "success" → logger.info
+      - "warning"          → logger.warning
+      - "error"            → logger.error
     """
-    file = sys.stderr if level in ("warning", "error") else sys.stdout
-    # 注意：不能用 f"[studio] {msg}"，否则被批量 _say 替换正则误伤。
-    print("[studio] " + str(msg), file=file, flush=True)
+    text = str(msg)
+    if level == "error":
+        _log.error(text)
+    elif level == "warning":
+        _log.warning(text)
+    else:
+        _log.info(text)
 
 
 def _npm_argv(npm: str, args: list[str]) -> list[str]:
@@ -251,31 +262,29 @@ class ProcGroup:
 
 
 def _print_npm_install_hint() -> None:
-    """`find_npm()` 返回 None 时打印平台相关安装提示。
+    """`find_npm()` 返回 None 时输出平台相关安装提示。
 
-    放 stderr，与 `[studio] 错误：找不到 npm` 同流；root 环境去掉 sudo（直接 root 跑装包）。
+    一条 error 记录（多行，续行无前缀）；root 环境去掉 sudo（直接 root 跑装包）。
     """
-    _say("错误：找不到 npm。请安装 Node.js 18+", "error")
+    lines = ["找不到 npm。请安装 Node.js 18+"]
     if os.name == "nt":
-        print(
+        lines.append(
             "  Windows：前往 https://nodejs.org 下载安装包，"
-            "或用 winget install OpenJS.NodeJS.LTS",
-            file=sys.stderr,
+            "或用 winget install OpenJS.NodeJS.LTS"
         )
     else:
         sudo = "" if (hasattr(os, "getuid") and os.getuid() == 0) else "sudo "
-        print(
+        lines.append(
             f"  Ubuntu/Debian：curl -fsSL https://deb.nodesource.com/setup_22.x "
-            f"| {sudo}bash - && {sudo}apt-get install -y nodejs",
-            file=sys.stderr,
+            f"| {sudo}bash - && {sudo}apt-get install -y nodejs"
         )
-        print(
+        lines.append(
             "  或使用 nvm（无需 sudo）："
             "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh "
-            "| bash && nvm install --lts",
-            file=sys.stderr,
+            "| bash && nvm install --lts"
         )
-    print("  安装后重新运行本命令。", file=sys.stderr)
+    lines.append("  安装后重新运行本命令。")
+    _say("\n".join(lines), "error")
 
 
 def cmd_build(_args: argparse.Namespace) -> int:
@@ -356,10 +365,7 @@ def _apply_pending_install() -> None:
         from studio.services.runtime import pending_install  # noqa: PLC0415
         pending_install.apply_pending()
     except Exception as exc:  # noqa: BLE001
-        print(
-            f"[studio] 警告：处理 pending 安装请求时异常（{exc}），跳过",
-            file=sys.stderr,
-        )
+        _say(f"处理 pending 安装请求时异常（{exc}），跳过", "warning")
 
 
 def _try_enable_flash_attn() -> None:
@@ -377,18 +383,14 @@ def _try_enable_flash_attn() -> None:
             _say("flash_attn 启用")
         else:
             # 装了 flash_attn 但 set_flash_attn_enabled 拒绝（_FLASH_ATTN_AVAILABLE=False）
-            # 通常意味着 import 时挂了（CUDA 版本不匹配等）；不噪声只 stderr 警告
-            print(
-                "[studio] 警告：flash_attn 已安装但模型层 import 失败，"
-                "继续走 SDPA fallback",
-                file=sys.stderr,
+            # 通常意味着 import 时挂了（CUDA 版本不匹配等）；不噪声只 warning 一行
+            _say(
+                "flash_attn 已安装但模型层 import 失败，继续走 SDPA fallback",
+                "warning",
             )
     except Exception as exc:  # noqa: BLE001
         # Studio 启动不能为这一项加速 fail；记 warn 但放行
-        print(
-            f"[studio] 警告：flash_attn 启用时异常（{exc}），跳过加速",
-            file=sys.stderr,
-        )
+        _say(f"flash_attn 启用时异常（{exc}），跳过加速", "warning")
 
 
 def _apply_gpu_selection() -> None:
@@ -440,28 +442,26 @@ def _check_torch_cuda() -> None:
         except Exception:  # noqa: BLE001
             has_gpu = False
         if has_gpu:
-            print(
-                f"[studio] 警告：检测到 NVIDIA GPU，但当前安装的是 CPU-only 版 PyTorch "
+            _say(
+                f"检测到 NVIDIA GPU，但当前安装的是 CPU-only 版 PyTorch "
                 f"({torch.__version__})。\n"
                 f"        训练 / 出图将跑在 CPU 上，速度极慢（单步常需数十秒）。\n"
                 f"        请卸载后重装 CUDA 版：\n"
                 f"          pip uninstall torch torchvision -y\n"
                 f"          # 按你的 CUDA 版本选；如 CUDA 12.8：\n"
                 f"          pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128",
-                file=sys.stderr,
+                "warning",
             )
         else:
-            print(
-                f"[studio] torch {torch.__version__}（CPU-only build，未检测到 NVIDIA GPU）"
-            )
+            _say(f"torch {torch.__version__}（CPU-only build，未检测到 NVIDIA GPU）")
         return
 
     # CUDA build 但运行时不可用：驱动 / WSL / 容器问题
-    print(
-        f"[studio] 警告：torch {torch.__version__}（CUDA {cuda_build} build），"
+    _say(
+        f"torch {torch.__version__}（CUDA {cuda_build} build），"
         f"但 torch.cuda.is_available()=False。\n"
         f"        可能原因：NVIDIA 驱动未安装 / 版本过低 / WSL 缺 CUDA 支持。",
-        file=sys.stderr,
+        "warning",
     )
 
 
@@ -601,12 +601,9 @@ def _apply_update_pending() -> None:
         from studio.services.runtime import updater  # noqa: PLC0415
         if not updater.has_pending():
             return
-        updater.apply_pending(emit=print)
+        updater.apply_pending(emit=_say)
     except Exception as exc:  # noqa: BLE001
-        print(
-            f"[studio] 警告：apply update pending 时异常（{exc}），跳过",
-            file=sys.stderr,
-        )
+        _say(f"apply update pending 时异常（{exc}），跳过", "warning")
 
 
 def _maybe_force_torch(args: argparse.Namespace) -> int:
@@ -628,7 +625,7 @@ def _maybe_force_torch(args: argparse.Namespace) -> int:
         _say(f"torch 重装完成: {res.get('version')} ({res.get('tag')})")
         return 0
     except KeyboardInterrupt:
-        print("\n[studio] 用户中断，跳过 torch 重装", file=sys.stderr)
+        _say("用户中断，跳过 torch 重装", "warning")
         return 0
     except RuntimeError as exc:
         _say(f"torch 重装失败: {exc}", "error")
@@ -759,10 +756,7 @@ def cmd_dev(args: argparse.Namespace) -> int:
             ],
         )
         frontend_url = f"http://127.0.0.1:{args.fe_port}/"
-        print(
-            f"[studio] frontend → {frontend_url}  "
-            f"backend → http://{args.host}:{args.port}/"
-        )
+        _say(f"frontend → {frontend_url}  backend → http://{args.host}:{args.port}/")
         if not args.no_browser:
             # dev 模式打开 Vite 端口（HMR 能用），不开 backend 端口
             _spawn_browser_opener(frontend_url, delay=2.0)
@@ -845,10 +839,12 @@ def main(argv: Optional[list[str]] = None) -> int:
     if _first_pos not in _subcmds:
         args_list = ['run'] + args_list
     args = parser.parse_args(args_list)
-    # PR-1 C4: 统一日志体系 (ADR-0009)。file=False — CLI 是 5s 短命周期，
-    # 启动信息不进 studio.log（用户决定 — round 2 §1.3）。console=True 让
-    # logger.x 调用走人读 stderr；现有 48 处 print() 不动（PR-3 _say() wrapper
-    # 收编）。env ANIMA_LOGGING_NO_BOOTSTRAP=1 时 noop（测试态）。
+    # 统一日志体系 (ADR-0009 / docs/design/logging-target-state.md §3.5)。
+    # file=False — CLI 是 5s 短命周期，启动信息不进 studio.log。console=True 让
+    # `_say` → studio.cli logger 走人读 stderr（Human 格式，级别读 ANIMA_LOG_LEVEL）。
+    # 必须在任何 `_say` 之前装好：所有 `_say` 都在 args.func 内，parse_args 之前
+    # 只有 argparse 自己的 usage/help 输出（不算日志）。env
+    # ANIMA_LOGGING_NO_BOOTSTRAP=1 时 noop（测试态）。
     from .infrastructure.logging import setup_logging
     setup_logging(f"cli:{args.cmd}", file=False, console=True)
     return args.func(args)

--- a/studio/infrastructure/logging.py
+++ b/studio/infrastructure/logging.py
@@ -6,15 +6,19 @@ C3：完整 setup_logging + JsonLineFormatter + HumanConsoleFormatter + silence 
 C5：ContextVar trace_id + Filter（待加）
 C6：跨进程 env / db.tasks.request_trace_id（待加）
 
-使用规则（ADR-0009 §未来开发指南简版）：
-    每个进程入口（webui / cli / worker）开头调一次 `setup_logging(process=...)`。
-    业务代码模块顶 `logger = logging.getLogger(__name__)`，调 `.info/.warning/.exception`。
+使用规则（ADR-0009 §未来开发指南简版 + docs/design/logging-target-state.md）：
+    每个进程入口（webui / cli / worker / runtime 脚本）开头调一次 `setup_logging(process=...)`。
+    业务代码模块顶 `logger = logging.getLogger(__name__)`，调 `.debug/.info/.warning/.exception`；
+    debug 永远被记录（自家命名空间恒 DEBUG），显示端按级别过滤。
     不要在 import time 调 setup_logging（破 import smoke test）。
+    不用裸 print 写日志内容——白名单只有 stdout 协议行、tty 交互进度、CLI banner
+    （tests/test_print_whitelist.py 锁死）。
 
 `process` 标识规范：
     "webui"                 webui server
     "cli:<subcmd>"          CLI run / dev / build / test
     "worker:<kind>/<id>"    worker subprocess（kind=download/tag/preprocess/reg_build）
+    "anima_train" / "anima_daemon" / "anima_generate" / "anima_reg_ai"  runtime 脚本
     "client"                前端上报（C 系列 PR-3 才用到）
 """
 from __future__ import annotations
@@ -59,9 +63,33 @@ _task_id_var: contextvars.ContextVar[Optional[int]] = contextvars.ContextVar(
     "studio_task_id", default=None
 )
 
+# 终端可读性开关（docs/design/logging-target-state.md §3.1）：只管 console
+# handler 的级别，不管记录。被 studio 拉起的子进程 stderr 就是 run.log，
+# supervisor / daemon spawn 时注入 DEBUG 让调试行落盘；人手跑默认 INFO。
+LOG_LEVEL_ENV = "ANIMA_LOG_LEVEL"
+DEFAULT_CONSOLE_LEVEL = "INFO"
+
+# 自家代码的顶层 logger 命名空间：这些永远 DEBUG（记录不过滤，显示才过滤）。
+# root 保持 INFO——第三方库有多少 debug 洪水没人数得清（python-multipart /
+# charset_normalizer / numba …），只给自己人开闸。runtime 脚本裸跑时顶层包是
+# training / utils / anima_*；tests 以 runtime.training 导入时多一层 runtime。
+OWN_LOGGER_NAMESPACES = (
+    "studio",
+    "training",
+    "utils",
+    "runtime",
+    "modeling",
+    "train_monitor",
+    "anima_train",
+    "anima_daemon",
+    "anima_generate",
+    "anima_reg_ai",
+)
+
 # 第三方库 logger 静音 list — root level=INFO 时这些库会大量出 INFO 噪音。
 # silence list 必须显式，避免漏一条让 stderr 爆 10×（B audit N.1 / A round2 §5.2）。
-# 在 setup_logging 末尾应用。
+# 在 setup_logging 末尾应用。子进程另有 TRANSFORMERS_VERBOSITY=error 等 env
+# 兜底（supervisor spawn 注入），主进程内的 tagger / eval 推理只靠这张表。
 _NOISY_LOGGERS = (
     "asyncio",
     "urllib3",
@@ -72,6 +100,21 @@ _NOISY_LOGGERS = (
     "modelscope",
     "huggingface_hub",
     "filelock",
+    "transformers",
+    "diffusers",
+    "accelerate",
+    "peft",
+    "wandb",
+    "spandrel",
+    "python_multipart",
+    "multipart",
+    "charset_normalizer",
+    "numba",
+    "fsspec",
+    "watchfiles",
+    # uvicorn access log：每个请求一行，与业务日志抢 studio.log 的 50MB 配额；
+    # uvicorn / uvicorn.error 的启动与错误信息保留 INFO。
+    "uvicorn.access",
 )
 
 # ── trace_id 公开 API ────────────────────────────────────────────────────
@@ -262,40 +305,54 @@ def make_studio_log_handler(
     return handler
 
 
+def console_level_from_env(default: str = DEFAULT_CONSOLE_LEVEL) -> int:
+    """`ANIMA_LOG_LEVEL` → logging 级别；未设 / 非法值回落 default。"""
+    raw = os.environ.get(LOG_LEVEL_ENV, "").strip().upper()
+    lvl = getattr(logging, raw, None) if raw else None
+    if not isinstance(lvl, int):
+        lvl = getattr(logging, default.upper(), logging.INFO)
+    return lvl
+
+
 def setup_logging(
     process: str,
     *,
     log_dir: Path | None = None,
-    level: str = "INFO",
+    level: str | None = None,
     console: str | bool = "auto",
     file: bool = True,
-    extra_handlers: list[logging.Handler] | None = None,
 ) -> None:
-    """安装全局 logging 配置。每个进程入口调一次（webui / cli / worker）。
+    """安装全局 logging 配置。每个进程入口调一次（webui / cli / worker / runtime 脚本）。
 
     幂等：同一 `process` 名重复调 noop（防 supervisor 重启 / 测试 reload 累加 handler）。
+
+    级别模型（docs/design/logging-target-state.md §3.1「记录不过滤，显示才过滤」）：
+      - 自家命名空间（OWN_LOGGER_NAMESPACES）永远 DEBUG；root 保持 INFO，第三方库
+        不跟着放闸；_NOISY_LOGGERS 再压到 WARNING。
+      - file handler 不设级别：自家 DEBUG + 第三方 INFO+ 全落 studio.log。
+      - console handler 级别 = `level` 参数 > env ANIMA_LOG_LEVEL > INFO。这是唯一的
+        「终端可读性」旋钮：webui/cli 的 stderr 默认只看 INFO+；被 studio 拉起的
+        子进程 stderr 就是 run.log，spawn 方注入 ANIMA_LOG_LEVEL=DEBUG 让调试行落盘。
 
     行为：
       1. reconfigure_console_utf8（Windows 编码兜底）
       2. 清 root logger 现有 handler（防累加）
       3. （可选）装 RotatingFileHandler 到 {log_dir}/studio.log（JSON line, 50MB×5）
-      4. 装 console handler（auto/json/bool 三态，详 below）
-      5. 装 extra_handlers（worker 用来塞 jobs/<id>.log handler）
-      6. 静音第三方库（asyncio/urllib3/PIL/...）→ WARNING
-      7. 接管 uvicorn.access / uvicorn.error logger（走我们的 root handler 而非 uvicorn 默认）
-      8. 装 sys.excepthook → logger.critical 记未捕获异常
-      9. 装 threading.excepthook → 同上（仅 Python 3.8+）
+      4. 装 console handler（Human 格式到 stderr；console="json" 才出 JSON）
+      5. 自家命名空间 DEBUG；第三方静音表 → WARNING（含 uvicorn.access）
+      6. 接管 uvicorn / uvicorn.error / uvicorn.access logger（走 root handler）
+      7. 装 sys.excepthook / threading.excepthook → logger.critical
 
     Args:
-        process: 进程标识（"webui" / "cli:run" / "worker:tag/42" / ...）
+        process: 进程标识（"webui" / "cli:run" / "worker:tag/42" / "anima_train" / ...）
         log_dir: studio.log 落盘目录；默认读 env ANIMA_LOG_DIR，否则 paths.LOGS_DIR
-        level: root logger level（"DEBUG" / "INFO" / "WARNING" / "ERROR"）
-        console: "auto" = stderr isatty → Human, 否则 JSON；
-                 "json" 强制 JSON；True 强制 Human；False 不装 console
-        file: 是否装 file handler 到 studio.log；webui 默认 True；
-              worker / cli 应传 False（worker 走 stdout 进 supervisor 重定向单写；
-              CLI 5s 短命周期落盘价值低）。0.13.x ADR-0009 §还的债"演进双写"后 worker 改 True
-        extra_handlers: 额外装到 root 的 handler（worker 用来塞 jobs/<id>.log）
+        level: console 级别显式覆盖（"DEBUG"/"INFO"/...）；None = 读 env
+        console: "auto" / True → Human 格式到 stderr；"json" → JSON line 到 stderr；
+                 False 不装 console。（"auto" 曾按 isatty 切 JSON——pipe 下与
+                 studio.log 内容完全重复且终端不可读，已改为恒 Human。）
+        file: 是否装 file handler 到 studio.log；只有 webui 传 True。
+              worker / runtime 脚本的 stderr 由 supervisor 重定向到 run.log，
+              各写各的（设计 D2：子进程不落 studio.log）。
     """
     # pytest 全局 fixture 设 ANIMA_LOGGING_NO_BOOTSTRAP=1 让业务代码 bootstrap
     # 调用全部 noop，避免污染 caplog / 反复装 handler；测 setup_logging 本身的
@@ -312,9 +369,9 @@ def setup_logging(
     # 清掉默认 / 累加的 handler（pytest fixture 反复调时关键）
     for h in list(root.handlers):
         root.removeHandler(h)
-    root.setLevel(getattr(logging, level.upper(), logging.INFO))
+    root.setLevel(logging.INFO)
 
-    # 1. 文件 handler — JSON line 到 studio.log（worker / cli 不装）
+    # 1. 文件 handler — JSON line 到 studio.log（worker / cli / runtime 不装）
     if file:
         effective_log_dir = log_dir or _resolve_log_dir()
         root.addHandler(make_studio_log_handler(log_dir=effective_log_dir, process=process))
@@ -322,6 +379,9 @@ def setup_logging(
     # 2. console handler
     console_handler = _build_console_handler(console, process)
     if console_handler is not None:
+        console_handler.setLevel(
+            getattr(logging, level.upper(), logging.INFO) if level else console_level_from_env()
+        )
         root.addHandler(console_handler)
 
     # ContextFilter — 装到每个 handler 而非 logger。
@@ -332,23 +392,20 @@ def setup_logging(
     for h in root.handlers:
         h.addFilter(_ctx_filter)
 
-    # 3. extra handlers（worker job log 等）— 同样装 ContextFilter
-    for h in extra_handlers or ():
-        h.addFilter(ContextFilter())
-        root.addHandler(h)
-
-    # 4. 第三方库静音（防 root=INFO 后 stderr 噪音爆 10×）
+    # 3. 自家命名空间放到 DEBUG（记录不过滤）；第三方静音到 WARNING
+    for name in OWN_LOGGER_NAMESPACES:
+        logging.getLogger(name).setLevel(logging.DEBUG)
     for name in _NOISY_LOGGERS:
         logging.getLogger(name).setLevel(logging.WARNING)
 
-    # 5. uvicorn logger 接管 — 让 access log 跟业务 log 同格式同 trace_id
+    # 4. uvicorn logger 接管 — 让 access log 跟业务 log 同格式同 trace_id
     #    (B audit 跨问题 C / A round2 §4.1 盲点 2)
     for uname in ("uvicorn", "uvicorn.access", "uvicorn.error"):
         u = logging.getLogger(uname)
         u.handlers = []        # 清掉 uvicorn 自带 StreamHandler
         u.propagate = True     # 让 root handler 接管
 
-    # 6. 未捕获异常路由进 logger
+    # 5. 未捕获异常路由进 logger
     _install_excepthooks()
 
 
@@ -366,12 +423,7 @@ def _resolve_log_dir() -> Path:
 def _build_console_handler(console: str | bool, process: str) -> logging.Handler | None:
     if console is False:
         return None
-    if console == "auto":
-        use_json = not sys.stderr.isatty()
-    elif console == "json":
-        use_json = True
-    else:  # True 或其它
-        use_json = False
+    use_json = console == "json"
     h = logging.StreamHandler(sys.stderr)
     h.setFormatter(JsonLineFormatter(process) if use_json else HumanConsoleFormatter())
     return h
@@ -438,7 +490,8 @@ def _reset_for_tests() -> None:
 # 编码兜底是无条件常量，导出给 workers/_base.py 旧 import 兼容
 __all__ = [
     "STUDIO_LOG_NAME", "STUDIO_LOG_MAX_BYTES", "STUDIO_LOG_BACKUP_COUNT",
-    "TRACE_HEADER", "TRACE_ENV", "PROCESS_ENV",
+    "TRACE_HEADER", "TRACE_ENV", "PROCESS_ENV", "LOG_LEVEL_ENV",
+    "OWN_LOGGER_NAMESPACES", "console_level_from_env",
     "JsonLineFormatter", "HumanConsoleFormatter", "ContextFilter",
     "make_studio_log_handler", "setup_logging", "reconfigure_console_utf8",
     "new_trace_id", "bind_trace_id", "reset_trace_id", "get_trace_id",

--- a/studio/infrastructure/logging.py
+++ b/studio/infrastructure/logging.py
@@ -29,6 +29,7 @@ import json
 import logging
 import logging.handlers
 import os
+import re
 import sys
 import traceback as _traceback
 import uuid
@@ -250,9 +251,13 @@ class JsonLineFormatter(logging.Formatter):
 
 
 class HumanConsoleFormatter(logging.Formatter):
-    """人读 console format，给 CLI / dev terminal。
+    """人读 console format —— 也是跨进程的**行契约**（docs/design/logging-target-state.md §3.2）。
 
     `2026-05-28 14:32:18.453 INFO  studio.api.routers.queue: queued task=42`
+
+    webui / cli / worker / runtime 脚本的 stderr 全用它，run.log 每行因此可被
+    LOG_LINE_RE 解析出 ts / level / logger；不匹配行头的行（traceback、多行消息）
+    是上一条记录的续行。改这里的格式 = 改契约，前端解析器要跟着改。
     """
 
     def __init__(self) -> None:
@@ -260,6 +265,16 @@ class HumanConsoleFormatter(logging.Formatter):
             fmt="%(asctime)s.%(msecs)03d %(levelname)-5s %(name)s: %(message)s",
             datefmt="%Y-%m-%d %H:%M:%S",
         )
+
+
+# 行契约的解析正则：`<ts> <LEVEL 左对齐补到 5>[空格]<logger>: <msg>`。`-5s` 只补
+# 不截：INFO 后跟两个空格，WARNING / CRITICAL 全名后跟一个空格。
+LOG_LINE_RE = re.compile(
+    r"^(?P<ts>\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}) "
+    r"(?P<level>[A-Z]+)\s+"
+    r"(?P<logger>[^\s:]+): "
+    r"(?P<msg>.*)$"
+)
 
 
 # ── Public API ────────────────────────────────────────────────────────────
@@ -491,7 +506,7 @@ def _reset_for_tests() -> None:
 __all__ = [
     "STUDIO_LOG_NAME", "STUDIO_LOG_MAX_BYTES", "STUDIO_LOG_BACKUP_COUNT",
     "TRACE_HEADER", "TRACE_ENV", "PROCESS_ENV", "LOG_LEVEL_ENV",
-    "OWN_LOGGER_NAMESPACES", "console_level_from_env",
+    "OWN_LOGGER_NAMESPACES", "console_level_from_env", "LOG_LINE_RE",
     "JsonLineFormatter", "HumanConsoleFormatter", "ContextFilter",
     "make_studio_log_handler", "setup_logging", "reconfigure_console_utf8",
     "new_trace_id", "bind_trace_id", "reset_trace_id", "get_trace_id",

--- a/studio/infrastructure/logging.py
+++ b/studio/infrastructure/logging.py
@@ -85,6 +85,8 @@ OWN_LOGGER_NAMESPACES = (
     "anima_daemon",
     "anima_generate",
     "anima_reg_ai",
+    # 兜底：任何以脚本 / `python -m` 方式跑的自家模块若仍用 getLogger(__name__)
+    "__main__",
 )
 
 # 第三方库 logger 静音 list — root level=INFO 时这些库会大量出 INFO 噪音。

--- a/studio/services/inference/daemon.py
+++ b/studio/services/inference/daemon.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Optional
 
+from ...infrastructure.logging import LOG_LEVEL_ENV, PROCESS_ENV, TRACE_ENV, new_trace_id
 from ...paths import REPO_ROOT
 from .. import generate_storage
 from ..runtime import xformers as _xformers_svc
@@ -285,6 +286,12 @@ class InferenceDaemon:
         env.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")
         env.setdefault("TRANSFORMERS_VERBOSITY", "error")
         env.setdefault("DIFFUSERS_VERBOSITY", "error")
+        # daemon 的 stderr 进 ring buffer 给 UI 抽屉：记录不过滤、显示才过滤
+        # （docs/design/logging-target-state.md D1），console 级别 DEBUG。
+        # trace / process 名与 supervisor 子进程对齐（之前 daemon 完全游离）。
+        env.setdefault(LOG_LEVEL_ENV, "DEBUG")
+        env.setdefault(TRACE_ENV, f"bg-{new_trace_id()}")
+        env.setdefault(PROCESS_ENV, "anima_daemon")
         # xformers 的 triton 探测会把无害的 ImportError traceback 打进 daemon
         # 日志抽屉；本 app 的 xformers 路径不用 triton kernel，无条件短路。
         _xformers_svc.disable_triton_probe(env)

--- a/studio/services/models/downloader.py
+++ b/studio/services/models/downloader.py
@@ -8,6 +8,7 @@ download_flat[_ms] 实际下载，调 paths.py / families 拿 target Path 和模
 """
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from dataclasses import dataclass, field
@@ -66,6 +67,8 @@ from .paths import (
 )
 from . import sources as _sources
 from .sources import MS_ANIMA_TEXT_ENCODER_PATH
+
+logger = logging.getLogger(__name__)
 
 # 提示：跨文件调用 download_flat[_ms] / _get_download_source / _resolve_endpoint /
 # _ms_wd14_repo_id 一律走 _sources.X(...) —— 这样测试 monkeypatch
@@ -555,10 +558,11 @@ def start_download_async(
             ds.log.append(line)
             if len(ds.log) > 200:
                 del ds.log[:-200]
-        # 回显到 backend stdout —— UI ring buffer 容量 200 行；长下载早期日志会被
-        # 截掉，print 让 studio_*.log / 终端保留完整流，调试 / oncall 排错时能直接 grep。
-        # 锁外执行避免持锁做 I/O 拖慢其它 download tasks 写日志。
-        print(line, flush=True)
+        # 回显到 backend logger —— UI ring buffer 容量 200 行；长下载早期日志会被
+        # 截掉，logger.debug 让 studio.log 保留完整流（自家 logger 恒 DEBUG，
+        # 记录不过滤），终端默认 INFO 不刷屏；调试 / oncall 排错时直接 grep
+        # studio.log。锁外执行避免持锁做 I/O 拖慢其它 download tasks 写日志。
+        logger.debug(line)
 
     def _run() -> None:
         bus.publish({

--- a/studio/services/runtime/pending_install.py
+++ b/studio/services/runtime/pending_install.py
@@ -18,7 +18,6 @@ from __future__ import annotations
 
 import json
 import logging
-import sys
 from typing import Any, Optional
 
 from ...paths import STUDIO_DATA
@@ -61,8 +60,9 @@ def clear_pending() -> None:
 def apply_pending() -> None:
     """启动期处理 pending 请求；必须在任何 `import torch` 之前调。
 
-    成功 → 清 marker；失败 → 保留 marker（下次启动再试一次）。错误打印到 stderr，
-    不抛异常，让 launcher 继续起 server（用户可以在 UI 里看到旧 torch 仍在用）。
+    成功 → 清 marker；失败 → 保留 marker（下次启动再试一次）。错误走 logger
+    （warning / error 级），不抛异常，让 launcher 继续起 server（用户可以在 UI
+    里看到旧 torch 仍在用）。
     """
     pending = read_pending()
     if not pending:
@@ -71,30 +71,24 @@ def apply_pending() -> None:
     kind = pending.get("kind")
     if kind == "torch":
         target = pending.get("target", "auto")
-        print(f"[studio] 检测到 pending torch 重装请求 (target={target})，开始安装...")
-        print("[studio] 提示：按 Ctrl+C 可跳过本次安装（marker 保留，下次启动重试）")
-        print(f"[studio] 若希望永久跳过，删除 marker 文件：{PENDING_MARKER}")
+        logger.info("检测到 pending torch 重装请求 (target=%s)，开始安装...", target)
+        logger.info("提示：按 Ctrl+C 可跳过本次安装（marker 保留，下次启动重试）")
+        logger.info("若希望永久跳过，删除 marker 文件：%s", PENDING_MARKER)
         # 延迟 import：torch_setup -> onnxruntime_setup 链触发的副作用全留到此刻
         from . import torch as torch_setup  # noqa: PLC0415
         try:
             res = torch_setup.reinstall(target, stream=True)
         except KeyboardInterrupt:
-            print("\n[studio] 用户中断 torch 重装，跳过。marker 保留，下次启动会重试。",
-                  file=sys.stderr)
-            print(f"[studio] 若希望永久跳过，删除 marker 文件：{PENDING_MARKER}",
-                  file=sys.stderr)
+            logger.warning("用户中断 torch 重装，跳过。marker 保留，下次启动会重试。")
+            logger.warning("若希望永久跳过，删除 marker 文件：%s", PENDING_MARKER)
             return  # 不 clear_pending，下次启动继续尝试
         except RuntimeError as exc:
-            print(f"[studio] torch 重装失败: {exc}", file=sys.stderr)
-            print("[studio] marker 保留，下次启动会重试", file=sys.stderr)
-            print(f"[studio] 若装包持续失败想永久跳过，删除 marker 文件：{PENDING_MARKER}",
-                  file=sys.stderr)
+            logger.error("torch 重装失败: %s", exc)
+            logger.error("marker 保留，下次启动会重试")
+            logger.error("若装包持续失败想永久跳过，删除 marker 文件：%s", PENDING_MARKER)
             return
-        print(f"[studio] torch 重装完成: {res.get('version')} ({res.get('tag')})")
+        logger.info("torch 重装完成: %s (%s)", res.get("version"), res.get("tag"))
     else:
-        print(
-            f"[studio] 警告：未知 pending install kind {kind!r}，忽略并清除",
-            file=sys.stderr,
-        )
+        logger.warning("未知 pending install kind %r，忽略并清除", kind)
 
     clear_pending()

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -36,6 +36,7 @@ from ..services import eval_auto, eval_validation
 from ..services.runtime import xformers as _xformers_svc
 from ..services.projects import jobs as project_jobs
 from ..infrastructure.log_tail import LogTailer, MonitorStatePoller
+from ..infrastructure.logging import LOG_LEVEL_ENV
 from ..paths import (
     LOGS_DIR,
     REPO_ROOT,
@@ -869,8 +870,22 @@ class Supervisor:
         # worker 自己 append 模式开 log，supervisor 这里只挂个 stdout 转发到同一文件
         log_fp = open(log_path, "ab")
 
-        cmd = self._job_cmd_builder(job)
-        proc = self._popen(cmd, log_fp)
+        # trace / process 注入与 _spawn_task 对齐：jobs 表没有 request_trace_id 列，
+        # 用 bg-{uuid} 兜底，至少让 worker 侧 studio.log / run.log 的 trace_id 与
+        # supervisor 这段 spawn 日志对得上（之前 job 路径完全不注入，worker 只能自造）。
+        from ..infrastructure.logging import (
+            PROCESS_ENV, TRACE_ENV, bind_trace_id, new_trace_id, reset_trace_id,
+        )
+        trace_id = job.get("request_trace_id") or f"bg-{new_trace_id()}"
+        _trace_token = bind_trace_id(trace_id)
+        try:
+            cmd = self._job_cmd_builder(job)
+            proc = self._popen(cmd, log_fp, extra_env={
+                TRACE_ENV: trace_id,
+                PROCESS_ENV: f"worker:{job['kind']}/{job['id']}",
+            })
+        finally:
+            reset_trace_id(_trace_token)
 
         with db.connection_for(self._db_path) as conn:
             project_jobs.mark_running(conn, job["id"], pid=proc.pid)
@@ -1275,6 +1290,10 @@ class Supervisor:
         env.setdefault("TRANSFORMERS_VERBOSITY", "error")
         env.setdefault("DIFFUSERS_VERBOSITY", "error")
         env.setdefault("ACCELERATE_DISABLE_RICH", "1")
+        # 子进程的 stderr 就是 run.log：记录不过滤、显示才过滤（docs/design/
+        # logging-target-state.md D1），所以 console 级别给 DEBUG 让调试行落盘；
+        # setdefault 保留外部显式设的值。
+        env.setdefault(LOG_LEVEL_ENV, "DEBUG")
         # xformers 的 triton 探测会把无害的 ImportError traceback 打进 task log
         # （Windows 无官方 triton wheel），被失败摘要误当失败原因；本 app 的
         # xformers 路径不用 triton kernel，无条件短路。

--- a/studio/workers/_base.py
+++ b/studio/workers/_base.py
@@ -27,9 +27,10 @@ def worker_main(run_fn: Callable[[int], int]) -> None:
             from ._base import worker_main
             worker_main(run)
 
-    PR-1 C4: 装 setup_logging (ADR-0009)。file=False — worker 走 stdout 进
-    supervisor 重定向 jobs/<id>.log 单写（C round2 §1.2 决策；0.13.x ADR-0009
-    §还的债"演进双写"后改 True）。process 名格式 "worker:<module>/<job_id>"，
+    PR-1 C4: 装 setup_logging (ADR-0009)。file=False — worker 的 stderr（logger）
+    与 stdout（`__EVENT__:` 协议行）由 supervisor 合流到 tasks/<id>/run.log，
+    子进程不落 studio.log（docs/design/logging-target-state.md D2）；console 级别
+    读 supervisor 注入的 ANIMA_LOG_LEVEL=DEBUG。process 名格式 "worker:<module>/<job_id>"，
     便于 jq 按 process 过滤；module 取 sys.argv[0] basename（download_worker.py
     → download_worker → 去掉 _worker 后缀 = download）。
 

--- a/studio/workers/download_worker.py
+++ b/studio/workers/download_worker.py
@@ -5,10 +5,11 @@
 `studio.services.downloader.download()` → 写日志 → 退出码反映成败。
 状态字段（running / done / failed）由 supervisor 在子进程结束时统一回写。
 
-日志只走 stdout：supervisor 在 `subprocess.Popen(stdout=log_fp,
-stderr=STDOUT)` 把整个子进程输出重定向到 task log 文件，worker 自己**不能**
-再 open 同一个 log 直接 write —— 否则同一行会落盘两次，LogTailer 读两次，
-前端就看到每条日志重复一次。
+日志只走 logger（stderr，Human 行契约见 docs/design/logging-target-state.md
+§3.2）：supervisor 在 `subprocess.Popen(stdout=log_fp, stderr=STDOUT)` 把整个
+子进程输出重定向到 task log 文件，worker 自己**不能**再 open 同一个 log 直接
+write —— 否则同一行会落盘两次，LogTailer 读两次，前端就看到每条日志重复一次。
+裸 print 只留给 stdout 协议行（`__EVENT__:`，见 preprocess_worker）。
 """
 from __future__ import annotations
 
@@ -27,16 +28,16 @@ def run(job_id: int) -> int:
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, job_id)
     if not job:
-        print(f"[error] job {job_id} not found", flush=True)
+        logger.error("job %s not found", job_id)
         return 1
     if job["kind"] != "download":
-        print(f"[error] wrong kind: {job['kind']}", flush=True)
+        logger.error("wrong kind: %s", job["kind"])
         return 1
 
     params = job.get("params_decoded") or {}
 
     def progress(line: str) -> None:
-        print(line, flush=True)
+        logger.info(line)
 
     try:
         with db.connection_for() as conn:

--- a/studio/workers/download_worker.py
+++ b/studio/workers/download_worker.py
@@ -18,7 +18,9 @@ import threading
 
 from studio import db, secrets
 
-logger = logging.getLogger(__name__)
+# 固定名：worker 经 `python -m studio.workers.download_worker` 拉起时 __name__ 是 __main__，
+# 行契约里的来源列会失真、也不在 OWN_LOGGER_NAMESPACES 里。
+logger = logging.getLogger("studio.workers.download_worker")
 from studio.services.projects import jobs as project_jobs, projects
 from studio.services.booru import downloader
 

--- a/studio/workers/eval_session_worker.py
+++ b/studio/workers/eval_session_worker.py
@@ -73,21 +73,21 @@ _RUNNERS: dict[
 
 def run(task_id: int) -> int:
     def progress(line: str) -> None:
-        print(line, flush=True)
+        logger.info(line)
 
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
         if not task:
-            progress(f"[error] task {task_id} not found")
+            logger.error("task %s not found", task_id)
             return 1
         params = task.get("params_decoded") or {}
         session_id = int(params.get("session_id") or 0)
         if not session_id:
-            progress(f"[error] task {task_id} has no session_id")
+            logger.error("task %s has no session_id", task_id)
             return 1
         session = eval_session.get_session(conn, session_id)
         if session is None:
-            progress(f"[error] eval session {session_id} not found")
+            logger.error("eval session %s not found", session_id)
             return 1
         project = projects.get_project(conn, int(session["project_id"] or 0))
         version = versions.get_version(conn, int(session["version_id"] or 0))
@@ -95,7 +95,7 @@ def run(task_id: int) -> int:
     if not project or not version:
         with db.connection_for() as conn:
             _fail(conn, session_id, "project / version 不存在")
-        progress("[error] project or version missing")
+        logger.error("project or version missing")
         return 1
 
     vdir = versions.version_dir(

--- a/studio/workers/eval_session_worker.py
+++ b/studio/workers/eval_session_worker.py
@@ -40,7 +40,9 @@ from studio.services import (
 )
 from studio.services.projects import projects, versions
 
-logger = logging.getLogger(__name__)
+# 固定名：worker 经 `python -m studio.workers.eval_session_worker` 拉起时 __name__ 是 __main__，
+# 行契约里的来源列会失真、也不在 OWN_LOGGER_NAMESPACES 里。
+logger = logging.getLogger("studio.workers.eval_session_worker")
 
 # runner key → (跑它的函数, 从 secrets 取默认模型名的取值器, 阶段级共享 scorer)
 #

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -26,7 +26,9 @@ from typing import Any, Callable
 
 from PIL import Image
 
-logger = logging.getLogger(__name__)
+# 固定名：worker 经 `python -m studio.workers.preprocess_worker` 拉起时 __name__ 是 __main__，
+# 行契约里的来源列会失真、也不在 OWN_LOGGER_NAMESPACES 里。
+logger = logging.getLogger("studio.workers.preprocess_worker")
 
 from studio import db
 from studio.domain.errors import DomainError

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -6,8 +6,9 @@
   - stage='upscale' (默认)：串行调 `studio.services.upscaler.upscale_file()`
   - stage='crop'：用 PIL 把 preprocess/ 下的图按归一化 rect 切成 N 张产物
 
-日志规范：只走 stdout（supervisor 重定向到 log 文件），不要再 open 同一个
-log 文件，避免 LogTailer 读两次。
+日志规范：只走 logger（supervisor 把 stdout/stderr 合流重定向到 log 文件），
+不要再 open 同一个 log 文件，避免 LogTailer 读两次。唯一裸 print 是
+`emit_event` 的 `__EVENT__:` stdout 协议行。
 
 取消：worker 主体在每张图前检测 SIGTERM/CTRL_BREAK 信号（Python 解释器
 默认对 SIGTERM 抛 KeyboardInterrupt 在 main thread 里）；当前轮的图处理完
@@ -67,10 +68,10 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, job_id)
     if not job:
-        print(f"[error] job {job_id} not found", flush=True)
+        logger.error("job %s not found", job_id)
         return 1
     if job["kind"] != preprocess.PREPROCESS_KIND:
-        print(f"[error] wrong kind: {job['kind']}", flush=True)
+        logger.error("wrong kind: %s", job["kind"])
         return 1
 
     params = job.get("params_decoded") or {}
@@ -78,11 +79,14 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
     stage = params.get("stage", preprocess.STAGE_UPSCALE)
 
     def log(line: str) -> None:
-        print(line, flush=True)
+        logger.info(line)
 
     def emit_event(evt_type: str, **payload) -> None:
         """通过 stdout 标记行 → supervisor 解析 → SSE。供前端实时更新用，
-        不会进 job 日志。supervisor 端常量见 `studio/supervisor.py:_EVENT_MARKER`。"""
+        不会进 job 日志。supervisor 端常量见 `studio/supervisor.py:_EVENT_MARKER`。
+
+        这里**必须**是裸 print（stdout 协议行白名单）：走 logger 会被 Human
+        formatter 加前缀，supervisor 就认不出 `__EVENT__:` 行头了。"""
         try:
             print(f"__EVENT__:{evt_type}:{json.dumps(payload, ensure_ascii=False)}", flush=True)
         except Exception:  # noqa: BLE001 — 推事件失败不影响主流程

--- a/studio/workers/reg_build_worker.py
+++ b/studio/workers/reg_build_worker.py
@@ -33,7 +33,9 @@ from typing import Any
 
 # PR-1 C4: setup_logging 内已统一调 reconfigure_console_utf8。
 
-logger = logging.getLogger(__name__)
+# 固定名：worker 经 `python -m studio.workers.reg_build_worker` 拉起时 __name__ 是 __main__，
+# 行契约里的来源列会失真、也不在 OWN_LOGGER_NAMESPACES 里。
+logger = logging.getLogger("studio.workers.reg_build_worker")
 
 # PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload。
 # auto_tag 路径会内联调 wd14_tagger（line ~105 `get_tagger("wd14")`），worker 是独立

--- a/studio/workers/reg_build_worker.py
+++ b/studio/workers/reg_build_worker.py
@@ -21,7 +21,7 @@
 
 不开子进程：把 WD14 / postprocess 直接 import 进来，progress 走同一 log_path。
 
-日志只走 stdout：见 `download_worker.py` 顶部的说明。
+日志只走 logger：见 `download_worker.py` 顶部的说明。
 """
 from __future__ import annotations
 
@@ -141,10 +141,10 @@ def run(job_id: int) -> int:
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, job_id)
     if not job:
-        print(f"[error] job {job_id} not found", flush=True)
+        logger.error("job %s not found", job_id)
         return 1
     if job["kind"] != "reg_build":
-        print(f"[error] wrong kind: {job['kind']}", flush=True)
+        logger.error("wrong kind: %s", job["kind"])
         return 1
 
     params: dict[str, Any] = job.get("params_decoded") or {}
@@ -152,7 +152,7 @@ def run(job_id: int) -> int:
     cancel_event = threading.Event()  # supervisor 走 SIGTERM；这里只为 API 完整性
 
     def progress(line: str) -> None:
-        print(line, flush=True)
+        logger.info(line)
 
     try:
         version_id = int(params["version_id"])

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -15,7 +15,7 @@
 
 打标永远覆盖 train/ 下全部 repeat 子目录（不再支持按 folder 划分）。
 
-日志只走 stdout：见 `download_worker.py` 顶部的说明。
+日志只走 logger：见 `download_worker.py` 顶部的说明。
 """
 from __future__ import annotations
 
@@ -105,16 +105,16 @@ def run(job_id: int) -> int:
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, job_id)
     if not job:
-        print(f"[error] job {job_id} not found", flush=True)
+        logger.error("job %s not found", job_id)
         return 1
     if job["kind"] != "tag":
-        print(f"[error] wrong kind: {job['kind']}", flush=True)
+        logger.error("wrong kind: %s", job["kind"])
         return 1
 
     params: dict[str, Any] = job.get("params_decoded") or {}
 
     def progress(line: str) -> None:
-        print(line, flush=True)
+        logger.info(line)
 
     try:
         tagger_name = params.get("tagger", "wd14")

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -27,7 +27,9 @@ from typing import Any
 # PR-1 C4: setup_logging 内已统一调 reconfigure_console_utf8，
 # worker 顶层不再单独调（B-4.6: 之前只 2/4 worker 调）。
 
-logger = logging.getLogger(__name__)
+# 固定名：worker 经 `python -m studio.workers.tag_worker` 拉起时 __name__ 是 __main__，
+# 行契约里的来源列会失真、也不在 OWN_LOGGER_NAMESPACES 里。
+logger = logging.getLogger("studio.workers.tag_worker")
 
 # PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload
 # （Linux: RTLD_GLOBAL 加载 torch 自带 CUDA so；Windows: os.add_dll_directory）。

--- a/tests/test_log_baseline.py
+++ b/tests/test_log_baseline.py
@@ -95,6 +95,11 @@ def test_logger_getlogger_name_uses_dunder_name() -> None:
                 # 固定名让 _say 的记录在两种入口下同名（logging-target-state §3.5）
                 if arg in ('"studio.cli"', "'studio.cli'"):
                     continue
+                # 允许 workers 固定名 "studio.workers.<kind>_worker" —— 经
+                # `python -m studio.workers.x_worker` 拉起时 __name__ 是 __main__，
+                # 行契约的来源列会失真（logging-target-state §3.2）
+                if arg.startswith('"studio.workers.') or arg.startswith("'studio.workers."):
+                    continue
                 bad.append(f"{py.relative_to(studio_root)}: getLogger({arg})")
     assert not bad, (
         "studio/ 内 getLogger 应该统一用 __name__；下列违反必须修或加 silence list 注释:\n"

--- a/tests/test_log_baseline.py
+++ b/tests/test_log_baseline.py
@@ -90,6 +90,11 @@ def test_logger_getlogger_name_uses_dunder_name() -> None:
                 # 分开，便于 jq 'select(.logger | startswith("studio.client"))' 过滤
                 if arg.startswith('"studio.client') or arg.startswith("'studio.client"):
                     continue
+                # 允许 logging.getLogger("studio.cli") — cli.py 既可 `python -m studio`
+                # （__name__ == studio.cli）也可 `python -m studio.cli`（__main__）跑，
+                # 固定名让 _say 的记录在两种入口下同名（logging-target-state §3.5）
+                if arg in ('"studio.cli"', "'studio.cli'"):
+                    continue
                 bad.append(f"{py.relative_to(studio_root)}: getLogger({arg})")
     assert not bad, (
         "studio/ 内 getLogger 应该统一用 __name__；下列违反必须修或加 silence list 注释:\n"

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -21,6 +21,8 @@ import pytest
 from studio.infrastructure.logging import (
     HumanConsoleFormatter,
     JsonLineFormatter,
+    LOG_LEVEL_ENV,
+    OWN_LOGGER_NAMESPACES,
     STUDIO_LOG_NAME,
     _NOISY_LOGGERS,
     _reset_for_tests,
@@ -41,10 +43,16 @@ def reset_logging(monkeypatch: pytest.MonkeyPatch):
     saved_handlers = list(logging.getLogger().handlers)
     saved_level = logging.getLogger().level
     saved_excepthook = sys.excepthook
+    saved_levels = {
+        n: logging.getLogger(n).level
+        for n in (*OWN_LOGGER_NAMESPACES, *_NOISY_LOGGERS, "uvicorn", "uvicorn.error", "uvicorn.access")
+    }
     yield
     _reset_for_tests()
     logging.getLogger().handlers = saved_handlers
     logging.getLogger().level = saved_level
+    for n, lv in saved_levels.items():
+        logging.getLogger(n).setLevel(lv)
     sys.excepthook = saved_excepthook
 
 
@@ -220,10 +228,85 @@ def test_setup_logging_excepthook_preserves_keyboardinterrupt(tmp_path: Path,
     assert critical_records == [], "KeyboardInterrupt 不应路由到 logger.critical"
 
 
-def test_setup_logging_extra_handlers_attached(tmp_path: Path) -> None:
-    extra = logging.StreamHandler()
-    setup_logging("worker:tag/1", log_dir=tmp_path, console=False, extra_handlers=[extra])
-    assert extra in logging.getLogger().handlers
+# ── 级别模型（docs/design/logging-target-state.md §3.1）──────────────────
+
+
+def _console_handlers() -> list[logging.Handler]:
+    return [
+        h for h in logging.getLogger().handlers
+        if type(h) is logging.StreamHandler
+    ]
+
+
+def test_own_namespaces_debug_root_info(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """自家命名空间恒 DEBUG（记录不过滤），root 保持 INFO 防第三方 debug 洪水。"""
+    monkeypatch.delenv(LOG_LEVEL_ENV, raising=False)
+    for n in OWN_LOGGER_NAMESPACES:
+        logging.getLogger(n).setLevel(logging.NOTSET)
+    setup_logging("webui", log_dir=tmp_path, console=False)
+    assert logging.getLogger().level == logging.INFO
+    for n in OWN_LOGGER_NAMESPACES:
+        assert logging.getLogger(n).getEffectiveLevel() == logging.DEBUG, n
+    # 未列入的第三方 logger 跟 root 走 INFO
+    assert logging.getLogger("some_third_party_lib").getEffectiveLevel() == logging.INFO
+
+
+def test_file_handler_records_own_debug(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(LOG_LEVEL_ENV, raising=False)
+    setup_logging("webui", log_dir=tmp_path, console=False)
+    logging.getLogger("studio.test_dbg").debug("dbg-line")
+    for h in logging.getLogger().handlers:
+        h.flush()
+    text = (tmp_path / STUDIO_LOG_NAME).read_text(encoding="utf-8")
+    assert "dbg-line" in text
+
+
+def test_console_level_defaults_info_and_reads_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(LOG_LEVEL_ENV, raising=False)
+    setup_logging("cli:x", log_dir=tmp_path, console=True, file=False)
+    (h,) = _console_handlers()
+    assert h.level == logging.INFO
+
+    _reset_for_tests()
+    monkeypatch.setenv(LOG_LEVEL_ENV, "debug")
+    setup_logging("cli:y", log_dir=tmp_path, console=True, file=False)
+    (h,) = _console_handlers()
+    assert h.level == logging.DEBUG
+
+    _reset_for_tests()
+    monkeypatch.setenv(LOG_LEVEL_ENV, "bogus")
+    setup_logging("cli:z", log_dir=tmp_path, console=True, file=False)
+    (h,) = _console_handlers()
+    assert h.level == logging.INFO, "非法 env 值回落 INFO"
+
+
+def test_console_level_param_overrides_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(LOG_LEVEL_ENV, "DEBUG")
+    setup_logging("cli:w", log_dir=tmp_path, console=True, file=False, level="WARNING")
+    (h,) = _console_handlers()
+    assert h.level == logging.WARNING
+
+
+def test_console_auto_is_human_even_when_piped(tmp_path: Path) -> None:
+    """pipe 下不再输出 JSON（与 studio.log 重复且终端不可读）。测试进程 stderr 即非 tty。"""
+    assert not sys.stderr.isatty()
+    setup_logging("webui", log_dir=tmp_path, console="auto")
+    (h,) = _console_handlers()
+    assert isinstance(h.formatter, HumanConsoleFormatter)
+
+
+def test_console_json_explicit(tmp_path: Path) -> None:
+    setup_logging("webui", log_dir=tmp_path, console="json")
+    (h,) = _console_handlers()
+    assert isinstance(h.formatter, JsonLineFormatter)
+
+
+def test_uvicorn_access_silenced_others_kept(tmp_path: Path) -> None:
+    for n in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        logging.getLogger(n).setLevel(logging.NOTSET)
+    setup_logging("webui", log_dir=tmp_path, console=False)
+    assert logging.getLogger("uvicorn.access").level == logging.WARNING
+    assert logging.getLogger("uvicorn.error").getEffectiveLevel() == logging.INFO
 
 
 def test_reconfigure_console_utf8_does_not_crash() -> None:

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -22,6 +22,7 @@ from studio.infrastructure.logging import (
     HumanConsoleFormatter,
     JsonLineFormatter,
     LOG_LEVEL_ENV,
+    LOG_LINE_RE,
     OWN_LOGGER_NAMESPACES,
     STUDIO_LOG_NAME,
     _NOISY_LOGGERS,
@@ -312,3 +313,29 @@ def test_uvicorn_access_silenced_others_kept(tmp_path: Path) -> None:
 def test_reconfigure_console_utf8_does_not_crash() -> None:
     """无论 stdout/stderr 是何种 stream 都不应 crash（包括测试下的 pipe）。"""
     reconfigure_console_utf8()  # 不抛即通过
+
+
+# ── 行契约（docs/design/logging-target-state.md §3.2）────────────────────────
+
+
+@pytest.mark.parametrize("level,expect", [
+    (logging.DEBUG, "DEBUG"), (logging.INFO, "INFO"),
+    (logging.WARNING, "WARNING"), (logging.ERROR, "ERROR"), (logging.CRITICAL, "CRITICAL"),
+])
+def test_human_line_matches_contract_regex(level: int, expect: str) -> None:
+    fmt = HumanConsoleFormatter()
+    rec = logging.LogRecord(
+        name="training.progress", level=level, pathname="/x.py", lineno=1,
+        msg="epoch=%d step=%d", args=(0, 50), exc_info=None,
+    )
+    line = fmt.format(rec)
+    m = LOG_LINE_RE.match(line)
+    assert m, line
+    assert m["level"] == expect
+    assert m["logger"] == "training.progress"
+    assert m["msg"] == "epoch=0 step=50"
+
+
+def test_contract_regex_rejects_continuation_lines() -> None:
+    for cont in ("Traceback (most recent call last):", '  File "x.py", line 1', "ValueError: boom", ""):
+        assert LOG_LINE_RE.match(cont) is None, cont

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -1,9 +1,11 @@
-"""PR-6 — model_downloader._on_log per-line print。
+"""PR-6 — model_downloader._on_log per-line 回显（现走 logger.debug，
+logging-target-state §3.2）。
 PR-S3 — _resolve_endpoint env > secrets > None 优先级。
 MS-1  — _get_download_source / download_flat_ms rename+cleanup 逻辑。
 """
 from __future__ import annotations
 
+import logging
 import threading
 import time
 from pathlib import Path
@@ -11,6 +13,8 @@ from pathlib import Path
 import pytest
 
 from studio.services import models as model_downloader
+
+_DL_LOGGER = "studio.services.models.downloader"
 
 
 @pytest.fixture
@@ -38,9 +42,10 @@ def _wait_done(key: str, timeout: float = 2.0) -> None:
 
 
 def test_on_log_writes_to_ring_buffer_and_stdout(
-    reset_downloads, capfd: pytest.CaptureFixture
+    reset_downloads, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """on_log 同时写：(1) ring buffer ds.log，(2) stdout（print(line, flush=True)）。"""
+    """on_log 同时写：(1) ring buffer ds.log，(2) 模块 logger DEBUG（自家 logger 恒
+    DEBUG → 进 studio.log 保留完整流；终端默认 INFO 不刷屏）。"""
     lines_to_emit = ["downloading file 1", "downloading file 2", "✓ done"]
 
     def fake_fn(on_log):
@@ -48,8 +53,9 @@ def test_on_log_writes_to_ring_buffer_and_stdout(
             on_log(line)
         return True
 
-    model_downloader.start_download_async("test-key", fake_fn)
-    _wait_done("test-key")
+    with caplog.at_level(logging.DEBUG, logger=_DL_LOGGER):
+        model_downloader.start_download_async("test-key", fake_fn)
+        _wait_done("test-key")
 
     # ring buffer 完整保留
     with model_downloader._LOCK:
@@ -57,10 +63,13 @@ def test_on_log_writes_to_ring_buffer_and_stdout(
         assert ds.status == "done"
         assert ds.log == lines_to_emit
 
-    # stdout 也都拿到（用 capfd 抓 fd 级 stdout，覆盖跨线程 print）
-    out = capfd.readouterr().out
+    # logger 也都拿到（DEBUG 级，跨线程 propagate 到 root 的 caplog handler）
+    logged = [
+        r.getMessage() for r in caplog.records
+        if r.name == _DL_LOGGER and r.levelno == logging.DEBUG
+    ]
     for line in lines_to_emit:
-        assert line in out
+        assert line in logged
 
 
 # ---------------------------------------------------------------------------
@@ -144,43 +153,45 @@ def test_resolve_endpoint_env_with_whitespace_treated_empty(
 def test_on_log_does_not_hold_lock_during_print(
     reset_downloads,
 ) -> None:
-    """print 在锁外：on_log 调用本身不应让 _LOCK 在 I/O 期间被占着。
+    """日志回显在锁外：on_log 调用本身不应让 _LOCK 在 I/O 期间被占着。
 
-    检测方式：让 print 阻塞（替成 sleep 兼带计时），同时另一线程尝试拿锁；
-    若锁外执行，并发 acquire 应当能立刻成功。
+    检测方式：给模块 logger 挂一个会阻塞的 handler（模拟慢 I/O），同时另一
+    线程尝试拿锁；若锁外执行，并发 acquire 应当能立刻成功。
     """
-    import builtins
+    emit_started = threading.Event()
+    can_finish_emit = threading.Event()
 
-    print_started = threading.Event()
-    can_finish_print = threading.Event()
+    class _SlowHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            emit_started.set()
+            can_finish_emit.wait(timeout=2.0)
 
-    real_print = builtins.print
-
-    def slow_print(*args, **kwargs):
-        print_started.set()
-        can_finish_print.wait(timeout=2.0)
-        return real_print(*args, **kwargs)
-
-    def fake_fn(on_log):
-        builtins.print = slow_print
-        try:
+    dl_logger = logging.getLogger(_DL_LOGGER)
+    handler = _SlowHandler(level=logging.DEBUG)
+    prev_level = dl_logger.level
+    dl_logger.addHandler(handler)
+    dl_logger.setLevel(logging.DEBUG)
+    try:
+        def fake_fn(on_log):
             on_log("first")
-        finally:
-            builtins.print = real_print
-        return True
+            return True
 
-    model_downloader.start_download_async("test-lock", fake_fn)
+        model_downloader.start_download_async("test-lock", fake_fn)
 
-    assert print_started.wait(timeout=2.0), "fake_fn 没进 print"
+        assert emit_started.wait(timeout=2.0), "fake_fn 没进 logger emit"
 
-    # 此时 _on_log 应已离开 with _LOCK 块（先写 ring buffer 再 print），
-    # 主线程能在 100ms 内拿到锁
-    acquired = model_downloader._LOCK.acquire(timeout=0.1)
-    assert acquired, "_on_log 在 print 期间持锁，违反 PR-6 设计"
-    model_downloader._LOCK.release()
+        # 此时 _on_log 应已离开 with _LOCK 块（先写 ring buffer 再 logger），
+        # 主线程能在 100ms 内拿到锁
+        acquired = model_downloader._LOCK.acquire(timeout=0.1)
+        assert acquired, "_on_log 在日志 I/O 期间持锁，违反 PR-6 设计"
+        model_downloader._LOCK.release()
 
-    can_finish_print.set()
-    _wait_done("test-lock")
+        can_finish_emit.set()
+        _wait_done("test-lock")
+    finally:
+        can_finish_emit.set()
+        dl_logger.removeHandler(handler)
+        dl_logger.setLevel(prev_level)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pending_install.py
+++ b/tests/test_pending_install.py
@@ -4,11 +4,23 @@
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 
 from studio.services.runtime import pending_install
+
+_LOGGER = "studio.services.runtime.pending_install"
+
+
+def _msgs(caplog: pytest.LogCaptureFixture, *, min_level: int) -> str:
+    """pending_install 的输出走模块 logger（不再 print）：INFO=原 stdout、
+    WARNING+=原 stderr。"""
+    return "\n".join(
+        r.getMessage() for r in caplog.records
+        if r.name == _LOGGER and r.levelno >= min_level
+    )
 
 
 @pytest.fixture
@@ -67,7 +79,7 @@ def test_apply_pending_no_marker_is_noop(
 
 
 def test_apply_pending_runs_torch_reinstall_and_clears(
-    isolated_marker: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    isolated_marker: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """有 pending=torch → 调 reinstall + 清 marker。"""
     pending_install.register_torch_reinstall("cu128")
@@ -85,15 +97,16 @@ def test_apply_pending_runs_torch_reinstall_and_clears(
         }
 
     monkeypatch.setattr(torch_setup, "reinstall", fake_reinstall)
-    pending_install.apply_pending()
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        pending_install.apply_pending()
     assert captured == ["cu128"]
     assert not isolated_marker.exists()  # 成功后清掉
-    out = capsys.readouterr().out
-    assert "torch 重装完成" in out
+    assert "torch 重装完成" in _msgs(caplog, min_level=logging.INFO)
+    assert _msgs(caplog, min_level=logging.WARNING) == ""  # 成功路径无 warning/error
 
 
 def test_apply_pending_keeps_marker_on_failure(
-    isolated_marker: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    isolated_marker: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     """reinstall 抛 RuntimeError → marker 保留，下次启动重试。"""
     pending_install.register_torch_reinstall("cu128")
@@ -103,23 +116,28 @@ def test_apply_pending_keeps_marker_on_failure(
         raise RuntimeError("network failed")
 
     monkeypatch.setattr(torch_setup, "reinstall", fake_reinstall)
-    pending_install.apply_pending()
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        pending_install.apply_pending()
     # marker 保留
     assert isolated_marker.exists()
     assert pending_install.read_pending()["target"] == "cu128"
-    err = capsys.readouterr().err
+    err = _msgs(caplog, min_level=logging.ERROR)
     assert "torch 重装失败" in err
     assert "network failed" in err
 
 
 def test_apply_pending_unknown_kind_clears_marker(
-    isolated_marker: Path, capsys
+    isolated_marker: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
     """未知 kind → warn + 清 marker（防止永久卡住）。"""
     isolated_marker.write_text(
         '{"kind": "modelscope", "target": "auto"}', encoding="utf-8"
     )
-    pending_install.apply_pending()
+    with caplog.at_level(logging.INFO, logger=_LOGGER):
+        pending_install.apply_pending()
     assert not isolated_marker.exists()
-    err = capsys.readouterr().err
-    assert "未知" in err
+    warn = [
+        r for r in caplog.records
+        if r.name == _LOGGER and r.levelno == logging.WARNING
+    ]
+    assert warn and "未知" in warn[0].getMessage()

--- a/tests/test_print_whitelist.py
+++ b/tests/test_print_whitelist.py
@@ -1,0 +1,112 @@
+"""裸 print 白名单锁（docs/design/logging-target-state.md 不变量 1「一个格式」）。
+
+日志内容一律走 logger（同一 formatter → run.log / studio.log 每行有 ts/level/来源）。
+裸 `print` 只剩三类合法用途，逐一登记在下面的白名单里：
+  - stdout 协议行（`__EVENT__:` / daemon line-JSON）
+  - tty 交互（rich/plain 进度行、input() 配套提示、独立 CLI 工具 `__main__` 的结果输出）
+  - CLI 启动 banner
+
+新增 print 会让本测试红：要么改 logger，要么在这里登记并写明属于哪一类。
+用 AST 扫，键 = (仓库相对路径, 最近的函数名或 "<module>" / "<__main__>")。
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCAN_ROOTS = ("runtime", "utils", "studio")
+SKIP_PARTS = {"web", "__pycache__", "node_modules"}
+
+# 路径 → 允许出现 print 的上下文集合。上下文 = 最近的 def 名；模块级用 "<module>"；
+# `if __name__ == "__main__":` 块内用 "<__main__>"。
+WHITELIST: dict[str, set[str]] = {
+    # tty 交互：plain 模式 `\r` 进度行 / ctx.emit 的 tty 分支
+    "runtime/training/loop.py": {"run"},
+    "runtime/training/context.py": {"emit"},
+    # tty 交互：input() 配套提示
+    "runtime/training/cli.py": {"_ask_int", "_ask_float"},
+    # 独立 CLI 工具的结果输出
+    "utils/caption_utils.py": {"<__main__>"},
+    # stdout 协议行
+    "studio/workers/preprocess_worker.py": {"emit_event"},
+    # CLI 启动 banner（setup_logging 之前）
+    "studio/api/main.py": {"main"},
+}
+
+
+def _context_of(path: list[ast.AST]) -> str:
+    for node in reversed(path):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return node.name
+        if isinstance(node, ast.If) and _is_main_guard(node.test):
+            return "<__main__>"
+    return "<module>"
+
+
+def _is_main_guard(test: ast.AST) -> bool:
+    return (
+        isinstance(test, ast.Compare)
+        and isinstance(test.left, ast.Name)
+        and test.left.id == "__name__"
+        and any(isinstance(c, ast.Constant) and c.value == "__main__" for c in test.comparators)
+    )
+
+
+def _iter_prints(tree: ast.AST):
+    stack: list[ast.AST] = []
+
+    def visit(node: ast.AST):
+        stack.append(node)
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "print"
+        ):
+            yield node.lineno, _context_of(stack[:-1])
+        for child in ast.iter_child_nodes(node):
+            yield from visit(child)
+        stack.pop()
+
+    yield from visit(tree)
+
+
+def _py_files():
+    for root in SCAN_ROOTS:
+        for p in (REPO / root).rglob("*.py"):
+            if SKIP_PARTS & set(p.parts):
+                continue
+            yield p
+
+
+def test_bare_print_only_in_whitelisted_contexts() -> None:
+    offenders: list[str] = []
+    for p in _py_files():
+        rel = p.relative_to(REPO).as_posix()
+        try:
+            tree = ast.parse(p.read_text(encoding="utf-8"))
+        except SyntaxError as e:  # pragma: no cover
+            offenders.append(f"{rel}: 无法解析 ({e})")
+            continue
+        allowed = WHITELIST.get(rel, set())
+        for lineno, ctx in _iter_prints(tree):
+            if ctx not in allowed:
+                offenders.append(f"{rel}:{lineno} in {ctx}")
+    assert not offenders, (
+        "发现白名单外的裸 print（日志内容请走 logger；协议行/tty 交互/banner 请在 "
+        "tests/test_print_whitelist.py WHITELIST 登记）:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_whitelist_entries_still_exist() -> None:
+    """白名单不长草：登记的文件必须存在且该上下文里确实还有 print。"""
+    stale: list[str] = []
+    for rel, ctxs in WHITELIST.items():
+        p = REPO / rel
+        if not p.exists():
+            stale.append(f"{rel}: 文件不存在")
+            continue
+        found = {ctx for _, ctx in _iter_prints(ast.parse(p.read_text(encoding="utf-8")))}
+        for ctx in ctxs - found:
+            stale.append(f"{rel}: 上下文 {ctx} 已无 print，可从白名单删除")
+    assert not stale, "\n".join(stale)

--- a/tests/test_studio_cli.py
+++ b/tests/test_studio_cli.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,38 @@ from studio import cli
 # ---------------------------------------------------------------------------
 # 工具
 # ---------------------------------------------------------------------------
+
+
+def _cli_msgs(caplog: pytest.LogCaptureFixture, *, min_level: int = logging.DEBUG) -> str:
+    """`_say` 现在走 `studio.cli` logger（logging-target-state §3.5）；把该 logger
+    在 [min_level, ∞) 的记录拼成一段文本，替代以前 capsys 的 out / err 断言：
+      - 原 stdout（info）  → min_level=INFO 且过滤掉 WARNING+
+      - 原 stderr（warn+） → min_level=WARNING
+    """
+    return "\n".join(
+        r.getMessage() for r in caplog.records
+        if r.name == "studio.cli" and r.levelno >= min_level
+    )
+
+
+def _cli_info(caplog: pytest.LogCaptureFixture) -> str:
+    """只取 INFO 级（原「stdout」流）。"""
+    return "\n".join(
+        r.getMessage() for r in caplog.records
+        if r.name == "studio.cli" and r.levelno == logging.INFO
+    )
+
+
+def _cli_warn_plus(caplog: pytest.LogCaptureFixture) -> str:
+    """WARNING 及以上（原「stderr」流）。"""
+    return _cli_msgs(caplog, min_level=logging.WARNING)
+
+
+@pytest.fixture
+def cli_log(caplog: pytest.LogCaptureFixture) -> pytest.LogCaptureFixture:
+    """把 studio.cli logger 放到 DEBUG 抓全，测试用 _cli_info / _cli_warn_plus 分流。"""
+    caplog.set_level(logging.DEBUG, logger="studio.cli")
+    return caplog
 
 
 @pytest.fixture
@@ -325,7 +358,7 @@ def _install_fake_torch(monkeypatch: pytest.MonkeyPatch, torch_module) -> None:
 
 
 def test_check_torch_cuda_silent_when_torch_missing(
-    monkeypatch: pytest.MonkeyPatch, capsys
+    monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
 ) -> None:
     """torch 没装时静默返回，让 _ensure_python_deps 接手。"""
     import sys as _sys
@@ -340,28 +373,26 @@ def test_check_torch_cuda_silent_when_torch_missing(
 
     monkeypatch.setattr("builtins.__import__", _fake_import)
     cli._check_torch_cuda()
-    out = capsys.readouterr()
-    assert out.out == ""
-    assert out.err == ""
+    assert _cli_msgs(cli_log) == ""
 
 
 def test_check_torch_cuda_prints_ok_when_available(
-    monkeypatch: pytest.MonkeyPatch, capsys
+    monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
 ) -> None:
-    """CUDA 可用 → stdout 一行 OK，无 stderr 噪声。"""
+    """CUDA 可用 → 一行 INFO OK，无 WARNING/ERROR 噪声。"""
     _install_fake_torch(
         monkeypatch,
         _FakeTorch(available=True, cuda_build="12.8", version="2.5.0", device_name="RTX 5090"),
     )
     cli._check_torch_cuda()
-    out = capsys.readouterr()
-    assert "RTX 5090" in out.out
-    assert "2.5.0" in out.out
-    assert out.err == ""  # 一切正常不该写 stderr
+    info = _cli_info(cli_log)
+    assert "RTX 5090" in info
+    assert "2.5.0" in info
+    assert _cli_warn_plus(cli_log) == ""  # 一切正常不该出 warning
 
 
 def test_check_torch_cuda_warns_on_cpu_only_with_gpu(
-    monkeypatch: pytest.MonkeyPatch, capsys
+    monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
 ) -> None:
     """CPU-only torch + 检测到 NVIDIA GPU → 大警告 + 重装命令（最常见误装）。"""
     _install_fake_torch(
@@ -375,18 +406,18 @@ def test_check_torch_cuda_warns_on_cpu_only_with_gpu(
         lambda: {"available": True, "driver_version": "551.86", "gpu_name": "RTX 5090"},
     )
     cli._check_torch_cuda()
-    out = capsys.readouterr()
-    assert out.out == ""  # 警告全走 stderr
-    assert "CPU-only" in out.err
-    assert "pip install torch" in out.err
-    assert "--index-url" in out.err
+    assert _cli_info(cli_log) == ""  # 警告全走 WARNING 级
+    warn = _cli_warn_plus(cli_log)
+    assert "CPU-only" in warn
+    assert "pip install torch" in warn
+    assert "--index-url" in warn
     # 不该再用 emoji
-    assert "✓" not in out.err
-    assert "⚠" not in out.err
+    assert "✓" not in warn
+    assert "⚠" not in warn
 
 
 def test_check_torch_cuda_info_on_cpu_only_without_gpu(
-    monkeypatch: pytest.MonkeyPatch, capsys
+    monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
 ) -> None:
     """CPU-only torch + 没 NVIDIA GPU → benign info（用户确实在 CPU 机器）。"""
     _install_fake_torch(
@@ -400,14 +431,14 @@ def test_check_torch_cuda_info_on_cpu_only_without_gpu(
         lambda: {"available": False, "driver_version": None, "gpu_name": None},
     )
     cli._check_torch_cuda()
-    out = capsys.readouterr()
-    assert "CPU-only build" in out.out
-    assert "未检测到 NVIDIA GPU" in out.out
-    assert out.err == ""
+    info = _cli_info(cli_log)
+    assert "CPU-only build" in info
+    assert "未检测到 NVIDIA GPU" in info
+    assert _cli_warn_plus(cli_log) == ""
 
 
 def test_check_torch_cuda_warns_on_cuda_build_but_unavailable(
-    monkeypatch: pytest.MonkeyPatch, capsys
+    monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
 ) -> None:
     """CUDA build + cuda.is_available()=False → 驱动 / WSL 警告。"""
     _install_fake_torch(
@@ -415,11 +446,11 @@ def test_check_torch_cuda_warns_on_cuda_build_but_unavailable(
         _FakeTorch(available=False, cuda_build="12.8", version="2.5.0+cu128"),
     )
     cli._check_torch_cuda()
-    out = capsys.readouterr()
-    assert "CUDA 12.8 build" in out.err
-    assert "is_available()=False" in out.err
+    warn = _cli_warn_plus(cli_log)
+    assert "CUDA 12.8 build" in warn
+    assert "is_available()=False" in warn
     # 该路径不应给出 pip install 重装建议（torch 装得没问题，是驱动 / WSL 问题）
-    assert "pip install torch" not in out.err
+    assert "pip install torch" not in warn
 
 
 # ---------------------------------------------------------------------------
@@ -427,23 +458,30 @@ def test_check_torch_cuda_warns_on_cuda_build_but_unavailable(
 # ---------------------------------------------------------------------------
 
 
-def test_npm_hint_windows(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+def test_npm_hint_windows(
+    monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
+) -> None:
     monkeypatch.setattr(cli.os, "name", "nt")
     cli._print_npm_install_hint()
-    err = capsys.readouterr().err
+    err = _cli_warn_plus(cli_log)
     assert "Node.js 18+" in err
     assert "winget install" in err
     assert "nodejs.org" in err
     # 不应该泄漏 Linux-only 内容
     assert "nodesource" not in err
     assert "nvm" not in err
+    # 整段提示是一条 ERROR 记录（多行续行无前缀），不是拆成多条
+    errs = [r for r in cli_log.records if r.name == "studio.cli" and r.levelno >= logging.ERROR]
+    assert len(errs) == 1
 
 
-def test_npm_hint_linux_non_root(monkeypatch: pytest.MonkeyPatch, capsys) -> None:
+def test_npm_hint_linux_non_root(
+    monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
+) -> None:
     monkeypatch.setattr(cli.os, "name", "posix")
     monkeypatch.setattr(cli.os, "getuid", lambda: 1000, raising=False)
     cli._print_npm_install_hint()
-    err = capsys.readouterr().err
+    err = _cli_warn_plus(cli_log)
     assert "nodesource.com" in err
     assert "sudo bash" in err  # 非 root → 命令带 sudo 前缀
     assert "nvm" in err
@@ -452,12 +490,12 @@ def test_npm_hint_linux_non_root(monkeypatch: pytest.MonkeyPatch, capsys) -> Non
 
 
 def test_npm_hint_linux_root_drops_sudo(
-    monkeypatch: pytest.MonkeyPatch, capsys
+    monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
 ) -> None:
     monkeypatch.setattr(cli.os, "name", "posix")
     monkeypatch.setattr(cli.os, "getuid", lambda: 0, raising=False)
     cli._print_npm_install_hint()
-    err = capsys.readouterr().err
+    err = _cli_warn_plus(cli_log)
     # root 环境直接跑命令，sudo 字样不应出现（避免误导：sudo 在容器里常无）
     assert " sudo " not in err
     assert "sudo bash" not in err
@@ -465,14 +503,14 @@ def test_npm_hint_linux_root_drops_sudo(
 
 
 def test_cmd_build_no_npm_prints_install_hint(
-    monkeypatch: pytest.MonkeyPatch, capsys
+    monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
 ) -> None:
     """cmd_build 找不到 npm 时应通过 _print_npm_install_hint 输出（不只是「找不到 npm」一行）。"""
     monkeypatch.setattr(cli, "find_npm", lambda: None)
     monkeypatch.setattr(cli.os, "name", "nt")
     rc = cli.main(["build"])
     assert rc == 2
-    err = capsys.readouterr().err
+    err = _cli_warn_plus(cli_log)
     assert "winget" in err
     assert "Node.js 18+" in err
 
@@ -535,7 +573,7 @@ def _stub_run_bootstrap(
 
 
 def test_cmd_run_returns_42_when_installer_changed(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
 ) -> None:
     """server 退出 + restart flag 在 + installer hash 变了 → return 42, flag 保留。
 
@@ -561,7 +599,7 @@ def test_cmd_run_returns_42_when_installer_changed(
     rc = cli.main(["run", "--no-browser"])
     assert rc == cli._INSTALLER_RELOAD_EXIT_CODE == 42
     assert fake_flag.exists(), "flag 必须保留给 wrapper 走 exec-self 路径"
-    assert "launcher 文件更新" in capsys.readouterr().out
+    assert "launcher 文件更新" in _cli_info(cli_log)
 
 
 def test_cmd_run_normal_restart_when_installer_unchanged(
@@ -591,7 +629,7 @@ def test_cmd_run_normal_restart_when_installer_unchanged(
 
 
 def test_cmd_run_ctrl_c_returns_130_without_traceback(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cli_log: pytest.LogCaptureFixture
 ) -> None:
     """终端 Ctrl+C：父进程在 subprocess.call 等 server 期间收到的
     KeyboardInterrupt 会在子进程退出后才抛出 —— 应按用户主动停机处理
@@ -606,7 +644,7 @@ def test_cmd_run_ctrl_c_returns_130_without_traceback(
 
     rc = cli.main(["run", "--no-browser"])
     assert rc == 130
-    assert "Ctrl+C" in capsys.readouterr().out
+    assert "Ctrl+C" in _cli_info(cli_log)
 
 
 def test_cmd_run_no_flag_no_dispatch(

--- a/tests/test_trace_id_subprocess.py
+++ b/tests/test_trace_id_subprocess.py
@@ -269,3 +269,90 @@ def test_worker_main_generates_trace_when_env_missing(
 
     assert captured["trace"] is not None
     assert len(captured["trace"]) == 24, "兜底应是 new_trace_id (24 字符 hex)"
+
+
+# ── 日志目标态刀 1：_spawn_job / daemon / _popen 的 env 注入 ─────────────────
+
+
+def test_spawn_job_injects_trace_and_process_env(tmp_path: Path,
+                                                  monkeypatch: pytest.MonkeyPatch) -> None:
+    """job 路径之前完全不注入 trace/process；现与 _spawn_task 对齐（bg- 兜底）。"""
+    import contextlib
+
+    from studio.supervisor.core import Supervisor
+
+    captured_env: dict = {}
+
+    def fake_popen(self_, cmd, log_fp, extra_env=None):
+        captured_env.update(extra_env or {})
+        proc = MagicMock(); proc.pid = 3; proc.poll = lambda: None
+        return proc
+
+    monkeypatch.setattr(Supervisor, "_popen", fake_popen)
+    monkeypatch.setattr(Supervisor, "_make_job_log_callback",
+                        lambda self_, *a: (lambda line: None))
+    monkeypatch.setattr("studio.supervisor.core.LogTailer",
+                        lambda *a, **kw: MagicMock(start=lambda: None))
+    monkeypatch.setattr("studio.supervisor.core.db.connection_for",
+                        lambda *_a, **_k: contextlib.nullcontext(MagicMock()))
+    monkeypatch.setattr("studio.supervisor.core.project_jobs.mark_running", lambda *a, **k: None)
+
+    sup = Supervisor(on_event=lambda evt: None, job_cmd_builder=lambda job: ["python", "-c", "0"])
+    job = {"id": 9, "kind": "tag", "project_id": 1, "version_id": None,
+           "log_path": str(tmp_path / "run.log")}
+    sup._spawn_job(MagicMock(name="DATA"), job)
+
+    assert captured_env[TRACE_ENV].startswith("bg-")
+    assert captured_env[PROCESS_ENV] == "worker:tag/9"
+
+
+def test_popen_injects_debug_console_level_by_default(tmp_path: Path,
+                                                      monkeypatch: pytest.MonkeyPatch) -> None:
+    """子进程 stderr 即 run.log：记录不过滤 → 注入 ANIMA_LOG_LEVEL=DEBUG；外部显式设的值不覆盖。"""
+    from studio.infrastructure.logging import LOG_LEVEL_ENV
+    from studio.supervisor import core as core_mod
+
+    seen: dict = {}
+
+    class _FakeProc:
+        pid = 1
+
+    def fake_popen(cmd, **kw):
+        seen.update(kw["env"])
+        return _FakeProc()
+
+    monkeypatch.setattr(core_mod.subprocess, "Popen", fake_popen)
+    monkeypatch.setattr(core_mod._secrets, "load", lambda: MagicMock(
+        training=MagicMock(ram_guard=True), wandb=MagicMock(enabled=False)))
+    sup = core_mod.Supervisor(on_event=lambda evt: None)
+
+    monkeypatch.delenv(LOG_LEVEL_ENV, raising=False)
+    sup._popen(["python", "-c", "0"], open(tmp_path / "a.log", "wb"))
+    assert seen[LOG_LEVEL_ENV] == "DEBUG"
+
+    seen.clear()
+    monkeypatch.setenv(LOG_LEVEL_ENV, "WARNING")
+    sup._popen(["python", "-c", "0"], open(tmp_path / "b.log", "wb"))
+    assert seen[LOG_LEVEL_ENV] == "WARNING"
+
+
+def test_daemon_start_injects_log_level_trace_process(monkeypatch: pytest.MonkeyPatch) -> None:
+    from studio.infrastructure.logging import LOG_LEVEL_ENV
+    from studio.services.inference import daemon as daemon_mod
+
+    seen: dict = {}
+
+    def fake_popen(cmd, **kw):
+        seen.update(kw["env"])
+        raise RuntimeError("stop here")  # 不真起进程
+
+    monkeypatch.setattr(daemon_mod.subprocess, "Popen", fake_popen)
+    monkeypatch.delenv(LOG_LEVEL_ENV, raising=False)
+    monkeypatch.delenv(TRACE_ENV, raising=False)
+    monkeypatch.delenv(PROCESS_ENV, raising=False)
+    d = daemon_mod.InferenceDaemon()
+    with pytest.raises(RuntimeError):
+        d.start()
+    assert seen[LOG_LEVEL_ENV] == "DEBUG"
+    assert seen[TRACE_ENV].startswith("bg-")
+    assert seen[PROCESS_ENV] == "anima_daemon"

--- a/utils/caption_utils.py
+++ b/utils/caption_utils.py
@@ -7,10 +7,13 @@ Caption 处理工具
 from __future__ import annotations
 
 import json
+import logging
 import random
 import sys
 from pathlib import Path
 from typing import Optional
+
+logger = logging.getLogger(__name__)
 
 # 兼容 `python utils/caption_utils.py` 直接当脚本跑：python 默认只把脚本目录加入
 # sys.path，导致 studio.* 不可见。手动把仓库根注入一次，作为模块导入时 sys.path
@@ -264,7 +267,7 @@ def batch_convert_json(
             
             count += 1
         except Exception as e:
-            print(f"Error converting {json_path}: {e}")
+            logger.warning(f"Error converting {json_path}: {e}")
     
     return count
 

--- a/utils/lycoris_adapter.py
+++ b/utils/lycoris_adapter.py
@@ -211,7 +211,7 @@ class LycorisAdapter:
             self.network.apply_to()
 
         if _dropout_filter.dropped:
-            logger.info(
+            logger.warning(
                 "LoKr/LoHa 不支持 normal dropout（lora_dropout=%s），已静默忽略；"
                 "上游逐层告警 %d 条已收敛。rank_dropout/module_dropout 不受影响。",
                 self.dropout,

--- a/utils/optimizer_utils.py
+++ b/utils/optimizer_utils.py
@@ -295,9 +295,11 @@ def create_8bit_adamw(
             "Install with: pip install bitsandbytes"
         )
     
-    print(f"Creating 8-bit AdamW optimizer (lr={lr}, weight_decay={weight_decay})")
-    print(f"  min_8bit_size: {min_8bit_size}")
-    
+    logger.info(
+        f"Creating 8-bit AdamW optimizer (lr={lr}, weight_decay={weight_decay}, "
+        f"min_8bit_size={min_8bit_size})"
+    )
+
     # 将参数转换为列表（bitsandbytes 需要可索引的参数）
     param_list = list(params)
     
@@ -317,7 +319,7 @@ def create_8bit_adamw(
     # 8-bit 优化器状态：约 2 bytes per parameter (vs 8 bytes for 32-bit)
     # 节省约 75% 的优化器状态内存
     estimated_savings_gb = (total_params * 6) / (1024 ** 3)  # 节省 6 bytes per param
-    print(f"  [OK] 8-bit AdamW created (estimated memory savings: {estimated_savings_gb:.2f} GB)")
+    logger.info(f"8-bit AdamW created (estimated memory savings: {estimated_savings_gb:.2f} GB)")
     
     return optimizer
 
@@ -351,8 +353,8 @@ def create_standard_adamw(
     Returns:
         AdamW: 标准 AdamW 优化器
     """
-    print(f"Creating standard AdamW optimizer (lr={lr}, weight_decay={weight_decay})")
-    
+    logger.info(f"Creating standard AdamW optimizer (lr={lr}, weight_decay={weight_decay})")
+
     # 将参数转换为列表
     param_list = list(params)
     
@@ -365,7 +367,7 @@ def create_standard_adamw(
         **kwargs
     )
     
-    print("  [OK] AdamW optimizer created")
+    logger.info("AdamW optimizer created")
 
     return optimizer
 
@@ -735,11 +737,11 @@ def create_automagic(
         weight_decay=weight_decay,
         **kwargs,
     )
-    print(
+    logger.info(
         f"Creating Automagic optimizer (lr={lr}, min_lr={min_lr}, max_lr={max_lr}, "
         f"lr_bump={lr_bump}, beta2={beta2}, weight_decay={weight_decay})"
     )
-    print("  [OK] Automagic optimizer created")
+    logger.info("Automagic optimizer created")
     return optimizer
 
 
@@ -1063,8 +1065,8 @@ def create_lion(
         )
     param_list = params if _is_param_groups(params) else list(params)
     optimizer = Lion(param_list, lr=lr, betas=betas, weight_decay=weight_decay, **kwargs)
-    print(f"Creating Lion optimizer (lr={lr}, betas={betas}, weight_decay={weight_decay})")
-    print("  [OK] Lion optimizer created")
+    logger.info(f"Creating Lion optimizer (lr={lr}, betas={betas}, weight_decay={weight_decay})")
+    logger.info("Lion optimizer created")
     return optimizer
 
 
@@ -1333,13 +1335,13 @@ def create_prodigy(
         ) from e
 
     if abs(lr - 1.0) > 1e-9:
-        print(
-            f"[WARN] Prodigy requires lr=1.0 (received {lr}); forcing lr=1.0. "
+        logger.warning(
+            f"Prodigy requires lr=1.0 (received {lr}); forcing lr=1.0. "
             f"Tune d_coef/weight_decay instead of lr."
         )
         lr = 1.0
 
-    print(
+    logger.info(
         f"Creating Prodigy optimizer (lr={lr}, weight_decay={weight_decay}, "
         f"d_coef={d_coef}, safeguard_warmup={safeguard_warmup})"
     )
@@ -1358,7 +1360,7 @@ def create_prodigy(
         **kwargs,
     )
 
-    print("  [OK] Prodigy optimizer created")
+    logger.info("Prodigy optimizer created")
 
     return optimizer
 
@@ -1676,9 +1678,11 @@ def create_optimizer_grouped_parameters(
     # 打印统计信息
     num_decay_params = sum(p.numel() for p in decay_params)
     num_no_decay_params = sum(p.numel() for p in no_decay_params)
-    print(f"Parameter groups:")
-    print(f"  With weight decay: {len(decay_params)} params, {num_decay_params:,} elements")
-    print(f"  Without weight decay: {len(no_decay_params)} params, {num_no_decay_params:,} elements")
+    logger.info(
+        f"Parameter groups: with weight decay: {len(decay_params)} params, "
+        f"{num_decay_params:,} elements; without weight decay: "
+        f"{len(no_decay_params)} params, {num_no_decay_params:,} elements"
+    )
     
     return optimizer_grouped_parameters
 


### PR DESCRIPTION
日志体系重构四刀之一。设计稿 `docs/design/logging-target-state.md`（四项拍板 D1-D4、五条不变量、四刀分工）与 ADR 0009 Addendum 1 随本 PR 进。

## 拍板（D1-D4）
- **D1** 调试开关进 UI 设置：全局开关（后端字段 `system.log_debug_default`，刀 3 加）只管默认；每个日志视图独立开关（不持久化）；调试行靠**显示过滤**隐藏而不是不记录 ⇒ run.log / daemon ring **恒记 DEBUG**
- **D2** 子进程 / daemon 不落 studio.log
- **D3** 训练进度行算日志（pipe 模式走 logger）
- **D4** run.log 不做 GC

## 本刀改动（后端一致性）
- **`setup_logging`**：自家命名空间（`OWN_LOGGER_NAMESPACES`）恒 DEBUG，root 保持 INFO 防第三方 debug 洪水；file handler 记全部；console 级别 = 参数 > `ANIMA_LOG_LEVEL` > INFO——**唯一的开关，从「进程日志级别」退化为「终端可读性」**；`console="auto"` 在 pipe 下不再输出 JSON（与 studio.log 重复）；噪音表扩到 transformers/diffusers/accelerate/peft/wandb/spandrel/multipart/…；`uvicorn.access` 压到 WARNING；删死参数 `extra_handlers`
- **四个 runtime 入口**（anima_train / daemon / generate / reg_ai）弃各自 `basicConfig` 改 `setup_logging`（同 formatter；process 名 / trace 取 supervisor 注入 env）；`anima_train` logger 固定名
- **spawn 注入**：`_popen` 注入 `ANIMA_LOG_LEVEL=DEBUG`（子进程 stderr 即 run.log）；`_spawn_job` 与 daemon spawn 补 trace/process 注入（之前只有 `_spawn_task` 有）
- **裸 print 收编**（runtime 35 处 / studio 41 处）：训练进度行 → `training.progress`、`ctx.emit` 非 tty → `training.emit`；bootstrap / optimizer_utils / caption_utils / workers progress 闭包与 `[error]` 校验 / `cli._say`（改为 `studio.cli` logger 薄包装，`level` 真起作用）/ pending_install / downloader 回显（→ debug）
- **级别是级别、tag 是主题**：sampling.py 11 条 `[Debug]` → debug 去前缀（VAE offload 提示保留 info）；lycoris `[WARN]` → warning；generate/reg_ai `logger.error(str(e))` → `exception` 保栈
- **行契约**：`HumanConsoleFormatter` 即跨进程契约，导出 `LOG_LINE_RE`；续行无前缀
- **白名单锁**：`tests/test_print_whitelist.py` AST 扫描，只允许 `__EVENT__:` 协议行 / tty 交互（rich-plain 进度、input 提示、CLI 工具 `__main__`）/ `api/main.py` banner
- worker logger 固定名 `studio.workers.<kind>_worker`（`python -m` 下 `__name__` 是 `__main__`）

## 用户可见的中间态
刀 3 前，任务日志 tab / 抽屉里的行会带 `ts LEVEL name:` 前缀（之前是裸行），且训练调试行（切桶释放、采样内部数值等）会出现在 run.log 里。刀 3 上 LogView 后按级别着色/过滤。

## 验证
- 关联 pytest 全绿（logging setup 27 / bootstrap / trace env 12 / cli / workers / loop / supervisor / optimizer / lycoris / sampling，共 320+）
- 真机 smoke：`ANIMA_LOG_LEVEL=DEBUG python -m studio.workers.tag_worker --job-id 999999` 输出 `2026-08-19 15:42:03.485 ERROR studio.workers.tag_worker: job 999999 not found`；`import anima_train` 后 `training.loop` debug 在 env=DEBUG 时可见、默认 INFO 不可见
- 未跑全量 pytest（交 CI）

## 后续
刀 2 读取面（`/api/logs` 分页 + SSE seq 统一 + error_msg 取 ERROR 块）→ 刀 3 前端 LogView + 调试开关 → 刀 4 诊断包。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
