### PR TITLE
feat(logging): 刀 2 读取面——/api/logs 分页 + raw、SSE 统一 seq/end_offset、error_msg 取最后错误块

### DIFF
--- a/docs/design/logging-target-state.md
+++ b/docs/design/logging-target-state.md
@@ -1,6 +1,6 @@
 # 日志体系目标态：统一行契约 + 显示级过滤
 
-状态：四项关键决策已拍板（2026-08-19）；**刀 1 已实施**（分支 feat/logging-unify，见 ADR 0009 Addendum 1）。分刀见 §6。
+状态：四项关键决策已拍板（2026-08-19）；**刀 1 已合（#507）、刀 2 已实施**（分支 feat/logging-read-surface）。分刀见 §6。
 触发：issue #505 的切桶释放日志无处可去 → 全仓盘点发现 8 处 `logger.debug` 在任何配置下都不可见、run.log 是无级别的裸字节流、前端 6 套日志视图零级别解析。盘点原稿在 `tmp/logging-inventory.md`（本地）。
 上游：ADR 0009（logging/error system）定的 studio 侧骨架（`setup_logging` / JSON line / trace_id / 错误 envelope）不推翻，本文只补它没覆盖的子进程与显示面，并把跨进程的行契约定下来。
 
@@ -68,7 +68,7 @@ Traceback (most recent call last):
 - 训练 pipe 模式：`log_every` 进度行、`ctx.emit` 消息全部 `logger.info`；tty 模式不变（rich Progress / plain `\r`）。`ctx.emit` 的三路分流保留，只把最后的 `print` 分支换成 logger。
 - 裸 print 合法白名单：`__EVENT__:` 协议行（`snapshot.emit_event`、`preprocess_worker`）、daemon `_emit*` line-JSON、rich/plain tty 进度、`api/main.py` banner。其余 print → logger（runtime 35 处 / studio 41 处，清单见盘点稿 §1）。
 - 严重度只由级别表达：`[Debug]`（sampling.py 11 处）→ `logger.debug` 去前缀；`[WARN]` → `logger.warning`；`[OK]` print → `logger.info`。主题 tag（`[显存]` `[navit]` `[text-cache]` `[masked-loss]` …）保留；级别按事件本身定，tag 不携带级别语义。
-- `error_msg` 回写：从 run.log 尾部取**最后一个 ERROR 级记录块**（含续行），找不到再退回现在的 Traceback/末 12 行策略。
+- `error_msg` 回写：从 run.log 尾部（只读末 256KB）取**最后一个 ERROR/CRITICAL 记录块**（行头去前缀 + 续行）；块外更靠后的裸 `Traceback`（子进程未捕获异常）盖过它；都没有退回末 12 行。
 
 ### 3.3 显示面
 
@@ -96,13 +96,13 @@ Traceback (most recent call last):
 
 | 端点 / 事件 | 现状 | 目标 |
 |---|---|---|
-| `GET /api/logs/{task_id}` | 全文 `{content,size}` | `?tail=N`（默认 500 行）/ `?before=<offset>&limit=N`；返回 `{lines: [{offset,text}], start_offset, end_offset, size}`；服务端仍剥 `__EVENT__:` 行；不再一次性读整文件 |
+| `GET /api/logs/{task_id}` | 全文 `{content,size}` | `?tail=N`（默认 500 行）/ `?before=<offset>&limit=N`（往前翻）/ `?after=<offset>&limit=N`（断线补拉）；返回 `{lines: [{offset,text}], start_offset, end_offset, size, has_more_before}`，`offset` = 行起始字节、`end_offset` = 最后一行结束后的偏移（after 游标）；按字节切行再逐行 `clean_log_line`，与 LogTailer 同文本；末尾半行不返回；服务端仍剥 `__EVENT__:` 行；只按 64KB 块从尾部读 |
 | `GET /api/logs/{task_id}/raw` | 无 | 原始文件下载（诊断包 / 下载按钮用） |
-| SSE `task_log_appended` / `job_log_appended` | 两种形状（LogTailer 带 seq、daemon 回写不带） | 统一 `{type, task_id|job_id, seq, offset, text}`；daemon 回写路径补 seq/offset |
+| SSE `task_log_appended` / `job_log_appended` | 两种形状（LogTailer 带 seq、daemon 回写不带） | 统一 `{type, task_id|job_id, seq, end_offset, text}`（`end_offset` 与 API 的 after 游标同坐标系，LogTailer 改按字节切行计算）；daemon 回写路径补 seq/end_offset（`fp.tell()`） |
 | SSE `daemon_log_line` | `{ts, seq, line}` | 不变 |
 | `GET /api/generate/daemon/logs` | `since_seq` / `limit` | 不变（已是目标形状） |
-| `event_malformed` | task 路径 emit、job 路径不 emit、前端不消费 | job 路径补 emit；前端 LogView 收到后插一条 WARNING 伪记录「事件解析失败」 |
-| `_on_task_log` / `_on_line` | try 块包住 `_on_event` | 只包解析，广播移出 try |
+| `event_malformed` | task 路径 emit、job 路径不 emit、前端不消费 | job 路径补 emit（刀 2 已做）；前端 LogView 收到后插一条 WARNING 伪记录「事件解析失败」（刀 3） |
+| `_on_task_log` / `_on_line` | try 块包住 `_on_event` | 只包解析（`_parse_event_marker`），广播移出 try（刀 2 已做） |
 
 ### 3.5 CLI / 终端
 

--- a/studio/api/routers/logs.py
+++ b/studio/api/routers/logs.py
@@ -1,31 +1,56 @@
 """任务日志读取（PR-6 commit 1 从 server.py 抽出）。
 
-1 route：
-    GET /api/logs/{task_id}    读 tasks/<id>/run.log（老 task fallback
-                               LOGS_DIR/<id>.log），去掉 worker EVENT 行
+2 route（docs/design/logging-target-state.md §3.4）：
+    GET /api/logs/{task_id}        分页读 tasks/<id>/run.log（老 task fallback
+                                   LOGS_DIR/<id>.log），去掉 worker EVENT 行。
+                                   三种模式：tail=N（默认，末 N 行）/
+                                   before=<offset>&limit=N（往前翻）/
+                                   after=<offset>&limit=N（断线补拉）
+    GET /api/logs/{task_id}/raw    原始文件下载（诊断包 / 下载按钮）
+
+行 offset = 该行在文件里的起始字节偏移；page.end_offset = 最后一行结束后的偏移
+（= 断线补拉的 after 游标，与 SSE task_log_appended.end_offset 同一坐标系）。
+按**字节**切行、逐行 clean_log_line 解码，与 LogTailer 给 SSE 的文本一致。
+末尾没有换行的半行（子进程写到一半）不返回，游标停在它前面。
 """
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Query
+from fastapi.responses import FileResponse
 
+from ...domain.errors import NotFoundError, ValidationError
+from ...infrastructure.log_tail import clean_log_line
 from ...paths import LOGS_DIR, task_log_path
 
 router = APIRouter()
+
+_EVENT_PREFIX = b"__EVENT__:"
+_READ_CHUNK = 64 * 1024
+DEFAULT_TAIL_LINES = 500
+MAX_PAGE_LINES = 5000
+
+
+def _resolve_log_path(task_id: int) -> Path | None:
+    """新 task 走 tasks/<id>/run.log；老 task 在 studio_data/logs/<id>.log，
+    不写迁移脚本（DB 里也没记 log 路径，看哪个存在），按存在性 fallback。"""
+    p = task_log_path(task_id)
+    if p.exists():
+        return p
+    p = LOGS_DIR / f"{task_id}.log"
+    return p if p.exists() else None
 
 
 def read_task_log(task_id: int) -> str:
     """task 全量日志文本（剥掉 __EVENT__: 协议行）；不存在返回 ""。
 
-    新 task 走 tasks/<id>/run.log；老 task 在 studio_data/logs/<id>.log，
-    不写迁移脚本（DB 里也没记 log 路径，看哪个存在），按存在性 fallback。
-    其他 router（training.py 的 reg 先验回放端点）也复用这个 helper。
+    只给整段回放的老调用方（training.py 的 reg 先验回放端点）用；前端日志
+    视图走分页的 read_task_log_page。
     """
-    p = task_log_path(task_id)
-    if not p.exists():
-        p = LOGS_DIR / f"{task_id}.log"
-    if not p.exists():
+    p = _resolve_log_path(task_id)
+    if p is None:
         return ""
     raw = p.read_text(encoding="utf-8", errors="replace")
     return "".join(
@@ -34,7 +59,122 @@ def read_task_log(task_id: int) -> str:
     )
 
 
+def _empty_page(task_id: int) -> dict[str, Any]:
+    return {
+        "task_id": task_id, "lines": [], "start_offset": 0, "end_offset": 0,
+        "size": 0, "has_more_before": False,
+    }
+
+
+def _split_complete_lines(buf: bytes, base: int) -> tuple[list[tuple[int, bytes]], int]:
+    """buf 从文件偏移 base 起；返回 [(line_start_offset, line_bytes)] 与「完整行
+    结束后的偏移」。末尾无换行的半行不算。"""
+    out: list[tuple[int, bytes]] = []
+    pos = base
+    end = base
+    for part in buf.split(b"\n")[:-1]:  # 最后一段是半行（或空串），丢
+        out.append((pos, part))
+        pos += len(part) + 1
+        end = pos
+    return out, end
+
+
+def read_task_log_page(
+    task_id: int,
+    *,
+    tail: int | None = None,
+    before: int | None = None,
+    after: int | None = None,
+    limit: int = DEFAULT_TAIL_LINES,
+) -> dict[str, Any]:
+    """分页读 run.log。tail / before / after 三选一（都不给 = tail）。"""
+    p = _resolve_log_path(task_id)
+    if p is None:
+        return _empty_page(task_id)
+    limit = max(1, min(int(limit), MAX_PAGE_LINES))
+    size = p.stat().st_size
+
+    if after is not None:
+        # 断线补拉：从 after 往后最多 limit 行；半行不返回
+        start = max(0, min(int(after), size))
+        with open(p, "rb") as f:
+            f.seek(start)
+            buf = f.read()
+        raw_lines, end = _split_complete_lines(buf, start)
+        kept = [(off, b) for off, b in raw_lines if not b.startswith(_EVENT_PREFIX)]
+        if len(kept) > limit:
+            kept = kept[:limit]
+            last_off, last_b = kept[-1]
+            end = last_off + len(last_b) + 1  # 游标停在最后一条返回行之后
+        lines = [{"offset": off, "text": clean_log_line(b)} for off, b in kept]
+        return {
+            "task_id": task_id, "lines": lines,
+            "start_offset": start, "end_offset": end, "size": size,
+            "has_more_before": start > 0,
+        }
+
+    # tail / before：从 upper 往前按块读，直到凑够 limit 行（剥掉 EVENT 行后）或到文件头
+    upper = size if before is None else max(0, min(int(before), size))
+    lower = upper
+    collected: list[tuple[int, bytes]] = []
+    while lower > 0 and len(collected) < limit:
+        new_lower = max(0, lower - _READ_CHUNK)
+        with open(p, "rb") as f:
+            f.seek(new_lower)
+            buf = f.read(upper - new_lower)
+        # 窗口不从 0 起时第一段可能是半行：丢掉，它属于更早的一块（下一轮的
+        # upper 退到它的换行之后，届时它作为完整行被收进来）。整块没有换行
+        # （单行 > 64KB）时整块都是半行，upper 不动、只把 lower 再往前推。
+        parts = buf.split(b"\n")
+        if new_lower == 0:
+            first_partial = 0
+        elif len(parts) > 1:
+            first_partial = len(parts[0]) + 1
+        else:
+            first_partial = len(buf)
+        window_lines, _ = _split_complete_lines(buf[first_partial:], new_lower + first_partial)
+        # 窗口末尾落在文件末尾且最后一段无换行 → 半行已被 _split_complete_lines 丢掉
+        collected = [(o, b) for o, b in window_lines if not b.startswith(_EVENT_PREFIX)] + collected
+        lower = new_lower
+        upper = new_lower + first_partial
+    if len(collected) > limit:
+        collected = collected[-limit:]
+    lines = [{"offset": off, "text": clean_log_line(b)} for off, b in collected]
+    start_offset = collected[0][0] if collected else (size if before is None else upper)
+    if collected:
+        last_off, last_b = collected[-1]
+        end_offset = last_off + len(last_b) + 1
+    else:
+        end_offset = start_offset
+    return {
+        "task_id": task_id, "lines": lines,
+        "start_offset": start_offset, "end_offset": end_offset, "size": size,
+        "has_more_before": start_offset > 0,
+    }
+
+
 @router.get("/api/logs/{task_id}")
-def get_log(task_id: int) -> dict[str, Any]:
-    text = read_task_log(task_id)
-    return {"task_id": task_id, "content": text, "size": len(text.encode("utf-8"))}
+def get_log(
+    task_id: int,
+    tail: int | None = Query(None, ge=1),
+    before: int | None = Query(None, ge=0),
+    after: int | None = Query(None, ge=0),
+    limit: int | None = Query(None, ge=1),
+) -> dict[str, Any]:
+    if sum(x is not None for x in (tail, before, after)) > 1:
+        raise ValidationError(
+            "tail / before / after are mutually exclusive", code="log.query_conflict",
+        )
+    lim = limit if limit is not None else (tail if tail is not None else DEFAULT_TAIL_LINES)
+    return read_task_log_page(task_id, tail=tail, before=before, after=after, limit=lim)
+
+
+@router.get("/api/logs/{task_id}/raw")
+def get_log_raw(task_id: int) -> FileResponse:
+    p = _resolve_log_path(task_id)
+    if p is None:
+        raise NotFoundError("Log not found", code="log.not_found", details={"task_id": task_id})
+    return FileResponse(
+        path=str(p), media_type="text/plain; charset=utf-8",
+        filename=f"task-{task_id}.log",
+    )

--- a/studio/infrastructure/log_tail.py
+++ b/studio/infrastructure/log_tail.py
@@ -21,8 +21,20 @@ from typing import Any, Callable
 _ANSI_CSI_RE = re.compile(r"\x1b\[[\d;?]*[A-Za-z]")
 
 
+def clean_log_line(raw: bytes) -> str:
+    """一行 run.log 原始字节 → 干净文本：utf-8/replace 解码、剥 ANSI CSI 与 NUL、
+    去行尾 \\r。LogTailer（SSE 增量）与 /api/logs 分页读取共用，保证两条路
+    给前端的同一行文本一致。"""
+    text = raw.decode("utf-8", errors="replace")
+    return _ANSI_CSI_RE.sub("", text).replace("\x00", "").rstrip("\r")
+
+
 class LogTailer:
-    """轮询 log 文件，把新增字节按行送给 `on_line(line)`。
+    """轮询 log 文件，把新增字节按行送给 `on_line(line, end_offset)`。
+
+    `end_offset` = 该行结束（含换行符）后的文件字节偏移，是前端断线补拉的游标
+    （`GET /api/logs/{id}?after=<end_offset>`）。按**字节**切行再逐行解码，
+    偏移才与文件真实位置一致（docs/design/logging-target-state.md §3.4）。
 
     线程安全；start/stop 各调一次；不抛错（IO 失败静默重试）。
     """
@@ -30,7 +42,7 @@ class LogTailer:
     def __init__(
         self,
         path: Path,
-        on_line: Callable[[str], None],
+        on_line: Callable[[str, int], None],
         *,
         poll_interval: float = 0.3,
     ) -> None:
@@ -39,8 +51,8 @@ class LogTailer:
         self._poll = poll_interval
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
-        self._offset = 0
-        self._buffer = ""
+        self._offset = 0          # 已从文件读走的字节数
+        self._buffer = b""        # 末尾不完整的一行（无换行）
 
     def start(self) -> None:
         if self._thread:
@@ -55,12 +67,12 @@ class LogTailer:
         if self._thread:
             self._thread.join(timeout=timeout)
             self._thread = None
-        # 收尾：flush 残余 buffer 作为最后一行
+        # 收尾：flush 残余 buffer 作为最后一行（游标 = 已读到的文件末尾）
         if self._buffer.strip():
             try:
-                self._on_line(self._buffer.rstrip("\r\n"))
+                self._on_line(clean_log_line(self._buffer), self._offset)
             finally:
-                self._buffer = ""
+                self._buffer = b""
 
     def _run(self) -> None:
         while not self._stop.is_set():
@@ -85,15 +97,15 @@ class LogTailer:
             if not chunk:
                 return
             self._offset += len(chunk)
-        raw = chunk.decode("utf-8", errors="replace")
-        # 剥 ANSI CSI 转义 + NUL 字节（onnxruntime 等 C++ 库直写 fd 2 的副产物）
-        cleaned = _ANSI_CSI_RE.sub("", raw).replace("\x00", "")
-        text = self._buffer + cleaned
-        # 拆行；最后一段不完整就留在 buffer 里下次拼
-        lines = text.split("\n")
-        self._buffer = lines.pop()
-        for line in lines:
-            self._on_line(line.rstrip("\r"))
+        buf = self._buffer + chunk
+        # 按字节拆行；最后一段不完整就留在 buffer 里下次拼
+        parts = buf.split(b"\n")
+        self._buffer = parts.pop()
+        # 第一行的起点 = 已读末尾 - 残段 - 全部完整行（含各自换行符）
+        pos = self._offset - len(self._buffer) - sum(len(p) + 1 for p in parts)
+        for p in parts:
+            pos += len(p) + 1
+            self._on_line(clean_log_line(p), pos)
 
 
 class MonitorStatePoller:

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -22,6 +22,7 @@ builder / _maybe_finalize_version / _kill_process_tree）已搬到 sibling
 from __future__ import annotations
 
 import itertools
+import json
 import logging
 import os
 import signal
@@ -35,8 +36,8 @@ from .. import db, secrets as _secrets
 from ..services import eval_auto, eval_validation
 from ..services.runtime import xformers as _xformers_svc
 from ..services.projects import jobs as project_jobs
-from ..infrastructure.log_tail import LogTailer, MonitorStatePoller
-from ..infrastructure.logging import LOG_LEVEL_ENV
+from ..infrastructure.log_tail import LogTailer, MonitorStatePoller, clean_log_line
+from ..infrastructure.logging import LOG_LEVEL_ENV, LOG_LINE_RE
 from ..paths import (
     LOGS_DIR,
     REPO_ROOT,
@@ -72,27 +73,66 @@ from .slot import SLOT_DATA, SLOT_TRAIN, _Slot
 logger = logging.getLogger(__name__)
 
 
+_ERROR_MSG_TAIL_BYTES = 256 * 1024
+
+
+def _parse_event_marker(line: str) -> tuple[str, dict[str, Any]]:
+    """`__EVENT__:type:json` → (type, payload)；格式不对抛异常由 caller 处理。"""
+    rest = line[len(_EVENT_MARKER):]
+    evt_type, payload_str = rest.split(":", 1)
+    payload = json.loads(payload_str) if payload_str else {}
+    if not isinstance(payload, dict):
+        raise ValueError("event payload must be a JSON object")
+    return evt_type, payload
+
+
 def _tail_log_for_error_msg(log_path: Path, max_lines: int = 12, max_chars: int = 800) -> str:
-    """B-1.6: 失败 task 的 db.error_msg 从 "exit code 1" 升级为 traceback 摘要。
+    """失败 task 的 db.error_msg：从 run.log 尾部取「最后一个错误块」。
 
-    策略：读 jobs/<id>.log 末 N 行；找到最后一处 'Traceback' 截取那一段；
-    没有则取末 N 行。截断到 max_chars 适配 UI 显示宽度。
-
+    行契约（LOG_LINE_RE）落地后 run.log 每条记录有行头，续行（traceback）无前缀：
+      1. 找最后一条 ERROR/CRITICAL 记录（行头 + 其续行，去掉行头前缀）；
+      2. 找最后一个裸 `Traceback` 行（子进程未捕获异常直接打到 stderr，不经 logger）；
+      3. 两者取位置靠后的那个；都没有则退回末 N 行。
+    只读文件尾 256KB（长训练 run.log 上百 MB 不能整读）；截断到 max_chars 适配 UI。
     失败兜底返 ""（caller 用 "exit code N" 默认值）。
     """
     try:
         if not log_path.exists():
             return ""
-        text = log_path.read_text(encoding="utf-8", errors="replace")
-        lines = text.splitlines()
+        size = log_path.stat().st_size
+        with open(log_path, "rb") as f:
+            if size > _ERROR_MSG_TAIL_BYTES:
+                f.seek(size - _ERROR_MSG_TAIL_BYTES)
+                f.readline()  # 丢掉切在中间的半行
+            lines = [clean_log_line(b) for b in f.read().split(b"\n")]
+        while lines and not lines[-1].strip():
+            lines.pop()
         if not lines:
             return ""
-        tb_start = None
+        err_start = tb_start = None
         for i in range(len(lines) - 1, -1, -1):
-            if lines[i].startswith("Traceback"):
+            m = LOG_LINE_RE.match(lines[i])
+            if m and err_start is None and m["level"] in ("ERROR", "CRITICAL"):
+                err_start = i
+            if tb_start is None and lines[i].startswith("Traceback"):
                 tb_start = i
+            if err_start is not None and tb_start is not None:
                 break
-        snippet_lines = lines[tb_start:] if tb_start is not None else lines[-max_lines:]
+        err_end = None
+        if err_start is not None:
+            # 记录块 = 行头（去前缀只留 msg）+ 到下一条记录行头之前的续行
+            err_end = err_start + 1
+            while err_end < len(lines) and not LOG_LINE_RE.match(lines[err_end]):
+                err_end += 1
+        # 裸 Traceback 若落在 ERROR 记录块内（logger.exception 的续行）就属于该块，
+        # 不单拎；只有块外更靠后的裸 Traceback（子进程未捕获异常）才盖过记录块
+        if err_start is not None and (tb_start is None or tb_start < err_end):
+            head = LOG_LINE_RE.match(lines[err_start])
+            snippet_lines = [head["msg"] if head else lines[err_start], *lines[err_start + 1:err_end]]
+        elif tb_start is not None:
+            snippet_lines = lines[tb_start:]
+        else:
+            snippet_lines = lines[-max_lines:]
         out = "\n".join(snippet_lines).strip()
         if len(out) > max_chars:
             out = "..." + out[-(max_chars - 3):]
@@ -724,21 +764,18 @@ class Supervisor:
 
     def _make_task_log_callback(
         self, slot: _Slot, tid: int
-    ) -> Callable[[str], None]:
+    ) -> Callable[[str, int], None]:
         """LogTailer 回调：识别 __EVENT__: 协议 → 镜像状态到 slot + publish SSE；
-        普通行 → task_log_appended。
+        普通行 → task_log_appended（带 seq + end_offset，前端断线按 end_offset 补拉）。
 
         ADR 0006 PR-2：训练 worker 通过 __EVENT__: 协议跟 supervisor 通信
         （pause_state / train_loop_started / auto_epoch_backup_written /
         resume_state_loaded）。跟 jobs 的 _on_line 路径对齐。
         """
-        def _on_task_log(line: str) -> None:
+        def _on_task_log(line: str, end_offset: int) -> None:
             if line.startswith(_EVENT_MARKER):
                 try:
-                    rest = line[len(_EVENT_MARKER):]
-                    evt_type, payload_str = rest.split(":", 1)
-                    import json as _json
-                    payload = _json.loads(payload_str) if payload_str else {}
+                    evt_type, payload = _parse_event_marker(line)
                 except Exception:
                     # B-4.4: malformed event 静默丢导致 UI pause_state 永远收不到
                     # → 暂停按钮永远灰。logger.exception 进 studio.log；
@@ -788,6 +825,7 @@ class Supervisor:
                 "task_id": tid,
                 "text": line,
                 "seq": next(self._log_seq),
+                "end_offset": end_offset,
             })
         return _on_task_log
 
@@ -926,31 +964,40 @@ class Supervisor:
         pid_: Optional[int],
         vid: Optional[int],
         kind: str,
-    ) -> Callable[[str], None]:
+    ) -> Callable[[str, int], None]:
         """LogTailer 回调：识别 __EVENT__: 协议 publish typed SSE；普通行
-        → job_log_appended。
+        → job_log_appended（带 seq + end_offset）。
 
         结构化事件标记：worker 写 `__EVENT__:type:json_payload` 让 supervisor
         publish 成 typed SSE 事件（不进 job log）。比专门搭 IPC 通道轻，比
         让前端按文本 grep 日志靠谱。job_id / project_id 由 supervisor 注入。
         """
-        def _on_line(line: str) -> None:
+        def _on_line(line: str, end_offset: int) -> None:
             if line.startswith(_EVENT_MARKER):
+                # try 只包解析：广播自身抛错不能被误报成 malformed marker
                 try:
-                    rest = line[len(_EVENT_MARKER):]
-                    evt_type, payload_str = rest.split(":", 1)
-                    import json as _json
-                    payload = _json.loads(payload_str) if payload_str else {}
+                    evt_type, payload = _parse_event_marker(line)
+                except Exception:
+                    # 与 task 路径对齐（B-4.4 之前只落了一半）：进 studio.log +
+                    # SSE event_malformed 让前端可见
+                    logger.exception("malformed event marker: %r", line[:200])
                     self._on_event({
-                        "type": evt_type,
+                        "type": "event_malformed",
                         "job_id": jid,
                         "project_id": pid_,
                         "version_id": vid,
                         "kind": kind,
-                        **payload,
+                        "raw_preview": line[:200],
                     })
-                except Exception:
-                    logger.exception("malformed event marker: %r", line[:200])
+                    return
+                self._on_event({
+                    "type": evt_type,
+                    "job_id": jid,
+                    "project_id": pid_,
+                    "version_id": vid,
+                    "kind": kind,
+                    **payload,
+                })
                 return  # 不当成日志推
 
             self._on_event({
@@ -961,6 +1008,7 @@ class Supervisor:
                 "kind": kind,
                 "text": line,
                 "seq": next(self._log_seq),
+                "end_offset": end_offset,
             })
         return _on_line
 
@@ -1133,6 +1181,7 @@ class Supervisor:
             "seq": entry.get("seq"),
             "line": line,
         })
+        end_offset: int | None = None
         with self._daemon_lock:
             tid = self._daemon_active_task_id
             fp = self._daemon_log_fp
@@ -1140,12 +1189,20 @@ class Supervisor:
                 try:
                     fp.write((line + "\n").encode("utf-8", errors="replace"))
                     fp.flush()
+                    end_offset = fp.tell()
                 except Exception:
                     logger.exception("write daemon task log failed")
             else:
                 tid = None
         if tid is not None and isinstance(line, str):
-            self._on_event({"type": "task_log_appended", "task_id": tid, "text": line})
+            # 与 LogTailer 路径同形状（seq + end_offset），前端不用区分来源
+            self._on_event({
+                "type": "task_log_appended",
+                "task_id": tid,
+                "text": line,
+                "seq": next(self._log_seq),
+                "end_offset": end_offset,
+            })
 
     def _on_daemon_global_event(self, event: dict[str, Any]) -> None:
         """daemon 进程级事件（loaded / unloaded / stopped）。"""

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -1743,10 +1743,28 @@ export interface QueueHoldState {
   pending_waiting: number
 }
 
-export interface LogResponse {
+/** `GET /api/logs/{id}` 分页响应（docs/design/logging-target-state.md §3.4）。
+ *  `lines[].offset` = 该行起始字节；`end_offset` = 最后一行结束后的偏移，既是
+ *  「往后补拉」的 after 游标，也与 SSE task_log_appended.end_offset 同坐标系；
+ *  `start_offset` 给「加载更早」当 before。末尾半行不返回。 */
+export interface LogPage {
   task_id: number
-  content: string
+  lines: { offset: number; text: string }[]
+  start_offset: number
+  end_offset: number
   size: number
+  has_more_before: boolean
+}
+
+/** 分页查询参数：tail / before / after 三选一（都不给 = tail，服务端默认 500 行）。 */
+export type LogPageQuery =
+  | { tail?: number }
+  | { before: number; limit?: number }
+  | { after: number; limit?: number }
+
+/** 把一页日志拼回文本（刀 3 LogView 上线前的过渡：现有视图仍按字符串渲染）。 */
+export function logPageText(page: LogPage): string {
+  return page.lines.length ? page.lines.map((l) => l.text).join('\n') + '\n' : ''
 }
 
 /** /api/state — per-task monitor state written by the training process */
@@ -3180,7 +3198,13 @@ export const api = {
       method: 'POST',
       body: JSON.stringify({ ordered_ids: orderedIds }),
     }),
-  getLog: (id: number) => req<LogResponse>(`/api/logs/${id}`),
+  getLog: (id: number, q: LogPageQuery = {}) => {
+    const qs = new URLSearchParams()
+    for (const [k, v] of Object.entries(q)) if (v != null) qs.set(k, String(v))
+    const s = qs.toString()
+    return req<LogPage>(`/api/logs/${id}${s ? `?${s}` : ''}`)
+  },
+  logRawUrl: (id: number) => `/api/logs/${id}/raw`,
   /** 默认拉全量历史（max_points=0，server 跳过降采样）；想要降采样预览
    *  传具体数字。cold start 是一次性 HTTP，长训练（10k+ 步）下也只是 ~500KB
    *  payload，不值得为视觉损耗换网络节省。 */

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -2769,6 +2769,10 @@
       "invalid": "Invalid snapshot id",
       "id_collision": "Could not allocate a snapshot id; please retry"
     },
+    "log": {
+      "not_found": "Log file not found",
+      "query_conflict": "tail / before / after are mutually exclusive"
+    },
     "task": {
       "not_found": "Task not found",
       "already_finished": "This task has already finished",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -2769,6 +2769,10 @@
       "invalid": "快照标识无效",
       "id_collision": "无法分配快照编号，请重试"
     },
+    "log": {
+      "not_found": "日志文件不存在",
+      "query_conflict": "tail / before / after 只能指定一个"
+    },
     "task": {
       "not_found": "任务不存在",
       "already_finished": "该任务已结束",

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { Link, useLocation, useNavigate, useParams } from 'react-router-dom'
 import {
   api,
+  logPageText,
   type EvalSessionSummary,
   type Task,
   type TaskOutputs,
@@ -666,7 +667,7 @@ function LogTab({ taskId }: { taskId: number }) {
   const setBoth = useCallback((s: string) => { contentRef.current = s; setContent(s) }, [])
 
   const refresh = useCallback(async () => {
-    try { const log = await api.getLog(taskId); setBoth(log.content); setError(null) }
+    try { const log = await api.getLog(taskId, { tail: 2000 }); setBoth(logPageText(log)); setError(null) }
     catch (e) { setError(String(e)) }
   }, [taskId, setBoth])
 
@@ -744,8 +745,8 @@ function useEvalLogSource(
       const latest = sessions[0] ?? null
       setSession(latest)
       if (!latest?.task_id) { setBaseLines([]); return }
-      const log = await api.getLog(latest.task_id)
-      setBaseLines((log.content || '').split('\n'))
+      const log = await api.getLog(latest.task_id, { tail: 1000 })
+      setBaseLines(log.lines.map((l) => l.text))
       setLiveLines([])  // 已并进 base，避免与 SSE 追加的重复
     } catch {
       // 辅助信息，拉失败不打扰

--- a/studio/web/src/pages/project/EvalJobsPanel.tsx
+++ b/studio/web/src/pages/project/EvalJobsPanel.tsx
@@ -36,8 +36,8 @@ function useRunningEvalLog(sessions: EvalSessionSummary[]): LogSource | null {
   useEffect(() => {
     if (!taskId) { setBaseLines([]); setLiveLines([]); return }
     let alive = true
-    void api.getLog(taskId)
-      .then((log) => { if (alive) { setBaseLines((log.content || '').split('\n')); setLiveLines([]) } })
+    void api.getLog(taskId, { tail: 1000 })
+      .then((log) => { if (alive) { setBaseLines(log.lines.map((l) => l.text)); setLiveLines([]) } })
       .catch(() => {})
     return () => { alive = false }
   }, [taskId])

--- a/tests/_snapshots/studio_routes.json
+++ b/tests/_snapshots/studio_routes.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "generated_from": "studio.server.app",
-  "count": 206,
+  "count": 207,
   "routes": [
     {
       "path": "/",
@@ -263,6 +263,14 @@
         "GET"
       ],
       "name": "get_log",
+      "type": "APIRoute"
+    },
+    {
+      "path": "/api/logs/{task_id}/raw",
+      "methods": [
+        "GET"
+      ],
+      "name": "get_log_raw",
       "type": "APIRoute"
     },
     {

--- a/tests/test_download_endpoints.py
+++ b/tests/test_download_endpoints.py
@@ -206,7 +206,7 @@ def test_get_job_log_via_task_logs(client: TestClient, isolated, monkeypatch) ->
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("a\nb\nc\nd\n", encoding="utf-8")
     r = client.get(f"/api/logs/{job['id']}").json()
-    assert r["content"].splitlines() == ["a", "b", "c", "d"]
+    assert [l["text"] for l in r["lines"]] == ["a", "b", "c", "d"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_error_response_baseline.py
+++ b/tests/test_error_response_baseline.py
@@ -75,7 +75,7 @@ def test_unknown_task_log_returns_empty_not_error(client: TestClient) -> None:
     resp = client.get("/api/logs/999999")
     assert resp.status_code == 200, f"unknown task log expected 200 empty, got {resp.status_code}"
     body = resp.json()
-    assert body == {"task_id": 999999, "content": "", "size": 0}
+    assert body["task_id"] == 999999 and body["lines"] == [] and body["size"] == 0
 
 
 def test_validation_error_returns_422_with_detail(client: TestClient) -> None:

--- a/tests/test_log_tail.py
+++ b/tests/test_log_tail.py
@@ -18,7 +18,7 @@ def test_tailer_picks_up_appended_lines(tmp_path: Path) -> None:
     log = tmp_path / "x.log"
     log.touch()
     received: list[str] = []
-    tailer = LogTailer(log, received.append, poll_interval=0.05)
+    tailer = LogTailer(log, lambda line, _off: received.append(line), poll_interval=0.05)
     tailer.start()
     try:
         with open(log, "a", encoding="utf-8") as f:
@@ -37,7 +37,7 @@ def test_tailer_handles_missing_file(tmp_path: Path) -> None:
     """文件还没出现时不应抛错；出现后正常 tail。"""
     log = tmp_path / "later.log"
     received: list[str] = []
-    tailer = LogTailer(log, received.append, poll_interval=0.05)
+    tailer = LogTailer(log, lambda line, _off: received.append(line), poll_interval=0.05)
     tailer.start()
     try:
         time.sleep(0.1)  # 文件不存在的轮询周期
@@ -53,7 +53,7 @@ def test_tailer_flushes_partial_line_on_stop(tmp_path: Path) -> None:
     log = tmp_path / "p.log"
     log.write_text("abc", encoding="utf-8")
     received: list[str] = []
-    tailer = LogTailer(log, received.append, poll_interval=0.05)
+    tailer = LogTailer(log, lambda line, _off: received.append(line), poll_interval=0.05)
     tailer.start()
     time.sleep(0.1)
     tailer.stop()
@@ -198,7 +198,7 @@ def test_tailer_strips_ansi_and_nul(tmp_path: Path) -> None:
     )
     log.write_bytes(raw)
     received: list[str] = []
-    tailer = LogTailer(log, received.append, poll_interval=0.05)
+    tailer = LogTailer(log, lambda line, _off: received.append(line), poll_interval=0.05)
     tailer.start()
     _wait_lines(received, 2)
     tailer.stop()

--- a/tests/test_logs_paging.py
+++ b/tests/test_logs_paging.py
@@ -1,0 +1,167 @@
+"""`GET /api/logs/{task_id}` 分页读取（docs/design/logging-target-state.md §3.4）。
+
+覆盖：tail 默认 / tail 跨块 / before 往前翻 / after 断线补拉 / EVENT 行剥离 /
+末尾半行不返回 / 单行超块 / offset 与 SSE（LogTailer）同坐标系 / raw 下载 /
+tail·before·after 互斥。
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from studio.api.routers import logs as logs_mod
+from studio.infrastructure.log_tail import LogTailer
+
+
+@pytest.fixture
+def log_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    from studio.infrastructure import paths as _paths
+    monkeypatch.setattr(_paths, "TASKS_DIR", tmp_path / "tasks")
+    monkeypatch.setattr(logs_mod, "LOGS_DIR", tmp_path / "legacy")
+    p = _paths.task_log_path(7)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _write_lines(p: Path, n: int, *, trailing_newline: bool = True, width: int = 0) -> list[bytes]:
+    lines = [f"line-{i:05d}".encode() + (b"x" * width) for i in range(n)]
+    data = b"\n".join(lines) + (b"\n" if trailing_newline else b"")
+    p.write_bytes(data)
+    return lines
+
+
+def test_missing_returns_empty_page() -> None:
+    page = logs_mod.read_task_log_page(999)
+    assert page["lines"] == [] and page["size"] == 0 and page["has_more_before"] is False
+
+
+def test_tail_default_and_offsets(log_file: Path) -> None:
+    lines = _write_lines(log_file, 10)
+    page = logs_mod.read_task_log_page(7, tail=3, limit=3)
+    assert [l["text"] for l in page["lines"]] == ["line-00007", "line-00008", "line-00009"]
+    # offset = 行起始字节；end_offset = 文件末尾（最后一行含换行）
+    assert page["lines"][0]["offset"] == sum(len(x) + 1 for x in lines[:7])
+    assert page["end_offset"] == log_file.stat().st_size == page["size"]
+    assert page["has_more_before"] is True
+
+
+def test_tail_more_than_file_returns_all(log_file: Path) -> None:
+    _write_lines(log_file, 4)
+    page = logs_mod.read_task_log_page(7, limit=500)
+    assert len(page["lines"]) == 4
+    assert page["start_offset"] == 0 and page["has_more_before"] is False
+
+
+def test_tail_spans_multiple_read_chunks(log_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(logs_mod, "_READ_CHUNK", 64)  # 每块只装几行，逼出跨块拼接
+    lines = _write_lines(log_file, 200)
+    page = logs_mod.read_task_log_page(7, limit=50)
+    assert [l["text"].encode() for l in page["lines"]] == lines[-50:]
+    assert page["lines"][0]["offset"] == sum(len(x) + 1 for x in lines[:150])
+
+
+def test_before_pages_backwards_without_overlap(log_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(logs_mod, "_READ_CHUNK", 64)
+    lines = _write_lines(log_file, 30)
+    p1 = logs_mod.read_task_log_page(7, limit=10)
+    p2 = logs_mod.read_task_log_page(7, before=p1["start_offset"], limit=10)
+    p3 = logs_mod.read_task_log_page(7, before=p2["start_offset"], limit=10)
+    p4 = logs_mod.read_task_log_page(7, before=p3["start_offset"], limit=10)
+    got = [l["text"].encode() for l in p3["lines"] + p2["lines"] + p1["lines"]]
+    assert got == lines
+    assert p3["has_more_before"] is False and p4["lines"] == []
+
+
+def test_after_returns_new_lines_and_cursor(log_file: Path) -> None:
+    lines = _write_lines(log_file, 5)
+    page = logs_mod.read_task_log_page(7, limit=500)
+    cursor = page["end_offset"]
+    with open(log_file, "ab") as f:
+        f.write(b"new-a\nnew-b\npartial")
+    more = logs_mod.read_task_log_page(7, after=cursor, limit=500)
+    assert [l["text"] for l in more["lines"]] == ["new-a", "new-b"]
+    # 半行不返回，游标停在它前面
+    assert more["end_offset"] == cursor + len(b"new-a\nnew-b\n")
+    assert more["lines"][0]["offset"] == sum(len(x) + 1 for x in lines)
+    # 半行补齐换行后再拉，只拿到它
+    with open(log_file, "ab") as f:
+        f.write(b"-done\n")
+    rest = logs_mod.read_task_log_page(7, after=more["end_offset"], limit=500)
+    assert [l["text"] for l in rest["lines"]] == ["partial-done"]
+
+
+def test_after_limit_cuts_and_cursor_precise(log_file: Path) -> None:
+    lines = _write_lines(log_file, 10)
+    page = logs_mod.read_task_log_page(7, after=0, limit=3)
+    assert [l["text"].encode() for l in page["lines"]] == lines[:3]
+    assert page["end_offset"] == sum(len(x) + 1 for x in lines[:3])
+    nxt = logs_mod.read_task_log_page(7, after=page["end_offset"], limit=3)
+    assert [l["text"].encode() for l in nxt["lines"]] == lines[3:6]
+
+
+def test_event_lines_stripped_in_all_modes(log_file: Path) -> None:
+    log_file.write_bytes(
+        b"a\n__EVENT__:progress:{\"step\":1}\nb\n__EVENT__:pause_state:{}\nc\n"
+    )
+    tail = logs_mod.read_task_log_page(7, limit=500)
+    assert [l["text"] for l in tail["lines"]] == ["a", "b", "c"]
+    after = logs_mod.read_task_log_page(7, after=0, limit=500)
+    assert [l["text"] for l in after["lines"]] == ["a", "b", "c"]
+    # 剥掉 EVENT 行后仍凑满 limit（不是先截 limit 再剥）
+    two = logs_mod.read_task_log_page(7, limit=2)
+    assert [l["text"] for l in two["lines"]] == ["b", "c"]
+
+
+def test_trailing_partial_line_excluded_from_tail(log_file: Path) -> None:
+    _write_lines(log_file, 3, trailing_newline=False)
+    page = logs_mod.read_task_log_page(7, limit=500)
+    assert [l["text"] for l in page["lines"]] == ["line-00000", "line-00001"]
+    assert page["end_offset"] == len(b"line-00000\nline-00001\n")
+
+
+def test_single_line_larger_than_chunk(log_file: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(logs_mod, "_READ_CHUNK", 64)
+    lines = _write_lines(log_file, 3, width=300)
+    page = logs_mod.read_task_log_page(7, limit=2)
+    assert [l["text"].encode() for l in page["lines"]] == lines[-2:]
+    assert page["lines"][0]["offset"] == len(lines[0]) + 1
+
+
+def test_offsets_match_log_tailer_cursor(log_file: Path) -> None:
+    """SSE 的 end_offset 与 API 的 after 游标是同一坐标系：tailer 推到哪，after 就从哪续。"""
+    _write_lines(log_file, 5)
+    seen: list[tuple[str, int]] = []
+    tailer = LogTailer(log_file, lambda line, off: seen.append((line, off)), poll_interval=0.01)
+    tailer._read_chunk()
+    assert [t for t, _ in seen] == [f"line-{i:05d}" for i in range(5)]
+    last_end = seen[-1][1]
+    assert last_end == log_file.stat().st_size
+    with open(log_file, "ab") as f:
+        f.write(b"tail-1\n")
+    page = logs_mod.read_task_log_page(7, after=last_end, limit=500)
+    assert [l["text"] for l in page["lines"]] == ["tail-1"]
+
+
+def test_query_modes_are_mutually_exclusive(log_file: Path) -> None:
+    from fastapi.testclient import TestClient
+    from studio import server
+    client = TestClient(server.app)
+    _write_lines(log_file, 2)
+    r = client.get("/api/logs/7?tail=1&after=0")
+    assert r.status_code == 422
+    assert r.json()["error"]["code"] == "log.query_conflict"
+
+
+def test_raw_download_and_404(log_file: Path) -> None:
+    from fastapi.testclient import TestClient
+    from studio import server
+    client = TestClient(server.app)
+    _write_lines(log_file, 2)
+    r = client.get("/api/logs/7/raw")
+    assert r.status_code == 200
+    assert r.content == log_file.read_bytes()
+    assert "task-7.log" in r.headers.get("content-disposition", "")
+    r404 = client.get("/api/logs/8/raw")
+    assert r404.status_code == 404
+    assert r404.json()["error"]["code"] == "log.not_found"

--- a/tests/test_studio_queue_endpoints.py
+++ b/tests/test_studio_queue_endpoints.py
@@ -722,7 +722,7 @@ def test_status_filter_accepts_scheduled(client: TestClient) -> None:
 def test_logs_missing_returns_empty(client: TestClient) -> None:
     resp = client.get("/api/logs/9999")
     assert resp.status_code == 200
-    assert resp.json()["content"] == ""
+    assert resp.json()["lines"] == []
 
 
 def test_logs_returns_content(client: TestClient, isolated: Path) -> None:
@@ -730,4 +730,4 @@ def test_logs_returns_content(client: TestClient, isolated: Path) -> None:
     log_path.write_text("hello world\n", encoding="utf-8")
     resp = client.get("/api/logs/42")
     assert resp.status_code == 200
-    assert resp.json()["content"] == "hello world\n"
+    assert [l["text"] for l in resp.json()["lines"]] == ["hello world"]

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -547,3 +547,22 @@ def test_daemon_log_line_no_active_task_no_appended(env) -> None:
     sup._on_daemon_log_line({"line": "idle noise", "ts": 1, "seq": 1})
     assert not any(e.get("type") == "task_log_appended" for e in events)
     assert any(e.get("type") == "daemon_log_line" for e in events)
+
+
+def test_daemon_log_line_appended_has_seq_and_end_offset(env) -> None:
+    """daemon 回写路径与 LogTailer 路径同形状：seq + end_offset（= 写入后文件位置）。"""
+    events, on_event = _events_collector()
+    sup = _make_sup(env, on_event)
+    tid = 778
+    lp = env["tasks"] / str(tid) / "run.log"
+    lp.parent.mkdir(parents=True, exist_ok=True)
+    sup._daemon_active_task_id = tid
+    sup._daemon_log_fp = open(lp, "ab")
+    try:
+        sup._on_daemon_log_line({"line": "ab", "ts": 1, "seq": 1})
+        sup._on_daemon_log_line({"line": "cde", "ts": 2, "seq": 2})
+    finally:
+        sup._daemon_log_fp.close()
+    appended = [e for e in events if e.get("type") == "task_log_appended"]
+    assert [e["end_offset"] for e in appended] == [3, 7]
+    assert appended[0]["seq"] < appended[1]["seq"]

--- a/tests/test_supervisor_error_msg.py
+++ b/tests/test_supervisor_error_msg.py
@@ -101,7 +101,7 @@ def test_malformed_event_publishes_sse_event_malformed(
 
     callback = sup._make_task_log_callback(slot, 42)
     # 喂一行 malformed event（payload 不是合法 JSON）
-    callback('__EVENT__:pause_state:{not json}')
+    callback('__EVENT__:pause_state:{not json}', 0)
 
     malformed = [e for e in events if e["type"] == "event_malformed"]
     assert malformed, f"应 publish event_malformed；实际 events: {events}"
@@ -124,7 +124,111 @@ def test_well_formed_event_does_not_publish_event_malformed(
     slot.pause_state_path = None
 
     callback = sup._make_task_log_callback(slot, 7)
-    callback('__EVENT__:pause_state:{"state_path": "/x.bin", "step": 100}')
+    callback('__EVENT__:pause_state:{"state_path": "/x.bin", "step": 100}', 0)
 
     malformed = [e for e in events if e["type"] == "event_malformed"]
     assert not malformed
+
+
+# ── 日志目标态刀 2：error_msg 取最后一个错误块；SSE 形状统一 ────────────────
+
+
+_H = "2026-08-19 15:00:00.000 "
+
+
+def test_tail_log_prefers_last_error_record_block(tmp_path: Path) -> None:
+    """行契约落地后：最后一条 ERROR 记录（行头去前缀 + 续行）优先于末 N 行。"""
+    from studio.supervisor.core import _tail_log_for_error_msg
+    log = tmp_path / "run.log"
+    log.write_text(
+        _H + "INFO  training.loop: step=1\n"
+        + _H + "ERROR training.bootstrap: 配置校验失败（2 处）:\n"
+        + "  epochs: must be > 0\n"
+        + "  lr: must be > 0\n"
+        + _H + "INFO  training.loop: bye\n",
+        encoding="utf-8",
+    )
+    out = _tail_log_for_error_msg(log)
+    assert out.splitlines() == [
+        "配置校验失败（2 处）:", "  epochs: must be > 0", "  lr: must be > 0",
+    ]
+
+
+def test_tail_log_error_record_with_traceback_continuation(tmp_path: Path) -> None:
+    """logger.exception 的 traceback 是该记录的续行，整块进 error_msg。"""
+    from studio.supervisor.core import _tail_log_for_error_msg
+    log = tmp_path / "run.log"
+    log.write_text(
+        _H + "ERROR studio.workers.tag_worker: job crashed\n"
+        + "Traceback (most recent call last):\n"
+        + '  File "x.py", line 1\n'
+        + "RuntimeError: boom\n",
+        encoding="utf-8",
+    )
+    out = _tail_log_for_error_msg(log)
+    assert out.startswith("job crashed\nTraceback")
+    assert out.endswith("RuntimeError: boom")
+
+
+def test_tail_log_raw_traceback_after_error_record_wins(tmp_path: Path) -> None:
+    """早先一条可恢复的 ERROR 记录，之后子进程裸崩（traceback 不经 logger）：取后者。"""
+    from studio.supervisor.core import _tail_log_for_error_msg
+    log = tmp_path / "run.log"
+    log.write_text(
+        _H + "ERROR training.loop: recoverable thing\n"
+        + _H + "INFO  training.loop: continuing\n"
+        + "Traceback (most recent call last):\n"
+        + "ValueError: real crash\n",
+        encoding="utf-8",
+    )
+    out = _tail_log_for_error_msg(log)
+    assert out.startswith("Traceback") and out.endswith("ValueError: real crash")
+
+
+def test_tail_log_reads_only_file_tail(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """上百 MB 的 run.log 不整读：只看尾部窗口。"""
+    from studio.supervisor import core as core_mod
+    monkeypatch.setattr(core_mod, "_ERROR_MSG_TAIL_BYTES", 128)
+    log = tmp_path / "run.log"
+    body = (_H + "ERROR training.loop: too-old-to-see\n") + ("x" * 500 + "\n") + (_H + "ERROR training.loop: recent\n")
+    log.write_text(body, encoding="utf-8")
+    assert core_mod._tail_log_for_error_msg(log) == "recent"
+
+
+def test_task_and_job_log_events_carry_seq_and_end_offset(tmp_path: Path) -> None:
+    from unittest.mock import MagicMock
+
+    from studio.supervisor.core import Supervisor
+    events: list = []
+    sup = Supervisor(on_event=events.append, db_path=tmp_path / "studio.db")
+    sup._make_task_log_callback(MagicMock(), 1)("hello", 123)
+    sup._make_job_log_callback(2, 3, None, "tag")("world", 456)
+    t = next(e for e in events if e["type"] == "task_log_appended")
+    j = next(e for e in events if e["type"] == "job_log_appended")
+    assert t["end_offset"] == 123 and isinstance(t["seq"], int)
+    assert j["end_offset"] == 456 and isinstance(j["seq"], int)
+    assert t["seq"] < j["seq"]
+
+
+def test_job_malformed_event_publishes_event_malformed(tmp_path: Path) -> None:
+    """job 路径之前只 logger.exception 不 emit；现与 task 路径对齐。"""
+    from studio.supervisor.core import Supervisor
+    events: list = []
+    sup = Supervisor(on_event=events.append, db_path=tmp_path / "studio.db")
+    sup._make_job_log_callback(9, 1, None, "download")("__EVENT__:progress:{nope", 0)
+    m = [e for e in events if e["type"] == "event_malformed"]
+    assert m and m[0]["job_id"] == 9 and "progress" in m[0]["raw_preview"]
+    assert not [e for e in events if e["type"] == "job_log_appended"]
+
+
+def test_event_broadcast_error_is_not_reported_as_malformed(tmp_path: Path) -> None:
+    """广播自身抛错不能被误报成 malformed marker（try 只包解析）。"""
+    from studio.supervisor.core import Supervisor
+
+    def boom(evt):
+        if evt["type"] == "progress":
+            raise RuntimeError("sse down")
+
+    sup = Supervisor(on_event=boom, db_path=tmp_path / "studio.db")
+    with pytest.raises(RuntimeError, match="sse down"):
+        sup._make_job_log_callback(9, 1, None, "download")('__EVENT__:progress:{"a":1}', 0)

--- a/tests/test_terminal_resume.py
+++ b/tests/test_terminal_resume.py
@@ -123,7 +123,7 @@ def test_auto_epoch_backup_event_persists_to_db(env) -> None:
         "epoch": 3,
         "step": 300,
     }
-    cb(f"__EVENT__:auto_epoch_backup_written:{json.dumps(payload)}")
+    cb(f"__EVENT__:auto_epoch_backup_written:{json.dumps(payload)}", 0)
 
     # slot 内存态照旧（is_pausable 信号依赖）
     assert slot.last_auto_epoch_state_path == payload["state_path"]
@@ -148,7 +148,7 @@ def test_auto_epoch_backup_event_overwrites_previous(env) -> None:
             "config_path": "/s/auto_epoch_state.config.json",
             "epoch": epoch,
             "step": epoch * 100,
-        }))
+        }), 0)
     task = _get_task(env, tid)
     assert task["last_state_epoch"] == 2
     assert task["last_state_step"] == 200

--- a/tests/test_worker_event_baseline.py
+++ b/tests/test_worker_event_baseline.py
@@ -60,7 +60,7 @@ def test_logs_router_filters_event_lines(tmp_path: Path,
     resp = client.get("/api/logs/42")
     assert resp.status_code == 200
     body = resp.json()
-    content = body["content"]
+    content = "\n".join(l["text"] for l in body["lines"])
     assert "[start] tagging 100 images" in content
     assert "tagged 50/100" in content
     assert "[done] tagged 100 images" in content
@@ -85,7 +85,7 @@ def test_logs_router_prefers_task_scoped_path(tmp_path: Path,
     db.init_db(tmp_path / "studio.db")
     client = TestClient(server.app)
     body = client.get("/api/logs/99").json()
-    assert body["content"] == "NEW\n"
+    assert [l["text"] for l in body["lines"]] == ["NEW"]
 
 
 def test_logs_router_falls_back_to_legacy_logs_dir(tmp_path: Path,
@@ -102,7 +102,7 @@ def test_logs_router_falls_back_to_legacy_logs_dir(tmp_path: Path,
     db.init_db(tmp_path / "studio.db")
     client = TestClient(server.app)
     body = client.get("/api/logs/55").json()
-    assert body["content"] == "OLD_ONLY\n"
+    assert [l["text"] for l in body["lines"]] == ["OLD_ONLY"]
 
 
 def test_event_marker_unused_task_returns_empty_not_error(tmp_path: Path,
@@ -117,4 +117,5 @@ def test_event_marker_unused_task_returns_empty_not_error(tmp_path: Path,
 
     resp = client.get("/api/logs/9999")
     assert resp.status_code == 200
-    assert resp.json() == {"task_id": 9999, "content": "", "size": 0}
+    body = resp.json()
+    assert body["task_id"] == 9999 and body["lines"] == [] and body["size"] == 0


### PR DESCRIPTION
日志体系四刀之二（设计稿 `docs/design/logging-target-state.md` §3.4；刀 1 = #507）。后端读取契约立起来，给刀 3 的 LogView 用；前端只做最小适配（三个 `getLog` 消费点改拉 tail），UI 不变。

## 改动

**`GET /api/logs/{task_id}`**（`studio/api/routers/logs.py`）
- `?tail=N`（默认 500）/ `?before=<offset>&limit=N`（往前翻）/ `?after=<offset>&limit=N`（断线补拉）三选一（冲突 → 422 `log.query_conflict`）
- 返回 `{lines:[{offset,text}], start_offset, end_offset, size, has_more_before}`：`offset` = 行起始字节，`end_offset` = 最后一行结束后的偏移（after 游标），`start_offset` 给 before
- 按**字节**切行、逐行 `clean_log_line`（与 LogTailer 共用，SSE/API 同文本）；只按 64KB 块从尾部读，不再整文件进内存；末尾半行不返回；仍剥 `__EVENT__:`
- `GET /api/logs/{task_id}/raw` 原始下载（404 → `log.not_found`）；`read_task_log` 全文 helper 保留给 reg 先验回放端点

**SSE**（`supervisor/core.py` + `infrastructure/log_tail.py`）
- LogTailer 改按字节切行，回调 `(line, end_offset)`
- `task_log_appended` / `job_log_appended` 三条路径（LogTailer task / job / daemon 回写）统一带 `seq` + `end_offset`（daemon 回写用 `fp.tell()`），与 API 的 after 游标同坐标系
- job 路径 malformed marker 补 emit `event_malformed`（之前只 task 路径有）；两处解析 try 只包 `_parse_event_marker`，广播移出 try（广播抛错不再误报 malformed）

**`error_msg`**（`_tail_log_for_error_msg`）
- 只读尾 256KB；取最后一条 ERROR/CRITICAL 记录块（行头去前缀 + 续行，含 `logger.exception` 的 traceback）；块外更靠后的裸 `Traceback`（子进程未捕获异常）盖过它；都没有退回末 N 行（老格式日志行为不变）

**前端最小适配**
- `LogResponse` → `LogPage`；`getLog(id, {tail|before|after})`；`logRawUrl`；`logPageText()` 过渡 helper
- QueueDetail LogTab 拉 `tail=2000`、`useEvalLogSource` / EvalJobsPanel 拉 `tail=1000`（TaskLogDrawer 本就 slice 1000）；`errors.log.*` i18n；route snapshot 重建

## 验证
- 新增 `tests/test_logs_paging.py` 13 条（tail 跨块 / before 无重叠 / after 游标精确 / EVENT 剥离后仍凑满 limit / 半行 / 单行超块 / 与 LogTailer 游标同坐标系 / 互斥 / raw）+ error_msg/SSE 形状 8 条；既有端点测试改到新形状；关联 pytest 208 绿
- 真实 388KB run.log（task 1848）smoke：tail/before/after 游标首尾相接、全量 4674 行、raw 下载 OK；老格式日志 error_msg 走回退分支
- `tsc` / vitest（QueueDetail、project）/ `npm run build` 通过
- 本机 8765 跑的是旧实例没重启，未做浏览器验证；端点行为由 TestClient 覆盖

## 中间态
LogTab 现在默认只显示末 2000 行（之前全量）；刀 3 的 LogView 补「加载更早」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
