### PR TITLE
fix(block-swap): 换出层权重打包进 2 的幂 pinned 大块，消掉 host allocator 取整的 1.47× 白锁

### DIFF
--- a/docs/design/block-swap.md
+++ b/docs/design/block-swap.md
@@ -703,3 +703,52 @@ checkpoint 时它是唯一的换回时机。
 2. **非确定性环境里要先测噪声底再做判据**。第一次排查时我直接拿「梯度不逐位相等」
    当证据，其实无 swap 跑两遍也不相等 —— 缺对照组的测量会同时制造假阳性（当时）
    和假阴性（原单测）。判据应是「与对照组自身重复性同量级」。
+
+### 9.12 pinned 实际锁定 = 权重 × 1.47（5080 / 32GB 内存真机撞死，已修）
+
+**现象**：16GB 卡 + 32GB 内存的机器开 `blocks_to_swap=28`，`load_krea2_model` 在
+`tensor.pin_memory()` 处抛 `CUDA error: out of memory` —— 此时 DiT 一层都还没上卡，
+这不是显存 OOM，是 `cudaHostAlloc`（主机页锁定内存）失败。
+
+**两个叠加因素**：
+
+1. **Windows WDDM 对 `cudaHostAlloc` 有硬上限 ≈ 物理内存的 50%**，由 Windows 管理、
+   驱动改不了，与分配块大小无关（NVIDIA 论坛多贴确认）。`check_pinned_budget` 只按
+   可用内存比例算，没建模这条线。
+2. **PyTorch host caching allocator 把每次 pinned 分配向上取整到 2 的幂**
+   （`CachingHostAllocator.h` `PowerOf2Ceil`），而 loader 逐张量 `pin_memory()`。
+   krea2 的尺寸恰恰都很吃亏：
+
+   | 张量 | 实际 | 锁定 |
+   |---|---|---|
+   | 16384×6144 fp8 | 96 MB | 128 MB |
+   | 6144×6144 fp8 | 36 MB | 64 MB |
+   | 1536×6144 fp8 | 9 MB | 16 MB |
+
+   | blocks_to_swap | 日志/护栏计的 pinned | **真实锁定** |
+   |---|---|---|
+   | 14 | 5.66 GB | 8.31 GB |
+   | 18 | 7.28 GB | 10.69 GB |
+   | 28 | 11.32 GB | **16.63 GB** |
+
+   §9.5c 的 `pinned 11.32 GB` 是 `numel × element_size` 累加值，不是 allocator 真占用；
+   那台 5090 内存大（可用 37.5GB）所以 16.6GB 塞得下没暴露。32GB 机器 50% 线 = 16GB，
+   28 层 16.63GB 必炸 —— 而护栏按 11.32GB 放行。anima 2B 张量尺寸正好是 2 的幂
+   （1.02×），anima 36 层版 1.29×。
+
+**修法（`PinnedPacker`，`training/block_swap.py`）**：不逐张量 pin，按**精确总量**
+的二进制分解一次性预分配若干块（8G+2G+1G+256M+64M，每块恰为 2 的幂 → allocator
+零取整），每个张量 best-fit 装进某块、256B 对齐、返回块上的 view。多族多配置模拟
+（krea2 fp8/bf16 × 14/18/28、anima 2048/5120 × 8/14/全）实际锁定 = 权重 × 1.00–1.03；
+装不进的张量走溢出路径（`pow2_ceil(nbytes)` 单独一块 = 旧行为，永远不更差）。两条
+pin 路径都接了：krea2 loader 直落（计划字节由 `_swapped_pinned_bytes` 镜像加载规则
+——fp8 原样、其余按计算 dtype——从 header 精确算出）、`PinnedBlockSwap._build` 的
+非预 pinned 路径（anima 放置 / GPU 常驻）。view 语义对既有机制透明：`is_pinned()`
+成立、`param.data = view` 照旧、H2D 照常、`release_pinned_host_cache` 仍按 §9.7 归还。
+
+顺带把 `cudaHostAlloc` 失败翻译成可行动的文案（`PinnedAllocationError`：说明是页
+锁定内存不是显存、要锁多少、Windows 上限在哪、调小 `blocks_to_swap`）。
+
+**没改的**：护栏仍按 `numel × element_size` 口径且不建模 50% 线、`_build` 的
+`pinned x GB` 日志仍是 numel 口径 —— 修好打包后两者与真实锁定只差 ≤3%，误差方向
+可接受；loader 新增一行「权重 X GB 打包进 N 块，实际锁定 Y GB」的日志供真机核对。

--- a/runtime/training/block_swap.py
+++ b/runtime/training/block_swap.py
@@ -41,6 +41,148 @@ logger = logging.getLogger(__name__)
 
 _GIB = 1024 ** 3
 
+def _pow2_ceil(n: int) -> int:
+    """>= n 的最小 2 的幂（n <= 1 → 1）。与 CachingHostAllocator 的取整同口径。"""
+    return 1 if n <= 1 else 1 << (n - 1).bit_length()
+
+
+def _pow2_decomposition(total: int) -> list[int]:
+    """把 total 拆成若干**互不相同**的 2 的幂（即二进制表示），降序。"""
+    sizes: list[int] = []
+    bit = 1
+    while total:
+        if total & 1:
+            sizes.append(bit)
+        total >>= 1
+        bit <<= 1
+    sizes.reverse()
+    return sizes
+
+
+def _alloc_pinned_bytes(nbytes: int) -> torch.Tensor:
+    return torch.empty(nbytes, dtype=torch.uint8, pin_memory=True)
+
+
+class PinnedAllocationError(RuntimeError):
+    """pinned（页锁定）内存分配失败（doc §8.1 / B6：报错不静默降级）。
+
+    ``cudaHostAlloc`` 失败在 torch 里也报 ``CUDA error: out of memory``，极易被
+    误读成显存不够；这里把「是主机页锁定内存、要锁多少、Windows 上限在哪」说清楚。
+    """
+
+    def __init__(self, nbytes: int, detail: str) -> None:
+        self.nbytes = nbytes
+        self.detail = detail
+        super().__init__(
+            f"pinned（页锁定）内存分配失败：本次要锁定 {nbytes / _GIB:.2f} GB。"
+            f"这不是显存不足 —— 换出层的权重要锁在系统内存里，Windows 对可锁定"
+            f"内存有系统级上限（经验上约为物理内存的一半）。请调小 blocks_to_swap，"
+            f"或关闭其他占内存的应用后重试。底层错误：{detail}"
+        )
+
+
+class PinnedPacker:
+    """把多个张量打包进少数几块 **2 的幂大小** 的 pinned 大块里，再切 view 返回。
+
+    为什么不能逐张量 ``pin_memory()``：PyTorch 的 host caching allocator 会把**每次**
+    pinned 分配向上取整到 2 的幂（``CachingHostAllocator.h`` ``PowerOf2Ceil``），
+    而 DiT 的权重尺寸恰恰都很吃亏 —— krea2 的 16384×6144 fp8 = 96MB 占 128MB、
+    6144×6144 = 36MB 占 64MB、1536×6144 = 9MB 占 16MB，28 层 11.32GB 的权重实际
+    锁定 **16.63GB**（1.47×）。Windows 对 ``cudaHostAlloc`` 的上限约为物理内存一半，
+    32GB 内存的机器就是在这里撞死的（5080 真机案例），而护栏按 11.32GB 放行。
+
+    做法：按**总字节数**的二进制分解一次性预分配若干块（8G+2G+1G+256M+…，每块
+    恰为 2 的幂 → allocator 零取整），每个张量按 best-fit 装进某块并 256B 对齐，
+    返回的是块上的 view（``is_pinned()`` 成立、可直接 ``param.data = view``、
+    H2D 拷贝照常）。多族多配置模拟下实际锁定 = 权重字节 × 1.00–1.03。
+
+    - ``total_bytes`` 是调用方算好的**将要 pin 的精确字节数**（不是估算：高估
+      即白锁）；给 0 则不预分配，退化为按需开块。
+    - 装不进任何已有块的张量（块边界碎片）走溢出路径：单独开一块
+      ``pow2_ceil(nbytes)`` —— 与逐张量 pin 等价，永远不比旧行为差。
+    - 所有分配在**构造时**完成（B6：失败只发生在启动那一刻，fail-fast），失败抛
+      ``PinnedAllocationError``。
+    - 释放跟随张量：所有 view 丢引用后大块回到 host 缓存池，再由
+      ``release_pinned_host_cache`` 真正还给系统（§9.7 不变）。
+    """
+
+    #: 总量向上取整的粒度：太粗则小配置（anima 8 层 1GB）白锁一大截，太细则
+    #: 块数变多、边界碎片变多。64MB 在全部真实配置模拟里都在 0.3%–3% 内。
+    GRANULARITY = 64 * 1024 ** 2
+    #: 块内偏移对齐（任何 dtype 的 view 都合法，且对 DMA 友好）
+    ALIGN = 256
+
+    def __init__(
+        self,
+        total_bytes: int = 0,
+        *,
+        granularity: int = GRANULARITY,
+        align: int = ALIGN,
+        allocate=None,
+    ) -> None:
+        self._align = int(align)
+        self._allocate = allocate or _alloc_pinned_bytes
+        # [buffer(uint8 pinned), 已用字节]
+        self._chunks: list[list] = []
+        self.packed_bytes = 0
+        self.overflow_chunks = 0
+        planned = 0
+        if total_bytes > 0:
+            planned = -(-int(total_bytes) // granularity) * granularity
+        for size in _pow2_decomposition(planned):
+            self._chunks.append([self._new_chunk(size), 0])
+
+    def _new_chunk(self, nbytes: int) -> torch.Tensor:
+        try:
+            buf = self._allocate(nbytes)
+        except RuntimeError as exc:  # cudaHostAlloc 失败（torch.AcceleratorError 亦是其子类）
+            raise PinnedAllocationError(self.allocated_bytes + nbytes, str(exc)) from exc
+        if buf.numel() != nbytes or buf.dtype != torch.uint8:
+            raise RuntimeError("PinnedPacker 的 allocate 必须返回 nbytes 个 uint8")
+        return buf
+
+    @property
+    def allocated_bytes(self) -> int:
+        """实际分配（= 实际锁定）的字节数。"""
+        return sum(int(buf.numel()) for buf, _used in self._chunks)
+
+    @property
+    def num_chunks(self) -> int:
+        return len(self._chunks)
+
+    def _reserve(self, nbytes: int) -> tuple[torch.Tensor, int]:
+        """在某块里划出 ``nbytes``（best-fit + 对齐），返回 (块, 起始偏移)。"""
+        best = None  # (剩余, chunk, 起始偏移)
+        for chunk in self._chunks:
+            buf, used = chunk
+            offset = -(-used // self._align) * self._align
+            left = int(buf.numel()) - offset - nbytes
+            if left >= 0 and (best is None or left < best[0]):
+                best = (left, chunk, offset)
+        if best is None:
+            chunk = [self._new_chunk(_pow2_ceil(nbytes)), 0]
+            self._chunks.append(chunk)
+            self.overflow_chunks += 1
+            offset = 0
+        else:
+            _left, chunk, offset = best
+        chunk[1] = offset + nbytes
+        self.packed_bytes += nbytes
+        return chunk[0], offset
+
+    def pin(self, tensor: torch.Tensor, *, dtype: torch.dtype | None = None) -> torch.Tensor:
+        """把 ``tensor`` 的内容拷进 pinned 大块，返回同形状的 pinned view。
+
+        ``dtype`` 给定时顺带 cast（拷贝即转换，省一次中间副本）。``tensor`` 可在
+        任意设备（GPU 张量直接 D2H 进 pinned）。
+        """
+        target_dtype = dtype or tensor.dtype
+        nbytes = tensor.numel() * torch.empty(0, dtype=target_dtype).element_size()
+        buf, offset = self._reserve(nbytes)
+        out = buf[offset: offset + nbytes].view(target_dtype).view(tuple(tensor.shape))
+        out.copy_(tensor)
+        return out
+
 
 class PinnedBlockSwap:
     """管理一个 ``nn.ModuleList`` 中末尾 ``num_swap`` 个 block 的权重换入换出。
@@ -121,6 +263,19 @@ class PinnedBlockSwap:
         pinned 分配失败在此抛出（启动期，可 fail-fast，doc §8.1）。
         """
         try:
+            # 尚未 pinned 的基权重全部经 PinnedPacker 打包（逐张量 pin_memory 会被
+            # host allocator 按 2 的幂取整、白锁最多 1.47×，见 PinnedPacker）。
+            # 先数总量再一次性分配：失败即 fail-fast，不会搬了一半才炸。
+            to_pack = 0
+            for absolute in range(self.first_swapped, self.total):
+                for param in blocks[absolute].parameters():
+                    if param.requires_grad or (
+                        param.device.type == "cpu" and param.is_pinned()
+                    ):
+                        continue
+                    to_pack += param.numel() * param.element_size()
+            packer = PinnedPacker(to_pack) if to_pack > 0 else None
+
             for rel, absolute in enumerate(range(self.first_swapped, self.total)):
                 block = blocks[absolute]
                 cpu_w: dict[str, torch.Tensor] = {}
@@ -131,14 +286,14 @@ class PinnedBlockSwap:
                     # 相对底模极小，没有换出的价值。
                     if param.requires_grad:
                         continue
-                    # 已在 CPU 就地接管（loader 可直接把尾部层载到 CPU，让 GPU
-                    # 峰值从不经过完整模型——12/16GB 目标的前提）；已 pinned 则
-                    # 不重复拷贝。否则从 GPU 搬下来再 pin。
+                    # 已在 CPU 且已 pinned 就地接管（loader 可直接把尾部层载到 CPU
+                    # pinned，让 GPU 峰值从不经过完整模型——12/16GB 目标的前提）；
+                    # 否则（CPU 可分页 / 还在 GPU）打包进 pinned 大块。
                     src = param.detach()
-                    if src.device.type == "cpu":
-                        pinned = src if src.is_pinned() else src.pin_memory()
+                    if src.device.type == "cpu" and src.is_pinned():
+                        pinned = src
                     else:
-                        pinned = src.to("cpu").pin_memory()
+                        pinned = packer.pin(src)
                     cpu_w[name] = pinned
                     specs.append((name, param.shape, param.dtype))
                     self._pinned_bytes += pinned.numel() * pinned.element_size()

--- a/runtime/training/families/krea2/loader.py
+++ b/runtime/training/families/krea2/loader.py
@@ -16,6 +16,7 @@ repository.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -28,6 +29,8 @@ from training.families.krea2.quant_fp8 import (
     patch_fp8_linears,
 )
 
+
+logger = logging.getLogger(__name__)
 
 _PREFIX_CANDIDATES = (
     "",
@@ -350,6 +353,39 @@ def _swapped_bytes_from_checkpoint(
     return total
 
 
+def _swapped_pinned_bytes(
+    checkpoint: Path,
+    prefixes: tuple[str, ...],
+    normalized_to_source: dict,
+    dtype: torch.dtype,
+) -> int:
+    """换出层**实际将 pin 的**字节数（只读 header），给 ``PinnedPacker`` 做预分配计划。
+
+    与 ``_swapped_bytes_from_checkpoint``（预算护栏口径 = checkpoint 原始字节）
+    的差别：必须镜像 ``load_krea2_model`` 的落盘规则 —— fp8 张量原样 pin（按
+    checkpoint dtype），其余先 cast 到计算 dtype 再 pin（按 ``dtype`` 算）。
+    计划数字要**精确**：高估即白锁（packer 按它一次性预分配），低估则多开溢出块。
+    header 读不出来返回 0（packer 退化为按需开块，不比逐张量 pin 差）。
+    """
+    compute_size = torch.empty(0, dtype=dtype).element_size()
+    total = 0
+    try:
+        with safe_open(str(checkpoint), framework="pt", device="cpu") as handle:
+            for normalized, source_key in normalized_to_source.items():
+                if not normalized.startswith(prefixes):
+                    continue
+                slice_ = handle.get_slice(source_key)
+                numel = 1
+                for dim in slice_.get_shape():
+                    numel *= dim
+                name = str(slice_.get_dtype()).upper()
+                per_elem = _dtype_size(name) if name.startswith("F8_") else compute_size
+                total += numel * per_elem
+    except Exception:  # noqa: BLE001
+        return 0
+    return total
+
+
 #: safetensors dtype 字符串 → 字节宽度（header 里是字符串不是 torch.dtype）
 _DTYPE_BYTES = {
     "F64": 8, "I64": 8,
@@ -426,10 +462,19 @@ def load_krea2_model(
     checkpoint = _checkpoint_path(path)
 
     swapped_prefixes = _swapped_block_prefixes(config, blocks_to_swap)
+    packer = None
     if swapped_prefixes:
         _check_swap_budget(
             config, blocks_to_swap, dtype, normalized_to_source, checkpoint,
         )
+        # 换出层不逐张量 pin_memory（host allocator 按 2 的幂取整会白锁 1.47×，
+        # 32GB 内存机器直接撞 Windows 可锁定上限），而是按精确总量一次性预分配
+        # 2 的幂大块再切 view —— 预算护栏过了这里才分配，分配失败即 fail-fast
+        from training.block_swap import PinnedPacker
+
+        packer = PinnedPacker(_swapped_pinned_bytes(
+            checkpoint, swapped_prefixes, normalized_to_source, dtype,
+        ))
 
     with safe_open(str(checkpoint), framework="pt", device="cpu") as handle:
         for normalized, source_key in normalized_to_source.items():
@@ -445,14 +490,14 @@ def load_krea2_model(
             ):
                 # fp8 原样常驻（显存收益所在），不 cast dtype
                 state_dict[normalized] = (
-                    tensor.pin_memory() if swapped
+                    packer.pin(tensor) if swapped
                     else tensor.to(device=target_device)
                 )
                 if normalized.endswith(".weight"):
                     layer = normalized[: -len(".weight")]
                     fp8_scales.setdefault(layer, None)
             elif swapped:
-                state_dict[normalized] = tensor.to(dtype=dtype).pin_memory()
+                state_dict[normalized] = packer.pin(tensor, dtype=dtype)
             else:
                 state_dict[normalized] = tensor.to(
                     device=target_device,
@@ -466,6 +511,12 @@ def load_krea2_model(
     model.load_state_dict(state_dict, strict=True, assign=True)
     del state_dict
     model.requires_grad_(False)
+    if packer is not None:
+        logger.info(
+            "block swap pinned：权重 %.2f GB 打包进 %d 块，实际锁定 %.2f GB（溢出块 %d）",
+            packer.packed_bytes / 1024 ** 3, packer.num_chunks,
+            packer.allocated_bytes / 1024 ** 3, packer.overflow_chunks,
+        )
     if fp8_scales:
         # scale 恒放计算设备：换出层的权重此刻在 CPU，跟随它会导致前向 device
         # 不匹配（见 patch_fp8_linears docstring）

--- a/tests/test_block_swap.py
+++ b/tests/test_block_swap.py
@@ -626,3 +626,33 @@ def test_allocation_error_carries_context():
     assert err.first_swapped == 14
     assert "out of memory" in str(err)
     assert "14" in str(err)
+
+
+def test_build_packs_unpinned_weights_into_pow2_chunks():
+    """未 pinned 的基权重（anima 放置路径 / GPU 常驻路径）经 PinnedPacker 打包：
+    主副本全部 pinned，且落在少数几个共享大块上（不是逐张量 pin 各自一块）。"""
+    PinnedBlockSwap, _ = _import()
+    device = torch.device("cuda")
+    blocks = _make_blocks(4, 16, device)
+    # 末尾 2 层模拟 anima 放置：CPU 可分页；前 2 层留 GPU（验证 GPU→pinned 也走打包）
+    for b in list(blocks)[3:]:
+        for p in b.parameters():
+            p.data = p.detach().to("cpu")
+    ref = {n: p.detach().clone().cpu() for n, p in blocks.named_parameters()}
+    x = torch.randn(3, 16, device=device)
+    expected = _run_resident(_make_blocks(4, 16, device), x)  # 同 seed 的常驻基线
+
+    swap = PinnedBlockSwap(blocks, num_swap=2, device=device)
+
+    storages = set()
+    for rel in range(swap.num_swap):
+        for _name, t in swap._cpu_weights[rel].items():
+            assert t.is_pinned() and t.device.type == "cpu"
+            storages.add(t.untyped_storage().data_ptr())
+    # 2 层 × 4 个参数 = 8 张量，但只应有 1 个共享大块（总量 < 64MB 粒度）
+    assert len(storages) == 1
+    for n, p in blocks.named_parameters():
+        if n.startswith(("2.", "3.")):
+            assert torch.equal(p.detach().cpu(), ref[n])
+    # 行为不变：前向仍与常驻一致
+    torch.testing.assert_close(_run_swap(swap, blocks, x), expected)

--- a/tests/test_krea2_loader.py
+++ b/tests/test_krea2_loader.py
@@ -460,3 +460,99 @@ def test_validate_fp8_base_noop_for_bf16(tmp_path: Path) -> None:
     _write_checkpoint(bf16, _state_dict(_tiny_config()))
     ctx = _fp8_ctx(tmp_path, transformer_path=str(bf16), grad_checkpoint=False)
     _validate_fp8_base(ctx)  # bf16 底模不受 fp8 约束
+
+
+# ---------------------------------------------------------------- block swap 打包落 pinned
+
+
+@pytest.fixture
+def fake_pinned_alloc(monkeypatch: pytest.MonkeyPatch):
+    """CPU 机器上用普通 uint8 张量顶替 pinned 大块，并记录每次分配尺寸。"""
+    import training.block_swap as bs
+
+    sizes: list[int] = []
+
+    def _alloc(nbytes: int) -> torch.Tensor:
+        sizes.append(nbytes)
+        return torch.empty(nbytes, dtype=torch.uint8)
+
+    monkeypatch.setattr(bs, "_alloc_pinned_bytes", _alloc)
+    return sizes
+
+
+def test_swapped_layers_are_packed_views_not_per_tensor_pins(
+    tmp_path: Path, fake_pinned_alloc: list[int],
+) -> None:
+    """blocks_to_swap>0：换出层权重落在少数 2 的幂大块的 view 上，内容逐位正确；
+    非换出层照常上目标设备。预分配计划（_swapped_pinned_bytes）与实际打包量一致。"""
+    config = _tiny_config()
+    expected = _state_dict(config)
+    checkpoint = tmp_path / "raw.safetensors"
+    _write_checkpoint(checkpoint, expected)
+
+    model = load_krea2_model(
+        checkpoint, "cpu", torch.bfloat16, config=config, blocks_to_swap=1,
+    )
+
+    # 只分配了一块（总量 < 64MB 粒度 → 64MB 一块），且是 2 的幂
+    assert fake_pinned_alloc == [64 * 1024 ** 2]
+    storages = set()
+    swapped = 0
+    for name, param in model.named_parameters():
+        assert param.dtype == torch.bfloat16
+        torch.testing.assert_close(param.detach(), expected[name].to(torch.bfloat16))
+        if name.startswith("blocks.1."):
+            swapped += 1
+            storages.add(param.untyped_storage().data_ptr())
+            assert (param.data_ptr() - param.untyped_storage().data_ptr()) % 256 == 0
+    assert swapped > 0 and len(storages) == 1
+
+    prefixes = krea2_loader._swapped_block_prefixes(config, 1)
+    n2s = {key: key for key in expected}
+    planned = krea2_loader._swapped_pinned_bytes(checkpoint, prefixes, n2s, torch.bfloat16)
+    # 计划按计算 dtype（bf16）算，而 checkpoint 是 fp32 —— 必须是一半而不是原始字节
+    assert planned == sum(v.numel() * 2 for k, v in expected.items() if k.startswith(prefixes))
+    assert planned == krea2_loader._swapped_bytes_from_checkpoint(checkpoint, prefixes, n2s) // 2
+
+
+def test_fp8_scaled_swapped_layers_keep_fp8_in_packed_views(
+    tmp_path: Path, fake_pinned_alloc: list[int],
+) -> None:
+    """fp8_scaled + swap：换出层的 fp8 权重原样（dtype 不变）落 pinned 大块，scale
+    留在计算设备；计划字节按 fp8 原样 + 其余按计算 dtype 镜像加载规则。"""
+    config = _tiny_config()
+    state_dict = _state_dict(config)
+    checkpoint = tmp_path / "fp8_scaled.safetensors"
+    layers = _write_fp8_scaled_checkpoint(checkpoint, state_dict)
+
+    model = load_krea2_model(
+        checkpoint, "cpu", torch.bfloat16, config=config, blocks_to_swap=1,
+    )
+
+    assert fake_pinned_alloc == [64 * 1024 ** 2]
+    chunk_ptrs = set()
+    for name, param in model.named_parameters():
+        if not name.startswith("blocks.1."):
+            continue
+        layer = name[: -len(".weight")] if name.endswith(".weight") else None
+        if layer in layers:
+            assert param.dtype == torch.float8_e4m3fn
+        else:
+            assert param.dtype == torch.bfloat16
+        chunk_ptrs.add(param.untyped_storage().data_ptr())
+    assert len(chunk_ptrs) == 1
+
+    prefixes = krea2_loader._swapped_block_prefixes(config, 1)
+    info, n2s, _scales = krea2_loader._inspect(
+        checkpoint, config,
+        expected_shapes={k: tuple(v.shape) for k, v in state_dict.items()},
+        allow_fp8=True,
+    )
+    planned = krea2_loader._swapped_pinned_bytes(checkpoint, prefixes, n2s, torch.bfloat16)
+    want = 0
+    for key, value in state_dict.items():
+        if not key.startswith(prefixes):
+            continue
+        layer = key[: -len(".weight")] if key.endswith(".weight") else None
+        want += value.numel() * (1 if layer in layers else 2)
+    assert planned == want

--- a/tests/test_pinned_packer.py
+++ b/tests/test_pinned_packer.py
@@ -95,7 +95,8 @@ def test_pin_returns_aligned_views_with_same_content_dtype_shape():
         # 同一大块上的 view，偏移 256B 对齐
         storage_ptr = out.untyped_storage().data_ptr()
         assert storage_ptr == chunk_ptr
-        assert (out.data_ptr() - chunk_ptr) % PinnedPacker.ALIGN == 0
+        if out.numel():  # 空张量的 data_ptr() 在 Linux 上返回 0，对齐断言无意义
+            assert (out.data_ptr() - chunk_ptr) % PinnedPacker.ALIGN == 0
     assert packer.packed_bytes == total
 
     # 改 view 等于改大块（param.data = view 后就是靠这个语义工作的）

--- a/tests/test_pinned_packer.py
+++ b/tests/test_pinned_packer.py
@@ -1,0 +1,199 @@
+"""PinnedPacker —— 换出层权重打包进 2 的幂大块的 pinned 内存（5080 真机案例修复）。
+
+背景：PyTorch host caching allocator 把**每次** pinned 分配向上取整到 2 的幂
+（CachingHostAllocator.h PowerOf2Ceil）。krea2 逐张量 pin 时 28 层 11.32GB 的权重
+实际锁定 16.63GB（1.47×），Windows 对 cudaHostAlloc 的上限约为物理内存一半，32GB
+内存机器就此撞死；而预算护栏按 11.32GB 放行。
+
+不需要 CUDA：packer 的分配函数可注入，用普通 uint8 张量模拟 pinned 大块；
+断言的是**分配的尺寸序列**（必须全是 2 的幂、总量贴近权重字节）与 view 语义。
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+_ROOT = Path(__file__).resolve().parent.parent
+for _p in (_ROOT, _ROOT / "runtime"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from training import block_swap as bs  # noqa: E402
+from training.block_swap import PinnedAllocationError, PinnedPacker  # noqa: E402
+
+_MIB = 1024 ** 2
+
+
+def _is_pow2(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+class _FakeAlloc:
+    """记录每次分配尺寸的假 pinned 分配器（返回普通 uint8 张量）。"""
+
+    def __init__(self, fail_at_total: int | None = None) -> None:
+        self.sizes: list[int] = []
+        self.fail_at_total = fail_at_total
+
+    def __call__(self, nbytes: int) -> torch.Tensor:
+        if self.fail_at_total is not None and sum(self.sizes) + nbytes > self.fail_at_total:
+            raise RuntimeError("CUDA error: out of memory")
+        self.sizes.append(nbytes)
+        return torch.empty(nbytes, dtype=torch.uint8)
+
+
+def test_pow2_helpers():
+    assert [bs._pow2_ceil(n) for n in (0, 1, 2, 3, 4, 5, 1000)] == [1, 1, 2, 4, 4, 8, 1024]
+    assert bs._pow2_decomposition(0) == []
+    assert bs._pow2_decomposition(11) == [8, 2, 1]
+    assert bs._pow2_decomposition(64 * _MIB) == [64 * _MIB]
+
+
+def test_preallocates_binary_decomposition_of_total():
+    """总量按粒度取整后二进制分解、每块恰为 2 的幂，且在构造时全部分配完。"""
+    alloc = _FakeAlloc()
+    total = 100 * _MIB  # 取整到 128MB → 一块 128MB
+    packer = PinnedPacker(total, granularity=64 * _MIB, allocate=alloc)
+    assert alloc.sizes == [128 * _MIB]
+    assert packer.num_chunks == 1 and packer.allocated_bytes == 128 * _MIB
+
+    alloc2 = _FakeAlloc()
+    total2 = 11 * 1024 * _MIB + 300 * _MIB  # 11.29GB → 取整 11.3125GB = 8G+2G+1G+256M+64M
+    packer2 = PinnedPacker(total2, granularity=64 * _MIB, allocate=alloc2)
+    assert alloc2.sizes == [8192 * _MIB, 2048 * _MIB, 1024 * _MIB, 256 * _MIB, 64 * _MIB]
+    assert all(_is_pow2(s) for s in alloc2.sizes)
+    assert packer2.allocated_bytes - total2 < 64 * _MIB
+
+
+def test_pin_returns_aligned_views_with_same_content_dtype_shape():
+    alloc = _FakeAlloc()
+    tensors = [
+        torch.randn(37, 53, dtype=torch.float32),
+        torch.randn(5, dtype=torch.bfloat16),
+        torch.tensor(3.5, dtype=torch.float32),          # 0-dim 标量
+        torch.randn(0, 8, dtype=torch.float16),          # 空张量
+        torch.randn(16, 16).to(torch.float8_e4m3fn),     # fp8 原样
+        torch.randn(9, 7, dtype=torch.float32).t(),      # 非连续
+    ]
+    total = sum(t.numel() * t.element_size() for t in tensors)
+    packer = PinnedPacker(total, allocate=alloc)
+    outs = [packer.pin(t) for t in tensors]
+
+    assert packer.num_chunks == 1 and packer.overflow_chunks == 0
+    chunk_ptr = packer._chunks[0][0].data_ptr()
+    for src, out in zip(tensors, outs):
+        assert out.shape == src.shape and out.dtype == src.dtype
+        assert out.is_contiguous()
+        if src.dtype == torch.float8_e4m3fn:
+            assert torch.equal(out.view(torch.uint8), src.contiguous().view(torch.uint8))
+        else:
+            assert torch.equal(out, src)
+        # 同一大块上的 view，偏移 256B 对齐
+        storage_ptr = out.untyped_storage().data_ptr()
+        assert storage_ptr == chunk_ptr
+        assert (out.data_ptr() - chunk_ptr) % PinnedPacker.ALIGN == 0
+    assert packer.packed_bytes == total
+
+    # 改 view 等于改大块（param.data = view 后就是靠这个语义工作的）
+    outs[0].fill_(1.0)
+    assert torch.equal(outs[0], torch.ones_like(tensors[0]))
+
+
+def test_pin_with_dtype_casts_on_the_fly():
+    alloc = _FakeAlloc()
+    src = torch.randn(8, 8, dtype=torch.float32)
+    packer = PinnedPacker(src.numel() * 2, allocate=alloc)
+    out = packer.pin(src, dtype=torch.bfloat16)
+    assert out.dtype == torch.bfloat16
+    assert torch.equal(out, src.to(torch.bfloat16))
+    assert packer.packed_bytes == src.numel() * 2
+
+
+def test_overflow_opens_pow2_chunk_never_worse_than_per_tensor_pin():
+    """装不进任何块的张量单独开 pow2_ceil(nbytes) 的块 —— 等价于旧的逐张量 pin。"""
+    alloc = _FakeAlloc()
+    packer = PinnedPacker(64 * _MIB, allocate=alloc)  # 一块 64MB
+    big = torch.empty(100 * _MIB, dtype=torch.uint8)  # 100MB 塞不进
+    out = packer.pin(big)
+    assert out.shape == big.shape
+    assert packer.overflow_chunks == 1
+    assert alloc.sizes == [64 * _MIB, 128 * _MIB]
+    # 溢出块同样参与后续 best-fit：128MB 块剩 28MB < 64MB 块剩 64MB → 小张量落溢出块
+    small = torch.empty(10 * _MIB, dtype=torch.uint8)
+    out2 = packer.pin(small)
+    ptr2 = out2.untyped_storage().data_ptr()  # 先取出来再断言，避免失败时 repr 整块存储
+    assert ptr2 == packer._chunks[1][0].data_ptr()
+    assert alloc.sizes == [64 * _MIB, 128 * _MIB]  # 没有再开块
+
+
+def test_zero_total_means_lazy_allocation():
+    alloc = _FakeAlloc()
+    packer = PinnedPacker(0, allocate=alloc)
+    assert alloc.sizes == [] and packer.num_chunks == 0
+    packer.pin(torch.empty(3 * _MIB, dtype=torch.uint8))
+    assert alloc.sizes == [4 * _MIB]
+
+
+def test_allocation_failure_is_actionable_and_fail_fast():
+    """cudaHostAlloc 失败也报 "CUDA error: out of memory"，必须翻译成用户能行动的话。"""
+    alloc = _FakeAlloc(fail_at_total=1024 * _MIB)
+    with pytest.raises(PinnedAllocationError) as info:
+        PinnedPacker(4096 * _MIB, allocate=alloc)
+    msg = str(info.value)
+    assert "blocks_to_swap" in msg and "不是显存不足" in msg and "GB" in msg
+    assert isinstance(info.value, RuntimeError)  # 上层按 RuntimeError 兜底
+
+
+def _krea2_swapped_sizes(blocks_to_swap: int, *, fp8: bool) -> list[int]:
+    """真实 krea2 换出层的逐张量字节序列（meta 模型，不读盘）。"""
+    from training.families.krea2.loader import (
+        KREA2_CONFIG, SingleStreamDiT, _swapped_block_prefixes,
+    )
+
+    prefixes = _swapped_block_prefixes(KREA2_CONFIG, blocks_to_swap)
+    with torch.device("meta"):
+        probe = SingleStreamDiT(KREA2_CONFIG)
+    sizes = []
+    for name, p in probe.named_parameters():
+        if not name.startswith(prefixes):
+            continue
+        per_elem = 1 if (fp8 and p.dim() == 2) else 2
+        sizes.append(p.numel() * per_elem)
+    return sizes
+
+
+@pytest.mark.parametrize("blocks,fp8", [(28, True), (18, True), (14, True), (28, False)])
+def test_real_krea2_layout_packs_within_three_percent(blocks: int, fp8: bool):
+    """**回归**：真实 krea2 尺寸序列下，实际锁定 ≤ 权重字节 × 1.03（旧行为 1.47×）。
+
+    用 ``alloc`` 直接给假块、用零内容 uint8 张量代替权重走完整 best-fit 装填，
+    断言分配序列全是 2 的幂且总和贴近权重字节 —— 这就是 cudaHostAlloc 真正会
+    锁住的量。
+    """
+    sizes = _krea2_swapped_sizes(blocks, fp8=fp8)
+    raw = sum(sizes)
+    per_tensor_pow2 = sum(bs._pow2_ceil(n) for n in sizes)
+    assert per_tensor_pow2 / raw > 1.4  # 旧行为的浪费（问题成立的前提）
+
+    # 只走装填记账（_reserve），不真搬 11GB：假块用零存储的 expand 张量顶替
+    # （numel / dtype 与真块一致，_reserve 只看 numel）
+    alloc = _ZeroStorageAlloc()
+    packer = PinnedPacker(raw, allocate=alloc)
+    for n in sizes:
+        packer._reserve(n)
+    assert all(_is_pow2(s) for s in alloc.sizes)
+    assert packer.packed_bytes == raw
+    assert packer.allocated_bytes == sum(alloc.sizes)
+    assert packer.allocated_bytes / raw <= 1.03, (
+        f"{blocks} 层 fp8={fp8}: 实际锁定 {packer.allocated_bytes / raw:.3f}× 权重"
+    )
+
+
+class _ZeroStorageAlloc(_FakeAlloc):
+    def __call__(self, nbytes: int) -> torch.Tensor:
+        self.sizes.append(nbytes)
+        return torch.empty(1, dtype=torch.uint8).expand(nbytes)


### PR DESCRIPTION
## 问题

5080（16GB）+ 32GB 内存的用户开 `blocks_to_swap=28` 训 K2，在 `load_krea2_model` 的 `tensor.pin_memory()` 处报 `CUDA error: out of memory`。此时 DiT 一层都还没上卡 —— 这不是显存 OOM，是 `cudaHostAlloc`（主机页锁定内存）失败：

1. Windows WDDM 对 `cudaHostAlloc` 有硬上限 ≈ 物理内存的 50%（[NVIDIA 论坛](https://forums.developer.nvidia.com/t/change-limit-of-50-for-cudahostalloc-pinned-memory-on-windows-10-11/228235)），32GB 机器 = 16GB。
2. PyTorch host caching allocator 把**每次** pinned 分配向上取整到 2 的幂（`CachingHostAllocator.h` `PowerOf2Ceil`），而 loader 逐张量 `pin_memory()`。krea2 的张量尺寸恰好都很吃亏（96MB→128MB / 36MB→64MB / 9MB→16MB）：

| blocks_to_swap | 日志/护栏计的 pinned | 真实锁定 |
|---|---|---|
| 14 | 5.66 GB | 8.31 GB |
| 18 | 7.28 GB | 10.69 GB |
| 28 | 11.32 GB | **16.63 GB** |

28 层 16.63GB > 16GB 上限必炸，而护栏按 11.32GB 放行。之前 5090 真机内存大所以没暴露。

## 修法

- `training/block_swap.py` 新增 `PinnedPacker`：按**精确总量**的二进制分解一次性预分配若干 2 的幂大块（8G+2G+1G+256M+64M，allocator 零取整），每个张量 best-fit 装填 + 256B 对齐，返回块上的 view —— `is_pinned()` / `param.data = view` / H2D / `release_pinned_host_cache` 语义全部不变。装不进的张量走 `pow2_ceil(nbytes)` 溢出块（= 旧行为，永远不更差）。多族多配置模拟（krea2 fp8/bf16 × 14/18/28、anima 2048/5120 × 8/14/全）实际锁定 = 权重 × 1.00–1.03。
- 分配失败抛 `PinnedAllocationError`：说明是页锁定内存不是显存、要锁多少、Windows 上限在哪、调小 `blocks_to_swap`。
- krea2 loader 换出层改走 packer；`_swapped_pinned_bytes` 镜像加载规则（fp8 原样、其余按计算 dtype）从 header 精确算计划字节；加一行「权重 X GB 打包进 N 块，实际锁定 Y GB」日志供真机核对。
- `PinnedBlockSwap._build` 的非预 pinned 路径（anima 放置 / GPU 常驻）同走 packer（anima 36 层版原本也有 1.29× 浪费）。

**刻意没改**：`check_pinned_budget` 仍不建模 Windows 50% 线、`_build` 的 `pinned x GB` 日志仍是 numel 口径（修好打包后与真实锁定只差 ≤3%）。

## 测试

- `tests/test_pinned_packer.py`（CPU，注入分配器）：分解/对齐/view 内容与 dtype/溢出/懒分配/失败文案 + **真实 krea2 布局回归**（28/18/14 fp8、28 bf16：分配序列全是 2 的幂且 ≤ 1.03×，旧行为 >1.4×）。
- `tests/test_krea2_loader.py` 两条集成：bf16 与 fp8_scaled + swap 下换出层是同一大块上的 view、内容逐位正确、计划字节与加载规则一致。
- `tests/test_block_swap.py` 一条 CUDA：`_build` 打包未 pinned 权重（本机无 GPU，交 CI / 真机）。
- 本地：`test_pinned_packer.py` 11 passed、`test_krea2_loader.py` + `test_block_swap_budget.py` 38 passed、其余 swap 测试 43 passed。

docs/design/block-swap.md §9.12 记录始末。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
