### PR TITLE
feat(logging): TaskLog 进度通道收编——worker/services 回调升级为带级别协议

### DIFF
--- a/studio/cli.py
+++ b/studio/cli.py
@@ -599,9 +599,11 @@ def _apply_update_pending() -> None:
     """
     try:
         from studio.services.runtime import updater  # noqa: PLC0415
+        from studio.infrastructure.task_log import TaskLog  # noqa: PLC0415
         if not updater.has_pending():
             return
-        updater.apply_pending(emit=_say)
+        # 与 _say 同一个 logger，updater 内部升级到级别方法时黄/红行自动落对
+        updater.apply_pending(emit=TaskLog(_log))
     except Exception as exc:  # noqa: BLE001
         _say(f"apply update pending 时异常（{exc}），跳过", "warning")
 

--- a/studio/infrastructure/task_log.py
+++ b/studio/infrastructure/task_log.py
@@ -1,0 +1,90 @@
+"""级别化的任务日志通道（设计稿 tmp/log-text-audit/leveling-rules.md R7）。
+
+worker 与 services 之间传递的进度回调从裸 ``Callable[[str], None]`` 收编为
+本模块的对象：旧签名 ``fn(line)`` 仍然兼容（落 INFO），新代码用
+``.debug/.info/.warning/.error`` 把级别交给底下的 logging 体系——级别到
+着色、显示过滤、``error_msg`` ERROR 块提取都由行契约接管，不再靠
+``[error]`` / ``⚠`` 之类的伪级别前缀表达严重度。
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class TaskLogLike(Protocol):
+    """进度/日志回调的协议类型。
+
+    ``__call__(line)`` 与历史 ``Callable[[str], None]`` 签名兼容（语义 INFO）；
+    级别方法与 ``logging.Logger`` 同形（``msg, *args`` 惰性格式化）。
+    """
+
+    def __call__(self, line: str) -> None: ...
+
+    def debug(self, msg: str, *args: Any) -> None: ...
+
+    def info(self, msg: str, *args: Any) -> None: ...
+
+    def warning(self, msg: str, *args: Any, exc_info: bool = False) -> None: ...
+
+    def error(self, msg: str, *args: Any, exc_info: bool = False) -> None: ...
+
+
+class TaskLog:
+    """标准实现：级别原样转发给一个 ``logging.Logger``。
+
+    worker 进程里它落 stderr → run.log，行契约（级别/续行/着色）由
+    ``setup_logging`` 的 formatter 保证。
+    """
+
+    def __init__(self, logger: logging.Logger) -> None:
+        self._logger = logger
+
+    def __call__(self, line: str) -> None:
+        self._logger.info(line)
+
+    def debug(self, msg: str, *args: Any) -> None:
+        self._logger.debug(msg, *args)
+
+    def info(self, msg: str, *args: Any) -> None:
+        self._logger.info(msg, *args)
+
+    def warning(self, msg: str, *args: Any, exc_info: bool = False) -> None:
+        self._logger.warning(msg, *args, exc_info=exc_info)
+
+    def error(self, msg: str, *args: Any, exc_info: bool = False) -> None:
+        self._logger.error(msg, *args, exc_info=exc_info)
+
+
+class CallbackTaskLog:
+    """把任意 line-callback 适配成 :class:`TaskLogLike`。
+
+    级别信息在回调侧丢失（回调只收文本），仅用于旧接口过渡与静默场景；
+    exc_info 无处附着，忽略。
+    """
+
+    def __init__(self, fn: Callable[[str], None]) -> None:
+        self._fn = fn
+
+    def _emit(self, msg: str, args: tuple[Any, ...]) -> None:
+        self._fn(msg % args if args else msg)
+
+    def __call__(self, line: str) -> None:
+        self._fn(line)
+
+    def debug(self, msg: str, *args: Any) -> None:
+        self._emit(msg, args)
+
+    def info(self, msg: str, *args: Any) -> None:
+        self._emit(msg, args)
+
+    def warning(self, msg: str, *args: Any, exc_info: bool = False) -> None:
+        self._emit(msg, args)
+
+    def error(self, msg: str, *args: Any, exc_info: bool = False) -> None:
+        self._emit(msg, args)
+
+
+#: 丢弃一切输出的空实现（库函数默认值用，替代 ``lambda _l: None``）。
+NULL_LOG = CallbackTaskLog(lambda _l: None)

--- a/studio/services/booru/downloader.py
+++ b/studio/services/booru/downloader.py
@@ -28,8 +28,9 @@ import requests
 
 from . import api as booru_api, pool as booru_pool
 from ..proxy_manager import get_proxy_dict
+from studio.infrastructure.task_log import TaskLogLike
 
-ProgressFn = Callable[[str], None]
+ProgressFn = TaskLogLike
 ImageSavedFn = Callable[[Path], None]
 
 

--- a/studio/services/dataset/uploads.py
+++ b/studio/services/dataset/uploads.py
@@ -47,9 +47,11 @@ from PIL import Image
 from ..booru.api import flatten_alpha, has_alpha
 from .scan import IMAGE_EXTS
 
+from studio.infrastructure.task_log import TaskLogLike
+
 logger = logging.getLogger(__name__)
 
-LogFn = Callable[[str], None]
+LogFn = TaskLogLike
 
 # PP10 起复用全链路白名单：上传 / 下载 / curation / 训练共用一份。
 ALLOWED_IMAGE_EXTS = IMAGE_EXTS

--- a/studio/services/eval_auto.py
+++ b/studio/services/eval_auto.py
@@ -22,9 +22,11 @@ from typing import Any, Callable, Optional
 from studio.services import eval_session
 from studio.services.projects import projects, versions
 
+from studio.infrastructure.task_log import TaskLogLike
+
 logger = logging.getLogger(__name__)
 
-ProgressFn = Callable[[str], None]
+ProgressFn = TaskLogLike
 
 
 def _version_eval_config(

--- a/studio/services/eval_ccip.py
+++ b/studio/services/eval_ccip.py
@@ -18,6 +18,7 @@ from typing import Any, Callable
 
 from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
+from studio.infrastructure.task_log import TaskLogLike
 
 JOB_KIND = "eval_ccip"
 DEFAULT_MODEL_NAME = "ccip-caformer-24-randaug-pruned"
@@ -29,7 +30,7 @@ _CCIP_MEAN = (0.48145466, 0.4578275, 0.40821073)
 _CCIP_STD = (0.26862954, 0.26130258, 0.27577711)
 
 CcipScorer = Callable[
-    [dict[str, Any], Path, str, Callable[[str], None]],
+    [dict[str, Any], Path, str, TaskLogLike],
     dict[str, Any],
 ]
 
@@ -51,7 +52,7 @@ def run_ccip_job(
     *,
     scorer: CcipScorer | None = None,
     model_name: str | None = None,
-    on_progress: Callable[[str], None] | None = None,
+    on_progress: TaskLogLike | None = None,
     eval_root: Path | None = None,
 ) -> dict[str, Any]:
     """Compute CCIP-I for one completed eval sample run."""
@@ -278,7 +279,7 @@ def _ccip_preprocess(path: Path):
     return (arr - mean) / std  # (3, 384, 384)
 
 
-def _load_ccip(model_name: str, progress: Callable[[str], None]):
+def _load_ccip(model_name: str, progress: TaskLogLike):
     import json
 
     from studio.services.models.downloader import ensure_ccip_model
@@ -344,7 +345,7 @@ def _default_scorer(run, version_dir, model_name, progress, pool=None):
 
 
 @contextlib.contextmanager
-def shared_scorer(progress: Callable[[str], None] | None = None):
+def shared_scorer(progress: TaskLogLike | None = None):
     """阶段级共享的 scorer：CCIP session 只加载一次，跑完全部候选后释放。
 
     `_stage_metric` 本来就是「一个指标跑完所有候选再换下一个」，但

--- a/studio/services/eval_clip.py
+++ b/studio/services/eval_clip.py
@@ -15,13 +15,14 @@ from typing import Any, Callable
 
 from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
+from studio.infrastructure.task_log import TaskLogLike
 
 JOB_KIND = "eval_clip"
 DEFAULT_MODEL_NAME = "openai/clip-vit-base-patch32"
 CACHE_KEY = "clip"
 
 ClipScorer = Callable[
-    [dict[str, Any], Path, str, Callable[[str], None]],
+    [dict[str, Any], Path, str, TaskLogLike],
     dict[str, Any],
 ]
 
@@ -38,7 +39,7 @@ def run_clip_job(
     *,
     scorer: ClipScorer | None = None,
     model_name: str | None = None,
-    on_progress: Callable[[str], None] | None = None,
+    on_progress: TaskLogLike | None = None,
     eval_root: Path | None = None,
 ) -> dict[str, Any]:
     """Compute CLIP-T / CLIP-I for one completed eval sample run."""
@@ -278,7 +279,7 @@ def _int_or_none(value: Any) -> int | None:
         return None
 
 
-def _load_clip(model_name: str, progress: Callable[[str], None]):
+def _load_clip(model_name: str, progress: TaskLogLike):
     import torch
     from transformers import CLIPModel, CLIPProcessor
 
@@ -298,7 +299,7 @@ def _default_scorer(
     run: dict[str, Any],
     version_dir: Path,
     model_name: str,
-    progress: Callable[[str], None],
+    progress: TaskLogLike,
     pool: eval_model_pool.ModelPool | None = None,
 ) -> dict[str, Any]:
     import numpy as np
@@ -379,7 +380,7 @@ def _encode_images(
     processor,
     paths: list[Path],
     device: str,
-    progress: Callable[[str], None],
+    progress: TaskLogLike,
     *,
     label: str = "generated",
 ):
@@ -568,7 +569,7 @@ def _rel_to_version(version_dir: Path, path: Path) -> str:
 
 
 @contextlib.contextmanager
-def shared_scorer(progress: Callable[[str], None] | None = None):
+def shared_scorer(progress: TaskLogLike | None = None):
     """阶段级共享的 scorer：CLIP 只加载一次，跑完全部候选后释放。
 
     `_stage_metric` 本来就是「一个指标跑完所有候选再换下一个」，但

--- a/studio/services/eval_dino.py
+++ b/studio/services/eval_dino.py
@@ -14,13 +14,14 @@ from typing import Any, Callable
 
 from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
+from studio.infrastructure.task_log import TaskLogLike
 
 JOB_KIND = "eval_dino"
 DEFAULT_MODEL_NAME = "facebook/dinov2-small"
 CACHE_KEY = "dino"
 
 DinoScorer = Callable[
-    [dict[str, Any], Path, str, Callable[[str], None]],
+    [dict[str, Any], Path, str, TaskLogLike],
     dict[str, Any],
 ]
 
@@ -37,7 +38,7 @@ def run_dino_job(
     *,
     scorer: DinoScorer | None = None,
     model_name: str | None = None,
-    on_progress: Callable[[str], None] | None = None,
+    on_progress: TaskLogLike | None = None,
     eval_root: Path | None = None,
 ) -> dict[str, Any]:
     """Compute DINO-I for one completed eval sample run."""
@@ -244,7 +245,7 @@ def _int_or_none(value: Any) -> int | None:
         return None
 
 
-def _load_dino(model_name: str, progress: Callable[[str], None]):
+def _load_dino(model_name: str, progress: TaskLogLike):
     import torch
     from transformers import AutoImageProcessor, AutoModel
 
@@ -264,7 +265,7 @@ def _default_scorer(
     run: dict[str, Any],
     version_dir: Path,
     model_name: str,
-    progress: Callable[[str], None],
+    progress: TaskLogLike,
     pool: eval_model_pool.ModelPool | None = None,
 ) -> dict[str, Any]:
     import numpy as np
@@ -335,7 +336,7 @@ def _encode_images(
     processor,
     paths: list[Path],
     device: str,
-    progress: Callable[[str], None],
+    progress: TaskLogLike,
     *,
     label: str = "generated",
 ):
@@ -472,7 +473,7 @@ def _rel_to_version(version_dir: Path, path: Path) -> str:
 
 
 @contextlib.contextmanager
-def shared_scorer(progress: Callable[[str], None] | None = None):
+def shared_scorer(progress: TaskLogLike | None = None):
     """阶段级共享的 scorer：DINO 只加载一次，跑完全部候选后释放。
 
     `_stage_metric` 本来就是「一个指标跑完所有候选再换下一个」，但

--- a/studio/services/eval_generation.py
+++ b/studio/services/eval_generation.py
@@ -36,6 +36,8 @@ from studio.domain.common import supports_capability
 from studio.services import version_config
 from studio.services.inference.daemon import InferenceDaemon
 
+from studio.infrastructure.task_log import TaskLogLike
+
 logger = logging.getLogger(__name__)
 
 # 一个候选的出图上限。daemon 单 task 串行跑 prompts，验证集再大也不该无限等。
@@ -177,7 +179,7 @@ class DaemonSampleGenerator:
 
     def __init__(
         self,
-        progress: Callable[[str], None],
+        progress: TaskLogLike,
         *,
         task_id: int = 0,
         daemon: Optional[InferenceDaemon] = None,
@@ -211,7 +213,7 @@ class DaemonSampleGenerator:
         self,
         run: dict[str, Any],
         version_dir: Path,
-        progress: Callable[[str], None],
+        progress: TaskLogLike,
     ) -> None:
         from studio.services import eval_samples
 

--- a/studio/services/eval_model_pool.py
+++ b/studio/services/eval_model_pool.py
@@ -25,6 +25,8 @@ import gc
 import logging
 from typing import Any, Callable, Optional
 
+from studio.infrastructure.task_log import TaskLogLike
+
 logger = logging.getLogger(__name__)
 
 
@@ -49,7 +51,7 @@ class ModelPool:
         self._key = key
         return self._value
 
-    def release(self, progress: Optional[Callable[[str], None]] = None) -> None:
+    def release(self, progress: Optional[TaskLogLike] = None) -> None:
         """丢掉模型引用并把显存还给 caching allocator。未加载时是 no-op。"""
         if self._value is None:
             return

--- a/studio/services/eval_samples.py
+++ b/studio/services/eval_samples.py
@@ -25,6 +25,8 @@ from typing import Any, Callable
 from . import eval_validation
 from .projects import versions
 
+from studio.infrastructure.task_log import TaskLogLike
+
 logger = logging.getLogger(__name__)
 
 EVAL_DIRNAME = "eval"
@@ -46,7 +48,7 @@ class EvalSamplesError(Exception):
     """Business error for eval sample runs."""
 
 
-SampleGenerator = Callable[[dict[str, Any], Path, Callable[[str], None]], None]
+SampleGenerator = Callable[[dict[str, Any], Path, TaskLogLike], None]
 
 
 def _eval_root(version_dir: Path, eval_root: Path | None = None) -> Path:
@@ -410,7 +412,7 @@ def run_sample_job(
     run_id: str,
     *,
     generator: SampleGenerator,
-    on_progress: Callable[[str], None] | None = None,
+    on_progress: TaskLogLike | None = None,
     eval_root: Path | None = None,
 ) -> dict[str, Any]:
     """跑一个候选的出图。

--- a/studio/services/eval_tag.py
+++ b/studio/services/eval_tag.py
@@ -14,13 +14,14 @@ from typing import Any, Callable
 
 from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
+from studio.infrastructure.task_log import TaskLogLike
 
 JOB_KIND = "eval_tag"
 DEFAULT_MODEL_NAME = "wd14"
 METRIC_KEY = "tag_recall"
 
 TagScorer = Callable[
-    [dict[str, Any], Path, str, Callable[[str], None]],
+    [dict[str, Any], Path, str, TaskLogLike],
     dict[str, Any],
 ]
 
@@ -66,7 +67,7 @@ def run_tag_job(
     *,
     scorer: TagScorer | None = None,
     model_name: str | None = None,
-    on_progress: Callable[[str], None] | None = None,
+    on_progress: TaskLogLike | None = None,
     eval_root: Path | None = None,
 ) -> dict[str, Any]:
     """Compute tag-recall for one completed eval sample run."""
@@ -241,7 +242,7 @@ def _mean(values: list[float]) -> float | None:
 # ---------------------------------------------------------------------------
 
 
-def _load_tagger(progress: Callable[[str], None]):
+def _load_tagger(progress: TaskLogLike):
     from studio.services.tagging.wd14 import WD14Tagger
 
     tagger = WD14Tagger()
@@ -257,7 +258,7 @@ def _default_scorer(
     run: dict[str, Any],
     version_dir: Path,
     model_name: str,
-    progress: Callable[[str], None],
+    progress: TaskLogLike,
     pool: eval_model_pool.ModelPool | None = None,
 ) -> dict[str, Any]:
     eval_root = _run_eval_root(run)
@@ -304,7 +305,7 @@ def _default_scorer(
 
 
 @contextlib.contextmanager
-def shared_scorer(progress: Callable[[str], None] | None = None):
+def shared_scorer(progress: TaskLogLike | None = None):
     """阶段级共享的 scorer：WD14 tagger 只加载一次，跑完全部候选后释放。
 
     `_stage_metric` 本来就是「一个指标跑完所有候选再换下一个」，但

--- a/studio/services/inference/upscaler.py
+++ b/studio/services/inference/upscaler.py
@@ -31,6 +31,8 @@ from typing import Any, Callable, Optional
 import torch
 from PIL import Image
 
+from studio.infrastructure.task_log import TaskLogLike, NULL_LOG
+
 logger = logging.getLogger(__name__)
 
 # spandrel `ImageModelDescriptor` 的最小协议：我们只用到 `.model` 和 `.scale`。
@@ -255,7 +257,7 @@ def upscale_file(
     device: str = "auto",
     precision: str = "auto",
     target_area: Optional[int] = None,
-    on_log: Callable[[str], None] = lambda _l: None,
+    on_log: TaskLogLike = NULL_LOG,
     prewarm_thumb_sizes: Optional[list[int]] = None,
     save_kwargs: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:

--- a/studio/services/models/downloader.py
+++ b/studio/services/models/downloader.py
@@ -68,7 +68,12 @@ from .paths import (
 from . import sources as _sources
 from .sources import MS_ANIMA_TEXT_ENCODER_PATH
 
+from studio.infrastructure.task_log import TaskLogLike, TaskLog
+
 logger = logging.getLogger(__name__)
+
+#: 手跑 / 无人传 on_log 时的兜底：走本模块 logger（终端 INFO 可见，不再裸 print）。
+_DEFAULT_LOG = TaskLog(logger)
 
 # 提示：跨文件调用 download_flat[_ms] / _get_download_source / _resolve_endpoint /
 # _ms_wd14_repo_id 一律走 _sources.X(...) —— 这样测试 monkeypatch
@@ -77,7 +82,7 @@ logger = logging.getLogger(__name__)
 
 def download_taeflux(
     *, root: Optional[Path] = None,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """同步下载 TAEFlux（config + weights）到本地。任意一个文件失败则返 False。"""
     target_dir = taeflux_dir(root)
@@ -91,7 +96,7 @@ def download_taeflux(
 
 
 def download_anima_main(
-    root: Path, variant: str, *, on_log: Callable[[str], None] = print
+    root: Path, variant: str, *, on_log: TaskLogLike = _DEFAULT_LOG
 ) -> bool:
     if variant == "latest":
         variant = LATEST_ANIMA
@@ -106,7 +111,7 @@ def download_anima_main(
     return _sources.download_flat(ANIMA_REPO, subpath, target, on_log=on_log)
 
 
-def download_anima_vae(root: Path, *, on_log: Callable[[str], None] = print) -> bool:
+def download_anima_vae(root: Path, *, on_log: TaskLogLike = _DEFAULT_LOG) -> bool:
     # 落点是族无关共享资产（Krea2 同用）；下载渠道走 Anima repo（文件在那儿）。
     target = qwen_image_vae_target(root)
     on_log("\n📥 Anima VAE (~250 MB)")
@@ -116,7 +121,7 @@ def download_anima_vae(root: Path, *, on_log: Callable[[str], None] = print) -> 
 
 
 def download_krea2_main(
-    root: Path, variant: str, *, on_log: Callable[[str], None] = print
+    root: Path, variant: str, *, on_log: TaskLogLike = _DEFAULT_LOG
 ) -> bool:
     """从 HuggingFace 官方仓库或 ModelScope Comfy-Org 镜像下载 Krea2。"""
     if variant == "latest":
@@ -138,7 +143,7 @@ def download_krea2_main(
 
 
 def download_qwen3_vl(
-    root: Path, *, on_log: Callable[[str], None] = print
+    root: Path, *, on_log: TaskLogLike = _DEFAULT_LOG
 ) -> bool:
     """下载 Krea 2 使用的完整 Qwen3-VL-4B-Instruct transformers 目录。"""
     target_dir = qwen3_vl_dir(root)
@@ -166,7 +171,7 @@ def download_qwen3_vl(
 
 
 def download_qwen3_vl_fp8(
-    root: Path, *, on_log: Callable[[str], None] = print
+    root: Path, *, on_log: TaskLogLike = _DEFAULT_LOG
 ) -> bool:
     """下载官方 fp8_scaled 单文件 TE + config/tokenizer 小文件到独立目录。
 
@@ -191,7 +196,7 @@ def download_qwen3_vl_fp8(
     return ok
 
 
-def download_qwen3(root: Path, *, on_log: Callable[[str], None] = print) -> bool:
+def download_qwen3(root: Path, *, on_log: TaskLogLike = _DEFAULT_LOG) -> bool:
     """下载文本编码器（Qwen3）。
 
     - HuggingFace 源：从 Qwen/Qwen3-0.6B-Base 下载完整目录所需的 6 个文件。
@@ -227,7 +232,7 @@ def download_qwen3(root: Path, *, on_log: Callable[[str], None] = print) -> bool
 
 
 def download_t5_tokenizer(
-    root: Path, *, on_log: Callable[[str], None] = print
+    root: Path, *, on_log: TaskLogLike = _DEFAULT_LOG
 ) -> bool:
     target_dir = t5_tokenizer_dir(root)
     on_log(f"\n📥 T5 tokenizer (3 个文件) → {target_dir}")
@@ -243,7 +248,7 @@ def download_cltagger(
     target_root: Path,
     cfg: Optional["secrets.CLTaggerConfig"] = None,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     cfg = cfg or secrets.load().cltagger
     model_path, tag_mapping_path = cltagger_canonical_file_paths(
@@ -264,7 +269,7 @@ def download_upscaler(
     label: str = DEFAULT_UPSCALER,
     root: Optional[Path] = None,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """下载放大器权重到 `{models_root}/upscalers/{filename}`。
 
@@ -301,7 +306,7 @@ def download_upscaler_custom(
     filename: str,
     root: Optional[Path] = None,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """自定义 repo 下载：用户指定 HF/MS 仓库 + 文件名，落到 `{upscalers}/{filename}`。
 
@@ -333,7 +338,7 @@ def download_main_custom(
     filename: str,
     root: Optional[Path] = None,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """统一来源候选的第三方主模型单文件下载 → `{models_root}/diffusion_models/`。
 
@@ -371,7 +376,7 @@ def download_wd14(
     model_id: str,
     root: Optional[Path] = None,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """下载 WD14 单个 model_id 的两个文件到 `{models_root}/wd14/{safe_id}/`。
 
@@ -404,7 +409,7 @@ def download_eval_model(
     model_id: str,
     root: Optional[Path] = None,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """下载 CLIP / DINO eval 模型整个 repo 到 `{models_root}/eval/{kind}/{safe_id}/`。
 
@@ -429,7 +434,7 @@ def ensure_eval_model(
     model_id: str,
     root: Optional[Path] = None,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> Path:
     """返回 eval 模型本地目录，缺失则先下载（懒加载兜底，路径与下载卡片一致）。
 
@@ -459,7 +464,7 @@ def download_ccip_model(
     variant: str,
     root: Optional[Path] = None,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """下 deepghs/ccip_onnx 指定变体的 3 个文件到 `{models_root}/eval/ccip/{variant}/`。"""
     r = root or models_root()
@@ -475,7 +480,7 @@ def ensure_ccip_model(
     variant: str,
     root: Optional[Path] = None,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> Path:
     """返回 CCIP 变体本地目录，缺 3 个文件则先下载（懒加载兜底）。"""
     r = root or models_root()
@@ -536,8 +541,56 @@ def _failure_summary(log: list[str]) -> str:
     return err or "下载失败，详见下载日志"
 
 
+class _RingLog:
+    """单个下载任务的日志 sink（实现 TaskLogLike）：UI ring + studio.log mirror。
+
+    不变量：ring 是下载卡 UI 的唯一数据面、无级别概念，任何级别都**无条件
+    append**——级别只影响 logger mirror 一侧，绝不用于过滤 ring，否则下载卡
+    会被打空。
+
+    mirror 侧：ring 容量 200 行，长下载早期日志会被截掉，logger 让 studio.log
+    保留完整流（自家 logger 恒 DEBUG，记录不过滤）。旧签名 `__call__` 与
+    info/debug mirror 成 DEBUG（终端默认 INFO 不刷屏）；warning/error 按真实
+    级别 mirror（下载失败应在终端与诊断包里可见）。锁外做 logger I/O，避免
+    持锁拖慢其它 download tasks 写日志。
+    """
+
+    def __init__(self, ds: DownloadStatus) -> None:
+        self._ds = ds
+
+    def _append(self, line: str) -> None:
+        with _LOCK:
+            self._ds.log.append(line)
+            if len(self._ds.log) > 200:
+                del self._ds.log[:-200]
+
+    def __call__(self, line: str) -> None:
+        self._append(line)
+        logger.debug(line)
+
+    def debug(self, msg: str, *args: Any) -> None:
+        text = msg % args if args else msg
+        self._append(text)
+        logger.debug(text)
+
+    def info(self, msg: str, *args: Any) -> None:
+        text = msg % args if args else msg
+        self._append(text)
+        logger.debug(text)
+
+    def warning(self, msg: str, *args: Any, exc_info: bool = False) -> None:
+        text = msg % args if args else msg
+        self._append(text)
+        logger.warning(text, exc_info=exc_info)
+
+    def error(self, msg: str, *args: Any, exc_info: bool = False) -> None:
+        text = msg % args if args else msg
+        self._append(text)
+        logger.error(text, exc_info=exc_info)
+
+
 def start_download_async(
-    key: str, fn: Callable[[Callable[[str], None]], bool]
+    key: str, fn: Callable[[TaskLogLike], bool]
 ) -> DownloadStatus:
     """启动后台 thread 跑 `fn(on_log)`；fn 返回 True=成功。
 
@@ -553,16 +606,7 @@ def start_download_async(
         )
         _DOWNLOADS[key] = ds
 
-    def _on_log(line: str) -> None:
-        with _LOCK:
-            ds.log.append(line)
-            if len(ds.log) > 200:
-                del ds.log[:-200]
-        # 回显到 backend logger —— UI ring buffer 容量 200 行；长下载早期日志会被
-        # 截掉，logger.debug 让 studio.log 保留完整流（自家 logger 恒 DEBUG，
-        # 记录不过滤），终端默认 INFO 不刷屏；调试 / oncall 排错时直接 grep
-        # studio.log。锁外执行避免持锁做 I/O 拖慢其它 download tasks 写日志。
-        logger.debug(line)
+    _on_log = _RingLog(ds)
 
     def _run() -> None:
         bus.publish({

--- a/studio/services/models/sources.py
+++ b/studio/services/models/sources.py
@@ -8,11 +8,18 @@
 """
 from __future__ import annotations
 
+import logging
 import os
 from pathlib import Path
 from typing import Callable, Optional
 
 from ... import secrets
+from studio.infrastructure.task_log import TaskLogLike, TaskLog
+
+logger = logging.getLogger(__name__)
+
+#: 手跑 / 无人传 on_log 时的兜底：走本模块 logger（终端 INFO 可见，不再裸 print）。
+_DEFAULT_LOG = TaskLog(logger)
 
 # ---------------------------------------------------------------------------
 # ModelScope 镜像源映射
@@ -171,7 +178,7 @@ def download_flat_ms(
     repo_subpath: str,
     target: Path,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """用 modelscope Python API 下载单个文件到 target。
 
@@ -231,7 +238,7 @@ def download_flat(
     repo_subpath: str,
     target: Path,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """从 HF 下载 repo_subpath，扁平落到 target；返回 True = 已就绪。
 
@@ -297,7 +304,7 @@ def download_snapshot(
     target_dir: Path,
     *,
     allow_patterns: Optional[list[str]] = None,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """从 HF 把整个 repo 下到 target_dir（多文件 transformers 模型用）。
 
@@ -340,7 +347,7 @@ def download_snapshot_ms(
     ms_repo_id: str,
     target_dir: Path,
     *,
-    on_log: Callable[[str], None] = print,
+    on_log: TaskLogLike = _DEFAULT_LOG,
 ) -> bool:
     """从 ModelScope 把整个 repo 下到 target_dir（多文件模型用）。
 

--- a/studio/services/reg/analysis.py
+++ b/studio/services/reg/analysis.py
@@ -37,9 +37,10 @@ from PIL import Image
 from ...services.dataset.scan import IMAGE_EXTS
 from ..booru import api as booru_api, pool as booru_pool
 from ..dataset import tagedit
+from studio.infrastructure.task_log import TaskLogLike
 
 
-ProgressFn = Callable[[str], None]
+ProgressFn = TaskLogLike
 
 # IMAGE_EXTS 在 datasets.py 用 ".xxx" 形式；这里需要不带点的形式（与 file_ext 比对）
 _IMAGE_EXT_NODOT = {e.lstrip(".") for e in IMAGE_EXTS}

--- a/studio/services/reg/builder.py
+++ b/studio/services/reg/builder.py
@@ -49,9 +49,10 @@ from .analysis import (
     collect_source_image_ids,
     find_best_match,
 )
+from studio.infrastructure.task_log import TaskLogLike
 
 
-ProgressFn = Callable[[str], None]
+ProgressFn = TaskLogLike
 
 VIDEO_EXTS = {
     "mp4", "webm", "avi", "mov", "mkv", "flv", "wmv", "mpg", "mpeg", "m4v",

--- a/studio/services/reg/postprocess.py
+++ b/studio/services/reg/postprocess.py
@@ -44,8 +44,9 @@ from PIL import Image
 from sklearn.cluster import KMeans
 
 from ...services.dataset.scan import IMAGE_EXTS
+from studio.infrastructure.task_log import TaskLogLike
 
-ProgressFn = Callable[[str], None]
+ProgressFn = TaskLogLike
 
 VALID_METHODS = {"smart", "stretch", "crop"}
 

--- a/studio/services/runtime/updater.py
+++ b/studio/services/runtime/updater.py
@@ -37,7 +37,12 @@ from typing import Any, Callable, Optional
 from ... import __version__
 from ...paths import REPO_ROOT, STUDIO_DATA
 
+from studio.infrastructure.task_log import TaskLogLike, TaskLog
+
 logger = logging.getLogger(__name__)
+
+#: 无人传 emit 时的兜底：走本模块 logger（终端 INFO 可见，不再裸 print）。
+_DEFAULT_LOG = TaskLog(logger)
 
 # ----- Flag / 缓存文件路径 ------------------------------------------------
 RESTART_FLAG = REPO_ROOT / "tmp" / "restart"
@@ -809,7 +814,7 @@ def _backup_preserved_files(log_lines: list[str]) -> list[str]:
 
 
 def _restore_preserved_files(
-    saved: list[str], emit: Callable[[str], None], log_lines: list[str],
+    saved: list[str], emit: TaskLogLike, log_lines: list[str],
 ) -> None:
     """reset 后：把备份里"被 reset 删掉"的模型数据文件还原（更新零感知），收尾清
     备份目录。目标版本仍带该文件（如回滚到旧版）时 dst 已存在 → 不覆盖。"""
@@ -844,7 +849,7 @@ def _discard_preserved() -> None:
         pass
 
 
-def apply_pending(emit: Callable[[str], None] = print) -> bool:
+def apply_pending(emit: TaskLogLike = _DEFAULT_LOG) -> bool:
     """cli.py 启动期调。返回 True = 走过 pull 路径；False = 无 pending 跳过。
 
     流程：

--- a/studio/workers/download_worker.py
+++ b/studio/workers/download_worker.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import threading
 
+from studio.infrastructure.task_log import TaskLog
 from studio import db, secrets
 
 # 固定名：worker 经 `python -m studio.workers.download_worker` 拉起时 __name__ 是 __main__，
@@ -38,8 +39,7 @@ def run(job_id: int) -> int:
 
     params = job.get("params_decoded") or {}
 
-    def progress(line: str) -> None:
-        logger.info(line)
+    progress = TaskLog(logger)
 
     try:
         with db.connection_for() as conn:

--- a/studio/workers/eval_session_worker.py
+++ b/studio/workers/eval_session_worker.py
@@ -27,6 +27,7 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
+from studio.infrastructure.task_log import TaskLog
 from studio import db, secrets
 from studio.services import (
     eval_ccip,
@@ -74,8 +75,7 @@ _RUNNERS: dict[
 
 
 def run(task_id: int) -> int:
-    def progress(line: str) -> None:
-        logger.info(line)
+    progress = TaskLog(logger)
 
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -30,6 +30,7 @@ from PIL import Image
 # 行契约里的来源列会失真、也不在 OWN_LOGGER_NAMESPACES 里。
 logger = logging.getLogger("studio.workers.preprocess_worker")
 
+from studio.infrastructure.task_log import TaskLog
 from studio import db
 from studio.domain.errors import DomainError
 from studio.services.preprocess import core as preprocess
@@ -80,8 +81,7 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
     # 缺 stage 字段视为老 upscale job（向后兼容）
     stage = params.get("stage", preprocess.STAGE_UPSCALE)
 
-    def log(line: str) -> None:
-        logger.info(line)
+    log = TaskLog(logger)
 
     def emit_event(evt_type: str, **payload) -> None:
         """通过 stdout 标记行 → supervisor 解析 → SSE。供前端实时更新用，

--- a/studio/workers/reg_build_worker.py
+++ b/studio/workers/reg_build_worker.py
@@ -40,6 +40,7 @@ logger = logging.getLogger("studio.workers.reg_build_worker")
 # PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload。
 # auto_tag 路径会内联调 wd14_tagger（line ~105 `get_tagger("wd14")`），worker 是独立
 # subprocess，必须自己 import；否则 CUDA EP 静默降级到 CPU，用户看不到任何信号。
+from studio.infrastructure.task_log import TaskLog
 from studio.services.runtime import onnxruntime as onnxruntime_setup  # noqa: F401
 
 from studio import db, secrets
@@ -153,8 +154,7 @@ def run(job_id: int) -> int:
 
     cancel_event = threading.Event()  # supervisor 走 SIGTERM；这里只为 API 完整性
 
-    def progress(line: str) -> None:
-        logger.info(line)
+    progress = TaskLog(logger)
 
     try:
         version_id = int(params["version_id"])

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -35,6 +35,7 @@ logger = logging.getLogger("studio.workers.tag_worker")
 # （Linux: RTLD_GLOBAL 加载 torch 自带 CUDA so；Windows: os.add_dll_directory）。
 # cli.py / server.py 已覆盖各自进程；worker 是独立 subprocess，靠 get_tagger
 # 懒加载链触发太晚（懒加载在 main() 里，某些路径下来不及）—— worker 顶层显式 import。
+from studio.infrastructure.task_log import TaskLog
 from studio.services.runtime import onnxruntime as onnxruntime_setup  # noqa: F401
 
 from studio import db
@@ -115,8 +116,7 @@ def run(job_id: int) -> int:
 
     params: dict[str, Any] = job.get("params_decoded") or {}
 
-    def progress(line: str) -> None:
-        logger.info(line)
+    progress = TaskLog(logger)
 
     try:
         tagger_name = params.get("tagger", "wd14")

--- a/tests/test_task_log.py
+++ b/tests/test_task_log.py
@@ -1,0 +1,75 @@
+"""TaskLog 通道（R7 收编）：级别转发、旧签名兼容、协议一致性。"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from studio.infrastructure.task_log import (
+    NULL_LOG,
+    CallbackTaskLog,
+    TaskLog,
+    TaskLogLike,
+)
+
+
+@pytest.fixture()
+def log_and_records(caplog):
+    logger = logging.getLogger("test.task_log")
+    caplog.set_level(logging.DEBUG, logger="test.task_log")
+    return TaskLog(logger), caplog
+
+
+class TestTaskLog:
+    def test_call_is_info(self, log_and_records):
+        tl, caplog = log_and_records
+        tl("plain line")
+        (rec,) = caplog.records
+        assert rec.levelno == logging.INFO
+        assert rec.message == "plain line"
+
+    def test_level_methods_forward(self, log_and_records):
+        tl, caplog = log_and_records
+        tl.debug("d %s", 1)
+        tl.info("i %s", 2)
+        tl.warning("w %s", 3)
+        tl.error("e %s", 4)
+        levels = [(r.levelno, r.message) for r in caplog.records]
+        assert levels == [
+            (logging.DEBUG, "d 1"),
+            (logging.INFO, "i 2"),
+            (logging.WARNING, "w 3"),
+            (logging.ERROR, "e 4"),
+        ]
+
+    def test_exc_info_attaches_traceback(self, log_and_records):
+        tl, caplog = log_and_records
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            tl.warning("failed", exc_info=True)
+            tl.error("failed hard", exc_info=True)
+        assert all(r.exc_info for r in caplog.records)
+
+    def test_satisfies_protocol(self, log_and_records):
+        tl, _ = log_and_records
+        assert isinstance(tl, TaskLogLike)
+
+
+class TestCallbackTaskLog:
+    def test_all_levels_degrade_to_callback(self):
+        lines: list[str] = []
+        cb = CallbackTaskLog(lines.append)
+        cb("a")
+        cb.debug("b %s", 1)
+        cb.info("c")
+        cb.warning("d", exc_info=True)
+        cb.error("e %s %s", 1, 2)
+        assert lines == ["a", "b 1", "c", "d", "e 1 2"]
+
+    def test_satisfies_protocol(self):
+        assert isinstance(CallbackTaskLog(lambda _l: None), TaskLogLike)
+
+    def test_null_log_swallows(self):
+        NULL_LOG("x")
+        NULL_LOG.error("y", exc_info=True)


### PR DESCRIPTION
日志二期（文本与级别复审）刀 0：进度回调通道收编。

## 背景

worker 的 `progress()/log()` 闭包与 services 的 159 处 `on_progress`/`on_log` 回调文本最终落 run.log / 下载卡 ring，是用户实际看到的行，但通道类型是裸 `Callable[[str], None]`——无级别概念。后果：35+ 处用 `[error]`/`⚠` 伪前缀表达错误语义，`error_msg` 按 ERROR 块提取永远抓不到 worker 失败原因，视图不着色。

## 改动

- 新增 `studio/infrastructure/task_log.py`：`TaskLogLike` 协议（`__call__(line)` 兼容旧签名 = INFO；`.debug/.info/.warning/.error(exc_info=)` 与 logging.Logger 同形）+ `TaskLog(logger)` 标准实现 + `CallbackTaskLog` 适配器 + `NULL_LOG`
- 5 个 worker 的闭包 → `TaskLog(logger)` 实例
- services 17 文件 57 处 `Callable[[str], None]` 类型放宽为 `TaskLogLike`；`= print` / `= lambda` 默认值收编为模块 logger 兜底
- `models/downloader._on_log` → `_RingLog`：ring 无条件 append（下载卡数据面不过滤，注释锁死不变量），`warning/error` 按真实级别 mirror 到 studio.log
- `cli.apply_pending(emit=_say)` → `emit=TaskLog(_log)`，级别透传就绪

本刀零行为变化（现有调用全走 `__call__` = INFO，与原 `logger.info(line)` 一致）；级别方法的实际使用在后续刀。

## 测试

新增 `tests/test_task_log.py`（协议/转发/exc_info/适配器）；关联测试 375 passed（workers/eval/downloader/booru/updater/uploads 全域）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
