### PR TITLE
feat(logging): 日志二期主体——风暴节流 + i18n 字典 + 三域 879 条文案终稿

### DIFF
--- a/modeling/anima/cosmos_predict2_modeling.py
+++ b/modeling/anima/cosmos_predict2_modeling.py
@@ -134,7 +134,8 @@ def warn_flash_fallback(stage: str, shape: tuple, reason: str) -> None:
         return
     _FLASH_FALLBACK_WARNED.add(key)
     _logger.warning(
-        "flash_attn fallback at %s shape=%s: %s（同 shape 只警告这一次）",
+        "flash_attn fallback at %s shape=%s: %s — this shape runs on PyTorch SDPA "
+        "(same shape warns only once)",
         stage,
         shape,
         reason,
@@ -148,7 +149,8 @@ def warn_xformers_fallback(stage: str, shape: tuple, reason: str) -> None:
         return
     _XFORMERS_FALLBACK_WARNED.add(key)
     _logger.warning(
-        "xformers fallback at %s shape=%s: %s（同 shape 只警告这一次）",
+        "xformers fallback at %s shape=%s: %s — this shape runs on PyTorch SDPA "
+        "(same shape warns only once)",
         stage,
         shape,
         reason,

--- a/modeling/wan/vae2_1.py
+++ b/modeling/wan/vae2_1.py
@@ -7,6 +7,9 @@ import torch.nn as nn
 import torch.nn.functional as F
 from einops import rearrange
 
+# 模块 logger（根 logger 会让日志行失去「每行可定位模块」的定位能力）
+_logger = logging.getLogger(__name__)
+
 CACHE_T = 2
 
 
@@ -605,7 +608,7 @@ def _video_vae(pretrained_path=None, z_dim=None, device='cpu', **kwargs):
         model = WanVAE_(**cfg)
 
     # load checkpoint
-    logging.info(f'loading {pretrained_path}')
+    _logger.debug('wan_vae: loading weights path=%s', pretrained_path)
     model.load_state_dict(
         torch.load(pretrained_path, map_location=device), assign=True)
 

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -96,12 +96,12 @@ def _keep_third_party_logs_off_stdout(
             if getattr(handler, "stream", None) is sys.stdout:
                 third.removeHandler(handler)
         if not third.handlers:
+            # formatter 必须走行契约（HumanConsoleFormatter）：自拼格式的行头
+            # 匹配不上 LOG_LINE_RE，会被 ring/LogView 解析器当成上一条的续行、
+            # 继承别人的级别（tmp/log-text-audit 刀 1 机制修复）。
+            from studio.infrastructure.logging import HumanConsoleFormatter
             stderr_handler = logging.StreamHandler(sys.stderr)
-            stderr_handler.setFormatter(
-                logging.Formatter(
-                    "%(asctime)s %(levelname)s %(name)s: %(message)s", "%H:%M:%S",
-                )
-            )
+            stderr_handler.setFormatter(HumanConsoleFormatter())
             third.addHandler(stderr_handler)
 
 

--- a/runtime/anima_daemon.py
+++ b/runtime/anima_daemon.py
@@ -66,10 +66,24 @@ except Exception:
     pass
 
 # 日志走 stderr（setup_logging 的 console handler 即 stderr），stdout 留给协议
+from studio.infrastructure.log_messages import msg  # noqa: E402
 from studio.infrastructure.logging import PROCESS_ENV, setup_logging  # noqa: E402
 
 setup_logging(os.environ.get(PROCESS_ENV) or "anima_daemon", file=False, console=True)
 logger = logging.getLogger("anima_daemon")
+
+#: 中间预览解码失败计数（节流方案 D）：首条带 traceback，之后静默计数，
+#: 任务收尾 :func:`_drain_preview_failures` 补一条汇总。预览失败不阻塞出图，
+#: 一旦失败会按预览频率刷屏（25 步 × N 图 = 数百条）。
+_PREVIEW_FAILS = [0]
+
+
+def _drain_preview_failures() -> None:
+    if _PREVIEW_FAILS[0] > 1:
+        logger.debug(
+            "preview decode failed %d times during this task", _PREVIEW_FAILS[0],
+        )
+    _PREVIEW_FAILS[0] = 0
 
 
 # 会往 stdout 写日志的第三方 logger。stdout 是本进程的协议流，它们必须掰到 stderr。
@@ -118,9 +132,9 @@ _TE_ENCODE_FALLBACK = 2 * _GIB
 # ---------------------------------------------------------------------------
 
 
-def _emit(msg: dict[str, Any]) -> None:
+def _emit(message: dict[str, Any]) -> None:
     """写一条协议消息到 stdout（line-delimited JSON）。"""
-    sys.stdout.write(json.dumps(msg) + "\n")
+    sys.stdout.write(json.dumps(message) + "\n")
     sys.stdout.flush()
 
 
@@ -165,10 +179,17 @@ def _reload_adapter_weights(adapter: Any, spec: LoRASpec, device: str, dtype: An
     )
     missing = len(getattr(result, "missing_keys", []) or [])
     unexpected = len(getattr(result, "unexpected_keys", []) or [])
-    logger.info(
-        f"已热换 LoRA 权重: {Path(spec.path).name} "
-        f"(scale={spec.scale}; missing={missing}, unexpected={unexpected})"
+    name = Path(spec.path).name
+    logger.debug(
+        "lora hot reload: name=%s scale=%s missing=%d unexpected=%d",
+        name, spec.scale, missing, unexpected,
     )
+    if missing or unexpected:
+        logger.warning(
+            "LoRA hot reload left keys unmatched: name=%s missing=%d "
+            "unexpected=%d; this image may not reflect the full LoRA",
+            name, missing, unexpected,
+        )
 
 
 def _move_module_to_device(module: Any, device: str) -> None:
@@ -265,8 +286,8 @@ def _sample_with_cuda_oom_retry(
         if torch.device(device).type != "cuda" or not _is_cuda_oom(exc):
             raise
         logger.warning(
-            "transient CUDA OOM during generation; clearing allocator state "
-            "and retrying once with seed=%d",
+            "Transient VRAM shortage during sampling; freed cached blocks and "
+            "retried the same seed (seed=%d)",
             seed,
         )
 
@@ -449,7 +470,7 @@ class ModelCache:
         device = "cuda" if torch.cuda.is_available() else "cpu"
         dtype = _torch_dtype_from_precision(cfg.get("mixed_precision", "bf16"))
         family = _T.get_family(family_id)
-        logger.info("loading text encoders (TE 先行) %s", text_encoder_path)
+        logger.info(msg("model.load_text_encoder_ahead", path=text_encoder_path))
         self.text_stack = family.load_text(
             text_encoder_path, device, dtype,
             purpose="generate",
@@ -562,7 +583,9 @@ class ModelCache:
         use_xformers = backend == "xformers"
 
         family = _T.get_family(family_id)
-        logger.info("loading transformer [%s] %s", family_id, transformer_path)
+        logger.info(msg(
+            "model.load_transformer", family=family_id, path=transformer_path,
+        ))
         swap_extra: dict[str, Any] = {}
         if blocks_to_swap > 0:
             if "block_swap" not in family.spec.capabilities:
@@ -572,7 +595,7 @@ class ModelCache:
                 )
             # 换出层由 loader 直接落 CPU pinned，不经显存
             swap_extra["blocks_to_swap"] = blocks_to_swap
-            logger.info("block swap: last %d blocks stay in RAM", blocks_to_swap)
+            logger.info(msg("model.block_swap_enabled", n=blocks_to_swap))
         model = family.load_dit(
             transformer_path, device, dtype,
             attention_backend=("flash_attn" if use_flash else "none"), repo_root=repo_root,
@@ -605,7 +628,7 @@ class ModelCache:
         ):
             text_stack = self.text_stack
         else:
-            logger.info("loading text encoders %s", text_encoder_path)
+            logger.info(msg("model.load_text_encoder", path=text_encoder_path))
             text_stack = family.load_text(
                 text_encoder_path, device, dtype,
                 t5_tokenizer_path=t5_tokenizer_path or None,
@@ -701,7 +724,10 @@ class ModelCache:
                         break
                     current_metas.append(read_lora_meta(spec.path))
             except Exception:
-                logger.exception("read LoRA metadata failed")
+                logger.warning(
+                    "Reading LoRA metadata failed: path=%s; falling back to a "
+                    "full adapter re-injection", spec.path, exc_info=True,
+                )
                 current_metas = []
 
         can_hot_reload = (
@@ -719,7 +745,10 @@ class ModelCache:
                 for adapter, spec in zip(self.adapters, specs):
                     _reload_adapter_weights(adapter, spec, self.device, self.lora_dtype)
             except Exception:
-                logger.exception("LoRA hot reload failed; reinjecting adapters")
+                logger.warning(
+                    "LoRA hot reload failed; re-injecting adapters instead "
+                    "(this run takes longer)", exc_info=True,
+                )
             else:
                 self.last_lora_specs = specs
                 self.last_lora_metas = current_metas
@@ -728,17 +757,25 @@ class ModelCache:
                 return self.adapters
 
         all_detached = True
-        for adapter in self.adapters:
+        adapter_total = len(self.adapters)
+        for adapter_idx, adapter in enumerate(self.adapters, start=1):
             try:
                 if not adapter.detach():
                     all_detached = False
             except Exception:
-                logger.exception("adapter detach failed")
+                logger.warning(
+                    "Adapter detach failed (adapter %d/%d); its LoRA hooks may "
+                    "still be attached", adapter_idx, adapter_total,
+                    exc_info=True,
+                )
                 all_detached = False
         self.adapters = []
 
         if not all_detached and self.last_lora_specs:
-            logger.warning("detach failed, reloading model to ensure clean state")
+            logger.warning(
+                "Reloading the base model to drop leftover LoRA hooks; this adds "
+                "one full model load to this task"
+            )
             saved_paths = (
                 self.transformer_path, self.vae_path,
                 self.text_encoder_path, self.t5_tokenizer_path,
@@ -833,11 +870,11 @@ class ModelCache:
             # 否则按钮空转（实测 20GB 纹丝不动）。
             _reclaim_cuda_leftovers()
             return
-        logger.info("unloading model")
+        # 秒级动作只记结果（S3）——开场行删掉，卸载完成时打 model.unloaded。
         # 埋点必须在**丢引用之前**取基线，否则丢引用那一步的回收量测不到
         from training.sysmem import available_ram_bytes, trim_working_set
 
-        _ram_marks: list[tuple[str, int | None]] = [("起点", available_ram_bytes())]
+        _ram_marks: list[tuple[str, int | None]] = [("start", available_ram_bytes())]
         had_block_swap = self.block_swap is not None
         if had_block_swap:
             # 摘钩子并丢弃管理对象。注意**丢引用不等于还内存**：pinned 走
@@ -860,7 +897,7 @@ class ModelCache:
         self.last_lora_specs = []
         self.last_lora_metas = []
         self.last_lora_merge_precision = None
-        _ram_marks.append(("丢引用", available_ram_bytes()))
+        _ram_marks.append(("drop refs", available_ram_bytes()))
 
         try:
             import gc
@@ -883,7 +920,7 @@ class ModelCache:
             # 静默，无 CUDA 环境下是安全 no-op。
             if had_block_swap:
                 _release_pinned_host_cache()
-                _ram_marks.append(("pinned 归还", available_ram_bytes()))
+                _ram_marks.append(("pinned release", available_ram_bytes()))
             # 大权重的 mmap 文件缓存页（DiT 13-26GB + TE）在 working set 里赖着
             # 不走 —— 加载后 trim 过一次，卸载后同样要 trim（此前漏了）
             trim_working_set()
@@ -901,9 +938,9 @@ class ModelCache:
                 prev = value
             tail = _ram_marks[-1][1]
             if tail is not None:
-                logger.info(
-                    "[卸载] 可用内存 %.1fGB（%s）",
-                    tail / 1024**3, "，".join(parts) or "无变化",
+                logger.info(msg("model.unloaded", ram=f"{tail / 1024**3:.1f}"))
+                logger.debug(
+                    "unload reclaim: %s", ", ".join(parts) or "no change",
                 )
         except Exception:  # noqa: BLE001
             pass
@@ -936,7 +973,10 @@ def _reclaim_cuda_leftovers() -> None:
             torch.cuda.empty_cache()
         _release_pinned_host_cache()
     except Exception:
-        logger.exception("CUDA leftovers reclaim failed")
+        logger.warning(
+            "Reclaiming leftover VRAM failed; some VRAM stays reserved until "
+            "the daemon restarts", exc_info=True,
+        )
 
 
 CACHE = ModelCache()
@@ -1000,17 +1040,19 @@ def _precache_prompts_and_release(
             vram_policy, CACHE.device, te_increment,
         )
         if budget is not None:
-            logger.info(
-                "TE/DiT auto 预算：free=%.1fGiB, TE=%s %.1fGiB, "
-                "margin=%.1fGiB → %s",
+            logger.debug(
+                "te_dit_budget: free=%.1fGiB te=%.1fGiB source=%s "
+                "margin=%.1fGiB decision=%s",
                 budget["free"] / _GIB,
-                estimate_source,
                 budget["te_increment"] / _GIB,
+                estimate_source,
                 budget["margin"] / _GIB,
-                "DiT 让位" if yielded_dit else "允许同驻",
+                "yield_dit" if yielded_dit else "coresident",
             )
         elif yielded_dit:
-            logger.info("TE 预编码：%s 策略先将 DiT 移到 CPU", vram_policy)
+            logger.info(msg(
+                "daemon.dit_yields_for_text_encoder", policy=vram_policy,
+            ))
         if yielded_dit:
             CACHE._move_dit_and_adapters("cpu")
 
@@ -1050,13 +1092,16 @@ def _precache_prompts_and_release(
                 max(previous[0], peak_delta),
                 max(previous[1], encode_delta),
             )
-            logger.info(
-                "TE 峰值校准：load+encode=%.1fGiB，resident encode=%.1fGiB",
+            logger.debug(
+                "te_peak_calibration: load_encode=%.1fGiB resident_encode=%.1fGiB",
                 peak_delta / _GIB,
                 encode_delta / _GIB,
             )
     except Exception:
-        logger.exception("prompt 预编码失败；退回逐格惰性编码")
+        logger.warning(
+            "Prompt pre-encoding failed; falling back to lazy per-image "
+            "encoding (slower, output unchanged)", exc_info=True,
+        )
     finally:
         if vram_policy != "performance" and success:
             release = getattr(CACHE.text_stack, "release_model", None)
@@ -1075,9 +1120,9 @@ def _precache_prompts_and_release(
         return
     if encoded:
         if vram_policy == "performance":
-            logger.info("krea2 预编码 %d 条 prompt；performance 保持 TE 驻留", encoded)
+            logger.info(msg("generate.prompts_precached_resident", n=encoded))
         else:
-            logger.info("krea2 预编码 %d 条 prompt；TE 已释放，采样期零占用", encoded)
+            logger.info(msg("generate.prompts_precached_released", n=encoded))
 
 
 def _begin_initial_te_peak_calibration(cfg: dict[str, Any]) -> int | None:
@@ -1095,7 +1140,10 @@ def _begin_initial_te_peak_calibration(cfg: dict[str, Any]) -> int | None:
         torch.cuda.reset_peak_memory_stats("cuda")
         return start_allocated
     except Exception:
-        logger.exception("failed to start initial TE peak calibration")
+        logger.debug(
+            "te_peak_calibration: start failed, this measurement is skipped",
+            exc_info=True,
+        )
         return None
 
 
@@ -1114,9 +1162,14 @@ def _finish_initial_te_peak_calibration(start_allocated: int | None) -> None:
             max(previous[0], peak_delta),
             previous[1],
         )
-        logger.info("initial TE peak calibrated: load+encode=%.1fGiB", peak_delta / _GIB)
+        logger.debug(
+            "te_peak_calibration: initial load_encode=%.1fGiB", peak_delta / _GIB,
+        )
     except Exception:
-        logger.exception("failed to finish initial TE peak calibration")
+        logger.debug(
+            "te_peak_calibration: finish failed, measurement discarded",
+            exc_info=True,
+        )
 
 
 def _set_lora_multiplier(adapter: Any, scale: float) -> None:
@@ -1238,7 +1291,10 @@ def _setup_monitor(cfg: dict[str, Any]) -> Any:
         })
         return update_monitor
     except Exception as e:
-        logger.warning("monitor 初始化失败: %s", e)
+        logger.warning(
+            "Progress monitor failed to start: %s; the task runs normally but "
+            "progress and previews may not update", e,
+        )
         return None
 
 
@@ -1346,7 +1402,14 @@ def _decode_latent2rgb_preview(latent: Any) -> Optional[Any]:
                 )
             return img
     except Exception:
-        logger.exception("latent2rgb preview decode failed")
+        # 方案 D：首条带 traceback，之后只累加计数，任务收尾 drain 一条汇总。
+        # 预览失败不阻塞出图，用户无动作可做 → 全程 DEBUG。
+        _PREVIEW_FAILS[0] += 1
+        if _PREVIEW_FAILS[0] == 1:
+            logger.debug(
+                "preview decode failed; further failures in this task are "
+                "counted only", exc_info=True,
+            )
         return None
 
 
@@ -1503,7 +1566,10 @@ def _run_generate(
             except GenerationCanceled:
                 raise
             except Exception as e:
-                logger.exception("generate failed")
+                logger.warning(
+                    "Image %d/%d failed: seed=%d; continuing with the remaining "
+                    "images", img_idx + 1, total, seed, exc_info=True,
+                )
                 image_errors.append(str(e))
                 _emit_for(req_id, "image_error", step=img_idx + 1, message=str(e))
             img_idx += 1
@@ -1553,7 +1619,7 @@ def _run_xy(
 
     if base_seed == 0:
         base_seed = random.randint(0, 2**31 - 1)
-        logger.info("XY 共享种子（cfg.seed=0 随机化）: %d", base_seed)
+        logger.info(msg("generate.xy_shared_seed", seed=base_seed))
 
     base_scales = [float(s.scale) for s in CACHE.last_lora_specs]
     base_lora_paths = [str(s.path) for s in CACHE.last_lora_specs]
@@ -1661,7 +1727,10 @@ def _run_xy(
             except GenerationCanceled:
                 raise
             except Exception as e:
-                logger.exception("XY [%d,%d] failed", xi, yi)
+                logger.warning(
+                    "XY cell %d,%d failed: seed=%d; continuing with the "
+                    "remaining cells", xi, yi, cur_seed, exc_info=True,
+                )
                 image_errors.append(str(e))
                 _emit_for(
                     req_id, "image_error",
@@ -1686,13 +1755,14 @@ def _run_generate_worker(
         _run_generate(req_id, task_id, cfg, output_dir, cancel_event)
         _emit_for(req_id, "done", task_id=task_id)
     except GenerationCanceled:
-        logger.info("generate canceled: task_id=%s", task_id)
+        logger.info(msg("generate.canceled", task_id=task_id))
         _emit_for(req_id, "canceled", task_id=task_id)
     except Exception as e:
-        logger.exception("generate failed")
+        logger.exception("Generation task failed: task=%s", task_id)
         _emit_for(req_id, "error", task_id=task_id, message=str(e))
         failed = True
     finally:
+        _drain_preview_failures()
         if failed:
             # 必须在 except 块结束（异常对象被隐式 del）之后清扫，traceback
             # 钉住的 frame locals（如 OOM 时半上卡的 state_dict）才收得掉
@@ -1725,9 +1795,9 @@ def _start_generate_worker(req_id: str, task_id: int, cfg: dict[str, Any], outpu
 # ---------------------------------------------------------------------------
 
 
-def _handle_message(msg: dict[str, Any]) -> None:
-    action = msg.get("action")
-    req_id = msg.get("id", "")
+def _handle_message(message: dict[str, Any]) -> None:
+    action = message.get("action")
+    req_id = message.get("id", "")
 
     if action == "ping":
         _emit_for(req_id, "pong")
@@ -1739,41 +1809,48 @@ def _handle_message(msg: dict[str, Any]) -> None:
         return
 
     if action == "cancel":
-        if _request_cancel(str(msg.get("target_id") or req_id)):
+        if _request_cancel(str(message.get("target_id") or req_id)):
             _emit_for(req_id, "cancel_ack")
         else:
             _emit_for(req_id, "cancel_missed")
         return
 
     if action == "generate":
-        task_id = int(msg.get("task_id", 0))
-        cfg = msg.get("config") or {}
-        output_dir = Path(msg.get("output_dir") or ".")
+        task_id = int(message.get("task_id", 0))
+        cfg = message.get("config") or {}
+        output_dir = Path(message.get("output_dir") or ".")
         if not _start_generate_worker(req_id, task_id, cfg, output_dir):
             _emit_for(req_id, "error", task_id=task_id, message="daemon is already running a task")
         return
 
-    logger.warning("unknown action: %r", action)
+    logger.warning("Unknown command from the server: action=%r; ignored", action)
     _emit_for(req_id, "error", message=f"unknown action: {action!r}")
 
 
 def main() -> int:
     _emit_evt("ready")
-    logger.info("anima daemon ready, waiting for stdin commands")
+    logger.info(msg("daemon.ready"))
     try:
         for raw_line in sys.stdin:
             line = raw_line.strip()
             if not line:
                 continue
             try:
-                msg = json.loads(line)
+                message = json.loads(line)
             except json.JSONDecodeError as e:
-                logger.warning("non-JSON stdin line: %r (%s)", line[:200], e)
+                logger.warning(
+                    "Malformed command from the server (not JSON): %r (%s); "
+                    "ignored", line[:200], e,
+                )
                 continue
             try:
-                _handle_message(msg)
+                _handle_message(message)
             except Exception:
-                logger.exception("message handler crashed")
+                logger.exception(
+                    "Daemon message handler crashed: action=%s; the daemon "
+                    "stays up for the next task",
+                    (message or {}).get("action") if isinstance(message, dict) else "?",
+                )
     except KeyboardInterrupt:
         pass
     finally:

--- a/runtime/anima_generate.py
+++ b/runtime/anima_generate.py
@@ -51,6 +51,7 @@ from studio.services.inference.core import (  # noqa: E402
     release_vae_after_decode,
 )
 
+from studio.infrastructure.log_messages import msg  # noqa: E402
 from studio.infrastructure.logging import PROCESS_ENV, setup_logging  # noqa: E402
 
 setup_logging(os.environ.get(PROCESS_ENV) or "anima_generate", file=False, console=True)
@@ -78,7 +79,7 @@ def main() -> None:
 
     cfg_path = Path(args.config)
     if not cfg_path.exists():
-        logger.error(f"配置文件不存在: {cfg_path}")
+        logger.error("Config file not found: %s; nothing to generate", cfg_path)
         sys.exit(1)
 
     with open(cfg_path, encoding="utf-8") as f:
@@ -133,7 +134,10 @@ def main() -> None:
         })
         _update_monitor = update_monitor
     except Exception as e:
-        logger.warning(f"monitor 初始化失败: {e}")
+        logger.warning(
+            "Progress monitor failed to start: %s; generation continues but "
+            "progress and previews may not update", e,
+        )
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
     dtype = _torch_dtype_from_precision(mixed_precision)
@@ -160,7 +164,7 @@ def main() -> None:
         label=f"VAE {vae_path}",
     )
 
-    logger.info("加载文本编码器...")
+    logger.info(msg("model.load_text_encoder", path=text_encoder_path))
     # 族 opaque 文本栈不拆包；ad-hoc prompt 关缓存（cached_varlen 族 TE 常驻）
     text_stack = family.load_text(
         text_encoder_path, device, dtype,
@@ -180,16 +184,24 @@ def main() -> None:
         try:
             encoded = precache([*[str(p) for p in prompts], negative_prompt])
         except Exception:
-            logger.exception("prompt 预编码失败；退回逐图惰性编码")
+            logger.warning(
+                "Prompt pre-encoding failed; falling back to lazy per-image "
+                "encoding (slower, output unchanged)", exc_info=True,
+            )
         else:
             if vram_policy != "performance":
                 release = getattr(text_stack, "release_model", None)
                 if callable(release):
                     release()
             if encoded:
-                logger.info("krea2 预编码 %d 条 prompt；TE 已释放", encoded)
+                logger.info(msg(
+                    "generate.prompts_precached_released", n=encoded,
+                ))
 
-    logger.info("加载 Transformer...")
+    logger.info(msg(
+        "model.load_transformer",
+        family=family.spec.family_id, path=transformer_path,
+    ))
     model = family.load_dit(
         transformer_path, device, dtype,
         attention_backend=("flash_attn" if use_flash else "none"), repo_root=repo_root,
@@ -216,7 +228,7 @@ def main() -> None:
     # XY 矩阵分支（schema 已校验：xy_matrix 设值时 prompts 单条 + count=1）
     xy_matrix = cfg.get("xy_matrix")
     if xy_matrix is not None:
-        _run_xy_matrix(
+        xy_ok, xy_failed, xy_total = _run_xy_matrix(
             xy_matrix=xy_matrix,
             base_specs=specs,
             adapters=_adapters,
@@ -236,21 +248,35 @@ def main() -> None:
             update_monitor=_update_monitor,
             vram_policy=vram_policy,
         )
-        logger.info("XY 矩阵生成完成")
+        if xy_failed:
+            logger.warning(
+                "XY grid finished with failures: ok=%d failed=%d total=%d",
+                xy_ok, xy_failed, xy_total,
+            )
+        else:
+            logger.info(msg("generate.xy_done", ok=xy_ok, total=xy_total))
         return
 
     # 生成循环
     total = count * len(prompts)
-    logger.info(f"开始生成：{len(prompts)} 个 prompt × {count} 次 = {total} 张")
+    logger.info(msg(
+        "generate.start", prompts=len(prompts), count=count, total=total,
+    ))
 
     img_idx = 0
+    ok_count = 0
+    failed_count = 0
     for pi, prompt in enumerate(prompts):
         for ci in range(count):
             seed = (base_seed + img_idx) if base_seed != 0 else random.randint(0, 2**31 - 1)
             torch.manual_seed(seed)
             random.seed(seed)
 
-            logger.info(f"[{img_idx + 1}/{total}] seed={seed}  prompt={prompt[:60]}...")
+            logger.info(msg(
+                "generate.image_start",
+                idx=img_idx + 1, total=total, seed=seed,
+                prompt=(prompt[:60] + "\u2026") if len(prompt) > 60 else prompt,
+            ))
             try:
                 try:
                     img = family.sample_image(
@@ -274,15 +300,26 @@ def main() -> None:
                 fname = f"gen_{img_idx:04d}_p{pi}_c{ci}_s{seed}.png"
                 out_path = output_dir / fname
                 img.save(out_path)
-                logger.info(f"已保存: {out_path}")
+                logger.info(msg("generate.image_saved", path=out_path))
+                ok_count += 1
                 if _update_monitor:
                     _update_monitor(sample_path=str(out_path), step=img_idx + 1)
-            except Exception as e:
-                logger.exception(f"生成失败 [{img_idx + 1}/{total}]: {e}")
+            except Exception:
+                failed_count += 1
+                logger.warning(
+                    "Image %d/%d failed: seed=%d; continuing with the remaining "
+                    "images", img_idx + 1, total, seed, exc_info=True,
+                )
 
             img_idx += 1
 
-    logger.info("生成完成")
+    if failed_count:
+        logger.warning(
+            "Generation finished with failures: ok=%d failed=%d total=%d",
+            ok_count, failed_count, total,
+        )
+    else:
+        logger.info(msg("generate.done", ok=ok_count, total=total))
 
 
 # ---------------------------------------------------------------------------
@@ -355,8 +392,8 @@ def _run_xy_matrix(
     update_monitor,
     distilled: bool = False,
     vram_policy: str = "auto",
-) -> None:
-    """循环 (yi, xi) 出 N×M 张图。
+) -> tuple[int, int, int]:
+    """循环 (yi, xi) 出 N×M 张图，返回 ``(成功数, 失败数, 总数)``。
 
     设计：
       - 每个 cell 从 base_* 派生本次参数（防上次 cell 修改泄漏到下次）；
@@ -397,13 +434,17 @@ def _run_xy_matrix(
 
     if base_seed == 0:
         base_seed = random.randint(0, 2**31 - 1)
-        logger.info(f"XY 共享种子（cfg.seed=0 随机化）: {base_seed}")
+        logger.info(msg("generate.xy_shared_seed", seed=base_seed))
 
     base_scales = [float(s.scale) for s in base_specs]
     total = len(x_values) * len(y_values)
-    logger.info(f"开始 XY 生成：{len(x_values)}×{len(y_values)} = {total} 张")
+    logger.info(msg(
+        "generate.xy_start", nx=len(x_values), ny=len(y_values), total=total,
+    ))
 
     img_idx = 0
+    ok_count = 0
+    failed_count = 0
     for yi, yv in enumerate(y_values):
         for xi, xv in enumerate(x_values):
             # 重置每个 LoRA 到 base scale，避免上次 cell 的 lora_scale 改动遗留
@@ -433,10 +474,12 @@ def _run_xy_matrix(
             torch.manual_seed(cur_seed)
             random.seed(cur_seed)
 
-            logger.info(
-                f"XY [{xi},{yi}] x={xv} y={yv} "
-                f"steps={cur_steps} cfg={cur_cfg_scale} seed={cur_seed} sampler={cur_sampler}"
-            )
+            logger.info(msg(
+                "generate.xy_cell",
+                xi=xi, yi=yi, xv=xv, yv=yv,
+                steps=cur_steps, cfg=cur_cfg_scale,
+                seed=cur_seed, sampler=cur_sampler,
+            ))
             try:
                 try:
                     img = family.sample_image(
@@ -460,17 +503,24 @@ def _run_xy_matrix(
                 fname = f"xy_x{xi:02d}_y{yi:02d}_s{cur_seed}.png"
                 out_path = output_dir / fname
                 img.save(out_path)
-                logger.info(f"已保存: {out_path}")
+                logger.info(msg("generate.image_saved", path=out_path))
+                ok_count += 1
                 if update_monitor:
                     update_monitor(
                         sample_path=str(out_path),
                         step=img_idx + 1,
                         xy={"xi": xi, "yi": yi, "xv": xv, "yv": yv},
                     )
-            except Exception as e:
-                logger.exception(f"XY [{xi},{yi}] 失败: {e}")
+            except Exception:
+                failed_count += 1
+                logger.warning(
+                    "XY cell %d,%d failed: seed=%d; continuing with the "
+                    "remaining cells", xi, yi, cur_seed, exc_info=True,
+                )
 
             img_idx += 1
+
+    return ok_count, failed_count, total
 
 
 if __name__ == "__main__":

--- a/runtime/anima_reg_ai.py
+++ b/runtime/anima_reg_ai.py
@@ -53,6 +53,8 @@ from studio.services.reg.builder import (  # noqa: E402
     read_meta,
     write_meta,
 )
+from studio.infrastructure.log_messages import msg  # noqa: E402
+from utils.log_throttle import ProgressThrottle, RepeatThrottle  # noqa: E402
 from studio.services.tagging.caption_format import (  # noqa: E402
     caption_json_to_tags,
     caption_json_to_text,
@@ -63,6 +65,11 @@ from studio.infrastructure.logging import PROCESS_ENV, setup_logging  # noqa: E4
 
 setup_logging(os.environ.get(PROCESS_ENV) or "anima_reg_ai", file=False, console=True)
 logger = logging.getLogger("anima_reg_ai")
+
+# 循环内同因重复告警的节流器（方案 A）：首条全文 WARNING、2..N 条 DEBUG、
+# 收尾 `_REPEAT.drain()` 补一条计数汇总。典型任务 1000 张图，故障时每条告警
+# 都是数据集规模，不收会把 run.log 冲成噪音。
+_REPEAT = RepeatThrottle(logger)
 
 IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif"}
 
@@ -150,7 +157,15 @@ def _caption_path_for_image(img_path: Path) -> Path | None:
             _read_tags_from_caption(p)
             return p
         except Exception as e:
-            logger.warning("caption 读取失败 %s: %s", p, e)
+            _REPEAT.hit(
+                "caption_unparsable",
+                "%d caption files could not be parsed (first: %s); those images "
+                "fell back to another caption or were skipped",
+                "Caption file could not be parsed: path=%s (%s); trying the next "
+                "caption file for this image",
+                p, e,
+                first=p,
+            )
     return None
 
 
@@ -374,7 +389,10 @@ def main() -> None:
     args = parse_args()
     cfg_path = Path(args.config)
     if not cfg_path.exists():
-        logger.error(f"配置文件不存在: {cfg_path}")
+        logger.error(
+            "Config file not found: %s; regularization image generation aborted",
+            cfg_path,
+        )
         sys.exit(1)
 
     cfg = json.loads(cfg_path.read_text(encoding="utf-8"))
@@ -410,18 +428,24 @@ def main() -> None:
         update_monitor(config={"type": "reg_ai"})
         _update_monitor = update_monitor
     except Exception as e:
-        logger.warning(f"monitor 初始化失败: {e}")
+        logger.warning(
+            "Progress monitor failed to start: %s; generation continues but "
+            "progress may not update", e,
+        )
 
     if not train_dir.exists():
-        logger.error(f"train 目录不存在: {train_dir}")
+        logger.error(
+            "Train folder not found: %s; there is nothing to build "
+            "regularization images from", train_dir,
+        )
         sys.exit(1)
 
     entries = _scan_train(train_dir)
     if not entries:
-        logger.error("train 目录没有任何图片")
+        logger.error("No images found in the train folder: %s", train_dir)
         sys.exit(1)
 
-    logger.info(f"train 共 {len(entries)} 张图")
+    logger.info(msg("regai.train_scanned", n=len(entries)))
 
     if incremental:
         to_generate = [
@@ -431,12 +455,14 @@ def main() -> None:
                 e["stem"],
             )
         ]
-        logger.info(f"incremental 模式：需生成 {len(to_generate)}/{len(entries)} 张")
+        logger.info(msg(
+            "regai.incremental_plan", todo=len(to_generate), total=len(entries),
+        ))
     else:
         to_generate = entries
 
     if not to_generate:
-        logger.info("所有图片已有对应正则图，无需生成")
+        logger.info(msg("regai.nothing_to_do"))
         _write_meta_final(reg_dir, entries, excluded_tags, incremental, 0)
         return
 
@@ -465,11 +491,11 @@ def main() -> None:
         stage="正则生成模型加载",
         settings_hint="设置 → 训练 → 训练参数",
     )
-    logger.info("加载 VAE...")
+    logger.info(msg("model.load_vae"))
     vae = family.load_vae(vae_path, device, dtype,
                           tiling=str(cfg.get("vae_tiling", "auto")))
 
-    logger.info("加载文本编码器...")
+    logger.info(msg("model.load_text_encoder", path=text_encoder_path))
     # 族 opaque 文本栈不拆包；ad-hoc prompt 关缓存（cached_varlen 族 TE 常驻）
     text_stack = family.load_text(
         text_encoder_path, device, dtype,
@@ -494,7 +520,14 @@ def main() -> None:
             # TE 上卡需求上界（bf16 ~11GB；fp8 更小）——不足时跳过，
             # 由 sample_image 内部的逐图路径兜底
             if free is not None and free < 12 * 1024**3:
-                logger.info("显存余量不足，本批跳过预编码（回退逐图编码）")
+                _REPEAT.hit(
+                    "precache_no_vram",
+                    "Batch pre-encoding was skipped %d times for lack of VRAM; "
+                    "those images used per-image encoding",
+                    "Skipping batch pre-encoding: only %.1f GB VRAM free, "
+                    "%.1f GB needed; falling back to per-image encoding (slower)",
+                    free / 1024**3, 12.0,
+                )
                 return
         prompts = [
             p for p in (
@@ -512,14 +545,31 @@ def main() -> None:
             if callable(release):
                 release()
             if encoded:
-                logger.info("本批预编码 %d 条 caption；TE 已释放", encoded)
+                if first:
+                    logger.info(msg(
+                        "regai.precache_strategy", batch=_PRECACHE_BATCH,
+                    ))
+                logger.debug(
+                    "caption precache: batch=%d encoded=%d, text encoder released",
+                    _PRECACHE_BATCH, encoded,
+                )
         except Exception:
-            logger.exception("批预编码失败；回退逐图惰性编码")
+            _REPEAT.hit(
+                "precache_failed",
+                "Batch caption pre-encoding failed %d times; those batches used "
+                "per-image encoding",
+                "Batch caption pre-encoding failed; falling back to per-image "
+                "encoding (slower, output unchanged)",
+                exc_info=True,
+            )
 
     if to_generate:
         _precache_batch(to_generate[:_PRECACHE_BATCH], first=True)
 
-    logger.info("加载 Transformer...")
+    logger.info(msg(
+        "model.load_transformer",
+        family=family.spec.family_id, path=transformer_path,
+    ))
     model = family.load_dit(
         transformer_path, device, dtype,
         attention_backend=("flash_attn" if use_flash else "none"), repo_root=repo_root,
@@ -531,12 +581,16 @@ def main() -> None:
     model.eval()
 
     if not incremental:
-        logger.info("full 模式：清空旧 reg 内容")
         clear_reg_dir(reg_dir)
+        logger.info(msg("regai.full_mode_clear"))
 
     # 生成循环
     total = len(to_generate)
     actual_count = 0
+    skipped_count = 0
+    failed_count = 0
+    # 逐图行降 DEBUG，可见进度由节流后的计数 INFO 承担（Q3 三件套）
+    throttle = ProgressThrottle(total)
 
     for idx, entry in enumerate(to_generate):
         if idx and idx % _PRECACHE_BATCH == 0:
@@ -555,24 +609,41 @@ def main() -> None:
         out_path = reg_sub / out_name
         caption_path = _copy_caption_for_reg(entry["img"], out_path)
         if caption_path is None:
-            logger.warning(f"[{idx + 1}/{total}] {entry['img'].name} 无 tag 文件，跳过")
+            skipped_count += 1
+            _REPEAT.hit(
+                "no_caption",
+                "%d images skipped: no caption file (first: %s)",
+                "Image %d/%d skipped: %s has no caption file",
+                idx + 1, total, entry["img"].name,
+                first=entry["img"].name,
+            )
             continue
 
         try:
             prompt = _rewrite_caption_for_prompt(caption_path, excluded_tags)
         except Exception as e:
-            logger.warning(f"[{idx + 1}/{total}] {caption_path.name} 读取失败，跳过: {e}")
+            skipped_count += 1
+            _REPEAT.hit(
+                "caption_unreadable",
+                "%d images skipped: caption unreadable (first: %s)",
+                "Image %d/%d skipped: caption %s could not be read (%s)",
+                idx + 1, total, caption_path.name, e,
+                first=caption_path.name,
+            )
             caption_path.unlink(missing_ok=True)
             continue
 
         if not prompt:
-            logger.warning(f"[{idx + 1}/{total}] {entry['img'].name} 过滤后无 tag，跳过")
+            skipped_count += 1
+            _REPEAT.hit(
+                "no_tags_left",
+                "%d images skipped: no tags left after filtering (first: %s)",
+                "Image %d/%d skipped: no tags left after the exclude filter (%s)",
+                idx + 1, total, entry["img"].name,
+                first=entry["img"].name,
+            )
             caption_path.unlink(missing_ok=True)
             continue
-
-        logger.info(f"[{idx + 1}/{total}] {entry['img'].name} -> {out_name}")
-        logger.info(f"  caption: {caption_path.name}")
-        logger.info(f"  prompt: {prompt[:80]}")
 
         try:
             img = family.sample_image(
@@ -591,16 +662,37 @@ def main() -> None:
             )
             img.save(out_path)
             actual_count += 1
-            logger.info(f"  已保存: {out_path}")
+            logger.debug(
+                "reg image: %d/%d src=%s out=%s seed=%d prompt=%.80s",
+                idx + 1, total, entry["img"].name, out_name, seed, prompt,
+            )
+            if throttle.should_emit(idx + 1):
+                logger.info(msg("regai.progress", done=idx + 1, total=total))
             if _update_monitor:
                 _update_monitor(sample_path=str(out_path), step=idx + 1)
-        except Exception as e:
-            logger.exception(f"  生成失败: {e}")
+        except Exception:
+            failed_count += 1
+            _REPEAT.hit(
+                "generate_failed",
+                "%d images failed during generation (first: %s)",
+                "Image %d/%d failed: %s; skipped and continuing",
+                idx + 1, total, entry["img"].name,
+                first=entry["img"].name,
+                exc_info=True,
+            )
             if not out_path.exists():
                 caption_path.unlink(missing_ok=True)
 
+    _REPEAT.drain()
     _write_meta_final(reg_dir, entries, excluded_tags, incremental, actual_count)
-    logger.info(f"完成: {actual_count}/{total} 张")
+    if skipped_count or failed_count:
+        logger.warning(
+            "Regularization images finished with gaps: generated=%d/%d "
+            "skipped=%d failed=%d",
+            actual_count, total, skipped_count, failed_count,
+        )
+    else:
+        logger.info(msg("regai.done", ok=actual_count, total=total))
 
 
 if __name__ == "__main__":

--- a/runtime/anima_train.py
+++ b/runtime/anima_train.py
@@ -12,7 +12,6 @@
 LoRA / LoKr 实现：见 utils.lycoris_adapter.AnimaLycorisAdapter（ADR 0001）。
 """
 
-import logging
 import os
 import sys
 from pathlib import Path
@@ -49,7 +48,6 @@ from studio.infrastructure.logging import (  # noqa: E402
 
 setup_logging(os.environ.get(PROCESS_ENV) or "anima_train", file=False, console=True)
 bind_trace_id(os.environ.get(TRACE_ENV) or new_trace_id())
-logger = logging.getLogger("anima_train")
 
 
 # ─── Re-exports for sister script / tests (ADR 0003 PR-A) ────────────────────

--- a/runtime/training/block_swap.py
+++ b/runtime/training/block_swap.py
@@ -319,8 +319,8 @@ class PinnedBlockSwap:
                 self.num_swap, self.first_swapped, str(exc)
             ) from exc
 
-        logger.info(
-            "block swap 就绪：换出末尾 %d/%d block，pinned %.2f GB，%d 个 GPU 槽",
+        logger.debug(
+            "block_swap: ready swapped=%d/%d pinned=%.2f GB gpu_slots=%d",
             self.num_swap, self.total, self._pinned_bytes / _GIB, self.num_slots,
         )
 
@@ -492,7 +492,7 @@ class PinnedBlockSwap:
             self._handles.append(block.register_forward_hook(post_hook))
             self._handles.append(block.register_full_backward_pre_hook(backward_pre_hook))
             self._handles.append(block.register_full_backward_hook(backward_hook))
-        logger.info("block swap 已挂载：%d 个 block 的前向/反向钩子", self.num_swap)
+        logger.debug("block_swap: forward/backward hooks attached blocks=%d", self.num_swap)
 
     def detach(self) -> None:
         """移除 attach 注册的钩子（权重不还原，需要时自行 ensure_resident）。"""

--- a/runtime/training/bootstrap.py
+++ b/runtime/training/bootstrap.py
@@ -15,6 +15,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from studio.infrastructure.log_messages import msg
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,16 +42,21 @@ def ensure_dependencies(auto_install: bool = False) -> None:
     missing_list = ", ".join(sorted(set(missing)))
     if not auto_install:
         logger.error(
-            f"Missing dependencies: {missing_list}. Install them with:\n"
-            f"  {sys.executable} -m pip install {missing_list}"
+            "Dependency check failed: missing=%s — training aborted; "
+            "install with: %s -m pip install %s",
+            missing_list, sys.executable, missing_list,
         )
         raise SystemExit(1)
-    logger.info(f"Missing dependencies: {missing_list}; installing...")
+    logger.info(msg("train.deps_installing", missing=missing_list))
     cmd = [sys.executable, "-m", "pip", "install", *sorted(set(missing))]
     try:
         subprocess.run(cmd, check=False)
     except Exception as exc:
-        logger.error(f"Auto-install failed: {exc}")
+        logger.exception(
+            "Dependency auto-install failed: %s — training aborted; "
+            "install manually: %s -m pip install %s",
+            exc, sys.executable, missing_list,
+        )
         raise SystemExit(1)
     still_missing = []
     for module_name, pip_name in required.items():
@@ -59,7 +66,11 @@ def ensure_dependencies(auto_install: bool = False) -> None:
             still_missing.append(pip_name)
     if still_missing:
         still_list = ", ".join(sorted(set(still_missing)))
-        logger.error(f"Still missing after install: {still_list}")
+        logger.error(
+            "Dependency check failed after auto-install: missing=%s — training "
+            "aborted; install manually: %s -m pip install %s",
+            still_list, sys.executable, still_list,
+        )
         raise SystemExit(1)
 
 
@@ -68,7 +79,11 @@ def load_yaml_config(config_path):
     try:
         import yaml
     except ImportError:
-        logger.error("PyYAML not installed. Install with: pip install pyyaml")
+        logger.error(
+            "Dependency check failed: missing=pyyaml — config file cannot be read, "
+            "training aborted; install with: %s -m pip install pyyaml",
+            sys.executable,
+        )
         raise SystemExit(1)
 
     config_path = Path(config_path)
@@ -107,7 +122,7 @@ def apply_yaml_config(args, config):
         return namespace_from_config(args, dict(config or {}), TrainingConfig)
     except ValidationError as exc:
         errors = exc.errors()
-        lines = [f"配置校验失败（{len(errors)} 处）:"]
+        lines = [f"Config validation failed: {len(errors)} problem(s) — training aborted"]
         for err in errors:
             loc = ".".join(str(p) for p in err["loc"]) or "config"
             lines.append(f"  {loc}: {err['msg']}")

--- a/runtime/training/context.py
+++ b/runtime/training/context.py
@@ -148,11 +148,15 @@ class TrainingContext:
             return self.task_archive_state_dir
         return self.state_dir()
 
-    def emit(self, msg: str) -> None:
+    def emit(self, msg: str, level: str = "info") -> None:
         """打印一条 user-facing 消息，按当前进度显示模式分流。
 
         tty 交互（rich live / progress / plain）三路不变；非 tty（studio spawn 的
         pipe）走 logger，与 run.log 其它行同契约（设计 D3：进度/提示也是日志）。
+
+        ``level``（日志改写 F2）：非 tty 出口按此级别派发到 training.emit logger
+        的对应方法。告警性质的 emit（暂停无恢复点、监控历史恢复失败等）不该以
+        INFO 混在叙事行里；tty 三路本就没有级别概念，原样打印。
         """
         if self.use_plain:
             print()  # 冲掉 loop 的 `\r` 进度行（tty 交互）
@@ -163,7 +167,7 @@ class TrainingContext:
         elif self.use_plain:
             print(msg)
         else:
-            _emit_logger.info(msg)
+            getattr(_emit_logger, level, _emit_logger.info)(msg)
 
     def get_next_sample_prompt(self) -> str:
         """取下一个采样提示词（轮换；sample_prompts 为空则返回默认）。"""
@@ -198,13 +202,14 @@ class TrainingContext:
         重复触发（已 interrupted 状态再来一次）= 强退。
         """
         # 延迟 import 避免循环依赖
+        from studio.infrastructure.log_messages import msg
         from training.snapshot import emit_event
 
         if self.interrupted:
-            self.emit("强制退出...")
+            self.emit(msg("train.force_exit"))
             sys.exit(1)
         self.interrupted = True
-        self.emit("\n检测到暂停信号，正在退出（保留最近一次 epoch 备份用于 resume）...")
+        self.emit(msg("train.pause_signal"))
         try:
             self.wandb_monitor.finish()
         except Exception:
@@ -216,7 +221,12 @@ class TrainingContext:
             "step": self.global_step,
         })
         if self.last_auto_epoch_state_path:
-            self.emit(f"已暂停！恢复点: {self.last_auto_epoch_state_path}")
+            self.emit(msg("train.paused_with_state", path=self.last_auto_epoch_state_path))
         else:
-            self.emit("首个 epoch 未完成，无 auto 备份可恢复 → 任务将标 canceled。")
+            self.emit(
+                "Pause without a resume state: the first epoch never finished, so no "
+                "epoch backup exists — the task is marked canceled and this run's "
+                "progress is discarded",
+                level="warning",
+            )
         sys.exit(0)

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -27,6 +27,8 @@ from pathlib import Path
 import torch
 from torch.utils.data import Dataset
 
+from studio.infrastructure.log_messages import msg
+
 # 相对导入：本模块被 studio server 以 `runtime.training.dataset` 复用（bucket
 # 分布预览），那边 sys.path 只有仓库根，`training.*` 绝对导入会 ModuleNotFoundError。
 from .families.anima import ANIMA_SPEC
@@ -282,8 +284,9 @@ class ImageDataset(Dataset):
         self.native_align = int(native_align or _ANIMA_LATENT.align_px)
         if self.native_resolution and len(self.resolutions) > 1:
             logger.warning(
-                "[navit-native] navit_native_resolution 下多分辨率 fan-out 无意义"
-                "（同图各档产同一原生尺寸）：已忽略额外分辨率档 %s，按原生单份处理。",
+                "[navit] Extra resolutions ignored: %s — native resolution mode "
+                "trains each image at its own size, so the extra buckets would only "
+                "duplicate identical samples",
                 self.resolutions[1:],
             )
             # 真正收拢 fan-out（_scan 之前）：不收的话同图仍按每档复制样本、每档各
@@ -299,6 +302,8 @@ class ImageDataset(Dataset):
         # 几何变换后 area 下采样到 latent 分辨率，作为 loss 空间权重。
         self.load_masks = bool(load_masks)
         self._mask_warned: set = set()
+        #: mask 问题分路计数（unreadable / size_mismatch），供收尾汇总。
+        self._mask_problem_counts: dict = {}
         
         # 尝试导入 caption_utils（直接导入避开 __init__.py）
         self.caption_utils = None
@@ -323,17 +328,27 @@ class ImageDataset(Dataset):
                         "normalize": caption_module.normalize_caption_json,
                         "build": caption_module.build_caption_from_json,
                     }
-                    logger.info("JSON caption 模式已启用（分类 shuffle）")
+                    logger.info(msg("train.caption_json_mode"))
                 else:
-                    logger.warning(f"caption_utils.py 未找到: {utils_path}")
+                    logger.warning(
+                        "Caption JSON helper not found: %s — falling back to TXT "
+                        "captions", utils_path,
+                    )
             except Exception as e:
-                logger.warning(f"caption_utils 加载失败: {e}，回退到 TXT 模式")
+                logger.warning(
+                    "Caption JSON helper failed to load: %s — falling back to TXT "
+                    "captions", e,
+                )
         
         self.samples = self._scan()
         json_count = sum(1 for s in self.samples if s.get("json_path"))
         txt_count = len(self.samples) - json_count
         unique_count = len(set(id(s) for s in self.samples))
-        logger.info(f"数据集: {unique_count} 张图 → {len(self.samples)} 样本（含 repeat）(JSON: {json_count}, TXT: {txt_count})")
+        logger.info(msg(
+            "train.dataset_summary",
+            images=unique_count, samples=len(self.samples),
+            json_count=json_count, txt_count=txt_count,
+        ))
         self._preflight_json_captions()
         self.bucket_for_index = self._build_bucket_for_index()
 
@@ -523,10 +538,11 @@ class ImageDataset(Dataset):
         # 日志：每个文件夹的 repeat × 分辨率
         for name, rep, resos, cnt in folder_info:
             reso_str = "/".join(str(r) for r in resos)
-            logger.info(
-                f"  文件夹 {name}: {cnt} 张 × repeat {rep} × 分辨率[{reso_str}] "
-                f"= {cnt * rep * len(resos)} 样本"
-            )
+            logger.info(msg(
+                "train.dataset_folder",
+                name=name, images=cnt, repeat=rep, resolutions=reso_str,
+                samples=cnt * rep * len(resos),
+            ))
 
         return samples
 
@@ -658,20 +674,50 @@ class ImageDataset(Dataset):
                 raw.load()
                 mask = raw.convert("L") if raw.mode != "L" else raw.copy()
         except Exception as e:  # noqa: BLE001
-            if str(mp) not in self._mask_warned:
-                self._mask_warned.add(str(mp))
-                logger.warning(f"[masked-loss] mask 不可读，按无 mask 处理: {mp} ({e})")
+            if self._note_mask_problem(mp, "unreadable"):
+                logger.warning(
+                    "[masked-loss] Mask unreadable: %s (%s) — this image trains "
+                    "without a mask; same warning is not repeated", mp, e,
+                )
             return None
         if mask.size != tuple(size):
-            if str(mp) not in self._mask_warned:
-                self._mask_warned.add(str(mp))
+            if self._note_mask_problem(mp, "size_mismatch"):
                 logger.warning(
-                    "[masked-loss] mask 尺寸 %sx%s 与图片 %sx%s 不匹配，按无 mask 处理"
-                    "（外部改图后请重画 mask）: %s",
+                    "[masked-loss] Mask size %sx%s does not match image %sx%s: %s — "
+                    "this image trains without a mask; redraw the mask after editing "
+                    "the image; same warning is not repeated",
                     mask.size[0], mask.size[1], size[0], size[1], mp,
                 )
             return None
         return mask
+
+    #: 两路 mask 问题共用的全文配额（R8）：超出后只计数，收尾一条汇总。
+    _MASK_WARN_FULL_TEXT_QUOTA = 5
+
+    def _note_mask_problem(self, mask_path, kind: str) -> bool:
+        """登记一条 mask 问题，返回是否该打全文 WARNING。
+
+        按路径去重（同一张图每 epoch 都会重进），再按全局配额封顶——1000 张图
+        mask 全坏时首条之外只计数，总量由 ``log_mask_warning_summary`` 收口。
+        """
+        key = str(mask_path)
+        if key in self._mask_warned:
+            return False
+        self._mask_warned.add(key)
+        self._mask_problem_counts[kind] = self._mask_problem_counts.get(kind, 0) + 1
+        return len(self._mask_warned) <= self._MASK_WARN_FULL_TEXT_QUOTA
+
+    def log_mask_warning_summary(self) -> None:
+        """收尾汇总（由 finalize phase 调用）：一共多少张图没用上 mask。"""
+        unreadable = self._mask_problem_counts.get("unreadable", 0)
+        mismatch = self._mask_problem_counts.get("size_mismatch", 0)
+        if not (unreadable or mismatch):
+            return
+        logger.warning(
+            "[masked-loss] %d image(s) have no usable mask: unreadable=%d "
+            "size_mismatch=%d — those images trained on the full image",
+            unreadable + mismatch, unreadable, mismatch,
+        )
 
     def caption_for_sample(self, sample) -> str:
         """解析一个 sample 的最终 caption，不打开图片。
@@ -1054,7 +1100,10 @@ class CachedLatentDataset(Dataset):
             with self.np.load(npz_path) as data:
                 if "latent" not in data.files:
                     npz_path.unlink()
-                    logger.debug(f"已删除不兼容缓存: {npz_path.name}")
+                    logger.debug(
+                        "latent_cache: dropped incompatible entry file=%s",
+                        npz_path.name,
+                    )
                     return False
                 cache_fp = (
                     str(data["latent_fingerprint"].item())
@@ -1070,9 +1119,10 @@ class CachedLatentDataset(Dataset):
                         or cache_ver != LATENT_CACHE_LAYOUT_VERSION):
                     npz_path.unlink()
                     logger.debug(
-                        f"已删除指纹失配缓存: {npz_path.name} "
-                        f"({cache_fp} v{cache_ver} != "
-                        f"{self.latent_spec.fingerprint} v{LATENT_CACHE_LAYOUT_VERSION})"
+                        "latent_cache: dropped stale entry file=%s cache_fp=%s "
+                        "cache_ver=%s want_fp=%s want_ver=%s",
+                        npz_path.name, cache_fp, cache_ver,
+                        self.latent_spec.fingerprint, LATENT_CACHE_LAYOUT_VERSION,
                     )
                     return False
                 if getattr(self, "flip_augment", False) and "latent_flipped" not in data.files:
@@ -1113,8 +1163,8 @@ class CachedLatentDataset(Dataset):
         分辨率的图用 `img.r{reso}.npz` 分文件。按 npz_path 去重，每个 (图, reso) 最多
         encode 一次；否则同 npz 会被反复覆盖写 N 次（flip_augment 模式下再乘 2）。
         """
-        tag = f"（{self.label}）" if self.label else ""
-        logger.info(f"检查 VAE latent 缓存{tag}...")
+        dataset_label = msg(self.label) if self.label else msg("train.label_training_set")
+        logger.info(msg("train.vae_cache_check", dataset=dataset_label))
         to_encode = []
         seen_npz = set()
         unique_total = 0
@@ -1130,10 +1180,15 @@ class CachedLatentDataset(Dataset):
                 to_encode.append(i)
 
         if to_encode:
-            logger.info(f"需要编码 {len(to_encode)}/{unique_total} 张图像{tag}...")
+            logger.info(msg(
+                "train.vae_cache_encode_todo",
+                dataset=dataset_label, todo=len(to_encode), total=unique_total,
+            ))
             self._encode_and_save(to_encode, vae, device, dtype)
         else:
-            logger.info(f"所有 {unique_total} 张图像已缓存{tag}")
+            logger.info(msg(
+                "train.vae_cache_all_hit", dataset=dataset_label, total=unique_total,
+            ))
 
         self._fill_bucket_for_index()
 
@@ -1174,6 +1229,19 @@ class CachedLatentDataset(Dataset):
         want_flip = self.flip_augment and base_img is not None
         pending = {}
         encoded_count = 0
+        tiled_count = 0
+        total_to_encode = len(indices)
+        # 进度步长自适应（Q3）：固定每 10 张在 1000 张数据集上是 100 行；按总数
+        # 取十分之一封顶在 ~11 条/次。
+        progress_stride = max(10, total_to_encode // 10)
+
+        def _report_encode_progress():
+            """两条编码路径（分块 / 批量）共用的进度行。"""
+            if encoded_count % progress_stride == 0 or encoded_count == total_to_encode:
+                logger.info(msg(
+                    "train.vae_cache_progress",
+                    done=encoded_count, total=total_to_encode,
+                ))
 
         def _encode_pixels(pixel_tensors):
             pixels = torch.stack(pixel_tensors, dim=0).to(device, dtype=dtype)
@@ -1194,7 +1262,7 @@ class CachedLatentDataset(Dataset):
             return lat.detach().cpu().float()[0]
 
         def _flush(bucket_key):
-            nonlocal encoded_count
+            nonlocal encoded_count, tiled_count
             batch = pending.pop(bucket_key, [])
             if not batch:
                 return
@@ -1217,10 +1285,12 @@ class CachedLatentDataset(Dataset):
                 return out
 
             if use_tiled:
-                logger.info(
-                    "[cache-tiled] %dx%d 超像素预算，分块 encode（tile=%d overlap=%d）",
-                    w, h, self.encode_tile_px, self.encode_tile_overlap,
+                logger.debug(
+                    "vae_cache: tiled encode size=%dx%d budget=%dpx tile=%dpx overlap=%dpx",
+                    w, h, self.encode_max_pixels,
+                    self.encode_tile_px, self.encode_tile_overlap,
                 )
+                tiled_count += len(batch)
                 for entry in batch:
                     lat = _encode_tiled_single(entry["pixels"])
                     lat_f = _encode_tiled_single(entry["pixels_flipped"]) if want_flip else None
@@ -1240,8 +1310,7 @@ class CachedLatentDataset(Dataset):
                         **npz_kwargs,
                     )
                     encoded_count += 1
-                    if encoded_count % 10 == 0 or encoded_count == len(indices):
-                        logger.info(f"  编码进度: {encoded_count}/{len(indices)}")
+                    _report_encode_progress()
                 return
 
             latents = _encode_pixels([entry["pixels"] for entry in batch])
@@ -1268,10 +1337,9 @@ class CachedLatentDataset(Dataset):
                     **npz_kwargs,
                 )
                 encoded_count += 1
-                if encoded_count % 10 == 0 or encoded_count == len(indices):
-                    logger.info(f"  编码进度: {encoded_count}/{len(indices)}")
+                _report_encode_progress()
 
-        logger.info(f"VAE cache batch size: {self.cache_batch_size}")
+        logger.debug("vae_cache: batch_size=%d", self.cache_batch_size)
         for i in indices:
             if base_img is not None:
                 # 显式控制 flip，避免随机性 baked 进 npz
@@ -1304,6 +1372,10 @@ class CachedLatentDataset(Dataset):
 
         for bucket_key in list(pending):
             _flush(bucket_key)
+
+        # 分块明细降 DEBUG 后，保留一条汇总解释「为什么缓存这么慢」。
+        if tiled_count:
+            logger.info(msg("train.vae_cache_tiled_summary", n=tiled_count))
 
     def __len__(self):
         return len(self.samples)
@@ -1591,22 +1663,24 @@ class NavitPackBatchSampler:
         mx = max(self.token_counts) if self.token_counts else 0
         if self.token_counts and self.token_budget < mx:
             logger.warning(
-                "[NavitPack] token_budget=%d < 最大单图 token=%d：该图将单独成包，"
-                "可能超出预算并 OOM。建议 token_budget >= 最大单图 token。",
-                self.token_budget, mx,
+                "[navit] token_budget=%d is below the largest single image (%d "
+                "tokens): that image is packed alone and may exceed the budget and "
+                "OOM — raise token_budget to at least %d",
+                self.token_budget, mx, mx,
             )
-        logger.info(
-            "[NavitPack] dataset_len=%d token_budget=%d max_images_per_pack=%s "
-            "strategy=%s ffd_window=%s (token 数范围 %d..%d)",
+        logger.debug(
+            "navit_pack: dataset_len=%d token_budget=%d max_images_per_pack=%s "
+            "strategy=%s ffd_window=%s tokens_per_image=%d..%d",
             len(self.token_counts), self.token_budget,
-            self.max_images_per_pack or "∞", self.strategy,
-            (self.ffd_window or "全局") if self.strategy == "ffd" else "-",
+            self.max_images_per_pack or "unlimited", self.strategy,
+            (self.ffd_window or "global") if self.strategy == "ffd" else "-",
             min(self.token_counts) if self.token_counts else 0, mx,
         )
         if self.strategy == "ffd" and self.ffd_window <= 0:
             logger.warning(
-                "[NavitPack] strategy=ffd 且 ffd_window<=0（全局 FFD）：每 epoch 的包将完全相同"
-                "（按尺寸排序固定），削弱小数据 SGD 的 batch 多样性。多 epoch 训练建议设正窗口。"
+                "[navit] strategy=ffd with ffd_window<=0: every epoch packs images "
+                "in the same fixed size order, so batches never vary — set a "
+                "positive ffd_window for multi-epoch training"
             )
 
     def set_epoch(self, epoch):

--- a/runtime/training/dataset.py
+++ b/runtime/training/dataset.py
@@ -617,7 +617,18 @@ class ImageDataset(Dataset):
                 tag_dropout=self.tag_dropout,
             )
         except Exception as e:
-            logger.warning(f"JSON 处理失败 {json_path}: {e}")
+            # 按 json_path 去重（R8/R9）：坏 JSON × epochs × repeats 会灌上千条；
+            # 每个坏文件只记一次全文。Dataset 无收尾时机，run 级汇总不在此实现。
+            warned = getattr(self, "_caption_json_warned", None)
+            if warned is None:
+                warned = self._caption_json_warned = set()
+            if str(json_path) not in warned:
+                warned.add(str(json_path))
+                logger.warning(
+                    "Caption JSON parse failed: %s (%s) — the caption is treated "
+                    "as empty; repeats of this file are not logged again",
+                    json_path, e,
+                )
             return None
 
     def __len__(self):

--- a/runtime/training/families/anima/comfy_qwen.py
+++ b/runtime/training/families/anima/comfy_qwen.py
@@ -307,8 +307,8 @@ def select_encoder_state_dict(expected_keys, state_dict, *, source: str = "") ->
         )
     extra = provided - expected
     if extra:
-        logging.getLogger(__name__).info(
-            "comfy_qwen3 encoder ignoring %d unexpected checkpoint keys (e.g. %s)",
+        logging.getLogger(__name__).debug(
+            "comfy_qwen3: ignoring %d unexpected checkpoint keys (e.g. %s)",
             len(extra), sorted(extra)[:4],
         )
     return {k: state_dict[k] for k in expected}

--- a/runtime/training/families/anima/family.py
+++ b/runtime/training/families/anima/family.py
@@ -29,6 +29,7 @@ class AnimaFamily:
             path, device, dtype, repo_root,
             flash_attn=(attention_backend == "flash_attn"),
             blocks_to_swap=blocks_to_swap,
+            attention_backend=attention_backend,
         )
         if attention_backend == "xformers":
             enable_xformers(model)

--- a/runtime/training/families/anima/loader.py
+++ b/runtime/training/families/anima/loader.py
@@ -11,6 +11,7 @@ import logging
 import re
 from pathlib import Path
 
+from studio.infrastructure.log_messages import msg
 from training.model_loading import (
     _load_safetensors_state_dict,
     _load_weights_best_effort,
@@ -94,20 +95,24 @@ def place_model_for_block_swap(model, device, dtype, blocks_to_swap: int) -> int
     # .to() 恢复时会把 CPU 主副本搬上卡，swap 白做且瞬时占用=完整模型），
     # families/anima/sampling.py 按它分流
     model.blocks_to_swap = num_swap
-    logger.info(
-        "block swap 放置：末尾 %d/%d 层留在内存（%.2f GB），其余上卡",
+    logger.debug(
+        "block_swap: placement swapped=%d/%d pinned=%.2f GB rest_on_gpu=true",
         num_swap, total, need / 1024 ** 3,
     )
     return num_swap
 
 
 def load_anima_model(transformer_path, device, dtype, repo_root, *,
-                     flash_attn: bool = True, blocks_to_swap: int = 0):
+                     flash_attn: bool = True, blocks_to_swap: int = 0,
+                     attention_backend: str = ""):
     """加载 Anima transformer 模型。
 
     `flash_attn=False` 显式禁用 flash_attn fast path（attention_backend=xformers/none
     时由 caller 传入），让 caller 完全决定 attention 实现 —— PR #17 那版默认
     fn(True) 强制开 flash_attn 不让用户关，与 cfg.attention_backend 解耦不彻底。
+
+    `attention_backend` 只用于日志：告诉用户「flash_attn 没开是因为你选了哪个
+    backend」，与「装没装 flash_attn 包」是两个不同的原因。
     """
     from safetensors import safe_open
 
@@ -128,7 +133,10 @@ def load_anima_model(transformer_path, device, dtype, repo_root, *,
                 flash_enabled = (effective == "flash_attn") or flash_enabled
                 continue
             except Exception as exc:  # noqa: BLE001
-                logger.warning("attention backend 设置失败，继续走 SDPA fallback: %s", exc)
+                logger.warning(
+                    "Attention backend could not be set: %s — attention falls back "
+                    "to PyTorch SDPA", exc,
+                )
                 continue
         fn = getattr(module, "set_flash_attn_enabled", None)
         if fn is None:
@@ -136,12 +144,20 @@ def load_anima_model(transformer_path, device, dtype, repo_root, *,
         try:
             flash_enabled = bool(fn(flash_attn)) or flash_enabled
         except Exception as exc:  # noqa: BLE001
-            logger.warning("flash_attn 启用失败，继续走 SDPA fallback: %s", exc)
+            logger.warning(
+                "flash_attn could not be enabled: %s — attention falls back to "
+                "PyTorch SDPA", exc,
+            )
     if flash_enabled:
-        logger.info("flash_attn 启用（训练 + sample 走 fast path）")
+        logger.info(msg("train.flash_attn_on"))
+    elif not flash_attn:
+        # 「设置里关掉」与「包没装」是两个确定原因，各给一条确定文案。
+        logger.info(msg(
+            "train.flash_attn_off_by_setting",
+            backend=attention_backend or "none",
+        ))
     else:
-        logger.info("flash_attn 关闭（attention_backend=%s 或包未安装）",
-                    "flash_attn" if flash_attn else "non-flash")
+        logger.info(msg("train.flash_attn_off_missing"))
 
     # 从 checkpoint 推断配置
     with safe_open(transformer_path, framework="pt", device="cpu") as f:
@@ -187,7 +203,10 @@ def load_anima_model(transformer_path, device, dtype, repo_root, *,
     if not has_llm_adapter and hasattr(model, "llm_adapter"):
         try:
             model.llm_adapter = None
-            logger.warning("检测到 checkpoint 不包含 llm_adapter 权重：已禁用 llm_adapter（回退为直接使用 Qwen embeddings）")
+            logger.warning(
+                "The model file has no text-adapter weights: the adapter is "
+                "disabled and the text encoder output is fed to the model directly"
+            )
         except Exception:
             pass
     if blocks_to_swap > 0:
@@ -196,7 +215,9 @@ def load_anima_model(transformer_path, device, dtype, repo_root, *,
         model = model.to(device=device, dtype=dtype)
     model.requires_grad_(False)
 
-    logger.info(f"Anima 模型加载完成: {model_channels}ch, {num_blocks} blocks")
+    logger.info(msg(
+        "train.anima_model_loaded", channels=model_channels, blocks=num_blocks,
+    ))
     return model
 
 
@@ -229,9 +250,10 @@ def load_text_encoders(
         t5_tokenizer = t5_cls.from_pretrained(t5_tokenizer_path)
     else:
         logger.warning(
-            "T5 tokenizer 本地目录缺失（t5_tokenizer_path=%s），"
-            "开始从 Hugging Face 下载 google/t5-v1_1-xxl",
-            t5_tokenizer_path or "未配置",
+            "T5 tokenizer not found locally (t5_tokenizer_path=%s): downloading "
+            "google/t5-v1_1-xxl from Hugging Face — this needs a working internet "
+            "connection",
+            t5_tokenizer_path or "unset",
         )
         try:
             t5_tokenizer = t5_cls.from_pretrained("google/t5-v1_1-xxl")
@@ -242,5 +264,5 @@ def load_text_encoders(
                 f"并确认 t5_tokenizer_path（当前值：{t5_tokenizer_path or '未配置'}）指向该目录。"
             ) from e
 
-    logger.info("文本编码器加载完成")
+    logger.info(msg("train.text_encoder_loaded"))
     return qwen_model, qwen_tokenizer, t5_tokenizer

--- a/runtime/training/families/anima/sampling.py
+++ b/runtime/training/families/anima/sampling.py
@@ -296,13 +296,10 @@ def sample_image(
 
     sampler_name, scheduler = _resolve_parity_sampler_scheduler(sampler_name, scheduler)
 
-    logger.debug(f"Sampling start. Prompt: {prompt[:50]}...")
+    logger.debug('sampling: start prompt="%s"', prompt[:50])
 
-    # Check VAE scale
-    if isinstance(vae.scale, list) and len(vae.scale) == 2:
-        m, s = vae.scale
-        logger.debug(f"VAE scale: mean_shape={m.shape}, std_inv_shape={s.shape}")
-        logger.debug(f"VAE scale values: mean={m.mean().item():.4f}, std_inv={s.mean().item():.4f}")
+    # VAE scale 是加载期常量，明细行已挪到 training/vae.py 的 load_vae（每次
+    # 采样都打既重复又各带一次 GPU→CPU 同步）。
 
     # 对齐 ComfyUI：负面提示词没有隐式默认，None 即空。
     negative_prompt = "" if negative_prompt is None else str(negative_prompt)
@@ -323,7 +320,13 @@ def sample_image(
                 device,
                 preserve_empty_text=True,
             )
-            logger.debug(f"Qwen embeds: {qwen_embeds.shape}, mean={qwen_embeds.mean().item():.4f}")
+            if logger.isEnabledFor(logging.DEBUG):
+                # 统计量求值包在 isEnabledFor 里：日志不该在关闭时仍付出
+                # GPU→CPU 同步的代价（T7 求值时机）。
+                logger.debug(
+                    "text_encode: embeds shape=%s mean=%.4f",
+                    tuple(qwen_embeds.shape), qwen_embeds.mean().item(),
+                )
             qwen_embeds = qwen_embeds.to(device=device, dtype=dtype)
             t5_ids = t5_ids.to(device)
             t5_attn = t5_attn.to(device)
@@ -341,9 +344,9 @@ def sample_image(
         # 无条件/负面提示词 (negative prompt)
         cross_uncond = build_cross(negative_prompt)
 
-    except Exception as e:
-        logger.error(f"文本编码失败: {e}")
-        raise e
+    except Exception:
+        # 不在这里记：丢栈且与上层 sample_runner 的 exc_info=True 重复上报。
+        raise
 
     # sigmas（对齐 ComfyUI supported_models.Anima: shift=3.0, multiplier=1.0）
     lat_h = height // _ANIMA_LATENT.spatial_stride
@@ -364,7 +367,11 @@ def sample_image(
     # 初始化噪声（ComfyUI CONST.noise_scaling: x = sigma*noise + (1-sigma)*latent_image；txt2img latent_image=0）
     empty_latent = _prepare_comfy_ksampler_txt2img_latent(height, width, device="cpu")
     x = _prepare_comfy_t2i_noise(tuple(empty_latent.shape), sigmas, device=device, seed=seed)
-    logger.debug(f"Latents init: {x.shape}, mean={x.mean().item():.4f}, std={x.std().item():.4f}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "sampling: latents init shape=%s mean=%.4f std=%.4f",
+            tuple(x.shape), x.mean().item(), x.std().item(),
+        )
 
     pad_mask = torch.zeros(1, 1, lat_h, lat_w, device=device, dtype=dtype)
     device_type = "cuda" if str(device).startswith("cuda") else "cpu"
@@ -414,7 +421,11 @@ def sample_image(
         if torch.isnan(v).any():
             if _set_model_xformers_enabled(model, False):
                 xformers_disabled_for_nan = True
-                logger.warning("xformers attention produced NaN; retrying denoise with SDPA fallback")
+                logger.warning(
+                    "xformers attention produced NaN: retrying this image with "
+                    "PyTorch SDPA — output for this image will not match ComfyUI "
+                    "exactly; xformers is re-enabled for the next image"
+                )
                 v = _run_model_forward()
             if torch.isnan(v).any():
                 raise RuntimeError("v contains NaN during sampling")
@@ -423,7 +434,10 @@ def sample_image(
         return x_in - sigma_5d * v.float()
 
     sampler_name_l = str(sampler_name).lower().strip()
-    logger.debug(f"Sampler={sampler_name_l}, Scheduler={scheduler}, steps={steps}, cfg={cfg_scale}")
+    logger.debug(
+        "sampling: sampler=%s scheduler=%s steps=%s cfg=%s",
+        sampler_name_l, scheduler, steps, cfg_scale,
+    )
 
     # PR-C：通过 inference_samplers plugin registry 派发；白名单已在入口校验
     from training.inference_samplers import build_inference_sampler
@@ -450,13 +464,17 @@ def sample_image(
             # 本张图剩余步数已用 SDPA 跑完（保持步内一致）；进程级开关复位，
             # 下一张图重新尝试 xformers。
             _set_model_xformers_enabled(model, True)
-            logger.warning("xformers re-enabled after per-image SDPA fallback（本张图非 exact parity）")
+            logger.debug("sampling: xformers re-enabled after per-image SDPA fallback")
 
     # VAE 解码
     if phase_callback:
         phase_callback("vae")
     latents = x.to(device=device, dtype=dtype)
-    logger.debug(f"Final latents: mean={latents.mean().item():.4f}, std={latents.std().item():.4f}")
+    if logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "sampling: final latents mean=%.4f std=%.4f",
+            latents.mean().item(), latents.std().item(),
+        )
     del denoise_fn, x, cross_cond, cross_uncond, pad_mask, sigmas, empty_latent
     offloaded_modules: list[tuple[object, torch.device]] = []
     try:
@@ -467,7 +485,10 @@ def sample_image(
         # VAEWrapper.should_offload_for_whole_decode。
         _should_offload = getattr(vae, "should_offload_for_whole_decode", None)
         if device_type == "cuda" and callable(_should_offload) and _should_offload(latents):
-            logger.info("[显存] VAE decode：显存紧张且峰值在崖下，offload 非活跃模块以整图 decode")
+            logger.debug(
+                "vae_decode: offloading idle modules to CPU for whole-image decode "
+                "(free VRAM is tight but the projected peak fits)"
+            )
             offloaded_modules = _offload_modules_for_vae_decode(
                 *_decode_offload_targets(model, qwen_model)
             )
@@ -483,12 +504,12 @@ def sample_image(
         del images, latents
         if device_type == "cuda" and torch.cuda.is_available():
             torch.cuda.empty_cache()
-    except Exception as e:
-        logger.error(f"VAE decode 失败: {e}")
+    except Exception:
+        # 同文本编码：不在这里记，上层 sample_runner 带栈兜住。
         raise
     finally:
         if offloaded_modules:
-            logger.debug("VAE decode: restoring offloaded modules after cleanup")
+            logger.debug("vae_decode: offloaded modules restored")
             _restore_offloaded_modules(offloaded_modules)
 
     model.train()

--- a/runtime/training/families/anima/sra_align.py
+++ b/runtime/training/families/anima/sra_align.py
@@ -99,10 +99,9 @@ class SRAAligner:
             self._hook_fn
         )
         n_params = sum(p.numel() for p in self.proj.parameters())
-        logger.info(
-            f"SRA v2: hook on block[{block_idx}], "
-            f"proj {model_channels} → {out_per_token}, "
-            f"{n_params / 1e6:.1f}M params, normalize={normalize}"
+        logger.debug(
+            "sra: hook block=%d proj=%d->%d params=%.1fM normalize=%s",
+            block_idx, model_channels, out_per_token, n_params / 1e6, normalize,
         )
 
     def _hook_fn(self, module, input, output):

--- a/runtime/training/families/anima/text_encoding.py
+++ b/runtime/training/families/anima/text_encoding.py
@@ -16,12 +16,7 @@
 
 from __future__ import annotations
 
-import logging
-
 import torch
-
-
-logger = logging.getLogger(__name__)
 
 
 def encode_qwen(model, tokenizer, texts, device, preserve_empty_text: bool = False):

--- a/runtime/training/families/krea2/__init__.py
+++ b/runtime/training/families/krea2/__init__.py
@@ -37,6 +37,7 @@ from ..spec import (
     TextSpec,
 )
 # 单源数据（刀 1 / R3）：见 anima/__init__.py 同位注释的依赖方向说明
+from studio.infrastructure.log_messages import msg
 from studio.domain.common import (
     FAMILY_CAPABILITIES,
     FAMILY_CONFIG_DEFAULTS,
@@ -145,10 +146,7 @@ class Krea2Family:
         from training.families.krea2.loader import load_krea2_model
 
         if attention_backend != "none":
-            logger.info(
-                "Krea2 当前固定使用 PyTorch SDPA；忽略 attention_backend=%s",
-                attention_backend,
-            )
+            logger.info(msg("train.krea2_sdpa_only", backend=attention_backend))
         return load_krea2_model(
             path, device, dtype, purpose=purpose, blocks_to_swap=blocks_to_swap,
         )
@@ -263,7 +261,7 @@ class Krea2Family:
                 else _TE_LOAD_NEED_BYTES
             )
             if need_te_move and _should_yield_dit(vram_policy, device, te_need):
-                logger.info("krea2 显存编排：编码前 DiT 让位到 CPU")
+                logger.debug("krea2: moving the Transformer to CPU before text encoding")
                 model.to("cpu")
                 if torch.cuda.is_available():
                     torch.cuda.empty_cache()
@@ -287,6 +285,7 @@ class Krea2Family:
                 offload()
         if dit_yielded:
             model.to(torch.device(device))
+            logger.debug("krea2: Transformer moved back to GPU after text encoding")
         return sample_image(
             model,
             vae,

--- a/runtime/training/families/krea2/loader.py
+++ b/runtime/training/families/krea2/loader.py
@@ -512,8 +512,9 @@ def load_krea2_model(
     del state_dict
     model.requires_grad_(False)
     if packer is not None:
-        logger.info(
-            "block swap pinned：权重 %.2f GB 打包进 %d 块，实际锁定 %.2f GB（溢出块 %d）",
+        logger.debug(
+            "block_swap: pinned packing weights=%.2f GB chunks=%d locked=%.2f GB "
+            "overflow=%d",
             packer.packed_bytes / 1024 ** 3, packer.num_chunks,
             packer.allocated_bytes / 1024 ** 3, packer.overflow_chunks,
         )

--- a/runtime/training/families/krea2/lora_fp8_merge.py
+++ b/runtime/training/families/krea2/lora_fp8_merge.py
@@ -45,6 +45,7 @@ import zlib
 import torch
 from torch import Tensor
 
+from studio.infrastructure.log_messages import msg
 from training.families.krea2.quant_fp8 import _FP8_TORCH_DTYPES
 
 
@@ -365,7 +366,8 @@ def merge_loras_into_fp8_model(
         raise ValueError(f"LoRA 全部层都无法对应到当前模型：{missing[:5]} ...")
     if missing:
         logger.warning(
-            "fp8 merge：%d 个 LoRA 层在模型中无对应 Linear，跳过（comfy 同款行为）：%s%s",
+            "fp8 merge: %d LoRA layer(s) have no matching layer in the model and "
+            "were skipped (%s%s) — those LoRA layers do not affect the output",
             len(missing), missing[:5], " ..." if len(missing) > 5 else "",
         )
 
@@ -440,10 +442,13 @@ def merge_loras_into_fp8_model(
         ):
             torch.cuda.empty_cache()
 
-    logger.info(
-        "Krea2 fp8 merge：%d 份 LoRA 烘进 %d 个 Linear（delta=%s；chunk_rows=%s；%s）",
-        len(sources), len(per_layer), str(compute_dtype).removeprefix("torch."),
+    logger.info(msg(
+        "train.fp8_merge_done", loras=len(sources), layers=len(per_layer),
+    ))
+    logger.debug(
+        "fp8_merge: delta=%s chunk_rows=%s backup=%s",
+        str(compute_dtype).removeprefix("torch."),
         normalized_chunk_rows or "off",
-        "含备份，可 detach 还原" if keep_backup else "无备份，换 LoRA 走重载兜底",
+        "kept (detach can restore)" if keep_backup else "none (reload to swap LoRA)",
     )
     return Fp8LoraMergeAdapter(model, backup, can_restore=keep_backup)

--- a/runtime/training/families/krea2/quant_fp8.py
+++ b/runtime/training/families/krea2/quant_fp8.py
@@ -127,7 +127,7 @@ def patch_fp8_linears(
         module.forward = MethodType(_fp8_linear_forward, module)
         patched += 1
     if patched:
-        logger.info("Krea2 fp8 推理：%d 个 Linear 挂 dequant 前向", patched)
+        logger.debug("fp8: dequant forward attached module=dit layers=%d", patched)
     return patched
 
 

--- a/runtime/training/families/krea2/text_encoding.py
+++ b/runtime/training/families/krea2/text_encoding.py
@@ -25,6 +25,7 @@ from typing import Any, Callable, Iterable, Mapping, Sequence
 import torch
 from torch import Tensor
 
+from studio.infrastructure.log_messages import msg
 from ...text_cache import TextCacheEntry, TextCacheStore
 
 
@@ -154,8 +155,9 @@ def patch_manual_cast(model: torch.nn.Module, compute_dtype: torch.dtype) -> int
             module.forward = MethodType(_cast_embedding_forward, module)
             patched += 1
     if patched:
-        logger.info(
-            "Krea2 TE manual_cast：%d 个模块以 %s 计算（权重常驻存储 dtype）",
+        logger.debug(
+            "krea2_te: manual cast modules=%d compute_dtype=%s "
+            "(weights kept in storage dtype)",
             patched, compute_dtype,
         )
     return patched
@@ -198,7 +200,7 @@ def _load_comfy_single_file_te(
         patch_fp8_linears,
     )
 
-    logger.info("加载 Krea2 Qwen3-VL（comfy 单文件形态）：%s", weights_file)
+    logger.info(msg("train.loading_text_encoder_file", path=weights_file))
     config = AutoConfig.from_pretrained(str(model_path), local_files_only=True)
     try:
         from accelerate import init_empty_weights
@@ -266,7 +268,9 @@ def _load_comfy_single_file_te(
     model.to(device)
     if scales:
         patch_fp8_linears(model, scales)
-        logger.info("Qwen3-VL fp8_scaled：%d 层挂 dequant 前向", len(scales))
+        logger.debug(
+            "fp8: dequant forward attached module=text_encoder layers=%d", len(scales),
+        )
     return model.eval().requires_grad_(False)
 
 
@@ -288,7 +292,7 @@ def _default_model_loader(
     single = _comfy_te_single_file(model_path)
     if single is not None:
         return _load_comfy_single_file_te(model_path, single, device, dtype)
-    logger.info("加载 Krea2 Qwen3-VL 文本编码器：%s", model_path)
+    logger.info(msg("train.loading_text_encoder_file", path=model_path))
     model = Qwen3VLForConditionalGeneration.from_pretrained(
         str(model_path),
         dtype=dtype,
@@ -572,7 +576,9 @@ class Krea2TextStack:
         # 训练中 miss repair 走的也是本函数，那边一两条不刷屏。
         encoded: dict[str, Tensor] = {}
         unique = list(dict.fromkeys(str(caption) for caption in captions))
-        next_mark = 10
+        # 进度步长自适应（Q3）：固定每 10 条在 1000 条数据集上是 100 行。
+        stride = max(10, len(unique) // 10)
+        next_mark = stride
         for start in range(0, len(unique), self.cache_batch_size):
             chunk = unique[start:start + self.cache_batch_size]
             contexts = self._encode_many(chunk)
@@ -581,9 +587,11 @@ class Krea2TextStack:
             if log_progress:
                 done = len(encoded)
                 if done >= next_mark or done == len(unique):
-                    logger.info("  文本编码进度: %d/%d", done, len(unique))
+                    logger.info(msg(
+                        "train.text_cache_progress", done=done, total=len(unique),
+                    ))
                     while next_mark <= done:
-                        next_mark += 10
+                        next_mark += stride
         return encoded
 
     def _validate_context(self, context: object, *, source: str) -> Tensor:
@@ -634,15 +642,15 @@ class Krea2TextStack:
         ]
         if self._caption_entries:
             if to_encode:
-                logger.info(
-                    "[text-cache] caption sidecar 命中 %d/%d，需编码 %d 条...",
-                    len(contexts), len(self._caption_entries), len(to_encode),
-                )
+                logger.info(msg(
+                    "train.text_cache_hits",
+                    hit=len(contexts), total=len(self._caption_entries),
+                    todo=len(to_encode),
+                ))
             else:
-                logger.info(
-                    "[text-cache] caption sidecar 全部命中（%d 条），跳过编码",
-                    len(self._caption_entries),
-                )
+                logger.info(msg(
+                    "train.text_cache_all_hit", n=len(self._caption_entries),
+                ))
         contexts.update(self._encode_in_chunks(to_encode, log_progress=True))
         for caption, entries in missing_entries.items():
             for entry in entries:

--- a/runtime/training/inference_samplers/dpmpp_3m_sde.py
+++ b/runtime/training/inference_samplers/dpmpp_3m_sde.py
@@ -100,10 +100,16 @@ def _build_noise_sampler(
             raise RuntimeError(
                 "Comfy parity dpmpp_3m_sde requires torchsde BrownianTree noise"
             ) from exc
-        import logging
-        logging.getLogger(__name__).warning(
-            "torchsde 未安装，dpmpp_3m_sde 回退独立 Gaussian 噪声（与 ComfyUI / er_sde 差异变化）"
-        )
+        global _torchsde_warned
+        if not _torchsde_warned:
+            _torchsde_warned = True
+            import logging
+            logging.getLogger(__name__).warning(
+                "torchsde is not installed: dpmpp_3m_sde falls back to independent "
+                "Gaussian noise — images will differ from ComfyUI output at the same "
+                "seed; install torchsde for matching results (same warning is not "
+                "repeated)"
+            )
         return _gaussian_noise_sampler(x, seed=seed)
 
 

--- a/runtime/training/inference_samplers/dpmpp_3m_sde.py
+++ b/runtime/training/inference_samplers/dpmpp_3m_sde.py
@@ -26,6 +26,9 @@ warnings.filterwarnings(
     module="torchsde",
 )
 
+# torchsde 缺失回退告警只出一次（R8 warn-once）
+_torchsde_warned = False
+
 
 class _BrownianTreeNoiseSampler:
     """对齐 ComfyUI BrownianTreeNoiseSampler + BatchedBrownianTree。

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -267,6 +267,32 @@ def run(ctx: TrainingContext) -> None:
 
     bucket_switch = _BucketSwitchCacheRelease(ctx.device)
 
+    # NaN 风暴节流（R8/R9）：loss/grad NaN 各打一条首条全文，之后只计数，
+    # epoch 末一条汇总；连续 50 个 optimizer step 无有效更新时升一条 ERROR
+    # （不改控制流，不自动停训）。逐条刷 WARNING 会在 NaN 崩溃场景灌满
+    # run.log，把最后的真 ERROR 块埋掉（error_msg 提取按 ERROR 块）。
+    nan_stats = {
+        "loss_first": True, "grad_first": True,
+        "epoch_micro_skipped": 0, "epoch_micro_total": 0,
+        "epoch_steps_skipped": 0, "epoch_steps_total": 0,
+        "consecutive_skipped": 0, "first_skipped_step": 0, "error_emitted": False,
+    }
+
+    def _note_skipped_step() -> None:
+        nan_stats["epoch_steps_skipped"] += 1
+        if nan_stats["consecutive_skipped"] == 0:
+            nan_stats["first_skipped_step"] = ctx.global_step
+        nan_stats["consecutive_skipped"] += 1
+        if nan_stats["consecutive_skipped"] >= 50 and not nan_stats["error_emitted"]:
+            nan_stats["error_emitted"] = True
+            logger.error(
+                "No effective update for %d consecutive steps: every optimizer step "
+                "since step %d was skipped on NaN/Inf — the run is burning time "
+                "without learning; stop the task and lower the learning rate or "
+                "turn off fp16",
+                nan_stats["consecutive_skipped"], nan_stats["first_skipped_step"],
+            )
+
     for epoch in range(ctx.start_epoch, args.epochs):
         ctx.current_epoch = epoch
         epoch_loss_sum = 0.0
@@ -588,10 +614,17 @@ def run(ctx: TrainingContext) -> None:
             # 不 zero_grad —— 同一累积组内其它 micro-batch 已积累的正常梯度要保留；
             # 也不跳过组尾结算 —— 否则组尾撞上 NaN 时整组梯度作废且 global_step 冻结。
             loss_is_finite = bool(torch.isfinite(loss))
+            nan_stats["epoch_micro_total"] += 1
             if not loss_is_finite:
-                logger.warning(
-                    f"step {ctx.global_step} micro-batch {batch_idx}: loss={loss.item():.4g}，跳过 backward"
-                )
+                nan_stats["epoch_micro_skipped"] += 1
+                if nan_stats["loss_first"]:
+                    nan_stats["loss_first"] = False
+                    logger.warning(
+                        "Loss is NaN/Inf at step %d micro-batch %d: loss=%.4g — "
+                        "backward skipped for this micro-batch; further NaN steps "
+                        "are counted and summarized at each epoch end",
+                        ctx.global_step, batch_idx, loss.item(),
+                    )
             else:
                 loss = loss / group_size
                 if ctx.scaler is not None:
@@ -600,10 +633,12 @@ def run(ctx: TrainingContext) -> None:
                     loss.backward()
 
             if is_group_end:
+                nan_stats["epoch_steps_total"] += 1
                 # 组内所有 micro-batch 都被跳过 → 无梯度可结算：不 step、不推进
                 # global_step（无梯度的 step 会污染 Prodigy 的 k / scheduler 进度；
                 # fp16 下 GradScaler 对空梯度组 step 会直接 assert 崩）。
                 if not any(p.grad is not None for p in ctx.trainable_params):
+                    _note_skipped_step()
                     continue
                 if ctx.scaler is not None:
                     ctx.scaler.unscale_(ctx.optimizer)
@@ -613,7 +648,15 @@ def run(ctx: TrainingContext) -> None:
                     for p in ctx.trainable_params
                 )
                 if has_nan_grad:
-                    logger.warning(f"step {ctx.global_step}: 梯度含 NaN/Inf，跳过 optimizer.step()")
+                    if nan_stats["grad_first"]:
+                        nan_stats["grad_first"] = False
+                        logger.warning(
+                            "Gradient contains NaN/Inf at step %d: optimizer step "
+                            "skipped and gradients cleared — further NaN steps are "
+                            "counted and summarized at each epoch end",
+                            ctx.global_step,
+                        )
+                    _note_skipped_step()
                     ctx.optimizer.zero_grad()
                     if ctx.scaler is not None:
                         ctx.scaler.update()
@@ -629,6 +672,9 @@ def run(ctx: TrainingContext) -> None:
                 if ctx.scheduler is not None and ctx.optimizer_type != "prodigy_plus_schedulefree":
                     ctx.scheduler.step()
                 ctx.optimizer.zero_grad()
+                # 有效更新：连续跳步计数清零，允许下一轮 NaN 段再次升 ERROR
+                nan_stats["consecutive_skipped"] = 0
+                nan_stats["error_emitted"] = False
                 ctx.global_step += 1
 
                 # 自适应采样器：刷新采样分布；baseline 是 no-op
@@ -807,6 +853,17 @@ def run(ctx: TrainingContext) -> None:
                     break
 
         # epoch 结束后的操作
+        if nan_stats["epoch_micro_skipped"] or nan_stats["epoch_steps_skipped"]:
+            logger.warning(
+                "NaN summary for epoch %d: %d/%d micro-batches skipped on NaN loss, "
+                "%d/%d optimizer steps skipped on NaN gradients — those samples did "
+                "not train",
+                epoch,
+                nan_stats["epoch_micro_skipped"], nan_stats["epoch_micro_total"],
+                nan_stats["epoch_steps_skipped"], nan_stats["epoch_steps_total"],
+            )
+        nan_stats["epoch_micro_skipped"] = nan_stats["epoch_micro_total"] = 0
+        nan_stats["epoch_steps_skipped"] = nan_stats["epoch_steps_total"] = 0
         ctx.current_epoch = epoch + 1
         if epoch_step_count > 0:
             ctx.wandb_monitor.log(

--- a/runtime/training/loop.py
+++ b/runtime/training/loop.py
@@ -17,6 +17,7 @@ from typing import Any
 import torch
 import torch.nn.functional as F
 
+from studio.infrastructure.log_messages import msg
 from training.context import TrainingContext
 from training.loss_weighting import compute_loss_weight
 from training.noise import make_noise, noise_params_from_args
@@ -37,6 +38,27 @@ logger = logging.getLogger(__name__)
 # 训练进度行（step/loss/lr/speed）专用 logger：与本模块其它日志分名，方便
 # 显示端按名折叠/过滤高频行（docs/design/logging-target-state.md §7 open question 2）。
 _progress_logger = logging.getLogger("training.progress")
+
+
+def _progress_line(
+    *, epoch: int, epochs: Any, step: int, loss: float,
+    denoise: float, sra_align: Any, sra_weighted: Any,
+    lr: float, speed: float,
+) -> str:
+    """训练进度行的**唯一**格式来源（tty `\\r` 行与 pipe 日志行共用）。
+
+    `{sra}` 是纯 ASCII 的 key=value 片段（denoise / sra / sra_w），带尾空格，
+    不进字典 —— 字典模板只在它前后留位。
+    """
+    if sra_align is not None and sra_weighted is not None:
+        sra = f"denoise={denoise:.6f} sra={sra_align:.6f} sra_w={sra_weighted:.6f} "
+    else:
+        sra = f"denoise={denoise:.6f} "
+    return msg(
+        "train.progress",
+        epoch=epoch, epochs=epochs, step=step,
+        loss=f"{loss:.6f}", sra=sra, lr=f"{lr:.2e}", speed=f"{speed:.2f}",
+    )
 
 
 def _resolve_sra_weight(args: Any) -> float:
@@ -221,12 +243,12 @@ class _BucketSwitchCacheRelease:
             return
         after = _cuda_reserved_gb(self._device)
         detail = (
-            f"（torch 保留 {before:.2f}GB→{after:.2f}GB）"
+            f", reserved {before:.2f} GB -> {after:.2f} GB"
             if before is not None and after is not None
             else ""
         )
         logger.debug(
-            "[显存] ARB 切桶 %sx%s→%sx%s：已归还上一个桶的 allocator 缓存%s",
+            "[vram] ARB bucket switch %sx%s -> %sx%s: allocator cache returned%s",
             prev[0], prev[1], hw[0], hw[1], detail,
         )
 
@@ -255,11 +277,7 @@ def run(ctx: TrainingContext) -> None:
         _r = getattr(args, "resolution", 1024)
         _base_reso = int(_r[0] if isinstance(_r, (list, tuple)) else _r)
         res_shift_base_tokens = max(1, (_base_reso // 16) ** 2)
-        logger.info(
-            "[res-shift] timestep shift 分辨率修正已启用：s_i=sqrt(token_i/%d)"
-            "（基准档 %dpx），作用于采样后的 t。",
-            res_shift_base_tokens, _base_reso,
-        )
+        logger.info(msg("train.res_shift_enabled", base=_base_reso))
         if getattr(ctx.timestep_sampler, "applies_resolution_shift", False):
             raise ValueError(
                 "timestep_shift_resolution_aware 不能与自带分辨率 shift 的 timestep sampler 同时启用"
@@ -772,35 +790,35 @@ def run(ctx: TrainingContext) -> None:
                                 from rich.console import Group
                                 ctx.live.update(Group(ctx.progress, panel))
                     elif ctx.use_plain:
-                        sra_suffix = (
-                            f" denoise={denoise_loss_val:.6f}"
-                            f" sra={sra_align_loss_val:.6f}"
-                            f" sra_w={sra_weighted_loss_val:.6f}"
-                            if sra_align_loss_val is not None and sra_weighted_loss_val is not None
-                            else f" denoise={denoise_loss_val:.6f}"
+                        print(
+                            _progress_line(
+                                epoch=epoch + 1, epochs=args.epochs,
+                                step=ctx.global_step, loss=loss_val,
+                                denoise=denoise_loss_val,
+                                sra_align=sra_align_loss_val,
+                                sra_weighted=sra_weighted_loss_val,
+                                lr=lr, speed=ctx.speed_ema,
+                            ),
+                            end="\r", flush=True,
                         )
-                        print(f"epoch {epoch+1}/{args.epochs} step {ctx.global_step} loss={loss_val:.6f}{sra_suffix} lr={lr:.2e} speed={ctx.speed_ema:.2f} it/s", end="\r", flush=True)
                     elif args.log_every and ctx.global_step % args.log_every == 0:
-                        sra_suffix = (
-                            f" denoise={denoise_loss_val:.6f}"
-                            f" sra={sra_align_loss_val:.6f}"
-                            f" sra_w={sra_weighted_loss_val:.6f}"
-                            if sra_align_loss_val is not None and sra_weighted_loss_val is not None
-                            else f" denoise={denoise_loss_val:.6f}"
-                        )
                         # pipe 模式（studio spawn）：进度行也是日志（设计 D3），走
                         # 独立 logger 名 training.progress，与其它行同契约、前端可
                         # 单独折叠。StreamHandler 每条 flush，不会滞留 8KB 缓冲。
-                        _progress_logger.info(
-                            "epoch=%d step=%d loss=%.6f%s lr=%.2e speed=%.2f it/s",
-                            epoch, ctx.global_step, loss_val, sra_suffix, lr, steps_per_sec,
-                        )
+                        _progress_logger.info(_progress_line(
+                            epoch=epoch + 1, epochs=args.epochs,
+                            step=ctx.global_step, loss=loss_val,
+                            denoise=denoise_loss_val,
+                            sra_align=sra_align_loss_val,
+                            sra_weighted=sra_weighted_loss_val,
+                            lr=lr, speed=steps_per_sec,
+                        ))
 
                 # 按 step 采样（轮换提示词）
                 if args.sample_steps > 0 and ctx.global_step % args.sample_steps == 0:
                     prompt = ctx.get_next_sample_prompt()
                     prompt_short = prompt[:50] + "..." if len(prompt) > 50 else prompt
-                    ctx.emit(f"采样中 (step {ctx.global_step}): {prompt_short}")
+                    ctx.emit(msg("train.sampling_step", step=ctx.global_step, prompt=prompt_short))
                     run_sample(
                         ctx,
                         prompt=prompt,
@@ -817,7 +835,7 @@ def run(ctx: TrainingContext) -> None:
                     # PPSF：保存 averaged weights 的 LoRA
                     with optimizer_eval_mode(ctx.optimizer):
                         ctx.injector.save(lora_path)
-                    ctx.emit(f"Saved LoRA: {lora_path}")
+                    ctx.emit(msg("train.lora_saved_step", step=ctx.global_step, path=lora_path))
                     ctx.wandb_monitor.upload_model(lora_path)
 
                 # 定期保存训练状态（断点续训）
@@ -845,7 +863,8 @@ def run(ctx: TrainingContext) -> None:
                         # 同时保存 LoRA 权重
                         lora_path = ctx.output_dir / f"{args.output_name}_step{ctx.global_step}.safetensors"
                         ctx.injector.save(lora_path)
-                    ctx.emit(f"Saved training state (step {ctx.global_step}): {state_path.name}")
+                    # 保存的叙事行由 save_training_state 打（state.py）——这里再
+                    # emit 一次是同一次保存的第二条记录。
                     ctx.wandb_monitor.upload_state_manual(state_path)
 
                 # 检查 max_steps
@@ -880,14 +899,14 @@ def run(ctx: TrainingContext) -> None:
                 # PPSF：保存 averaged weights 的 LoRA
                 with optimizer_eval_mode(ctx.optimizer):
                     ctx.injector.save(save_path)
-                ctx.emit(f"Saved LoRA: {save_path}")
+                ctx.emit(msg("train.lora_saved_epoch", epoch=ctx.current_epoch, path=save_path))
                 ctx.wandb_monitor.upload_model(save_path)
 
             # 采样（轮换提示词）
             if args.sample_every > 0 and ctx.current_epoch % args.sample_every == 0:
                 prompt = ctx.get_next_sample_prompt()
                 prompt_short = prompt[:50] + "..." if len(prompt) > 50 else prompt
-                ctx.emit(f"采样中 (epoch {ctx.current_epoch}): {prompt_short}")
+                ctx.emit(msg("train.sampling_epoch", epoch=ctx.current_epoch, prompt=prompt_short))
                 run_sample(
                     ctx,
                     prompt=prompt,
@@ -923,7 +942,7 @@ def run(ctx: TrainingContext) -> None:
                     lora_path = ctx.output_dir / f"{args.output_name}_epoch{ctx.current_epoch}.safetensors"
                     if not lora_path.exists():
                         ctx.injector.save(lora_path)
-                ctx.emit(f"Saved training state (epoch {ctx.current_epoch}): {state_path.name}")
+                # 保存的叙事行由 save_training_state 打（state.py），不重复 emit。
                 ctx.wandb_monitor.upload_state_manual(state_path)
 
             # ADR 0006 Addendum 1 方案 Δ：每 epoch 末尾**强制**写 auto_epoch_state.pt（覆盖式）。
@@ -952,6 +971,7 @@ def run(ctx: TrainingContext) -> None:
                     sra_aligner=ctx.sra_aligner,
                     scaler=ctx.scaler,
                     model_family=ctx.family.spec.family_id,
+                    internal=True,  # 系统级恢复点，不是用户产物 → DEBUG
                 )
             ctx.wandb_monitor.upload_state_auto(auto_state_path)
             # 更新 ctx 字段供 handle_interrupt emit pause_state 用

--- a/runtime/training/model_loading.py
+++ b/runtime/training/model_loading.py
@@ -21,6 +21,8 @@ from pathlib import Path
 
 import torch
 
+from studio.infrastructure.log_messages import msg
+
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +41,10 @@ def enable_xformers(model):
     try:
         from xformers.ops import memory_efficient_attention  # noqa: F401
     except ImportError:
-        logger.warning("xformers 未安装，跳过启用")
+        logger.warning(
+            "xformers is not installed: attention runs on PyTorch SDPA instead — "
+            "speed and VRAM use will differ from what the xformers setting implies"
+        )
         return False
 
     enabled_count = 0
@@ -60,7 +65,10 @@ def enable_xformers(model):
             if fn(True):
                 module_switches += 1
         except Exception as exc:  # noqa: BLE001
-            logger.warning("xformers 模组开关启用失败 (%s): %s", module_name, exc)
+            logger.warning(
+                "xformers switch failed for %s: %s — that module keeps PyTorch "
+                "SDPA attention", module_name, exc,
+            )
 
     for name, module in model.named_modules():
         # 查找 attention 模块并替换
@@ -72,14 +80,17 @@ def enable_xformers(model):
             enabled_count += 1
 
     if module_switches > 0 or enabled_count > 0:
-        logger.info(
-            "xformers 已启用: module_switches=%d, module_hooks=%d",
-            module_switches,
-            enabled_count,
+        logger.info(msg("train.xformers_enabled"))
+        logger.debug(
+            "xformers: module_switches=%d module_hooks=%d",
+            module_switches, enabled_count,
         )
         return True
 
-    logger.warning("xformers 已安装，但当前模型没有可启用的 xformers attention hook")
+    logger.warning(
+        "xformers is installed but no attention hook matched this model: "
+        "attention runs on PyTorch SDPA"
+    )
     return False
 
 
@@ -100,7 +111,8 @@ def find_diffusion_pipe_root():
     """
     if os.environ.get("DIFFUSION_PIPE_ROOT"):
         logger.warning(
-            "DIFFUSION_PIPE_ROOT 已不支持（模型代码随仓库发布，走正常 import），忽略该变量"
+            "DIFFUSION_PIPE_ROOT is no longer supported and was ignored: model "
+            "code now ships with the repository"
         )
     repo_root = Path(__file__).resolve().parent.parent.parent
     return repo_root / "modeling" / "anima"
@@ -243,9 +255,15 @@ def _load_weights_best_effort(model: torch.nn.Module, sd: dict, label: str) -> d
     coverage = matched_after / max(1, len(model_keys))
     remap_name = "+".join(prefixes) if prefixes else "none"
 
-    logger.info(
-        f"{label} 权重加载: remap={remap_name}, 匹配 {matched_after}/{len(model_keys)} ({coverage:.1%}), "
-        f"missing={len(missing)}, unexpected={len(unexpected)}"
+    logger.info(msg(
+        "train.weights_loaded",
+        label=label, matched=matched_after, total=len(model_keys),
+        coverage=f"{coverage:.1%}",
+    ))
+    logger.debug(
+        "weights: label=%s remap=%s matched=%d/%d missing=%d unexpected=%d",
+        label, remap_name, matched_after, len(model_keys),
+        len(missing), len(unexpected),
     )
 
     # 关键层缺失会直接导致输出接近 0，采样就是纯噪点

--- a/runtime/training/noise.py
+++ b/runtime/training/noise.py
@@ -16,6 +16,9 @@ import torch.nn.functional as F
 
 logger = logging.getLogger(__name__)
 
+# pyramid_noise 回退告警只出一次（R8 warn-once；见 tmp/log-text-audit）
+_pyramid_warned = False
+
 
 def noise_params_from_args(args) -> tuple[float, int, float]:
     """按 noise_enhancement_type 分派生效的噪声增强参数 → (offset, iters, discount)。
@@ -84,6 +87,14 @@ def make_noise(
                     break
             noise = cur / cur.std().clamp(min=1e-6)
         except Exception as exc:
-            logger.warning(f"pyramid_noise 失败，回退标准噪声: {exc}")
+            # warn-once（R8）：make_noise 每 step 调，逐条告警最坏 3 万行/任务
+            global _pyramid_warned
+            if not _pyramid_warned:
+                _pyramid_warned = True
+                logger.warning(
+                    "Pyramid noise failed: %s — falling back to standard Gaussian "
+                    "noise for the rest of the run; same warning is not repeated",
+                    exc,
+                )
 
     return noise

--- a/runtime/training/observability.py
+++ b/runtime/training/observability.py
@@ -16,8 +16,28 @@ import time
 from pathlib import Path
 from typing import Any, Optional
 
+from studio.infrastructure.log_messages import msg
+
 
 logger = logging.getLogger(__name__)
+
+
+def _delete_artifact_version(artifact_name: str, artifact) -> bool:
+    """删一个旧 artifact 版本；两条清理路径（api 扫描 / 上一次句柄）共用一处实现。"""
+    version = getattr(artifact, "version", "?")
+    try:
+        artifact.delete(delete_aliases=True)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "W&B artifact version delete failed: %s:%s (%s) — the old version "
+            "stays and keeps using storage quota", artifact_name, version, exc,
+        )
+        return False
+    logger.debug(
+        "wandb_artifact: old version deleted name=%s version=%s",
+        artifact_name, version,
+    )
+    return True
 
 
 def render_loss_curve(losses, width=60, height=10):
@@ -94,6 +114,10 @@ class WandBMonitor:
         # W&B 上报失败节流（R8）：log() 每 step 调，首条全文，finish() 汇总
         self._log_fail_count = 0
         self._log_fail_last = ""
+        # 采样图上报失败节流（R8）：每张图一条 → warn-once + finish 汇总
+        self._image_fail_count = 0
+        self._image_fail_last = ""
+        self._resize_fail_warned = False
 
     @property
     def enabled(self) -> bool:
@@ -143,7 +167,12 @@ class WandBMonitor:
                     img = img.resize(new_size, Image.LANCZOS)
                 return self._wandb.Image(img, caption=caption)
         except Exception as exc:
-            logger.warning(f"W&B 图片缩放失败，改传原图: {exc}")
+            if not self._resize_fail_warned:
+                self._resize_fail_warned = True
+                logger.warning(
+                    "W&B image resize failed: %s — uploading the full-size image "
+                    "instead; same warning is not repeated", exc,
+                )
             return self._wandb.Image(str(image_path), caption=caption)
 
     def log_image(self, key: str, image_path: Path, *, caption: str, step: Optional[int] = None) -> None:
@@ -155,7 +184,14 @@ class WandBMonitor:
             self._run.log({key: [self._prepare_image(image_path, caption)]}, step=step)
             self._last_logged_step = step
         except Exception as exc:
-            logger.warning(f"W&B 图片记录失败: {exc}")
+            self._image_fail_count += 1
+            self._image_fail_last = str(exc)
+            if self._image_fail_count == 1:
+                logger.warning(
+                    "W&B image upload failed: %s — this sample image is missing "
+                    "from the dashboard; further failures are counted and reported "
+                    "at the end", exc,
+                )
 
     def _delete_previous_artifact_versions(self, artifact_name: str, artifact_type: str, keep_artifact) -> None:
         keep_version = getattr(keep_artifact, "version", None)
@@ -166,16 +202,18 @@ class WandBMonitor:
             for artifact in api.artifacts(type_name=artifact_type, name=collection_name):
                 if getattr(artifact, "version", None) == keep_version:
                     continue
-                try:
-                    artifact.delete(delete_aliases=True)
+                if _delete_artifact_version(artifact_name, artifact):
                     deleted += 1
-                    logger.info(f"W&B artifact 旧版本已删除: {artifact_name}:{artifact.version}")
-                except Exception as exc:
-                    logger.warning(f"W&B 删除旧 artifact 版本失败 ({artifact_name}:{getattr(artifact, 'version', '?')}): {exc}")
             if deleted:
-                logger.info(f"W&B artifact 已清理旧版本: {artifact_name} ({deleted} 个)")
+                logger.debug(
+                    "wandb_artifact: old versions cleaned name=%s deleted=%d",
+                    artifact_name, deleted,
+                )
         except Exception as exc:
-            logger.warning(f"W&B artifact 历史版本清理失败 ({artifact_name}): {exc}")
+            logger.warning(
+                "W&B artifact cleanup failed: %s (%s) — old versions keep "
+                "accumulating and using storage quota", artifact_name, exc,
+            )
 
     def _upload_artifact(self, file_path: Path, artifact_name: str, artifact_type: str, policy: str) -> None:
         if not self.enabled:
@@ -184,15 +222,32 @@ class WandBMonitor:
             artifact = self._wandb.Artifact(artifact_name, type=artifact_type)
             artifact.add_file(str(file_path), name=file_path.name)
             size_mb = file_path.stat().st_size / 1024 / 1024
-            logger.info(f"W&B artifact 开始上传: {artifact_name} ({file_path.name}, {size_mb:.1f} MB)")
+            logger.debug(
+                "wandb_artifact: upload started name=%s file=%s size=%.1f MB",
+                artifact_name, file_path.name, size_mb,
+            )
             logged_artifact = self._run.log_artifact(artifact)
             start_time = time.monotonic()
             done = threading.Event()
 
             def report_waiting() -> None:
-                while not done.wait(10):
+                slow_warned = False
+                # 30s 一条 DEBUG 心跳；超 5 分钟另打一条 WARNING（慢上传从
+                # 「刷屏 INFO」改成「一条告警」）。
+                while not done.wait(30):
                     elapsed = time.monotonic() - start_time
-                    logger.info(f"W&B artifact 仍在上传: {artifact_name} ({elapsed:.0f}s, {size_mb:.1f} MB)")
+                    logger.debug(
+                        "wandb_artifact: upload in progress name=%s elapsed=%.1f s "
+                        "size=%.1f MB", artifact_name, elapsed, size_mb,
+                    )
+                    if elapsed >= 300 and not slow_warned:
+                        slow_warned = True
+                        logger.warning(
+                            "W&B artifact upload still running after %.1f s: %s "
+                            "(%.1f MB) — training continues, the upload may be "
+                            "stuck on a slow connection",
+                            elapsed, artifact_name, size_mb,
+                        )
 
             progress_thread = threading.Thread(target=report_waiting, daemon=True)
             progress_thread.start()
@@ -202,19 +257,22 @@ class WandBMonitor:
                 done.set()
                 progress_thread.join(timeout=1)
             elapsed = time.monotonic() - start_time
-            logger.info(f"W&B artifact 已上传: {artifact_name} ({file_path.name}, {size_mb:.1f} MB, {elapsed:.1f}s)")
+            logger.info(msg(
+                "train.wandb_artifact_uploaded",
+                name=artifact_name, file=file_path.name,
+                size=f"{size_mb:.1f}", elapsed=f"{elapsed:.1f}",
+            ))
             if policy == "last":
                 self._delete_previous_artifact_versions(artifact_name, artifact_type, logged_artifact)
                 prev = self._last_artifact.get(artifact_name)
                 if prev is not None and getattr(prev, "version", None) != getattr(logged_artifact, "version", None):
-                    try:
-                        prev.delete(delete_aliases=True)
-                        logger.info(f"W&B artifact 旧版本已删除: {artifact_name}:{prev.version}")
-                    except Exception as exc:
-                        logger.warning(f"W&B 删除旧 artifact 失败: {exc}")
+                    _delete_artifact_version(artifact_name, prev)
                 self._last_artifact[artifact_name] = logged_artifact
         except Exception as exc:
-            logger.warning(f"W&B artifact 上传失败 ({artifact_name}): {exc}")
+            logger.warning(
+                "W&B artifact upload failed: %s (%s) — the file exists locally "
+                "only, nothing was uploaded to W&B", artifact_name, exc,
+            )
 
     def upload_model(self, file_path: Path) -> None:
         if not self._upload_model_enabled or not self.enabled:
@@ -243,10 +301,19 @@ class WandBMonitor:
                 "dashboard is incomplete (last error: %s)",
                 self._log_fail_count, self._log_fail_last,
             )
+        if self._image_fail_count > 1:
+            logger.warning(
+                "W&B image upload failed %d time(s) during this run: the "
+                "dashboard is incomplete (last error: %s)",
+                self._image_fail_count, self._image_fail_last,
+            )
         try:
             self._run.finish()
         except Exception as exc:
-            logger.warning(f"W&B finish 失败: {exc}")
+            logger.warning(
+                "W&B run failed to close: %s — the run may stay marked as running "
+                "on the dashboard", exc,
+            )
 
 
 def init_wandb_monitor(args, output_dir: Path, config_path: Optional[Path]) -> WandBMonitor:
@@ -321,7 +388,7 @@ def init_wandb_monitor(args, output_dir: Path, config_path: Optional[Path]) -> W
         config=cfg,
         dir=str(wandb_dir),
     )
-    logger.info(f"W&B 监控已启用: project={project}, run={run_name}, mode={mode}")
+    logger.info(msg("train.wandb_enabled", project=project, run=run_name, mode=mode))
     return WandBMonitor(
         wandb,
         run,

--- a/runtime/training/observability.py
+++ b/runtime/training/observability.py
@@ -91,6 +91,9 @@ class WandBMonitor:
         self._upload_state_auto_enabled = upload_state_auto
         self._upload_state_auto_policy = upload_state_auto_policy
         self._last_artifact: dict[str, Any] = {}
+        # W&B 上报失败节流（R8）：log() 每 step 调，首条全文，finish() 汇总
+        self._log_fail_count = 0
+        self._log_fail_last = ""
 
     @property
     def enabled(self) -> bool:
@@ -102,7 +105,14 @@ class WandBMonitor:
         try:
             self._run.log(data, step=step)
         except Exception as exc:
-            logger.warning(f"W&B log 失败: {exc}")
+            self._log_fail_count += 1
+            self._log_fail_last = str(exc)
+            if self._log_fail_count == 1:
+                logger.warning(
+                    "W&B metric upload failed: %s — metrics for this step are "
+                    "missing from the dashboard; further failures are counted "
+                    "and reported at the end", exc,
+                )
 
     def _should_log_step(self, key: str, step: Optional[int]) -> bool:
         # baseline / epoch 边界一律放行；step 模式按 sample_every_n_steps 节流。
@@ -227,6 +237,12 @@ class WandBMonitor:
     def finish(self) -> None:
         if not self.enabled:
             return
+        if self._log_fail_count > 1:
+            logger.warning(
+                "W&B metric upload failed %d time(s) during this run: the "
+                "dashboard is incomplete (last error: %s)",
+                self._log_fail_count, self._log_fail_last,
+            )
         try:
             self._run.finish()
         except Exception as exc:

--- a/runtime/training/optimizers/automagic.py
+++ b/runtime/training/optimizers/automagic.py
@@ -52,13 +52,14 @@ def validate(args) -> None:
         grad_clip = float(getattr(args, "grad_clip_max_norm", 0) or 0)
         if grad_clip > 0:
             logger.warning(
-                "Automagic v2 使用 fused backward hook，grad_clip=%.2g 将无效"
-                "（参数在 backward 中已更新）", grad_clip
+                "Automagic v2 updates weights inside the backward pass: "
+                "grad_clip=%.2g has no effect — remove it or switch to another "
+                "optimizer", grad_clip,
             )
     else:
         grad_clip = float(getattr(args, "grad_clip_max_norm", 0) or 0)
         if grad_clip > 0:
             logger.warning(
-                "Automagic v1 内置 RMS clip (clip_threshold)；外部 grad_clip=%.2g "
-                "会双重裁剪梯度", grad_clip
+                "Automagic v1 already clips gradients by RMS (clip_threshold): the "
+                "external grad_clip=%.2g clips them a second time", grad_clip,
             )

--- a/runtime/training/phases/bootstrap.py
+++ b/runtime/training/phases/bootstrap.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 import torch
 
+from studio.infrastructure.log_messages import msg
 from training.bootstrap import apply_yaml_config, ensure_dependencies, load_yaml_config
 from training.cli import prompt_for_args
 from training.context import TrainingContext
@@ -44,13 +45,17 @@ def _maybe_apply_pause_snapshot(args, resume_state_path: Path) -> None:
         snapshot = json.loads(raw)
     except Exception as exc:
         logger.warning(
-            f"读取 pause snapshot 失败，沿用现有 args: {snapshot_path} ({exc})"
+            "Pause snapshot could not be read: %s (%s) — continuing with the "
+            "current training settings", snapshot_path, exc,
         )
         return
     if not isinstance(snapshot, dict) or not isinstance(snapshot.get("args"), dict):
-        logger.warning(f"pause snapshot schema 不识别，沿用现有 args: {snapshot_path}")
+        logger.warning(
+            "Pause snapshot format not recognized: %s — continuing with the "
+            "current training settings", snapshot_path,
+        )
         return
-    logger.info(f"加载 pause snapshot 覆盖训练参数: {snapshot_path}")
+    logger.info(msg("train.pause_snapshot_applied", path=snapshot_path))
     snap_args: dict = snapshot["args"]
     skipped = {"resume_state", "config"}
     for k, v in snap_args.items():
@@ -76,7 +81,7 @@ def _resolve_sample_seed(args) -> None:
     if int(getattr(args, "sample_seed", 0) or 0):
         return
     args.sample_seed = random.randint(1, 2**31 - 1)
-    logger.info(f"sample_seed=0 → 训练用随机种子: {args.sample_seed}")
+    logger.info(msg("train.sample_seed_random", seed=args.sample_seed))
 
 
 def run(ctx: TrainingContext) -> None:
@@ -105,7 +110,7 @@ def run(ctx: TrainingContext) -> None:
     # apply_yaml_config 经 pydantic 构造统一补齐（迁移 / 族 overlay / 校验一并生效）
     config = {}
     if args.config:
-        logger.info(f"加载配置文件: {args.config}")
+        logger.info(msg("train.config_loaded", path=args.config))
         ctx.config_path = Path(args.config).resolve()
         ctx.config_dir = ctx.config_path.parent
         config = load_yaml_config(args.config)
@@ -145,8 +150,9 @@ def run(ctx: TrainingContext) -> None:
     # 误伤想跑小 batch 的用户），启动期显式提示
     if getattr(args, "lora_type", "") == "tlora" and int(getattr(args, "batch_size", 1)) > 1:
         logger.warning(
-            "T-LoRA 与 batch_size=%s 同用：rank mask 按 batch 均值 timestep 生成，"
-            "per-sample 掩码退化为批均值近似；要获得论文行为请用 batch_size=1",
+            "T-LoRA with batch_size=%s: the rank mask is built from the batch-mean "
+            "timestep, so per-image masking degrades to a batch average — set "
+            "batch_size=1 for the behavior described in the paper",
             args.batch_size,
         )
 
@@ -201,7 +207,10 @@ def run(ctx: TrainingContext) -> None:
         try:
             ctx.lora_task_id = int(_env_tid)
         except ValueError:
-            logger.warning(f"LORA_TASK_ID={_env_tid!r} 不是 int，按 unknown 处理")
+            logger.debug(
+                'env: LORA_TASK_ID=%r is not an int, using "unknown" '
+                '(state dir falls back to task_unknown/)', _env_tid,
+            )
     ctx.wandb_monitor = init_wandb_monitor(args, ctx.output_dir, ctx.config_path)
 
     # Loss 函数（mse / huber；通过 losses/ plugin registry 派发）
@@ -236,7 +245,10 @@ def run(ctx: TrainingContext) -> None:
                 "data_dir": str(args.data_dir),
             },
         )
-        logger.info(f"📊 训练监控状态文件: {state_path}")
+        logger.debug("monitor: state file path=%s", state_path)
     except Exception as e:
-        logger.warning(f"监控状态写入初始化失败: {e}")
+        logger.warning(
+            "Monitor state file could not be initialized: %s — the training "
+            "dashboard will show no data for this task", e,
+        )
         ctx.monitor_server = None

--- a/runtime/training/phases/dataset.py
+++ b/runtime/training/phases/dataset.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import torch
 from torch.utils.data import DataLoader
 
+from studio.infrastructure.log_messages import msg
 from training.context import TrainingContext
 from training.dataset import (
     BucketBatchSampler,
@@ -65,11 +66,14 @@ def _native_dataset_kwargs(args, ctx) -> dict:
         native_over_budget=str(getattr(args, "navit_native_over_budget", "downscale") or "downscale"),
         native_max_side_tokens=_rope_max_side_tokens(ctx),
     )
-    logger.info(
-        "[navit-native] 原生定尺寸已启用：单图 floor 对齐 16px、零 padding，绕过 ARB 桶量化；"
-        "超预算策略=%s，token 预算=%d，RoPE 单边上限=%s tokens。",
-        kwargs["native_over_budget"], kwargs["native_token_budget"],
-        kwargs["native_max_side_tokens"] or "不限",
+    logger.info(msg(
+        "train.navit_native_enabled",
+        budget=kwargs["native_token_budget"],
+        policy=kwargs["native_over_budget"],
+    ))
+    logger.debug(
+        "navit_native: floor_align=16px padding=0 arb_bucket=bypassed rope_side_limit=%s",
+        kwargs["native_max_side_tokens"] or "none",
     )
     return kwargs
 
@@ -100,7 +104,8 @@ def run(ctx: TrainingContext) -> None:
     load_masks = bool(getattr(args, "masked_loss", False))
     if load_masks and bool(getattr(args, "navit_packing", False)):
         logger.warning(
-            "[masked-loss] NaViT 打包路径暂不支持 masked loss：本次训练忽略 mask"
+            "[masked-loss] NaViT packing does not support masked loss yet: "
+            "masks are ignored for this run"
         )
         load_masks = False
         args.masked_loss = False
@@ -128,14 +133,14 @@ def run(ctx: TrainingContext) -> None:
             if ctx.base_dataset._mask_path_for(s["image"]).is_file()
         )
         if n_masked > 0:
-            logger.info(
-                "[masked-loss] 已启用：%d/%d 张图带 mask（其余全图正常学习）",
-                n_masked, len(ctx.base_dataset.samples),
-            )
+            logger.info(msg(
+                "train.masked_loss_enabled",
+                n=n_masked, total=len(ctx.base_dataset.samples),
+            ))
         else:
-            logger.info(
-                "[masked-loss] 开关已开但训练集没有任何 mask 文件（无 .mask sidecar）"
-                "——本次训练等效于未开启"
+            logger.warning(
+                "[masked-loss] Masked loss is on but no mask file was found in the "
+                "training set: this run behaves exactly as if it were off"
             )
 
     # 正则数据集（Kohya 风格，防过拟合）
@@ -143,9 +148,14 @@ def run(ctx: TrainingContext) -> None:
     ctx.reg_dataset = None
     if reg_data_dir:
         if not Path(reg_data_dir).exists():
-            logger.warning(f"正则数据集路径不存在，已跳过: {reg_data_dir}")
+            logger.warning(
+                "Regularization set skipped: path does not exist (%s)", reg_data_dir,
+            )
         elif len(ctx.base_dataset) == 0:
-            logger.warning("主数据集为空，正则集已跳过")
+            logger.error(
+                "Training set is empty: no usable image found — training cannot "
+                "produce anything; check the dataset path and the image file formats"
+            )
         else:
             reg_caption = (getattr(args, "reg_caption", "") or "").strip()
             reg_base = ImageDataset(
@@ -163,13 +173,19 @@ def run(ctx: TrainingContext) -> None:
             if len(reg_base) == 0:
                 # 空正则集不接线：包 CachedLatentDataset 会打出"所有 0 张图像已
                 # 缓存"迷惑日志，进 MergedDataset 也是纯空转。
-                logger.info(f"正则数据集为空（无有效图片），已跳过: {reg_data_dir}")
+                logger.warning(
+                    "Regularization set skipped: no usable image in %s", reg_data_dir,
+                )
             else:
                 ctx.reg_dataset = reg_base
                 reg_weight = float(getattr(args, "reg_weight", 1.0) or 1.0)
                 cap_preview = f", caption=\"{reg_caption[:50]}{'...' if len(reg_caption) > 50 else ''}\"" if reg_caption else ""
                 weight_info = f", weight={reg_weight}" if reg_weight != 1.0 else ""
-                logger.info(f"正则数据集: {reg_data_dir} ({len(reg_base)} 样本, per-folder repeat{weight_info}){cap_preview}")
+                logger.info(msg(
+                    "train.reg_set_summary",
+                    path=reg_data_dir, samples=len(reg_base),
+                    weight=weight_info, caption=cap_preview,
+                ))
 
     # 缓存 VAE latents（在 repeat 之前）
     ctx.use_cached = getattr(args, "cache_latents", False)
@@ -185,7 +201,7 @@ def run(ctx: TrainingContext) -> None:
             encode_tile_px=getattr(args, "cache_encode_tile_px", 1024),
             encode_tile_overlap=getattr(args, "cache_encode_tile_overlap", 128),
             encode_max_pixels=getattr(args, "cache_encode_max_pixels", 0),
-            label="训练集",
+            label="train.label_training_set",
         )
     if ctx.reg_dataset is not None and ctx.use_cached:
         ctx.reg_dataset = CachedLatentDataset(
@@ -195,7 +211,7 @@ def run(ctx: TrainingContext) -> None:
             encode_tile_px=getattr(args, "cache_encode_tile_px", 1024),
             encode_tile_overlap=getattr(args, "cache_encode_tile_overlap", 128),
             encode_max_pixels=getattr(args, "cache_encode_max_pixels", 0),
-            label="正则集",
+            label="train.label_regularization_set",
         )
 
     # repeat: 主数据集和正则数据集均通过文件夹名 Kohya 风格 repeat（如 5_concept），无需全局 repeat
@@ -204,7 +220,10 @@ def run(ctx: TrainingContext) -> None:
         ctx.dataset = MergedDataset(ctx.dataset, ctx.reg_dataset, reg_weight=reg_weight)
 
     if args.num_workers > 0 and os.name == "nt":
-        logger.warning("num_workers > 0 在 Windows 上容易崩溃：已强制设为 0（避免多进程 spawn 问题）")
+        logger.warning(
+            "num_workers forced to 0: worker processes crash often on Windows — "
+            "data loading runs in the main process"
+        )
         args.num_workers = 0
 
     if getattr(args, "navit_packing", False):
@@ -268,7 +287,11 @@ def run(ctx: TrainingContext) -> None:
                 recon0 = ctx.vae.decode(z0).squeeze(2)                           # [1,3,H,W]
                 recon0 = (recon0.clamp(-1, 1) + 1) / 2
             arr0 = (recon0[0].permute(1, 2, 0).detach().cpu().float().numpy() * 255).clip(0, 255).astype("uint8")
-            Image.fromarray(arr0).save(ctx.sample_dir / "vae_roundtrip.png")
-            logger.info("VAE roundtrip 自检已保存: samples/vae_roundtrip.png")
+            roundtrip_path = ctx.sample_dir / "vae_roundtrip.png"
+            Image.fromarray(arr0).save(roundtrip_path)
+            logger.info(msg("train.vae_selftest_saved", path=roundtrip_path))
     except Exception as e:
-        logger.warning(f"VAE roundtrip 自检失败（若 sample 仍是噪点，请优先修这个）: {e}")
+        logger.warning(
+            "VAE self-test failed: %s — the VAE may be broken, sample images will "
+            "likely come out as noise", e, exc_info=True,
+        )

--- a/runtime/training/phases/finalize.py
+++ b/runtime/training/phases/finalize.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 
+from studio.infrastructure.log_messages import msg
 from training.context import TrainingContext
 from training.observability import render_loss_curve
 from training.snapshot import emit_event
@@ -43,9 +44,13 @@ def _release_block_swap(ctx: TrainingContext) -> None:
 
         gc.collect()
         release_pinned_host_cache()
-        logger.info("block swap 已释放：归还 pinned 内存 %.2fGB", freed / 1024**3)
-    except Exception:  # noqa: BLE001
-        logger.debug("block swap 释放失败（不影响训练结果）", exc_info=True)
+        logger.debug("block_swap: released pinned=%.2f GB", freed / 1024**3)
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Block swap teardown failed: %s — %.2f GB of pinned memory stays locked "
+            "until this process exits, the post-training evaluation may run short "
+            "of RAM", e, freed / 1024**3, exc_info=True,
+        )
 
 
 def run(ctx: TrainingContext) -> None:
@@ -76,6 +81,12 @@ def run(ctx: TrainingContext) -> None:
 
     _release_block_swap(ctx)
 
+    # mask 问题的收尾汇总（明细在训练期按图去重 + 配额封顶，见 dataset.py）。
+    # 只有主训练集会加载 mask，正则集恒不带。
+    _mask_summary = getattr(ctx.base_dataset, "log_mask_warning_summary", None)
+    if callable(_mask_summary):
+        _mask_summary()
+
     # 清理进度显示
     if ctx.live:
         ctx.live.stop()
@@ -85,9 +96,10 @@ def run(ctx: TrainingContext) -> None:
     # 显示最终 loss 曲线
     if args.loss_curve_steps and ctx.loss_history:
         chart = render_loss_curve(ctx.loss_history, width=min(80, len(ctx.loss_history)), height=10)
-        ctx.emit(f"Loss curve (first {len(ctx.loss_history)} steps):\n{chart}")
+        # 首行入字典，ASCII 图表本体作为续行原样输出（不翻译）
+        ctx.emit(msg("train.loss_curve", n=len(ctx.loss_history)) + f"\n{chart}")
 
-    ctx.emit(f"Saved final LoRA: {final_path}")
     ctx.wandb_monitor.upload_model(final_path)
     ctx.wandb_monitor.finish()
-    logger.info("训练完成!")
+    # 「最终 LoRA 已存」与「训练完成」是相邻同语义两行，合并成一条收尾行。
+    logger.info(msg("train.finished", path=final_path))

--- a/runtime/training/phases/models.py
+++ b/runtime/training/phases/models.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from studio.infrastructure.log_messages import msg
 from training.context import TrainingContext
 from training.families import resolve_family
 from training.families.anima import ANIMA_SPEC as _ANIMA_SPEC
@@ -22,11 +23,21 @@ from training.model_loading import (
 
 logger = logging.getLogger(__name__)
 
+#: 日志里 lora_type 的规范大小写。裸 ``.upper()`` 会打出「LOKR」这种不成词的
+#: 拼写；schema 的 Literal 集合是权威来源，新增变体在此补一行。
+_LORA_TYPE_LABELS = {
+    "lora": "LoRA",
+    "lokr": "LoKr",
+    "loha": "LoHa",
+    "ortho": "Ortho",
+    "tlora": "T-LoRA",
+}
+
 
 def _resolve_paths(ctx: TrainingContext) -> None:
     args = ctx.args
     ctx.repo_root = find_diffusion_pipe_root()
-    logger.info("模型代码路径: %s", ctx.repo_root)
+    logger.debug("model_code: path=%s", ctx.repo_root)
 
     phases_dir = Path(__file__).resolve().parent
     training_dir = phases_dir.parent
@@ -76,10 +87,8 @@ def _load_dit(ctx: TrainingContext) -> None:
     args = ctx.args
     backend = getattr(args, "attention_backend", "flash_attn")
     if backend == "none":
-        logger.info(
-            "attention_backend=none，flash_attn / xformers 都不启用，走 PyTorch SDPA"
-        )
-    logger.info("加载 Transformer...")
+        logger.info(msg("train.attention_sdpa"))
+    logger.info(msg("train.loading_transformer"))
     extra = {}
     blocks_to_swap = int(getattr(args, "blocks_to_swap", 0) or 0)
     if blocks_to_swap > 0:
@@ -92,7 +101,10 @@ def _load_dit(ctx: TrainingContext) -> None:
             )
         # 换出层由 loader 直接落 CPU pinned，不经过显存（12/16GB 目标的前提）
         extra["blocks_to_swap"] = blocks_to_swap
-        logger.info("block swap：末尾 %d 层将常驻内存，不载入显存", blocks_to_swap)
+        logger.debug(
+            "block_swap: planned swap_blocks=%d (tail blocks stay in pinned memory, "
+            "never loaded to VRAM)", blocks_to_swap,
+        )
     ctx.model = ctx.family.load_dit(
         args.transformer_path,
         ctx.device,
@@ -105,23 +117,24 @@ def _load_dit(ctx: TrainingContext) -> None:
     from training.sysmem import trim_working_set
 
     trim_working_set()
-    log_vram("DiT 加载后", ctx.device)
+    log_vram("train.vram_stage_transformer_loaded", ctx.device)
 
 
 def _log_train_start_vram(ctx: TrainingContext) -> None:
     """训练循环开始前的显存基线 —— 判断 blocks_to_swap 实际效果的读数点。"""
     swap = getattr(ctx, "block_swap", None)
     if swap is not None:
-        logger.info(
-            "block swap 生效：换出 %d/%d 层，pinned %.2fGB",
-            swap.num_swap, swap.total, swap.pinned_bytes / 1024**3,
-        )
-    log_vram("训练开始前", ctx.device)
+        logger.info(msg(
+            "train.block_swap_active",
+            n=swap.num_swap, total=swap.total,
+            pinned=f"{swap.pinned_bytes / 1024**3:.2f}",
+        ))
+    log_vram("train.vram_stage_train_start", ctx.device)
 
 
 def _load_vae(ctx: TrainingContext) -> None:
     args = ctx.args
-    logger.info("加载 VAE...")
+    logger.info(msg("train.loading_vae"))
     ctx.vae = ctx.family.load_vae(
         args.vae_path,
         ctx.device,
@@ -132,7 +145,7 @@ def _load_vae(ctx: TrainingContext) -> None:
 
 def _load_text(ctx: TrainingContext) -> None:
     args = ctx.args
-    logger.info("加载文本编码器...")
+    logger.info(msg("train.loading_text_encoder"))
     ctx.text_stack = ctx.family.load_text(
         args.text_encoder_path,
         ctx.device,
@@ -165,12 +178,16 @@ def _setup_block_swap(ctx: TrainingContext) -> None:
         ctx.model.blocks, min(blocks_to_swap, len(ctx.model.blocks)), ctx.device,
     )
     ctx.block_swap.attach()
-    log_vram("block swap 挂载后", ctx.device)
+    log_vram("train.vram_stage_block_swap_ready", ctx.device)
 
 
 def _inject_adapter(ctx: TrainingContext) -> None:
     args = ctx.args
-    logger.info("注入 %s...", args.lora_type.upper())
+    lora_type = str(args.lora_type)
+    logger.info(msg(
+        "train.injecting_lora",
+        lora_type=_LORA_TYPE_LABELS.get(lora_type, lora_type),
+    ))
     from training.adapters import build_adapter
 
     ctx.injector = build_adapter(args, preset=ctx.family.lora_preset())
@@ -185,7 +202,7 @@ def _inject_adapter(ctx: TrainingContext) -> None:
                 f"当前 model_family='{ctx.family.spec.family_id}'"
             )
         ctx.injector.load(args.resume_lora)
-        logger.info("将从已有 LoRA 继续训练: %s", args.resume_lora)
+        logger.info(msg("train.resume_from_lora", path=args.resume_lora))
 
     _setup_block_swap(ctx)
 
@@ -197,7 +214,7 @@ def _inject_adapter(ctx: TrainingContext) -> None:
         num_blocks = len(ctx.model.blocks)
         if block_idx >= num_blocks:
             logger.warning(
-                "sra_block=%d >= 模型 blocks 数(%d)，clamp 到 %d",
+                "sra_block=%d is beyond the model block count (%d): clamped to %d",
                 block_idx,
                 num_blocks,
                 num_blocks - 1,
@@ -255,9 +272,7 @@ def _validate_fp8_base(ctx: TrainingContext) -> None:
         raise RuntimeError(
             "fp8 底模与当前配置不兼容：\n- " + "\n- ".join(problems)
         )
-    logger.info(
-        "检测到 fp8 底模：以 fp8_base 语义训练（权重常驻 fp8，前向逐层 dequant）"
-    )
+    logger.info(msg("train.fp8_base_detected"))
 
 
 def run(ctx: TrainingContext) -> None:
@@ -270,9 +285,7 @@ def run(ctx: TrainingContext) -> None:
     _validate_fp8_base(ctx)
 
     if _defer_dit_for_text_cache(ctx):
-        logger.info(
-            "文本缓存已开启：先加载 VAE/Qwen3-VL，缓存并释放 TE 后再加载 Transformer"
-        )
+        logger.info(msg("train.text_cache_order"))
         # 分段预算：本段只加载 VAE + TE（DiT 由 finish 段单独预算）。
         # 开关来自 设置 → 训练 → 训练参数（supervisor 经 env 注入，默认开）。
         check_load_budget(
@@ -312,7 +325,7 @@ def finish(ctx: TrainingContext) -> None:
         return
     from training.sysmem import check_load_budget, guard_enabled_from_env
 
-    logger.info("文本缓存完成且文本编码器已释放；继续加载 Transformer...")
+    logger.info(msg("train.text_cache_done_loading"))
     check_load_budget(
         guard_enabled_from_env(),
         weight_paths=[getattr(ctx.args, "transformer_path", "")],

--- a/runtime/training/phases/optimizer.py
+++ b/runtime/training/phases/optimizer.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import logging
 
+from studio.infrastructure.log_messages import msg
 from training.context import TrainingContext
 
 
@@ -35,19 +36,24 @@ def run(ctx: TrainingContext) -> None:
     if ctx.sra_aligner is not None:
         sra_groups = ctx.sra_aligner.get_param_groups(lr=None)
         param_groups = param_groups + sra_groups
-        logger.info(f"SRA v2: 已将 projection MLP 参数加入 optimizer ({sum(p.numel() for g in sra_groups for p in g['params'])/1e6:.1f}M params)")
+        logger.debug(
+            "sra: projection layer params added to optimizer params=%.1fM",
+            sum(p.numel() for g in sra_groups for p in g["params"]) / 1e6,
+        )
 
     from training.optimizers import build_optimizer, validate_optimizer
     validate_optimizer(args)  # PPSF 检查 lr_scheduler=none 等启动期约束
     ctx.optimizer = build_optimizer(args, param_groups, args.learning_rate, ctx.weight_decay)
     if ctx.weight_decay > 0:
-        wd_info = f"{ctx.optimizer_type} weight_decay={ctx.weight_decay}"
-        if ctx.injector.use_lokr:
-            wd_info += "（w1 排除 weight_decay）"
-        logger.info(wd_info)
+        # LoKr 的 w1 不参与 weight_decay —— 条件后缀做成整句变体而不是拼片段
+        # （i18n 惯例：译者要能调整整句语序）。
+        logger.info(msg(
+            "train.weight_decay_lokr" if ctx.injector.use_lokr else "train.weight_decay",
+            optimizer=ctx.optimizer_type, wd=ctx.weight_decay,
+        ))
     ctx.grad_clip = float(getattr(args, "grad_clip_max_norm", 0) or 0)
     if ctx.grad_clip > 0:
-        logger.info(f"梯度裁剪 max_norm={ctx.grad_clip}")
+        logger.info(msg("train.grad_clip", value=ctx.grad_clip))
     ctx.trainable_params = [p for group in ctx.optimizer.param_groups for p in group["params"]]
 
     # 计算总步数
@@ -77,9 +83,14 @@ def run(ctx: TrainingContext) -> None:
     candidates = [c for c in (by_epochs, by_max_steps) if c is not None and c > 0]
     ctx.total_steps = min(candidates) if candidates else None
 
-    logger.info(
-        f"数据集大小: {len(ctx.dataset)}, 每 epoch 步数: {ctx.steps_per_epoch}, "
-        f"总步数: {ctx.total_steps} (by_epochs={by_epochs}, by_max_steps={by_max_steps})"
+    logger.info(msg(
+        "train.step_plan",
+        samples=len(ctx.dataset), steps_per_epoch=ctx.steps_per_epoch,
+        total_steps=ctx.total_steps,
+    ))
+    logger.debug(
+        "steps: by_epochs=%s by_max_steps=%s chosen=%s",
+        by_epochs, by_max_steps, ctx.total_steps,
     )
 
     # 学习率调度器：PR-C 通过 schedulers/ plugin registry 派发；"none" 自动返回 None

--- a/runtime/training/phases/resume.py
+++ b/runtime/training/phases/resume.py
@@ -5,21 +5,18 @@
 
 from __future__ import annotations
 
-import logging
 import os
 import signal
 import time
 from pathlib import Path
 
+from studio.infrastructure.log_messages import msg
 from training.bootstrap import init_progress
 from training.context import TrainingContext
 from training.observability import render_curve_panel
 from training.sample_runner import run_sample
 from training.snapshot import emit_event
 from training.state import load_training_state
-
-
-logger = logging.getLogger(__name__)
 
 
 def run(ctx: TrainingContext) -> None:
@@ -67,7 +64,7 @@ def run(ctx: TrainingContext) -> None:
             scaler=ctx.scaler,
             expected_family=ctx.family.spec.family_id,
         )
-        ctx.emit(f"从断点恢复训练: epoch={ctx.start_epoch}, step={ctx.global_step}")
+        # resume 的叙事行由 load_training_state 打（state.py），此处不重复。
 
         # 恢复监控面板的历史数据（loss 曲线等）
         if ctx.monitor_server and saved_monitor_state:
@@ -81,9 +78,16 @@ def run(ctx: TrainingContext) -> None:
                     step=ctx.global_step,
                     total_steps=ctx.total_steps,
                 )
-                ctx.emit(f"监控面板历史数据已恢复: {len(saved_monitor_state.get('losses', []))} 个 loss 点")
+                ctx.emit(msg(
+                    "train.monitor_history_restored",
+                    n=len(saved_monitor_state.get("losses", [])),
+                ))
             except Exception as e:
-                ctx.emit(f"监控数据恢复失败: {e}")
+                ctx.emit(
+                    f"Dashboard history could not be restored: {e} — the loss chart "
+                    f"starts from this step, training itself is not affected",
+                    level="warning",
+                )
 
         # ADR §`_on_line` 识别此事件后清理上次 pause 文件对（PR-3 cmd_builder 接入）。
         emit_event("resume_state_loaded", {"path": str(args.resume_state)})
@@ -117,7 +121,7 @@ def run(ctx: TrainingContext) -> None:
     # 只在新训练时执行（global_step == 0），resume 时跳过
     sampling_enabled = args.sample_steps > 0 or args.sample_every > 0
     if ctx.global_step == 0 and sampling_enabled:
-        ctx.emit("采样中 (step 0, 基线)...")
+        ctx.emit(msg("train.baseline_sampling"))
         for i, prompt in enumerate(ctx.sample_prompts[:3]):  # 最多测试 3 个
             sample_path = ctx.sample_dir / f"step_0_baseline_{i}.png"
             run_sample(
@@ -130,7 +134,7 @@ def run(ctx: TrainingContext) -> None:
                 seed_offset=i,
             )
     elif ctx.global_step > 0 and sampling_enabled:
-        ctx.emit(f"跳过启动基线采样（从 step {ctx.global_step} 恢复，非 step 0）")
+        ctx.emit(msg("train.baseline_sampling_skipped", step=ctx.global_step))
 
     # ADR §8.1 is_pausable 信号：resume phase 全部跑完 → 训练进入主循环 →
     # 允许用户暂停。supervisor `_on_line` 收到此事件后 slot.train_loop_started = True

--- a/runtime/training/phases/text_cache.py
+++ b/runtime/training/phases/text_cache.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from studio.infrastructure.log_messages import msg
 from training.context import TrainingContext
 from training.text_cache import TextCacheEntry
 
@@ -85,9 +86,7 @@ def run(ctx: TrainingContext) -> None:
         raise ValueError(f"未知文本策略: {strategy!r}")
 
     if not bool(getattr(ctx.args, "text_encoder_cache", True)):
-        logger.info(
-            "[text-cache] 缓存已关闭：不扫描/读写 sidecar，文本编码器常驻并逐 batch 编码"
-        )
+        logger.info(msg("train.text_cache_off"))
         ctx.family.prepare_text_cache(
             [],
             [],
@@ -104,10 +103,7 @@ def run(ctx: TrainingContext) -> None:
     # train/：放那里会被数据集扫描当成 concept 文件夹误触。纯 CLI（无 task
     # 档案）退回 output_dir，同样在数据集扫描范围之外。
     cache_root = ctx.task_archive_dir or ctx.output_dir
-    logger.info(
-        "[text-cache] 预缓存 %d 张图片 caption + %d 条采样/负面 prompt（varlen）",
-        len(entries), len(extras),
-    )
+    logger.info(msg("train.text_cache_plan", images=len(entries), prompts=len(extras)))
     ctx.family.prepare_text_cache(
         captions,
         extras,

--- a/runtime/training/sample_runner.py
+++ b/runtime/training/sample_runner.py
@@ -89,7 +89,7 @@ def run_sample(
     # 训练都走 PCIe，表现为采样后持续整机卡顿（显存/内存数字反而稳定）。
     # 采样前这次顺带结算「上一段训练步」的峰值并重置，于是采样后那次报出的
     # 就是纯采样期峰值 —— 两个数字合起来才能回答「这张卡够不够」
-    _log_vram_watermark("采样前", peak_label="训练步")
+    _log_vram_watermark("before_sample", peak_label="train_step")
     if torch.cuda.is_available():
         torch.cuda.empty_cache()
     try:
@@ -107,7 +107,9 @@ def run_sample(
                 seed=(s_seed + seed_offset) if s_seed else None,
             )
             img.save(sample_path)
-            ctx.emit(f"采样保存: {sample_path.name}")
+            # 与 loop.py 的「采样中」是同一次采样的两条记录；这条降 DEBUG 并
+            # 改直调 logger，默认视图只留前者。
+            logger.debug("sample: image saved name=%s", sample_path.name)
             if wandb_key and ctx.wandb_monitor.log_samples:
                 ctx.wandb_monitor.log_image(
                     wandb_key,
@@ -122,7 +124,10 @@ def run_sample(
                 except Exception:
                     pass
     except Exception as exc:
-        logger.warning("采样失败，已跳过本次预览，不中断训练: %s", exc, exc_info=True)
+        logger.warning(
+            "Sample image failed: %s — the preview is skipped, training continues",
+            exc, exc_info=True,
+        )
     finally:
         if was_training:
             ctx.model.train()
@@ -131,7 +136,7 @@ def run_sample(
         # 归还采样期的新形状分配，训练继续时 allocator 干净
         if torch.cuda.is_available():
             torch.cuda.empty_cache()
-        _log_vram_watermark("采样后", peak_label="采样期")
+        _log_vram_watermark("after_sample", peak_label="sampling")
 
 
 def _log_vram_watermark(stage: str, *, peak_label: str = "") -> None:
@@ -149,10 +154,12 @@ def _log_vram_watermark(stage: str, *, peak_label: str = "") -> None:
             return
         alloc = torch.cuda.memory_allocated() / 1e9
         reserved = torch.cuda.memory_reserved() / 1e9
-        line = f"[{stage}] 显存 alloc={alloc:.1f}GB reserved={reserved:.1f}GB"
+        line = (
+            f"[vram] {stage}: allocated={alloc:.2f} GB reserved={reserved:.2f} GB"
+        )
         if peak_label:
             peak = torch.cuda.max_memory_allocated() / 1e9
-            line += f" | {peak_label}峰值={peak:.1f}GB"
+            line += f" peak_{peak_label}={peak:.2f} GB"
             torch.cuda.reset_peak_memory_stats()
         try:
             import pynvml
@@ -163,11 +170,11 @@ def _log_vram_watermark(stage: str, *, peak_label: str = "") -> None:
             try:
                 info = pynvml.nvmlDeviceGetMemoryInfo(
                     nvml_handle_for_torch_device(pynvml))
-                line += f" 全卡={info.used / 1e9:.1f}GB"
+                line += f" device_used={info.used / 1e9:.2f} GB"
             finally:
                 pynvml.nvmlShutdown()
         except Exception:
             pass
-        logger.info(line)
+        logger.debug(line)
     except Exception:
         pass

--- a/runtime/training/schedulers/cosine.py
+++ b/runtime/training/schedulers/cosine.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+from studio.infrastructure.log_messages import msg
+
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +15,10 @@ def build(args, optimizer, total_steps: Optional[int]):
     """实例化 CosineAnnealingLR。total_steps 未知时记 warn + 返回 None
     （回退到 no-scheduler）—— 跟原 main() 老逻辑等价。"""
     if total_steps is None:
-        logger.warning("cosine 调度器需要已知 total_steps，回退到 none")
+        logger.warning(
+            "cosine schedule needs a known total step count: falling back to a "
+            "constant learning rate"
+        )
         return None
     import torch
 
@@ -21,5 +26,8 @@ def build(args, optimizer, total_steps: Optional[int]):
     scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
         optimizer, T_max=total_steps, eta_min=eta_min,
     )
-    logger.info(f"学习率调度: cosine (T_max={total_steps}, eta_min={eta_min})")
+    logger.info(msg(
+        "train.lr_schedule",
+        detail=f"cosine (T_max={total_steps}, eta_min={eta_min})",
+    ))
     return scheduler

--- a/runtime/training/schedulers/cosine_with_restart.py
+++ b/runtime/training/schedulers/cosine_with_restart.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 from typing import Optional
 
+from studio.infrastructure.log_messages import msg
+
 
 logger = logging.getLogger(__name__)
 
@@ -20,5 +22,8 @@ def build(args, optimizer, total_steps: Optional[int]):
     scheduler = torch.optim.lr_scheduler.CosineAnnealingWarmRestarts(
         optimizer, T_0=t0, T_mult=t_mult, eta_min=eta_min,
     )
-    logger.info(f"学习率调度: cosine_with_restart (T_0={t0}, T_mult={t_mult}, eta_min={eta_min})")
+    logger.info(msg(
+        "train.lr_schedule",
+        detail=f"cosine_with_restart (T_0={t0}, T_mult={t_mult}, eta_min={eta_min})",
+    ))
     return scheduler

--- a/runtime/training/schedulers/cosine_with_warmup.py
+++ b/runtime/training/schedulers/cosine_with_warmup.py
@@ -6,13 +6,18 @@ import logging
 import math
 from typing import Optional
 
+from studio.infrastructure.log_messages import msg
+
 
 logger = logging.getLogger(__name__)
 
 
 def build(args, optimizer, total_steps: Optional[int]):
     if total_steps is None:
-        logger.warning("cosine_with_warmup 调度器需要已知 total_steps，回退到 none")
+        logger.warning(
+            "cosine_with_warmup schedule needs a known total step count: falling "
+            "back to a constant learning rate"
+        )
         return None
 
     import torch
@@ -21,13 +26,17 @@ def build(args, optimizer, total_steps: Optional[int]):
     warmup_steps = int(getattr(args, "lr_scheduler_warmup_steps", 100) or 0)
     eta_min = max(0.0, float(getattr(args, "lr_scheduler_eta_min", 0.0) or 0.0))
     if total_steps <= 0:
-        logger.warning("cosine_with_warmup 调度器 total_steps<=0，回退到 none")
+        logger.warning(
+            "cosine_with_warmup schedule got total_steps<=0: falling back to a "
+            "constant learning rate"
+        )
         return None
     warmup_steps = max(0, min(warmup_steps, total_steps))
     if total_steps <= warmup_steps:
         logger.warning(
-            "cosine_with_warmup: total_steps(%s) <= warmup_steps(%s)，"
-            "整个训练只跑 warmup，没有 cosine 衰减段",
+            "cosine_with_warmup: total_steps=%s <= warmup_steps=%s — the whole run "
+            "stays in warmup and never reaches the cosine decay; lower "
+            "warmup_steps or train longer",
             total_steps, warmup_steps,
         )
 
@@ -50,10 +59,11 @@ def build(args, optimizer, total_steps: Optional[int]):
         optimizer,
         lr_lambda=[make_lambda(group["lr"]) for group in optimizer.param_groups],
     )
-    logger.info(
-        "学习率调度: cosine_with_warmup (total_steps=%s, warmup_steps=%s, eta_min=%s)",
-        total_steps,
-        warmup_steps,
-        eta_min,
-    )
+    logger.info(msg(
+        "train.lr_schedule",
+        detail=(
+            f"cosine_with_warmup (total_steps={total_steps}, "
+            f"warmup_steps={warmup_steps}, eta_min={eta_min})"
+        ),
+    ))
     return scheduler

--- a/runtime/training/state.py
+++ b/runtime/training/state.py
@@ -17,20 +17,30 @@ from pathlib import Path
 
 import torch
 
+from studio.infrastructure.log_messages import msg
+
 
 logger = logging.getLogger(__name__)
+
+# warn-once（R8）：state_dict() hook 缺失是**持久**原因，每次周期 save 都会
+# 重触发（10 epoch auto backup + 用户周期 save ≈ 20 行/任务）。首条全文后闭嘴。
+_sra_state_dict_warned = False
+_sampler_state_dict_warned = False
 
 
 def save_training_state(
     path, injector, optimizer, epoch, global_step,
     loss_history=None, rng_state=None, monitor_state=None,
     scheduler=None, timestep_sampler=None, sra_aligner=None,
-    scaler=None, model_family=None,
+    scaler=None, model_family=None, internal=False,
 ):
     """保存完整训练状态，支持断点续训。
 
     timestep_sampler（ADR 0006 Addendum 1）：自适应采样器（InfoNoise）的 EMA / CDF / FIFO buffer。
     无状态采样器（baseline）的 state_dict() 是 {}，跳过不存，避免 ckpt 文件无谓增大。
+
+    ``internal``：True = 系统内部的每 epoch auto backup（ADR 0006 Addendum 1 方案 Δ），
+    不是用户产物 → 收尾行走 DEBUG；False = 用户开的周期 save → INFO 叙事行。
     """
     state = {
         "lora_state_dict": injector.state_dict(),
@@ -53,14 +63,28 @@ def save_training_state(
         try:
             state["sra_aligner_state"] = sra_aligner.state_dict()
         except Exception as e:
-            logger.warning(f"sra_aligner.state_dict() 失败（跳过）: {e}")
+            global _sra_state_dict_warned
+            if not _sra_state_dict_warned:
+                _sra_state_dict_warned = True
+                logger.warning(
+                    "SRA aligner state_dict() failed: %s — the resume state is saved "
+                    "without SRA state, resuming will cold-start the projection layer; "
+                    "same warning is not repeated", e,
+                )
     if timestep_sampler is not None and hasattr(timestep_sampler, "state_dict"):
         # hasattr 防御：Protocol 不提供 default dispatch，未来新加的 sampler 若忘记
         # 实现这两个 hook，要静默跳过而非崩溃（训练 8 小时不能因 resume hook 缺失废）
         try:
             sampler_state = timestep_sampler.state_dict()
         except Exception as e:
-            logger.warning(f"timestep_sampler.state_dict() 失败（跳过）: {e}")
+            global _sampler_state_dict_warned
+            if not _sampler_state_dict_warned:
+                _sampler_state_dict_warned = True
+                logger.warning(
+                    "Timestep sampler state_dict() failed: %s — the resume state is "
+                    "saved without sampler state, resuming will repeat its warmup; "
+                    "same warning is not repeated", e,
+                )
             sampler_state = None
         if sampler_state:  # 空 dict（baseline）不存
             state["timestep_sampler_state"] = sampler_state
@@ -79,7 +103,15 @@ def save_training_state(
         os.replace(tmp_path, path)
     finally:
         tmp_path.unlink(missing_ok=True)
-    logger.info(f"训练状态已保存: {path} (epoch={epoch}, step={global_step})")
+    if internal:
+        logger.debug(
+            "resume_state: auto epoch backup saved path=%s epoch=%s step=%s",
+            path, epoch, global_step,
+        )
+    else:
+        logger.info(msg(
+            "train.resume_state_saved", path=path, epoch=epoch, step=global_step,
+        ))
 
 
 def load_training_state(path, injector, optimizer, scheduler=None, timestep_sampler=None, sra_aligner=None, scaler=None, expected_family=None):
@@ -88,7 +120,7 @@ def load_training_state(path, injector, optimizer, scheduler=None, timestep_samp
     timestep_sampler（ADR 0006 Addendum 1）：如 ckpt 含 timestep_sampler_state 且 sampler
     实现了 load_state_dict，把 EMA / CDF / FIFO 灌回去；否则保持冷启动（warning 提示）。
     """
-    logger.info(f"加载训练状态: {path}")
+    logger.info(msg("train.resume_state_loading", path=path))
     state = torch.load(path, map_location="cpu", weights_only=False)
 
     # 多模型 D13：跨族 resume fail-fast。无标记的存量 state grandfather 为 anima。
@@ -105,11 +137,19 @@ def load_training_state(path, injector, optimizer, scheduler=None, timestep_samp
     # 走默认初始化路径而非崩溃；用户应当从头训练新格式 ckpt。
     lora_sd = state["lora_state_dict"]
     result = injector.load_state_dict(lora_sd, strict=False)
-    missing = len(getattr(result, "missing_keys", [])) if hasattr(result, "missing_keys") else 0
-    unexpected = len(getattr(result, "unexpected_keys", [])) if hasattr(result, "unexpected_keys") else 0
+    missing_keys = list(getattr(result, "missing_keys", []) or [])
+    unexpected_keys = list(getattr(result, "unexpected_keys", []) or [])
+    missing = len(missing_keys)
+    unexpected = len(unexpected_keys)
     if missing or unexpected:
+        # T2：只报数量，排障者判断不了严重性 —— 各带一个样例 key。
         logger.warning(
-            f"resume LoRA: missing={missing}, unexpected={unexpected}（旧格式 ckpt？）"
+            'Resume LoRA state incomplete: missing=%d unexpected=%d '
+            '(e.g. missing "%s", unexpected "%s") — unmatched layers start from '
+            'scratch; the checkpoint may come from an older LoRA format',
+            missing, unexpected,
+            missing_keys[0] if missing_keys else "-",
+            unexpected_keys[0] if unexpected_keys else "-",
         )
 
     # 恢复 SRA v2 projection MLP（如启用）。必须在 optimizer state 恢复前完成，
@@ -118,11 +158,18 @@ def load_training_state(path, injector, optimizer, scheduler=None, timestep_samp
         if "sra_aligner_state" in state and hasattr(sra_aligner, "load_state_dict"):
             try:
                 sra_aligner.load_state_dict(state["sra_aligner_state"])
-                logger.info("SRA v2 projection MLP 状态已恢复")
+                logger.debug("sra: projection layer state restored")
             except Exception as e:
-                logger.warning(f"SRA v2 projection MLP 状态恢复失败（冷启动）: {e}")
+                logger.warning(
+                    "SRA projection layer state failed to restore: %s — the layer "
+                    "cold-starts, alignment quality drops for the first steps after "
+                    "resume", e,
+                )
         else:
-            logger.warning("checkpoint 不含 SRA v2 状态；projection MLP 将冷启动")
+            logger.warning(
+                "Resume state has no SRA state: the projection layer cold-starts, "
+                "alignment quality drops for the first steps after resume"
+            )
 
     # 加载优化器状态
     optimizer.load_state_dict(state["optimizer_state_dict"])
@@ -132,15 +179,23 @@ def load_training_state(path, injector, optimizer, scheduler=None, timestep_samp
         try:
             scheduler.load_state_dict(state["scheduler_state_dict"])
         except Exception as e:
-            logger.warning(f"调度器状态恢复失败（将从头开始）: {e}")
+            logger.warning(
+                "LR scheduler state failed to restore: %s — the schedule restarts "
+                "from step 0, the learning rate will not continue the previous "
+                "curve", e,
+            )
 
     # 恢复 GradScaler（fp16）。老 ckpt / bf16·fp32 run 无此 key → 保持默认 scale 冷启动。
     if scaler is not None and "scaler_state" in state:
         try:
             scaler.load_state_dict(state["scaler_state"])
-            logger.info("GradScaler 状态已恢复")
+            logger.debug("amp: fp16 loss scaler state restored")
         except Exception as e:
-            logger.warning(f"GradScaler 状态恢复失败（按默认 scale 冷启动）: {e}")
+            logger.warning(
+                "fp16 loss scaler state failed to restore: %s — scaling restarts "
+                "from the default value, the first steps after resume may be "
+                "skipped", e,
+            )
 
     # 恢复随机数状态
     if "rng_state" in state:
@@ -160,9 +215,12 @@ def load_training_state(path, injector, optimizer, scheduler=None, timestep_samp
     ):
         try:
             timestep_sampler.load_state_dict(state["timestep_sampler_state"])
-            logger.info("timestep_sampler 状态已恢复（自适应 schedule 接力）")
+            logger.debug("timestep_sampler: adaptive schedule state restored")
         except Exception as e:
-            logger.warning(f"timestep_sampler 状态恢复失败（冷启动重 warmup）: {e}")
+            logger.warning(
+                "Timestep sampler state failed to restore: %s — the adaptive "
+                "schedule cold-starts and repeats its warmup", e,
+            )
 
     # ADR 0006 Addendum 1 第 7 条：Schedule-Free 系优化器（PPSF 等）resume 守护。
     # PPSF 内部维护 group['train_mode'] flag + Polyak averaged x/y/z 三组权重；
@@ -175,12 +233,15 @@ def load_training_state(path, injector, optimizer, scheduler=None, timestep_samp
         try:
             optimizer.train()
         except Exception as e:
-            logger.warning(f"optimizer.train() 调用失败（PPSF 可能 broken）: {e}")
+            logger.warning(
+                "optimizer.train() failed after resume: %s — the schedule-free "
+                "optimizer may stay in eval mode and stop updating weights", e,
+            )
 
     epoch = state.get("epoch", 0)
     global_step = state.get("global_step", 0)
     loss_history = state.get("loss_history", [])
     monitor_state = state.get("monitor_state", None)  # 恢复监控数据
 
-    logger.info(f"训练状态已恢复: epoch={epoch}, step={global_step}")
+    logger.info(msg("train.resume_done", epoch=epoch, step=global_step))
     return epoch, global_step, loss_history, monitor_state

--- a/runtime/training/sysmem.py
+++ b/runtime/training/sysmem.py
@@ -32,7 +32,7 @@ def trim_working_set() -> bool:
         handle = ctypes.windll.kernel32.GetCurrentProcess()
         ok = bool(ctypes.windll.psapi.EmptyWorkingSet(handle))
         if ok:
-            logger.info("working set 已 trim（mmap 文件缓存页归还系统）")
+            logger.debug("sysmem: working set trimmed, mmap file cache pages returned to the OS")
         return ok
     except Exception:
         return False
@@ -205,11 +205,14 @@ def check_pinned_budget(need_bytes: int, *, blocks: int) -> None:
         )
 
 
-def log_vram(stage: str, device=None) -> None:
+def log_vram(stage_id: str, device=None) -> None:
     """在关键节点打一行显存/内存快照，方便判断 block swap 等旋钮的实际效果。
 
     刻意同时打 torch 已分配量与**全卡**已用量：WDDM 下两者可能差很多（驱动
     侧开销 + 其他进程），只看 torch 的数会低估真实占用。查询失败静默跳过。
+
+    ``stage_id``：阶段标签的 msg_id（``train.vram_stage_*``），由本函数按当前
+    UI 语言渲染 —— 调用点传中文串会让整行的语言随调用点漂移。
     """
     try:
         import torch
@@ -225,12 +228,17 @@ def log_vram(stage: str, device=None) -> None:
         used = (total - free) / 1024**3
     except Exception:  # noqa: BLE001
         return
+    from studio.infrastructure.log_messages import msg
+
     ram = available_ram_bytes()
-    ram_note = f"，可用内存 {ram / 1024**3:.1f}GB" if ram else ""
-    logger.info(
-        "[显存] %s：torch 已分配 %.2fGB / 保留 %.2fGB，全卡已用 %.2fGB / %.1fGB%s",
-        stage, allocated, reserved, used, total / 1024**3, ram_note,
-    )
+    ram_note = msg("train.vram_ram_suffix", ram=f"{ram / 1024**3:.1f}") if ram else ""
+    logger.info(msg(
+        "train.vram_snapshot",
+        stage=msg(stage_id),
+        alloc=f"{allocated:.2f}", reserved=f"{reserved:.2f}",
+        used=f"{used:.2f}", total=f"{total / 1024**3:.1f}",
+        ram=ram_note,
+    ))
 
 
 def torch_device_pci_bus_id() -> str | None:

--- a/runtime/training/timestep_samplers/infonoise.py
+++ b/runtime/training/timestep_samplers/infonoise.py
@@ -38,6 +38,8 @@ from typing import Optional
 import numpy as np
 import torch
 
+from studio.infrastructure.log_messages import msg
+
 logger = logging.getLogger(__name__)
 
 
@@ -153,11 +155,10 @@ class InfoNoiseScheduler:
         # 静默走 baseline，logger.warning 一次性提醒用户避免"花算力没效果"。
         if self._cdf_values is None and not self._warned_cold_start:
             logger.warning(
-                "InfoNoise: warmup 已过且各 bin 样本充足，但首次 schedule "
-                "刷新仍未产生有效 CDF（原因：%s）。当前继续使用 logit-normal "
-                "baseline 采样；若该状态持续到训练后期，说明你的 loss 分布在 "
-                "log-σ 空间过于均匀（如已收敛模型），InfoNoise 无加速效果，"
-                "建议关闭 infonoise_enabled。",
+                "InfoNoise produced no usable schedule after warmup: %s — sampling "
+                "stays on the logit-normal baseline, so InfoNoise costs compute "
+                "without changing anything; turn infonoise off if this keeps "
+                "happening (same warning is not repeated)",
                 self._last_refresh_status,
             )
             self._warned_cold_start = True
@@ -201,9 +202,9 @@ class InfoNoiseScheduler:
         if saved_version != self._STATE_VERSION:
             # v1 用 σ³ 公式 + buggy pivot，跟 v2 数学语义不兼容；丢 mse_ema/cdf 走冷启动
             logger.warning(
-                "InfoNoise resume: state_dict version %d (current=%d) — 算法已变更"
-                "（σ³→σ² entropy rate + paper-aligned gate pivot），丢弃 mse_ema/cdf "
-                "走冷启动 warmup。",
+                "InfoNoise resume: saved state version %d does not match current "
+                "%d — the algorithm changed, the saved statistics are discarded "
+                "and warmup starts over",
                 saved_version, self._STATE_VERSION,
             )
             return
@@ -212,8 +213,9 @@ class InfoNoiseScheduler:
         if saved_K != self.K or saved_B != self.B:
             # 已经跑了几小时，配置改了不要崩 —— 退回冷启动让 warmup 重走。
             logger.warning(
-                "InfoNoise resume: shape mismatch (saved K=%d B=%d, current K=%d B=%d) "
-                "—— 跳过 sampler state 加载，从冷启动重 warmup。",
+                "InfoNoise resume: saved bin layout (K=%d B=%d) does not match "
+                "current (K=%d B=%d) — the saved sampler state is skipped and "
+                "warmup starts over",
                 saved_K, saved_B, self.K, self.B,
             )
             return
@@ -293,8 +295,20 @@ def build(args, total_steps: Optional[int]) -> InfoNoiseScheduler:
     """
     n_warm_cfg = int(getattr(args, "infonoise_N_warm", 0) or 0)
     if n_warm_cfg <= 0:
-        n_warm_cfg = max(200, int((total_steps or 5000) * 0.2))
-        logger.info(f"InfoNoise N_warm 自动设置为 {n_warm_cfg} 步（总步数 {total_steps} × 20%）")
+        # 三种分支说法不同：20% 生效 / 200 步下限生效 / total_steps 未知（走
+        # 5000 兜底）。共用一句会打出「总步数 None × 20%」这种对不上的文案。
+        _pct = int((total_steps or 5000) * 0.2)
+        n_warm_cfg = max(200, _pct)
+        if total_steps is None:
+            logger.info(msg("train.infonoise_warmup_unknown_total", steps=n_warm_cfg))
+        elif n_warm_cfg > _pct:
+            logger.info(msg(
+                "train.infonoise_warmup_floor", steps=n_warm_cfg, total=total_steps,
+            ))
+        else:
+            logger.info(msg(
+                "train.infonoise_warmup_auto", steps=n_warm_cfg, total=total_steps,
+            ))
 
     scheduler = InfoNoiseScheduler(
         K=int(getattr(args, "infonoise_K", 64) or 64),
@@ -309,12 +323,13 @@ def build(args, total_steps: Optional[int]) -> InfoNoiseScheduler:
         baseline_mix_low_prob=float(getattr(args, "timestep_mix_low_prob", 0.0) or 0.0),
         baseline_timestep_schedule_shift=float(getattr(args, "timestep_schedule_shift", 1.0) or 1.0),
     )
-    logger.info(
-        f"InfoNoise 已启用：K={scheduler.K}, N_warm={scheduler.N_warm}, "
-        f"M={scheduler.M}, B={scheduler.B}, beta={scheduler.beta}, "
-        f"gate_pivot_c={scheduler.gate_pivot_c}, "
-        f"baseline={scheduler.baseline_mode}(shift={scheduler.baseline_shift}, "
-        f"mix_low_prob={scheduler.baseline_mix_low_prob}, "
-        f"timestep_schedule_shift={scheduler.baseline_timestep_schedule_shift})"
+    logger.info(msg("train.infonoise_enabled"))
+    logger.debug(
+        "infonoise: K=%s N_warm=%s M=%s B=%s beta=%s gate_pivot_c=%s baseline=%s "
+        "shift=%s mix_low_prob=%s timestep_schedule_shift=%s",
+        scheduler.K, scheduler.N_warm, scheduler.M, scheduler.B, scheduler.beta,
+        scheduler.gate_pivot_c, scheduler.baseline_mode, scheduler.baseline_shift,
+        scheduler.baseline_mix_low_prob,
+        scheduler.baseline_timestep_schedule_shift,
     )
     return scheduler

--- a/runtime/training/vae.py
+++ b/runtime/training/vae.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import torch
 
+from studio.infrastructure.log_messages import msg
 from training.model_loading import (
     _load_safetensors_state_dict,
     _load_weights_best_effort,
@@ -160,7 +161,8 @@ class VAEWrapper:
                 # 默认不显示，免得「已用 X > 总显存」被误读成显存不足。
                 self._log_once(
                     "auto_decode", logger.debug,
-                    "VAE decode 主动分块（tiling=auto）：已用 %.1fG + 预计峰值 %.1fG > 总显存 %.1fG×%.2f",
+                    "vae: auto tiling for decode used=%.2f GB projected_peak=%.2f GB "
+                    "limit=%.2f GB x %.2f",
                     used / 1024 ** 3, est / 1024 ** 3, total / 1024 ** 3, self._TILE_VRAM_FRACTION,
                 )
                 return self._tiled_decode(z)
@@ -172,8 +174,8 @@ class VAEWrapper:
             torch.cuda.empty_cache()
             self._log_once(
                 "oom_decode", logger.warning,
-                "VAE 整图 decode OOM，回退到 tiled decode "
-                "(tile=%dpx, overlap=%dpx)（同类后续不再重复）",
+                "VAE decode ran out of VRAM: falling back to tiled decode "
+                "(tile=%dpx, overlap=%dpx) — same warning is not repeated",
                 self._TILE_LATENT * self._UPSAMPLE,
                 (self._TILE_LATENT - self._STRIDE_LATENT) * self._UPSAMPLE,
             )
@@ -198,7 +200,8 @@ class VAEWrapper:
                 # 默认不显示，免得「已用 X > 总显存」被误读成显存不足。
                 self._log_once(
                     "auto_encode", logger.debug,
-                    "VAE encode 主动分块（tiling=auto）：已用 %.1fG + 预计峰值 %.1fG > 总显存 %.1fG×%.2f",
+                    "vae: auto tiling for encode used=%.2f GB projected_peak=%.2f GB "
+                    "limit=%.2f GB x %.2f",
                     used / 1024 ** 3, est / 1024 ** 3, total / 1024 ** 3, self._TILE_VRAM_FRACTION,
                 )
                 return self._tiled_encode(pixels)
@@ -209,8 +212,8 @@ class VAEWrapper:
             torch.cuda.empty_cache()
             self._log_once(
                 "oom_encode", logger.warning,
-                "VAE 整图 encode OOM，回退到 tiled encode "
-                "(tile=%dpx, overlap=%dpx)（同类后续不再重复）",
+                "VAE encode ran out of VRAM: falling back to tiled encode "
+                "(tile=%dpx, overlap=%dpx) — same warning is not repeated",
                 self._TILE_LATENT * self._UPSAMPLE,
                 (self._TILE_LATENT - self._STRIDE_LATENT) * self._UPSAMPLE,
             )
@@ -368,5 +371,14 @@ def load_vae(vae_path, device, dtype, repo_root, *, tiling: str = "auto"):
         3.2687, 2.1526, 2.8652, 1.5579, 1.6382, 1.1253, 2.8251, 1.9160
     ], dtype=dtype, device=device)
 
-    logger.info("VAE 加载完成")
+    logger.info(msg("train.vae_loaded"))
+    # scale 是加载期常量 —— 原先每张采样图打两条 DEBUG（还各带一次 GPU→CPU
+    # 同步的 .item()），这里打一次即可。
+    if logger.isEnabledFor(logging.DEBUG):
+        _std_inv = 1.0 / std
+        logger.debug(
+            "vae: scale mean_shape=%s std_inv_shape=%s mean=%.4f std_inv=%.4f",
+            tuple(mean.shape), tuple(_std_inv.shape),
+            mean.mean().item(), _std_inv.mean().item(),
+        )
     return VAEWrapper(model, mean, std, tiling=tiling)

--- a/studio/api/exception_handlers.py
+++ b/studio/api/exception_handlers.py
@@ -72,11 +72,17 @@ def _error_envelope(
 
 
 async def _domain_error_handler(req: Request, exc: DomainError) -> JSONResponse:
-    # 4xx 业务异常用 info（非异常路径，是契约的一部分）；5xx 才 exception。
+    # 4xx 业务异常走 DEBUG（非异常路径，是契约的一部分）；5xx 才 exception。
     if exc.http_status >= 500:
-        logger.exception("domain error %s: %s", exc.code, exc.message)
+        logger.exception(
+            "domain error: code=%s method=%s path=%s msg=%s",
+            exc.code, req.method, req.url.path, exc.message,
+        )
     else:
-        logger.info("domain error %s: %s", exc.code, exc.message)
+        logger.debug(
+            "domain error (4xx): code=%s method=%s path=%s msg=%s",
+            exc.code, req.method, req.url.path, exc.message,
+        )
     return JSONResponse(
         status_code=exc.http_status,
         content=_error_envelope(
@@ -129,7 +135,7 @@ async def _fallback_handler(req: Request, exc: Exception) -> JSONResponse:
     # 未捕获异常 — 进 logger.exception 带完整 traceback + trace_id 给开发查；
     # response body 脱敏不含 traceback 防 leak。
     logger.exception(
-        "unhandled exception in %s %s", req.method, req.url.path,
+        "unhandled exception: method=%s path=%s", req.method, req.url.path,
     )
     return JSONResponse(
         status_code=500,

--- a/studio/api/lifespan.py
+++ b/studio/api/lifespan.py
@@ -151,12 +151,18 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
         try:
             if _md.taeflux_available():
                 return
-            logger.info("background-downloading TAEFlux (~1.6MB)…")
-            ok = _md.download_taeflux(on_log=lambda m: logger.info("[taeflux] %s", m))
+            logger.info("[taeflux] downloading in background: size=~1.6 MB")
+            ok = _md.download_taeflux(on_log=lambda m: logger.debug("[taeflux] %s", m))
             if not ok:
-                logger.warning("taeflux background download failed; preview disabled until manual install")
+                logger.warning(
+                    "[taeflux] background download failed; latent preview stays "
+                    "disabled until TAEFlux is installed manually"
+                )
         except Exception:
-            logger.exception("taeflux background download crashed")
+            logger.warning(
+                "[taeflux] background download thread crashed; latent preview stays disabled",
+                exc_info=True,
+            )
     threading.Thread(target=_bg_download_taeflux, name="taeflux-bg-download", daemon=True).start()
 
     # Tag 翻译词典（约 30MB SQLite）后台下载：仅当 active.json 不存在时拉取；失败只
@@ -166,12 +172,12 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
         try:
             if _td.ACTIVE_JSON.exists():
                 return
-            logger.info("background-downloading tag dictionary (~30MB)…")
+            logger.info("downloading tag dictionary in background: size=~30 MB")
             _td.download_default()
         except Exception as exc:
             logger.warning(
-                "tag dictionary background download failed (%s); "
-                "user can retry from Settings → Tag dictionary",
+                "tag dictionary background download failed: %s; "
+                "retry from Settings → Tag dictionary",
                 exc,
             )
     threading.Thread(target=_bg_download_tag_dict, name="tag-dict-bg-download", daemon=True).start()
@@ -185,7 +191,9 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
             with db.connection_for() as conn:
                 eval_cleanup.cleanup_legacy_eval_on_startup(conn)
         except Exception:
-            logger.exception("legacy eval cleanup failed (harmless; will retry next start)")
+            logger.warning(
+                "legacy eval cleanup failed; will retry on the next start", exc_info=True,
+            )
     threading.Thread(
         target=_bg_cleanup_legacy_eval, name="legacy-eval-cleanup", daemon=True
     ).start()
@@ -215,7 +223,7 @@ async def lifespan(app_: FastAPI) -> AsyncIterator[None]:
         n = generate_cache.total_count()
         if n:
             generate_cache.clear_all()
-            logger.info("flushed generate disk cache (%d images) after SSE idle", n)
+            logger.info("flushed generate disk cache: images=%d reason=sse_idle", n)
         _disconnect_timer["t"] = None
 
     bus.set_connection_callbacks(

--- a/studio/api/main.py
+++ b/studio/api/main.py
@@ -31,7 +31,8 @@ def main() -> None:
     args = parser.parse_args()
 
     # ADR 0012：SPA 入口在根路径 /（不再用 /studio 子路径）。
-    print(f"[AnimaStudio] http://{args.host}:{args.port}/")
+    # URL 由 cli.py 的 `cli.backend_started` 行打印（带 ts/级别，符合行契约），
+    # 这里不再重复一条裸 print banner。
     uvicorn.run(
         "studio.server:app",
         host=args.host,

--- a/studio/api/routers/client_errors.py
+++ b/studio/api/routers/client_errors.py
@@ -45,6 +45,30 @@ _RATE_LIMIT_MAX_PER_WINDOW = 10
 _ip_buckets: Dict[str, Deque[float]] = {}
 _bucket_lock = Lock()
 
+# 限流丢弃的窗口汇总（T5）：前端错误风暴时 server 端不跟着放大 —— 逐条不记，
+# 每 60s 至多一条 DEBUG 计数汇总。
+_DROP_SUMMARY_WINDOW_SECONDS = 60.0
+_drop_counts: Dict[str, int] = {}
+_drop_last_report = 0.0
+
+
+def _note_rate_limit_drop(ip: str) -> None:
+    """累加丢弃计数；每窗口至多输出一条汇总（不记单条）。"""
+    global _drop_last_report
+    now = time.monotonic()
+    with _bucket_lock:
+        _drop_counts[ip] = _drop_counts.get(ip, 0) + 1
+        if now - _drop_last_report < _DROP_SUMMARY_WINDOW_SECONDS:
+            return
+        _drop_last_report = now
+        snapshot = sorted(_drop_counts.items(), key=lambda kv: -kv[1])
+        _drop_counts.clear()
+    for ip_, dropped in snapshot:
+        logger.debug(
+            "client_errors rate-limited: dropped=%d ip=%s window=%ds",
+            dropped, ip_, int(_RATE_LIMIT_WINDOW_SECONDS),
+        )
+
 
 def _rate_limit_ok(ip: str, *, now: float | None = None) -> bool:
     """True = 在限额内可上报；False = 超 10/min 拒收（silently 204）。
@@ -85,15 +109,15 @@ async def report_client_error(request: Request) -> Response:
     """前端上报。**永远 204** — 不让上报失败级联前端 UI。"""
     ip = _client_ip(request)
     if not _rate_limit_ok(ip):
-        # 超限 silently drop；偶尔记一行 INFO 防完全失明
-        logger.info("client_errors rate-limit drop ip=%s", ip)
+        # 超限 silently drop；只按窗口汇总，防前端错误风暴在 server 端二次放大
+        _note_rate_limit_drop(ip)
         return Response(status_code=204)
 
     try:
         body: Dict[str, Any] = await request.json()
     except Exception:
         # 非 JSON body — 不上报
-        logger.warning("client_errors malformed body from ip=%s", ip)
+        logger.warning("client_errors malformed body: ip=%s", ip)
         return Response(status_code=204)
 
     if not isinstance(body, dict):
@@ -130,5 +154,8 @@ async def report_client_error(request: Request) -> Response:
 
 def _reset_rate_limit_for_tests() -> None:
     """测试钩子 — 清 ip_buckets 让每个测试独立。"""
+    global _drop_last_report
     with _bucket_lock:
         _ip_buckets.clear()
+        _drop_counts.clear()
+        _drop_last_report = 0.0

--- a/studio/api/routers/generate.py
+++ b/studio/api/routers/generate.py
@@ -170,9 +170,12 @@ def enqueue_generate(body: GenerateRequest) -> dict[str, Any]:
         # （"model_family=X 不支持 block swap"），整个出图直接崩。用户并没有为这个
         # 模型要求 block swap，所以忽略而不是报错。
         if blocks_to_swap and not supports_capability(body.model_family, "block_swap"):
-            logger.info(
-                "model_family=%s 不支持 block swap，本次出图忽略全局设置的 "
-                "blocks_to_swap=%s", body.model_family, blocks_to_swap,
+            # 与评估出图共用同一条记录点（含按族去重），两处不再各打一句
+            from ...services.eval_generation import (  # noqa: PLC0415 — 惰性避免 import 环
+                note_block_swap_unsupported,
+            )
+            note_block_swap_unsupported(
+                body.model_family, blocks_to_swap, scope="generate",
             )
             blocks_to_swap = 0
 

--- a/studio/api/routers/installs.py
+++ b/studio/api/routers/installs.py
@@ -211,7 +211,9 @@ def flash_attn_status() -> dict[str, Any]:
     except Exception as exc:  # noqa: BLE001
         # logger.exception 把 traceback 落盘 + 带 trace_id（trace middleware bound）
         import logging  # noqa: PLC0415
-        logging.getLogger(__name__).exception("flash_attn status endpoint failed")
+        logging.getLogger(__name__).warning(
+            "flash_attn status probe failed; returning installed=false", exc_info=True,
+        )
         return {
             "installed": False,
             "version": None,

--- a/studio/api/routers/projects/curation.py
+++ b/studio/api/routers/projects/curation.py
@@ -94,7 +94,10 @@ def delete_project_files(
                 try:
                     m.unlink()
                 except OSError as exc:
-                    logger.warning("删 metadata 失败 %s: %s", m, exc)
+                    logger.warning(
+                        "delete metadata failed: path=%s err=%s; "
+                        "a stale metadata file may remain", m, exc,
+                    )
         deleted.append(name)
     return {"deleted": deleted, "missing": missing}
 
@@ -198,7 +201,7 @@ def project_thumb(
             f = pdir / "preprocess" / name
 
     if not f.exists() or f.suffix.lower() not in datasets.IMAGE_EXTS:
-        logger.info("thumb 404: pid=%s bucket=%s name=%s -> %s", pid, bucket, name, f)
+        logger.debug("thumb 404: pid=%s bucket=%s name=%s tried=%s", pid, bucket, name, f)
         raise NotFoundError(
             "Thumbnail not found", code="dataset.thumbnail_not_found",
         )

--- a/studio/api/routers/projects/ingestion.py
+++ b/studio/api/routers/projects/ingestion.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, BinaryIO
+from typing import Any, BinaryIO, Callable
 
 from fastapi import APIRouter, File, Form, UploadFile
 from fastapi.concurrency import run_in_threadpool
@@ -183,6 +183,21 @@ def _publish_upload_log(pid: int, line: str) -> None:
     bus.publish({"type": "project_upload_log", "project_id": pid, "line": line})
 
 
+def _upload_log_factory(pid: int, source: str) -> Callable[[str], None]:
+    """两个上传端点共用的 on_log 回调工厂。
+
+    SSE 推给用户看的仍是原样一行；studio.log 侧降 DEBUG 并带 `source=` kv
+    （files = 浏览器多选上传，path = server 本地路径导入），两个端点的回显
+    行在同一份日志里仍可区分。
+    """
+
+    def _on_log(line: str) -> None:
+        logger.debug("upload source=%s: %s", source, line)
+        _publish_upload_log(pid, line)
+
+    return _on_log
+
+
 def _publish_upload_state(pid: int, status: str) -> None:
     """推 upload 状态转换（running / done / failed）给 SSE 订阅者。
 
@@ -242,9 +257,7 @@ async def upload_local_files(
         pairs.append((f.filename or "", f.file))
     sec = secrets.load()
 
-    def _on_log(line: str) -> None:
-        logger.info(line)
-        _publish_upload_log(pid, line)
+    _on_log = _upload_log_factory(pid, "files")
 
     _publish_upload_state(pid, "running")
     try:
@@ -289,9 +302,7 @@ def upload_local_file_from_path(pid: int, body: UploadFromPathBody) -> dict[str,
     pdir = projects.project_dir(p["id"], p["slug"]) / "download"
     sec = secrets.load()
 
-    def _on_log(line: str) -> None:
-        logger.info(line)
-        _publish_upload_log(pid, line)
+    _on_log = _upload_log_factory(pid, "path")
 
     _publish_upload_state(pid, "running")
     try:

--- a/studio/api/routers/projects/training.py
+++ b/studio/api/routers/projects/training.py
@@ -926,8 +926,8 @@ def version_thumb(
     else:
         f = _safe_join_or_400(vdir, name)
     if not f.exists() or f.suffix.lower() not in datasets.IMAGE_EXTS:
-        logger.info(
-            "version thumb 404: pid=%s vid=%s bucket=%s folder=%s name=%s -> %s",
+        logger.debug(
+            "version thumb 404: pid=%s vid=%s bucket=%s folder=%s name=%s tried=%s",
             pid, vid, bucket, folder, name, f,
         )
         raise NotFoundError("Image not found", code="image.not_found")

--- a/studio/api/routers/queue/lifecycle.py
+++ b/studio/api/routers/queue/lifecycle.py
@@ -17,6 +17,7 @@
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any, Optional
 
@@ -40,6 +41,7 @@ from ....supervisor.resources import (
     TASK_TYPE_RESOURCE_CLASS,
 )
 
+logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # R-5 档位视图：GPU 视图 = exclusive 档（train/reg_ai/generate/eval_session），
@@ -471,12 +473,10 @@ def _delete_generate_outputs(task: dict[str, Any]) -> None:
     全程 best-effort:行已删,文件清理失败只 log。
     """
     import json as _json
-    import logging
     import shutil
 
     from ....services.generate_storage import TEST_IMAGES_DIR
 
-    logger = logging.getLogger(__name__)
     raw = task.get("generate_images")
     try:
         images = _json.loads(raw) if raw else []
@@ -508,11 +508,23 @@ def _delete_generate_outputs(task: dict[str, Any]) -> None:
             folders.add(p.parent)
         else:
             files.append(p)
+    # T6 节流：一个被占用的目录会让每张图各刷一条黄行 —— 逐条 DEBUG，
+    # 收尾一条计数 WARNING（带首个原因）。
+    failed = 0
+    first_error = ""
     for p in files:
         try:
             p.unlink(missing_ok=True)
-        except OSError:
-            logger.warning("delete generate image failed: %s", p, exc_info=True)
+        except OSError as exc:
+            failed += 1
+            if not first_error:
+                first_error = f"{type(exc).__name__}: {exc}"
+            logger.debug("delete generate image failed: path=%s", p, exc_info=True)
+    if failed:
+        logger.warning(
+            "delete generate images: failed=%d total=%d first error: %s",
+            failed, len(files), first_error,
+        )
     for d in folders:
         if d != base and str(d).startswith(str(base)):
             shutil.rmtree(d, ignore_errors=True)

--- a/studio/api/routers/samples.py
+++ b/studio/api/routers/samples.py
@@ -77,7 +77,7 @@ def get_sample(
                 resolved = p
                 break
         if resolved is None:
-            logger.info(
+            logger.debug(
                 "sample 404: task_id=%s file=%s tried=%s",
                 task_id, filename, [str(p) for p in candidates],
             )

--- a/studio/api/routers/secrets.py
+++ b/studio/api/routers/secrets.py
@@ -39,7 +39,10 @@ def put_secrets(body: dict[str, Any]) -> dict[str, Any]:
         from ...services.inference.daemon import get_daemon
         get_daemon().sync_idle_timeout_from_secrets()
     except Exception:
-        logger.warning("failed to sync idle_timeout to daemon", exc_info=True)
+        logger.warning(
+            "failed to sync idle_timeout to daemon; the daemon keeps the previous value",
+            exc_info=True,
+        )
     return secrets.to_masked_dict(new)
 
 

--- a/studio/cli.py
+++ b/studio/cli.py
@@ -29,6 +29,8 @@ import webbrowser
 from pathlib import Path
 from typing import Optional
 
+from studio.infrastructure.log_messages import msg
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WEB_DIR = REPO_ROOT / "studio" / "web"
 WEB_DIST = WEB_DIR / "dist"
@@ -68,7 +70,7 @@ _PIP_MIRROR = "https://mirrors.cloud.tencent.com/pypi/simple/"
 _log = logging.getLogger("studio.cli")
 
 
-def _say(msg: str, level: str = "info") -> None:
+def _say(line: str, level: str = "info") -> None:
     """统一 CLI 用户输出入口 —— `studio.cli` logger 的薄包装。
 
     行契约见 docs/design/logging-target-state.md §3.2 / §3.5：CLI 不再自己
@@ -82,7 +84,7 @@ def _say(msg: str, level: str = "info") -> None:
       - "warning"          → logger.warning
       - "error"            → logger.error
     """
-    text = str(msg)
+    text = str(line)
     if level == "error":
         _log.error(text)
     elif level == "warning":
@@ -138,12 +140,15 @@ def npm_install_if_missing(npm: str) -> int:
     except ValueError:
         rel = NODE_MODULES
     if package_files_changed:
-        _say("studio/web/package.json 或 package-lock.json 比 node_modules 新，运行 npm install...")
+        _say(msg("cli.npm_install_stale"))
     else:
-        _say(f"{rel} 不完整或不存在，运行 npm install（3 分钟超时）...")
+        _say(msg("cli.npm_install_missing", rel=rel))
     rc = _npm_call(npm, ["install"], str(WEB_DIR), timeout=180)
     if rc != 0:
-        _say(f"npm install 失败或超时，切换国内源 ({_NPM_MIRROR}) 重试...")
+        _say(
+            f"npm install failed or timed out; retrying on the {_NPM_MIRROR} mirror",
+            "warning",
+        )
         rc = subprocess.call(
             _npm_argv(npm, ["install", "--registry", _NPM_MIRROR]),
             cwd=str(WEB_DIR),
@@ -155,7 +160,10 @@ def _pip_install(args: list[str]) -> int:
     """运行 pip install；失败时切换阿里云镜像重试。"""
     rc = subprocess.call([find_python(), "-m", "pip", "install"] + args)
     if rc != 0:
-        _say(f"pip install 失败，切换国内源 ({_PIP_MIRROR}) 重试...")
+        _say(
+            f"pip install failed; retrying on the {_PIP_MIRROR} mirror",
+            "warning",
+        )
         rc = subprocess.call(
             [find_python(), "-m", "pip", "install"] + args
             + ["-i", _PIP_MIRROR],
@@ -174,12 +182,12 @@ def _ensure_python_deps() -> int:
             return 0
     except Exception:
         pass
-    _say("检测到 fastapi 缺失，重新安装 Python 依赖（requirements.txt）...")
+    _say(msg("cli.reinstall_python_deps"))
     return _pip_install(["-r", str(req)])
 
 
 def npm_build(npm: str) -> int:
-    _say("构建前端 (npm run build)...")
+    _say(msg("cli.build_frontend"))
     return subprocess.call(_npm_argv(npm, ["run", "build"]), cwd=str(WEB_DIR))
 
 
@@ -215,7 +223,10 @@ class ProcGroup:
             creationflags=creationflags,
             preexec_fn=preexec_fn,
         )
-        _say(f"{label} pid={proc.pid}: {' '.join(cmd)}")
+        _say(msg(
+            "cli.process_spawned", label=label, pid=proc.pid,
+            cmd=" ".join(cmd),
+        ))
         self.procs.append((label, proc))
         return proc
 
@@ -225,7 +236,10 @@ class ProcGroup:
             for label, p in self.procs:
                 rc = p.poll()
                 if rc is not None:
-                    _say(f"{label} 退出 (rc={rc})")
+                    if rc == 0:
+                        _say(msg("cli.process_exited", label=label))
+                    else:
+                        _say(f"{label} exited with rc={rc}", "warning")
                     return rc
             try:
                 # 让 KeyboardInterrupt 有机会触发
@@ -240,7 +254,7 @@ class ProcGroup:
         for label, p in self.procs:
             if p.poll() is not None:
                 continue
-            _say(f"停止 {label}...")
+            _say(msg("cli.stopping_process", label=label))
             try:
                 if os.name == "nt":
                     p.send_signal(signal.CTRL_BREAK_EVENT)
@@ -252,7 +266,10 @@ class ProcGroup:
             try:
                 p.wait(timeout=grace)
             except subprocess.TimeoutExpired:
-                _say(f"{label} 超时未退出，强杀")
+                _say(
+                    f"{label} did not exit in {grace:.1f}s; "
+                    "killing process tree", "warning",
+                )
                 p.kill()
 
 
@@ -266,24 +283,24 @@ def _print_npm_install_hint() -> None:
 
     一条 error 记录（多行，续行无前缀）；root 环境去掉 sudo（直接 root 跑装包）。
     """
-    lines = ["找不到 npm。请安装 Node.js 18+"]
+    lines = ["npm not found; install Node.js 18+ to build the frontend"]
     if os.name == "nt":
         lines.append(
-            "  Windows：前往 https://nodejs.org 下载安装包，"
-            "或用 winget install OpenJS.NodeJS.LTS"
+            "  Windows: download the installer from https://nodejs.org, "
+            "or run winget install OpenJS.NodeJS.LTS"
         )
     else:
         sudo = "" if (hasattr(os, "getuid") and os.getuid() == 0) else "sudo "
         lines.append(
-            f"  Ubuntu/Debian：curl -fsSL https://deb.nodesource.com/setup_22.x "
+            f"  Ubuntu/Debian: curl -fsSL https://deb.nodesource.com/setup_22.x "
             f"| {sudo}bash - && {sudo}apt-get install -y nodejs"
         )
         lines.append(
-            "  或使用 nvm（无需 sudo）："
+            "  or use nvm (no sudo): "
             "curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.3/install.sh "
             "| bash && nvm install --lts"
         )
-    lines.append("  安装后重新运行本命令。")
+    lines.append("  re-run this command after installing")
     _say("\n".join(lines), "error")
 
 
@@ -365,7 +382,10 @@ def _apply_pending_install() -> None:
         from studio.services.runtime import pending_install  # noqa: PLC0415
         pending_install.apply_pending()
     except Exception as exc:  # noqa: BLE001
-        _say(f"处理 pending 安装请求时异常（{exc}），跳过", "warning")
+        _say(
+            f"handling the pending install request failed: {exc}; skipped",
+            "warning",
+        )
 
 
 def _try_enable_flash_attn() -> None:
@@ -380,17 +400,18 @@ def _try_enable_flash_attn() -> None:
             return
         from modeling.anima.cosmos_predict2_modeling import set_flash_attn_enabled  # noqa: PLC0415
         if set_flash_attn_enabled(True):
-            _say("flash_attn 启用")
+            _say(msg("cli.flash_attn_enabled"))
         else:
             # 装了 flash_attn 但 set_flash_attn_enabled 拒绝（_FLASH_ATTN_AVAILABLE=False）
             # 通常意味着 import 时挂了（CUDA 版本不匹配等）；不噪声只 warning 一行
             _say(
-                "flash_attn 已安装但模型层 import 失败，继续走 SDPA fallback",
+                "flash_attn is installed but importing the model layer failed; "
+                "falling back to SDPA",
                 "warning",
             )
     except Exception as exc:  # noqa: BLE001
         # Studio 启动不能为这一项加速 fail；记 warn 但放行
-        _say(f"flash_attn 启用时异常（{exc}），跳过加速", "warning")
+        _say(f"enabling flash_attn failed: {exc}; running without it", "warning")
 
 
 def _apply_gpu_selection() -> None:
@@ -430,7 +451,7 @@ def _check_torch_cuda() -> None:
             name = torch.cuda.get_device_name(0)
         except Exception:  # noqa: BLE001
             name = "?"
-        _say(f"torch {torch.__version__}（GPU: {name}）")
+        _say(msg("cli.torch_gpu", version=torch.__version__, name=name))
         return
 
     cuda_build = getattr(torch.version, "cuda", None)
@@ -443,24 +464,25 @@ def _check_torch_cuda() -> None:
             has_gpu = False
         if has_gpu:
             _say(
-                f"检测到 NVIDIA GPU，但当前安装的是 CPU-only 版 PyTorch "
-                f"({torch.__version__})。\n"
-                f"        训练 / 出图将跑在 CPU 上，速度极慢（单步常需数十秒）。\n"
-                f"        请卸载后重装 CUDA 版：\n"
-                f"          pip uninstall torch torchvision -y\n"
-                f"          # 按你的 CUDA 版本选；如 CUDA 12.8：\n"
-                f"          pip install torch torchvision --index-url https://download.pytorch.org/whl/cu128",
+                f"NVIDIA GPU detected but the installed PyTorch is a CPU-only "
+                f"build ({torch.__version__}); training and generation would run "
+                f"on the CPU and be very slow (tens of seconds per step)\n"
+                f"  pip uninstall torch torchvision -y\n"
+                f"  # pick the index for your CUDA version, e.g. CUDA 12.8:\n"
+                f"  pip install torch torchvision "
+                f"--index-url https://download.pytorch.org/whl/cu128",
                 "warning",
             )
         else:
-            _say(f"torch {torch.__version__}（CPU-only build，未检测到 NVIDIA GPU）")
+            _say(msg("cli.torch_cpu_only", version=torch.__version__))
         return
 
     # CUDA build 但运行时不可用：驱动 / WSL / 容器问题
     _say(
-        f"torch {torch.__version__}（CUDA {cuda_build} build），"
-        f"但 torch.cuda.is_available()=False。\n"
-        f"        可能原因：NVIDIA 驱动未安装 / 版本过低 / WSL 缺 CUDA 支持。",
+        f"torch {torch.__version__} is a CUDA {cuda_build} build but "
+        f"torch.cuda.is_available()=False\n"
+        f"  likely causes: the NVIDIA driver is not installed, the driver is "
+        f"too old, or WSL is missing CUDA support",
         "warning",
     )
 
@@ -482,21 +504,23 @@ def _check_onnxruntime() -> None:
         installed = rt.get("installed") or "?"
         ver = rt.get("version") or "?"
         if rt.get("cuda_available"):
-            _say(f"onnxruntime: {installed}=={ver}（CUDA EP 可用）")
+            _say(msg("cli.onnxruntime_gpu", installed=installed, ver=ver))
             return
 
         cuda = onnxruntime_setup.detect_cuda()
         if cuda.get("available"):
             _say(
-                f"检测到 NVIDIA GPU 但 onnxruntime 只有 CPU EP（installed={installed}）。"
-                f"WD14 / CLTagger 打标会跑 CPU（较慢）。可在 Settings → ONNX Runtime 重装为 GPU 版。",
+                f"NVIDIA GPU detected but onnxruntime has only the CPU EP "
+                f"(installed={installed}); WD14 and CLTagger tagging will run "
+                f"on the CPU; reinstall the GPU build from "
+                f"Settings → ONNX Runtime",
                 "warning",
             )
         else:
-            _say(f"onnxruntime: {installed}=={ver}（CPU only，未检测到 NVIDIA GPU）")
+            _say(msg("cli.onnxruntime_cpu", installed=installed, ver=ver))
 
     except Exception as exc:  # noqa: BLE001
-        _say(f"onnxruntime 状态检查异常（已忽略）: {exc}", "error")
+        _say(f"onnxruntime status check failed: {exc}; ignored", "warning")
 
 
 WEB_SRC = WEB_DIR / "src"
@@ -605,7 +629,7 @@ def _apply_update_pending() -> None:
         # 与 _say 同一个 logger，updater 内部升级到级别方法时黄/红行自动落对
         updater.apply_pending(emit=TaskLog(_log))
     except Exception as exc:  # noqa: BLE001
-        _say(f"apply update pending 时异常（{exc}），跳过", "warning")
+        _say(f"applying the pending update failed: {exc}; skipped", "warning")
 
 
 def _maybe_force_torch(args: argparse.Namespace) -> int:
@@ -618,19 +642,23 @@ def _maybe_force_torch(args: argparse.Namespace) -> int:
     current = torch_setup.detect_torch()
     current_build = current.get('cuda_build') or ('未安装' if not current.get('installed') else 'unknown')
     if current.get('installed') and current.get('cuda_build') == tag:
-        _say(f"torch 已是 {tag}，跳过重装")
+        _say(msg("cli.torch_already_tag", tag=tag))
         return 0
-    _say(f"--torch {tag} 指定（当前: {current_build}），开始重装...")
-    _say("提示：按 Ctrl+C 可跳过")
+    _say(msg(
+        "cli.torch_reinstall_start", tag=tag, current_build=current_build,
+    ))
     try:
         res = torch_setup.reinstall(tag, stream=True)
-        _say(f"torch 重装完成: {res.get('version')} ({res.get('tag')})")
+        _say(msg(
+            "cli.torch_reinstall_done",
+            version=res.get("version"), tag=res.get("tag"),
+        ))
         return 0
     except KeyboardInterrupt:
-        _say("用户中断，跳过 torch 重装", "warning")
+        _say("torch reinstall interrupted by user; skipped", "warning")
         return 0
     except RuntimeError as exc:
-        _say(f"torch 重装失败: {exc}", "error")
+        _say(f"torch reinstall failed: {exc}", "error")
         return 1
 
 
@@ -671,12 +699,12 @@ def cmd_run(args: argparse.Namespace) -> int:
 
         if not args.no_build:
             if not WEB_DIST.exists():
-                _say("studio/web/dist 不存在，先构建前端...")
+                _say(msg("cli.frontend_dist_missing"))
                 rc = cmd_build(args)
                 if rc != 0:
                     return rc
             elif _web_dist_is_stale():
-                _say("studio/web/dist 比 src 旧（git pull 后未重建？），重新构建前端...")
+                _say(msg("cli.frontend_dist_stale"))
                 rc = cmd_build(args)
                 if rc != 0:
                     return rc
@@ -687,7 +715,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         _try_enable_flash_attn()
         _check_onnxruntime()
         url = f"http://{args.host}:{args.port}/"
-        _say(f"启动后端 → {url}")
+        _say(msg("cli.backend_started", url=url))
         if not args.no_browser and not opened_browser:
             _spawn_browser_opener(url)
             opened_browser = True
@@ -699,7 +727,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             # 终端 Ctrl+C：CTRL_C_EVENT 同时广播给 server 子进程（它自己走
             # graceful shutdown）；父进程这边阻塞在 wait 的 KeyboardInterrupt
             # 要等子进程退干净后才抛出来。用户主动停机，不打 traceback。
-            _say("已停止（Ctrl+C）")
+            _say(msg("cli.stopped_ctrl_c"))
             return 130
 
         if not _RESTART_FLAG.exists():
@@ -710,8 +738,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         # 走 exec self 路径。flag 保留是关键 —— wrapper 检测到 (exit==42 &&
         # flag exists) 才会 re-exec；只剩 flag 而 exit!=42 则走普通 restart。
         if _installer_hashes() != startup_installer:
-            _say("检测到 launcher 文件更新（cli.py / studio.sh / studio.bat），"
-                  "退出码 42 让 wrapper 重新加载...")
+            _say(msg("cli.launcher_reload"))
             return _INSTALLER_RELOAD_EXIT_CODE
 
         # 收到重启请求：删除标志 + loop 回去重新 bootstrap
@@ -719,7 +746,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             _RESTART_FLAG.unlink()
         except OSError:
             pass
-        _say("收到重启请求，重新启动...")
+        _say(msg("cli.restart_requested"))
 
 
 def cmd_dev(args: argparse.Namespace) -> int:
@@ -758,7 +785,10 @@ def cmd_dev(args: argparse.Namespace) -> int:
             ],
         )
         frontend_url = f"http://127.0.0.1:{args.fe_port}/"
-        _say(f"frontend → {frontend_url}  backend → http://{args.host}:{args.port}/")
+        _say(msg(
+            "cli.dev_urls", frontend_url=frontend_url,
+            backend_url=f"http://{args.host}:{args.port}/",
+        ))
         if not args.no_browser:
             # dev 模式打开 Vite 端口（HMR 能用），不开 backend 端口
             _spawn_browser_opener(frontend_url, delay=2.0)
@@ -770,18 +800,18 @@ def cmd_dev(args: argparse.Namespace) -> int:
 
 def cmd_test(_args: argparse.Namespace) -> int:
     """跑 pytest + vitest。任一失败 → 非零退出。"""
-    _say("pytest...")
+    _say(msg("cli.pytest_start"))
     rc = subprocess.call([find_python(), "-m", "pytest", "tests/"], cwd=str(REPO_ROOT))
     if rc != 0:
         return rc
     npm = find_npm()
     if not npm:
-        _say("跳过 vitest (未安装 npm)")
+        _say(msg("cli.vitest_skipped_no_npm"))
         return 0
     if not NODE_MODULES.exists():
-        _say("跳过 vitest (node_modules 缺失，先 npm install)")
+        _say(msg("cli.vitest_skipped_no_modules"))
         return 0
-    _say("vitest...")
+    _say(msg("cli.vitest_start"))
     return subprocess.call(_npm_argv(npm, ["run", "test"]), cwd=str(WEB_DIR))
 
 

--- a/studio/infrastructure/_messages_server.py
+++ b/studio/infrastructure/_messages_server.py
@@ -1,0 +1,9 @@
+"""server 用户面（cli / 下载卡 / updater / services 进度回调）的用户可见 INFO 文案。
+
+msg_id 前缀：``cli.* download.* modelsrc.* upscale.* update.* eval.* booru.* reg.*``。
+终稿来源 tmp/log-text-audit/rewrite-c-server.md 的「msg_id 字典汇总」节。
+"""
+from __future__ import annotations
+
+MESSAGES: dict[str, dict[str, str]] = {
+}

--- a/studio/infrastructure/_messages_server.py
+++ b/studio/infrastructure/_messages_server.py
@@ -120,6 +120,25 @@ MESSAGES: dict[str, dict[str, str]] = {
         "en": "Running vitest",
     },
 
+    # -------------------------------------------------------------- install.*
+    "install.torch_reinstall_registered": {
+        "zh": "已注册 torch 重装: target={target}（下次启动时执行）",
+        "en": "torch reinstall registered: target={target} (runs on the next start)",
+    },
+    "install.torch_reinstall_start": {
+        "zh": "检测到待执行的 torch 重装: target={target}，开始安装\n"
+              "  按 Ctrl+C 可跳过本次安装（marker 保留，下次启动重试）\n"
+              "  若希望永久跳过，删除 marker 文件: {marker}",
+        "en": "pending torch reinstall detected: target={target}; installing now\n"
+              "  press Ctrl+C to skip this run (the marker is kept and retried "
+              "on the next start)\n"
+              "  to skip permanently, delete the marker file: {marker}",
+    },
+    "install.torch_reinstall_done": {
+        "zh": "torch 重装完成: {version}（{tag}）",
+        "en": "torch reinstall done: version={version} tag={tag}",
+    },
+
     # ---------------------------------------------------------------- booru.*
     "booru.canceled": {
         "zh": "下载已停止：用户请求",

--- a/studio/infrastructure/_messages_server.py
+++ b/studio/infrastructure/_messages_server.py
@@ -2,8 +2,457 @@
 
 msg_id 前缀：``cli.* download.* modelsrc.* upscale.* update.* eval.* booru.* reg.*``。
 终稿来源 tmp/log-text-audit/rewrite-c-server.md 的「msg_id 字典汇总」节。
+
+``upscale.*`` 本轮 0 条：``inference/upscaler.py`` 的两条 ``on_log`` 都判 DEBUG，
+按 Q1 走英文排障行，不进字典。
 """
 from __future__ import annotations
 
 MESSAGES: dict[str, dict[str, str]] = {
+    # ------------------------------------------------------------------ cli.*
+    "cli.npm_install_stale": {
+        "zh": "package.json/package-lock.json 比 node_modules 新，运行 npm install（可能需要几分钟）",
+        "en": "package.json/package-lock.json are newer than node_modules; "
+              "running npm install (this can take a few minutes)",
+    },
+    "cli.npm_install_missing": {
+        "zh": "{rel} 不存在或不完整，运行 npm install（超时 3 分钟）",
+        "en": "{rel} is missing or incomplete; running npm install (3 min timeout)",
+    },
+    "cli.reinstall_python_deps": {
+        "zh": "未检测到 fastapi，重新安装 Python 依赖（requirements.txt，可能需要几分钟）",
+        "en": "fastapi is missing; reinstalling Python dependencies from "
+              "requirements.txt (this can take a few minutes)",
+    },
+    "cli.build_frontend": {
+        "zh": "构建前端（npm run build）",
+        "en": "Building the frontend (npm run build)",
+    },
+    "cli.process_spawned": {
+        "zh": "{label} 已启动：pid={pid} cmd={cmd}",
+        "en": "{label} started: pid={pid} cmd={cmd}",
+    },
+    "cli.process_exited": {
+        "zh": "{label} 已退出：rc=0",
+        "en": "{label} exited: rc=0",
+    },
+    "cli.stopping_process": {
+        "zh": "正在停止 {label}",
+        "en": "Stopping {label}",
+    },
+    "cli.flash_attn_enabled": {
+        "zh": "flash_attn 已启用",
+        "en": "flash_attn enabled",
+    },
+    "cli.torch_gpu": {
+        "zh": "torch {version}（GPU：{name}）",
+        "en": "torch {version} (GPU: {name})",
+    },
+    "cli.torch_cpu_only": {
+        "zh": "torch {version}（CPU-only 构建，未检测到 NVIDIA GPU）",
+        "en": "torch {version} (CPU-only build, no NVIDIA GPU detected)",
+    },
+    "cli.onnxruntime_gpu": {
+        "zh": "onnxruntime：{installed}=={ver}（CUDA EP 可用）",
+        "en": "onnxruntime: {installed}=={ver} (CUDA EP available)",
+    },
+    "cli.onnxruntime_cpu": {
+        "zh": "onnxruntime：{installed}=={ver}（仅 CPU，未检测到 NVIDIA GPU）",
+        "en": "onnxruntime: {installed}=={ver} (CPU only, no NVIDIA GPU detected)",
+    },
+    "cli.torch_already_tag": {
+        "zh": "torch 已是 {tag}，跳过重装",
+        "en": "torch is already {tag}; reinstall skipped",
+    },
+    "cli.torch_reinstall_start": {
+        "zh": "--torch {tag} 已指定（当前 {current_build}），开始重装\n  按 Ctrl+C 可跳过",
+        "en": "--torch {tag} requested (current: {current_build}); reinstalling\n"
+              "  press Ctrl+C to skip",
+    },
+    "cli.torch_reinstall_done": {
+        "zh": "torch 重装完成：{version}（{tag}）",
+        "en": "torch reinstall done: {version} ({tag})",
+    },
+    "cli.frontend_dist_missing": {
+        "zh": "studio/web/dist 不存在，先构建前端",
+        "en": "studio/web/dist is missing; building the frontend first",
+    },
+    "cli.frontend_dist_stale": {
+        "zh": "studio/web/dist 比 src 旧（git pull 后未重建？），重新构建前端",
+        "en": "studio/web/dist is older than src (not rebuilt after a git pull?); "
+              "rebuilding the frontend",
+    },
+    "cli.backend_started": {
+        "zh": "后端已启动 → {url}",
+        "en": "Backend started → {url}",
+    },
+    "cli.stopped_ctrl_c": {
+        "zh": "已停止（Ctrl+C）",
+        "en": "Stopped (Ctrl+C)",
+    },
+    "cli.launcher_reload": {
+        "zh": "launcher 文件有更新（cli.py / studio.sh / studio.bat），以退出码 42 让 wrapper 重新加载",
+        "en": "launcher files changed (cli.py / studio.sh / studio.bat); "
+              "exiting with code 42 so the wrapper reloads",
+    },
+    "cli.restart_requested": {
+        "zh": "收到重启请求，正在重启",
+        "en": "Restart requested; restarting",
+    },
+    "cli.dev_urls": {
+        "zh": "前端 → {frontend_url}　后端 → {backend_url}",
+        "en": "frontend → {frontend_url}　backend → {backend_url}",
+    },
+    "cli.pytest_start": {
+        "zh": "运行 pytest",
+        "en": "Running pytest",
+    },
+    "cli.vitest_skipped_no_npm": {
+        "zh": "跳过 vitest（未安装 npm）",
+        "en": "vitest skipped (npm is not installed)",
+    },
+    "cli.vitest_skipped_no_modules": {
+        "zh": "跳过 vitest（node_modules 缺失，先运行 npm install）",
+        "en": "vitest skipped (node_modules is missing; run npm install first)",
+    },
+    "cli.vitest_start": {
+        "zh": "运行 vitest",
+        "en": "Running vitest",
+    },
+
+    # ---------------------------------------------------------------- booru.*
+    "booru.canceled": {
+        "zh": "下载已停止：用户请求",
+        "en": "Download stopped: user request",
+    },
+    "booru.no_more_posts": {
+        "zh": "已到最后一页：服务器返回空页",
+        "en": "Reached the last page: the server returned an empty page",
+    },
+    "booru.saved": {
+        "zh": "[{n}/{total}] 已保存 {name}",
+        "en": "[{n}/{total}] saved {name}",
+    },
+    "booru.page_short_end": {
+        "zh": "已到最后一页：本页 {n} 条 < 每页上限 {limit}",
+        "en": "Reached the last page: {n} posts < page limit {limit}",
+    },
+    "booru.no_valid_posts": {
+        "zh": "本页没有可用图片，停止",
+        "en": "No usable posts on this page; stopping",
+    },
+    "booru.summary": {
+        "zh": "下载完成：已保存 {saved}，已跳过 {skipped}",
+        "en": "Download finished: saved={saved} skipped={skipped}",
+    },
+
+    # ------------------------------------------------------------------ reg.*
+    "reg.build_start": {
+        "zh": "[reg] 正则集构建开始：来源 {api}，训练集 {train_dir}",
+        "en": "[reg] Regularization set build started: source {api}, "
+              "training set {train_dir}",
+    },
+    "reg.source_ids": {
+        "zh": "[reg] 训练集图片 ID 共 {n} 个，用于去重",
+        "en": "[reg] Collected {n} training set image IDs for de-duplication",
+    },
+    "reg.mode_flat": {
+        "zh": "[reg] flat 模式：目标 {total} 张，全部放在 1_data/",
+        "en": "[reg] Flat mode: target {total} images, all in 1_data/",
+    },
+    "reg.mode_mirror": {
+        "zh": "[reg] mirror 模式：目标 {total} 张（训练集共 {train_total} 张），镜像 {n} 个子文件夹",
+        "en": "[reg] Mirror mode: target {total} images (training set has "
+              "{train_total}), mirroring {n} subfolders",
+    },
+    "reg.mode_incremental": {
+        "zh": "[reg] incremental 模式：已有 {existing} 张、{n} 个子文件夹",
+        "en": "[reg] Incremental mode: {existing} existing images across {n} subfolders",
+    },
+    "reg.deleted_ids_excluded_total": {
+        "zh": "[reg] 已排除 booru 上已删除的 ID 共 {n} 个",
+        "en": "[reg] Excluded {n} post IDs that were deleted on booru in total",
+    },
+    "reg.subfolder_start": {
+        "zh": "子文件夹开始：{label}",
+        "en": "Subfolder started: {label}",
+    },
+    "reg.subfolder_plan": {
+        "zh": "目标 {target} 张，批次 {batch}，最多 {max_tags} 个 tag",
+        "en": "Target {target} images, batch {batch}, up to {max_tags} tags",
+    },
+    "reg.deleted_ids_excluded_sub": {
+        "zh": "已排除 booru 上已删除的 {n} 个 ID",
+        "en": "Excluded {n} post IDs that were deleted on booru",
+    },
+    "reg.incremental_reuse": {
+        "zh": "增量模式：沿用已有 {existing} 张（起点 {downloaded}/{target}）",
+        "en": "Incremental mode: reusing {existing} existing images "
+              "(starting at {downloaded}/{target})",
+    },
+    "reg.incremental_done": {
+        "zh": "增量模式：已有图片已达目标，无需补足",
+        "en": "Incremental mode: the existing images already meet the target",
+    },
+    "reg.canceled": {
+        "zh": "构建已停止：用户请求",
+        "en": "Build stopped: user request",
+    },
+    "reg.weights_reached": {
+        "zh": "所有标签已达目标权重",
+        "en": "All tags reached their target weight",
+    },
+    "reg.image_saved": {
+        "zh": "[{n}/{target}] 已保存 {post_id}",
+        "en": "[{n}/{target}] saved {post_id}",
+    },
+    "reg.total_limit_reached": {
+        "zh": "已达总数量限制 {total}",
+        "en": "Total image limit {total} reached",
+    },
+    "reg.subfolder_done": {
+        "zh": "子文件夹 {label} 完成：{n}/{target}（已跳过 {skipped}）",
+        "en": "Subfolder {label} finished: {n}/{target} (skipped {skipped})",
+    },
+    "reg.total_target_reached": {
+        "zh": "[reg] 已达总目标 {total}，跳过剩余子文件夹",
+        "en": "[reg] Total target {total} reached; the remaining subfolders are skipped",
+    },
+    "reg.build_done": {
+        "zh": "[reg] 正则集构建完成：{n}/{total} 张（{ok}/{subs} 个子文件夹达 80%）",
+        "en": "[reg] Regularization set build finished: {n}/{total} images "
+              "({ok}/{subs} subfolders reached 80%)",
+    },
+    "reg.pp_collect": {
+        "zh": "[postprocess] 收集图片（方式 {method}，最大裁剪 {max_crop}）",
+        "en": "[postprocess] Collecting images (method {method}, max crop {max_crop})",
+    },
+    "reg.pp_no_images": {
+        "zh": "[postprocess] 没有图片，跳过",
+        "en": "[postprocess] No images; skipped",
+    },
+    "reg.pp_image_count": {
+        "zh": "[postprocess] 共 {n} 张图片",
+        "en": "[postprocess] {n} images",
+    },
+    "reg.pp_clusters": {
+        "zh": "[postprocess] 聚为 {n} 个分辨率组",
+        "en": "[postprocess] Grouped into {n} resolution clusters",
+    },
+    "reg.pp_cluster_start": {
+        "zh": "[postprocess] 处理分辨率组 {cid}（{n} 张）→ {target}",
+        "en": "[postprocess] Processing resolution cluster {cid} ({n} images) → {target}",
+    },
+    "reg.pp_canceled": {
+        "zh": "[postprocess] 后处理已停止：用户请求",
+        "en": "[postprocess] Postprocess stopped: user request",
+    },
+    "reg.pp_done": {
+        "zh": "[postprocess] 后处理完成：已处理 {processed} 张，分辨率组 {clusters} 个",
+        "en": "[postprocess] Postprocess finished: processed={processed} "
+              "clusters={clusters}",
+    },
+    "reg.analysis_subfolder": {
+        "zh": "[{key}] {n} 张图片，{tags} 种 tag",
+        "en": "[{key}] {n} images, {tags} distinct tags",
+    },
+
+    # ----------------------------------------------------------------- eval.*
+    "eval.ccip_start": {
+        "zh": "[eval-ccip] 开始评分：run={run_id} 模型={model}",
+        "en": "[eval-ccip] Scoring: run={run_id} model={model}",
+    },
+    "eval.ccip_loading": {
+        "zh": "[eval-ccip] 加载 CCIP 模型（阈值 {threshold}）",
+        "en": "[eval-ccip] Loading the CCIP model (threshold {threshold})",
+    },
+    "eval.ccip_extract": {
+        "zh": "[eval-ccip] 提取 {n} 对图片的特征",
+        "en": "[eval-ccip] Extracting features for {n} image pairs",
+    },
+    "eval.ccip_done": {
+        "zh": "[eval-ccip] 角色一致性完成：{status}",
+        "en": "[eval-ccip] Character consistency done: {status}",
+    },
+    "eval.clip_start": {
+        "zh": "[eval-clip] 开始评分：run={run_id} 模型={model}",
+        "en": "[eval-clip] Scoring: run={run_id} model={model}",
+    },
+    "eval.clip_loading": {
+        "zh": "[eval-clip] 在 {device} 上加载 CLIP",
+        "en": "[eval-clip] Loading CLIP on {device}",
+    },
+    "eval.clip_encoding": {
+        "zh": "[eval-clip] 编码{label}图片 {start}-{end}",
+        "en": "[eval-clip] Encoding {label} images {start}-{end}",
+    },
+    "eval.clip_done": {
+        "zh": "[eval-clip] 完成：图文匹配 {clip_t}，图像相似度 {clip_i}",
+        "en": "[eval-clip] Done: prompt match {clip_t}, image similarity {clip_i}",
+    },
+    "eval.dino_start": {
+        "zh": "[eval-dino] 开始评分：run={run_id} 模型={model}",
+        "en": "[eval-dino] Scoring: run={run_id} model={model}",
+    },
+    "eval.dino_loading": {
+        "zh": "[eval-dino] 在 {device} 上加载 DINO",
+        "en": "[eval-dino] Loading DINO on {device}",
+    },
+    "eval.dino_encoding": {
+        "zh": "[eval-dino] 编码{label}图片 {start}-{end}",
+        "en": "[eval-dino] Encoding {label} images {start}-{end}",
+    },
+    "eval.dino_done": {
+        "zh": "[eval-dino] 图像相似度完成：{status}",
+        "en": "[eval-dino] Image similarity done: {status}",
+    },
+    "eval.tag_start": {
+        "zh": "[eval-tag] 开始评分：run={run_id}（WD14 tag 召回）",
+        "en": "[eval-tag] Scoring: run={run_id} (WD14 tag recall)",
+    },
+    "eval.tag_loading": {
+        "zh": "[eval-tag] 加载 WD14",
+        "en": "[eval-tag] Loading WD14",
+    },
+    "eval.tag_tagging": {
+        "zh": "[eval-tag] 用 WD14 给 {n} 张生成图打标",
+        "en": "[eval-tag] Tagging {n} generated images with WD14",
+    },
+    "eval.tag_progress": {
+        "zh": "[eval-tag] {done}/{total}",
+        "en": "[eval-tag] {done}/{total}",
+    },
+    "eval.tag_done": {
+        "zh": "[eval-tag] tag 召回完成：{status}",
+        "en": "[eval-tag] Tag recall done: {status}",
+    },
+    "eval.samples_daemon_ready": {
+        "zh": "[eval-samples] 出图服务就绪，底模只加载一次",
+        "en": "[eval-samples] Generation service ready; the base model is loaded once",
+    },
+    "eval.samples_progress": {
+        "zh": "[eval-samples] {n}/{total} prompt={prompt}",
+        "en": "[eval-samples] {n}/{total} prompt={prompt}",
+    },
+    "eval.samples_daemon_stopped": {
+        "zh": "[eval-samples] 出图服务已退出，显存已释放",
+        "en": "[eval-samples] Generation service stopped; VRAM released",
+    },
+
+    # ------------------------------------------------------------- download.*
+    "download.anima_base": {
+        "zh": "下载 Anima 主模型 [{variant}]（约 {size} GB）→ {target}",
+        "en": "Downloading Anima base model [{variant}] (~{size} GB) → {target}",
+    },
+    "download.anima_vae": {
+        "zh": "下载 Anima VAE（约 {size} MB）→ {target}",
+        "en": "Downloading Anima VAE (~{size} MB) → {target}",
+    },
+    "download.anima_te_ms": {
+        "zh": "下载 Anima 文本编码器（ModelScope 权重 + HuggingFace tokenizer）→ {target}",
+        "en": "Downloading the Anima text encoder (ModelScope weights + "
+              "HuggingFace tokenizer) → {target}",
+    },
+    "download.anima_te_hf": {
+        "zh": "下载 Anima 文本编码器 Qwen3-0.6B-Base（约 {size} GB）→ {target}",
+        "en": "Downloading the Anima text encoder Qwen3-0.6B-Base (~{size} GB) → {target}",
+    },
+    "download.krea2_base": {
+        "zh": "下载 Krea 2 [{variant}]（约 {size} GB）→ {target}",
+        "en": "Downloading Krea 2 [{variant}] (~{size} GB) → {target}",
+    },
+    "download.krea2_te": {
+        "zh": "下载 Krea 2 文本编码器 Qwen3-VL-4B-Instruct（约 {size} GB，来源 {source}）→ {target}",
+        "en": "Downloading Krea 2 text encoder Qwen3-VL-4B-Instruct "
+              "(~{size} GB, source {source}) → {target}",
+    },
+    "download.krea2_te_fp8": {
+        "zh": "下载 Krea 2 文本编码器 Qwen3-VL fp8（约 {size} GB，来源 {source}）→ {target}",
+        "en": "Downloading Krea 2 text encoder Qwen3-VL fp8 "
+              "(~{size} GB, source {source}) → {target}",
+    },
+    "download.t5_tokenizer": {
+        "zh": "下载 T5 tokenizer（{n} 个文件）→ {target}",
+        "en": "Downloading the T5 tokenizer ({n} files) → {target}",
+    },
+    "download.cltagger": {
+        "zh": "下载 CLTagger → {target}",
+        "en": "Downloading CLTagger → {target}",
+    },
+    "download.upscaler": {
+        "zh": "下载放大模型 {label}（约 {size} MB）→ {target}",
+        "en": "Downloading upscaler {label} (~{size} MB) → {target}",
+    },
+    "download.custom_upscaler": {
+        "zh": "下载自定义放大模型 {repo_id}/{subpath}（来源 {source}）→ {target}",
+        "en": "Downloading custom upscaler {repo_id}/{subpath} (source {source}) → {target}",
+    },
+    "download.custom_base": {
+        "zh": "下载自定义主模型 {repo_id}/{filename} → {target}",
+        "en": "Downloading custom base model {repo_id}/{filename} → {target}",
+    },
+    "download.wd14": {
+        "zh": "下载 WD14 {model_id} → {target}",
+        "en": "Downloading WD14 {model_id} → {target}",
+    },
+    "download.wd14_via_ms": {
+        "zh": "下载 WD14 {model_id}（经 ModelScope：{ms_repo}）→ {target}",
+        "en": "Downloading WD14 {model_id} (via ModelScope: {ms_repo}) → {target}",
+    },
+    "download.eval_model": {
+        "zh": "下载评估模型 {kind} {model_id} → {target}",
+        "en": "Downloading evaluation model {kind} {model_id} → {target}",
+    },
+    "download.eval_model_via_ms": {
+        "zh": "下载评估模型 {kind} {model_id}（经 ModelScope：{ms_repo}）→ {target}",
+        "en": "Downloading evaluation model {kind} {model_id} "
+              "(via ModelScope: {ms_repo}) → {target}",
+    },
+    "download.ccip": {
+        "zh": "下载 CCIP {variant} → {target}",
+        "en": "Downloading CCIP {variant} → {target}",
+    },
+
+    # ------------------------------------------------------------- modelsrc.*
+    "modelsrc.file_done": {
+        "zh": "{name} 已下载（来源 {source}）",
+        "en": "{name} downloaded (source {source})",
+    },
+    "modelsrc.dir_done": {
+        "zh": "{name} 已下载（来源 {source}）",
+        "en": "{name} downloaded (source {source})",
+    },
+    "modelsrc.dir_present": {
+        "zh": "{name} 已存在，跳过（来源 {source}）",
+        "en": "{name} is already present; skipped (source {source})",
+    },
+    "modelsrc.present_summary": {
+        "zh": "已存在 {n}/{total} 个文件，跳过",
+        "en": "{n}/{total} files already present; skipped",
+    },
+
+    # --------------------------------------------------------------- update.*
+    "update.models_preserved": {
+        "zh": "[updater] 已保留 {n} 个已下载的模型文件，更新无需重新下载",
+        "en": "[updater] Kept {n} downloaded model files; the update does not "
+              "re-download them",
+    },
+    "update.applying": {
+        "zh": "[updater] 正在应用更新 → {target}{force}",
+        "en": "[updater] Applying update → {target}{force}",
+    },
+    "update.git_updated": {
+        "zh": "[updater] 代码已更新 → {commit}",
+        "en": "[updater] Code updated → {commit}",
+    },
+    "update.pip_install": {
+        "zh": "[updater] requirements.txt 有变更，正在 pip install（可能需要几分钟）",
+        "en": "[updater] requirements.txt changed; running pip install "
+              "(this can take a few minutes)",
+    },
+    "update.npm_install": {
+        "zh": "[updater] studio/web/package.json 有变更，正在 npm install（可能需要几分钟）",
+        "en": "[updater] studio/web/package.json changed; running npm install "
+              "(this can take a few minutes)",
+    },
 }

--- a/studio/infrastructure/_messages_train.py
+++ b/studio/infrastructure/_messages_train.py
@@ -1,0 +1,9 @@
+"""训练主链（runtime/training + anima_train）的用户可见 INFO 文案。
+
+msg_id 前缀：``train.*``。终稿来源 tmp/log-text-audit/rewrite-a-training.md
+的「msg_id 字典汇总」节；新增条目双语齐全，占位符用 ``{name}`` 形式。
+"""
+from __future__ import annotations
+
+MESSAGES: dict[str, dict[str, str]] = {
+}

--- a/studio/infrastructure/_messages_train.py
+++ b/studio/infrastructure/_messages_train.py
@@ -2,8 +2,331 @@
 
 msg_id 前缀：``train.*``。终稿来源 tmp/log-text-audit/rewrite-a-training.md
 的「msg_id 字典汇总」节；新增条目双语齐全，占位符用 ``{name}`` 形式。
+
+分两组：
+- **标签类**（``train.label_*`` / ``train.vram_stage_*`` / ``train.vram_ram_suffix``）
+  ——被其它条目以占位符引用的可译片段，调用点先 ``msg()`` 渲染再当参数传；
+- **叙事行**——一行日志一条 msg_id。
+
+数值格式化由调用点负责（``f"{x:.2f}"`` 后作为字符串传入），字典模板只做
+占位。这样译者不必理解 ``:.2f`` 这类格式串，也避免 ``str.format`` 在类型
+不符时抛错。
 """
 from __future__ import annotations
 
 MESSAGES: dict[str, dict[str, str]] = {
+    # ─── 标签类（被其它条目以占位符引用）───
+    "train.label_training_set": {
+        "zh": "训练集",
+        "en": "training set",
+    },
+    "train.label_regularization_set": {
+        "zh": "正则集",
+        "en": "regularization set",
+    },
+    "train.vram_stage_transformer_loaded": {
+        "zh": "Transformer 加载后",
+        "en": "after Transformer load",
+    },
+    "train.vram_stage_block_swap_ready": {
+        "zh": "Block 交换挂载后",
+        "en": "after block swap attach",
+    },
+    "train.vram_stage_train_start": {
+        "zh": "训练开始前",
+        "en": "before training starts",
+    },
+    # train.vram_snapshot 的可选末段（无内存读数时整段省略）
+    "train.vram_ram_suffix": {
+        "zh": "，可用内存 {ram} GB",
+        "en": ", RAM free {ram} GB",
+    },
+
+    # ─── 叙事行 ───
+    "train.deps_installing": {
+        "zh": "安装缺失依赖: {missing}",
+        "en": "Installing missing dependencies: {missing}",
+    },
+    "train.force_exit": {
+        "zh": "收到第二次中断信号: 强制退出",
+        "en": "Second interrupt received: forcing exit",
+    },
+    "train.pause_signal": {
+        "zh": "收到暂停信号: 正在退出，保留最近一次 epoch 的恢复点",
+        "en": "Pause signal received: exiting, keeping the latest epoch resume state",
+    },
+    "train.paused_with_state": {
+        "zh": "已暂停，恢复点: {path}",
+        "en": "Paused, resume state: {path}",
+    },
+    "train.caption_json_mode": {
+        "zh": "打标文本来源: JSON（按分类打乱标签顺序）",
+        "en": "Caption source: JSON (tags shuffled by category)",
+    },
+    "train.dataset_summary": {
+        "zh": "训练集: {images} 张图 → {samples} 样本（含 repeat；打标文本 JSON {json_count} / TXT {txt_count}）",
+        "en": "Training set: {images} images -> {samples} samples (with repeat; captions JSON {json_count} / TXT {txt_count})",
+    },
+    "train.dataset_folder": {
+        "zh": "文件夹 {name}: {images} 张 × repeat {repeat} × 分辨率 {resolutions} = {samples} 样本",
+        "en": "Folder {name}: {images} images x repeat {repeat} x resolutions {resolutions} = {samples} samples",
+    },
+    "train.vae_cache_check": {
+        "zh": "VAE 缓存: 检查 {dataset}",
+        "en": "VAE cache: checking {dataset}",
+    },
+    "train.vae_cache_encode_todo": {
+        "zh": "VAE 缓存: {dataset} 需编码 {todo}/{total} 张图",
+        "en": "VAE cache: {dataset}, {todo}/{total} images to encode",
+    },
+    "train.vae_cache_all_hit": {
+        "zh": "VAE 缓存: {dataset} 全部命中（{total} 张图），跳过编码",
+        "en": "VAE cache: {dataset} fully cached ({total} images), encoding skipped",
+    },
+    "train.vae_cache_tiled_summary": {
+        "zh": "VAE 缓存: {n} 张图超出单次像素预算，已改用分块编码",
+        "en": "VAE cache: {n} image(s) over the per-pass pixel budget, encoded in tiles",
+    },
+    "train.vae_cache_progress": {
+        "zh": "VAE 缓存: 编码进度 {done}/{total}",
+        "en": "VAE cache: encoded {done}/{total}",
+    },
+    "train.res_shift_enabled": {
+        "zh": "[res-shift] 分辨率修正已启用: 以 {base}px 为基准，按每张图的实际尺寸缩放 timestep shift",
+        "en": "[res-shift] Resolution-aware timestep shift enabled: scaled per image against the {base}px baseline",
+    },
+    "train.progress": {
+        "zh": "epoch={epoch}/{epochs} step={step} loss={loss} {sra}lr={lr} speed={speed} it/s",
+        "en": "epoch={epoch}/{epochs} step={step} loss={loss} {sra}lr={lr} speed={speed} it/s",
+    },
+    "train.sampling_step": {
+        "zh": "采样中 (step {step}): {prompt}",
+        "en": "Sampling (step {step}): {prompt}",
+    },
+    "train.sampling_epoch": {
+        "zh": "采样中 (epoch {epoch}): {prompt}",
+        "en": "Sampling (epoch {epoch}): {prompt}",
+    },
+    "train.lora_saved_step": {
+        "zh": "已保存 LoRA (step {step}): {path}",
+        "en": "Saved LoRA (step {step}): {path}",
+    },
+    "train.lora_saved_epoch": {
+        "zh": "已保存 LoRA (epoch {epoch}): {path}",
+        "en": "Saved LoRA (epoch {epoch}): {path}",
+    },
+    # 注：rewrite-a §1.6 遗留观察采纳「删 loop.py 的 emit、留 state.py:82」，
+    # 故 train.resume_state_saved_{step,epoch} 无调用点，未入本字典。
+    "train.resume_state_saved": {
+        "zh": "已保存恢复点: {path}（epoch={epoch}, step={step}）",
+        "en": "Saved resume state: {path} (epoch={epoch}, step={step})",
+    },
+    "train.resume_state_loading": {
+        "zh": "读取恢复点: {path}",
+        "en": "Loading resume state: {path}",
+    },
+    "train.resume_done": {
+        "zh": "已从恢复点继续训练: epoch={epoch}, step={step}",
+        "en": "Resumed training: epoch={epoch}, step={step}",
+    },
+    "train.wandb_artifact_uploaded": {
+        "zh": "W&B 已上传: {name}（{file}，{size} MB，{elapsed} s）",
+        "en": "W&B upload done: {name} ({file}, {size} MB, {elapsed} s)",
+    },
+    "train.wandb_enabled": {
+        "zh": "W&B 监控已启用: project={project}, run={run}, mode={mode}",
+        "en": "W&B monitoring enabled: project={project}, run={run}, mode={mode}",
+    },
+    "train.xformers_enabled": {
+        "zh": "xformers 已启用",
+        "en": "xformers enabled",
+    },
+    "train.weights_loaded": {
+        "zh": "{label} 权重加载完成: 匹配 {matched}/{total}（{coverage}）",
+        "en": "{label} weights loaded: {matched}/{total} matched ({coverage})",
+    },
+    "train.vae_loaded": {
+        "zh": "VAE 加载完成",
+        "en": "VAE loaded",
+    },
+    "train.vram_snapshot": {
+        "zh": "[vram] {stage}: torch 已分配 {alloc} GB / 保留 {reserved} GB，全卡已用 {used} GB / {total} GB{ram}",
+        "en": "[vram] {stage}: torch allocated {alloc} GB / reserved {reserved} GB, device used {used} GB / {total} GB{ram}",
+    },
+    "train.pause_snapshot_applied": {
+        "zh": "已套用暂停时保存的训练参数: {path}",
+        "en": "Applied the training settings saved at pause time: {path}",
+    },
+    "train.sample_seed_random": {
+        "zh": "采样种子设为 0，本次改用随机种子: {seed}",
+        "en": "Sample seed is 0, using a random seed for this run: {seed}",
+    },
+    "train.config_loaded": {
+        "zh": "加载配置文件: {path}",
+        "en": "Loaded config file: {path}",
+    },
+    "train.navit_native_enabled": {
+        "zh": "[navit] 原生尺寸已启用: 每张图按自身尺寸训练（不再缩放到分辨率档），token 预算 {budget}，超预算时 {policy}",
+        "en": "[navit] Native resolution enabled: each image trains at its own size instead of a fixed resolution bucket, token budget {budget}, over-budget policy {policy}",
+    },
+    "train.masked_loss_enabled": {
+        "zh": "[masked-loss] 已启用: {n}/{total} 张图带 mask（其余按整图学习）",
+        "en": "[masked-loss] Enabled: {n}/{total} images have a mask (the rest train on the full image)",
+    },
+    "train.reg_set_summary": {
+        "zh": "正则集: {path}（{samples} 样本，按文件夹 repeat{weight}{caption}）",
+        "en": "Regularization set: {path} ({samples} samples, per-folder repeat{weight}{caption})",
+    },
+    "train.vae_selftest_saved": {
+        "zh": "VAE 自检图已保存: {path}（图片经 VAE 编码再解码的还原效果）",
+        "en": "VAE self-test image saved: {path} (an image encoded and then decoded again by the VAE)",
+    },
+    "train.attention_sdpa": {
+        "zh": "attention_backend=none: 不启用 flash_attn / xformers，使用 PyTorch SDPA",
+        "en": "attention_backend=none: neither flash_attn nor xformers is enabled, using PyTorch SDPA",
+    },
+    "train.loading_transformer": {
+        "zh": "加载 Transformer",
+        "en": "Loading Transformer",
+    },
+    "train.block_swap_active": {
+        "zh": "Block 交换生效: 换出末尾 {n}/{total} 层，常驻内存 {pinned} GB",
+        "en": "Block swap active: {n}/{total} tail layers offloaded, {pinned} GB pinned memory",
+    },
+    "train.loading_vae": {
+        "zh": "加载 VAE",
+        "en": "Loading VAE",
+    },
+    "train.loading_text_encoder": {
+        "zh": "加载文本编码器",
+        "en": "Loading text encoder",
+    },
+    "train.loading_text_encoder_file": {
+        "zh": "加载文本编码器: Qwen3-VL（{path}）",
+        "en": "Loading text encoder: Qwen3-VL ({path})",
+    },
+    "train.injecting_lora": {
+        "zh": "注入 LoRA 适配器（{lora_type}）",
+        "en": "Injecting LoRA adapter ({lora_type})",
+    },
+    "train.resume_from_lora": {
+        "zh": "从已有 LoRA 继续训练: {path}",
+        "en": "Continuing from an existing LoRA: {path}",
+    },
+    "train.fp8_base_detected": {
+        "zh": "检测到 fp8 底模: 按 fp8 训练（权重以 fp8 常驻显存，前向时逐层还原成 bf16 计算）",
+        "en": "fp8 base model detected: training in fp8 (weights stay in fp8 in VRAM, each layer is restored to bf16 for the forward pass)",
+    },
+    "train.text_cache_order": {
+        "zh": "文本缓存已开启: 先加载 VAE 与文本编码器，缓存完成并释放后再加载 Transformer",
+        "en": "Text cache enabled: loading the VAE and the text encoder first, then the Transformer once captions are cached and the encoder is released",
+    },
+    "train.text_cache_done_loading": {
+        "zh": "文本缓存完成，文本编码器已释放，继续加载 Transformer",
+        "en": "Text cache done, text encoder released, loading the Transformer",
+    },
+    "train.weight_decay": {
+        "zh": "权重衰减已启用: {optimizer} weight_decay={wd}",
+        "en": "Weight decay enabled: {optimizer} weight_decay={wd}",
+    },
+    "train.weight_decay_lokr": {
+        "zh": "权重衰减已启用: {optimizer} weight_decay={wd}（LoKr 的 w1 不参与）",
+        "en": "Weight decay enabled: {optimizer} weight_decay={wd} (LoKr w1 excluded)",
+    },
+    "train.grad_clip": {
+        "zh": "梯度裁剪已启用: max_norm={value}",
+        "en": "Gradient clipping enabled: max_norm={value}",
+    },
+    "train.step_plan": {
+        "zh": "训练规模: {samples} 样本，每 epoch {steps_per_epoch} 步，共 {total_steps} 步",
+        "en": "Training size: {samples} samples, {steps_per_epoch} steps per epoch, {total_steps} steps total",
+    },
+    "train.text_cache_off": {
+        "zh": "[text-cache] 缓存已关闭: 文本编码器常驻显存，每个 batch 现场编码打标文本",
+        "en": "[text-cache] Cache off: the text encoder stays in VRAM and encodes captions batch by batch",
+    },
+    "train.text_cache_plan": {
+        "zh": "[text-cache] 预缓存 {images} 张图的打标文本 + {prompts} 条采样提示词",
+        "en": "[text-cache] Caching captions for {images} images plus {prompts} sample prompts",
+    },
+    "train.text_cache_progress": {
+        "zh": "[text-cache] 编码进度 {done}/{total}",
+        "en": "[text-cache] Encoded {done}/{total}",
+    },
+    "train.text_cache_hits": {
+        "zh": "[text-cache] 已缓存 {hit}/{total} 条打标文本，需编码 {todo} 条",
+        "en": "[text-cache] {hit}/{total} captions already cached, {todo} to encode",
+    },
+    "train.text_cache_all_hit": {
+        "zh": "[text-cache] 打标文本全部已缓存（{n} 条），跳过编码",
+        "en": "[text-cache] All {n} captions already cached, encoding skipped",
+    },
+    "train.loss_curve": {
+        "zh": "Loss 曲线（前 {n} 步）:",
+        "en": "Loss curve (first {n} steps):",
+    },
+    "train.finished": {
+        "zh": "训练完成，最终 LoRA: {path}",
+        "en": "Training finished, final LoRA: {path}",
+    },
+    "train.monitor_history_restored": {
+        "zh": "监控面板历史已恢复: {n} 个 loss 点",
+        "en": "Dashboard history restored: {n} loss points",
+    },
+    "train.baseline_sampling": {
+        "zh": "采样中 (step 0，基线)",
+        "en": "Sampling (step 0, baseline)",
+    },
+    "train.baseline_sampling_skipped": {
+        "zh": "跳过基线采样: 从 step {step} 恢复，不是从 step 0 开始",
+        "en": "Baseline sampling skipped: resumed at step {step}, not from step 0",
+    },
+    "train.lr_schedule": {
+        "zh": "学习率调度: {detail}",
+        "en": "LR schedule: {detail}",
+    },
+    "train.infonoise_warmup_auto": {
+        "zh": "InfoNoise 预热步数自动设为 {steps} 步（总步数 {total} 的 20%）",
+        "en": "InfoNoise warmup set to {steps} steps (20% of {total} total steps)",
+    },
+    "train.infonoise_warmup_floor": {
+        "zh": "InfoNoise 预热步数自动设为下限 {steps} 步（总步数 {total} 的 20% 不足 {steps}）",
+        "en": "InfoNoise warmup set to the {steps}-step minimum (20% of {total} total steps is below it)",
+    },
+    "train.infonoise_warmup_unknown_total": {
+        "zh": "InfoNoise 预热步数自动设为 {steps} 步（总步数未知，按 5000 步估算）",
+        "en": "InfoNoise warmup set to {steps} steps (total step count unknown, estimated from 5000)",
+    },
+    "train.infonoise_enabled": {
+        "zh": "InfoNoise 已启用: 训练中自适应调整 timestep 采样分布",
+        "en": "InfoNoise enabled: the timestep sampling distribution adapts during training",
+    },
+    "train.flash_attn_on": {
+        "zh": "flash_attn 已启用（训练与采样都使用）",
+        "en": "flash_attn enabled (used for both training and sampling)",
+    },
+    "train.flash_attn_off_by_setting": {
+        "zh": "flash_attn 未启用: attention_backend={backend}",
+        "en": "flash_attn not enabled: attention_backend={backend}",
+    },
+    "train.flash_attn_off_missing": {
+        "zh": "flash_attn 未启用: 未安装 flash_attn，使用 PyTorch SDPA",
+        "en": "flash_attn not enabled: the flash_attn package is not installed, using PyTorch SDPA",
+    },
+    "train.anima_model_loaded": {
+        "zh": "Anima 模型加载完成: {channels}ch，{blocks} 层",
+        "en": "Anima model loaded: {channels}ch, {blocks} blocks",
+    },
+    "train.text_encoder_loaded": {
+        "zh": "文本编码器加载完成",
+        "en": "Text encoder loaded",
+    },
+    "train.krea2_sdpa_only": {
+        "zh": "Krea2 固定使用 PyTorch SDPA: 已忽略 attention_backend={backend}",
+        "en": "Krea2 always uses PyTorch SDPA: attention_backend={backend} ignored",
+    },
+    "train.fp8_merge_done": {
+        "zh": "LoRA 已合并进 fp8 底模: {loras} 份 LoRA → {layers} 个层",
+        "en": "LoRA merged into the fp8 base model: {loras} LoRA(s) into {layers} layers",
+    },
 }

--- a/studio/infrastructure/_messages_worker.py
+++ b/studio/infrastructure/_messages_worker.py
@@ -2,8 +2,351 @@
 
 msg_id 前缀：``daemon.* generate.* regai.* worker.<name>.* optim.* model.*``。
 终稿来源 tmp/log-text-audit/rewrite-b-subprocess.md 的「msg_id 字典汇总」节。
+
+占位符两语言同名同数（约定 C4）；``key=value`` 的 key 与主题 tag 一律英文小写
+不翻译（C1/C2），保证一条 grep 同时命中中英两种日志。
 """
 from __future__ import annotations
 
 MESSAGES: dict[str, dict[str, str]] = {
+    # --- model.*：三个 runtime 入口共用的模型加载/编排 ---------------------
+    "model.load_text_encoder": {
+        "zh": "加载文本编码器: {path}",
+        "en": "Loading text encoder: {path}",
+    },
+    "model.load_text_encoder_ahead": {
+        "zh": "加载文本编码器（先于 Transformer，用于预编码）: {path}",
+        "en": "Loading text encoder ahead of the transformer for pre-encoding: {path}",
+    },
+    "model.load_transformer": {
+        "zh": "加载 Transformer（{family}）: {path}",
+        "en": "Loading transformer ({family}): {path}",
+    },
+    "model.load_vae": {
+        "zh": "加载 VAE",
+        "en": "Loading VAE",
+    },
+    "model.block_swap_enabled": {
+        "zh": "Block 交换: 后 {n} 层留在内存，用到时再搬进显存",
+        "en": "Block swap: last {n} blocks stay in RAM, moved to VRAM on demand",
+    },
+    "model.unloaded": {
+        "zh": "已卸载模型: 可用内存 {ram} GB",
+        "en": "Model unloaded: {ram} GB RAM available",
+    },
+
+    # --- daemon.* ---------------------------------------------------------
+    "daemon.ready": {
+        "zh": "出图服务已就绪，等待任务",
+        "en": "Generation daemon ready, waiting for tasks",
+    },
+    "daemon.dit_yields_for_text_encoder": {
+        "zh": "预编码 prompt: 先把 Transformer 移到内存腾显存（显存策略 {policy}）",
+        "en": (
+            "Pre-encoding prompts: moved the transformer to RAM first to free VRAM "
+            "(VRAM policy {policy})"
+        ),
+    },
+
+    # --- generate.*：daemon 与 anima_generate 共用 -------------------------
+    "generate.prompts_precached_released": {
+        "zh": "已预编码 {n} 条 prompt: 文本编码器已释放",
+        "en": "Pre-encoded {n} prompts: text encoder released",
+    },
+    "generate.prompts_precached_resident": {
+        "zh": "已预编码 {n} 条 prompt: 文本编码器保持驻留（显存策略 performance）",
+        "en": "Pre-encoded {n} prompts: text encoder stays resident (VRAM policy performance)",
+    },
+    "generate.start": {
+        "zh": "开始出图: {prompts} 个 prompt × {count} 次 = {total} 张",
+        "en": "Generating {total} images: {prompts} prompts × {count} each",
+    },
+    "generate.image_start": {
+        "zh": "出图 {idx}/{total}: seed={seed} prompt={prompt}",
+        "en": "Image {idx}/{total}: seed={seed} prompt={prompt}",
+    },
+    "generate.image_saved": {
+        "zh": "已保存: {path}",
+        "en": "Saved: {path}",
+    },
+    "generate.done": {
+        "zh": "出图完成: {ok}/{total} 张",
+        "en": "Generation finished: {ok}/{total} images",
+    },
+    "generate.canceled": {
+        "zh": "出图已取消: task={task_id}",
+        "en": "Generation canceled: task={task_id}",
+    },
+    "generate.xy_shared_seed": {
+        "zh": "XY 共享种子: {seed}（seed 设 0 时随机取一个）",
+        "en": "XY grid shared seed: {seed} (randomized because seed was 0)",
+    },
+    "generate.xy_start": {
+        "zh": "开始 XY 出图: {nx}×{ny} = {total} 张",
+        "en": "Generating XY grid: {nx}×{ny} = {total} images",
+    },
+    "generate.xy_cell": {
+        "zh": (
+            "XY 第 {xi},{yi} 格: x={xv} y={yv} steps={steps} cfg={cfg} "
+            "seed={seed} sampler={sampler}"
+        ),
+        "en": (
+            "XY cell {xi},{yi}: x={xv} y={yv} steps={steps} cfg={cfg} "
+            "seed={seed} sampler={sampler}"
+        ),
+    },
+    "generate.xy_done": {
+        "zh": "XY 出图完成: {ok}/{total} 张",
+        "en": "XY grid finished: {ok}/{total} images",
+    },
+
+    # --- regai.*：正则集 AI 生成 -------------------------------------------
+    "regai.train_scanned": {
+        "zh": "训练集共 {n} 张图",
+        "en": "Train set: {n} images",
+    },
+    "regai.incremental_plan": {
+        "zh": "增量模式: 需生成 {todo}/{total} 张",
+        "en": "Incremental mode: {todo}/{total} images to generate",
+    },
+    "regai.nothing_to_do": {
+        "zh": "每张训练图都已有正则图，无需生成",
+        "en": "Every train image already has a regularization image; nothing to generate",
+    },
+    "regai.full_mode_clear": {
+        "zh": "全量模式: 已清空正则集目录的旧内容",
+        "en": "Full mode: cleared the existing regularization images",
+    },
+    "regai.precache_strategy": {
+        "zh": "按批预编码 caption: 每批 {batch} 条，编码后释放文本编码器",
+        "en": (
+            "Pre-encoding captions in batches of {batch}; the text encoder is "
+            "released after each batch"
+        ),
+    },
+    "regai.progress": {
+        "zh": "已生成 {done}/{total} 张",
+        "en": "Generated {done}/{total} images",
+    },
+    "regai.done": {
+        "zh": "正则集生成完成: {ok}/{total} 张",
+        "en": "Regularization images finished: {ok}/{total}",
+    },
+
+    # --- lora.*：注入 / 保存 / 加载 ----------------------------------------
+    "lora.injected": {
+        "zh": "已注入 {algo} 到 {n} 层（{detail}）",
+        "en": "Injected {algo} into {n} layers ({detail})",
+    },
+    "lora.tlora_mask_enabled": {
+        "zh": "T-LoRA 时间步 rank 掩码已启用: {n}/{total} 层（min_rank={min_rank} alpha_rank_scale={scale}）",
+        "en": (
+            "T-LoRA timestep rank mask enabled: {n}/{total} layers "
+            "(min_rank={min_rank} alpha_rank_scale={scale})"
+        ),
+    },
+    "lora.saved": {
+        "zh": "LoRA 已保存: {path}",
+        "en": "LoRA saved: {path}",
+    },
+    "lora.saved_baked": {
+        "zh": "LoRA 已保存（OrthoLoRA 已烘焙成普通 LoRA）: {path}",
+        "en": "LoRA saved (OrthoLoRA baked into a plain LoRA): {path}",
+    },
+    "lora.loaded": {
+        "zh": "已加载 LoRA 权重: {path}",
+        "en": "Loaded LoRA weights: {path}",
+    },
+    "lora.reg_dims_applied": {
+        "zh": "已按 lora_reg_dims 覆盖 {n} 个模块的 rank",
+        "en": "Applied lora_reg_dims rank overrides to {n} modules",
+    },
+
+    # --- optim.* -----------------------------------------------------------
+    "optim.created": {
+        "zh": "优化器 {name} 已创建: {params}",
+        "en": "Optimizer {name} created: {params}",
+    },
+    "optim.trainable_params": {
+        "zh": "可训练参数: {tensors} 个张量 / {elements} 个元素",
+        "en": "Trainable parameters: {tensors} tensors / {elements} elements",
+    },
+
+    # --- caption.* ---------------------------------------------------------
+    "caption.convert_done": {
+        "zh": "已转换 {n} 个 caption 文件",
+        "en": "Converted {n} caption files",
+    },
+
+    # --- worker.download.* -------------------------------------------------
+    "worker.download.start": {
+        "zh": "开始下载: tag={tag} count={count} source={source} exclude={exclude}",
+        "en": "Download started: tag={tag} count={count} source={source} exclude={exclude}",
+    },
+    "worker.download.done": {
+        "zh": "下载完成: 已保存 {saved} 张",
+        "en": "Download finished: {saved} images saved",
+    },
+
+    # --- worker.tag.* ------------------------------------------------------
+    "worker.tag.start": {
+        "zh": "开始打标: tagger={tagger} version={version} images={total} on_existing={mode}",
+        "en": "Tagging started: tagger={tagger} version={version} images={total} on_existing={mode}",
+    },
+    "worker.tag.no_images": {
+        "zh": "没有需要打标的图（范围 {scope}）",
+        "en": "No images to tag in scope {scope}",
+    },
+    "worker.tag.trigger_word": {
+        "zh": "触发词 {word} 会写在每张 caption 的第一位",
+        "en": "Trigger word {word} is written first in every caption",
+    },
+    "worker.tag.overrides": {
+        "zh": "本次打标参数覆盖: {overrides}",
+        "en": "Tagger options overridden for this run: {overrides}",
+    },
+    "worker.tag.ready": {
+        "zh": "{tagger} 模型已就绪",
+        "en": "{tagger} model ready",
+    },
+    "worker.tag.progress": {
+        "zh": "已打标 {done}/{total}",
+        "en": "Tagged {done}/{total}",
+    },
+    "worker.tag.done": {
+        "zh": "打标完成: {done}/{total} 张（跳过 {skipped}，失败 {errors}）",
+        "en": "Tagging finished: {done}/{total} images (skipped {skipped}, failed {errors})",
+    },
+
+    # --- worker.regbuild.* -------------------------------------------------
+    "worker.regbuild.start": {
+        "zh": (
+            "开始构建正则集: version={version} source={source} max_tags={max_tags} "
+            "auto_tag={auto_tag} incremental={incremental} auto_dedup={auto_dedup} "
+            "postprocess={pp_method}/{pp_max_crop}"
+        ),
+        "en": (
+            "Regularization build started: version={version} source={source} "
+            "max_tags={max_tags} auto_tag={auto_tag} incremental={incremental} "
+            "auto_dedup={auto_dedup} postprocess={pp_method}/{pp_max_crop}"
+        ),
+    },
+    "worker.regbuild.built": {
+        "zh": "正则集已构建: {actual}/{target} 张",
+        "en": "Regularization set built: {actual}/{target} images",
+    },
+    "worker.regbuild.autotag_no_images": {
+        "zh": "[auto-tag] 正则集没有图，跳过打标",
+        "en": "[auto-tag] no regularization images to tag, skipping",
+    },
+    "worker.regbuild.autotag_start": {
+        "zh": "[auto-tag] 开始给正则集打标: tagger={tagger} images={total}",
+        "en": "[auto-tag] tagging the regularization set: tagger={tagger} images={total}",
+    },
+    "worker.regbuild.autotag_ready": {
+        "zh": "[auto-tag] {tagger} 模型已就绪",
+        "en": "[auto-tag] {tagger} model ready",
+    },
+    "worker.regbuild.autotag_progress": {
+        "zh": "[auto-tag] 已打标 {done}/{total}",
+        "en": "[auto-tag] tagged {done}/{total}",
+    },
+    "worker.regbuild.autotag_done": {
+        "zh": "[auto-tag] 打标完成: {done}/{total} 张（失败 {errors}）",
+        "en": "[auto-tag] tagging finished: {done}/{total} (failed {errors})",
+    },
+    "worker.regbuild.dedup_scan": {
+        "zh": "[dedup] 第 {round}/{rounds} 轮: 扫描重复图",
+        "en": "[dedup] round {round}/{rounds}: scanning for duplicates",
+    },
+    "worker.regbuild.dedup_none": {
+        "zh": "[dedup] 第 {round} 轮: 没有可删的重复图，结束去重",
+        "en": "[dedup] round {round}: no duplicates left, deduplication done",
+    },
+    "worker.regbuild.dedup_purged": {
+        "zh": "[dedup] 第 {round} 轮: 已删 {count} 张重复图",
+        "en": "[dedup] round {round}: removed {count} duplicates",
+    },
+    "worker.regbuild.dedup_target_met": {
+        "zh": "[dedup] 第 {round} 轮: 已达目标张数，结束去重",
+        "en": "[dedup] round {round}: target count reached, deduplication done",
+    },
+    "worker.regbuild.dedup_refill": {
+        "zh": "[dedup] 第 {round} 轮: 还缺 {shortfall} 张，按增量模式补足",
+        "en": "[dedup] round {round}: {shortfall} images short, refilling incrementally",
+    },
+    "worker.regbuild.dedup_refilled": {
+        "zh": "[dedup] 第 {round} 轮: 补足后 {actual}/{target} 张",
+        "en": "[dedup] round {round}: {actual}/{target} images after refill",
+    },
+
+    # --- worker.preprocess.* -----------------------------------------------
+    "worker.preprocess.no_images": {
+        "zh": "没有需要处理的图",
+        "en": "No images to process",
+    },
+    "worker.preprocess.upscale_start": {
+        "zh": (
+            "开始放大: mode={mode} model={model} tile={tile}+{pad} device={device} "
+            "target={target} images={total}"
+        ),
+        "en": (
+            "Upscaling started: mode={mode} model={model} tile={tile}+{pad} "
+            "device={device} target={target} images={total}"
+        ),
+    },
+    "worker.preprocess.model_ready": {
+        "zh": "放大器 {model} 已加载到 {device}",
+        "en": "Upscaler {model} loaded on {device}",
+    },
+    "worker.preprocess.progress": {
+        "zh": "已处理 {done}/{total}",
+        "en": "Processed {done}/{total}",
+    },
+    "worker.preprocess.upscale_done": {
+        "zh": "放大完成: 成功 {succeeded}，失败 {failed}，跳过 {skipped}",
+        "en": "Upscaling finished: succeeded={succeeded} failed={failed} skipped={skipped}",
+    },
+    "worker.preprocess.no_crops": {
+        "zh": "没有裁剪框，无需处理",
+        "en": "No crop boxes to apply",
+    },
+    "worker.preprocess.crop_start": {
+        "zh": "开始裁剪: images={total}",
+        "en": "Cropping started: images={total}",
+    },
+    "worker.preprocess.crop_done": {
+        "zh": "裁剪完成: 成功 {succeeded}，失败 {failed}，跳过 {skipped}",
+        "en": "Cropping finished: succeeded={succeeded} failed={failed} skipped={skipped}",
+    },
+
+    # --- worker.eval.* -----------------------------------------------------
+    "worker.eval.start": {
+        "zh": "开始评估: session={session} candidates={n}（含基线） stages={stages}",
+        "en": "Evaluation started: session={session} candidates={n} (baseline included) stages={stages}",
+    },
+    "worker.eval.generate_all_done": {
+        "zh": "[generate] 全部候选都已出图，跳过出图阶段",
+        "en": "[generate] every candidate already has samples, skipping the generation stage",
+    },
+    "worker.eval.candidate_skipped": {
+        "zh": "[generate] {label} 已出图，跳过",
+        "en": "[generate] {label} already generated, skipping",
+    },
+    "worker.eval.candidate_start": {
+        "zh": "[generate] {label} 开始出图: run={run_id}",
+        "en": "[generate] {label} generating: run={run_id}",
+    },
+    "worker.eval.candidate_done": {
+        "zh": "[generate] {label} 出图完成: {done}/{total}",
+        "en": "[generate] {label} generated {done}/{total}",
+    },
+    "worker.eval.metric_start": {
+        "zh": "[{stage}] {label} 开始算指标: run={run_id}",
+        "en": "[{stage}] {label} scoring: run={run_id}",
+    },
+    "worker.eval.done": {
+        "zh": "评估完成: session={session} candidates={n} metrics_done={m}",
+        "en": "Evaluation finished: session={session} candidates={n} metrics_done={m}",
+    },
 }

--- a/studio/infrastructure/_messages_worker.py
+++ b/studio/infrastructure/_messages_worker.py
@@ -1,0 +1,9 @@
+"""子进程域（daemon / generate / reg_ai / utils / workers）的用户可见 INFO 文案。
+
+msg_id 前缀：``daemon.* generate.* regai.* worker.<name>.* optim.* model.*``。
+终稿来源 tmp/log-text-audit/rewrite-b-subprocess.md 的「msg_id 字典汇总」节。
+"""
+from __future__ import annotations
+
+MESSAGES: dict[str, dict[str, str]] = {
+}

--- a/studio/infrastructure/event_bus.py
+++ b/studio/infrastructure/event_bus.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import threading
+import weakref
 from typing import Any, Callable, Optional
 
 _drop_logger = logging.getLogger(__name__)
@@ -82,17 +83,39 @@ class EventBus:
                 pass
 
 
+# B-1.5 + R8：慢消费者丢事件是**持续状态**不是离散事件——训练进度风暴时逐条
+# WARNING 能刷上千行黄。状态化：进入丢弃态 1 条、丢弃期间只计数、恢复时 1 条带
+# 累计数（一次拥塞恒定 2 条）。_safe_put 只在 event loop 线程执行，无竞态；
+# WeakKeyDictionary 随队列 unsubscribe 自动清。
+_drop_states: "weakref.WeakKeyDictionary[asyncio.Queue, dict[str, Any]]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
 def _safe_put(q: asyncio.Queue[dict[str, Any]], event: dict[str, Any]) -> None:
+    st = _drop_states.get(q)
     try:
         q.put_nowait(event)
     except asyncio.QueueFull:
-        # B-1.5: 慢消费者：丢弃，不阻塞 publisher；但必须 log（之前是静默丢
-        # → 前端 progress/task_state_changed 看似掉帧但后端日志干净到看不出问题）。
-        # 用 module logger 走 studio.log，自带 trace_id（如果 publisher 在 request ctx 内）。
+        if st is None:
+            st = _drop_states[q] = {"dropped": 0, "last_type": "?"}
+        if st["dropped"] == 0:
+            # 用 module logger 走 studio.log，自带 trace_id（publisher 在 request ctx 内时）
+            _drop_logger.warning(
+                "event_bus slow consumer: queue full, dropping events "
+                "(type=%s queue_maxsize=%d)",
+                event.get("type", "?"), q.maxsize,
+            )
+        st["dropped"] += 1
+        st["last_type"] = event.get("type", "?")
+        return
+    if st is not None and st["dropped"]:
         _drop_logger.warning(
-            "event_bus slow consumer: queue full, dropped event type=%s",
-            event.get("type", "?"),
+            "event_bus slow consumer recovered: dropped %d event(s) "
+            "(last type=%s)",
+            st["dropped"], st["last_type"],
         )
+        st["dropped"] = 0
 
 
 # 进程内单例（server.py 用）

--- a/studio/infrastructure/log_messages.py
+++ b/studio/infrastructure/log_messages.py
@@ -1,0 +1,74 @@
+"""用户可见 INFO 叙事行的 i18n 字典（tmp/log-text-audit Q1 拍板）。
+
+分层口径：
+- **INFO 叙事行（用户可见面：run.log / daemon ring / 下载卡 / CLI 终端）**
+  走本模块 ``msg(msg_id, **kwargs)``，按 UI 语言输出中/英文；
+- WARNING / ERROR / DEBUG 排障行与 studio.log 面统一英文，不进字典；
+- traceback 与第三方库输出原样。
+
+语言解析顺序：``ANIMA_UI_LANG`` env（supervisor / daemon spawn 时从
+``secrets.system.ui_language`` 注入）→ 兜底读 secrets（手跑 / CLI 场景）→ zh。
+
+字典按域拆三个数据文件（``_messages_{train,worker,server}.py``），避免多人/
+多刀并行编辑冲突；msg_id 命名 ``<domain>.<event>``（snake_case），全仓唯一，
+重复定义在 import 时报错。新增用户可见 INFO 行必须进字典——这是 Q1 口径的
+长期成本，勿绕过。
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+UI_LANG_ENV = "ANIMA_UI_LANG"
+_SUPPORTED = ("zh", "en")
+_FALLBACK = "zh"
+
+from ._messages_train import MESSAGES as _TRAIN  # noqa: E402
+from ._messages_worker import MESSAGES as _WORKER  # noqa: E402
+from ._messages_server import MESSAGES as _SERVER  # noqa: E402
+
+MESSAGES: dict[str, dict[str, str]] = {}
+for _part in (_TRAIN, _WORKER, _SERVER):
+    _dup = MESSAGES.keys() & _part.keys()
+    if _dup:
+        raise RuntimeError(f"duplicate log msg_id across domains: {sorted(_dup)}")
+    MESSAGES.update(_part)
+
+_secrets_lang: Optional[str] = None
+
+
+def current_lang() -> str:
+    """当前日志语言。env 优先；缺失时读一次 secrets 并缓存；再兜底 zh。"""
+    lang = os.environ.get(UI_LANG_ENV, "").strip().lower()
+    if lang in _SUPPORTED:
+        return lang
+    global _secrets_lang
+    if _secrets_lang is None:
+        try:
+            from .secrets import load  # noqa: PLC0415 — 惰性避免 import 环
+
+            _secrets_lang = str(load().system.ui_language)
+        except Exception:
+            _secrets_lang = _FALLBACK
+    return _secrets_lang if _secrets_lang in _SUPPORTED else _FALLBACK
+
+
+def msg(msg_id: str, **kwargs: object) -> str:
+    """按当前语言渲染一条用户可见 INFO 文案。
+
+    缺 key / 占位符不匹配时不抛——日志路径绝不能因文案问题崩（T7 精神）：
+    缺 key 返回 ``msg_id + 参数``（在日志里显眼可 grep，等于 fail-loud）。
+    """
+    entry = MESSAGES.get(msg_id)
+    if entry is None:
+        return f"{msg_id} {kwargs}" if kwargs else msg_id
+    template = entry.get(current_lang()) or entry.get("zh") or entry.get("en") or msg_id
+    try:
+        return template.format(**kwargs)
+    except Exception:
+        return template
+
+
+def _reset_lang_cache_for_tests() -> None:
+    global _secrets_lang
+    _secrets_lang = None

--- a/studio/infrastructure/logging.py
+++ b/studio/infrastructure/logging.py
@@ -504,8 +504,21 @@ def _reset_for_tests() -> None:
     # 不还原 sys.excepthook（测试间也不应该依赖那个）
 
 
+def log_file_vanished_during_migration(
+    logger: logging.Logger, rel: object,
+) -> None:
+    """「迁移期间文件消失，跳过」的共享模板。
+
+    models root 迁移（services/models_storage.py）与 studio_data 迁移
+    （services/studio_data.py）原来各有一份逐字相同的拷贝。逐文件、尽力
+    而为的动作 → DEBUG（进度条最多停在 <100%，用户无感）。
+    """
+    logger.debug("file vanished during migration; skipped: rel=%s", rel)
+
+
 # 编码兜底是无条件常量，导出给 workers/_base.py 旧 import 兼容
 __all__ = [
+    "log_file_vanished_during_migration",
     "STUDIO_LOG_NAME", "STUDIO_LOG_MAX_BYTES", "STUDIO_LOG_BACKUP_COUNT",
     "TRACE_HEADER", "TRACE_ENV", "PROCESS_ENV", "LOG_LEVEL_ENV",
     "OWN_LOGGER_NAMESPACES", "console_level_from_env", "LOG_LINE_RE",

--- a/studio/infrastructure/paths.py
+++ b/studio/infrastructure/paths.py
@@ -44,11 +44,15 @@ def resolve_studio_data(pointer_file: Path | None = None) -> Path:
             if target.is_absolute() and target.is_dir():
                 return target
             logging.getLogger(__name__).warning(
-                "studio_data 指针目标无效（不存在或非绝对路径），回退默认位置: %s", target,
+                "studio_data pointer target is invalid (missing or not an absolute "
+                "path); using the default location: %s; data at the pointer target "
+                "is left untouched", target,
             )
     except Exception:
         logging.getLogger(__name__).warning(
-            "studio_data 指针文件解析失败，回退默认位置: %s", ptr, exc_info=True,
+            "studio_data pointer file could not be parsed; using the default "
+            "location: %s; data at the pointer target is left untouched",
+            ptr, exc_info=True,
         )
     return DEFAULT_STUDIO_DATA
 

--- a/studio/infrastructure/secrets.py
+++ b/studio/infrastructure/secrets.py
@@ -647,6 +647,11 @@ class SystemConfig(BaseModel):
     #: 的 PCI 序号，启动期由 runtime.gpu_select 注入 CUDA_DEVICE_ORDER=PCI_BUS_ID
     #: + CUDA_VISIBLE_DEVICES 使训练/出图/打标全走这张卡；重启生效。
     gpu_index: Optional[int] = None
+    #: UI 语言（zh/en），前端切语言时同步写入。作为**子进程日志语言**的注入源：
+    #: supervisor / daemon spawn 时读它注入 ANIMA_UI_LANG，用户可见 INFO 叙事行
+    #: 按此语言输出（infrastructure/log_messages.py；排障行恒英文）。前端自身的
+    #: 显示语言仍以 localStorage 为准（首屏无闪烁），本字段只需最终一致。
+    ui_language: str = "zh"
     #: 日志视图默认是否显示 DEBUG 行（docs/design/logging-target-state.md D1）。
     #: 只管显示默认值：run.log / daemon ring 恒记 DEBUG，每个日志视图有自己的
     #: 「调试」开关（不持久化）以此为初值。报错后用户可在视图里临时打开，不用重跑。

--- a/studio/infrastructure/single_instance.py
+++ b/studio/infrastructure/single_instance.py
@@ -80,6 +80,9 @@ class SingleInstanceLock:
                 fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         except OSError:
             # close() 也会随句柄释放锁；这里失败不影响正确性
-            logger.warning("unlock failed for %s", self.path, exc_info=True)
+            logger.warning(
+                "unlock failed for %s; the lock is reclaimed on the next start",
+                self.path, exc_info=True,
+            )
         finally:
             handle.close()

--- a/studio/infrastructure/tag_dictionary.py
+++ b/studio/infrastructure/tag_dictionary.py
@@ -85,7 +85,8 @@ def parse_csv(text: str) -> dict[str, list[str]]:
         entries[tag] = aliases
     if truncated:
         logger.warning(
-            "tag_dictionary: 超过 %d 条上限，截断；丢弃了后续行", MAX_ENTRIES
+            "tag dictionary exceeds the %d entry limit; truncated, "
+            "the remaining lines are dropped", MAX_ENTRIES
         )
     return entries
 
@@ -112,7 +113,8 @@ def parse_sqlite(path: Path) -> dict[str, list[str]]:
         conn.close()
     if total > MAX_ENTRIES:
         logger.info(
-            "tag_dictionary: 源共 %d 条，按 post_count 取前 %d 条", total, MAX_ENTRIES
+            "tag dictionary imported: source=%d kept=%d (top by post_count)",
+            total, MAX_ENTRIES,
         )
     entries: dict[str, list[str]] = {}
     for name, cn_name in rows:
@@ -155,7 +157,10 @@ def load_active() -> Optional[tuple[dict[str, list[str]], dict[str, Any]]]:
             return None
         return entries, meta
     except Exception:
-        logger.exception("tag_dictionary: active.json 损坏，视作未加载")
+        logger.warning(
+            "active.json is corrupt; the tag dictionary is treated as not loaded "
+            "(re-download it from Settings)", exc_info=True,
+        )
         return None
 
 
@@ -200,7 +205,7 @@ def download_default() -> dict[str, Any]:
     SOURCE_FILE.unlink(missing_ok=True)  # 留底只保留当前 active 的源文件
     meta = _meta(DEFAULT_SOURCE_NAME, DEFAULT_URL, "default", len(entries))
     _write_active(entries, meta)
-    logger.info("tag_dictionary: 默认词典已下载 (%d 条)", len(entries))
+    logger.info("default tag dictionary downloaded: entries=%d", len(entries))
     return meta
 
 
@@ -225,7 +230,9 @@ def apply_uploaded(content: bytes, filename: str) -> dict[str, Any]:
     SOURCE_SQLITE.unlink(missing_ok=True)  # 留底只保留当前 active 的源文件
     meta = _meta(filename or "user-upload", "", "user", len(entries))
     _write_active(entries, meta)
-    logger.info("tag_dictionary: 用户上传词典已加载 (%d 条, %s)", len(entries), filename)
+    logger.info(
+        "user tag dictionary loaded: entries=%d name=%s", len(entries), filename,
+    )
     return meta
 
 

--- a/studio/infrastructure/task_log.py
+++ b/studio/infrastructure/task_log.py
@@ -88,3 +88,15 @@ class CallbackTaskLog:
 
 #: 丢弃一切输出的空实现（库函数默认值用，替代 ``lambda _l: None``）。
 NULL_LOG = CallbackTaskLog(lambda _l: None)
+
+
+def as_task_log(fn: Any) -> TaskLogLike:
+    """把裸 ``Callable[[str], None]`` 适配成 :class:`TaskLogLike`。
+
+    已经带级别方法的对象原样返回。库函数（下载原语等）对外仍接受历史的
+    单参回调 —— 内部想调 ``.warning`` / ``.error`` 时先过这一道，调用方
+    传 lambda 也不会 AttributeError。
+    """
+    if callable(getattr(fn, "warning", None)) and callable(getattr(fn, "debug", None)):
+        return fn
+    return CallbackTaskLog(fn)

--- a/studio/services/announcements.py
+++ b/studio/services/announcements.py
@@ -93,10 +93,15 @@ def list_posts(directory: Optional[Path] = None) -> list[AnnouncementPost]:
         tag = str(meta.get("tag", "")).strip()
         title_zh = str(meta.get("title", "")).strip()
         if not (date and tag and title_zh):
-            logger.warning("announcement %s 缺 date/tag/title，跳过", zh_path.name)
+            logger.warning(
+                "announcement %s is missing date/tag/title; skipped", zh_path.name,
+            )
             continue
         if tag not in VALID_TAGS:
-            logger.warning("announcement %s tag=%r 不在白名单，跳过", zh_path.name, tag)
+            logger.warning(
+                "announcement %s has tag=%r outside the allowed list; skipped",
+                zh_path.name, tag,
+            )
             continue
 
         # en 配对：缺文件 / 缺字段时 fallback 中文

--- a/studio/services/booru/downloader.py
+++ b/studio/services/booru/downloader.py
@@ -28,7 +28,8 @@ import requests
 
 from . import api as booru_api, pool as booru_pool
 from ..proxy_manager import get_proxy_dict
-from studio.infrastructure.task_log import TaskLogLike
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import NULL_LOG, TaskLogLike, as_task_log
 
 ProgressFn = TaskLogLike
 ImageSavedFn = Callable[[Path], None]
@@ -78,7 +79,7 @@ def download(
     opts: DownloadOptions,
     dest_dir: Path,
     *,
-    on_progress: ProgressFn = print,
+    on_progress: ProgressFn = NULL_LOG,
     on_image_saved: Optional[ImageSavedFn] = None,
     cancel_event: Optional[threading.Event] = None,
     session: Optional[requests.Session] = None,
@@ -95,6 +96,8 @@ def download(
     控（API 2 / CDN 5 req/s）。`session=` 仍接受外部 session（旧 test 用），
     内部用 `client.search_posts/download_image` 包装。
     """
+    # 对外仍接受历史的单参回调（tools / 测试传 lambda）；内部按级别分派
+    on_progress = as_task_log(on_progress)
     dest_dir.mkdir(parents=True, exist_ok=True)
     if not opts.tag.strip():
         raise ValueError("tag 不能为空")
@@ -156,6 +159,7 @@ def _download_with_client(
     saved = 0
     skipped = 0
     failed = 0
+    first_error = ""
     page = 1
     api_limit = 100 if opts.api_source == "gelbooru" else 200
     # 跨 worker 线程共享的「已 emit」计数器，仅供 _fetch_one 实时打 [N/count] 用。
@@ -165,9 +169,9 @@ def _download_with_client(
 
     while saved < opts.count:
         if cancel_event and cancel_event.is_set():
-            on_progress("[cancel] user requested stop")
+            on_progress(msg("booru.canceled"))
             return saved
-        on_progress(f"[page {page}] fetching ...")
+        on_progress.debug("booru search: fetching page=%d", page)
         try:
             posts = client.search_posts(
                 opts.api_source,
@@ -179,10 +183,13 @@ def _download_with_client(
                 username=opts.username,
             )
         except requests.RequestException as exc:
-            on_progress(f"[err] search failed: {exc}")
+            on_progress.warning(
+                "booru search failed: page=%d err=%s; stopping with %d images "
+                "saved", page, exc, saved,
+            )
             return saved
         if not posts:
-            on_progress("[done] no more posts (server returned empty page)")
+            on_progress(msg("booru.no_more_posts"))
             break
 
         # 收集本页所有「待下载」候选；并发拉图
@@ -201,7 +208,9 @@ def _download_with_client(
             target = dest_dir / f"{post_id}.{ext}"
             if opts.skip_existing and target.exists():
                 skipped += 1
-                on_progress(f"[skip] {target.name} already exists")
+                on_progress.debug(
+                    "booru skip: file already exists name=%s", target.name,
+                )
                 continue
             candidates.append((post_id, file_url, file_ext, tags_str, target))
 
@@ -229,13 +238,16 @@ def _download_with_client(
                     with emit_lock:
                         emit_state["n"] += 1
                         n = emit_state["n"]
-                    on_progress(f"[{n}/{opts.count}] saved {final.name}")
+                    on_progress(msg(
+                        "booru.saved", n=n, total=opts.count, name=final.name,
+                    ))
                     return final
                 except requests.RequestException as exc:
                     last_exc = exc
                     backoff = 2 ** (attempt - 1)
-                    on_progress(
-                        f"[retry {attempt}/{max_retries}] {target.name}: {exc}"
+                    on_progress.debug(
+                        "booru retry %d/%d: name=%s err=%s",
+                        attempt, max_retries, target.name, exc,
                     )
                     if cancel_event and cancel_event.wait(backoff):
                         raise RuntimeError("canceled") from exc
@@ -247,15 +259,24 @@ def _download_with_client(
 
         for (post_id, _url, _ext, tags_str, target), final, exc in results:
             if cancel_event and cancel_event.is_set():
-                on_progress("[cancel] user requested stop")
+                on_progress(msg("booru.canceled"))
                 return saved
             if exc is not None:
                 # 取消引发的 RuntimeError("canceled") 在 _fetch_one 里抛出，
                 # 不当成「下载失败」report，否则用户取消会看到一堆 [err]。
                 if isinstance(exc, RuntimeError) and "canceled" in str(exc):
                     continue
-                on_progress(f"[err] {target.name}: {exc}")
+                # T6 节流：站点挂掉时整页每张一条 —— 首条全文，之后逐条 DEBUG
                 failed += 1
+                if failed == 1:
+                    first_error = f"{target.name}: {exc}"
+                    on_progress.warning(
+                        "booru download failed: name=%s err=%s", target.name, exc,
+                    )
+                else:
+                    on_progress.debug(
+                        "booru download failed: name=%s err=%s", target.name, exc,
+                    )
                 continue
             assert isinstance(final, Path)
             if opts.save_tags and tags_str:
@@ -270,22 +291,26 @@ def _download_with_client(
                 break
 
         if len(posts) < api_limit:
-            on_progress(
-                f"[done] page returned {len(posts)} < limit {api_limit}, "
-                "reached end"
-            )
+            on_progress(msg(
+                "booru.page_short_end", n=len(posts), limit=api_limit,
+            ))
             break
         if page_valid == 0:
-            on_progress("[done] no valid posts on this page; stopping")
+            on_progress(msg("booru.no_valid_posts"))
             break
         page += 1
         if cancel_event and cancel_event.wait(page_delay):
-            on_progress("[cancel] user requested stop")
+            on_progress(msg("booru.canceled"))
             return saved
 
-    on_progress(
-        f"[summary] saved={saved} skipped={skipped} failed={failed}"
-    )
+    # R10：部分失败的收尾汇总记 WARNING（用户会想重跑失败的那部分）
+    if failed:
+        on_progress.warning(
+            "booru download finished with failures: saved=%d skipped=%d "
+            "failed=%d; first error: %s", saved, skipped, failed, first_error,
+        )
+    else:
+        on_progress(msg("booru.summary", saved=saved, skipped=skipped))
     return saved
 
 

--- a/studio/services/booru/pool.py
+++ b/studio/services/booru/pool.py
@@ -130,8 +130,7 @@ class BooruClient:
         self.cfg = cfg or BooruPoolConfig()
         self._session = session or requests.Session()
         patch_requests_session(self._session)
-        # 外部传入的 session 不一定是 requests.Session（测试里有最小 FakeSession 只实现 .get）
-        logger.info("BooruClient session proxies: %s", getattr(self._session, "proxies", {}))
+        # proxy patch 的结果由 proxy_manager 自己记一条 DEBUG，这里不再打第二遍
         self._owns_session = session is None
         self._api_bucket = TokenBucket(self.cfg.api_rate_per_sec)
         self._cdn_bucket = TokenBucket(self.cfg.cdn_rate_per_sec)
@@ -201,14 +200,15 @@ class BooruClient:
 
         if log_new_window:
             logger.warning(
-                "[booru_pool] %s 收到 %d，sticky backoff %.0fs",
+                "[booru_pool] %s returned %d; sticky backoff %.1fs",
                 kind, status_code, backoff,
             )
         if do_halve:
             self._api_bucket.set_rate(self.cfg.api_rate_per_sec)
             self._cdn_bucket.set_rate(self.cfg.cdn_rate_per_sec)
             logger.warning(
-                "[booru_pool] 429 触发速率永久减半（API %.2f / CDN %.2f req/s）",
+                "[booru_pool] 429 received; request rate halved for the rest "
+                "of this run (api=%.2f cdn=%.2f req/s)",
                 self.cfg.api_rate_per_sec,
                 self.cfg.cdn_rate_per_sec,
             )

--- a/studio/services/dataset/thumb_cache.py
+++ b/studio/services/dataset/thumb_cache.py
@@ -32,6 +32,9 @@ _KEY_LOCKS: dict[str, threading.Lock] = {}
 # Pillow 9.1+ 把 LANCZOS 挪到 Image.Resampling 下；旧版本仍可用 Image.LANCZOS。
 _RESAMPLE = getattr(Image, "Resampling", Image).LANCZOS  # type: ignore[attr-defined]
 
+#: 已记过一次 WARNING 的源图（R8 去重）：同一张坏图被反复请求时不刷屏
+_THUMB_FAIL_SEEN: set[str] = set()
+
 
 def _key_lock(key: str) -> threading.Lock:
     with _LOCKS_LOCK:
@@ -52,7 +55,7 @@ def _key_for(src: Path, size: int) -> Optional[str]:
     try:
         mtime = src.stat().st_mtime_ns
     except OSError as exc:
-        logger.warning("thumb cache: stat failed for %s: %s", src, exc)
+        logger.debug("stat failed: path=%s err=%s", src, exc)
         return None
     payload = f"{src.resolve()}|{mtime}|{size}".encode("utf-8")
     return hashlib.sha1(payload).hexdigest()
@@ -96,9 +99,18 @@ def get_or_make_thumb(src: Path, size: int) -> Path:
                 img.save(tmp, "JPEG", quality=80, optimize=True)
             os.replace(tmp, out)
         except Exception as exc:
-            logger.warning(
-                "thumb generation failed for %s (size=%d): %s", src, size, exc
-            )
+            # 同一张坏图会被反复请求 —— 进程内按 src 只记首条（R8）
+            if str(src) not in _THUMB_FAIL_SEEN:
+                _THUMB_FAIL_SEEN.add(str(src))
+                logger.warning(
+                    "thumbnail generation failed: path=%s size=%d err=%s",
+                    src, size, exc,
+                )
+            else:
+                logger.debug(
+                    "thumbnail generation failed: path=%s size=%d err=%s",
+                    src, size, exc,
+                )
             try:
                 tmp.unlink(missing_ok=True)
             except OSError:
@@ -147,8 +159,9 @@ def prewarm_from_image(
                 os.replace(tmp, out)
                 written.append(out)
             except Exception as exc:
-                logger.warning(
-                    "thumb prewarm failed for %s (size=%d): %s", src, size, exc
+                logger.debug(
+                    "thumbnail generation failed (prewarm): path=%s size=%d "
+                    "err=%s", src, size, exc,
                 )
                 try:
                     tmp.unlink(missing_ok=True)

--- a/studio/services/diagnostics.py
+++ b/studio/services/diagnostics.py
@@ -134,7 +134,10 @@ def studio_log_slice(start: float, end: float, *, max_bytes: int = STUDIO_LOG_SL
                         chunks.append(f"... truncated at {max_bytes} bytes ...\n")
                         return "".join(chunks)
         except OSError:
-            logger.exception("read %s failed", p)
+            logger.warning(
+                "diagnostics bundle: read failed for %s; the entry is omitted from "
+                "the bundle", p, exc_info=True,
+            )
     return "".join(chunks)
 
 

--- a/studio/services/eval_auto.py
+++ b/studio/services/eval_auto.py
@@ -129,13 +129,13 @@ def queue_training_finished_eval(
     selected = select_checkpoints(all_ckpts, skip_count=skip_count)
     if not selected:
         logger.info(
-            "after-training eval skipped for task=%s: no checkpoint in output/",
+            "after-training eval skipped: task_id=%s reason=no_checkpoint_in_output",
             task.get("id"),
         )
         return None
     if len(selected) != len(all_ckpts):
         logger.info(
-            "eval checkpoint sampling skip=%s: %s/%s checkpoints selected",
+            "eval checkpoint sampling: keeping 1 of every %s, selected=%s/%s",
             skip_count, len(selected), len(all_ckpts),
         )
 
@@ -148,8 +148,10 @@ def queue_training_finished_eval(
             skip_count=skip_count,
         )
     except Exception:
-        logger.exception(
-            "after-training eval session creation failed for task=%s", task.get("id")
+        logger.warning(
+            "after-training eval session creation failed: task_id=%s; training "
+            "finished and was saved, no evaluation was created",
+            task.get("id"), exc_info=True,
         )
         return None
 
@@ -281,6 +283,8 @@ def _checkpoint_relative_to_output(
     try:
         rel = path.resolve().relative_to(output_dir)
     except ValueError:
-        logger.warning("eval checkpoint outside output dir: %s", raw_path)
+        logger.warning(
+            "eval checkpoint is outside the output dir: path=%s; skipped", raw_path,
+        )
         return None
     return f"output/{rel.as_posix()}"

--- a/studio/services/eval_ccip.py
+++ b/studio/services/eval_ccip.py
@@ -18,6 +18,7 @@ from typing import Any, Callable
 
 from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
+from studio.infrastructure.log_messages import msg
 from studio.infrastructure.task_log import TaskLogLike
 
 JOB_KIND = "eval_ccip"
@@ -67,14 +68,14 @@ def run_ccip_job(
         clear_value=True, eval_root=eval_root,
     )
     try:
-        progress(f"[eval-ccip] scoring run={run['run_id']} model={model}")
+        progress(msg("eval.ccip_start", run_id=run["run_id"], model=model))
         scored = (scorer or _default_scorer)(run, version_dir, model, progress)
         result = _result_from_scores(scored, model)
         saved = eval_metrics.save_result(
             version_dir, str(run["run_id"]), result, eval_root=eval_root,
         )
         state = saved["metric_states"][METRIC_KEY]
-        progress(f"[eval-ccip] done ccip_i={state['status']}")
+        progress(msg("eval.ccip_done", status=state["status"]))
         return saved
     except Exception as exc:
         _save_failed(version_dir, str(run["run_id"]), model, str(exc), eval_root)
@@ -288,7 +289,7 @@ def _load_ccip(model_name: str, progress: TaskLogLike):
     threshold = float(
         json.loads((model_dir / "metrics.json").read_text(encoding="utf-8"))["threshold"]
     )
-    progress(f"[eval-ccip] loading CCIP onnx (threshold={threshold:.4f})")
+    progress(msg("eval.ccip_loading", threshold=f"{threshold:.4f}"))
     feat_sess = _make_session(model_dir / "model_feat.onnx")
     metric_sess = _make_session(model_dir / "model_metrics.onnx")
     return (
@@ -326,7 +327,7 @@ def _default_scorer(run, version_dir, model_name, progress, pool=None):
         return np.asarray(out).reshape(-1).astype(np.float32)  # (768,)
 
     n = len(pairs)
-    progress(f"[eval-ccip] extracting CCIP features for {n} pairs")
+    progress(msg("eval.ccip_extract", n=n))
     gen_feats = [_feat(g) for g, _ in pairs]
     ref_feats = [_feat(r) for _, r in pairs]
     stacked = np.stack(gen_feats + ref_feats, axis=0).astype(np.float32)  # (2n,768)

--- a/studio/services/eval_cleanup.py
+++ b/studio/services/eval_cleanup.py
@@ -129,7 +129,7 @@ def purge_legacy_jobs(
             continue
         shutil.rmtree(d, ignore_errors=True)
         if d.exists():
-            logger.warning("purge_legacy_jobs: rmtree 未清干净 %s", d)
+            logger.warning("legacy eval job dir not fully removed: path=%s", d)
             continue
         removed_dirs += 1
         freed += int(job["bytes"])
@@ -144,7 +144,7 @@ def purge_legacy_jobs(
     conn.commit()
 
     logger.info(
-        "purged %s legacy eval job rows (%s log dirs, %.1f MB)",
+        "legacy eval cleanup: job_rows=%s log_dirs=%s freed=%.1f MB",
         removed_rows, removed_dirs, freed / 1_048_576,
     )
     return {
@@ -185,9 +185,4 @@ def cleanup_legacy_eval_on_startup(conn: sqlite3.Connection) -> dict[str, Any]:
         return {"skipped": True, "reason": "already done"}
     result = purge_legacy_jobs(conn, with_size=False)
     mark_done(conn)
-    if result["removed_rows"]:
-        logger.info(
-            "legacy eval cleanup: removed %s job rows and %s log dirs (#465)",
-            result["removed_rows"], result["removed_dirs"],
-        )
     return {"skipped": False, **result}

--- a/studio/services/eval_clip.py
+++ b/studio/services/eval_clip.py
@@ -15,6 +15,7 @@ from typing import Any, Callable
 
 from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
+from studio.infrastructure.log_messages import msg
 from studio.infrastructure.task_log import TaskLogLike
 
 JOB_KIND = "eval_clip"
@@ -64,7 +65,7 @@ def run_clip_job(
     )
 
     try:
-        progress(f"[eval-clip] scoring run={run['run_id']} model={model}")
+        progress(msg("eval.clip_start", run_id=run["run_id"], model=model))
         scored = (scorer or _default_scorer)(run, version_dir, model, progress)
         result = _result_from_scores(scored, model)
         saved = eval_metrics.save_result(
@@ -73,11 +74,11 @@ def run_clip_job(
             result,
             eval_root=eval_root,
         )
-        progress(
-            "[eval-clip] done "
-            f"clip_t={saved['metric_states']['clip_t']['status']} "
-            f"clip_i={saved['metric_states']['clip_i']['status']}"
-        )
+        progress(msg(
+            "eval.clip_done",
+            clip_t=saved["metric_states"]["clip_t"]["status"],
+            clip_i=saved["metric_states"]["clip_i"]["status"],
+        ))
         return saved
     except Exception as exc:
         _save_failed(version_dir, str(run["run_id"]), model, str(exc), eval_root)
@@ -288,7 +289,7 @@ def _load_clip(model_name: str, progress: TaskLogLike):
     from studio.services.models.downloader import ensure_eval_model
 
     local_dir = ensure_eval_model("clip", model_name, on_log=progress)
-    progress(f"[eval-clip] loading CLIP on {device}")
+    progress(msg("eval.clip_loading", device=device))
     processor = CLIPProcessor.from_pretrained(str(local_dir))
     model = CLIPModel.from_pretrained(str(local_dir)).to(device)
     model.eval()
@@ -393,7 +394,9 @@ def _encode_images(
     for start in range(0, len(paths), batch_size):
         batch_paths = paths[start:start + batch_size]
         end = start + len(batch_paths)
-        progress(f"[eval-clip] encoding {label} images {start + 1}-{end}")
+        progress(msg(
+            "eval.clip_encoding", label=label, start=start + 1, end=end,
+        ))
         images = []
         for path in batch_paths:
             with Image.open(path) as img:

--- a/studio/services/eval_dino.py
+++ b/studio/services/eval_dino.py
@@ -14,6 +14,7 @@ from typing import Any, Callable
 
 from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
+from studio.infrastructure.log_messages import msg
 from studio.infrastructure.task_log import TaskLogLike
 
 JOB_KIND = "eval_dino"
@@ -56,7 +57,7 @@ def run_dino_job(
     )
 
     try:
-        progress(f"[eval-dino] scoring run={run['run_id']} model={model}")
+        progress(msg("eval.dino_start", run_id=run["run_id"], model=model))
         scored = (scorer or _default_scorer)(run, version_dir, model, progress)
         result = _result_from_scores(scored, model)
         saved = eval_metrics.save_result(
@@ -66,7 +67,7 @@ def run_dino_job(
             eval_root=eval_root,
         )
         state = saved["metric_states"]["dino_i"]
-        progress(f"[eval-dino] done dino_i={state['status']}")
+        progress(msg("eval.dino_done", status=state["status"]))
         return saved
     except Exception as exc:
         _save_failed(version_dir, str(run["run_id"]), model, str(exc), eval_root)
@@ -254,7 +255,7 @@ def _load_dino(model_name: str, progress: TaskLogLike):
     from studio.services.models.downloader import ensure_eval_model
 
     local_dir = ensure_eval_model("dino", model_name, on_log=progress)
-    progress(f"[eval-dino] loading DINO on {device}")
+    progress(msg("eval.dino_loading", device=device))
     processor = AutoImageProcessor.from_pretrained(str(local_dir))
     model = AutoModel.from_pretrained(str(local_dir)).to(device)
     model.eval()
@@ -349,7 +350,9 @@ def _encode_images(
     for start in range(0, len(paths), batch_size):
         batch_paths = paths[start:start + batch_size]
         end = start + len(batch_paths)
-        progress(f"[eval-dino] encoding {label} images {start + 1}-{end}")
+        progress(msg(
+            "eval.dino_encoding", label=label, start=start + 1, end=end,
+        ))
         images = []
         for path in batch_paths:
             with Image.open(path) as img:

--- a/studio/services/eval_generation.py
+++ b/studio/services/eval_generation.py
@@ -36,7 +36,8 @@ from studio.domain.common import supports_capability
 from studio.services import version_config
 from studio.services.inference.daemon import InferenceDaemon
 
-from studio.infrastructure.task_log import TaskLogLike
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import TaskLogLike, as_task_log
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,25 @@ class EvalGenerationError(RuntimeError):
 
 # 「该族不支持 block swap」只提示一次（见 _generate_settings）
 _BLOCK_SWAP_NOTICED: set[str] = set()
+
+
+def note_block_swap_unsupported(
+    family_id: str, blocks_to_swap: Any, *, scope: str,
+) -> None:
+    """「这个族不支持 block swap，本次忽略全局设置」的唯一记录点。
+
+    评估出图（每候选走一遍 `_generate_settings`）与测试出图（`api/routers/
+    generate.py`）是同一句话的两个调用方，去重集合也共用：按族记一次，
+    200 个 checkpoint 不会打 200 行同样的话。``scope`` 区分 generate/eval。
+    """
+    if family_id in _BLOCK_SWAP_NOTICED:
+        return
+    _BLOCK_SWAP_NOTICED.add(family_id)
+    logger.info(
+        "block swap is not supported by model_family=%s; "
+        "ignoring blocks_to_swap=%s for scope=%s",
+        family_id, blocks_to_swap, scope,
+    )
 
 _FALLBACK_SETTINGS: dict[str, Any] = {
     "vae_precision": "bf16", "lora_merge_precision": "fp32",
@@ -80,18 +100,16 @@ def _generate_settings(family_id: str) -> dict[str, Any]:
             "blocks_to_swap": int(getattr(gen, "blocks_to_swap", 0) or 0),
         }
     except Exception:
-        logger.warning("读取出图设置失败，评估出图用保守默认", exc_info=True)
+        logger.warning(
+            "read generate settings failed; evaluation images use conservative defaults",
+            exc_info=True,
+        )
         return dict(_FALLBACK_SETTINGS)
 
     if settings["blocks_to_swap"] and not supports_capability(family_id, "block_swap"):
-        # 每个候选都会走一遍本函数，逐次打就是 200 个 checkpoint 打 200 行同样的话
-        # ——正是 #465 抱怨的那种噪音。按族记一次就够。
-        if family_id not in _BLOCK_SWAP_NOTICED:
-            _BLOCK_SWAP_NOTICED.add(family_id)
-            logger.info(
-                "model_family=%s 不支持 block swap，评估出图忽略全局设置的 "
-                "blocks_to_swap=%s", family_id, settings["blocks_to_swap"],
-            )
+        note_block_swap_unsupported(
+            family_id, settings["blocks_to_swap"], scope="eval",
+        )
         settings["blocks_to_swap"] = 0
     return settings
 
@@ -184,7 +202,7 @@ class DaemonSampleGenerator:
         task_id: int = 0,
         daemon: Optional[InferenceDaemon] = None,
     ) -> None:
-        self._progress = progress
+        self._progress = as_task_log(progress)
         self._task_id = int(task_id)
         # cache_images=False：图归评估的 run 目录，不进测试页的 generate_cache
         self._daemon = daemon or InferenceDaemon(cache_images=False)
@@ -193,7 +211,7 @@ class DaemonSampleGenerator:
     # ---------------------------------------------------------------- 生命周期
     def __enter__(self) -> "DaemonSampleGenerator":
         self._daemon.start()
-        self._progress("[eval-samples] 出图 daemon 就绪（底模按需加载一次，之后候选间只热换 LoRA）")
+        self._progress(msg("eval.samples_daemon_ready"))
         return self
 
     def __exit__(self, *_exc: Any) -> None:
@@ -204,9 +222,12 @@ class DaemonSampleGenerator:
             return
         try:
             self._daemon.stop()
-            self._progress("[eval-samples] 出图 daemon 已退出，显存释放")
+            self._progress(msg("eval.samples_daemon_stopped"))
         except Exception:
-            logger.warning("停止评估 daemon 失败", exc_info=True)
+            logger.warning(
+                "stopping the evaluation daemon failed; VRAM stays held until "
+                "the process exits", exc_info=True,
+            )
 
     # ---------------------------------------------------------------- 出图
     def __call__(
@@ -217,6 +238,8 @@ class DaemonSampleGenerator:
     ) -> None:
         from studio.services import eval_samples
 
+        # 调用方可能仍传裸单参回调（旧接口 / 测试桩）
+        progress = as_task_log(progress)
         items = run.get("items") if isinstance(run.get("items"), list) else []
         if not items:
             return
@@ -242,10 +265,11 @@ class DaemonSampleGenerator:
                         state["run"] = eval_samples.mark_item_running(
                             version_dir, state["run"], idx, eval_root
                         )
-                        progress(
-                            f"[eval-samples] {idx + 1}/{len(items)} "
-                            f"prompt={str(items[idx].get('prompt') or '')[:80]}"
-                        )
+                        progress(msg(
+                            "eval.samples_progress",
+                            n=idx + 1, total=len(items),
+                            prompt=str(items[idx].get("prompt") or "")[:80],
+                        ))
                 elif kind == "image_done":
                     self._write_image(evt, items, images_dir)
                     idx = int(evt.get("step") or 0) - 1
@@ -260,13 +284,20 @@ class DaemonSampleGenerator:
                         state["run"] = eval_samples.mark_item_failed(
                             version_dir, state["run"], idx, message, eval_root
                         )
-                    progress(f"[eval-samples] 第 {idx + 1} 张失败：{message}")
+                    progress.warning(
+                        "eval-samples: image %d of %d failed: %s; the metrics for "
+                        "this candidate are computed from fewer images",
+                        idx + 1, len(items), message,
+                    )
                 elif kind in ("done", "error", "canceled"):
                     if kind != "done":
                         failure.append(str(evt.get("message") or kind))
                     done.set()
             except Exception as exc:  # noqa: BLE001
-                logger.exception("评估出图事件处理失败 (kind=%s)", kind)
+                logger.exception(
+                    "evaluation image event handling failed: session=%s kind=%s; "
+                    "the evaluation may stall", run.get("run_id"), kind,
+                )
                 failure.append(str(exc))
                 done.set()
 

--- a/studio/services/eval_model_pool.py
+++ b/studio/services/eval_model_pool.py
@@ -25,7 +25,7 @@ import gc
 import logging
 from typing import Any, Callable, Optional
 
-from studio.infrastructure.task_log import TaskLogLike
+from studio.infrastructure.task_log import TaskLogLike, as_task_log
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +66,7 @@ class ModelPool:
         except Exception:
             # torch 没装 / CUDA 不可用都不该让评估失败 —— 引用已经丢了，
             # 剩下的交给 GC
-            logger.debug("%s: empty_cache 跳过", self._label, exc_info=True)
+            logger.debug("%s: empty_cache skipped", self._label, exc_info=True)
         if progress is not None:
-            progress(f"[eval-{self._label}] 模型已释放")
+            # 显存编排的内部动作，用户无从对照 → DEBUG（英文排障行）
+            as_task_log(progress).debug("[eval-%s] model released", self._label)

--- a/studio/services/eval_session.py
+++ b/studio/services/eval_session.py
@@ -308,7 +308,8 @@ def create_session(
 
     _write_plan_file(session_id, plan)
     logger.info(
-        "created eval session=%s task=%s trigger=%s candidates=%s metrics=%s",
+        "created eval session: session=%s task_id=%s trigger=%s candidates=%s "
+        "metrics=%s",
         session_id, task_id, trigger, len(rows), metric_keys_planned,
     )
     return get_session(conn, session_id) or {}
@@ -323,7 +324,10 @@ def _write_plan_file(session_id: int, plan: dict[str, Any]) -> None:
         tmp.write_text(json.dumps(plan, ensure_ascii=False, indent=2), encoding="utf-8")
         os.replace(tmp, path)
     except OSError:
-        logger.warning("failed writing plan.json for session=%s", session_id, exc_info=True)
+        logger.warning(
+            "write plan.json failed: session=%s; the session runs without a "
+            "persisted plan", session_id, exc_info=True,
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -804,7 +808,10 @@ def write_report(conn: sqlite3.Connection, session_id: int) -> Optional[dict[str
         tmp.write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
         os.replace(tmp, path)
     except OSError:
-        logger.warning("failed writing report.json for session=%s", session_id, exc_info=True)
+        logger.warning(
+            "write report.json failed: session=%s; metrics stay in the database "
+            "only", session_id, exc_info=True,
+        )
     return report
 
 
@@ -858,7 +865,10 @@ def reconcile_with_task(
         status=status, stage=None, finished_at=time.time(),
         error=(message or None) if status != STATUS_DONE else None,
     )
-    logger.info("reconciled eval session=%s → %s (task=%s)", session_id, status, task_id)
+    logger.debug(
+        "reconciled eval session: session=%s status=%s task_id=%s",
+        session_id, status, task_id,
+    )
     return get_session(conn, session_id) or session
 
 
@@ -912,7 +922,7 @@ def retry_session(conn: sqlite3.Connection, session_id: int) -> dict[str, Any]:
         task_id=int(task_id), status=STATUS_PENDING, stage=None,
         started_at=None, finished_at=None, error=None,
     )
-    logger.info("retry eval session=%s → task=%s", session_id, task_id)
+    logger.info("retry eval session: session=%s task_id=%s", session_id, task_id)
     return get_session(conn, session_id) or {}
 
 

--- a/studio/services/eval_tag.py
+++ b/studio/services/eval_tag.py
@@ -9,11 +9,13 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import time
 from pathlib import Path
 from typing import Any, Callable
 
 from . import eval_metrics, eval_model_pool, eval_samples
 from .projects import jobs as project_jobs
+from studio.infrastructure.log_messages import msg
 from studio.infrastructure.task_log import TaskLogLike
 
 JOB_KIND = "eval_tag"
@@ -84,14 +86,14 @@ def run_tag_job(
         eval_root=eval_root,
     )
     try:
-        progress(f"[eval-tag] scoring run={run['run_id']} (WD14 tag-recall)")
+        progress(msg("eval.tag_start", run_id=run["run_id"]))
         scored = (scorer or _default_scorer)(run, version_dir, model, progress)
         result = _result_from_scores(scored, model)
         saved = eval_metrics.save_result(
             version_dir, str(run["run_id"]), result, eval_root=eval_root,
         )
         state = saved["metric_states"][METRIC_KEY]
-        progress(f"[eval-tag] done tag_recall={state['status']}")
+        progress(msg("eval.tag_done", status=state["status"]))
         return saved
     except Exception as exc:
         _save_failed(version_dir, str(run["run_id"]), model, str(exc), eval_root)
@@ -246,10 +248,10 @@ def _load_tagger(progress: TaskLogLike):
     from studio.services.tagging.wd14 import WD14Tagger
 
     tagger = WD14Tagger()
-    ok, msg = tagger.is_available()
+    ok, reason = tagger.is_available()
     if not ok:
-        raise EvalTagError(f"WD14 模型不可用：{msg}")
-    progress("[eval-tag] loading WD14")
+        raise EvalTagError(f"WD14 模型不可用：{reason}")
+    progress(msg("eval.tag_loading"))
     tagger.prepare()
     return tagger, {_norm_tag(t) for t in tagger.known_tags()}
 
@@ -279,11 +281,18 @@ def _default_scorer(
             "tag_recall_reason": "no in-vocabulary booru-tag prompts",
         }
 
-    progress(f"[eval-tag] tagging {len(scored_items)} generated images with WD14")
+    progress(msg("eval.tag_tagging", n=len(scored_items)))
     paths = [it["_image_path"] for it, _ in scored_items]
-    preds = list(tagger.tag(
-        paths, on_progress=lambda d, t: progress(f"[eval-tag] {d}/{t}"),
-    ))
+    # 40 图 × 3 组接近 R9 预算上限 —— 每 2s 或最后一张各记一次
+    _tag_progress_at = [0.0]
+
+    def _on_tag_progress(done: int, total: int) -> None:
+        now = time.monotonic()
+        if done >= total or now - _tag_progress_at[0] >= 2.0:
+            _tag_progress_at[0] = now
+            progress(msg("eval.tag_progress", done=done, total=total))
+
+    preds = list(tagger.tag(paths, on_progress=_on_tag_progress))
 
     recalls: list[float] = []
     for (_item, prompt_tags), pred in zip(scored_items, preds):

--- a/studio/services/generate_storage.py
+++ b/studio/services/generate_storage.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
 from datetime import date
@@ -254,7 +255,7 @@ def _build_external_metadata_safe(
         )
     except Exception:
         logger.warning(
-            "build external metadata failed for task %s", task_id, exc_info=True,
+            "build external metadata failed: task_id=%s", task_id, exc_info=True,
         )
         return {}
 
@@ -408,6 +409,38 @@ def xy_folder_for_task(task_id: int) -> Optional[Path]:
 # daemon 入口:image_done 处置
 # ---------------------------------------------------------------------------
 
+# 落盘失败节流（T6）：磁盘满 / 目录被占用时 XY 一格一条黄行 = 几十上百条。
+# 首条全文 WARNING（带文件名 + 原因）→ 同任务后续逐条 DEBUG → 收尾一条计数
+# 汇总。executor 是单线程（max_workers=1），这份状态只被那一个线程碰。
+_disk_store_failures: dict[int, dict[str, Any]] = {}
+
+
+def _note_disk_store_failure(task_id: int, filename: str) -> None:
+    st = _disk_store_failures.setdefault(task_id, {"n": 0, "first": ""})
+    st["n"] += 1
+    if st["n"] == 1:
+        exc = sys.exc_info()[1]
+        st["first"] = f"{type(exc).__name__}: {exc}" if exc is not None else "?"
+        logger.warning(
+            "disk store failed: task_id=%s file=%s; the image stays in the "
+            "session cache only", task_id, filename, exc_info=True,
+        )
+    else:
+        logger.debug(
+            "disk store failed: task_id=%s file=%s", task_id, filename, exc_info=True,
+        )
+
+
+def flush_disk_store_summary(task_id: int, total: Optional[int] = None) -> None:
+    """task 收尾：把该 task 的落盘失败计数收成一条 WARNING（没失败就 noop）。"""
+    st = _disk_store_failures.pop(int(task_id), None)
+    if not st or not st["n"]:
+        return
+    logger.warning(
+        "disk store failed for %d/%s images: task_id=%s; first error: %s",
+        st["n"], total if total is not None else "?", task_id, st["first"],
+    )
+
 
 def handle_image_done(
     task_id: int,
@@ -453,10 +486,7 @@ def _store_to_disk_safe(
         else:
             target = _write_single(task_id, filename, data, snapshot)
     except Exception:
-        logger.warning(
-            "generate_storage: disk store failed for task %s %s (image stays in "
-            "session cache only)", task_id, filename, exc_info=True,
-        )
+        _note_disk_store_failure(task_id, filename)
         return
     # 落盘成功 → cache 中转副本没有存在意义了(列表/回看走磁盘;live 显示
     # 与 composite 拼图靠 sample 端点的 disk fallback 按 src 反查)
@@ -464,7 +494,10 @@ def _store_to_disk_safe(
         from .inference import disk_cache as generate_cache
         generate_cache.drop_image(task_id, filename)
     except Exception:
-        logger.warning("generate_storage: drop cache copy failed", exc_info=True)
+        logger.warning(
+            "drop cache copy failed: task_id=%s file=%s",
+            task_id, filename, exc_info=True,
+        )
 
 
 def _write_single(

--- a/studio/services/generation_metadata.py
+++ b/studio/services/generation_metadata.py
@@ -125,7 +125,9 @@ def file_sha256(path_value: str | Path) -> str | None:
         except OSError:
             return None
         if (after.st_size, after.st_mtime_ns) != (before.st_size, before.st_mtime_ns):
-            logger.warning("resource changed while hashing; skip metadata hash: %s", path)
+            logger.debug(
+                "resource changed while hashing; metadata hash skipped: path=%s", path,
+            )
             return None
 
         result = digest.hexdigest()
@@ -137,7 +139,10 @@ def file_sha256(path_value: str | Path) -> str | None:
         try:
             _write_hash_cache(cache)
         except OSError:
-            logger.warning("write generation resource hash cache failed", exc_info=True)
+            logger.warning(
+                "write resource hash cache failed; hashes are recomputed next time",
+                exc_info=True,
+            )
         return result
 
 
@@ -161,7 +166,7 @@ def prewarm_resource_hashes(
             try:
                 file_sha256(p)
             except Exception:
-                logger.debug("hash prewarm failed for %s", p, exc_info=True)
+                logger.debug("hash prewarm failed: path=%s", p, exc_info=True)
 
     t = threading.Thread(target=_run, daemon=True, name="hash-prewarm")
     t.start()

--- a/studio/services/inference/core.py
+++ b/studio/services/inference/core.py
@@ -77,11 +77,13 @@ class DeferredVAE:
 
     def _ready(self) -> Any:
         if self._value is None:
-            logger.info("采样完成，开始加载 %s", self._label)
+            logger.info("sampling done; loading %s", self._label)
             self._value = self._loader()
             self._resident_device = self._device
         elif self._resident_device != self._device:
-            logger.info("将 %s 从 CPU 移回 %s 用于 decode", self._label, self._device)
+            logger.debug(
+                "moved %s back from CPU to %s for decode", self._label, self._device,
+            )
             self._move(self._value, self._device)
             self._resident_device = self._device
         return self._value
@@ -94,7 +96,10 @@ class DeferredVAE:
             return
         self._move(self._value, "cpu")
         self._resident_device = "cpu"
-        logger.info("%s decode 完成，已按 %s 策略移到 CPU RAM", self._label, vram_policy)
+        logger.debug(
+            "%s decode done; offloaded to CPU RAM by policy=%s",
+            self._label, vram_policy,
+        )
         try:
             import gc
             import torch
@@ -103,7 +108,9 @@ class DeferredVAE:
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
         except Exception:
-            logger.warning("VAE decode 后释放 CUDA cache 失败", exc_info=True)
+            logger.warning(
+                "releasing the CUDA cache after VAE decode failed", exc_info=True,
+            )
 
     def __getattr__(self, name: str) -> Any:
         # Only called after normal proxy attributes fail, so the loader itself
@@ -175,7 +182,10 @@ def read_lora_meta(path: str) -> LoRAMeta:
         with safe_open(str(path), framework="pt", device="cpu") as f:
             meta = f.metadata() or {}
     except Exception as e:
-        logger.warning(f"读 LoRA metadata 失败 {path}: {e}; 用默认参数")
+        logger.warning(
+            "read LoRA metadata failed: path=%s err=%s; using default parameters",
+            path, e,
+        )
         return LoRAMeta(_DEFAULT_RANK, _DEFAULT_ALPHA, _DEFAULT_ALGO, _DEFAULT_FACTOR)
 
     try:
@@ -221,7 +231,9 @@ def read_lora_meta(path: str) -> LoRAMeta:
             try:
                 parsed[str(k)] = int(v)
             except (ValueError, TypeError):
-                logger.warning(f"lora_reg_dims 条目跳过（rank 非整数）: {k!r}={v!r}")
+                logger.debug(
+                    "lora_reg_dims entry skipped (rank is not an integer): %r=%r", k, v,
+                )
         if parsed:
             lora_reg_dims = parsed
 
@@ -348,7 +360,10 @@ def apply_loras(
     for spec in specs:
         path = spec.path or ""
         if not path or not Path(path).exists():
-            logger.warning(f"LoRA 路径不存在，跳过: {path!r}")
+            logger.warning(
+                "LoRA file not found; skipped: path=%s "
+                "(this LoRA has no effect on the output)", path,
+            )
             continue
 
         meta = read_lora_meta(path)
@@ -429,9 +444,9 @@ def apply_loras(
                 f"（可能属于其他模型族，或是本路径尚不支持的键格式）。"
             )
         logger.info(
-            f"已加载 LoRA: {Path(path).name} "
-            f"(algo={algo}, rank={rank}, alpha={alpha}, "
-            f"scale={spec.scale}; missing={missing}, unexpected={unexpected})"
+            "loaded LoRA: name=%s algo=%s rank=%s alpha=%s scale=%s "
+            "missing=%d unexpected=%d",
+            Path(path).name, algo, rank, alpha, spec.scale, missing, unexpected,
         )
         adapters.append(adapter)
 
@@ -473,7 +488,9 @@ def apply_loras(
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
         except Exception:
-            logger.warning("failed to trim CUDA cache after fp8 LoRA merge", exc_info=True)
+            logger.warning(
+                "trimming the CUDA cache after the fp8 LoRA merge failed", exc_info=True,
+            )
         return [merged]
     return adapters
 
@@ -498,9 +515,9 @@ def cleanup_generate_tempdir(task_id: int) -> None:
         return
     try:
         shutil.rmtree(d)
-        logger.info(f"cleaned generate tempdir: {d}")
+        logger.debug("cleaned generate tempdir: %s", d)
     except OSError as e:
-        logger.warning(f"failed to clean {d}: {e}")
+        logger.debug("clean generate tempdir failed: path=%s", d, exc_info=True)
 
 
 def cleanup_stale_generate_tempdirs() -> None:
@@ -513,6 +530,8 @@ def cleanup_stale_generate_tempdirs() -> None:
             continue
         try:
             shutil.rmtree(d)
-            logger.info(f"cleaned stale generate tempdir: {d}")
+            logger.debug("cleaned stale generate tempdir: %s", d)
         except OSError as e:
-            logger.warning(f"failed to clean stale {d}: {e}")
+            logger.debug(
+                "clean stale generate tempdir failed: path=%s", d, exc_info=True,
+            )

--- a/studio/services/inference/daemon.py
+++ b/studio/services/inference/daemon.py
@@ -118,6 +118,8 @@ class InferenceDaemon:
         self._log_buffer: collections.deque[dict[str, Any]] = collections.deque(maxlen=2000)
         self._log_seq = 0
         self._log_listeners: list[EventCallback] = []
+        #: listener 连续失败计数（R8 摘除机制），key=id(cb)，成功一次清零
+        self._listener_fails: dict[int, int] = {}
         # idle timeout：daemon 闲 N 秒（模型已 load）自动 unload 释放 VRAM。
         # 0 = 关闭。supervisor 在 spawn 后通过 sync_idle_timeout_from_secrets() 注入；
         # PUT /api/secrets 后 router 也会调一次同步。
@@ -580,6 +582,35 @@ class InferenceDaemon:
                     logger.exception("daemon log listener failed during stderr-down emit")
 
     # ----------------------------------------------------------- log buffer
+    def _note_listener_failure(
+        self, cb, registry: list, lock, what: str, detail: str,
+    ) -> None:
+        """自我放大回路摘除（R8）：调用点处在「每行日志 / 每个事件 × 每个
+        listener」的路径上，坏掉的 listener 留在注册表里每行重试毫无收益，还把
+        日志量随输入线性放大。连续失败 ≥3 次即摘除（首条 + 摘除条，共 2 条）。
+
+        失败记录走 logger（studio.log），与失败目标（listener/SSE）是不同
+        通道——绝不能改成推给 listener 自己，否则是死循环。"""
+        key = id(cb)
+        n = self._listener_fails.get(key, 0) + 1
+        self._listener_fails[key] = n
+        name = getattr(cb, "__qualname__", None) or repr(cb)
+        if n == 1:
+            logger.warning(
+                "%s failed: listener=%s %s", what, name, detail, exc_info=True,
+            )
+        if n >= 3:
+            with lock:
+                try:
+                    registry.remove(cb)
+                except ValueError:
+                    pass
+            self._listener_fails.pop(key, None)
+            logger.warning(
+                "%s removed after %d consecutive failures: listener=%s; that "
+                "subscriber no longer receives these payloads", what, n, name,
+            )
+
     def _append_log(self, line: str) -> None:
         """收 daemon stderr 一行 → ring buffer + 推给 listeners（线程安全）。"""
         entry = {"ts": time.time(), "line": line}
@@ -593,7 +624,12 @@ class InferenceDaemon:
             try:
                 cb(entry_out)
             except Exception:
-                logger.exception("daemon log listener failed")
+                self._note_listener_failure(
+                    cb, self._log_listeners, self._log_lock,
+                    "daemon log listener", "seq=%d" % seq,
+                )
+            else:
+                self._listener_fails.pop(id(cb), None)
 
     def read_logs(self, since_seq: int = 0, limit: int = 2000) -> dict[str, Any]:
         """返回 ring buffer 历史。since_seq>0 时只返新于该 seq 的行（增量）。"""
@@ -639,7 +675,13 @@ class InferenceDaemon:
                 try:
                     cb(msg)
                 except Exception:
-                    logger.exception("global listener failed")
+                    self._note_listener_failure(
+                        cb, self._global_listeners, self._lock,
+                        "global event listener",
+                        "kind=%s msg_id=%s" % (kind, msg_id),
+                    )
+                else:
+                    self._listener_fails.pop(id(cb), None)
             return
 
         # task 事件

--- a/studio/services/inference/daemon.py
+++ b/studio/services/inference/daemon.py
@@ -121,6 +121,11 @@ class InferenceDaemon:
         self._log_listeners: list[EventCallback] = []
         #: listener 连续失败计数（R8 摘除机制），key=id(cb)，成功一次清零
         self._listener_fails: dict[int, int] = {}
+        #: 本次进程是否是我们主动停的（stop / request_unload 置位，退出后清）
+        #: —— 退出行按「预期 / 意外」分级用，比按 rc 推断可靠（§3.4）
+        self._expected_exit = False
+        #: stdout 非 JSON 行计数（T7：首条 WARNING，之后 DEBUG，退出汇总）
+        self._stdout_non_json = 0
         # idle timeout：daemon 闲 N 秒（模型已 load）自动 unload 释放 VRAM。
         # 0 = 关闭。supervisor 在 spawn 后通过 sync_idle_timeout_from_secrets() 注入；
         # PUT /api/secrets 后 router 也会调一次同步。
@@ -191,7 +196,7 @@ class InferenceDaemon:
             task_minutes = int(getattr(gen, "task_timeout_minutes", 0) or 0)
         except Exception:
             logger.warning(
-                "failed to read timeouts from secrets; keeping current values",
+                "read timeouts from secrets failed; keeping the current values",
                 exc_info=True,
             )
             return
@@ -270,15 +275,18 @@ class InferenceDaemon:
                 or self._state != STATE_BUSY or proc is None
             ):
                 return
-        logger.warning(
-            "generate task %s made no image progress within timeout (%.0fs); "
-            "killing daemon process",
-            active.task_id, timeout,
+        logger.error(
+            "generate task made no image progress within %.1fs: task_id=%s "
+            "pid=%d; killing the daemon, the task is marked failed",
+            timeout, active.task_id, proc.pid,
         )
         try:
             proc.kill()
         except Exception:
-            logger.exception("task-timeout kill failed")
+            logger.exception(
+                "task-timeout kill failed: pid=%d task_id=%s; the daemon stays "
+                "busy until it is killed manually", proc.pid, active.task_id,
+            )
 
     def _on_idle_timeout(self) -> None:
         """idle timer 到期回调：仍 idle+loaded 时触发 unload。
@@ -295,11 +303,14 @@ class InferenceDaemon:
             timeout = self._idle_timeout_seconds
         if not should_unload:
             return
-        logger.info("daemon idle for %.0fs; auto-unloading model", timeout)
+        logger.info("daemon idle for %.1fs; auto-unloading the model", timeout)
         try:
             self.request_unload()
         except Exception:
-            logger.exception("auto unload from idle timer failed")
+            logger.warning(
+                "auto unload from the idle timer failed; the model stays "
+                "resident and the next schedule retries", exc_info=True,
+            )
 
     # --------------------------------------------------------------- 生命周期
     def start(self) -> None:
@@ -338,7 +349,8 @@ class InferenceDaemon:
 
         cmd = [sys.executable, str(self._script)]
         logger.info("spawning inference daemon: %s", " ".join(cmd))
-        self._append_log(f"$ {' '.join(cmd)}")
+        # ring 行与上面那条讲同一件事，用同一种说法（不再用 shell 风格 `$ ` 前缀）
+        self._append_log("spawning inference daemon: %s" % " ".join(cmd))
 
         try:
             proc = subprocess.Popen(
@@ -356,7 +368,8 @@ class InferenceDaemon:
         except Exception:
             with self._lock:
                 self._state = STATE_STOPPED
-            logger.exception("failed to spawn daemon")
+            # 上抛给调用方；外层 supervisor 已按 ERROR 记并把 task 标失败（R3）
+            logger.debug("spawn daemon failed; raising to the caller", exc_info=True)
             raise
 
         with self._lock:
@@ -393,6 +406,8 @@ class InferenceDaemon:
         """关闭 daemon 子进程。优雅 → 强杀。"""
         with self._lock:
             proc = self._proc
+            # 主动停 → 退出行走「预期退出」分支（INFO），不再留一条假黄行
+            self._expected_exit = True
             if proc is None:
                 self._state = STATE_STOPPED
                 return
@@ -405,7 +420,10 @@ class InferenceDaemon:
         try:
             proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
-            logger.warning("daemon didn't exit in %.1fs, killing", timeout)
+            logger.warning(
+                "inference daemon did not exit in %.1fs; killing process tree: "
+                "pid=%d", timeout, proc.pid,
+            )
             try:
                 proc.kill()
                 proc.wait(timeout=3.0)
@@ -452,6 +470,8 @@ class InferenceDaemon:
                 mode=mode,
             )
             self._state = STATE_BUSY
+            # 新任务开跑 → 上一次 stop/unload 的「预期退出」标记作废
+            self._expected_exit = False
             self._reschedule_idle_timer_locked()
             # 任务超时兜底 timer（0=关闭；按单张图计时，图片边界事件里重置）
             self._restart_task_timer_locked(req_id)
@@ -473,7 +493,11 @@ class InferenceDaemon:
             stdin.write(json.dumps(msg) + "\n")
             stdin.flush()
         except Exception as e:
-            logger.exception("failed to send task to daemon")
+            # 外层 supervisor 的 daemon submit failed 是决定失败语义的层（R3）
+            logger.debug(
+                "send task to daemon failed: task_id=%s request_id=%s; raising "
+                "to the caller", task_id, req_id, exc_info=True,
+            )
             with self._lock:
                 self._state = STATE_IDLE
                 self._active = None
@@ -499,7 +523,10 @@ class InferenceDaemon:
             }) + "\n")
             stdin.flush()
         except Exception:
-            logger.exception("failed to send cancel")
+            logger.warning(
+                "send cancel to daemon failed: task_id=%s request_id=%s; the "
+                "task may keep running", task_id, req_id, exc_info=True,
+            )
             return False
         return True
 
@@ -512,17 +539,22 @@ class InferenceDaemon:
             if self._state == STATE_STOPPED:
                 return
             if self._state == STATE_BUSY:
-                logger.warning("unload requested while busy; ignored")
+                logger.debug("unload requested while busy; ignored")
                 return
             assert self._proc is not None and self._proc.stdin is not None
             stdin = self._proc.stdin
             self._state = STATE_UNLOADING
+            # 卸载后 daemon 常常顺带退出 —— 同样算预期退出
+            self._expected_exit = True
             self._reschedule_idle_timer_locked()
         try:
             stdin.write(json.dumps({"id": "_unload", "action": "unload"}) + "\n")
             stdin.flush()
         except Exception:
-            logger.exception("failed to send unload")
+            logger.warning(
+                "send unload to daemon failed; the model stays resident and "
+                "the next tick retries", exc_info=True,
+            )
 
     # ----------------------------------------------------------- 内部 reader
     def _read_stdout_loop(self, proc: subprocess.Popen) -> None:
@@ -536,11 +568,19 @@ class InferenceDaemon:
                 try:
                     msg = json.loads(line)
                 except json.JSONDecodeError:
-                    logger.warning("daemon stdout non-JSON: %r", line[:200])
+                    # T7 节流：首条全文，之后同进程内降 DEBUG，退出时一条汇总
+                    self._stdout_non_json += 1
+                    if self._stdout_non_json == 1:
+                        logger.warning("daemon stdout non-JSON: %r", line[:200])
+                    else:
+                        logger.debug("daemon stdout non-JSON: %r", line[:200])
                     continue
                 self._handle_event(msg)
         except Exception:
-            logger.exception("daemon stdout reader crashed")
+            logger.exception(
+                "daemon stdout reader crashed; no further events are received "
+                "from the daemon"
+            )
         finally:
             self._handle_proc_exit(proc)
 
@@ -567,8 +607,9 @@ class InferenceDaemon:
                 # 正常 EOF（proc 退出 stderr 关闭）— 退出 loop
                 return
             except Exception:
-                logger.exception(
-                    "daemon stderr reader crashed (attempt %d/2)", attempt
+                logger.debug(
+                    "daemon stderr reader crashed: attempt=%d/2",
+                    attempt, exc_info=True,
                 )
                 if attempt < 2 and proc.poll() is None:
                     # 短暂 backoff 再 restart 本 loop
@@ -583,10 +624,17 @@ class InferenceDaemon:
             )
             for cb in list(self._log_listeners):
                 try:
+                    # ring 行自带级别词：前端没有级别字段可用，靠行契约识别
                     cb({"ts": time.time(), "seq": -1,
-                        "line": "[stderr reader stopped — daemon log no longer captured]"})
+                        "line": "ERROR daemon stderr reader stopped; the daemon "
+                                "log is no longer captured"})
                 except Exception:
-                    logger.exception("daemon log listener failed during stderr-down emit")
+                    logger.warning(
+                        "daemon log listener failed during the stderr-down "
+                        "emit: listener=%s pid=%d",
+                        getattr(cb, "__qualname__", None) or repr(cb),
+                        proc.pid, exc_info=True,
+                    )
 
     # ----------------------------------------------------------- log buffer
     def _note_listener_failure(
@@ -675,6 +723,8 @@ class InferenceDaemon:
                 elif kind == "unloaded":
                     self._state = STATE_IDLE
                     self._model_loaded = False
+                    # 卸载完成而进程仍活着 → 之后再退出就不是「预期」了
+                    self._expected_exit = False
                 # `loaded` 进入 idle+loaded → 启动 idle timer；`unloaded` 模型走 → cancel
                 if kind in ("ready", "loaded", "unloaded"):
                     self._reschedule_idle_timer_locked()
@@ -695,7 +745,7 @@ class InferenceDaemon:
         with self._lock:
             active = self._active
         if active is None or active.request_id != msg_id:
-            logger.warning("event for unknown request: %s", msg_id)
+            logger.debug("event for an unknown request: msg_id=%s", msg_id)
             return
 
         # 任务超时按单张图计时：图片边界事件重置倒计时。语义是「一张图 N 分钟
@@ -729,7 +779,11 @@ class InferenceDaemon:
                     save_to_disk=active.save_to_disk,
                 )
             except Exception:
-                logger.exception("image_done handling failed for %s", filename)
+                logger.exception(
+                    "image_done handling failed: task_id=%s file=%s; this image "
+                    "is neither cached nor written to disk",
+                    active.task_id, filename,
+                )
             forward_msg = {k: v for k, v in msg.items() if k != "image_b64"}
 
         # done/error/canceled 先切状态，再回调 —— 让 callback 内查询 is_busy/state 时
@@ -745,12 +799,14 @@ class InferenceDaemon:
         try:
             active.on_event({**forward_msg, "task_id": active.task_id})
         except Exception:
-            logger.exception("task on_event handler failed")
+            logger.warning(
+                "task on_event handler failed: task_id=%s kind=%s; the UI "
+                "misses this update", active.task_id, kind, exc_info=True,
+            )
 
     def _handle_proc_exit(self, proc: subprocess.Popen) -> None:
         """子进程退出处理：标 STOPPED + 给 active task 推 error + 通知 listeners。"""
         rc = proc.wait()
-        logger.warning("inference daemon exited rc=%d", rc)
         with self._lock:
             self._proc = None
             prev_state = self._state
@@ -758,9 +814,32 @@ class InferenceDaemon:
             self._model_loaded = False
             active = self._active
             self._active = None
+            expected = self._expected_exit
+            self._expected_exit = False
+            non_json = self._stdout_non_json
+            self._stdout_non_json = 0
             listeners = list(self._global_listeners)
             self._cancel_task_timer_locked()
             self._reschedule_idle_timer_locked()
+
+        # §3.4 三分：有任务在跑就死了 = 用户任务失败（ERROR）；主动 stop/unload
+        # 且没在跑任务 = 正常收摊（INFO，不再留假黄行）；其余 = 非正常退出。
+        if active is not None and prev_state != STATE_UNLOADING:
+            logger.error(
+                "inference daemon exited unexpectedly: rc=%d task_id=%s; "
+                "the task is marked failed", rc, active.task_id,
+            )
+        elif expected and active is None:
+            logger.info("inference daemon exited: rc=%d (expected stop)", rc)
+        else:
+            logger.warning(
+                "inference daemon exited abnormally: rc=%d (no task in flight)", rc,
+            )
+        if non_json:
+            logger.warning(
+                "daemon stdout had %d non-JSON lines (the daemon may be writing "
+                "plain output to stdout)", non_json,
+            )
 
         if active is not None and prev_state != STATE_UNLOADING:
             try:
@@ -770,13 +849,21 @@ class InferenceDaemon:
                     "message": f"daemon exited unexpectedly (rc={rc})",
                 })
             except Exception:
-                logger.exception("error handler failed")
+                logger.exception(
+                    "daemon-exit error handler failed: task_id=%s; the task "
+                    "never receives the failure event and will hang until it "
+                    "times out", active.task_id,
+                )
 
         for cb in listeners:
             try:
                 cb({"id": "_evt", "kind": "stopped", "rc": rc})
             except Exception:
-                logger.exception("listener failed on proc exit")
+                logger.warning(
+                    "listener failed on daemon exit: listener=%s rc=%d",
+                    getattr(cb, "__qualname__", None) or repr(cb), rc,
+                    exc_info=True,
+                )
 
 
 # Singleton 句柄；server 启动时初始化（lazy spawn）

--- a/studio/services/inference/daemon.py
+++ b/studio/services/inference/daemon.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from ...infrastructure.logging import LOG_LEVEL_ENV, PROCESS_ENV, TRACE_ENV, new_trace_id
+from ...infrastructure.log_messages import UI_LANG_ENV
 from ...paths import REPO_ROOT
 from .. import generate_storage
 from ..runtime import xformers as _xformers_svc
@@ -319,6 +320,12 @@ class InferenceDaemon:
         # （docs/design/logging-target-state.md D1），console 级别 DEBUG。
         # trace / process 名与 supervisor 子进程对齐（之前 daemon 完全游离）。
         env.setdefault(LOG_LEVEL_ENV, "DEBUG")
+        # 子进程日志语言（Q1 i18n 字典口径）
+        try:
+            from ... import secrets as _sec  # noqa: PLC0415
+            env.setdefault(UI_LANG_ENV, str(_sec.load().system.ui_language))
+        except Exception:
+            pass
         env.setdefault(TRACE_ENV, f"bg-{new_trace_id()}")
         env.setdefault(PROCESS_ENV, "anima_daemon")
         # xformers 的 triton 探测会把无害的 ImportError traceback 打进 daemon

--- a/studio/services/inference/disk_cache.py
+++ b/studio/services/inference/disk_cache.py
@@ -173,12 +173,14 @@ class SessionCache:
             with self._lock:
                 self._index.pop(key, None)
                 self._bytes_total -= entry.size
-            logger.warning("disk cache file gone: %s", file_path)
+            logger.debug("disk cache file gone: path=%s", file_path)
             return None
         try:
             return _decrypt_and_strip(self.aes_key, blob)
         except Exception:
-            logger.exception("decrypt failed for %s", file_path)
+            logger.exception(
+                "decrypt failed: path=%s; this image cannot be recovered", file_path,
+            )
             return None
 
     # ---------------------------------------------------------------- 列表 / 删
@@ -222,7 +224,10 @@ class SessionCache:
             try:
                 shutil.rmtree(self.session_dir)
             except OSError:
-                logger.exception("clear_all: rmtree failed for %s", self.session_dir)
+                logger.warning(
+                    "clear cache: rmtree failed for %s; the directory is recreated",
+                    self.session_dir, exc_info=True,
+                )
         # 让后续 put() 能继续工作（重 mkdir）
         self.ensure_dir()
 
@@ -302,9 +307,12 @@ def startup_clean(root: Path) -> int:
                 shutil.rmtree(child)
                 n += 1
             except OSError:
-                logger.warning("startup_clean: rmtree failed for %s", child, exc_info=True)
+                logger.warning(
+                    "stale session dir cleanup: rmtree failed for %s",
+                    child, exc_info=True,
+                )
     if n:
-        logger.info("startup_clean: removed %d stale session dir(s) under %s", n, root)
+        logger.info("removed %d stale session dir(s) under %s", n, root)
     return n
 
 
@@ -411,4 +419,4 @@ def _safe_unlink(p: Path) -> None:
     except FileNotFoundError:
         pass
     except OSError:
-        logger.warning("unlink failed for %s", p, exc_info=True)
+        logger.debug("unlink failed: path=%s", p, exc_info=True)

--- a/studio/services/inference/upscaler.py
+++ b/studio/services/inference/upscaler.py
@@ -31,7 +31,7 @@ from typing import Any, Callable, Optional
 import torch
 from PIL import Image
 
-from studio.infrastructure.task_log import TaskLogLike, NULL_LOG
+from studio.infrastructure.task_log import TaskLogLike, NULL_LOG, as_task_log
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +53,10 @@ def resolve_device(device: str = "auto") -> torch.device:
     if device == "cuda":
         if torch.cuda.is_available():
             return torch.device("cuda")
-        logger.warning("requested cuda but cuda not available; falling back to cpu")
+        logger.warning(
+            "cuda was requested but is not available; falling back to cpu "
+            "(upscaling will be slow)"
+        )
         return torch.device("cpu")
     # auto
     return torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -278,6 +281,8 @@ def upscale_file(
 
     `device='cuda'` 但 GPU 不可用时静默降级 cpu。
     """
+    # 对外仍接受历史的单参回调（worker / 测试传 lambda）；内部按级别分派
+    on_log = as_task_log(on_log)
     t_start = time.monotonic()
 
     # 1) 先读图判断走哪条路（避免无谓的模型加载）
@@ -344,7 +349,9 @@ def upscale_file(
             from ..dataset import thumb_cache
             thumb_cache.prewarm_from_image(dst, out_img, prewarm_thumb_sizes)
         except Exception as exc:  # noqa: BLE001 — 缩略图预热失败不影响放大本体
-            on_log(f"   ⚠ thumb prewarm failed: {exc}")
+            on_log.debug(
+                "thumbnail prewarm failed: name=%s err=%s", dst.name, exc,
+            )
 
     elapsed = time.monotonic() - t_start
 
@@ -363,9 +370,9 @@ def upscale_file(
         "elapsed_seconds": round(elapsed, 3),
         "mtime": time.time(),
     }
-    on_log(
-        f"   ✓ [{action}] {src.name} → {dst.name}  "
-        f"{src_size[0]}×{src_size[1]} → {out_img.size[0]}×{out_img.size[1]}  "
-        f"({elapsed:.1f}s)"
+    on_log.debug(
+        "upscaled: action=%s src=%s dst=%s from=%dx%d to=%dx%d elapsed=%.1fs",
+        action, src.name, dst.name,
+        src_size[0], src_size[1], out_img.size[0], out_img.size[1], elapsed,
     )
     return meta

--- a/studio/services/models/downloader.py
+++ b/studio/services/models/downloader.py
@@ -68,12 +68,25 @@ from .paths import (
 from . import sources as _sources
 from .sources import MS_ANIMA_TEXT_ENCODER_PATH
 
-from studio.infrastructure.task_log import TaskLogLike, TaskLog
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import TaskLogLike, TaskLog, as_task_log
 
 logger = logging.getLogger(__name__)
 
 #: 手跑 / 无人传 on_log 时的兜底：走本模块 logger（终端 INFO 可见，不再裸 print）。
 _DEFAULT_LOG = TaskLog(logger)
+
+#: 头行里的体积估算（GB）：与 variant 元数据脱钩的硬编码在这里集中一次
+QWEN3_VL_SIZE_GB = 8.89
+QWEN3_VL_FP8_SIZE_GB = 5.24
+
+
+def _size_gb(info: Any, *, default: float) -> str:
+    """variant 元数据里的字节数 → 头行用的 GB 字符串；缺失走 default。"""
+    size = 0.0
+    if isinstance(info, dict):
+        size = float(info.get("size_estimate", 0) or 0)
+    return f"{size / 1e9:.1f}" if size else f"{default:.1f}"
 
 # 提示：跨文件调用 download_flat[_ms] / _get_download_source / _resolve_endpoint /
 # _ms_wd14_repo_id 一律走 _sources.X(...) —— 这样测试 monkeypatch
@@ -101,11 +114,17 @@ def download_anima_main(
     if variant == "latest":
         variant = LATEST_ANIMA
     if variant not in ANIMA_VARIANTS:
-        on_log(f"✗ 未知 variant {variant!r}")
+        as_task_log(on_log).error(
+            "unknown Anima variant %r; nothing was downloaded — pick a "
+            "variant from the model list", variant,
+        )
         return False
     target = anima_main_target(root, variant)
     subpath = ANIMA_VARIANTS[variant]
-    on_log(f"\n📥 Anima 主模型 [{variant}] (~4 GB)")
+    on_log(msg(
+        "download.anima_base", variant=variant,
+        size=_size_gb(ANIMA_VARIANTS[variant], default=4.0), target=target,
+    ))
     if _sources._source_for("training") == "modelscope":
         return _sources.download_flat_ms(ANIMA_REPO, subpath, target, on_log=on_log)
     return _sources.download_flat(ANIMA_REPO, subpath, target, on_log=on_log)
@@ -114,7 +133,7 @@ def download_anima_main(
 def download_anima_vae(root: Path, *, on_log: TaskLogLike = _DEFAULT_LOG) -> bool:
     # 落点是族无关共享资产（Krea2 同用）；下载渠道走 Anima repo（文件在那儿）。
     target = qwen_image_vae_target(root)
-    on_log("\n📥 Anima VAE (~250 MB)")
+    on_log(msg("download.anima_vae", size=250, target=target))
     if _sources._source_for("training") == "modelscope":
         return _sources.download_flat_ms(ANIMA_REPO, ANIMA_VAE_PATH, target, on_log=on_log)
     return _sources.download_flat(ANIMA_REPO, ANIMA_VAE_PATH, target, on_log=on_log)
@@ -128,11 +147,17 @@ def download_krea2_main(
         variant = LATEST_KREA2
     info = KREA2_VARIANTS.get(variant)
     if info is None:
-        on_log(f"✗ 未知 Krea 2 variant {variant!r}")
+        as_task_log(on_log).error(
+            "unknown Krea 2 variant %r; nothing was downloaded — pick a "
+            "variant from the model list", variant,
+        )
         return False
     target = krea2_main_target(root, variant)
     size_gb = float(info.get("size_estimate", 0)) / 1e9
-    on_log(f"\n📥 Krea 2 [{variant}] (~{size_gb:.1f} GB) → {target}")
+    on_log(msg(
+        "download.krea2_base", variant=variant, size=f"{size_gb:.1f}",
+        target=target,
+    ))
     if _sources._source_for("training") == "modelscope":
         return _sources.download_flat_ms(
             str(info["ms_repo"]), str(info["ms_subpath"]), target, on_log=on_log,
@@ -150,10 +175,10 @@ def download_qwen3_vl(
     target_dir.mkdir(parents=True, exist_ok=True)
     use_modelscope = _sources._source_for("training") == "modelscope"
     source_label = "ModelScope" if use_modelscope else "HuggingFace"
-    on_log(
-        f"\n📥 Krea 2 文本编码器 Qwen3-VL-4B-Instruct "
-        f"(~8.89 GB, {source_label}) → {target_dir}"
-    )
+    on_log(msg(
+        "download.krea2_te", size=QWEN3_VL_SIZE_GB, source=source_label,
+        target=target_dir,
+    ))
     ok = True
     for filename in QWEN3_VL_FILES:
         target = target_dir / filename
@@ -182,7 +207,10 @@ def download_qwen3_vl_fp8(
     target_dir = qwen3_vl_fp8_dir(root)
     target_dir.mkdir(parents=True, exist_ok=True)
     use_ms = _sources._source_for("training") == "modelscope"
-    on_log(f"\n📥 Krea 2 文本编码器 Qwen3-VL fp8 (~5.24 GB) → {target_dir}")
+    on_log(msg(
+        "download.krea2_te_fp8", size=QWEN3_VL_FP8_SIZE_GB,
+        source="ModelScope" if use_ms else "HuggingFace", target=target_dir,
+    ))
     download = _sources.download_flat_ms if use_ms else _sources.download_flat
     ok = download(
         QWEN3_VL_FP8_REPO, QWEN3_VL_FP8_SUBPATH,
@@ -209,7 +237,7 @@ def download_qwen3(root: Path, *, on_log: TaskLogLike = _DEFAULT_LOG) -> bool:
     ok = True
 
     if _sources._source_for("training") == "modelscope":
-        on_log(f"\n📥 Anima 文本编码器（ModelScope 权重 + HF tokenizer）→ {target_dir}")
+        on_log(msg("download.anima_te_ms", target=target_dir))
         # 魔搭 Anima repo 里只有权重；训练脚本仍要求完整 transformers 目录。
         ok &= _sources.download_flat_ms(
             ANIMA_REPO,
@@ -224,7 +252,7 @@ def download_qwen3(root: Path, *, on_log: TaskLogLike = _DEFAULT_LOG) -> bool:
                 ok = False
         return ok
 
-    on_log(f"\n📥 Qwen3-0.6B-Base (~1.2 GB) → {target_dir}")
+    on_log(msg("download.anima_te_hf", size=1.2, target=target_dir))
     for f in QWEN_FILES:
         if not _sources.download_flat(QWEN_REPO, f, target_dir / f, on_log=on_log):
             ok = False
@@ -235,7 +263,7 @@ def download_t5_tokenizer(
     root: Path, *, on_log: TaskLogLike = _DEFAULT_LOG
 ) -> bool:
     target_dir = t5_tokenizer_dir(root)
-    on_log(f"\n📥 T5 tokenizer (3 个文件) → {target_dir}")
+    on_log(msg("download.t5_tokenizer", n=len(T5_FILES), target=target_dir))
     target_dir.mkdir(parents=True, exist_ok=True)
     ok = True
     for f in T5_FILES:
@@ -256,7 +284,7 @@ def download_cltagger(
         cfg.model_path,
         cfg.tag_mapping_path,
     )
-    on_log(f"\n📥 CLTagger → {target_root}")
+    on_log(msg("download.cltagger", target=target_root))
     target_root.mkdir(parents=True, exist_ok=True)
     ok = True
     for f in cltagger_required_files(model_path, tag_mapping_path):
@@ -277,26 +305,35 @@ def download_upscaler(
     （e.g. R-ESRGAN_4x+Anime6B 没有 HF 镜像 → 用户即便选了 HF 也走 MS）。
     """
     if label not in UPSCALER_VARIANTS:
-        on_log(f"✗ 未知放大器 {label!r}")
+        as_task_log(on_log).error(
+            "unknown upscaler %r; nothing was downloaded — pick an upscaler "
+            "from the model list", label,
+        )
         return False
     info = UPSCALER_VARIANTS[label]
     hf_src = info.get("hf")
     ms_src = info.get("ms")
     if hf_src is None and ms_src is None:
-        on_log(f"✗ 放大器 {label!r} 未配置任何下载源")
+        as_task_log(on_log).error(
+            "upscaler %r has no download source configured; nothing was "
+            "downloaded — add a source in Settings → Models", label,
+        )
         return False
 
     target = upscaler_target(label, root)
     size_mb = info.get("size_mb", 64)
     prefer_ms = _sources._source_for("upscaler") == "modelscope"
-    on_log(f"\n📥 放大器 {label} (~{size_mb} MB) → {target}")
+    on_log(msg("download.upscaler", label=label, size=size_mb, target=target))
 
     if prefer_ms and ms_src is not None:
         return _sources.download_flat_ms(ms_src[0], ms_src[1], target, on_log=on_log)
     if hf_src is not None:
         return _sources.download_flat(hf_src[0], hf_src[1], target, on_log=on_log)
     # 偏好 HF 但 HF 缺失 → fallback MS
-    on_log(f"   ⚠ HF 无镜像，回退 ModelScope")
+    as_task_log(on_log).warning(
+        "upscaler %s has no HuggingFace source; falling back to ModelScope",
+        label,
+    )
     return _sources.download_flat_ms(ms_src[0], ms_src[1], target, on_log=on_log)  # type: ignore[index]
 
 
@@ -316,18 +353,30 @@ def download_upscaler_custom(
     但落地时会被剥成纯文件名（避免穿越）。
     """
     if source not in ("hf", "ms"):
-        on_log(f"✗ 未知下载源 {source!r}（支持 hf / ms）")
+        as_task_log(on_log).error(
+            "unknown download source %r (supported: hf, ms); nothing was "
+            "downloaded", source,
+        )
         return False
     repo_subpath = filename
     save_name = Path(filename).name  # 剥目录前缀，仅保留纯文件名
     if "/" in save_name or "\\" in save_name or ".." in save_name:
-        on_log(f"✗ 非法文件名 {save_name!r}")
+        as_task_log(on_log).error(
+            "invalid file name %r; use a plain file name without path "
+            "separators", save_name,
+        )
         return False
     if not save_name.lower().endswith(UPSCALER_EXTS):
-        on_log(f"✗ 仅支持 {UPSCALER_EXTS} 扩展名，收到 {save_name!r}")
+        as_task_log(on_log).error(
+            "unsupported file extension in %r; supported: %s",
+            save_name, ", ".join(UPSCALER_EXTS),
+        )
         return False
     target = upscaler_dir(root) / save_name
-    on_log(f"\n📥 自定义放大器 [{source}] {repo_id}/{repo_subpath} → {target}")
+    on_log(msg(
+        "download.custom_upscaler", repo_id=repo_id, subpath=repo_subpath,
+        source=source, target=target,
+    ))
     if source == "ms":
         return _sources.download_flat_ms(repo_id, repo_subpath, target, on_log=on_log)
     return _sources.download_flat(repo_id, repo_subpath, target, on_log=on_log)
@@ -348,11 +397,17 @@ def download_main_custom(
     """
     save_name = Path(filename).name
     if not save_name.lower().endswith(".safetensors"):
-        on_log(f"✗ 仅支持 .safetensors，收到 {save_name!r}")
+        as_task_log(on_log).error(
+            "unsupported file extension in %r; supported: .safetensors",
+            save_name,
+        )
         return False
     r = root or models_root()
     target = r / "diffusion_models" / save_name
-    on_log(f"\n📥 自定义主模型 {repo_id}/{filename} → {target}")
+    on_log(msg(
+        "download.custom_base", repo_id=repo_id, filename=filename,
+        target=target,
+    ))
     return _sources.download_flat(repo_id, filename, target, on_log=on_log)
 
 
@@ -390,14 +445,21 @@ def download_wd14(
     if _sources._source_for("wd14") == "modelscope":
         ms_repo = _sources._ms_wd14_repo_id(model_id)
         if ms_repo:
-            on_log(f"\n📥 WD14 {model_id} → {target}（via ModelScope: {ms_repo}）")
+            on_log(msg(
+                "download.wd14_via_ms", model_id=model_id, ms_repo=ms_repo,
+                target=target,
+            ))
             for f in WD14_FILES:
                 if not _sources.download_flat_ms(ms_repo, f, target / f, on_log=on_log):
                     ok = False
             return ok
-        on_log(f"\n📥 WD14 {model_id}：无魔搭映射，回退 HuggingFace")
+        as_task_log(on_log).warning(
+            "WD14 %s has no ModelScope mirror; falling back to HuggingFace",
+            model_id,
+        )
+        on_log(msg("download.wd14", model_id=model_id, target=target))
     else:
-        on_log(f"\n📥 WD14 {model_id} → {target}")
+        on_log(msg("download.wd14", model_id=model_id, target=target))
     for f in WD14_FILES:
         if not _sources.download_flat(model_id, f, target / f, on_log=on_log):
             ok = False
@@ -421,11 +483,22 @@ def download_eval_model(
     if _sources._source_for("eval") == "modelscope":
         ms_repo = _sources._ms_eval_repo_id(model_id)
         if ms_repo:
-            on_log(f"\n📥 {kind.upper()} {model_id} → {target}（via ModelScope: {ms_repo}）")
+            on_log(msg(
+                "download.eval_model_via_ms", kind=kind, model_id=model_id,
+                ms_repo=ms_repo, target=target,
+            ))
             return _sources.download_snapshot_ms(ms_repo, target, on_log=on_log)
-        on_log(f"\n📥 {kind.upper()} {model_id}：无魔搭映射，回退 HuggingFace")
+        as_task_log(on_log).warning(
+            "evaluation model %s %s has no ModelScope mirror; falling back "
+            "to HuggingFace", kind, model_id,
+        )
+        on_log(msg(
+            "download.eval_model", kind=kind, model_id=model_id, target=target,
+        ))
     else:
-        on_log(f"\n📥 {kind.upper()} {model_id} → {target}")
+        on_log(msg(
+            "download.eval_model", kind=kind, model_id=model_id, target=target,
+        ))
     return _sources.download_snapshot(model_id, target, on_log=on_log)
 
 
@@ -470,7 +543,9 @@ def download_ccip_model(
     r = root or models_root()
     eval_ccip_root = r / "eval" / "ccip"
     patterns = [f"{variant}/{f}" for f in CCIP_FILES]
-    on_log(f"\n📥 CCIP {variant} → {ccip_model_dir(r, variant)}")
+    on_log(msg(
+        "download.ccip", variant=variant, target=ccip_model_dir(r, variant),
+    ))
     return _sources.download_snapshot(
         CCIP_REPO, eval_ccip_root, allow_patterns=patterns, on_log=on_log,
     )
@@ -504,6 +579,10 @@ class DownloadStatus:
     finished_at: Optional[float] = None
     message: str = ""
     log: list[str] = field(default_factory=list)
+    #: 与 ``log`` 一一对应的 (level, text)。ring 给前端仍是纯文本（无级别
+    #: 概念）；``_failure_summary`` 从这里按级别选行，不再按 ✗ / ↳ 字符
+    #: 前缀 grep —— 那些字符已随文案改写消失（G1/G7 同批）。
+    leveled: list[tuple[str, str]] = field(default_factory=list)
 
 
 _LOCK = threading.Lock()
@@ -526,19 +605,31 @@ def get_status_snapshot() -> dict[str, dict[str, Any]]:
         }
 
 
-def _failure_summary(log: list[str]) -> str:
+def _failure_summary(entries: "list[tuple[str, str]] | list[str]") -> str:
     """从下载日志里提取一句可操作的失败原因（给前端 toast / message 用）。
 
-    download_flat 把错误写成 `   ✗ ...`；gated / 授权类失败再追加 `   ↳ ...提示`
-    （含 token / 申请授权指引）。优先返回带提示的那条，否则退回最后一条 ✗ 错误，
-    都没有再退到通用串。避免前端只看到 badge 红了却不知为何（原因只在终端 / 折叠
-    日志里）。
+    取**最后一条 ERROR 级别记录**的全文——gated / 授权提示现在是那条记录的
+    续行（同一条多行记录），所以「错误 + 怎么办」自然一起带出来。这取代了
+    旧的按 `✗` / `↳` 字符前缀 grep：那两个伪级别前缀已随文案改写删除。
+
+    入参是 ``DownloadStatus.leveled``（(level, text) 列表）。为兼容旧调用
+    与外部测试，纯字符串列表也接受：退化成「最后一条含 ✗ 的行 + ↳ 提示」。
     """
-    err = next((ln.strip() for ln in reversed(log) if ln.lstrip().startswith("✗")), "")
-    hint = next((ln.strip() for ln in reversed(log) if "↳" in ln), "")
-    if hint:
-        return f"{err} {hint}".strip() if err else hint
-    return err or "下载失败，详见下载日志"
+    if entries and isinstance(entries[0], str):
+        log = [str(x) for x in entries]
+        err = next(
+            (ln.strip() for ln in reversed(log) if ln.lstrip().startswith("✗")), "",
+        )
+        hint = next((ln.strip() for ln in reversed(log) if "↳" in ln), "")
+        if hint:
+            return f"{err} {hint}".strip() if err else hint
+        return err or "下载失败，详见下载日志"
+    for level, text in reversed(entries):  # type: ignore[misc]
+        if level == "error":
+            return " ".join(
+                ln.strip() for ln in str(text).splitlines() if ln.strip()
+            )
+    return "下载失败，详见下载日志"
 
 
 class _RingLog:
@@ -558,34 +649,36 @@ class _RingLog:
     def __init__(self, ds: DownloadStatus) -> None:
         self._ds = ds
 
-    def _append(self, line: str) -> None:
+    def _append(self, line: str, level: str) -> None:
         with _LOCK:
             self._ds.log.append(line)
+            self._ds.leveled.append((level, line))
             if len(self._ds.log) > 200:
                 del self._ds.log[:-200]
+                del self._ds.leveled[:-200]
 
     def __call__(self, line: str) -> None:
-        self._append(line)
+        self._append(line, "info")
         logger.debug(line)
 
     def debug(self, msg: str, *args: Any) -> None:
         text = msg % args if args else msg
-        self._append(text)
+        self._append(text, "debug")
         logger.debug(text)
 
     def info(self, msg: str, *args: Any) -> None:
         text = msg % args if args else msg
-        self._append(text)
+        self._append(text, "info")
         logger.debug(text)
 
     def warning(self, msg: str, *args: Any, exc_info: bool = False) -> None:
         text = msg % args if args else msg
-        self._append(text)
+        self._append(text, "warning")
         logger.warning(text, exc_info=exc_info)
 
     def error(self, msg: str, *args: Any, exc_info: bool = False) -> None:
         text = msg % args if args else msg
-        self._append(text)
+        self._append(text, "error")
         logger.error(text, exc_info=exc_info)
 
 
@@ -616,17 +709,22 @@ def start_download_async(
         })
         try:
             ok = fn(_on_log)
+            # 收尾汇总（「已存在 n/m」「失败 n/m」）必须在算 message 之前出，
+            # _failure_summary 取的就是最后一条 ERROR 记录。
+            _sources.finish_download_task(_on_log)
             with _LOCK:
                 ds.status = "done" if ok else "failed"
                 ds.finished_at = time.time()
                 if not ok:
-                    ds.message = _failure_summary(ds.log)
+                    ds.message = _failure_summary(ds.leveled)
         except Exception as exc:
+            # traceback 必须落 studio.log —— 否则诊断包里查不到下载线程为何崩
+            logger.exception("download thread crashed: key=%s", key)
+            _on_log.error("download thread crashed: %s", exc)
             with _LOCK:
                 ds.status = "failed"
                 ds.finished_at = time.time()
                 ds.message = str(exc)
-                ds.log.append(f"[exception] {exc}")
         bus.publish({
             "type": "model_download_changed",
             "key": key,

--- a/studio/services/models/sources.py
+++ b/studio/services/models/sources.py
@@ -10,11 +10,13 @@ from __future__ import annotations
 
 import logging
 import os
+import weakref
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 from ... import secrets
-from studio.infrastructure.task_log import TaskLogLike, TaskLog
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import TaskLogLike, TaskLog, as_task_log
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +63,141 @@ _MS_EVAL_REPO_IDS = {
 def _ms_eval_repo_id(hf_repo_id: str) -> Optional[str]:
     """CLIP / DINO 模型的 ModelScope 镜像 id；无映射返回 None（回退 HF）。"""
     return _MS_EVAL_REPO_IDS.get(hf_repo_id)
+
+
+# ---------------------------------------------------------------------------
+# 下载日志：统一模板 + 每任务计数（rewrite-c §2.5 的 T-* 模板）
+# ---------------------------------------------------------------------------
+
+#: gated / private 仓库的提示。作为失败记录的**续行**（2 空格缩进），不是独立
+#: 记录 —— 同一个 repo 反复失败时按 repo 去重，不再把这段长提示刷 12 遍。
+T_GATED_HF = (
+    "  the repository may be gated or private: request access on huggingface.co, "
+    "then set a HuggingFace token in Settings → Secrets (or the HF_TOKEN "
+    "environment variable) and retry"
+)
+T_GATED_MS = (
+    "  the repository may be private on ModelScope: request access, then set a "
+    "ModelScope token in Settings → Secrets and retry"
+)
+
+#: 每个下载任务（= 一个 on_log 对象）的计数/去重状态。用弱引用键，任务对象被
+#: 回收时状态自动消失，不需要显式清理。
+_TASK_STATE: "weakref.WeakKeyDictionary[Any, dict[str, Any]]" = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _state(on_log: TaskLogLike) -> dict[str, Any]:
+    try:
+        st = _TASK_STATE.get(on_log)
+    except TypeError:  # 不可弱引用的回调（极少数测试桩）→ 退化成无状态
+        return {
+            "attempted": 0, "present": 0, "failed": 0, "first_error": "",
+            "dep_seen": set(), "gated_seen": set(),
+        }
+    if st is None:
+        st = {
+            "attempted": 0, "present": 0, "failed": 0, "first_error": "",
+            "dep_seen": set(), "gated_seen": set(),
+        }
+        _TASK_STATE[on_log] = st
+    return st
+
+
+def finish_download_task(on_log: TaskLogLike) -> None:
+    """一次下载任务收尾：把逐文件的「已存在」「失败」计数收成汇总行。
+
+    `download_flat*` 的逐文件「已存在，跳过」是 DEBUG（重跑时最坏十几条
+    「什么都没发生」），这条汇总保住「为什么秒完成」的叙事；失败汇总按 R10
+    记 ERROR，也是 `_failure_summary` 取的那条。
+    """
+    try:
+        st = _TASK_STATE.pop(on_log, None)
+    except TypeError:  # 不可弱引用的回调 → 从来没攒过状态
+        return
+    if not st:
+        return
+    if st["present"]:
+        on_log(msg(
+            "modelsrc.present_summary", n=st["present"], total=st["attempted"],
+        ))
+    if st["failed"] > 1:
+        as_task_log(on_log).error(
+            "download failed for %d/%d files; first error: %s",
+            st["failed"], st["attempted"], st["first_error"],
+        )
+
+
+def _note_present(on_log: TaskLogLike, name: str, source: str) -> None:
+    st = _state(on_log)
+    st["attempted"] += 1
+    st["present"] += 1
+    as_task_log(on_log).debug(
+        "file already present; skipped: name=%s source=%s", name, source,
+    )
+
+
+def _note_dep_missing(on_log: TaskLogLike, package: str) -> None:
+    """可选依赖没装 → 下载彻底跑不了。同一任务里只说一次（R8）。"""
+    st = _state(on_log)
+    log = as_task_log(on_log)
+    if package in st["dep_seen"]:
+        log.debug("%s is still not installed; skipped", package)
+        return
+    st["dep_seen"].add(package)
+    log.error(
+        "%s is not installed; the download cannot run — pip install %s",
+        package, package,
+    )
+
+
+def _note_failure(
+    on_log: TaskLogLike, name: str, source: str, exc: object,
+    *, repo: str = "", gated_hint: str = "", throttle: bool = True,
+) -> None:
+    """单个文件/目录下载失败：首条全文 ERROR，之后逐条 DEBUG，收尾汇总。
+
+    gated 提示作为**同一条记录的续行**跟着首条走，按 repo 去重。
+    """
+    st = _state(on_log)
+    st["attempted"] += 1
+    st["failed"] += 1
+    text = (
+        "download failed: name=%s source=%s err=%s; the model is incomplete "
+        "and the download is marked failed"
+    )
+    hint = ""
+    if gated_hint and repo not in st["gated_seen"]:
+        st["gated_seen"].add(repo)
+        hint = "\n" + gated_hint
+    log = as_task_log(on_log)
+    if not throttle or st["failed"] == 1:
+        if st["failed"] == 1:
+            st["first_error"] = f"{name}: {exc}"
+        log.error(text + hint, name, source, exc)
+    else:
+        log.debug(text, name, source, exc)
+
+
+def _note_rename_failure(
+    on_log: TaskLogLike, src: object, dst: object, exc: object,
+) -> None:
+    """文件已下完但没落位 —— 下次要重下几 GB，这个影响必须写进文本。"""
+    st = _state(on_log)
+    st["failed"] += 1
+    if not st["first_error"]:
+        st["first_error"] = f"{dst}: {exc}"
+    as_task_log(on_log).error(
+        "moving the downloaded file into place failed: src=%s dst=%s err=%s; "
+        "the file will be downloaded again on the next attempt", src, dst, exc,
+    )
+
+
+def _note_done(on_log: TaskLogLike, name: str, source: str) -> None:
+    st = _state(on_log)
+    st["attempted"] += 1
+    on_log(msg("modelsrc.file_done", name=name, source=source))
 
 
 # ---------------------------------------------------------------------------
@@ -190,12 +327,12 @@ def download_flat_ms(
     token 优先读 MODELSCOPE_API_TOKEN env var，其次 secrets.modelscope.token。
     """
     if target.exists():
-        on_log(f"   ✓ {target.name} 已存在，跳过")
+        _note_present(on_log, target.name, "ms")
         return True
     try:
         from modelscope.hub.file_download import model_file_download
     except ImportError:
-        on_log("   ✗ 缺 modelscope（pip install modelscope）")
+        _note_dep_missing(on_log, "modelscope")
         return False
     target.parent.mkdir(parents=True, exist_ok=True)
     token = _ms_token()
@@ -209,7 +346,10 @@ def download_flat_ms(
             kwargs["token"] = token
         model_file_download(**kwargs)
     except Exception as exc:
-        on_log(f"   ✗ {target.name} (ModelScope): {exc}")
+        _note_failure(
+            on_log, target.name, "ms", exc, repo=ms_repo_id,
+            gated_hint=T_GATED_MS if _is_gated_auth_error(exc) else "",
+        )
         return False
     # model_file_download 保留 repo 内路径；与 download_flat 逻辑完全一致
     src = target.parent / repo_subpath
@@ -218,7 +358,7 @@ def download_flat_ms(
             target.unlink(missing_ok=True)
             src.rename(target)
         except OSError as exc:
-            on_log(f"   ✗ rename 失败 {src} → {target}: {exc}")
+            _note_rename_failure(on_log, src, target, exc)
             return False
         parent = src.parent
         while parent != target.parent and parent.exists():
@@ -229,7 +369,7 @@ def download_flat_ms(
             except OSError:
                 break
             parent = parent.parent
-    on_log(f"   ✓ {target.name} (via ModelScope)")
+    _note_done(on_log, target.name, "ModelScope")
     return True
 
 
@@ -246,12 +386,12 @@ def download_flat(
     再 rename 到 target（同卷 atomic，不重复 4 GB）。已存在直接跳过。
     """
     if target.exists():
-        on_log(f"   ✓ {target.name} 已存在，跳过")
+        _note_present(on_log, target.name, "hf")
         return True
     try:
         from huggingface_hub import hf_hub_download
     except ImportError:
-        on_log("   ✗ 缺 huggingface_hub")
+        _note_dep_missing(on_log, "huggingface_hub")
         return False
     target.parent.mkdir(parents=True, exist_ok=True)
     endpoint = _resolve_endpoint()
@@ -269,13 +409,10 @@ def download_flat(
             kwargs["token"] = token
         hf_hub_download(**kwargs)
     except Exception as exc:
-        on_log(f"   ✗ {target.name}: {exc}")
-        if _is_gated_auth_error(exc):
-            on_log(
-                "   ↳ 该仓库可能是 gated/private：请先到 huggingface.co 申请并接受"
-                "模型授权，再到 设置→密钥 填 HuggingFace token（或设 HF_TOKEN 环境"
-                "变量）后重试。"
-            )
+        _note_failure(
+            on_log, target.name, "hf", exc, repo=repo_id,
+            gated_hint=T_GATED_HF if _is_gated_auth_error(exc) else "",
+        )
         return False
     src = target.parent / repo_subpath
     if src != target:
@@ -283,7 +420,7 @@ def download_flat(
             target.unlink(missing_ok=True)
             src.rename(target)
         except OSError as exc:
-            on_log(f"   ✗ rename 失败 {src} → {target}: {exc}")
+            _note_rename_failure(on_log, src, target, exc)
             return False
         # 清理空中间目录
         parent = src.parent
@@ -295,7 +432,7 @@ def download_flat(
             except OSError:
                 break
             parent = parent.parent
-    on_log(f"   ✓ {target.name}")
+    _note_done(on_log, target.name, "HuggingFace")
     return True
 
 
@@ -312,12 +449,16 @@ def download_snapshot(
     落地，from_pretrained 直接指向 target_dir。已就绪（有 config.json）则跳过。
     """
     if (target_dir / "config.json").exists():
-        on_log(f"   ✓ {target_dir.name} 已存在，跳过")
+        # 整目录粒度（量 = 1）故意保 INFO —— 与逐文件那条的 DEBUG 差异是
+        # 有意的，别当成不一致改回去。
+        on_log(msg(
+            "modelsrc.dir_present", name=target_dir.name, source="HuggingFace",
+        ))
         return True
     try:
         from huggingface_hub import snapshot_download
     except ImportError:
-        on_log("   ✗ 缺 huggingface_hub")
+        _note_dep_missing(on_log, "huggingface_hub")
         return False
     target_dir.mkdir(parents=True, exist_ok=True)
     endpoint = _resolve_endpoint()
@@ -332,14 +473,16 @@ def download_snapshot(
             kwargs["token"] = token
         snapshot_download(**kwargs)
     except Exception as exc:
-        on_log(f"   ✗ {target_dir.name}: {exc}")
-        if _is_gated_auth_error(exc):
-            on_log(
-                "   ↳ 该仓库可能是 gated/private：请先到 huggingface.co 申请并接受"
-                "模型授权，再到 设置→密钥 填 HuggingFace token 后重试。"
-            )
+        # snapshot 粒度量 = 1，不需要节流
+        _note_failure(
+            on_log, target_dir.name, "hf", exc, repo=repo_id,
+            gated_hint=T_GATED_HF if _is_gated_auth_error(exc) else "",
+            throttle=False,
+        )
         return False
-    on_log(f"   ✓ {target_dir.name}")
+    on_log(msg(
+        "modelsrc.dir_done", name=target_dir.name, source="HuggingFace",
+    ))
     return True
 
 
@@ -354,12 +497,14 @@ def download_snapshot_ms(
     需要 ``pip install modelscope``；未安装返回 False。已就绪则跳过。
     """
     if (target_dir / "config.json").exists():
-        on_log(f"   ✓ {target_dir.name} 已存在，跳过")
+        on_log(msg(
+            "modelsrc.dir_present", name=target_dir.name, source="ModelScope",
+        ))
         return True
     try:
         from modelscope import snapshot_download as ms_snapshot
     except ImportError:
-        on_log("   ✗ 缺 modelscope（pip install modelscope）")
+        _note_dep_missing(on_log, "modelscope")
         return False
     target_dir.mkdir(parents=True, exist_ok=True)
     token = _ms_token()
@@ -369,9 +514,15 @@ def download_snapshot_ms(
             kwargs["token"] = token
         ms_snapshot(**kwargs)
     except Exception as exc:
-        on_log(f"   ✗ {target_dir.name} (ModelScope): {exc}")
+        _note_failure(
+            on_log, target_dir.name, "ms", exc, repo=ms_repo_id,
+            gated_hint=T_GATED_MS if _is_gated_auth_error(exc) else "",
+            throttle=False,
+        )
         return False
-    on_log(f"   ✓ {target_dir.name} (via ModelScope)")
+    on_log(msg(
+        "modelsrc.dir_done", name=target_dir.name, source="ModelScope",
+    ))
     return True
 
 

--- a/studio/services/models_storage.py
+++ b/studio/services/models_storage.py
@@ -32,6 +32,7 @@ from typing import Any, Callable
 
 from .. import secrets
 from ..infrastructure.event_bus import bus
+from ..infrastructure.logging import log_file_vanished_during_migration
 from ..infrastructure.paths import REPO_ROOT
 from .models import models_root
 
@@ -299,7 +300,7 @@ def _run_migration(
                 _copy_atomic(f, out)
             except FileNotFoundError:
                 # 扫描后被删（如临时文件）—— 跳过，进度可能停在 <100%，无碍
-                logger.info("迁移期间文件消失，跳过: %s", rel)
+                log_file_vanished_during_migration(logger, rel)
                 continue
             done_files += 1
             done_bytes += size
@@ -327,15 +328,19 @@ def _run_migration(
             "done_bytes": done_bytes,
         })
         logger.info(
-            "模型根目录迁移完成: %s → %s（%d 文件），已更新 secrets.models.root（立即生效）",
+            "models root migrated: from=%s to=%s files=%d; "
+            "secrets.models.root updated, effective immediately",
             src, dst, done_files,
         )
     except Exception as exc:
-        logger.exception("模型根目录迁移失败: %s → %s", src, dst)
+        logger.exception("models root migration failed: from=%s to=%s", src, dst)
         if dst_preexisted:
             # 合并模式：dst 的既有数据是用户的，绝不能整树删。已复制完成的文件
             # 都是完整有效副本（_copy_atomic 保证），留下无害；skip 幂等，重跑即续传。
-            logger.info("目标目录原有数据，保留已复制文件，不回滚: %s", dst)
+            logger.warning(
+                "migration was not rolled back because the target already had data; "
+                "the copied files are kept at %s", dst,
+            )
         else:
             # dst 开始前为空 / 不存在，整树清掉等于回到迁移前；
             # secret 未动；用户的 target 父目录不受影响。

--- a/studio/services/projects/versions.py
+++ b/studio/services/projects/versions.py
@@ -148,7 +148,7 @@ def reconcile_version_status(
         return v, False
 
     logger.warning(
-        "version %d status mismatch: stored=%r derived=%r → correcting",
+        "version status mismatch: version_id=%d stored=%r derived=%r; corrected",
         version_id, stored, derived,
     )
     update_version(conn, version_id, status=derived)

--- a/studio/services/proxy_manager.py
+++ b/studio/services/proxy_manager.py
@@ -42,10 +42,12 @@ def get_proxy_dict() -> Optional[Dict[str, str]]:
         if https_p:
             proxies["https"] = https_p
 
-        logger.info(f"Using proxies: {proxies}")
+        logger.debug("using proxies: %s", proxies)
         return proxies if proxies else None
     except Exception as e:
-        logger.error(f"Failed to get proxy: {e}")
+        logger.warning(
+            "read proxy settings failed; continuing without a proxy", exc_info=True,
+        )
         return None
 
 
@@ -65,7 +67,6 @@ def patch_requests_session(session):
     proxies = get_proxy_dict()
     if proxies:
         session.proxies.update(proxies)
-        logger.info(f"Patched session proxies: {session.proxies}")
-    else:
-        logger.info("No proxy configured, session unchanged")
+        logger.debug("patched session proxies: %s", session.proxies)
+    # 没配代理 = 什么都没发生，不记日志（答不出受众）
     return session

--- a/studio/services/reg/analysis.py
+++ b/studio/services/reg/analysis.py
@@ -37,7 +37,8 @@ from PIL import Image
 from ...services.dataset.scan import IMAGE_EXTS
 from ..booru import api as booru_api, pool as booru_pool
 from ..dataset import tagedit
-from studio.infrastructure.task_log import TaskLogLike
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import NULL_LOG, TaskLogLike, as_task_log
 
 
 ProgressFn = TaskLogLike
@@ -73,7 +74,7 @@ def analyze_tags_in_file(image_path: Path) -> list[str]:
 
 
 def analyze_dataset_structure(
-    dataset_path: Path, on_progress: ProgressFn = print
+    dataset_path: Path, on_progress: ProgressFn = NULL_LOG
 ) -> dict[str, Any]:
     """扫子文件夹 + 根目录，统计 tag 频率 / 分辨率 / 长宽比。
 
@@ -92,6 +93,8 @@ def analyze_dataset_structure(
     }
     ```
     """
+    # 对外仍接受历史的单参回调（tools / 测试传 lambda）；内部按级别分派
+    on_progress = as_task_log(on_progress)
     structure: dict[str, Any] = {
         "subfolders": {},
         "total_images": 0,
@@ -100,6 +103,9 @@ def analyze_dataset_structure(
         "resolutions": [],
         "aspect_ratios": [],
     }
+
+    # 逐图读尺寸失败按 R8 节流：首条全文 WARNING，之后 DEBUG，收尾汇总
+    size_fail = {"n": 0, "first": ""}
 
     def _scan_folder(folder: Path, key: str) -> None:
         data = {"images": [], "tag_freq": Counter(), "image_count": 0}
@@ -118,7 +124,18 @@ def analyze_dataset_structure(
                     if h > 0:
                         ar = w / h
             except Exception as exc:
-                on_progress(f"    警告：无法读取图片尺寸 {img.name}: {exc}")
+                size_fail["n"] += 1
+                if size_fail["n"] == 1:
+                    size_fail["first"] = f"{type(exc).__name__}: {exc}"
+                    on_progress.warning(
+                        "reg analysis: reading the image size failed: "
+                        "name=%s err=%s", img.name, exc,
+                    )
+                else:
+                    on_progress.debug(
+                        "reg analysis: reading the image size failed: "
+                        "name=%s err=%s", img.name, exc,
+                    )
             data["images"].append({
                 "image": img.name,
                 "tags": tags,
@@ -136,10 +153,10 @@ def analyze_dataset_structure(
                     structure["aspect_ratios"].append(ar)
         if data["image_count"] > 0:
             structure["subfolders"][key] = data
-            on_progress(
-                f"  [{key or '<root>'}] {data['image_count']} 张图片，"
-                f"{len(data['tag_freq'])} tag 种类"
-            )
+            on_progress(msg(
+                "reg.analysis_subfolder", key=key or "<root>",
+                n=data["image_count"], tags=len(data["tag_freq"]),
+            ))
 
     # 根目录直接图
     has_root_imgs = any(
@@ -153,6 +170,12 @@ def analyze_dataset_structure(
     for sub in sorted(dataset_path.iterdir()):
         if sub.is_dir():
             _scan_folder(sub, sub.name)
+
+    if size_fail["n"]:
+        on_progress.warning(
+            "reg analysis: the image size could not be read for %d images; "
+            "first error: %s", size_fail["n"], size_fail["first"],
+        )
 
     # 全局权重
     if structure["total_images"] > 0:

--- a/studio/services/reg/builder.py
+++ b/studio/services/reg/builder.py
@@ -49,7 +49,8 @@ from .analysis import (
     collect_source_image_ids,
     find_best_match,
 )
-from studio.infrastructure.task_log import TaskLogLike
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import NULL_LOG, TaskLogLike, as_task_log
 
 
 ProgressFn = TaskLogLike
@@ -176,15 +177,21 @@ def _build_for_subfolder(
 ) -> tuple[bool, int]:
     """单子文件夹批量循环。返回 (success_80%达成, 实际下载数)。"""
     label = subfolder_name or "<root>"
-    on_progress(f"\n===== 子文件夹 {label} =====")
+    on_progress(msg("reg.subfolder_start", label=label))
 
     target_count = subfolder_data["image_count"]
     remaining_quota = total_target_count - total_downloaded_so_far
     if remaining_quota <= 0:
-        on_progress(f"  ⚠️  已达总数量限制 {total_target_count}，跳过 {label}")
+        on_progress.warning(
+            "reg: total image limit %d reached; subfolder %s skipped",
+            total_target_count, label,
+        )
         return False, 0
     target_count = min(target_count, remaining_quota)
-    on_progress(f"  目标 {target_count} 张，批次 {opts.batch_size}，最多 {opts.max_search_tags} tag")
+    on_progress(msg(
+        "reg.subfolder_plan", target=target_count, batch=opts.batch_size,
+        max_tags=opts.max_search_tags,
+    ))
 
     if subfolder_name == "":
         out_sub = output_dir
@@ -203,9 +210,7 @@ def _build_for_subfolder(
     # 不计入 downloaded_count，因为它们已经不在盘上了。
     if deleted_ids:
         downloaded_ids.update(deleted_ids)
-        on_progress(
-            f"  [a2] 排除已删 booru ID {len(deleted_ids)} 个（来自 reg/.deleted_ids.json）"
-        )
+        on_progress(msg("reg.deleted_ids_excluded_sub", n=len(deleted_ids)))
 
     # PP5.1 — incremental：把已有图作为「已下载」计入起点 + 累加 current_weights
     if pre_existing and pre_existing.get("count"):
@@ -216,11 +221,12 @@ def _build_for_subfolder(
         for tags in pre_existing.get("tags") or []:
             for t in tags:
                 current_weights[t] += 1 / target_count
-        on_progress(
-            f"  [incremental] 沿用已有 {existing_count} 张（计入起点 {downloaded_count}/{target_count}）"
-        )
+        on_progress(msg(
+            "reg.incremental_reuse", existing=existing_count,
+            downloaded=downloaded_count, target=target_count,
+        ))
         if downloaded_count >= target_count:
-            on_progress("  [incremental] 已有图已达目标，无需补足")
+            on_progress(msg("reg.incremental_done"))
             return True, downloaded_count
 
     batch_round = 0
@@ -231,29 +237,34 @@ def _build_for_subfolder(
 
     while downloaded_count < target_count and batch_round < max_rounds:
         if cancel_event and cancel_event.is_set():
-            on_progress("  [cancel] 用户中止")
+            on_progress(msg("reg.canceled"))
             return False, downloaded_count
 
         batch_round += 1
         batch_remaining = min(opts.batch_size, target_count - downloaded_count)
-        on_progress(f"\n  ----- batch {batch_round} ({downloaded_count}/{target_count}) -----")
+        on_progress.debug(
+            "reg batch start: round=%d progress=%d/%d",
+            batch_round, downloaded_count, target_count,
+        )
 
         missing_tags = calculate_missing_tags(
             target_weights, current_weights, blacklist_tags, failed_tags
         )
         if not missing_tags:
-            on_progress("  所有标签已达目标权重")
+            on_progress(msg("reg.weights_reached"))
             break
 
         available_tags = [t for t, _ in missing_tags if t not in failed_tags]
         if not available_tags:
-            on_progress(f"  ⚠️  所有缺失标签都搜索失败：{list(failed_tags)}")
+            on_progress.warning(
+                "reg: every missing tag failed to search: %s", list(failed_tags),
+            )
             break
 
         info_preview = ", ".join(
             f"{t}(缺{w:.2f})" for t, w in missing_tags[:5]
         )
-        on_progress(f"  最缺失: {info_preview}")
+        on_progress.debug("reg most-missing tags: %s", info_preview)
 
         # 标签数递减：10 → 5 → 3 → 2 → 1
         tag_counts_seq = [10, 5, 3, 2, 1]
@@ -276,13 +287,17 @@ def _build_for_subfolder(
                 comb_key = tuple(sorted(cand_tags))
                 if comb_key in invalid_tag_combinations:
                     if offset == 0:
-                        on_progress(f"    跳过无效组合: {cand_tags}")
+                        on_progress.debug(
+                            "reg skip invalid tag combination: %s", cand_tags,
+                        )
                     continue
                 if comb_key in tried_combinations:
                     continue
                 tried_combinations.add(comb_key)
 
-                on_progress(f"    用 {tag_count} tag 搜索: {cand_tags}")
+                on_progress.debug(
+                    "reg search: tag_count=%d tags=%s", tag_count, cand_tags,
+                )
                 posts = _search_with_filters(
                     cand_tags,
                     api_source=opts.api_source,
@@ -302,12 +317,18 @@ def _build_for_subfolder(
                     break
                 if tag_count == 1:
                     failed_tags.add(cand_tags[0])
-                    on_progress(f"    ✗ tag '{cand_tags[0]}' 搜索失败，加入跳过列表")
+                    on_progress.debug(
+                        "reg tag search failed; added to the skip list: tag=%s",
+                        cand_tags[0],
+                    )
                     remaining_avail = [
                         t for t, _ in missing_tags if t not in failed_tags
                     ]
                     if not remaining_avail:
-                        on_progress(f"  ⚠️  所有缺失标签都已失败：{list(failed_tags)}")
+                        on_progress.warning(
+                            "reg: every missing tag has already failed: %s",
+                            list(failed_tags),
+                        )
                         all_tags_failed = True
                         break
             if posts or all_tags_failed:
@@ -315,8 +336,9 @@ def _build_for_subfolder(
 
         if not posts:
             consecutive_failures += 1
-            on_progress(
-                f"  ⚠️  无匹配（连续失败 {consecutive_failures}/{max_consecutive_failures}）"
+            on_progress.debug(
+                "reg no match: consecutive_failures=%d/%d",
+                consecutive_failures, max_consecutive_failures,
             )
             # 检测：所有可能组合都被标记为 invalid → 退出
             all_invalid = True
@@ -328,14 +350,20 @@ def _build_for_subfolder(
                     all_invalid = False
                     break
             if all_invalid and invalid_tag_combinations:
-                on_progress("  所有组合标记 invalid，停止搜索")
+                on_progress.warning(
+                    "reg: all tag combinations are marked invalid; stopping the "
+                    "search for subfolder=%s", label,
+                )
                 break
             if consecutive_failures >= max_consecutive_failures:
-                on_progress(f"  连续 {consecutive_failures} 次失败，停止")
+                on_progress.warning(
+                    "reg: %d consecutive failures; stopping the search for "
+                    "subfolder=%s", consecutive_failures, label,
+                )
                 break
             continue
         consecutive_failures = 0
-        on_progress(f"    候选 {len(posts)} 张")
+        on_progress.debug("reg candidates: %d", len(posts))
 
         # 从候选下载本批次
         batch_downloaded = 0
@@ -344,7 +372,7 @@ def _build_for_subfolder(
 
         while batch_downloaded < batch_remaining and attempts < max_attempts:
             if cancel_event and cancel_event.is_set():
-                on_progress("  [cancel] 用户中止")
+                on_progress(msg("reg.canceled"))
                 return False, downloaded_count
 
             attempts += 1
@@ -374,18 +402,24 @@ def _build_for_subfolder(
                 skipped += 1
                 continue
             if pid in source_image_ids:
-                on_progress(f"    跳过（源已有）: {pid}")
+                on_progress.debug(
+                    "reg skip (already in the training set): post_id=%s", pid,
+                )
                 skipped += 1
                 downloaded_ids.add(pid)
                 continue
             ext_lower = (file_ext or "").lower()
             if ext_lower in VIDEO_EXTS:
-                on_progress(f"    跳过（视频）: {pid} .{file_ext}")
+                on_progress.debug(
+                    "reg skip (video): post_id=%s ext=%s", pid, file_ext,
+                )
                 skipped += 1
                 downloaded_ids.add(pid)
                 continue
             if ext_lower not in _IMAGE_EXT_NODOT:
-                on_progress(f"    跳过（非图片）: {pid} .{file_ext}")
+                on_progress.debug(
+                    "reg skip (not an image): post_id=%s ext=%s", pid, file_ext,
+                )
                 skipped += 1
                 downloaded_ids.add(pid)
                 continue
@@ -397,7 +431,10 @@ def _build_for_subfolder(
                 max_ar=opts.max_aspect_ratio,
             ):
                 ar_v = pw / ph if pw and ph else 0
-                on_progress(f"    跳过（长宽比 {ar_v:.2f}）: {pid}")
+                on_progress.debug(
+                    "reg skip (aspect ratio %.2f out of range): post_id=%s",
+                    ar_v, pid,
+                )
                 skipped += 1
                 downloaded_ids.add(pid)
                 continue
@@ -410,7 +447,10 @@ def _build_for_subfolder(
                 try:
                     image_path.unlink()
                 except Exception as exc:
-                    on_progress(f"    警告：无法删 {image_path.name}: {exc}")
+                    on_progress.warning(
+                        "reg: deleting the partial file failed: name=%s err=%s",
+                        image_path.name, exc,
+                    )
 
             try:
                 if client is not None:
@@ -432,7 +472,9 @@ def _build_for_subfolder(
                         username=opts.username,
                     )
             except Exception as exc:
-                on_progress(f"    ✗ 下载失败: {pid} ({exc})")
+                on_progress.debug(
+                    "reg download failed: post_id=%s err=%s", pid, exc,
+                )
                 if image_path.exists():
                     try:
                         image_path.unlink()
@@ -460,28 +502,36 @@ def _build_for_subfolder(
             batch_downloaded += 1
             downloaded_ids.add(pid)
             matched = [t for t in post_tags if t in target_weights][:5]
-            on_progress(
-                f"    [{downloaded_count}/{target_count}] ✓ {pid} "
-                f"score={score:.4f} matched={matched}"
+            on_progress(msg(
+                "reg.image_saved", n=downloaded_count, target=target_count,
+                post_id=pid,
+            ))
+            # 打分明细是内部数值，进 DEBUG 而不是进用户面进度行
+            on_progress.debug(
+                "reg image scored: post_id=%s score=%.4f matched=%s",
+                pid, score, matched,
             )
 
             if (
                 total_target_count is not None
                 and total_downloaded_so_far + downloaded_count >= total_target_count
             ):
-                on_progress(f"  已达总数量限制 {total_target_count}")
+                on_progress(msg("reg.total_limit_reached", total=total_target_count))
                 break
 
             # PP9 — 删每图 0.5s 硬 sleep；速率由 BooruClient 的 token bucket 控
             if cancel_event and cancel_event.is_set():
-                on_progress("  [cancel] 用户中止")
+                on_progress(msg("reg.canceled"))
                 return False, downloaded_count
 
-        on_progress(f"  本批次下载: {batch_downloaded}")
+        on_progress.debug("reg batch downloaded: %d", batch_downloaded)
 
         if batch_downloaded == 0 and posts and search_tags:
             invalid_tag_combinations.add(tuple(sorted(search_tags)))
-            on_progress(f"  ⚠️  组合 {search_tags} 找到候选但未下载，标 invalid")
+            on_progress.debug(
+                "reg tag combination found candidates but downloaded none; "
+                "marked invalid: %s", search_tags,
+            )
             continue
         elif batch_downloaded > 0 and search_tags:
             invalid_tag_combinations.discard(tuple(sorted(search_tags)))
@@ -489,15 +539,22 @@ def _build_for_subfolder(
         if downloaded_count < target_count:
             if cancel_event:
                 if cancel_event.wait(1.0):
-                    on_progress("  [cancel] 用户中止")
+                    on_progress(msg("reg.canceled"))
                     return False, downloaded_count
             else:
                 time.sleep(1.0)
 
-    on_progress(
-        f"\n  子文件夹 {label} 完成: {downloaded_count}/{target_count} "
-        f"(skipped={skipped} failed={failed})"
-    )
+    if failed:
+        on_progress.warning(
+            "reg subfolder finished with failures: label=%s saved=%d/%d "
+            "skipped=%d failed=%d",
+            label, downloaded_count, target_count, skipped, failed,
+        )
+    else:
+        on_progress(msg(
+            "reg.subfolder_done", label=label, n=downloaded_count,
+            target=target_count, skipped=skipped,
+        ))
     success = downloaded_count >= target_count * 0.8
     return success, downloaded_count
 
@@ -505,7 +562,7 @@ def _build_for_subfolder(
 def build(
     opts: RegBuildOptions,
     *,
-    on_progress: ProgressFn = print,
+    on_progress: ProgressFn = NULL_LOG,
     cancel_event: Optional[threading.Event] = None,
     incremental: bool = False,
     client: Optional[booru_pool.BooruClient] = None,
@@ -523,7 +580,11 @@ def build(
     `current_weights` 从已有 caption 累加，仅补足缺口；旧 meta 的
     `incremental_runs + 1` 写回。
     """
-    on_progress(f"[reg] api={opts.api_source} train={opts.train_dir}")
+    # 对外仍接受历史的单参回调（tools / 测试传 lambda）；内部按级别分派
+    on_progress = as_task_log(on_progress)
+    on_progress(msg(
+        "reg.build_start", api=opts.api_source, train_dir=opts.train_dir,
+    ))
 
     if not opts.train_dir.exists():
         raise FileNotFoundError(f"train 目录不存在: {opts.train_dir}")
@@ -574,7 +635,7 @@ def _build_inner(
         raise ValueError(f"train 目录没有任何带 caption 的图片: {opts.train_dir}")
 
     source_image_ids = collect_source_image_ids(opts.train_dir)
-    on_progress(f"[reg] 源图片 ID 共 {len(source_image_ids)} 个，避免重复")
+    on_progress(msg("reg.source_ids", n=len(source_image_ids)))
 
     # 标签集合
     blacklist_tags = set(_normalize_tags(opts.blacklist_tags))
@@ -585,7 +646,7 @@ def _build_inner(
         ver_tag = opts.based_on_version.lower().strip().replace(" ", "_")
         if ver_tag and ver_tag not in blacklist_tags:
             blacklist_tags.add(ver_tag)
-            on_progress(f"[reg] 自动加入黑名单: {ver_tag}")
+            on_progress.debug("reg auto-blacklisted version tag: %s", ver_tag)
 
     failed_tags: set[str] = set()
     source_tags_used: set[str] = set()
@@ -603,15 +664,13 @@ def _build_inner(
         subfolders_plan: dict[str, dict[str, Any]] = {
             "1_data": {"image_count": total_target}
         }
-        on_progress(
-            f"[reg] flat 模式：目标 {total_target} 张，单桶 1_data/"
-        )
+        on_progress(msg("reg.mode_flat", total=total_target))
     else:
         subfolders_plan = structure["subfolders"]
-        on_progress(
-            f"[reg] mirror 模式：目标 {total_target} 张（train 总 "
-            f"{structure['total_images']}），镜像 {len(subfolders_plan)} 个子文件夹"
-        )
+        on_progress(msg(
+            "reg.mode_mirror", total=total_target,
+            train_total=structure["total_images"], n=len(subfolders_plan),
+        ))
 
     # 输出目录
     opts.output_dir.mkdir(parents=True, exist_ok=True)
@@ -623,17 +682,17 @@ def _build_inner(
         pre_existing_per_sub = collect_existing_reg_per_subfolder(opts.output_dir)
         prior_meta = read_meta(opts.output_dir)
         existing_total = sum(b["count"] for b in pre_existing_per_sub.values())
-        on_progress(
-            f"[reg] incremental 模式：已有 {existing_total} 张图、"
-            f"{len(pre_existing_per_sub)} 个子文件夹"
-        )
+        on_progress(msg(
+            "reg.mode_incremental", existing=existing_total,
+            n=len(pre_existing_per_sub),
+        ))
 
     # A2 — 用户从 UI 删除过的 booru ID（含跨子文件夹），无论 incremental 与否都
     # 应排除：fresh build 时 .deleted_ids.json 已被 DELETE /reg 清掉；
     # incremental 时这个集合才非空，避免补足把删除的图再拉回。
     deleted_ids = read_deleted_ids(opts.output_dir)
     if deleted_ids:
-        on_progress(f"[reg] 已删 booru ID 共 {len(deleted_ids)} 个（A2 排除）")
+        on_progress(msg("reg.deleted_ids_excluded_total", n=len(deleted_ids)))
 
     target_resolution = structure.get("median_resolution")
     target_aspect_ratio = structure.get("median_aspect_ratio")
@@ -668,12 +727,17 @@ def _build_inner(
                 success_subfolder_count += 1
             total_downloaded += dled
             if total_downloaded >= total_target:
-                on_progress(f"[reg] 已达总目标 {total_target}，停止剩余子文件夹")
+                on_progress(msg("reg.total_target_reached", total=total_target))
                 break
         except Exception as exc:
-            on_progress(f"[reg] 子文件夹 {sub_name} 出错: {exc}")
+            on_progress.warning(
+                "reg subfolder failed: name=%s err=%s; the build continues with "
+                "the next subfolder", sub_name, exc,
+            )
             import traceback
-            on_progress(traceback.format_exc())
+            on_progress.debug(
+                "reg subfolder traceback: %s", traceback.format_exc(),
+            )
 
     # 写 meta
     top_dist = dict(structure["global_tag_freq"].most_common(50))
@@ -705,11 +769,18 @@ def _build_inner(
     )
     write_meta(opts.output_dir, meta)
 
-    on_progress(
-        f"[reg] 完成: {total_downloaded}/{total_target}"
-        f" 张（{success_subfolder_count}/{len(subfolders_plan)} "
-        f"子文件夹达 80%）"
-    )
+    if success_subfolder_count < len(subfolders_plan):
+        on_progress.warning(
+            "reg build finished below target: images=%d/%d "
+            "subfolders_at_80pct=%d/%d",
+            total_downloaded, total_target,
+            success_subfolder_count, len(subfolders_plan),
+        )
+    else:
+        on_progress(msg(
+            "reg.build_done", n=total_downloaded, total=total_target,
+            ok=success_subfolder_count, subs=len(subfolders_plan),
+        ))
     return meta
 
 

--- a/studio/services/reg/postprocess.py
+++ b/studio/services/reg/postprocess.py
@@ -44,7 +44,8 @@ from PIL import Image
 from sklearn.cluster import KMeans
 
 from ...services.dataset.scan import IMAGE_EXTS
-from studio.infrastructure.task_log import TaskLogLike
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import NULL_LOG, TaskLogLike, as_task_log
 
 ProgressFn = TaskLogLike
 
@@ -352,7 +353,7 @@ def postprocess(
     *,
     method: str = "smart",
     max_crop_ratio: float = 0.1,
-    on_progress: ProgressFn = print,
+    on_progress: ProgressFn = NULL_LOG,
     cancel_event: Optional[threading.Event] = None,
 ) -> dict[str, Any]:
     """对 reg_dir 下所有图做分辨率聚类后处理（inplace 永远 True）。
@@ -369,8 +370,13 @@ def postprocess(
 
     异常都不抛 — 失败时 clusters=None / processed=0。
     """
+    # 对外仍接受历史的单参回调（tools / 测试传 lambda）；内部按级别分派
+    on_progress = as_task_log(on_progress)
     if method not in VALID_METHODS:
-        on_progress(f"[postprocess] 非法 method: {method}，跳过")
+        on_progress.warning(
+            "postprocess: unknown method=%s; skipped, the images are left "
+            "unchanged", method,
+        )
         return {
             "clusters": None, "processed": 0, "skipped": 0,
             "method": method, "max_crop_ratio": max_crop_ratio,
@@ -378,28 +384,33 @@ def postprocess(
         }
 
     if not reg_dir.exists():
-        on_progress(f"[postprocess] {reg_dir} 不存在，跳过")
+        on_progress.warning(
+            "postprocess: %s does not exist; skipped", reg_dir,
+        )
         return {
             "clusters": None, "processed": 0, "skipped": 0,
             "method": method, "max_crop_ratio": max_crop_ratio,
             "target_resolutions": [],
         }
 
-    on_progress(f"[postprocess] 收集图片 (method={method}, max_crop={max_crop_ratio})")
+    on_progress(msg(
+        "reg.pp_collect", method=method, max_crop=max_crop_ratio,
+    ))
     images = _collect_images(reg_dir)
     if not images:
-        on_progress("[postprocess] 没有图片，跳过")
+        on_progress(msg("reg.pp_no_images"))
         return {
             "clusters": None, "processed": 0, "skipped": 0,
             "method": method, "max_crop_ratio": max_crop_ratio,
             "target_resolutions": [],
         }
-    on_progress(f"[postprocess] 共 {len(images)} 张图片")
+    on_progress(msg("reg.pp_image_count", n=len(images)))
 
     clusters = cluster_by_resolution(images, max_crop_ratio, method)
     if clusters is None:
-        on_progress(
-            f"[postprocess] 无 K 满足 max_crop ≤ {max_crop_ratio}，保持原样不修改"
+        on_progress.warning(
+            "postprocess: no cluster count satisfies max_crop <= %s; the "
+            "images are left unchanged", max_crop_ratio,
         )
         return {
             "clusters": None, "processed": 0, "skipped": len(images),
@@ -407,8 +418,9 @@ def postprocess(
             "target_resolutions": [],
         }
 
-    on_progress(f"[postprocess] 聚类 {len(clusters)} 个 — 详情：")
-    # 每个 cluster 详细信息（与源脚本日志对齐）
+    on_progress(msg("reg.pp_clusters", n=len(clusters)))
+    # 每簇 6 行缩进明细 → 一条 DEBUG 多行记录（续行 2 空格）
+    detail_lines = ["postprocess cluster detail:"]
     for cid in sorted(clusters.keys()):
         cluster = clusters[cid]
         tw, th, tar = _adjusted_target_for_cluster(cluster)
@@ -418,34 +430,36 @@ def postprocess(
         max_crop = max(
             calculate_crop_ratio(i.width, i.height, tw, th, method) for i in cluster
         )
-        on_progress(f"  聚类 {cid}: {len(cluster)} 张")
-        on_progress(f"    目标分辨率: {tw}x{th} (长宽比: {tar:.3f})")
-        on_progress(
-            f"    平均分辨率: {int(np.mean(widths))}x{int(np.mean(heights))}"
+        detail_lines.append(
+            "  cluster=%d images=%d target=%dx%d ar=%.3f avg=%dx%d "
+            "ar_range=%.3f-%.3f max_crop=%.1f%% res_range=%dx%d to %dx%d"
+            % (
+                cid, len(cluster), tw, th, tar,
+                int(np.mean(widths)), int(np.mean(heights)),
+                min(ars), max(ars), max_crop * 100,
+                min(widths), min(heights), max(widths), max(heights),
+            )
         )
-        on_progress(
-            f"    长宽比范围: {min(ars):.3f} - {max(ars):.3f} "
-            f"(平均: {np.mean(ars):.3f})"
-        )
-        on_progress(f"    最大裁剪比例: {max_crop * 100:.1f}%")
-        on_progress(
-            f"    分辨率范围: {min(widths)}x{min(heights)} 到 "
-            f"{max(widths)}x{max(heights)}"
-        )
+    on_progress.debug("%s", "\n".join(detail_lines))
 
     processed = 0
     skipped = 0
+    resize_failed = 0
+    first_resize_error = ""
     targets: list[tuple[int, int, int]] = []
     for cid in sorted(clusters.keys()):
         if cancel_event and cancel_event.is_set():
-            on_progress("[postprocess] [cancel] 用户中止")
+            on_progress(msg("reg.pp_canceled"))
             break
         cluster = clusters[cid]
         tw, th, target_ar = _adjusted_target_for_cluster(cluster)
-        on_progress(
-            f"[postprocess] 处理聚类 {cid} ({len(cluster)} 张) → "
-            f"{'ar=' + format(target_ar, '.3f') if method == 'smart' else f'{tw}x{th}'}"
-        )
+        on_progress(msg(
+            "reg.pp_cluster_start", cid=cid, n=len(cluster),
+            target=(
+                "ar=" + format(target_ar, ".3f") if method == "smart"
+                else f"{tw}x{th}"
+            ),
+        ))
         targets.append((tw, th, len(cluster)))
         for info in cluster:
             if cancel_event and cancel_event.is_set():
@@ -460,17 +474,44 @@ def postprocess(
                 if info.width == tw and info.height == th:
                     skipped += 1
                     continue
-            ok = resize_and_crop_image(info.path, tw, th, info.path, method)
+            try:
+                ok = resize_and_crop_image(info.path, tw, th, info.path, method)
+                resize_err = ""
+            except Exception as exc:  # noqa: BLE001
+                ok = False
+                resize_err = f"{type(exc).__name__}: {exc}"
             if ok:
                 processed += 1
             else:
                 skipped += 1
-                on_progress(f"  ✗ resize 失败: {info.path.name}")
+                # T6 节流：逐图失败首条全文，之后 DEBUG，收尾一条汇总
+                resize_failed += 1
+                if resize_failed == 1:
+                    first_resize_error = resize_err or "resize returned false"
+                    on_progress.warning(
+                        "postprocess resize failed: name=%s err=%s",
+                        info.path.name, first_resize_error,
+                    )
+                else:
+                    on_progress.debug(
+                        "postprocess resize failed: name=%s err=%s",
+                        info.path.name, resize_err or "resize returned false",
+                    )
 
-    on_progress(
-        f"[postprocess] 完成: processed={processed}, skipped={skipped}, "
-        f"clusters={len(clusters)}"
-    )
+    if resize_failed:
+        on_progress.warning(
+            "postprocess resize failed for %d/%d images; first error: %s",
+            resize_failed, len(images), first_resize_error,
+        )
+    if skipped:
+        on_progress.warning(
+            "postprocess finished with skips: processed=%d skipped=%d "
+            "clusters=%d", processed, skipped, len(clusters),
+        )
+    else:
+        on_progress(msg(
+            "reg.pp_done", processed=processed, clusters=len(clusters),
+        ))
     return {
         "clusters": len(clusters),
         "processed": processed,

--- a/studio/services/runtime/gpu_select.py
+++ b/studio/services/runtime/gpu_select.py
@@ -41,7 +41,10 @@ def _selected_index() -> Optional[int]:
             return None
         return int(idx)
     except Exception:  # noqa: BLE001
-        logger.exception("读取计算显卡设置失败；本次跳过选卡注入")
+        logger.warning(
+            "read the compute GPU setting failed; using the CUDA default device",
+            exc_info=True,
+        )
         return None
 
 
@@ -91,8 +94,8 @@ def apply_gpu_selection_env(
         # 卡不在了（eGPU 拔线 / 换硬件）：忽略选择回 CUDA 默认——注入
         # 一个不存在的序号会让 torch 面对空设备列表，训练/出图全瘫。
         logger.warning(
-            "计算显卡设置 gpu_index=%d 超出当前卡数 %d，本次忽略（回 CUDA 默认）",
-            idx, count,
+            "compute GPU setting gpu_index=%d is out of range (device_count=%d); "
+            "ignored, using the CUDA default device", idx, count,
         )
         if applied_by_us:
             _revoke(env)
@@ -100,4 +103,6 @@ def apply_gpu_selection_env(
     env["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
     env["CUDA_VISIBLE_DEVICES"] = str(idx)
     env[_MARKER] = "1"
-    logger.info("计算显卡已钉定：PCI 序号 %d（CUDA_DEVICE_ORDER=PCI_BUS_ID）", idx)
+    logger.debug(
+        "compute GPU pinned: pci_index=%d (CUDA_DEVICE_ORDER=PCI_BUS_ID)", idx,
+    )

--- a/studio/services/runtime/onnxruntime.py
+++ b/studio/services/runtime/onnxruntime.py
@@ -394,11 +394,12 @@ def _ensure_preload() -> dict[str, Any]:
     _PRELOAD_RESULT = _preload_torch_cuda_libs()
     if sys.platform == "win32" and _PRELOAD_RESULT["preloaded"]:
         logger.info(
-            "[onnx_setup] DLL 搜索路径已加入 torch/lib（onnxruntime-gpu CUDA dlopen 用）"
+            "[onnx_setup] added torch/lib to the DLL search path (needed for "
+            "the onnxruntime-gpu CUDA dlopen)"
         )
     elif _PRELOAD_RESULT["preloaded"]:
-        logger.info(
-            "[onnx_setup] 预加载 torch 自带 CUDA 库 %d 个: %s",
+        logger.debug(
+            "[onnx_setup] preloaded %d bundled torch CUDA libraries: %s",
             len(_PRELOAD_RESULT["preloaded"]),
             ", ".join(
                 os.path.basename(p) for p in _PRELOAD_RESULT["preloaded"]
@@ -406,11 +407,13 @@ def _ensure_preload() -> dict[str, Any]:
         )
     elif _PRELOAD_RESULT.get("system_cuda_skip"):
         logger.info(
-            "[onnx_setup] 检测到系统 CUDA，跳过 torch wheel preload（避免 cuBLAS 版本错位）"
+            "[onnx_setup] system CUDA detected; skipping the torch wheel preload "
+            "(avoids a cuBLAS version mismatch)"
         )
     elif _PRELOAD_RESULT["applied"] and _PRELOAD_RESULT["candidates"] == 0:
         logger.debug(
-            "[onnx_setup] 未发现 torch 自带 CUDA wheel；GPU EP 依赖系统 CUDA"
+            "[onnx_setup] no bundled torch CUDA wheel found; the GPU EP relies "
+            "on system CUDA"
         )
     return _PRELOAD_RESULT
 
@@ -460,7 +463,7 @@ def detect_cuda() -> dict[str, Any]:
             check=False,
         )
     except (subprocess.SubprocessError, OSError) as exc:
-        logger.debug("nvidia-smi exec failed: %s", exc)
+        logger.debug("[onnx_setup] nvidia-smi exec failed: %s", exc)
         return {"available": False, "driver_version": None, "gpu_name": None}
     if out.returncode != 0:
         return {"available": False, "driver_version": None, "gpu_name": None}
@@ -665,7 +668,10 @@ def _install_cuda_runtime_wheels(major: Optional[int] = None) -> dict[str, Any]:
         }
     rc, out = _pip(["install", *targets])
     if rc != 0:
-        logger.warning("[onnx_setup] CUDA wheels pip 官方源失败，切换腾讯镜像重试...")
+        logger.warning(
+            "[onnx_setup] pip failed on the official index for the CUDA runtime "
+            "wheels; retrying on the Tencent mirror"
+        )
         rc, out = _pip(["install", *targets], mirror=_PIP_FALLBACK_MIRROR)
     if rc != 0:
         # 回滚：把本次想装的从 venv 里再卸掉，保持装包前的状态
@@ -701,7 +707,10 @@ def install_runtime(target: str = "auto") -> dict[str, Any]:
     rc1, log1 = _pip(["uninstall", "-y", *_MUTUALLY_EXCLUSIVE_PACKAGES])
     rc2, log2 = _pip(["install", "--upgrade", spec])
     if rc2 != 0:
-        logger.warning("[onnx_setup] pip 官方源失败，切换腾讯镜像重试...")
+        logger.warning(
+            "[onnx_setup] pip failed on the official index for the onnxruntime "
+            "wheels; retrying on the Tencent mirror"
+        )
         rc2, log2 = _pip(["install", "--upgrade", spec], mirror=_PIP_FALLBACK_MIRROR)
     if rc2 != 0:
         raise RuntimeError(f"安装 {spec} 失败（rc={rc2}）:\n{log2}")
@@ -715,7 +724,11 @@ def install_runtime(target: str = "auto") -> dict[str, Any]:
         except RuntimeError as exc:
             # CUDA wheels 装失败不致命：onnxruntime-gpu 已装上，让用户去 Settings 页
             # 看到 cuda_load_error + 手动修。日志记下原因，UI 也能拿到。
-            logger.error("[onnx_setup] CUDA runtime wheels 装失败: %s", exc)
+            logger.warning(
+                "[onnx_setup] installing the CUDA runtime wheels failed; tagging "
+                "keeps running on the CPU, reinstall from Settings → ONNX Runtime",
+                exc_info=True,
+            )
             cuda_runtime = {
                 "installed": [],
                 "skipped": [],

--- a/studio/services/runtime/pending_install.py
+++ b/studio/services/runtime/pending_install.py
@@ -35,7 +35,9 @@ def register_torch_reinstall(target: str) -> None:
         json.dumps({"kind": "torch", "target": target}, ensure_ascii=False),
         encoding="utf-8",
     )
-    logger.info("[pending_install] 已注册 torch reinstall: target=%s", target)
+    logger.info(
+        "[pending_install] torch reinstall registered: target=%s", target,
+    )
 
 
 def read_pending() -> Optional[dict[str, Any]]:
@@ -45,7 +47,9 @@ def read_pending() -> Optional[dict[str, Any]]:
     try:
         return json.loads(PENDING_MARKER.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        logger.warning("[pending_install] marker 解析失败: %s", exc)
+        logger.warning(
+            "[pending_install] marker file could not be parsed: %s; ignored", exc,
+        )
         return None
 
 
@@ -54,7 +58,10 @@ def clear_pending() -> None:
         try:
             PENDING_MARKER.unlink()
         except OSError as exc:
-            logger.warning("[pending_install] 删除 marker 失败: %s", exc)
+            logger.warning(
+                "[pending_install] deleting the marker failed: %s; the install "
+                "is retried on the next start", exc,
+            )
 
 
 def apply_pending() -> None:
@@ -71,24 +78,43 @@ def apply_pending() -> None:
     kind = pending.get("kind")
     if kind == "torch":
         target = pending.get("target", "auto")
-        logger.info("检测到 pending torch 重装请求 (target=%s)，开始安装...", target)
-        logger.info("提示：按 Ctrl+C 可跳过本次安装（marker 保留，下次启动重试）")
-        logger.info("若希望永久跳过，删除 marker 文件：%s", PENDING_MARKER)
+        # 一段提示 = 一条多行记录（续行 2 空格），不是三条独立记录
+        logger.info(
+            "[pending_install] pending torch reinstall detected: target=%s; "
+            "installing now\n"
+            "  press Ctrl+C to skip this run (the marker is kept and retried "
+            "on the next start)\n"
+            "  to skip permanently, delete the marker file: %s",
+            target, PENDING_MARKER,
+        )
         # 延迟 import：torch_setup -> onnxruntime_setup 链触发的副作用全留到此刻
         from . import torch as torch_setup  # noqa: PLC0415
         try:
             res = torch_setup.reinstall(target, stream=True)
         except KeyboardInterrupt:
-            logger.warning("用户中断 torch 重装，跳过。marker 保留，下次启动会重试。")
-            logger.warning("若希望永久跳过，删除 marker 文件：%s", PENDING_MARKER)
+            logger.warning(
+                "[pending_install] torch reinstall interrupted by user; the "
+                "marker is kept and retried on the next start\n"
+                "  to skip permanently, delete the marker file: %s",
+                PENDING_MARKER,
+            )
             return  # 不 clear_pending，下次启动继续尝试
         except RuntimeError as exc:
-            logger.error("torch 重装失败: %s", exc)
-            logger.error("marker 保留，下次启动会重试")
-            logger.error("若装包持续失败想永久跳过，删除 marker 文件：%s", PENDING_MARKER)
+            logger.exception(
+                "[pending_install] torch reinstall failed: %s\n"
+                "  the marker is kept and retried on the next start\n"
+                "  to skip permanently, delete the marker file: %s",
+                exc, PENDING_MARKER,
+            )
             return
-        logger.info("torch 重装完成: %s (%s)", res.get("version"), res.get("tag"))
+        logger.info(
+            "[pending_install] torch reinstall done: version=%s tag=%s",
+            res.get("version"), res.get("tag"),
+        )
     else:
-        logger.warning("未知 pending install kind %r，忽略并清除", kind)
+        logger.warning(
+            "[pending_install] unknown pending install kind %r; ignored and "
+            "cleared", kind,
+        )
 
     clear_pending()

--- a/studio/services/runtime/pending_install.py
+++ b/studio/services/runtime/pending_install.py
@@ -22,6 +22,8 @@ from typing import Any, Optional
 
 from ...paths import STUDIO_DATA
 
+from ...infrastructure.log_messages import msg
+
 logger = logging.getLogger(__name__)
 
 # studio_data/ 是 gitignore 的，跨重启保留
@@ -35,9 +37,7 @@ def register_torch_reinstall(target: str) -> None:
         json.dumps({"kind": "torch", "target": target}, ensure_ascii=False),
         encoding="utf-8",
     )
-    logger.info(
-        "[pending_install] torch reinstall registered: target=%s", target,
-    )
+    logger.info(msg("install.torch_reinstall_registered", target=target))
 
 
 def read_pending() -> Optional[dict[str, Any]]:
@@ -79,14 +79,9 @@ def apply_pending() -> None:
     if kind == "torch":
         target = pending.get("target", "auto")
         # 一段提示 = 一条多行记录（续行 2 空格），不是三条独立记录
-        logger.info(
-            "[pending_install] pending torch reinstall detected: target=%s; "
-            "installing now\n"
-            "  press Ctrl+C to skip this run (the marker is kept and retried "
-            "on the next start)\n"
-            "  to skip permanently, delete the marker file: %s",
-            target, PENDING_MARKER,
-        )
+        logger.info(msg(
+            "install.torch_reinstall_start", target=target, marker=PENDING_MARKER,
+        ))
         # 延迟 import：torch_setup -> onnxruntime_setup 链触发的副作用全留到此刻
         from . import torch as torch_setup  # noqa: PLC0415
         try:
@@ -107,10 +102,10 @@ def apply_pending() -> None:
                 exc, PENDING_MARKER,
             )
             return
-        logger.info(
-            "[pending_install] torch reinstall done: version=%s tag=%s",
-            res.get("version"), res.get("tag"),
-        )
+        logger.info(msg(
+            "install.torch_reinstall_done",
+            version=res.get("version"), tag=res.get("tag"),
+        ))
     else:
         logger.warning(
             "[pending_install] unknown pending install kind %r; ignored and "

--- a/studio/services/runtime/torch.py
+++ b/studio/services/runtime/torch.py
@@ -223,9 +223,14 @@ def _cleanup_zombie_dirs() -> list[str]:
                 entry.unlink()
             cleaned.append(entry.name)
         except OSError as exc:
-            logger.warning("[torch_setup] 清理僵尸目录 %s 失败: %s", entry, exc)
+            logger.warning(
+                "[torch_setup] removing the stale pip dir failed: path=%s err=%s",
+                entry, exc,
+            )
     if cleaned:
-        logger.info("[torch_setup] 清理 pip 僵尸目录: %s", ", ".join(cleaned))
+        logger.debug(
+            "[torch_setup] removed stale pip dir: %s", ", ".join(cleaned),
+        )
     return cleaned
 
 

--- a/studio/services/runtime/updater.py
+++ b/studio/services/runtime/updater.py
@@ -37,7 +37,8 @@ from typing import Any, Callable, Optional
 from ... import __version__
 from ...paths import REPO_ROOT, STUDIO_DATA
 
-from studio.infrastructure.task_log import TaskLogLike, TaskLog
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import TaskLogLike, TaskLog, as_task_log
 
 logger = logging.getLogger(__name__)
 
@@ -837,7 +838,7 @@ def _restore_preserved_files(
         log_lines.append(
             f"[preserve] 还原 {len(restored)} 个模型数据文件，更新不重下: {', '.join(restored)}"
         )
-        emit(f"[updater] 保留 {len(restored)} 个已下载模型文件，更新无需重下")
+        emit(msg("update.models_preserved", n=len(restored)))
 
 
 def _discard_preserved() -> None:
@@ -874,9 +875,13 @@ def apply_pending(emit: TaskLogLike = _DEFAULT_LOG) -> bool:
     if not has_pending():
         return False
 
+    # 对外仍接受历史的单参回调（旧 cli / 测试传 lambda）；内部按级别分派
+    emit = as_task_log(emit)
     target = UPDATE_PENDING.read_text(encoding="utf-8-sig").strip() or "origin/master"
     force = UPDATE_FORCE.exists()
-    emit(f"[updater] applying pending update → {target}{' (force)' if force else ''}")
+    emit(msg(
+        "update.applying", target=target, force=" (force)" if force else "",
+    ))
 
     started_at = time.time()
     cur = current_version()
@@ -918,18 +923,27 @@ def apply_pending(emit: TaskLogLike = _DEFAULT_LOG) -> bool:
     #    覆盖；下面的 git reset --hard 会丢弃这些本地改动，不可恢复）。
     if cur.is_dirty and not force:
         log_lines.append("[abort] working tree dirty")
-        emit("[updater] working tree dirty, aborting update")
+        emit.error(
+            "[updater] the working tree has uncommitted changes; the update was "
+            "aborted — commit or discard the changes, or run the update with force"
+        )
         return _done("aborted", "working tree dirty", cur.commit, False)
     if cur.is_dirty and force:
         log_lines.append("[force] working tree dirty; reset --hard 将覆盖本地未提交改动")
-        emit("[updater] working tree dirty but force requested, discarding local changes")
+        emit.warning(
+            "[updater] the working tree has uncommitted changes and force was "
+            "requested; all uncommitted local changes are being discarded"
+        )
 
     # 2. git fetch
     log_lines.append("[git] fetch origin")
     rc, _, stderr = _git("fetch", "origin", timeout=GIT_FETCH_TIMEOUT)
     if rc != 0:
         log_lines.append(f"[git fetch] FAILED rc={rc} stderr={stderr}")
-        emit(f"[updater] git fetch failed: {stderr[:200]}")
+        emit.error(
+            "[updater] git fetch failed: %s; the update was not applied and the "
+            "current version keeps running", stderr[:200],
+        )
         return _done("failed", f"git fetch: {stderr[:120]}", cur.commit, False)
 
     # 2.5 备份「早期误入库、后转 gitignore」的模型数据文件（hardcode 清单）：
@@ -942,7 +956,11 @@ def apply_pending(emit: TaskLogLike = _DEFAULT_LOG) -> bool:
     if rc != 0:
         _discard_preserved()  # reset 没成功，原文件没被动，丢弃备份即可
         log_lines.append(f"[git reset] FAILED rc={rc} stderr={stderr}")
-        emit(f"[updater] git reset failed: {stderr[:200]}")
+        emit.error(
+            "[updater] git reset failed: %s; preserved model files were already "
+            "restored but the working tree may be in a mixed state — run the "
+            "update again or fix the repository manually", stderr[:200],
+        )
         return _done("failed", f"git reset: {stderr[:120]}", cur.commit, False)
 
     # 3.5 还原被 reset 删掉的模型数据文件（见 _PRESERVE_ON_RESET）。
@@ -950,7 +968,7 @@ def apply_pending(emit: TaskLogLike = _DEFAULT_LOG) -> bool:
 
     new = current_version()
     log_lines.append(f"[ok] now at {new.commit_short} ({new.tag or new.branch})")
-    emit(f"[updater] git updated → {new.commit_short}")
+    emit(msg("update.git_updated", commit=new.commit_short))
 
     deps_changed = False
     deps_failed_reason = ""
@@ -959,7 +977,7 @@ def apply_pending(emit: TaskLogLike = _DEFAULT_LOG) -> bool:
     if _requirements_marker_stale():
         deps_changed = True
         log_lines.append("[pip] requirements.txt changed; pip install -r")
-        emit("[updater] requirements.txt changed, pip install (may take a few minutes)...")
+        emit(msg("update.pip_install"))
         rc = subprocess.call(
             [sys.executable, "-m", "pip", "install", "-r", str(REPO_ROOT / "requirements.txt")]
         )
@@ -974,12 +992,20 @@ def apply_pending(emit: TaskLogLike = _DEFAULT_LOG) -> bool:
                 ])
         else:
             deps_failed_reason = f"pip exit {rc}"
+            # :957 说了「要等几分钟」，之后无论成败都没有 emit —— 终端上是
+            # 一句省略号后的沉默；失败必须说一句（`_done("partial")` 只有
+            # UI banner 能看到）。
+            emit.warning(
+                "[updater] pip install failed (exit code %d); the code is updated "
+                "but Python dependencies may be incomplete — run the update again "
+                "or install requirements.txt manually", rc,
+            )
 
     # 5. package.json 改了 → npm install
     if _package_json_changed():
         deps_changed = True
         log_lines.append("[npm] package.json changed; npm install")
-        emit("[updater] studio/web/package.json changed, npm install...")
+        emit(msg("update.npm_install"))
         npm = shutil.which("npm") or shutil.which("npm.cmd")
         if npm:
             rc = subprocess.call([npm, "install"], cwd=str(REPO_ROOT / "studio" / "web"))
@@ -988,8 +1014,16 @@ def apply_pending(emit: TaskLogLike = _DEFAULT_LOG) -> bool:
                 deps_failed_reason = (
                     f"{deps_failed_reason + '; ' if deps_failed_reason else ''}npm exit {rc}"
                 )
+                emit.warning(
+                    "[updater] npm install failed (exit code %d); the code is "
+                    "updated but the frontend may fail to build", rc,
+                )
         else:
             log_lines.append("[npm] not found on PATH, skipping (cli.py bootstrap will retry)")
+            emit.warning(
+                "[updater] npm not found; the frontend was not rebuilt — install "
+                "Node.js 18+ and start again"
+            )
 
     if deps_failed_reason:
         log_lines.append(f"[partial] git ok 但 deps 失败: {deps_failed_reason}")
@@ -1076,7 +1110,9 @@ def _write_cache(result: UpdateCheckResult) -> None:
         tmp.write_text(json.dumps(asdict(result), indent=2), encoding="utf-8")
         tmp.replace(UPDATE_CACHE)
     except OSError as e:
-        logger.warning("failed to write update cache: %s", e)
+        logger.warning(
+            "write update cache failed: %s; the next check re-queries the remote", e,
+        )
 
 
 def _finalize(log_lines: list[str]) -> None:
@@ -1102,7 +1138,10 @@ def _write_status(status: UpdateStatus) -> None:
         tmp.write_text(json.dumps(asdict(status), indent=2), encoding="utf-8")
         tmp.replace(UPDATE_STATUS)
     except OSError as e:
-        logger.warning("failed to write .update_status: %s", e)
+        logger.warning(
+            "write .update_status failed: %s; the UI cannot show the result of "
+            "this update", e,
+        )
 
 
 def _requirements_marker_stale() -> bool:

--- a/studio/services/studio_data.py
+++ b/studio/services/studio_data.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from ..infrastructure.event_bus import bus
+from ..infrastructure.logging import log_file_vanished_during_migration
 from ..infrastructure.paths import DEFAULT_STUDIO_DATA, STUDIO_DATA, STUDIO_DATA_POINTER
 
 logger = logging.getLogger(__name__)
@@ -230,7 +231,7 @@ def _run_migration(src: Path, dst: Path, publish: Publish, pointer_file: Path) -
                     shutil.copy2(f, out)
             except FileNotFoundError:
                 # 扫描后被删（如临时文件）—— 跳过，进度可能停在 <100%，无碍
-                logger.info("迁移期间文件消失，跳过: %s", rel)
+                log_file_vanished_during_migration(logger, rel)
                 continue
             done_files += 1
             done_bytes += size
@@ -259,9 +260,12 @@ def _run_migration(src: Path, dst: Path, publish: Publish, pointer_file: Path) -
             "done_files": done_files,
             "done_bytes": done_bytes,
         })
-        logger.info("studio_data 迁移完成: %s → %s（%d 文件），重启后生效", src, dst, done_files)
+        logger.info(
+            "studio_data migrated: from=%s to=%s files=%d; effective after restart",
+            src, dst, done_files,
+        )
     except Exception as exc:
-        logger.exception("studio_data 迁移失败: %s → %s", src, dst)
+        logger.exception("studio_data migration failed: from=%s to=%s", src, dst)
         # dst 是 target/studio_data 落地目录，开始前为空 / 不存在
         # （validate_target 保证），整树清掉等于回到迁移前；用户的 target 父目录不动
         shutil.rmtree(dst, ignore_errors=True)

--- a/studio/services/system_stats.py
+++ b/studio/services/system_stats.py
@@ -42,7 +42,7 @@ def _ensure_nvml() -> bool:
             _nvml_state["ok"] = True
         except Exception as e:
             _nvml_state["ok"] = False
-            logger.info("pynvml unavailable; GPU stats disabled (%s)", e)
+            logger.info("pynvml unavailable; GPU stats disabled: %s", e)
         return _nvml_state["ok"]
 
 
@@ -80,7 +80,10 @@ def _torch_pci_bus_id() -> Optional[str]:
                         f"{domain:08X}:{bus:02X}:{device:02X}.0"
                     )
         except Exception:  # noqa: BLE001
-            logger.info("torch PCI bus id 查询失败；GPU active 标记停用")
+            logger.warning(
+                "torch PCI bus id lookup failed; the active-GPU marker is disabled "
+                "(on multi-GPU hosts the highlighted card may be wrong)"
+            )
         return _torch_pci_state["bus_id"]
 
 

--- a/studio/services/system_stats.py
+++ b/studio/services/system_stats.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import logging
 import threading
+import time
 from dataclasses import asdict, dataclass
 from typing import Any, Callable, Optional
 
@@ -140,11 +141,21 @@ class SystemStats:
 
 
 # ── 采集 ─────────────────────────────────────────────────────────────
+# 采集失败熔断状态（R8）：list 单元素当可变 cell 用（函数内免 global 声明）。
+_FUSE_LIMIT = 3
+_GPU_FAILS = [0]
+_GPU_DISABLED = [False]
+_PSUTIL_FAILS = [0]
+_PSUTIL_DISABLED = [False]
+
+
 def _bytes_to_gb(n: int) -> float:
     return round(n / (1024 ** 3), 2)
 
 
 def _collect_gpu() -> Optional[list[GpuStats]]:
+    if _GPU_DISABLED[0]:
+        return None
     if not _ensure_nvml():
         return None
     try:
@@ -172,13 +183,28 @@ def _collect_gpu() -> Optional[list[GpuStats]]:
                 temp_c=int(temp) if temp is not None else None,
                 active=(i == active_idx),
             ))
+        _GPU_FAILS[0] = 0
         return out
     except Exception:
-        logger.exception("gpu stats collection failed")
+        # 熔断（R8）：采样 2.5s 一 tick，NVML 坏死时逐条 exception 是
+        # ~1440 条带 traceback/小时，能吃穿 studio.log 配额。首次 WARNING
+        # 全文，连续 3 次后停止采集（重启进程恢复）——与 _ensure_nvml 的
+        # 一次性缓存失败模式同构。GPU 面板空了但 server 全功能正常。
+        _GPU_FAILS[0] += 1
+        if _GPU_FAILS[0] == 1:
+            logger.warning("gpu stats collection failed", exc_info=True)
+        elif _GPU_FAILS[0] >= _FUSE_LIMIT and not _GPU_DISABLED[0]:
+            _GPU_DISABLED[0] = True
+            logger.warning(
+                "gpu stats collection failed %d times in a row, sampling disabled "
+                "for this process (restart to recover)", _GPU_FAILS[0],
+            )
         return None
 
 
 def collect_stats() -> SystemStats:
+    if _PSUTIL_DISABLED[0]:
+        return SystemStats(cpu_pct=0.0, ram_used_gb=0.0, ram_total_gb=0.0, gpu=_collect_gpu())
     try:
         # interval=None: 返回自上次调用以来的 CPU 占用；首次调用返回 0.0，
         # 后续轮询拿到的就是 2-3s 平均值，对实时监控刚好。
@@ -186,8 +212,18 @@ def collect_stats() -> SystemStats:
         mem = psutil.virtual_memory()
         ram_used = _bytes_to_gb(mem.total - mem.available)
         ram_total = _bytes_to_gb(mem.total)
+        _PSUTIL_FAILS[0] = 0
     except Exception:
-        logger.exception("psutil stats collection failed")
+        # 熔断（R8）：同 _collect_gpu——psutil 挂掉是环境级问题，重试无意义
+        _PSUTIL_FAILS[0] += 1
+        if _PSUTIL_FAILS[0] == 1:
+            logger.warning("psutil stats collection failed", exc_info=True)
+        elif _PSUTIL_FAILS[0] >= _FUSE_LIMIT and not _PSUTIL_DISABLED[0]:
+            _PSUTIL_DISABLED[0] = True
+            logger.warning(
+                "psutil stats collection failed %d times in a row, reporting "
+                "zeros for this process (restart to recover)", _PSUTIL_FAILS[0],
+            )
         cpu = 0.0
         ram_used = 0.0
         ram_total = 0.0
@@ -243,10 +279,24 @@ class SystemStatsSampler:
             self._thread = None
 
     def _run(self) -> None:
+        # tick 兜底节流（R8）：首条 ERROR 全文（这层通常是 bus/序列化 bug），
+        # 之后每 60s 一条计数汇总；不熔断——下游可能恢复。
+        fail_count = 0
+        last_report = 0.0
         while not self._stop.is_set():
             try:
                 payload = stats_to_json(collect_stats())
                 self._on_sample(payload)
+                if fail_count:
+                    logger.info("system stats sampler recovered after %d failed tick(s)", fail_count)
+                    fail_count = 0
             except Exception:
-                logger.exception("system stats sampler tick failed")
+                fail_count += 1
+                now = time.monotonic()
+                if fail_count == 1:
+                    logger.exception("system stats sampler tick failed")
+                    last_report = now
+                elif now - last_report >= 60.0:
+                    logger.warning("system stats sampler still failing: %d tick(s) since last report", fail_count)
+                    last_report = now
             self._stop.wait(self._interval)

--- a/studio/services/tagging/llm.py
+++ b/studio/services/tagging/llm.py
@@ -529,8 +529,8 @@ class LLMTagger:
         if not needs_assist:
             if cfg.assist_tagger:
                 logger.warning(
-                    "LLM assist: assist_tagger=%s set but no {{tags}} placeholder in "
-                    "messages — assist is inert this run",
+                    "LLM assist: assist_tagger=%s is set but the prompt has no "
+                    "{{tags}} placeholder; assist does nothing this run",
                     cfg.assist_tagger,
                 )
             return {}
@@ -544,21 +544,41 @@ class LLMTagger:
         )
         out: dict[Path, str] = {}
         done = 0
+        failed = 0
+        first_error = ""
         total = len(image_paths)
+        last_progress = 0.0
         for result in assist.tag(image_paths):
             done += 1
             if result.get("error"):
-                logger.warning(
-                    "LLM assist: tagger failed on %s: %s",
-                    result.get("image"),
-                    result.get("error"),
-                )
+                failed += 1
+                # T6 节流：站点/模型挂掉时 1000 图 = 1000 条 —— 首条全文，
+                # 之后逐条 DEBUG，收尾一条计数汇总。
+                if failed == 1:
+                    first_error = str(result.get("error"))
+                    logger.warning(
+                        "LLM assist: tagger failed on %s: %s",
+                        result.get("image"), result.get("error"),
+                    )
+                else:
+                    logger.debug(
+                        "LLM assist: tagger failed on %s: %s",
+                        result.get("image"), result.get("error"),
+                    )
             else:
                 image = Path(result["image"])
                 out[image] = ", ".join(result.get("tags") or [])
-            # 每张一行，与 LLM 阶段 [progress] 的密度对齐——预打标是纯前置阶段，
-            # 任务进度条不动，日志是用户唯一能确认它在推进的地方。
-            logger.info("LLM assist: %d/%d pre-tagged", done, total)
+            # 预打标是纯前置阶段，任务进度条不动，日志是用户唯一能确认它在
+            # 推进的地方 —— 但不必每张一条：每 2s 或最后一张各记一次（R9）。
+            now = time.monotonic()
+            if done == total or now - last_progress >= 2.0:
+                last_progress = now
+                logger.info("LLM assist: %d/%d pre-tagged", done, total)
+        if failed:
+            logger.warning(
+                "LLM assist: pre-tagging failed for %d/%d images; first error: %s",
+                failed, total, first_error,
+            )
         return out
 
     def _tag_one(
@@ -637,13 +657,13 @@ class LLMTagger:
                 if rate_limiter is not None:
                     rate_limiter.wait()
                 started = time.monotonic()
-                logger.info(
-                    "LLM tagger POST %s model=%s endpoint=%s image=%s timeout=%ss",
+                logger.debug(
+                    "LLM tagger POST %s model=%s endpoint=%s image=%s timeout=%.1fs",
                     endpoint,
                     cfg.model,
                     cfg.endpoint,
                     image_path.name,
-                    cfg.timeout,
+                    float(cfg.timeout),
                 )
                 resp = self._session.post(
                     endpoint,
@@ -657,12 +677,12 @@ class LLMTagger:
                         f"HTTP {resp.status_code} after {elapsed_ms}ms at {endpoint}: {resp.text[:300]}"
                     )
                 content = _extract_llm_response_text(resp, endpoint=cfg.endpoint)
-                logger.info(
-                    "LLM tagger OK %s model=%s image=%s elapsed=%sms",
+                logger.debug(
+                    "LLM tagger ok %s model=%s image=%s elapsed=%d ms",
                     endpoint,
                     cfg.model,
                     image_path.name,
-                    elapsed_ms,
+                    int(elapsed_ms),
                 )
                 return content
             except Exception as exc:  # noqa: BLE001

--- a/studio/services/tagging/onnx_base.py
+++ b/studio/services/tagging/onnx_base.py
@@ -131,7 +131,8 @@ class OnnxTaggerBase:
                 raise
             err = str(exc)
             logger.warning(
-                "%s %s session 创建失败，降级 CPU 重试: %s", self.name, gpu_ep, err
+                "%s: creating the %s session failed; retrying on CPU: %s",
+                self.name, gpu_ep, err,
             )
             if gpu_ep == "CUDAExecutionProvider":
                 onnxruntime_setup.record_cuda_load_error(err)
@@ -150,7 +151,13 @@ class OnnxTaggerBase:
                         f"但 get_providers={actual}）。常见原因：驱动版本不够 / "
                         f"runtime so/DLL 缺失 / cuDNN ABI 错位 / DX12 不支持。"
                     )
-                    logger.warning("%s %s", self.name, msg)
+                    # 固定句式留在模板里（否则整句都在变量里，按文本 grep 不到）
+                    logger.warning(
+                        "%s: %s silently fell back to CPU (InferenceSession did "
+                        "not raise, get_providers=%s); common causes: driver too "
+                        "old, missing runtime DLL, cuDNN ABI mismatch, no DX12 "
+                        "support", self.name, gpu_ep, actual,
+                    )
                     if gpu_ep == "CUDAExecutionProvider":
                         onnxruntime_setup.record_cuda_load_error(msg)
                 elif gpu_ep == "CUDAExecutionProvider":
@@ -174,8 +181,9 @@ class OnnxTaggerBase:
         except ImportError:
             return False
         try:
-            logger.warning(
-                "%s CUDA 推理失败，降级 CPU InferenceSession（后续批次同样走 CPU）",
+            # 尝试行只记 DEBUG —— 这行跑在 try 的第一句，此刻还没降级成功
+            logger.debug(
+                "%s: CUDA inference failed; falling back to a CPU session",
                 self.name,
             )
             self._session = ort.InferenceSession(
@@ -186,9 +194,17 @@ class OnnxTaggerBase:
             onnxruntime_setup.record_cuda_load_error(
                 "CUDA 推理时发生 cuBLAS / CUDA 错误，已自动降级 CPU 运行"
             )
+            # 降级**成功之后**才是 WARNING，与下面的失败分支不再自相矛盾
+            logger.warning(
+                "%s: fell back to a CPU session; all later batches run on CPU "
+                "(slower)", self.name,
+            )
             return True
-        except Exception as exc:  # noqa: BLE001
-            logger.error("%s CPU session 降级失败: %s", self.name, exc)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "%s: the CPU session fallback failed; tagging cannot run",
+                self.name,
+            )
             return False
 
     @staticmethod

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -27,6 +27,7 @@ import logging
 import os
 import signal
 import subprocess
+import sys
 import threading
 import time
 from pathlib import Path
@@ -71,6 +72,47 @@ from .process import _kill_process_tree
 from .slot import SLOT_DATA, SLOT_TRAIN, _Slot
 
 logger = logging.getLogger(__name__)
+
+
+class _ErrorThrottle:
+    """轮询站点错误节流（R8）：首条全文 exception，之后同异常类型 60s 一条
+    计数 WARNING，异常类型变化重新全文记一次，恢复时一条 INFO。
+
+    supervisor 的 _poll=1.0s，持续故障下逐条 exception 是 3600 条带
+    traceback/小时 × 站点数，会吃穿 studio.log 配额并把诊断包冲成噪音。
+    """
+
+    def __init__(self, site: str, window: float = 60.0) -> None:
+        self._site = site
+        self._window = window
+        self._count = 0
+        self._last_type: Optional[str] = None
+        self._last_report = 0.0
+
+    def failed(self) -> None:
+        exc = sys.exc_info()[1]
+        exc_type = type(exc).__name__ if exc is not None else "?"
+        now = time.monotonic()
+        self._count += 1
+        if exc_type != self._last_type:
+            self._last_type = exc_type
+            self._last_report = now
+            logger.exception("%s failed", self._site)
+        elif now - self._last_report >= self._window:
+            self._last_report = now
+            logger.warning(
+                "%s still failing: count=%d err=%s",
+                self._site, self._count, exc_type,
+            )
+
+    def recovered(self) -> None:
+        if self._count:
+            logger.info(
+                "%s recovered after %d failures", self._site, self._count,
+            )
+            self._count = 0
+            self._last_type = None
+
 
 
 _ERROR_MSG_TAIL_BYTES = 256 * 1024
@@ -159,6 +201,11 @@ class Supervisor:
         terminate_grace: Optional[float] = None,
     ) -> None:
         self._on_event: EventCallback = on_event or (lambda _evt: None)
+        # 轮询站点错误节流（R8），各站点独立计数
+        self._tick_throttle = _ErrorThrottle("supervisor tick")
+        self._promote_throttle = _ErrorThrottle("promote_due_scheduled")
+        self._queue_held_throttle = _ErrorThrottle("read queue_held")
+        self._unload_throttle = _ErrorThrottle("daemon unload request")
         self._cmd_builder: CmdBuilder = cmd_builder or _default_cmd_builder
         self._job_cmd_builder: JobCmdBuilder = (
             job_cmd_builder or _default_job_cmd_builder
@@ -357,8 +404,9 @@ class Supervisor:
         while not self._stop.is_set():
             try:
                 self._tick()
+                self._tick_throttle.recovered()
             except Exception:
-                logger.exception("supervisor tick failed")
+                self._tick_throttle.failed()
             self._stop.wait(self._poll)
 
     def _reconcile_orphans(self) -> None:
@@ -417,8 +465,9 @@ class Supervisor:
         try:
             with db.connection_for(self._db_path) as conn:
                 promoted = db.promote_due_scheduled(conn)
+            self._promote_throttle.recovered()
         except Exception:
-            logger.exception("promote_due_scheduled failed")
+            self._promote_throttle.failed()
             return
         for tid in promoted:
             logger.info("scheduled task %d due → pending", tid)
@@ -523,9 +572,11 @@ class Supervisor:
         """ADR §3.2 queue hold 开关，跨 supervisor 重启保留（db kv）。"""
         try:
             with db.connection_for(self._db_path) as conn:
-                return db.get_queue_held(conn)
+                held = db.get_queue_held(conn)
+            self._queue_held_throttle.recovered()
+            return held
         except Exception:
-            logger.exception("failed to read queue_held")
+            self._queue_held_throttle.failed()
             return False  # 读失败默认放行，安全降级
 
     def _maybe_yield_daemon(self) -> bool:
@@ -550,8 +601,9 @@ class Supervisor:
         try:
             daemon.request_unload()
             logger.info("requested daemon unload to yield GPU")
+            self._unload_throttle.recovered()
         except Exception:
-            logger.exception("daemon unload request failed")
+            self._unload_throttle.failed()
         return True
 
     def _dispatch_data(self, slot: _Slot) -> None:
@@ -1185,13 +1237,28 @@ class Supervisor:
         with self._daemon_lock:
             tid = self._daemon_active_task_id
             fp = self._daemon_log_fp
-            if tid is not None and fp is not None and isinstance(line, str):
-                try:
-                    fp.write((line + "\n").encode("utf-8", errors="replace"))
-                    fp.flush()
-                    end_offset = fp.tell()
-                except Exception:
-                    logger.exception("write daemon task log failed")
+            if tid is not None and isinstance(line, str):
+                if fp is not None:
+                    try:
+                        fp.write((line + "\n").encode("utf-8", errors="replace"))
+                        fp.flush()
+                        end_offset = fp.tell()
+                    except Exception:
+                        # 自我放大回路摘除（R8）：本分支处在**每一行 daemon 日志**
+                        # 的路径上，写失败一次就关闭句柄置 None——后续行零日志、
+                        # SSE 广播继续（end_offset=None，前端已兼容）。这条失败
+                        # 记录走 logger（studio.log），与失败目标（run.log 句柄）
+                        # 是不同通道；绝不能改成写 run.log，否则是死循环。
+                        logger.warning(
+                            "write daemon task log failed: task_id=%s; run.log "
+                            "for this task is closed, the SSE log stream "
+                            "continues", tid, exc_info=True,
+                        )
+                        try:
+                            fp.close()
+                        except Exception:
+                            pass
+                        self._daemon_log_fp = None
             else:
                 tid = None
         if tid is not None and isinstance(line, str):

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -39,6 +39,7 @@ from ..services.runtime import xformers as _xformers_svc
 from ..services.projects import jobs as project_jobs
 from ..infrastructure.log_tail import LogTailer, MonitorStatePoller, clean_log_line
 from ..infrastructure.logging import LOG_LEVEL_ENV, LOG_LINE_RE
+from ..infrastructure.log_messages import UI_LANG_ENV
 from ..paths import (
     LOGS_DIR,
     REPO_ROOT,
@@ -1426,6 +1427,11 @@ class Supervisor:
         # 起默认关）。runtime 侧 env 缺省=开（CLI 直跑的安全兜底），只有
         # 关闭时才需要显式传；训练与正则 AI 子进程读它，generate daemon
         # 走自己的 cfg.ram_guard 不受影响。
+        # 子进程日志语言（Q1 i18n 字典口径）：INFO 叙事行按 UI 语言输出
+        try:
+            env.setdefault(UI_LANG_ENV, str(_secrets.load().system.ui_language))
+        except Exception:
+            pass
         try:
             if not _secrets.load().training.ram_guard:
                 env.setdefault("LORA_RAM_GUARD", "0")

--- a/studio/supervisor/core.py
+++ b/studio/supervisor/core.py
@@ -181,7 +181,10 @@ def _tail_log_for_error_msg(log_path: Path, max_lines: int = 12, max_chars: int 
             out = "..." + out[-(max_chars - 3):]
         return out
     except Exception:
-        logger.exception("tail log %s failed", log_path)
+        logger.warning(
+            "tail run log failed: path=%s; error_msg stays empty for this task",
+            log_path, exc_info=True,
+        )
         return ""
 
 
@@ -207,6 +210,8 @@ class Supervisor:
         self._promote_throttle = _ErrorThrottle("promote_due_scheduled")
         self._queue_held_throttle = _ErrorThrottle("read queue_held")
         self._unload_throttle = _ErrorThrottle("daemon unload request")
+        # 启动对账走到哪一步（reconcile 失败时进日志，见 _reconcile_orphans）
+        self._reconcile_stage = "init"
         self._cmd_builder: CmdBuilder = cmd_builder or _default_cmd_builder
         self._job_cmd_builder: JobCmdBuilder = (
             job_cmd_builder or _default_job_cmd_builder
@@ -259,7 +264,10 @@ class Supervisor:
         try:
             get_daemon().stop(timeout=timeout)
         except Exception:
-            logger.exception("inference daemon stop failed")
+            logger.warning(
+                "inference daemon stop failed during shutdown; the supervisor "
+                "exits anyway", exc_info=True,
+            )
         if self._thread:
             self._thread.join(timeout=timeout)
 
@@ -325,7 +333,10 @@ class Supervisor:
             if is_daemon_task:
                 if get_daemon().cancel_active_task(task_id):
                     return True
-                logger.warning("daemon cancel request missed; task_id=%s", task_id)
+                logger.warning(
+                    "daemon cancel request missed: task_id=%s; the task may keep "
+                    "running", task_id,
+                )
             return True
         return False
 
@@ -401,7 +412,10 @@ class Supervisor:
         try:
             self._reconcile_orphans()
         except Exception:
-            logger.exception("reconcile failed")
+            logger.exception(
+                "startup reconcile failed: stage=%s; orphan tasks may stay in the "
+                "running state until the next restart", self._reconcile_stage,
+            )
         while not self._stop.is_set():
             try:
                 self._tick()
@@ -414,9 +428,13 @@ class Supervisor:
         # ADR 0006 PR-2 兼容性 note：此处 list_tasks(status="running") 精确按
         # status 过滤，paused task（status='paused'）天然不进 this loop —
         # 跨 supervisor 重启的 paused task 保持状态不变（ADR §8.4）。
+        # 失败时上面那条 startup reconcile 行要说清卡在哪一步（G 清单「就近来源 —」）
+        self._reconcile_stage = "tasks"
+        orphan_tasks = 0
         with db.connection_for(self._db_path) as conn:
             for t in db.list_tasks(conn, status="running"):
-                logger.info("orphan running task %d → failed", t["id"])
+                orphan_tasks += 1
+                logger.debug("orphan running task marked failed: task_id=%d", t["id"])
                 db.update_task(
                     conn,
                     t["id"],
@@ -432,9 +450,16 @@ class Supervisor:
                         "status": "failed",
                     }
                 )
+            self._reconcile_stage = "jobs"
             n = project_jobs.cleanup_orphan_running(conn)
-            if n:
-                logger.info("orphan running jobs → failed: %d", n)
+        # 上次进程没干净退出的证据 —— 任务与作业合成一条，不再逐个孤儿刷屏
+        if orphan_tasks or n:
+            logger.warning(
+                "orphan running tasks and jobs marked failed on startup: "
+                "tasks=%d jobs=%d (the previous process did not exit cleanly)",
+                orphan_tasks, n,
+            )
+        self._reconcile_stage = "done"
 
     def _tick(self) -> None:
         # 0) 0.17 P-B：到点的 scheduled task 提升为 pending，让下面的 dispatch
@@ -471,7 +496,7 @@ class Supervisor:
             self._promote_throttle.failed()
             return
         for tid in promoted:
-            logger.info("scheduled task %d due → pending", tid)
+            logger.info("scheduled task due: task_id=%d → pending", tid)
             self._on_event(
                 {"type": "task_state_changed", "task_id": tid, "status": "pending"}
             )
@@ -601,7 +626,7 @@ class Supervisor:
             return True
         try:
             daemon.request_unload()
-            logger.info("requested daemon unload to yield GPU")
+            logger.debug("requested daemon unload to yield GPU")
             self._unload_throttle.recovered()
         except Exception:
             self._unload_throttle.failed()
@@ -736,7 +761,8 @@ class Supervisor:
                 }
             )
             logger.info(
-                "started task %d on slot=%s (pid=%d)", task["id"], slot.name, proc.pid
+                "started task: task_id=%d slot=%s pid=%d",
+                task["id"], slot.name, proc.pid,
             )
         finally:
             reset_trace_id(_trace_token)
@@ -762,7 +788,10 @@ class Supervisor:
             with db.connection_for(self._db_path) as conn:
                 summary = eval_validation.split_for_task(conn, task, cfg_path)
         except Exception:
-            logger.exception("validation split failed for task=%s", task.get("id"))
+            logger.warning(
+                "validation split failed: task_id=%s; training continues without "
+                "a validation set", task.get("id"), exc_info=True,
+            )
             return
         if summary and summary.get("moved"):
             try:
@@ -811,8 +840,9 @@ class Supervisor:
             from ..services import task_snapshot
             task_snapshot.freeze_config(task_id, cfg_path)
         except Exception:
-            logger.exception(
-                "task %s config snapshot freeze failed (non-fatal)", task_id
+            logger.warning(
+                "config snapshot freeze failed: task_id=%s; the task runs against "
+                "the live config", task_id, exc_info=True,
             )
 
     def _make_task_log_callback(
@@ -833,7 +863,10 @@ class Supervisor:
                     # B-4.4: malformed event 静默丢导致 UI pause_state 永远收不到
                     # → 暂停按钮永远灰。logger.exception 进 studio.log；
                     # SSE event_malformed 让前端可见（不阻断 task）。
-                    logger.exception("malformed event marker: %r", line[:200])
+                    logger.warning(
+                        "malformed event marker on the task stream: "
+                        "task_id=%s raw=%r", tid, line[:200], exc_info=True,
+                    )
                     self._on_event({
                         "type": "event_malformed",
                         "task_id": tid,
@@ -893,7 +926,10 @@ class Supervisor:
                     return
                 session = eval_auto.queue_training_finished_eval(conn, task, payload)
         except Exception:
-            logger.exception("after-training auto eval enqueue failed for task=%s", tid)
+            logger.warning(
+                "after-training auto eval enqueue failed: task_id=%s; training "
+                "finished and was saved, no evaluation was queued", tid, exc_info=True,
+            )
             return
         if not session:
             return
@@ -950,9 +986,9 @@ class Supervisor:
                         status=_versions.VersionStatus.TRAINING,
                     )
                 except Exception:
-                    logger.exception(
-                        "version.status=training write failed for task %s",
-                        task["id"],
+                    logger.warning(
+                        "version status write failed: task_id=%s; the status is "
+                        "corrected on the next read", task["id"], exc_info=True,
                     )
 
     def _spawn_job(self, slot: _Slot, job: dict[str, Any]) -> None:
@@ -1007,7 +1043,7 @@ class Supervisor:
             "status": "running",
         })
         logger.info(
-            "started job %d on slot=%s (kind=%s, pid=%d)",
+            "started job: job_id=%d slot=%s kind=%s pid=%d",
             jid, slot.name, kind, proc.pid,
         )
 
@@ -1033,7 +1069,11 @@ class Supervisor:
                 except Exception:
                     # 与 task 路径对齐（B-4.4 之前只落了一半）：进 studio.log +
                     # SSE event_malformed 让前端可见
-                    logger.exception("malformed event marker: %r", line[:200])
+                    logger.warning(
+                        "malformed event marker on the job stream: "
+                        "job_id=%s project_id=%s raw=%r",
+                        jid, pid_, line[:200], exc_info=True,
+                    )
                     self._on_event({
                         "type": "event_malformed",
                         "job_id": jid,
@@ -1103,7 +1143,10 @@ class Supervisor:
             try:
                 daemon.start()
             except Exception as e:
-                logger.exception("daemon start failed")
+                logger.exception(
+                    "inference daemon start failed: task_id=%s; the task is "
+                    "marked failed", task_id,
+                )
                 self._fail_daemon_task(task_id, f"daemon start failed: {e}")
                 return
 
@@ -1121,12 +1164,17 @@ class Supervisor:
             self._daemon_cancel_pending = False
             # 0.17 item1：开该 generate task 的 run.log（LogTab 读 /api/logs →
             # tasks/<id>/run.log）。daemon 串行跑一个，其间的日志都归这个 task。
+            lp = None
             try:
                 lp = task_log_path(task_id)
                 lp.parent.mkdir(parents=True, exist_ok=True)
                 self._daemon_log_fp = open(lp, "ab")
             except Exception:
-                logger.exception("open daemon task log failed")
+                logger.warning(
+                    "open daemon task log failed: task_id=%s path=%s; this task "
+                    "has no run.log, generation continues",
+                    task_id, lp, exc_info=True,
+                )
                 self._daemon_log_fp = None
 
         # poller：daemon 写 monitor_state.json → SSE monitor_progress (增量协议)
@@ -1161,10 +1209,12 @@ class Supervisor:
                 output_dir=output_dir,
                 on_event=self._on_daemon_task_event,
             )
-            logger.info("submitted generate task %d to daemon", task_id)
+            logger.info("submitted generate task to daemon: task_id=%d", task_id)
             self._emit_daemon_state()
         except Exception as e:
-            logger.exception("daemon submit failed")
+            logger.exception(
+                "daemon submit failed: task_id=%s; the task is marked failed", task_id,
+            )
             self._on_daemon_task_event({
                 "kind": "error",
                 "task_id": task_id,
@@ -1306,7 +1356,10 @@ class Supervisor:
                 "active_task_id": active_tid,
             })
         except Exception:
-            logger.exception("emit daemon state failed")
+            logger.warning(
+                "emit daemon state failed; the next state change re-publishes it",
+                exc_info=True,
+            )
 
     def _finalize_daemon_task(
         self,
@@ -1352,18 +1405,32 @@ class Supervisor:
         with db.connection_for(self._db_path) as conn:
             db.update_task(conn, task_id, **fields)
 
+        # 落盘失败节流（T6）的收尾汇总：逐图 DEBUG 之后在这里给一条计数 WARNING
         try:
-            from ..services.inference.core import cleanup_generate_tempdir
+            from ..services.generate_storage import flush_disk_store_summary
+            flush_disk_store_summary(task_id)
+        except Exception:  # noqa: BLE001 — 收尾日志不能反过来把收尾流程炸掉
+            pass
+
+        try:
+            from ..services.inference.core import cleanup_generate_tempdir, generate_tempdir
             cleanup_generate_tempdir(task_id)
-        except Exception as e:
-            logger.warning("cleanup generate tempdir failed: %s", e)
+        except Exception:
+            try:
+                _tmpdir: Any = generate_tempdir(task_id)
+            except Exception:
+                _tmpdir = None
+            logger.warning(
+                "cleanup generate tempdir failed: task_id=%s path=%s",
+                task_id, _tmpdir, exc_info=True,
+            )
 
         self._on_event({
             "type": "task_state_changed",
             "task_id": task_id,
             "status": status,
         })
-        logger.info("daemon task %d finished: %s", task_id, status)
+        logger.info("daemon task finished: task_id=%d status=%s", task_id, status)
 
     def _fail_daemon_task(self, task_id: int, msg: str) -> None:
         """generate task 在派给 daemon 之前的失败（config 缺失等）。"""
@@ -1436,7 +1503,10 @@ class Supervisor:
             if not _secrets.load().training.ram_guard:
                 env.setdefault("LORA_RAM_GUARD", "0")
         except Exception:
-            logger.exception("failed to load training ram_guard setting")
+            logger.warning(
+                "read training ram_guard setting failed; using the default",
+                exc_info=True,
+            )
         try:
             wandb_cfg = _secrets.load().wandb
             if wandb_cfg.enabled:
@@ -1462,7 +1532,10 @@ class Supervisor:
                 if wb.base_url:
                     env.setdefault("WANDB_BASE_URL", wb.base_url)
         except Exception:
-            logger.exception("failed to load wandb settings")
+            logger.warning(
+                "read wandb settings failed; this run reports nothing to wandb",
+                exc_info=True,
+            )
         if extra_env:
             env.update(extra_env)
         return subprocess.Popen(
@@ -1543,7 +1616,7 @@ class Supervisor:
             self._on_event(
                 {"type": "task_state_changed", "task_id": cid, "status": status}
             )
-            logger.info("task %d finished: %s (rc=%d)", cid, status, rc)
+            logger.info("task finished: task_id=%d status=%s rc=%d", cid, status, rc)
             if status == "done" and slot.eval_training_finished_payload is not None:
                 self._queue_auto_eval_after_training(
                     cid,
@@ -1570,7 +1643,7 @@ class Supervisor:
                 "kind": job["kind"] if job else None,
                 "status": status,
             })
-            logger.info("job %d finished: %s (rc=%d)", cid, status, rc)
+            logger.info("job finished: job_id=%d status=%s rc=%d", cid, status, rc)
 
         slot.reset()
 
@@ -1589,8 +1662,9 @@ class Supervisor:
             proc.wait(timeout=self._grace)
         except subprocess.TimeoutExpired:
             logger.warning(
-                "%s %s on slot=%s did not exit in %.0fs, killing process tree",
-                slot.kind, slot.id, slot.name, self._grace,
+                "%s did not exit in %.1fs; killing process tree: "
+                "%s_id=%s slot=%s pid=%d",
+                slot.kind, self._grace, slot.kind, slot.id, slot.name, proc.pid,
             )
             _kill_process_tree(proc.pid)
             try:
@@ -1622,8 +1696,8 @@ class Supervisor:
                 time.sleep(0.5)
             if proc.poll() is None:
                 logger.warning(
-                    "proc %d did not exit in %.0fs, killing process tree",
-                    proc.pid, grace,
+                    "process did not exit in %.1fs; killing process tree: pid=%d",
+                    grace, proc.pid,
                 )
                 _kill_process_tree(proc.pid)
 
@@ -1650,10 +1724,15 @@ class Supervisor:
             else:
                 proc.terminate()
         except Exception:
-            logger.exception("send terminate signal failed")
+            logger.warning(
+                "send terminate signal failed: pid=%d; falling back to force kill",
+                proc.pid, exc_info=True,
+            )
 
     @staticmethod
-    def _send_pause_signal(proc: subprocess.Popen) -> None:
+    def _send_pause_signal(
+        proc: subprocess.Popen, task_id: Optional[int] = None,
+    ) -> None:
         """Pause 软信号 — 子进程 handle_interrupt 接住保 state。
 
         Windows：`CTRL_BREAK_EVENT` 送达 CREATE_NEW_PROCESS_GROUP 子进程组，
@@ -1668,7 +1747,10 @@ class Supervisor:
             else:
                 proc.send_signal(signal.SIGINT)
         except Exception:
-            logger.exception("send pause signal failed")
+            logger.warning(
+                "send pause signal failed: pid=%d task_id=%s; the task keeps running",
+                proc.pid, task_id, exc_info=True,
+            )
 
     def _signal_pause_async(self, slot: _Slot) -> None:
         """非阻塞：发暂停信号，不带 grace 强杀。
@@ -1681,7 +1763,7 @@ class Supervisor:
         if not slot.proc:
             return
         slot.pause_pending = True
-        self._send_pause_signal(slot.proc)
+        self._send_pause_signal(slot.proc, slot.id)
 
     def _persist_last_state(self, task_id: int, payload: dict[str, Any]) -> None:
         """把 auto_epoch_backup_written 的恢复点信息写进 tasks 行（ADR Addendum 2）。
@@ -1702,7 +1784,10 @@ class Supervisor:
                     last_state_step=payload.get("step"),
                 )
         except Exception:
-            logger.exception("task %s last_state persist failed", task_id)
+            logger.warning(
+                "resume state persist failed: task_id=%s; this task cannot be "
+                "resumed later", task_id, exc_info=True,
+            )
 
     def _clear_pause_fields(self, task_id: int) -> None:
         """清 db `paused_*` 字段（ADR §5.5 / Addendum 2 修订）。

--- a/studio/supervisor/process.py
+++ b/studio/supervisor/process.py
@@ -28,7 +28,10 @@ def _kill_process_tree_psutil(pid: int) -> None:
     except psutil.NoSuchProcess:
         return
     except Exception:
-        logger.exception("psutil enumerate process tree failed for pid %d", pid)
+        logger.warning(
+            "psutil enumerate process tree failed: pid=%d; falling back to "
+            "taskkill/killpg", pid, exc_info=True,
+        )
         descendants = []
         try:
             root = psutil.Process(pid)
@@ -41,13 +44,18 @@ def _kill_process_tree_psutil(pid: int) -> None:
         except psutil.NoSuchProcess:
             pass
         except Exception:
-            logger.exception("psutil kill failed for child pid %d", proc.pid)
+            logger.warning(
+                "psutil kill failed: child_pid=%d; the root process is still killed",
+                proc.pid, exc_info=True,
+            )
     try:
         root.kill()
     except psutil.NoSuchProcess:
         pass
     except Exception:
-        logger.exception("psutil kill failed for root pid %d", pid)
+        logger.exception(
+            "psutil kill failed: root_pid=%d; the process may stay alive", pid,
+        )
 
 
 def _kill_process_tree_windows(pid: int) -> None:
@@ -63,11 +71,13 @@ def _kill_process_tree_windows(pid: int) -> None:
             errors="replace"
         ).strip()
         logger.warning(
-            "taskkill failed for pid %d (rc=%d): %s; falling back to psutil",
+            "taskkill failed: pid=%d rc=%d err=%s; falling back to psutil",
             pid, result.returncode, detail or "no output",
         )
     except Exception:
-        logger.exception("taskkill /T /F failed for pid %d", pid)
+        logger.warning(
+            "taskkill /T /F failed: pid=%d; falling back to psutil", pid, exc_info=True,
+        )
     _kill_process_tree_psutil(pid)
 
 
@@ -84,4 +94,6 @@ def _kill_process_tree(pid: int) -> None:
         try:
             os.killpg(os.getpgid(pid), signal.SIGKILL)
         except Exception:
-            logger.exception("killpg failed for pid %d", pid)
+            logger.exception(
+                "killpg failed: pid=%d; the process group may stay alive", pid,
+            )

--- a/studio/web/src/api/client.ts
+++ b/studio/web/src/api/client.ts
@@ -640,6 +640,9 @@ export interface SystemPrefsConfig {
   /** 计算显卡（多卡机器，#491）：NVML/nvidia-smi 的 PCI 序号；null = 未设置
    *  （CUDA 自选，快卡优先）。启动期注入 CUDA env，重启生效。 */
   gpu_index?: number | null
+  /** UI 语言（zh/en）。前端显示语言以 localStorage 为准；本字段是**子进程
+   *  日志语言**的注入源（ANIMA_UI_LANG），切语言时 fire-and-forget 同步。 */
+  ui_language?: string
   /** 日志视图默认是否显示 DEBUG 行（logging-target-state D1）。只管显示默认值：
    *  run.log 恒记 DEBUG，每个 LogView 的「调试」开关以此为初值、不持久化。 */
   log_debug_default?: boolean

--- a/studio/web/src/components/FirstRunLangModal.tsx
+++ b/studio/web/src/components/FirstRunLangModal.tsx
@@ -4,6 +4,7 @@
 // 无法预览要选的语言长什么样）。
 import { useEffect, useRef, useState } from 'react'
 import { ONBOARDING_EVENTS } from './FirstRunOnboardingModal'
+import { api } from '../api/client'
 import i18n, { getStoredLang, setStoredLang } from '../i18n'
 
 type Lang = 'en' | 'zh'
@@ -37,6 +38,8 @@ export function FirstRunLangModal() {
   const handlePick = (lang: Lang) => {
     setStoredLang(lang)
     void i18n.changeLanguage(lang)
+    // 同步后端 secrets.system.ui_language：子进程日志语言的注入源
+    void api.updateSecrets({ system: { ui_language: lang } }).catch(() => {})
     setOpen(false)
     // 通知 OnboardingModal: lang 已设好,可以接力弹引导。
     window.dispatchEvent(new Event(ONBOARDING_EVENTS.langSet))

--- a/studio/web/src/components/LogView.test.tsx
+++ b/studio/web/src/components/LogView.test.tsx
@@ -18,11 +18,10 @@ beforeEach(() => {
 })
 
 describe('LogView', () => {
-  it('按级别着色，默认（全局关）隐藏 DEBUG 行并提示条数；视图开关临时打开', async () => {
+  it('按级别着色，默认（全局关）隐藏 DEBUG 行；视图开关临时打开', async () => {
     mockGlobalDefault(false)
     render(<LogView lines={[H('DEBUG', 'training.loop', 'dbg-line'), H('INFO', 'training.loop', 'info-line'), H('WARNING', 'utils.x', 'warn-line'), H('ERROR', 'a.b', 'err-line'), 'Traceback (most recent call last):']} />)
-    await waitFor(() => expect(screen.getByText(/已隐藏 1 条调试行/)).toBeInTheDocument())
-    expect(screen.queryByText('dbg-line')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.queryByText('dbg-line')).not.toBeInTheDocument())
     expect(screen.getByText('err-line')).toHaveClass('text-err')
     expect(screen.getByText('warn-line')).toHaveClass('text-warn')
     // 续行继承 ERROR 且缩进

--- a/studio/web/src/components/LogView.tsx
+++ b/studio/web/src/components/LogView.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 
 import { isLineVisible, levelClass, parseLogLines, type LogLine } from '../lib/logLines'
@@ -25,6 +26,12 @@ export interface LogViewProps {
   toolbar?: boolean
   /** 工具栏右侧额外按钮（如 daemon 抽屉的「清屏」） */
   extraActions?: ReactNode
+  /** 工具栏外置：portal 到父级容器（抽屉把它并进自己的 header 行，避免
+   *  「抽屉 header + 工具栏行」两层）。非空时内联位置不再渲染工具栏。 */
+  toolbarContainer?: HTMLElement | null
+  /** 无边框模式：内容区去掉自带的 bg/border/rounded（背景由父级抽屉提供），
+   *  抽屉场景避免面板里再包一层框。 */
+  frameless?: boolean
   /** 没有任何行时的占位文案；缺省按 status 选 */
   emptyText?: string
   /** 容器 class（高度由父级给：flex-1 min-h-0 或固定 h-*） */
@@ -94,6 +101,8 @@ export default function LogView({
   downloadUrl = null,
   toolbar = true,
   extraActions,
+  toolbarContainer = null,
+  frameless = false,
   emptyText,
   className = '',
   maxRender,
@@ -157,48 +166,54 @@ export default function LogView({
       : status === 'waiting' || status === 'live' ? t('logView.waiting')
         : t('logView.empty'))
 
+  // 外置（portal 进抽屉 header）时不带底部间距；内联时保持原布局
+  const toolbarContent = toolbar ? (
+    <div
+      className={`flex items-center gap-3 text-xs shrink-0 flex-wrap ${toolbarContainer ? '' : 'pb-2'}`}
+      data-testid="log-view-toolbar"
+    >
+      <label className="text-fg-tertiary flex items-center gap-1.5 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={showDebug}
+          onChange={(e) => { touchedRef.current = true; setShowDebug(e.target.checked) }}
+          style={{ width: 14, height: 14, accentColor: 'var(--accent)' }}
+        />
+        {t('logView.debug')}
+        {!showDebug && hiddenDebug > 0 && (
+          <span className="text-fg-tertiary">（{t('logView.hiddenDebug', { n: hiddenDebug })}）</span>
+        )}
+      </label>
+      <label className="text-fg-tertiary flex items-center gap-1.5 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={autoScroll}
+          onChange={(e) => setAutoScroll(e.target.checked)}
+          style={{ width: 14, height: 14, accentColor: 'var(--accent)' }}
+        />
+        {t('logView.autoScroll')}
+      </label>
+      {!toolbarContainer && <span className="flex-1" />}
+      {extraActions}
+      <button type="button" className="btn btn-ghost btn-sm" onClick={() => void handleCopy()} disabled={visible.length === 0}>
+        {t('logView.copy')}
+      </button>
+      {downloadUrl && (
+        <a className="btn btn-ghost btn-sm" href={downloadUrl} download>
+          {t('logView.download')}
+        </a>
+      )}
+      {onRefresh && (
+        <button type="button" className="btn btn-ghost btn-sm" onClick={onRefresh}>
+          {t('common.refresh')}
+        </button>
+      )}
+    </div>
+  ) : null
+
   return (
     <div className={`flex flex-col min-h-0 ${className}`} data-testid="log-view">
-      {toolbar && (
-        <div className="flex items-center gap-3 text-xs pb-2 shrink-0 flex-wrap">
-          <label className="text-fg-tertiary flex items-center gap-1.5 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={showDebug}
-              onChange={(e) => { touchedRef.current = true; setShowDebug(e.target.checked) }}
-              style={{ width: 14, height: 14, accentColor: 'var(--accent)' }}
-            />
-            {t('logView.debug')}
-            {!showDebug && hiddenDebug > 0 && (
-              <span className="text-fg-tertiary">（{t('logView.hiddenDebug', { n: hiddenDebug })}）</span>
-            )}
-          </label>
-          <label className="text-fg-tertiary flex items-center gap-1.5 cursor-pointer">
-            <input
-              type="checkbox"
-              checked={autoScroll}
-              onChange={(e) => setAutoScroll(e.target.checked)}
-              style={{ width: 14, height: 14, accentColor: 'var(--accent)' }}
-            />
-            {t('logView.autoScroll')}
-          </label>
-          <span className="flex-1" />
-          {extraActions}
-          <button type="button" className="btn btn-ghost btn-sm" onClick={() => void handleCopy()} disabled={visible.length === 0}>
-            {t('logView.copy')}
-          </button>
-          {downloadUrl && (
-            <a className="btn btn-ghost btn-sm" href={downloadUrl} download>
-              {t('logView.download')}
-            </a>
-          )}
-          {onRefresh && (
-            <button type="button" className="btn btn-ghost btn-sm" onClick={onRefresh}>
-              {t('common.refresh')}
-            </button>
-          )}
-        </div>
-      )}
+      {toolbarContainer ? createPortal(toolbarContent, toolbarContainer) : toolbarContent}
       {status === 'error' && error && (
         <div className="mb-2 p-2.5 rounded-md bg-err-soft border border-err text-err text-xs font-mono shrink-0 flex items-center gap-2">
           <span className="flex-1 min-w-0 break-all">{error}</span>
@@ -209,7 +224,9 @@ export default function LogView({
       )}
       <div
         ref={bodyRef}
-        className="flex-1 min-h-0 overflow-auto bg-sunken border border-subtle rounded-md px-3 py-2 text-[11px] font-mono leading-relaxed"
+        className={`flex-1 min-h-0 overflow-auto px-3 py-2 text-[11px] font-mono leading-relaxed ${
+          frameless ? '' : 'bg-sunken border border-subtle rounded-md'
+        }`}
         data-testid="log-view-body"
       >
         {hasMoreBefore && onLoadEarlier && (

--- a/studio/web/src/components/LogView.tsx
+++ b/studio/web/src/components/LogView.tsx
@@ -126,7 +126,6 @@ export default function LogView({
     const v = parsed.filter((l) => isLineVisible(l, showDebug))
     return maxRender && v.length > maxRender ? v.slice(-maxRender) : v
   }, [parsed, showDebug, maxRender])
-  const hiddenDebug = parsed.length - parsed.filter((l) => isLineVisible(l, showDebug)).length
 
   // 跟随到底
   useEffect(() => {
@@ -180,9 +179,6 @@ export default function LogView({
           style={{ width: 14, height: 14, accentColor: 'var(--accent)' }}
         />
         {t('logView.debug')}
-        {!showDebug && hiddenDebug > 0 && (
-          <span className="text-fg-tertiary">（{t('logView.hiddenDebug', { n: hiddenDebug })}）</span>
-        )}
       </label>
       <label className="text-fg-tertiary flex items-center gap-1.5 cursor-pointer">
         <input

--- a/studio/web/src/components/TaskLogDrawer.test.tsx
+++ b/studio/web/src/components/TaskLogDrawer.test.tsx
@@ -135,3 +135,35 @@ describe('TaskLogDrawer (issue #251)', () => {
     expect(screen.queryByRole('button', { name: '重试' })).toBeNull()
   })
 })
+
+describe('抽屉一层化（日志二期 UI）', () => {
+  const HDR = (lvl: string, msg: string) =>
+    `2026-08-19 14:03:22.417 ${lvl.padEnd(5)} studio.workers.tag_worker: ${msg}`
+
+  it('收起态预览行跳过 DEBUG，显示最后一条 INFO+ 记录', () => {
+    render(
+      <TaskLogDrawer
+        sources={[makeSource({
+          status: 'done',
+          finishedAt: 1700000010,
+          lines: [HDR('INFO', 'tagging done 43/43'), HDR('DEBUG', 'internal detail')],
+        })]}
+      />,
+    )
+    expect(screen.getByText(/tagging done 43\/43/)).toBeInTheDocument()
+    expect(screen.queryByText(/internal detail/)).not.toBeInTheDocument()
+  })
+
+  it('展开后 LogView 工具栏渲染在 header 内（一层化），预览行让位', async () => {
+    const user = userEvent.setup()
+    render(<TaskLogDrawer sources={[makeSource({ status: 'done', finishedAt: 1700000010, lines: [HDR('INFO', 'hello world')] })]} />)
+    // 收起：预览可见、无工具栏
+    expect(screen.getByText(/hello world/)).toBeInTheDocument()
+    expect(screen.queryByTestId('log-view-toolbar')).not.toBeInTheDocument()
+    await user.click(screen.getByRole('button', { expanded: false }))
+    // 展开：工具栏出现且位于 header（aria-expanded 的开合条）内部
+    const toolbar = await screen.findByTestId('log-view-toolbar')
+    const header = screen.getByRole('button', { expanded: true })
+    expect(header.contains(toolbar)).toBe(true)
+  })
+})

--- a/studio/web/src/components/TaskLogDrawer.tsx
+++ b/studio/web/src/components/TaskLogDrawer.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { lastVisibleLine } from '../lib/logLines'
 import LogView from './LogView'
 
 export type LogSourceStatus =
@@ -81,6 +82,9 @@ export default function TaskLogDrawer({
 
   const [expanded, setExpanded] = useState(false)
   const prevRef = useRef<{ key: string; status: LogSourceStatus } | null>(null)
+  // LogView 工具栏 portal 进 header（避免「header + 工具栏」两层）；用 state 存
+  // element 保证容器挂载后 portal 才渲染
+  const [toolbarEl, setToolbarEl] = useState<HTMLElement | null>(null)
 
   const activeKey = active?.key ?? null
   const activeStatus = active?.status ?? null
@@ -101,12 +105,18 @@ export default function TaskLogDrawer({
     return () => window.clearInterval(id)
   }, [live])
 
+  // 收起态预览：最后一条非 DEBUG 记录（调试行不顶到 header 上）
+  const activeLines = active?.lines
+  const lastLine = useMemo(
+    () => (activeLines ? lastVisibleLine(activeLines) : ''),
+    [activeLines],
+  )
+
   if (!active) return null
 
   const elapsed = active.startedAt
     ? (active.finishedAt ?? Date.now() / 1000) - active.startedAt
     : null
-  const lastLine = active.lines[active.lines.length - 1] ?? ''
 
   return (
     <>
@@ -140,7 +150,20 @@ export default function TaskLogDrawer({
           {elapsed != null && elapsed > 0 && (
             <span className="text-fg-tertiary text-xs shrink-0">· {Math.round(elapsed)}s</span>
           )}
-          <span className="mono truncate flex-1 min-w-0 text-fg-secondary text-xs">{lastLine}</span>
+          {/* 展开时预览让位给工具栏（日志本体已可见，预览冗余）；收起时显示预览 */}
+          {expanded ? (
+            <>
+              <span className="flex-1 min-w-0" />
+              <div
+                ref={setToolbarEl}
+                className="flex items-center shrink-0"
+                onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+              />
+            </>
+          ) : (
+            <span className="mono truncate flex-1 min-w-0 text-fg-secondary text-xs">{lastLine}</span>
+          )}
           {live && active.onCancel && (
             <button
               onClick={(e) => {
@@ -181,7 +204,10 @@ export default function TaskLogDrawer({
               loadingEarlier={active.loadingEarlier}
               onLoadEarlier={active.onLoadEarlier}
               maxRender={1000}
-              className="h-full px-4 pt-2 pb-2"
+              toolbar={!!toolbarEl}
+              toolbarContainer={toolbarEl}
+              frameless
+              className="h-full"
             />
           )}
         </div>

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -190,7 +190,6 @@
   },
   "logView": {
     "debug": "Debug",
-    "hiddenDebug": "{{n}} debug lines hidden",
     "autoScroll": "Auto-scroll",
     "copy": "Copy",
     "copied": "Copied to clipboard",

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -201,7 +201,7 @@
     "loading": "(loading…)",
     "waiting": "(waiting for logs…)",
     "empty": "(no logs)",
-    "eventMalformed": "Malformed event:"
+    "eventMalformed": "Malformed line in the event stream:"
   },
   "jobProgress": {
     "waitingLogs": "(Waiting for logs...)"

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -201,7 +201,7 @@
     "loading": "（加载中…）",
     "waiting": "（等待日志…）",
     "empty": "（没有日志）",
-    "eventMalformed": "事件解析失败:"
+    "eventMalformed": "事件流中有一行无法解析："
   },
   "jobProgress": {
     "waitingLogs": "(等待日志...)"

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -190,7 +190,6 @@
   },
   "logView": {
     "debug": "调试",
-    "hiddenDebug": "已隐藏 {{n}} 条调试行",
     "autoScroll": "自动滚动",
     "copy": "复制",
     "copied": "已复制到剪贴板",

--- a/studio/web/src/lib/errors/report.ts
+++ b/studio/web/src/lib/errors/report.ts
@@ -95,7 +95,7 @@ export function reportClientError(input: ClientErrorReport): void {
   } catch {
     // fetch 都抛了（极罕见）也吞
     try {
-      console.warn('[reportClientError] failed silently')
+      console.warn('[reportClientError] send failed; the report was dropped')
     } catch {
       // even console.warn 不能用了，放弃
     }

--- a/studio/web/src/lib/logLines.test.ts
+++ b/studio/web/src/lib/logLines.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { isLineVisible, levelClass, parseLogLines } from './logLines'
+import { isLineVisible, lastVisibleLine, levelClass, parseLogLines } from './logLines'
 
 const H = (lvl: string, logger: string, msg: string, t = '14:03:22.417') =>
   `2026-08-19 ${t} ${lvl.padEnd(5)} ${logger}: ${msg}`
@@ -59,5 +59,33 @@ describe('过滤与着色', () => {
     expect(levelClass('WARNING')).toBe('text-warn')
     expect(levelClass('DEBUG')).toBe('text-fg-tertiary')
     expect(levelClass('INFO')).toBe(levelClass(null))
+  })
+})
+
+describe('lastVisibleLine（抽屉收起态预览）', () => {
+  it('跳过尾部的 DEBUG 行与续行，取最后一条 INFO+ 记录原文', () => {
+    const lines = [
+      H('INFO', 'w.tag', 'tagged 43/43'),
+      H('DEBUG', 'w.tag', 'internal detail'),
+      '  continuation of debug',
+    ]
+    expect(lastVisibleLine(lines)).toBe(lines[0])
+  })
+
+  it('WARNING/ERROR 不被跳过', () => {
+    const lines = [H('INFO', 'a', 'x'), H('ERROR', 'a', 'boom')]
+    expect(lastVisibleLine(lines)).toBe(lines[1])
+  })
+
+  it('全 plain（前端合成日志）退回最后一行原文', () => {
+    expect(lastVisibleLine(['a', 'b'])).toBe('b')
+  })
+
+  it('有行头但全 DEBUG → 空串（预览留白，不显示调试行）', () => {
+    expect(lastVisibleLine([H('DEBUG', 'a', 'x')])).toBe('')
+  })
+
+  it('空输入 → 空串', () => {
+    expect(lastVisibleLine([])).toBe('')
   })
 })

--- a/studio/web/src/lib/logLines.ts
+++ b/studio/web/src/lib/logLines.ts
@@ -78,6 +78,22 @@ export function isLineVisible(line: LogLine, showDebug: boolean): boolean {
   return line.level !== 'DEBUG'
 }
 
+/** 抽屉收起态的预览行：最后一条非 DEBUG 的记录（跳过续行与调试行）。
+ *  日志全无行头（前端合成 plain 文本）时退回最后一行原文；有行头但全是
+ *  DEBUG 时返回空串（预览留白好过把调试行顶到 header 上）。 */
+export function lastVisibleLine(lines: readonly string[]): string {
+  const parsed = parseLogLines(lines)
+  let sawLeveled = false
+  for (let i = parsed.length - 1; i >= 0; i--) {
+    const l = parsed[i]
+    if (l.kind === 'header' || l.kind === 'bare') {
+      sawLeveled = true
+      if (l.level !== 'DEBUG') return l.raw
+    }
+  }
+  return sawLeveled ? '' : (lines[lines.length - 1] ?? '')
+}
+
 /** 行内着色 token（与 Tailwind 色类一一对应，整站一套）。 */
 export function levelClass(level: LogLevel | null): string {
   switch (level) {

--- a/studio/web/src/lib/useTaskLog.test.ts
+++ b/studio/web/src/lib/useTaskLog.test.ts
@@ -96,13 +96,16 @@ describe('useTaskLog', () => {
     expect(getLog.mock.calls.length).toBe(calls)
   })
 
-  it('event_malformed 合成 WARNING 行；超出 maxLines 从头裁并标记可回翻', async () => {
+  it('event_malformed 合成完整行契约的 WARNING 行；超出 maxLines 从头裁并标记可回翻', async () => {
     const getLog = vi.spyOn(api, 'getLog')
     getLog.mockResolvedValueOnce(page([[0, 'a'], [2, 'b']]))
     const { result } = renderHook(() => useTaskLog(7, { maxLines: 3 }))
     await waitFor(() => expect(result.current.status).toBe('ready'))
     emit({ type: 'event_malformed', task_id: 7, raw_preview: '__EVENT__:x:{' })
-    expect(result.current.lines[2]).toMatch(/^WARNING: /)
+    // 行契约（后端 LOG_LINE_RE 同构）：ts + 级别 + logger 名，不再是裸 `WARNING: `
+    expect(result.current.lines[2]).toMatch(
+      /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} WARNING web\.logview: /,
+    )
     expect(result.current.lines[2]).toContain('__EVENT__:x:{')
     emit({ type: 'task_log_appended', task_id: 7, text: 'c', seq: 1, end_offset: 6 })
     expect(result.current.lines).toHaveLength(3)

--- a/studio/web/src/lib/useTaskLog.ts
+++ b/studio/web/src/lib/useTaskLog.ts
@@ -6,7 +6,7 @@
  *   （≤ 当前游标的事件是冷启动已含的或重复的）
  * - 断线重连（`useEventStream` onOpen）与任务状态变化时用 `after=<游标>` 补拉，
  *   断线期间丢的行不会丢
- * - `event_malformed` 合成一条 WARNING 行（裸前缀，LogView 解析着色）
+ * - `event_malformed` 合成一条 WARNING 行（完整行契约：ts + 级别 + `web.logview`）
  * - 客户端最多保留 `maxLines` 行：超出从头丢，丢掉的部分可再「加载更早」拿回
  *
  * 返回 `lines: string[]`（原文）；解析/着色在 LogView。
@@ -37,6 +37,16 @@ interface Entry { offset: number; text: string }
 
 const DEFAULT_TAIL = 500
 const DEFAULT_MAX = 5000
+
+/** 合成行的行头时间戳，与后端 LOG_LINE_RE 同格式：`YYYY-MM-DD HH:MM:SS.mmm`。 */
+function logTimestamp(now: Date = new Date()): string {
+  const p = (n: number, w = 2) => String(n).padStart(w, '0')
+  return (
+    `${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())} ` +
+    `${p(now.getHours())}:${p(now.getMinutes())}:${p(now.getSeconds())}.` +
+    `${p(now.getMilliseconds(), 3)}`
+  )
+}
 
 function _matches(evt: StudioEvent, id: number): boolean {
   if (evt.type === 'task_log_appended' || evt.type === 'event_malformed') {
@@ -91,7 +101,9 @@ export function useTaskLog(
     if (cursor === null) return
     if (evt.type === 'event_malformed') {
       const preview = typeof evt.raw_preview === 'string' ? evt.raw_preview : ''
-      appendEntries([{ offset: cursor, text: `WARNING: ${i18n.t('logView.eventMalformed')} ${preview}`.trimEnd() }])
+      // 完整行契约（ts + 级别 + 来源），不再只靠裸 `WARNING: ` 前缀兜底
+      const text = `${logTimestamp()} WARNING web.logview: ${i18n.t('logView.eventMalformed')} ${preview}`
+      appendEntries([{ offset: cursor, text: text.trimEnd() }])
       return
     }
     const text = typeof evt.text === 'string' ? evt.text : ''

--- a/studio/web/src/pages/tools/generate/DaemonLogDrawer.tsx
+++ b/studio/web/src/pages/tools/generate/DaemonLogDrawer.tsx
@@ -30,6 +30,8 @@ export default function DaemonLogDrawer({
 }) {
   const { t } = useTranslation()
   const [entries, setEntries] = useState<LogEntry[]>([])
+  // LogView 工具栏 portal 进 header（与 TaskLogDrawer 同构，避免两层工具栏行）
+  const [toolbarEl, setToolbarEl] = useState<HTMLElement | null>(null)
   const seqRef = useRef(0)
   const openRef = useRef(open)
   openRef.current = open
@@ -85,6 +87,7 @@ export default function DaemonLogDrawer({
         <span className="text-sm font-semibold text-fg-primary">{t('generate.logDrawerTitle')}</span>
         <span className="text-xs font-mono text-fg-tertiary">{entries.length}</span>
         <span className="flex-1" />
+        <div ref={setToolbarEl} className="flex items-center shrink-0" />
         <button className="btn btn-ghost btn-sm" onClick={onClose}>
           {t('generate.logDrawerClose')}
         </button>
@@ -92,10 +95,13 @@ export default function DaemonLogDrawer({
       {/* 关着时不渲染内容区，省掉隐藏抽屉的解析 / 滚动 */}
       {open && (
         <LogView
-          className="flex-1 min-h-0 px-4 pt-2 pb-2"
+          className="flex-1 min-h-0"
           lines={lines}
           status="live"
           emptyText={t('generate.logDrawerEmpty')}
+          toolbar={!!toolbarEl}
+          toolbarContainer={toolbarEl}
+          frameless
           extraActions={
             <button className="btn btn-ghost btn-sm" onClick={() => setEntries([])} disabled={entries.length === 0}>
               {t('generate.logDrawerClear')}

--- a/studio/web/src/pages/tools/settings/sections.tsx
+++ b/studio/web/src/pages/tools/settings/sections.tsx
@@ -1452,6 +1452,8 @@ export function DisplaySection() {
     setLang(newLang)
     setStoredLang(newLang)
     void i18n.changeLanguage(newLang)
+    // 同步后端 secrets.system.ui_language：子进程日志语言的注入源（最终一致即可）
+    void api.updateSecrets({ system: { ui_language: newLang } }).catch(() => {})
   }
 
   const densityLabel = (d: Density): string => {

--- a/studio/workers/download_worker.py
+++ b/studio/workers/download_worker.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import logging
 import threading
 
+from studio.infrastructure.log_messages import msg
 from studio.infrastructure.task_log import TaskLog
 from studio import db, secrets
 
@@ -31,10 +32,13 @@ def run(job_id: int) -> int:
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, job_id)
     if not job:
-        logger.error("job %s not found", job_id)
+        logger.error("Download job %s not found in the database; nothing to run", job_id)
         return 1
     if job["kind"] != "download":
-        logger.error("wrong kind: %s", job["kind"])
+        logger.error(
+            "Internal error: job %s has kind=%s, not a download job; aborting",
+            job_id, job["kind"],
+        )
         return 1
 
     params = job.get("params_decoded") or {}
@@ -45,7 +49,9 @@ def run(job_id: int) -> int:
         with db.connection_for() as conn:
             project = projects.get_project(conn, job["project_id"])
         if not project:
-            progress(f"[error] project {job['project_id']} missing")
+            progress.error(
+                "Project %s no longer exists; download aborted", job["project_id"]
+            )
             return 1
         dest = projects.project_dir(project["id"], project["slug"]) / "download"
         sec = secrets.load()
@@ -70,24 +76,25 @@ def run(job_id: int) -> int:
             api_key=api_key,
             exclude_tags=list(sec.download.exclude_tags),
         )
-        progress(
-            f"[start] tag={opts.tag!r} count={opts.count} "
-            f"source={opts.api_source} "
-            f"exclude={','.join(opts.exclude_tags) or '(none)'}"
-        )
+        progress.info(msg(
+            "worker.download.start",
+            tag=opts.tag,
+            count=opts.count,
+            source=opts.api_source,
+            exclude=",".join(opts.exclude_tags) or "(none)",
+        ))
         saved = downloader.download(
             opts,
             dest,
             on_progress=progress,
             cancel_event=threading.Event(),  # supervisor 走 SIGTERM
         )
-        progress(f"[done] saved={saved}")
+        progress.info(msg("worker.download.done", saved=saved))
         return 0
-    except Exception as exc:
-        # PR-1 C7: 同 tag_worker — logger.exception 带 trace_id 进 stderr，
-        # progress 给人读短摘要。
-        logger.exception("download worker crashed (job_id=%s)", job_id)
-        progress(f"[error] {exc}")
+    except Exception:
+        # PR-1 C7: logger.exception 带 trace_id 进 stderr；异常摘要由 traceback
+        # 提供，不再另发一条 progress（C6：{e} 与 traceback 二选一）。
+        logger.exception("Download worker crashed: job=%s", job_id)
         return 1
 
 

--- a/studio/workers/eval_session_worker.py
+++ b/studio/workers/eval_session_worker.py
@@ -27,7 +27,8 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
-from studio.infrastructure.task_log import TaskLog
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import TaskLog, TaskLogLike
 from studio import db, secrets
 from studio.services import (
     eval_ccip,
@@ -80,16 +81,21 @@ def run(task_id: int) -> int:
     with db.connection_for() as conn:
         task = db.get_task(conn, task_id)
         if not task:
-            logger.error("task %s not found", task_id)
+            logger.error(
+                "Evaluation task %s not found in the database; nothing to run", task_id
+            )
             return 1
         params = task.get("params_decoded") or {}
         session_id = int(params.get("session_id") or 0)
         if not session_id:
-            logger.error("task %s has no session_id", task_id)
+            logger.error(
+                "Evaluation task %s does not point at an evaluation session; aborting",
+                task_id,
+            )
             return 1
         session = eval_session.get_session(conn, session_id)
         if session is None:
-            logger.error("eval session %s not found", session_id)
+            logger.error("Evaluation session %s not found; aborting", session_id)
             return 1
         project = projects.get_project(conn, int(session["project_id"] or 0))
         version = versions.get_version(conn, int(session["version_id"] or 0))
@@ -97,7 +103,10 @@ def run(task_id: int) -> int:
     if not project or not version:
         with db.connection_for() as conn:
             _fail(conn, session_id, "project / version 不存在")
-        logger.error("project or version missing")
+        logger.error(
+            "Project %s or version %s no longer exists; evaluation session %s aborted",
+            session.get("project_id"), session.get("version_id"), session_id,
+        )
         return 1
 
     vdir = versions.version_dir(
@@ -118,10 +127,12 @@ def run(task_id: int) -> int:
             error=None,
         )
 
-    progress(
-        f"[start] eval session={session_id} candidates="
-        f"{len(plan.get('candidates') or [])}+baseline stages=1+{len(runners)}"
-    )
+    progress.info(msg(
+        "worker.eval.start",
+        session=session_id,
+        n=len(plan.get("candidates") or []) + 1,
+        stages=1 + len(runners),
+    ))
 
     try:
         _stage_generate(session_id, task_id, project, version, vdir, progress)
@@ -129,10 +140,9 @@ def run(task_id: int) -> int:
             _stage_metric(session_id, runner, project, version, vdir, progress)
         return _stage_aggregate(session_id, progress)
     except Exception as exc:  # noqa: BLE001
-        logger.exception("eval session worker crashed (session=%s)", session_id)
+        logger.exception("Evaluation session worker crashed: session=%s", session_id)
         with db.connection_for() as conn:
             _fail(conn, session_id, str(exc))
-        progress(f"[error] {exc}")
         return 1
 
 
@@ -146,7 +156,7 @@ def _stage_generate(
     project: dict[str, Any],
     version: dict[str, Any],
     vdir: Path,
-    progress: Callable[[str], None],
+    progress: TaskLogLike,
 ) -> None:
     eval_root = eval_session.samples_root(session_id)
     with db.connection_for() as conn:
@@ -155,7 +165,7 @@ def _stage_generate(
 
     pending = [c for c in candidates if not _generation_complete(c, vdir, eval_root)]
     if not pending:
-        progress("[generate] 全部候选已完成，跳过出图阶段")
+        progress.info(msg("worker.eval.generate_all_done"))
         return
 
     # daemon 的生命周期是**整个出图阶段**，不是单个候选 —— 底模常驻的收益全在这里。
@@ -174,13 +184,13 @@ def _generate_candidates(
     version: dict[str, Any],
     vdir: Path,
     eval_root: Path,
-    progress: Callable[[str], None],
+    progress: TaskLogLike,
 ) -> None:
     for cand in candidates:
         cid = int(cand["id"])
         label = f"{cand['role']}#{cand['ordinal']}"
         if _generation_complete(cand, vdir, eval_root):
-            progress(f"[generate] {label} 已完成，跳过")
+            progress.info(msg("worker.eval.candidate_skipped", label=label))
             continue
 
         with db.connection_for() as conn:
@@ -192,7 +202,10 @@ def _generate_candidates(
             if run_id and _load_run(vdir, run_id, eval_root) is None:
                 # run 文件没了（被清理 / 磁盘问题），DB 里的 id 已经失效。不丢弃它就会
                 # 拿着这个 id 反复调 run_sample_job 撞「run 不存在」，永远恢复不了。
-                progress(f"[generate] {label} run={run_id} 已丢失，重新出图")
+                progress.warning(
+                    "Sample run %s for candidate %s is missing; generating it again",
+                    run_id, label,
+                )
                 run_id = ""
             if not run_id:
                 stored = str(cand.get("checkpoint_path") or "")
@@ -217,7 +230,9 @@ def _generate_candidates(
                         conn, cid, run_id=run_id,
                         samples_total=int(run["summary"]["total"]),
                     )
-            progress(f"[generate] {label} run={run_id}")
+            progress.info(msg(
+                "worker.eval.candidate_start", label=label, run_id=run_id,
+            ))
             result = eval_samples.run_sample_job(
                 project, version, vdir, run_id,
                 generator=generate,
@@ -233,18 +248,30 @@ def _generate_candidates(
                     samples_done=done,
                     error=None if ok else str(result.get("error") or "出图未完成"),
                 )
-            progress(
-                f"[generate] {label} status={result.get('status')} "
-                f"done={done}/{summary.get('total')}"
-            )
+            if ok:
+                progress.info(msg(
+                    "worker.eval.candidate_done",
+                    label=label, done=done, total=summary.get("total"),
+                ))
+            else:
+                progress.warning(
+                    "Candidate %s finished with status=%s (%d/%d images); its "
+                    "metrics may be incomplete",
+                    label, result.get("status"), done, summary.get("total"),
+                )
         except Exception as exc:  # noqa: BLE001
-            # 单个候选失败不中断整个 Session —— 其余候选仍然值得跑完
-            logger.exception("candidate generation failed (candidate=%s)", cid)
+            # 单个候选失败不中断整个 Session —— 其余候选仍然值得跑完；
+            # 整体仍可能 partial 成功，因此是 WARNING 不是 ERROR。
+            # 异常摘要由 traceback 提供，正文不再拼 {exc}（C6）。
+            progress.warning(
+                "Candidate %s (id=%s) failed during generation; continuing with "
+                "the remaining candidates",
+                label, cid, exc_info=True,
+            )
             with db.connection_for() as conn:
                 eval_session.update_candidate(
                     conn, cid, status=eval_session.STATUS_FAILED, error=str(exc)
                 )
-            progress(f"[generate] {label} 失败：{exc}")
 
 
 def _load_run(vdir: Path, run_id: str, eval_root: Path) -> dict[str, Any] | None:
@@ -282,11 +309,14 @@ def _stage_metric(
     project: dict[str, Any],
     version: dict[str, Any],
     vdir: Path,
-    progress: Callable[[str], None],
+    progress: TaskLogLike,
 ) -> None:
     spec = _RUNNERS.get(runner)
     if spec is None:
-        progress(f"[metric:{runner}] 未知 runner，跳过")
+        progress.warning(
+            "Unknown metric runner %r in the session plan; skipped, its metrics "
+            "will be missing", runner,
+        )
         return
     run_fn, model_getter, shared_scorer = spec
     model_name = model_getter(secrets.load().eval_metrics)
@@ -322,7 +352,7 @@ def _score_candidates(
     model_name: str,
     metric_keys: list[str],
     stage: str,
-    progress: Callable[[str], None],
+    progress: TaskLogLike,
 ) -> None:
     for cand in candidates:
         cid = int(cand["id"])
@@ -334,17 +364,19 @@ def _score_candidates(
             _skip_metrics(
                 cid, metric_keys, model_name, reason="出图未完成，跳过指标",
             )
-            progress(f"[{stage}] {label} 无可用出图，跳过")
+            progress.debug("metric %s: %s has no usable samples, skipped", stage, label)
             continue
         if all(
             by_key.get(k, {}).get("status") == eval_session.STATUS_DONE
             for k in metric_keys
         ):
-            progress(f"[{stage}] {label} 已算过，跳过")
+            progress.debug("metric %s: %s already scored, skipped", stage, label)
             continue
 
         try:
-            progress(f"[{stage}] {label} run={run_id}")
+            progress.info(msg(
+                "worker.eval.metric_start", stage=stage, label=label, run_id=run_id,
+            ))
             saved = run_fn(
                 project, version, vdir, run_id,
                 scorer=scorer,
@@ -352,9 +384,11 @@ def _score_candidates(
             )
             _record_metrics(cid, metric_keys, saved, model_name)
         except Exception as exc:  # noqa: BLE001
-            logger.exception(
-                "metric runner failed (session=%s candidate=%s runner=%s)",
-                session_id, cid, runner,
+            # 指标失败写 DB FAILED、session 仍可 partial 成功 → WARNING 不是 ERROR。
+            progress.warning(
+                "Metric runner %s failed for candidate %s (session %s); its "
+                "metrics are recorded as failed and the session continues",
+                runner, label, session_id, exc_info=True,
             )
             with db.connection_for() as conn:
                 for key in metric_keys:
@@ -363,7 +397,6 @@ def _score_candidates(
                         status=eval_session.STATUS_FAILED,
                         model_ref=model_name, reason=str(exc),
                     )
-            progress(f"[{stage}] {label} 失败：{exc}")
 
 
 def _record_metrics(
@@ -426,7 +459,7 @@ def _int_or_none(raw: Any) -> int | None:
 # Stage 3：聚合
 # ---------------------------------------------------------------------------
 
-def _stage_aggregate(session_id: int, progress: Callable[[str], None]) -> int:
+def _stage_aggregate(session_id: int, progress: TaskLogLike) -> int:
     with db.connection_for() as conn:
         eval_session.update_session(conn, session_id, stage=eval_session.STAGE_AGGREGATE)
         candidates = eval_session.list_candidates(conn, session_id)
@@ -441,12 +474,22 @@ def _stage_aggregate(session_id: int, progress: Callable[[str], None]) -> int:
         1 for rows in results.values()
         for r in rows if r.get("status") == eval_session.STATUS_DONE
     )
-    progress(
-        f"[done] session={session_id} status={status} "
-        f"candidates={len(candidates)} metrics_done={n_metrics}"
-    )
+    if status in (eval_session.STATUS_PARTIAL, eval_session.STATUS_FAILED):
+        progress.warning(
+            "Evaluation finished with status=%s: session=%s candidates=%d "
+            "metrics_done=%d; some results are missing",
+            status, session_id, len(candidates), n_metrics,
+        )
+    else:
+        progress.info(msg(
+            "worker.eval.done",
+            session=session_id, n=len(candidates), m=n_metrics,
+        ))
     if report is None:
-        progress("[warn] report 生成失败（结果仍在数据库里）")
+        progress.warning(
+            "Writing the evaluation report failed; the results are still in the "
+            "database and visible in the app"
+        )
     # partial 仍算作业成功：有结果可看，队列不该标红
     return 0 if status in (eval_session.STATUS_DONE, eval_session.STATUS_PARTIAL) else 1
 

--- a/studio/workers/preprocess_worker.py
+++ b/studio/workers/preprocess_worker.py
@@ -30,7 +30,8 @@ from PIL import Image
 # 行契约里的来源列会失真、也不在 OWN_LOGGER_NAMESPACES 里。
 logger = logging.getLogger("studio.workers.preprocess_worker")
 
-from studio.infrastructure.task_log import TaskLog
+from studio.infrastructure.log_messages import msg
+from studio.infrastructure.task_log import TaskLog, TaskLogLike
 from studio import db
 from studio.domain.errors import DomainError
 from studio.services.preprocess import core as preprocess
@@ -39,6 +40,8 @@ from studio.services import models as model_downloader
 from studio.services.preprocess import manifest as preprocess_manifest
 from studio.services.preprocess import masks as train_masks
 from studio.services.inference import upscaler
+
+from utils.log_throttle import ProgressThrottle, RepeatThrottle
 
 
 _stop_requested = False
@@ -71,10 +74,13 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, job_id)
     if not job:
-        logger.error("job %s not found", job_id)
+        logger.error("Preprocess job %s not found in the database; nothing to run", job_id)
         return 1
     if job["kind"] != preprocess.PREPROCESS_KIND:
-        logger.error("wrong kind: %s", job["kind"])
+        logger.error(
+            "Internal error: job %s has kind=%s, not a preprocess job; aborting",
+            job_id, job["kind"],
+        )
         return 1
 
     params = job.get("params_decoded") or {}
@@ -98,17 +104,23 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
         with db.connection_for() as conn:
             project = projects.get_project(conn, job["project_id"])
         if not project:
-            log(f"[error] project {job['project_id']} missing")
+            log.error(
+                "Project %s no longer exists; preprocessing aborted",
+                job["project_id"],
+            )
             return 1
 
         version_id = job.get("version_id")
         if version_id is None:
-            log("[error] preprocess job 缺 version_id（ADR 0010 train scope）")
+            log.error(
+                "Internal error: the preprocess job does not say which version "
+                "to work on; aborting"
+            )
             return 1
         with db.connection_for() as conn:
             version = versions.get_version(conn, version_id)
         if not version:
-            log(f"[error] version {version_id} missing")
+            log.error("Version %s no longer exists; preprocessing aborted", version_id)
             return 1
         if stage == preprocess.STAGE_CROP:
             return _run_crop_train(project, version, params, log, emit_event)
@@ -116,13 +128,12 @@ def run(job_id: int) -> int:  # noqa: PLR0912, PLR0915 - 主流程线性可读
             return _run_upscale_train(
                 project, version, params, log, emit_event,
             )
-        log(f"[error] 未知 stage: {stage!r}")
+        log.error("Internal error: unknown preprocess stage %r; aborting", stage)
         return 1
-    except Exception as exc:  # noqa: BLE001
-        # PR-1 C7: 同 tag_worker — logger.exception 带 trace_id 进 stderr，
-        # log 给人读短摘要。
-        logger.exception("preprocess worker crashed (job_id=%s)", job_id)
-        log(f"[error] {exc}")
+    except Exception:  # noqa: BLE001
+        # PR-1 C7: logger.exception 带 trace_id 进 stderr；异常摘要由 traceback
+        # 提供，不再另发一条 log 行（C6）。
+        logger.exception("Preprocess worker crashed: job=%s", job_id)
         return 1
 
 
@@ -130,7 +141,7 @@ def _run_upscale_train(
     project: dict[str, Any],
     version: dict[str, Any],
     params: dict[str, Any],
-    log: Callable[[str], None],
+    log: TaskLogLike,
     emit_event: Callable[..., None],
 ) -> int:
     """ADR 0010 train-scope upscale。
@@ -157,8 +168,9 @@ def _run_upscale_train(
 
     model_path = model_downloader.upscaler_target(model_label)
     if not model_path.exists():
-        log(
-            f"[error] 模型权重不存在：{model_path}（请先在设置页下载 {model_label}）"
+        log.error(
+            "Upscaler weights not found: %s; download %s on the settings page first",
+            model_path, model_label,
         )
         return 1
 
@@ -167,52 +179,80 @@ def _run_upscale_train(
             project, version["label"], mode=mode, names=names
         )
     except DomainError as exc:
-        log(f"[error] 解析目标失败: {exc}")
+        log.error(
+            "Resolving which images to process failed: %s; preprocessing aborted",
+            exc,
+        )
         return 1
 
     total = len(sources)
     if total == 0:
-        log("[done] 没有需要处理的图")
+        log.info(msg("worker.preprocess.no_images"))
         return 0
 
     target_desc = (
         f"{int(math.sqrt(target_area))}²={target_area}px"
         if target_area else "off (直接 4×)"
     )
-    log(
-        f"[start] mode={mode} model={model_label} tile={tile_size}+{tile_pad} "
-        f"device={device} target={target_desc} total={total} scope=train"
-    )
+    log.info(msg(
+        "worker.preprocess.upscale_start",
+        mode=mode, model=model_label, tile=tile_size, pad=tile_pad,
+        device=device, target=target_desc, total=total,
+    ))
 
     try:
         import torch
         resolved_dev = upscaler.resolve_device(device)
         resolved_dtype = upscaler.resolve_dtype("auto", resolved_dev)
+        cuda_available = torch.cuda.is_available()
         gpu_name = (
             torch.cuda.get_device_name(0)
-            if resolved_dev.type == "cuda" and torch.cuda.is_available()
+            if resolved_dev.type == "cuda" and cuda_available
             else "—"
         )
-        log(
-            f"[device] resolved={resolved_dev} dtype={str(resolved_dtype).replace('torch.', '')} "
-            f"gpu={gpu_name} cuda_available={torch.cuda.is_available()}"
+        log.debug(
+            "device: resolved=%s dtype=%s gpu=%s cuda_available=%s",
+            resolved_dev, str(resolved_dtype).replace("torch.", ""),
+            gpu_name, cuda_available,
         )
+        if str(device).startswith("cuda") and not cuda_available:
+            log.warning(
+                "CUDA was requested but is not available; upscaling runs on the "
+                "CPU and will be roughly 10× slower"
+            )
         upscaler.load_model(model_path, device=resolved_dev, dtype=resolved_dtype)
-        log(f"[model] {model_label} loaded → {resolved_dev}")
+        log.info(msg(
+            "worker.preprocess.model_ready", model=model_label, device=resolved_dev,
+        ))
     except Exception as exc:  # noqa: BLE001
-        log(f"[device] diagnostic failed: {exc}（继续，但可能跑在 CPU 上）")
+        log.warning(
+            "Device diagnostics failed: %s; upscaling continues but may run on "
+            "the CPU (roughly 10× slower)", exc,
+        )
 
     succeeded = 0
     failed = 0
     skipped = 0
+    repeat = RepeatThrottle(log)
+    # 逐图行降 DEBUG，可见进度由节流后的计数 INFO 承担（Q3 三件套）。
+    throttle = ProgressThrottle(total)
 
     for idx, src_rel in enumerate(sources, start=1):
         if _stop_requested:
-            log(f"[cancel] 收到取消信号，已处理 {idx - 1}/{total}")
+            log.warning(
+                "Canceled by the user after %d/%d images; the rest were left "
+                "unprocessed", idx - 1, total,
+            )
             break
         src_path = train_dir / src_rel
         if not src_path.exists():
-            log(f"[skip] ({idx}/{total}) {src_rel}: 源已不存在")
+            repeat.hit(
+                "source_gone",
+                "%d images skipped: the source file was gone (first: %s)",
+                "Image %d/%d skipped: %s no longer exists",
+                idx, total, src_rel,
+                first=src_rel,
+            )
             skipped += 1
             emit_event(
                 "preprocess_progress",
@@ -244,7 +284,7 @@ def _run_upscale_train(
         else:
             save_kwargs = {"format": "PNG", "optimize": False}
 
-        log(f"[upscale] ({idx}/{total}) {src_rel}")
+        log.debug("upscale: %d/%d %s", idx, total, src_rel)
         try:
             meta = upscaler.upscale_file(
                 src_path,
@@ -269,8 +309,18 @@ def _run_upscale_train(
                 with Image.open(dst_path) as up_img:
                     train_masks.resize_mask_like(train_dir, src_rel, up_img.size)
             except Exception as exc:  # noqa: BLE001
-                log(f"   ⚠ mask 跟随放大失败: {exc}")
+                repeat.hit(
+                    "mask_resize_failed",
+                    "%d masks could not be resized (first: %s); those images are "
+                    "upscaled but their masks are stale",
+                    "Resizing the mask for %s failed: %s; the image was upscaled "
+                    "but its mask still has the old size",
+                    src_rel, exc,
+                    first=src_rel,
+                )
             succeeded += 1
+            if throttle.should_emit(idx):
+                log.info(msg("worker.preprocess.progress", done=idx, total=total))
             emit_event(
                 "preprocess_progress",
                 idx=idx, total=total, name=src_rel, status="done",
@@ -278,7 +328,13 @@ def _run_upscale_train(
                 succeeded=succeeded, failed=failed, skipped=skipped,
             )
         except Exception as exc:  # noqa: BLE001
-            log(f"[fail] {src_rel}: {exc}")
+            repeat.hit(
+                "upscale_failed",
+                "%d images failed to upscale (first: %s)",
+                "Upscaling %s failed: %s; image left unchanged",
+                src_rel, exc,
+                first=src_rel,
+            )
             failed += 1
             emit_event(
                 "preprocess_progress",
@@ -287,7 +343,17 @@ def _run_upscale_train(
                 succeeded=succeeded, failed=failed, skipped=skipped,
             )
 
-    log(f"[done] succeeded={succeeded} failed={failed} skipped={skipped}")
+    repeat.drain()
+    if failed:
+        log.warning(
+            "Upscaling finished with failures: succeeded=%d failed=%d skipped=%d",
+            succeeded, failed, skipped,
+        )
+    else:
+        log.info(msg(
+            "worker.preprocess.upscale_done",
+            succeeded=succeeded, failed=failed, skipped=skipped,
+        ))
     return 0
 
 
@@ -295,7 +361,7 @@ def _run_crop_train(
     project: dict[str, Any],
     version: dict[str, Any],
     params: dict[str, Any],
-    log: Callable[[str], None],
+    log: TaskLogLike,
     emit_event: Callable[..., None],
 ) -> int:
     """ADR 0010 train-scope crop。
@@ -311,7 +377,7 @@ def _run_crop_train(
 
     crops_param = params.get("crops") or {}
     if not crops_param:
-        log("[done] crops 为空，无事可做")
+        log.info(msg("worker.preprocess.no_crops"))
         return 0
     sources = sorted(crops_param.keys())
 
@@ -325,21 +391,33 @@ def _run_crop_train(
         emit_event("crop_progress", **payload)
 
     total = len(sources)
-    log(f"[start] stage=crop total={total} scope=train")
+    log.info(msg("worker.preprocess.crop_start", total=total))
 
     succeeded = 0
     failed = 0
     skipped = 0
+    repeat = RepeatThrottle(log)
+    # 逐图行降 DEBUG，可见进度由节流后的计数 INFO 承担（Q3 三件套）。
+    throttle = ProgressThrottle(total)
 
     for idx, src_rel in enumerate(sources, start=1):
         if _stop_requested:
-            log(f"[cancel] 收到取消信号，已处理 {idx - 1}/{total}")
+            log.warning(
+                "Canceled by the user after %d/%d images; the rest were left "
+                "unprocessed", idx - 1, total,
+            )
             break
         is_last = idx == total
         try:
             preprocess._validate_rel_name(src_rel)
         except DomainError as exc:
-            log(f"[skip] {src_rel}: {exc}")
+            repeat.hit(
+                "invalid_name",
+                "%d images skipped: invalid file name (first: %s)",
+                "Image %s skipped: invalid file name (%s)",
+                src_rel, exc,
+                first=src_rel,
+            )
             skipped += 1
             emit_throttled(
                 force=True,
@@ -350,7 +428,13 @@ def _run_crop_train(
 
         src_path = train_dir / src_rel
         if not src_path.is_file():
-            log(f"[skip] ({idx}/{total}) {src_rel}: 源不存在")
+            repeat.hit(
+                "source_gone",
+                "%d images skipped: the source file was gone (first: %s)",
+                "Image %d/%d skipped: %s no longer exists",
+                idx, total, src_rel,
+                first=src_rel,
+            )
             skipped += 1
             emit_throttled(
                 force=True,
@@ -378,7 +462,6 @@ def _run_crop_train(
             else [f"{folder}/{src_stem}_c{i}.png" for i in range(n)]
         )
 
-        log(f"[crop] ({idx}/{total}) {src_rel} → {n} 个产物")
         try:
             t0 = time.monotonic()
             with Image.open(src_path) as raw:
@@ -434,7 +517,15 @@ def _run_crop_train(
                             keep_sidecars=Path(stale_rel).stem in output_stems,
                         )
                     except OSError as exc:
-                        log(f"   ⚠ 删旧 {stale_rel} 失败: {exc}")
+                        repeat.hit(
+                            "stale_unlink_failed",
+                            "%d superseded files could not be removed (first: %s); "
+                            "they stay in the train folder",
+                            "Removing the superseded file %s failed: %s; it stays "
+                            "in the train folder",
+                            stale_rel, exc,
+                            first=stale_rel,
+                        )
 
             # mask sidecar 跟随：同 box 裁剪 + fan-out（源无 mask 时 no-op）
             try:
@@ -442,7 +533,14 @@ def _run_crop_train(
                     train_dir, src_rel, crop_boxes, out_rels,
                 )
             except Exception as exc:  # noqa: BLE001
-                log(f"   ⚠ mask 跟随裁剪失败: {exc}")
+                repeat.hit(
+                    "mask_crop_failed",
+                    "%d masks could not be cropped (first: %s); those crops have "
+                    "no mask",
+                    "Cropping the mask for %s failed: %s; the crops have no mask",
+                    src_rel, exc,
+                    first=src_rel,
+                )
 
             preprocess_manifest.train_replace_with_crops(
                 project_dir, version["label"],
@@ -458,14 +556,16 @@ def _run_crop_train(
                         piece.load()
                         thumb_cache.prewarm_from_image(out_path, piece, [256, 768])
             except Exception as exc:  # noqa: BLE001
-                log(f"   ⚠ thumb prewarm failed: {exc}")
+                log.debug("thumb prewarm failed for %s: %s", src_rel, exc)
 
             elapsed = time.monotonic() - t0
             succeeded += 1
-            log(
-                f"   ✓ {src_rel} → {', '.join(out_rels)}  "
-                f"({sw}×{sh} → {n} 块, {elapsed:.2f}s)"
+            log.debug(
+                "crop: %d/%d %s → %s (%dx%d, %d pieces, %.1fs)",
+                idx, total, src_rel, ", ".join(out_rels), sw, sh, n, elapsed,
             )
+            if throttle.should_emit(idx):
+                log.info(msg("worker.preprocess.progress", done=idx, total=total))
             emit_throttled(
                 force=(idx == 1 or is_last),
                 idx=idx, total=total, name=src_rel, status="done",
@@ -473,7 +573,13 @@ def _run_crop_train(
                 succeeded=succeeded, failed=failed, skipped=skipped,
             )
         except Exception as exc:  # noqa: BLE001
-            log(f"[fail] {src_rel}: {exc}")
+            repeat.hit(
+                "crop_failed",
+                "%d images failed to crop (first: %s)",
+                "Cropping %s failed: %s; image left unchanged",
+                src_rel, exc,
+                first=src_rel,
+            )
             failed += 1
             emit_throttled(
                 force=True,
@@ -482,7 +588,17 @@ def _run_crop_train(
                 succeeded=succeeded, failed=failed, skipped=skipped,
             )
 
-    log(f"[done] succeeded={succeeded} failed={failed} skipped={skipped}")
+    repeat.drain()
+    if failed:
+        log.warning(
+            "Cropping finished with failures: succeeded=%d failed=%d skipped=%d",
+            succeeded, failed, skipped,
+        )
+    else:
+        log.info(msg(
+            "worker.preprocess.crop_done",
+            succeeded=succeeded, failed=failed, skipped=skipped,
+        ))
     return 0
 
 

--- a/studio/workers/reg_build_worker.py
+++ b/studio/workers/reg_build_worker.py
@@ -39,8 +39,11 @@ logger = logging.getLogger("studio.workers.reg_build_worker")
 # PP9.5 — 必须在任何 `import onnxruntime` 之前 import 本模块，触发顶层 preload。
 # auto_tag 路径会内联调 wd14_tagger（line ~105 `get_tagger("wd14")`），worker 是独立
 # subprocess，必须自己 import；否则 CUDA EP 静默降级到 CPU，用户看不到任何信号。
+from studio.infrastructure.log_messages import msg
 from studio.infrastructure.task_log import TaskLog
 from studio.services.runtime import onnxruntime as onnxruntime_setup  # noqa: F401
+
+from utils.log_throttle import ProgressThrottle, RepeatThrottle
 
 from studio import db, secrets
 from studio.services.projects import jobs as project_jobs, projects, versions
@@ -114,27 +117,52 @@ def _run_auto_tag(reg_dir: Path, progress, kind: str = "wd14") -> bool:
     """
     images = _collect_reg_images(reg_dir)
     if not images:
-        progress("[auto-tag] 没有图，跳过")
+        progress.info(msg("worker.regbuild.autotag_no_images"))
         return False
-    progress(f"[auto-tag] 启动 {kind}，{len(images)} 张图")
+    total = len(images)
+    progress.info(msg("worker.regbuild.autotag_start", tagger=kind, total=total))
+    repeat = RepeatThrottle(progress)
     try:
         from studio.services.tagging.base import get_tagger
         tagger = get_tagger(kind)
         tagger.prepare()
-        progress(f"[auto-tag] {kind} 模型就绪")
+        progress.info(msg("worker.regbuild.autotag_ready", tagger=kind))
+
+        # 逐图行降 DEBUG，可见进度由节流后的计数 INFO 承担（Q3 三件套）。
+        throttle = ProgressThrottle(total)
+
+        def _on_progress(done: int, tot: int) -> None:
+            if throttle.should_emit(done):
+                progress.info(msg(
+                    "worker.regbuild.autotag_progress", done=done, total=tot,
+                ))
+
         ok = 0
         errs = 0
-        for r in tagger.tag(
-            images,
-            on_progress=lambda d, t: progress(f"[auto-tag] {d}/{t}"),
-        ):
+        for r in tagger.tag(images, on_progress=_on_progress):
             if r.get("error"):
-                progress(f"[auto-tag err] {r['image'].name}: {r['error']}")
+                repeat.hit(
+                    "autotag_failed",
+                    "%d regularization images could not be tagged (first: %s)",
+                    "Tagging failed for %s: %s; image skipped",
+                    r["image"].name, r["error"],
+                    first=r["image"].name,
+                )
                 errs += 1
                 continue
             tagedit.write_tags(r["image"], r.get("tags") or [])
             ok += 1
-        progress(f"[auto-tag] done {ok}/{len(images)} (errors={errs})")
+            progress.debug("auto-tag: tagged %s", r["image"].name)
+        if errs:
+            progress.warning(
+                "Regularization set tagging finished with failures: "
+                "tagged=%d/%d failed=%d",
+                ok, total, errs,
+            )
+        else:
+            progress.info(msg(
+                "worker.regbuild.autotag_done", done=ok, total=total, errors=errs,
+            ))
         return ok > 0
     except Exception:
         progress.warning(
@@ -142,16 +170,25 @@ def _run_auto_tag(reg_dir: Path, progress, kind: str = "wd14") -> bool:
             "but left untagged", exc_info=True,
         )
         return False
+    finally:
+        repeat.drain()
 
 
 def run(job_id: int) -> int:
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, job_id)
     if not job:
-        logger.error("job %s not found", job_id)
+        logger.error(
+            "Regularization build job %s not found in the database; nothing to run",
+            job_id,
+        )
         return 1
     if job["kind"] != "reg_build":
-        logger.error("wrong kind: %s", job["kind"])
+        logger.error(
+            "Internal error: job %s has kind=%s, not a regularization build job; "
+            "aborting",
+            job_id, job["kind"],
+        )
         return 1
 
     params: dict[str, Any] = job.get("params_decoded") or {}
@@ -165,7 +202,11 @@ def run(job_id: int) -> int:
         with db.connection_for() as conn:
             v = versions.get_version(conn, version_id)
             if not v or v["project_id"] != job["project_id"]:
-                progress(f"[error] version {version_id} not in project {job['project_id']}")
+                progress.error(
+                    "Version %s does not belong to project %s; regularization "
+                    "build aborted",
+                    version_id, job["project_id"],
+                )
                 return 1
             p = projects.get_project(conn, v["project_id"])
         assert p is not None
@@ -222,18 +263,23 @@ def run(job_id: int) -> int:
         incremental = bool(params.get("incremental", True))
         pp_method = str(params.get("postprocess_method", "smart"))
         pp_max_crop = float(params.get("postprocess_max_crop_ratio", 0.1))
-        progress(
-            f"[start] version={v['label']} api={api_source} "
-            f"max_tags={max_search_tags} auto_tag={opts.auto_tag} "
-            f"incremental={incremental} auto_dedup={opts.auto_dedup} "
-            f"pp={pp_method}/{pp_max_crop}"
-        )
+        progress.info(msg(
+            "worker.regbuild.start",
+            version=v["label"],
+            source=api_source,
+            max_tags=max_search_tags,
+            auto_tag=opts.auto_tag,
+            incremental=incremental,
+            auto_dedup=opts.auto_dedup,
+            pp_method=pp_method,
+            pp_max_crop=pp_max_crop,
+        ))
 
         # full mode：先清掉 reg/（图、子文件夹、meta、.deleted_ids.json），
         # 用户语义是「从零开始」。incremental mode 保留所有已有内容。
         if not incremental and output_dir.exists():
-            progress("[start] full mode：清空 reg/ 已有内容")
             reg_builder.clear_reg_dir(output_dir)
+            progress.info(msg("regai.full_mode_clear"))
 
         meta = reg_builder.build(
             opts,
@@ -241,7 +287,10 @@ def run(job_id: int) -> int:
             cancel_event=cancel_event,
             incremental=incremental,
         )
-        progress(f"[reg-done] actual={meta.actual_count}/{meta.target_count}")
+        progress.info(msg(
+            "worker.regbuild.built",
+            actual=meta.actual_count, target=meta.target_count,
+        ))
 
         # A4 — auto_dedup：build 后扫重复 → 每组留 1 张其余删 → 不够则
         # incremental 补足。最多 MAX_DEDUP_ROUNDS 轮，每轮删数为 0 提前退出。
@@ -249,34 +298,44 @@ def run(job_id: int) -> int:
             MAX_DEDUP_ROUNDS = 3
             for r in range(MAX_DEDUP_ROUNDS):
                 if cancel_event.is_set():
-                    progress("[dedup] 用户中止")
+                    progress.warning(
+                        "Deduplication canceled by the user; the regularization "
+                        "set may still contain duplicates"
+                    )
                     break
-                progress(f"[dedup r{r + 1}/{MAX_DEDUP_ROUNDS}] 扫描重复…")
+                progress.info(msg(
+                    "worker.regbuild.dedup_scan",
+                    round=r + 1, rounds=MAX_DEDUP_ROUNDS,
+                ))
                 to_delete = reg_dedup.scan_for_dedup(output_dir)
                 if not to_delete:
-                    progress(f"[dedup r{r + 1}] 无可删项，结束")
+                    progress.info(msg("worker.regbuild.dedup_none", round=r + 1))
                     break
                 purged = reg_dedup.purge_paths(output_dir, to_delete)
-                progress(f"[dedup r{r + 1}] 删 {purged['count']} 张")
+                progress.info(msg(
+                    "worker.regbuild.dedup_purged",
+                    round=r + 1, count=purged["count"],
+                ))
                 if purged["count"] == 0:
                     break  # scan 给了但全部 unlink 失败 / 不存在 → 防死循环
                 meta = reg_builder.read_meta(output_dir) or meta
                 shortfall = meta.target_count - meta.actual_count
                 if shortfall <= 0:
-                    progress(f"[dedup r{r + 1}] 已达目标，结束")
+                    progress.info(msg("worker.regbuild.dedup_target_met", round=r + 1))
                     break
-                progress(
-                    f"[dedup r{r + 1}] 缺 {shortfall} 张，自动 incremental 补足"
-                )
+                progress.info(msg(
+                    "worker.regbuild.dedup_refill", round=r + 1, shortfall=shortfall,
+                ))
                 meta = reg_builder.build(
                     opts,
                     on_progress=progress,
                     cancel_event=cancel_event,
                     incremental=True,
                 )
-                progress(
-                    f"[dedup r{r + 1}] 补足后 actual={meta.actual_count}/{meta.target_count}"
-                )
+                progress.info(msg(
+                    "worker.regbuild.dedup_refilled",
+                    round=r + 1, actual=meta.actual_count, target=meta.target_count,
+                ))
 
         # PP5.5 — 分辨率聚类后处理（auto_tag 之前，因为打标基于最终图）。
         # A4 顺序：必须在 dedup 之后 —— postprocess 会 resize 图，phash 会变。
@@ -295,11 +354,10 @@ def run(job_id: int) -> int:
             )
 
         return 0 if meta.actual_count > 0 else 1
-    except Exception as exc:
-        # PR-1 C7: 同 tag_worker — logger.exception 带 trace_id 进 stderr，
-        # progress 给人读短摘要。
-        logger.exception("reg_build worker crashed (job_id=%s)", job_id)
-        progress(f"[error] {exc}")
+    except Exception:
+        # PR-1 C7: logger.exception 带 trace_id 进 stderr；异常摘要由 traceback
+        # 提供，不再另发一条 progress（C6）。
+        logger.exception("Regularization build worker crashed: job=%s", job_id)
         return 1
 
 

--- a/studio/workers/reg_build_worker.py
+++ b/studio/workers/reg_build_worker.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import logging
 import threading
-import traceback
 from pathlib import Path
 from typing import Any
 
@@ -79,9 +78,12 @@ def _run_postprocess(
             on_progress=progress,
             cancel_event=cancel_event,
         )
-    except Exception as exc:
-        progress(f"[postprocess] 失败: {exc}")
-        progress(traceback.format_exc())
+    except Exception:
+        # exc_info 取代整段 format_exc 灌 INFO（traceback 作为续行归属本条 WARNING）
+        progress.warning(
+            "Regularization post-processing failed; skipped it, the "
+            "regularization set is still usable", exc_info=True,
+        )
         reg_builder.update_meta_postprocess(
             reg_dir, when=None, clusters=None, method=None, max_crop_ratio=None
         )
@@ -134,9 +136,11 @@ def _run_auto_tag(reg_dir: Path, progress, kind: str = "wd14") -> bool:
             ok += 1
         progress(f"[auto-tag] done {ok}/{len(images)} (errors={errs})")
         return ok > 0
-    except Exception as exc:
-        progress(f"[auto-tag] 失败: {exc}")
-        progress(traceback.format_exc())
+    except Exception:
+        progress.warning(
+            "Auto-tagging the regularization set failed; the images are kept "
+            "but left untagged", exc_info=True,
+        )
         return False
 
 

--- a/studio/workers/tag_worker.py
+++ b/studio/workers/tag_worker.py
@@ -35,8 +35,11 @@ logger = logging.getLogger("studio.workers.tag_worker")
 # （Linux: RTLD_GLOBAL 加载 torch 自带 CUDA so；Windows: os.add_dll_directory）。
 # cli.py / server.py 已覆盖各自进程；worker 是独立 subprocess，靠 get_tagger
 # 懒加载链触发太晚（懒加载在 main() 里，某些路径下来不及）—— worker 顶层显式 import。
+from studio.infrastructure.log_messages import msg
 from studio.infrastructure.task_log import TaskLog
 from studio.services.runtime import onnxruntime as onnxruntime_setup  # noqa: F401
+
+from utils.log_throttle import ProgressThrottle, RepeatThrottle
 
 from studio import db
 from studio.services.projects import jobs as project_jobs, projects, versions
@@ -108,15 +111,19 @@ def run(job_id: int) -> int:
     with db.connection_for() as conn:
         job = project_jobs.get_job(conn, job_id)
     if not job:
-        logger.error("job %s not found", job_id)
+        logger.error("Tagging job %s not found in the database; nothing to run", job_id)
         return 1
     if job["kind"] != "tag":
-        logger.error("wrong kind: %s", job["kind"])
+        logger.error(
+            "Internal error: job %s has kind=%s, not a tagging job; aborting",
+            job_id, job["kind"],
+        )
         return 1
 
     params: dict[str, Any] = job.get("params_decoded") or {}
 
     progress = TaskLog(logger)
+    repeat = RepeatThrottle(progress)
 
     try:
         tagger_name = params.get("tagger", "wd14")
@@ -134,7 +141,10 @@ def run(job_id: int) -> int:
         with db.connection_for() as conn:
             v = versions.get_version(conn, version_id)
             if not v or v["project_id"] != job["project_id"]:
-                progress(f"[error] version {version_id} not in project {job['project_id']}")
+                progress.error(
+                    "Version %s does not belong to project %s; tagging aborted",
+                    version_id, job["project_id"],
+                )
                 return 1
             p = projects.get_project(conn, v["project_id"])
         assert p is not None
@@ -142,44 +152,57 @@ def run(job_id: int) -> int:
 
         images = _collect_for_scope(version_dir, scope)
         if not images:
-            progress(f"[done] 没有图可打标（范围 {scope} 下没有图）")
+            progress.info(msg("worker.tag.no_images", scope=scope))
             return 0
         total_images = len(images)
 
-        progress(
-            f"[start] tagger={tagger_name} version={v['label']} "
-            f"images={total_images} on_existing={on_existing}"
-        )
+        progress.info(msg(
+            "worker.tag.start",
+            tagger=tagger_name,
+            version=v["label"],
+            total=total_images,
+            mode=on_existing,
+        ))
         if trigger_word:
-            progress(f"[trigger] '{trigger_word}' 将作为第一个 tag prepend 到每张图")
+            progress.info(msg("worker.tag.trigger_word", word=trigger_word))
         skipped = 0
         if on_existing == "skip":
             images, skipped_images = _filter_existing_captions(images)
             skipped = len(skipped_images)
             for img in skipped_images:
-                progress(f"[skip] {img.name}")
+                progress.debug("skip: %s already has a caption", img.name)
         if not images:
-            suffix = f" (skipped={skipped})" if skipped else ""
-            progress(f"[done] tagged {skipped}/{total_images} (errors=0){suffix}")
+            _log_tag_done(progress, done=0, total=total_images, skipped=skipped, errors=0)
             return 0
 
         tagger = get_tagger(tagger_name, overrides=overrides)
         tagger.prepare()
         if overrides:
-            progress(
-                f"[overrides] {', '.join(f'{k}={v}' for k, v in overrides.items())}"
-            )
-        progress(f"[ready] {tagger_name} 已就绪")
+            progress.info(msg(
+                "worker.tag.overrides",
+                overrides=", ".join(f"{k}={v}" for k, v in overrides.items()),
+            ))
+        progress.info(msg("worker.tag.ready", tagger=tagger_name))
+
+        # 逐图行降 DEBUG，可见进度由节流后的计数 INFO 承担（Q3 三件套）。
+        throttle = ProgressThrottle(len(images))
+
+        def _on_progress(done: int, total: int) -> None:
+            if throttle.should_emit(done):
+                progress.info(msg("worker.tag.progress", done=done, total=total))
 
         ok = 0
+        tagged = 0
         errs = 0
-        appended = 0
-        for r in tagger.tag(
-            images,
-            on_progress=lambda d, t: progress(f"[progress] {d}/{t}"),
-        ):
+        for r in tagger.tag(images, on_progress=_on_progress):
             if r.get("error"):
-                progress(f"[err] {r['image'].name}: {r['error']}")
+                repeat.hit(
+                    "tag_failed",
+                    "%d images could not be tagged (first: %s)",
+                    "Tagging failed for %s: %s; image skipped",
+                    r["image"].name, r["error"],
+                    first=r["image"].name,
+                )
                 errs += 1
                 continue
             action = _write_caption(
@@ -192,21 +215,40 @@ def run(job_id: int) -> int:
             )
             if action == "skipped":
                 skipped += 1
-                progress(f"[skip] {r['image'].name}")
-            elif action == "appended":
-                appended += 1
+                progress.debug(
+                    "skip: caption kept for %s (on_existing=skip)", r["image"].name
+                )
+            else:
+                tagged += 1
+                progress.debug("tagged: %s", r["image"].name)
             ok += 1
-        suffix = ""
-        if skipped or appended:
-            suffix = f" (skipped={skipped}, appended={appended})"
-        progress(f"[done] tagged {ok + skipped}/{total_images} (errors={errs}){suffix}")
+        _log_tag_done(
+            progress, done=tagged, total=total_images, skipped=skipped, errors=errs,
+        )
         return 0 if ok > 0 or errs == 0 else 1
-    except Exception as exc:  # noqa: BLE001
+    except Exception:  # noqa: BLE001
         # PR-1 C7: logger.exception 进 stderr（supervisor 收 → jobs/<id>.log），
-        # 同时带 trace_id 进 studio.unhandled chain；progress 给人读短摘要。
-        logger.exception("tag worker crashed (job_id=%s)", job_id)
-        progress(f"[error] {exc}")
+        # 同时带 trace_id 进 studio.unhandled chain；异常摘要由 traceback 提供（C6）。
+        logger.exception("Tag worker crashed: job=%s", job_id)
         return 1
+    finally:
+        repeat.drain()
+
+
+def _log_tag_done(
+    progress: TaskLog, *, done: int, total: int, skipped: int, errors: int
+) -> None:
+    """收尾汇总（R10）：有失败时整行升 WARNING，否则默认视图会全白。"""
+    if errors:
+        progress.warning(
+            "Tagging finished with failures: tagged=%d/%d skipped=%d failed=%d",
+            done, total, skipped, errors,
+        )
+    else:
+        progress.info(msg(
+            "worker.tag.done",
+            done=done, total=total, skipped=skipped, errors=errors,
+        ))
 
 
 def _prepend_trigger_to_tags(tags: list[str], trigger_word: str) -> list[str]:

--- a/tests/test_client_errors_endpoint.py
+++ b/tests/test_client_errors_endpoint.py
@@ -120,7 +120,7 @@ def test_rate_limit_kicks_in_after_10_per_ip(client: TestClient,
     from studio.api.routers.client_errors import _reset_rate_limit_for_tests
     _reset_rate_limit_for_tests()
 
-    with caplog.at_level(logging.INFO, logger="studio.client"):
+    with caplog.at_level(logging.DEBUG, logger="studio.client"):
         # 前 10 个都 200 + ERROR record
         for i in range(10):
             resp = client.post("/api/client-errors", json={"message": f"err {i}"})
@@ -129,16 +129,38 @@ def test_rate_limit_kicks_in_after_10_per_ip(client: TestClient,
                          if r.name == "studio.client" and r.levelname == "ERROR"]
         assert len(error_records) == 10
 
-        # 第 11 个仍 204 但不进 ERROR；进 INFO "rate-limit drop"
+        # 第 11 个仍 204 但不进 ERROR；丢弃只按窗口汇总一条 DEBUG（T5：前端错误
+        # 风暴时 server 端不跟着放大）
         caplog.clear()
         resp = client.post("/api/client-errors", json={"message": "over the limit"})
         assert resp.status_code == 204
         error_after = [r for r in caplog.records
                        if r.name == "studio.client" and r.levelname == "ERROR"]
         assert error_after == [], "rate-limit 后不应产生 ERROR record"
-        info_records = [r for r in caplog.records
-                        if r.name == "studio.client" and r.levelname == "INFO"]
-        assert any("rate-limit drop" in r.getMessage() for r in info_records)
+        debug_records = [r for r in caplog.records
+                         if r.name == "studio.client" and r.levelname == "DEBUG"]
+        assert any("client_errors rate-limited" in r.getMessage()
+                   for r in debug_records)
+        assert any("dropped=1" in r.getMessage() for r in debug_records)
+
+
+def test_rate_limit_drops_are_summarized_not_per_request(
+    client: TestClient, caplog: pytest.LogCaptureFixture,
+) -> None:
+    """T5：超限的 N 次请求只出一条窗口汇总，而不是 N 条日志。"""
+    from studio.api.routers.client_errors import _reset_rate_limit_for_tests
+    _reset_rate_limit_for_tests()
+
+    for i in range(10):
+        client.post("/api/client-errors", json={"message": f"err {i}"})
+    with caplog.at_level(logging.DEBUG, logger="studio.client"):
+        for i in range(20):
+            assert client.post(
+                "/api/client-errors", json={"message": f"over {i}"},
+            ).status_code == 204
+        drops = [r for r in caplog.records
+                 if "client_errors rate-limited" in r.getMessage()]
+        assert len(drops) == 1, "同一窗口内的丢弃只应汇总一条"
 
 
 def test_rate_limit_per_ip_isolated(client: TestClient) -> None:

--- a/tests/test_eval_model_pool.py
+++ b/tests/test_eval_model_pool.py
@@ -50,7 +50,8 @@ def test_release_reports_through_progress() -> None:
     pool.get("a", lambda: object())
     lines: list[str] = []
     pool.release(lines.append)
-    assert any("释放" in line for line in lines)
+    # 显存编排内部动作 → DEBUG 英文排障行（不进 msg_id 字典）
+    assert any("model released" in line for line in lines)
     # 没加载过时不该刷无意义的日志
     lines.clear()
     eval_model_pool.ModelPool("clip").release(lines.append)

--- a/tests/test_log_messages.py
+++ b/tests/test_log_messages.py
@@ -1,0 +1,62 @@
+"""log_messages i18n 字典：语言解析、渲染兜底、msg_id 唯一性。"""
+from __future__ import annotations
+
+import pytest
+
+from studio.infrastructure import log_messages as lm
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    lm._reset_lang_cache_for_tests()
+    monkeypatch.delenv(lm.UI_LANG_ENV, raising=False)
+    yield
+    lm._reset_lang_cache_for_tests()
+
+
+def test_env_selects_language(monkeypatch):
+    monkeypatch.setitem(lm.MESSAGES, "t.hello", {"zh": "你好 {name}", "en": "hello {name}"})
+    monkeypatch.setenv(lm.UI_LANG_ENV, "en")
+    assert lm.msg("t.hello", name="x") == "hello x"
+    monkeypatch.setenv(lm.UI_LANG_ENV, "zh")
+    assert lm.msg("t.hello", name="x") == "你好 x"
+
+
+def test_invalid_env_falls_back_to_secrets_then_zh(monkeypatch):
+    monkeypatch.setitem(lm.MESSAGES, "t.hello", {"zh": "中", "en": "e"})
+    monkeypatch.setenv(lm.UI_LANG_ENV, "fr")
+    # secrets 读失败 → zh
+    monkeypatch.setattr(lm, "_secrets_lang", None)
+    import studio.infrastructure.secrets as sec
+    monkeypatch.setattr(sec, "load", lambda: (_ for _ in ()).throw(RuntimeError()))
+    assert lm.msg("t.hello") == "中"
+
+
+def test_missing_key_is_loud_but_safe():
+    assert lm.msg("no.such.key") == "no.such.key"
+    out = lm.msg("no.such.key", a=1)
+    assert "no.such.key" in out and "1" in str(out)
+
+
+def test_bad_placeholder_returns_template(monkeypatch):
+    monkeypatch.setitem(lm.MESSAGES, "t.bad", {"zh": "值 {missing}"})
+    assert lm.msg("t.bad", other=1) == "值 {missing}"
+
+
+def test_partial_entry_falls_back_across_languages(monkeypatch):
+    monkeypatch.setitem(lm.MESSAGES, "t.zh_only", {"zh": "只有中文"})
+    monkeypatch.setenv(lm.UI_LANG_ENV, "en")
+    assert lm.msg("t.zh_only") == "只有中文"
+
+
+def test_no_duplicate_ids_across_domain_files():
+    from studio.infrastructure._messages_train import MESSAGES as a
+    from studio.infrastructure._messages_worker import MESSAGES as b
+    from studio.infrastructure._messages_server import MESSAGES as c
+    ids = list(a) + list(b) + list(c)
+    assert len(ids) == len(set(ids))
+
+
+def test_all_entries_bilingual():
+    for mid, entry in lm.MESSAGES.items():
+        assert set(entry) >= {"zh", "en"}, f"{mid} 缺语言: {sorted(entry)}"

--- a/tests/test_log_throttle_helpers.py
+++ b/tests/test_log_throttle_helpers.py
@@ -1,0 +1,166 @@
+"""`utils.log_throttle` 三个节流器的语义（verdicts-b-subprocess.md §4.2）。
+
+这三个类被 reg_ai / caption_utils / 4 个 worker / Automagic2 共用，语义错了
+会在故障路径上把 run.log 冲成噪音（或反过来把首条告警吞掉），单独锁一遍。
+"""
+from __future__ import annotations
+
+from utils.log_throttle import BackoffThrottle, ProgressThrottle, RepeatThrottle
+
+
+class _Recorder:
+    """只实现 TaskLogLike 里节流器用到的两个级别方法。"""
+
+    def __init__(self) -> None:
+        self.lines: list[tuple[str, str]] = []
+        self.exc_infos: list[bool] = []
+
+    def debug(self, msg: str, *args: object) -> None:
+        self.lines.append(("DEBUG", msg % args if args else msg))
+
+    def warning(self, msg: str, *args: object, exc_info: bool = False) -> None:
+        self.lines.append(("WARNING", msg % args if args else msg))
+        self.exc_infos.append(exc_info)
+
+
+# ── 方案 A：RepeatThrottle ──────────────────────────────────────────────
+
+
+def test_repeat_first_full_then_debug_then_summary() -> None:
+    """首条全文 WARNING、2..N 条降 DEBUG、drain 补一条计数汇总。"""
+    log = _Recorder()
+    throttle = RepeatThrottle(log)
+    for name in ("a.png", "b.png", "c.png"):
+        throttle.hit(
+            "gone",
+            "%d images skipped: the source file was gone (first: %s)",
+            "Image skipped: %s no longer exists",
+            name,
+            first=name,
+        )
+    throttle.drain()
+
+    assert [lv for lv, _ in log.lines] == ["WARNING", "DEBUG", "DEBUG", "WARNING"]
+    assert log.lines[0][1] == "Image skipped: a.png no longer exists"
+    # 汇总带总数与**首个**样例（不是最后一个）
+    assert log.lines[-1][1] == (
+        "3 images skipped: the source file was gone (first: a.png)"
+    )
+
+
+def test_repeat_single_hit_has_no_summary() -> None:
+    """只触发一次时首条就是全部信息，drain 不再重复一条汇总。"""
+    log = _Recorder()
+    throttle = RepeatThrottle(log)
+    throttle.hit("gone", "%d skipped (first: %s)", "Image skipped: %s", "solo.png",
+                 first="solo.png")
+    throttle.drain()
+
+    assert [lv for lv, _ in log.lines] == ["WARNING"]
+
+
+def test_repeat_summary_without_sample_takes_only_count() -> None:
+    """不带 first 的汇总串只有一个 %d（reg_ai 的批预编码两条就是这形态）。"""
+    log = _Recorder()
+    throttle = RepeatThrottle(log)
+    for _ in range(3):
+        throttle.hit(
+            "vram",
+            "Batch pre-encoding was skipped %d times",
+            "Skipping batch pre-encoding: %.1f GB VRAM free",
+            3.5,
+        )
+    throttle.drain()
+
+    assert log.lines[-1] == ("WARNING", "Batch pre-encoding was skipped 3 times")
+
+
+def test_repeat_groups_are_independent_and_exc_info_only_on_first() -> None:
+    """不同 key 各自计数；traceback 只挂首条（C6：每条都带会淹掉 run.log）。"""
+    log = _Recorder()
+    throttle = RepeatThrottle(log)
+    throttle.hit("a", "%d a (first: %s)", "a failed: %s", "x", first="x", exc_info=True)
+    throttle.hit("a", "%d a (first: %s)", "a failed: %s", "y", first="y", exc_info=True)
+    throttle.hit("b", "%d b (first: %s)", "b failed: %s", "z", first="z")
+
+    assert throttle.count("a") == 2
+    assert throttle.count("b") == 1
+    # 首条 WARNING 带 traceback；b 的首条不带
+    assert log.exc_infos == [True, False]
+
+    throttle.drain()
+    summaries = [ln for lv, ln in log.lines if lv == "WARNING"]
+    assert "2 a (first: x)" in summaries
+    assert not [s for s in summaries if s.startswith("1 b")]
+
+
+def test_repeat_drain_resets_state() -> None:
+    """drain 后计数清零——同一进程里跑第二个任务不会继承上个任务的数。"""
+    log = _Recorder()
+    throttle = RepeatThrottle(log)
+    for _ in range(2):
+        throttle.hit("k", "%d hit", "hit")
+    throttle.drain()
+    assert throttle.count("k") == 0
+
+    log.lines.clear()
+    throttle.hit("k", "%d hit", "hit")
+    assert [lv for lv, _ in log.lines] == ["WARNING"]  # 又是首条，不是 DEBUG
+
+
+# ── 方案 B：ProgressThrottle ────────────────────────────────────────────
+
+
+def test_progress_collapses_1000_items_to_about_100_lines() -> None:
+    """1000 张图的进度行从 1000 条收到 ~100 条，且首末必发。"""
+    throttle = ProgressThrottle(1000, min_interval=10_000)  # 关掉时间维度
+    emitted = [i for i in range(1, 1001) if throttle.should_emit(i)]
+
+    assert emitted[0] == 1
+    assert emitted[-1] == 1000
+    assert 90 <= len(emitted) <= 110
+
+
+def test_progress_small_task_emits_every_item() -> None:
+    """总数 < 100 时 step 退化成 1，每条都发（小任务不该只看到首末两行）。"""
+    throttle = ProgressThrottle(3, min_interval=10_000)
+    assert [i for i in range(1, 4) if throttle.should_emit(i)] == [1, 2, 3]
+
+
+def test_progress_time_window_emits_between_step_boundaries() -> None:
+    """步长没到但时间窗到了也要发——慢任务不能长时间零输出。"""
+    throttle = ProgressThrottle(1000, min_interval=0.0)
+    assert throttle.should_emit(7) is True
+
+
+def test_progress_tolerates_zero_total() -> None:
+    """total=0（空任务）不能除零；此时每次调用都放行，由调用方决定发不发。"""
+    throttle = ProgressThrottle(0)
+    assert throttle.should_emit(1) is True
+
+
+# ── 方案 C-2：BackoffThrottle ───────────────────────────────────────────
+
+
+def test_backoff_reports_at_first_then_powers_of_ten() -> None:
+    """十万量级的 NaN 风暴收成个位数条告警：第 1、10、100、1000… 次。"""
+    throttle = BackoffThrottle()
+    marks = []
+    for _ in range(1200):
+        count, kind = throttle.tick()
+        if kind:
+            marks.append((count, kind))
+
+    assert marks == [
+        (1, "first"), (10, "milestone"), (100, "milestone"), (1000, "milestone"),
+    ]
+    assert throttle.count == 1200
+
+
+def test_backoff_silent_ticks_still_count() -> None:
+    """静默区间照常累加，milestone 报的是累计数不是区间数。"""
+    throttle = BackoffThrottle()
+    for _ in range(9):
+        throttle.tick()
+    count, kind = throttle.tick()
+    assert (count, kind) == (10, "milestone")

--- a/tests/test_log_throttling.py
+++ b/tests/test_log_throttling.py
@@ -1,0 +1,129 @@
+"""刀 1 机制修复：_ErrorThrottle / event_bus 丢弃状态化 / system_stats 熔断。"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+# ── _ErrorThrottle ───────────────────────────────────────────────────
+class TestErrorThrottle:
+    def _make(self, monkeypatch, now: list[float]):
+        from studio.supervisor.core import _ErrorThrottle
+        import studio.supervisor.core as core
+        monkeypatch.setattr(core.time, "monotonic", lambda: now[0])
+        return _ErrorThrottle("test site")
+
+    def test_first_full_then_silent_within_window(self, monkeypatch, caplog):
+        now = [1000.0]
+        th = self._make(monkeypatch, now)
+        with caplog.at_level(logging.DEBUG, logger="studio.supervisor.core"):
+            for _ in range(5):
+                try:
+                    raise ValueError("x")
+                except ValueError:
+                    th.failed()
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelno == logging.ERROR  # exception
+
+    def test_window_summary_and_recovery(self, monkeypatch, caplog):
+        now = [1000.0]
+        th = self._make(monkeypatch, now)
+        with caplog.at_level(logging.DEBUG, logger="studio.supervisor.core"):
+            for _ in range(3):
+                try:
+                    raise ValueError("x")
+                except ValueError:
+                    th.failed()
+            now[0] += 61.0
+            try:
+                raise ValueError("x")
+            except ValueError:
+                th.failed()
+            th.recovered()
+        levels = [r.levelno for r in caplog.records]
+        assert levels == [logging.ERROR, logging.WARNING, logging.INFO]
+        assert "count=4" in caplog.records[1].message
+
+    def test_exception_type_change_relogs_full(self, monkeypatch, caplog):
+        now = [1000.0]
+        th = self._make(monkeypatch, now)
+        with caplog.at_level(logging.DEBUG, logger="studio.supervisor.core"):
+            try:
+                raise ValueError("x")
+            except ValueError:
+                th.failed()
+            try:
+                raise KeyError("y")
+            except KeyError:
+                th.failed()
+        assert [r.levelno for r in caplog.records] == [logging.ERROR, logging.ERROR]
+
+
+# ── event_bus 丢弃状态化 ─────────────────────────────────────────────
+class TestEventBusDropState:
+    def test_one_congestion_two_lines(self, caplog):
+        from studio.infrastructure.event_bus import _safe_put
+
+        async def scenario():
+            q: asyncio.Queue = asyncio.Queue(maxsize=1)
+            with caplog.at_level(logging.WARNING, logger="studio.infrastructure.event_bus"):
+                _safe_put(q, {"type": "a"})          # 放进去
+                for i in range(10):                   # 连续丢 10 个
+                    _safe_put(q, {"type": f"drop{i}"})
+                q.get_nowait()                        # 消费者恢复
+                _safe_put(q, {"type": "b"})          # 恢复 → 汇总条
+        asyncio.run(scenario())
+        msgs = [r.message for r in caplog.records]
+        assert len(msgs) == 2
+        assert "dropping events" in msgs[0]
+        assert "dropped 10 event(s)" in msgs[1]
+        assert "drop9" in msgs[1]  # last_type
+
+
+# ── system_stats 熔断 ────────────────────────────────────────────────
+@pytest.fixture()
+def reset_stats_state():
+    import studio.services.system_stats as ss
+    ss._GPU_FAILS[0] = 0
+    ss._GPU_DISABLED[0] = False
+    ss._PSUTIL_FAILS[0] = 0
+    ss._PSUTIL_DISABLED[0] = False
+    yield ss
+    ss._GPU_FAILS[0] = 0
+    ss._GPU_DISABLED[0] = False
+    ss._PSUTIL_FAILS[0] = 0
+    ss._PSUTIL_DISABLED[0] = False
+
+
+class TestSystemStatsFuse:
+    def test_gpu_fuse_after_three_failures(self, reset_stats_state, monkeypatch, caplog):
+        ss = reset_stats_state
+        monkeypatch.setattr(ss, "_ensure_nvml", lambda: True)
+        # 无 nvmlDeviceGetCount 属性 → 函数体 AttributeError 走 except
+        monkeypatch.setitem(sys.modules, "pynvml", SimpleNamespace())
+        with caplog.at_level(logging.DEBUG, logger="studio.services.system_stats"):
+            for _ in range(5):
+                assert ss._collect_gpu() is None
+        assert ss._GPU_DISABLED[0] is True
+        msgs = [r.message for r in caplog.records]
+        assert len(msgs) == 2  # 首条 + 熔断条，之后零日志
+        assert "sampling disabled" in msgs[1]
+
+    def test_psutil_fuse_reports_zeros(self, reset_stats_state, monkeypatch, caplog):
+        ss = reset_stats_state
+        def boom(*a, **kw):
+            raise RuntimeError("psutil down")
+        monkeypatch.setattr(ss.psutil, "cpu_percent", boom)
+        monkeypatch.setattr(ss, "_collect_gpu", lambda: None)
+        with caplog.at_level(logging.DEBUG, logger="studio.services.system_stats"):
+            for _ in range(5):
+                s = ss.collect_stats()
+        assert s.cpu_pct == 0.0
+        assert ss._PSUTIL_DISABLED[0] is True
+        msgs = [r.message for r in caplog.records]
+        assert len(msgs) == 2
+        assert "reporting zeros" in msgs[1]

--- a/tests/test_loop_bucket_switch_cache.py
+++ b/tests/test_loop_bucket_switch_cache.py
@@ -72,15 +72,15 @@ def test_each_switch_logged_at_debug_only(monkeypatch, caplog):
         tracker.observe(_lat(6, 10))
         tracker.observe(_lat(8, 8))
         tracker.observe(_lat(6, 10))
-    recs = [r for r in caplog.records if "ARB 切桶" in r.getMessage()]
+    recs = [r for r in caplog.records if "ARB bucket switch" in r.getMessage()]
     assert [r.levelname for r in recs] == ["DEBUG"] * 3
-    assert "8x8→6x10" in recs[0].getMessage()
-    assert "6x10→8x8" in recs[1].getMessage()
+    assert "8x8 -> 6x10" in recs[0].getMessage()
+    assert "6x10 -> 8x8" in recs[1].getMessage()
 
     caplog.clear()
     with caplog.at_level("INFO", logger=loop_mod.logger.name):
         tracker.observe(_lat(8, 8))
-    assert not [r for r in caplog.records if "ARB 切桶" in r.getMessage()]
+    assert not [r for r in caplog.records if "ARB bucket switch" in r.getMessage()]
 
 
 # ---------------------------------------------------------------- loop 接线

--- a/tests/test_lycoris_patch.py
+++ b/tests/test_lycoris_patch.py
@@ -106,16 +106,21 @@ def test_apply_when_not_installed_returns_skipped(
     assert fresh_patch_module.apply_lokr_device_patch() == "skipped_not_installed"
 
 
-def test_apply_unknown_version_skips_and_warns(
+def test_apply_unknown_version_skips_quietly(
     fresh_patch_module, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    """未知版本（如上游已修的 3.5.0）→ 跳过并 warn，避免覆盖上游修复。"""
+    """未知版本（如上游已修的 3.5.0）→ 跳过，避免覆盖上游修复。
+
+    这是「什么都没做」的正常路径：新版用户每次训练吃一条 WARNING 属误报，
+    按 leveling-rules R4 记 DEBUG（版本号仍在，排障可查）。
+    """
     pytest.importorskip("lycoris.modules.lokr")
     monkeypatch.setattr(fresh_patch_module, "version", lambda _: "999.0.0")
-    with caplog.at_level(logging.WARNING, logger="utils.lycoris_patch"):
+    with caplog.at_level(logging.DEBUG, logger="utils.lycoris_patch"):
         status = fresh_patch_module.apply_lokr_device_patch()
     assert status == "skipped_version_unknown"
     assert any("999.0.0" in rec.message for rec in caplog.records)
+    assert not [r for r in caplog.records if r.levelno >= logging.WARNING]
 
 
 def test_apply_idempotent(

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -331,7 +331,8 @@ def test_download_flat_ms_skips_existing(tmp_path: "Path") -> None:
         "some/repo", "split_files/foo.safetensors", target, on_log=logs.append
     )
     assert ok
-    assert any("已存在" in l for l in logs)
+    # 逐文件「已存在，跳过」判 DEBUG（英文排障行），收尾另有计数 INFO 汇总
+    assert any("already present" in l for l in logs)
 
 
 def test_download_flat_ms_rename_and_cleanup(
@@ -543,7 +544,9 @@ def test_download_upscaler_unknown_label_returns_false() -> None:
     logs: list[str] = []
     ok = model_downloader.download_upscaler("nope", on_log=logs.append)
     assert not ok
-    assert any("未知放大器" in l for l in logs)
+    assert any("unknown upscaler" in l for l in logs)
+    # 「下载完全没发生 + 不自愈」→ ERROR，且必须给出下一步动作（S6）
+    assert any("pick an upscaler from the model list" in l for l in logs)
 
 
 def test_download_upscaler_delegates_to_download_flat(
@@ -712,7 +715,9 @@ def test_download_upscaler_custom_rejects_bad_ext(
         "hf", "foo/bar", "evil.sh", tmp_path, on_log=logs.append
     )
     assert not ok
-    assert any("扩展名" in l for l in logs)
+    assert any("unsupported file extension" in l for l in logs)
+    # 支持的扩展名要逐个列出来，不能把 tuple 的 repr 甩给用户（T1）
+    assert any(".pth" in l and ".safetensors" in l for l in logs)
 
 
 def test_download_upscaler_custom_rejects_bad_source(
@@ -723,7 +728,7 @@ def test_download_upscaler_custom_rejects_bad_source(
         "ftp", "foo/bar", "a.pth", tmp_path, on_log=logs.append
     )
     assert not ok
-    assert any("未知下载源" in l for l in logs)
+    assert any("unknown download source" in l for l in logs)
 
 
 def test_upscaler_target_accepts_custom_filename(tmp_path: "Path") -> None:
@@ -893,25 +898,55 @@ def test_trigger_cltagger_v2_uses_dedicated_repo_and_target(
 
 
 def test_failure_summary_surfaces_gated_hint() -> None:
-    """下载失败 message 必须给出可操作原因（token / 授权），而非通用串。"""
+    """下载失败 message 必须给出可操作原因（token / 授权），而非通用串。
+
+    G7：选行判据是**级别**（最后一条 ERROR 记录的全文），不再按 ✗ / ↳ 字符
+    前缀 grep —— 那两个伪级别前缀已随文案改写删除。gated 提示是那条 ERROR
+    记录的续行，所以「错误 + 怎么办」自然一起带出来。
+    """
     from studio.services.models import downloader as dl
 
-    log = [
-        "📥 CLTagger → /models/cltagger",
-        "   ✗ model.onnx: 401 Client Error: Cannot access gated repo",
-        "   ↳ 该仓库可能是 gated/private：请到 设置→密钥 填 HuggingFace token 后重试。",
+    leveled = [
+        ("info", "Downloading CLTagger → /models/cltagger"),
+        (
+            "error",
+            "download failed: name=model.onnx source=hf err=401 Client Error: "
+            "Cannot access gated repo; the model is incomplete and the download "
+            "is marked failed\n"
+            "  the repository may be gated or private: request access on "
+            "huggingface.co, then set a HuggingFace token in Settings → Secrets "
+            "(or the HF_TOKEN environment variable) and retry",
+        ),
     ]
-    msg = dl._failure_summary(log)
-    assert "↳" in msg
+    msg = dl._failure_summary(leveled)
     assert "token" in msg.lower()
-    assert "✗" in msg  # 同时带上原始错误
+    assert "gated" in msg.lower()
+    assert "model.onnx" in msg  # 同时带上原始错误
+    assert "\n" not in msg  # 单行 message（前端 toast 用）
 
 
 def test_failure_summary_falls_back_to_last_error() -> None:
     from studio.services.models import downloader as dl
 
-    log = ["📥 ...", "   ✗ model.onnx: connection reset"]
-    assert dl._failure_summary(log) == "✗ model.onnx: connection reset"
+    leveled = [
+        ("info", "Downloading CLTagger → /models/cltagger"),
+        ("debug", "file already present; skipped: name=x source=hf"),
+        ("error", "download failed: name=model.onnx source=hf err=connection reset"),
+    ]
+    assert dl._failure_summary(leveled) == (
+        "download failed: name=model.onnx source=hf err=connection reset"
+    )
+
+
+def test_failure_summary_ignores_non_error_levels() -> None:
+    """WARNING / INFO 行不该被当成失败原因（回退到通用串）。"""
+    from studio.services.models import downloader as dl
+
+    leveled = [
+        ("info", "Downloading CLTagger → /models/cltagger"),
+        ("warning", "WD14 x has no ModelScope mirror; falling back to HuggingFace"),
+    ]
+    assert dl._failure_summary(leveled) == "下载失败，详见下载日志"
 
 
 def test_failure_summary_generic_when_no_error_line() -> None:

--- a/tests/test_pending_install.py
+++ b/tests/test_pending_install.py
@@ -122,7 +122,7 @@ def test_apply_pending_keeps_marker_on_failure(
     assert isolated_marker.exists()
     assert pending_install.read_pending()["target"] == "cu128"
     err = _msgs(caplog, min_level=logging.ERROR)
-    assert "torch 重装失败" in err
+    assert "torch reinstall failed" in err
     assert "network failed" in err
 
 
@@ -140,4 +140,4 @@ def test_apply_pending_unknown_kind_clears_marker(
         r for r in caplog.records
         if r.name == _LOGGER and r.levelno == logging.WARNING
     ]
-    assert warn and "未知" in warn[0].getMessage()
+    assert warn and "unknown pending install kind" in warn[0].getMessage()

--- a/tests/test_preprocess_worker_train.py
+++ b/tests/test_preprocess_worker_train.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 from PIL import Image
 
+from studio.infrastructure.task_log import NULL_LOG
 from studio.services.projects import projects
 from studio.services.preprocess import manifest as pm
 from studio.workers import preprocess_worker as worker
@@ -34,6 +35,7 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict:
     }
 
 
+# worker 的 log 通道已是 TaskLogLike（带级别方法）；emit_event 仍是裸回调。
 def _silence(*_args, **_kwargs) -> None:
     pass
 
@@ -83,7 +85,7 @@ def test_crop_train_single_rect_overwrites_source(env) -> None:
     rc = worker._run_crop_train(
         env["project"], env["version"],
         {"crops": {"1_data/X.png": [{"x": 0.2, "y": 0.0, "w": 0.5, "h": 1.0}]}},
-        _silence, _silence,
+        NULL_LOG, _silence,
     )
     assert rc == 0
     # 覆盖在原 path
@@ -105,7 +107,7 @@ def test_crop_train_single_rect_replaces_jpg_without_doubling(env) -> None:
     rc = worker._run_crop_train(
         env["project"], env["version"],
         {"crops": {"1_data/X.jpg": [{"x": 0.2, "y": 0.0, "w": 0.5, "h": 1.0}]}},
-        _silence, _silence,
+        NULL_LOG, _silence,
     )
     assert rc == 0
     assert not (sub / "X.jpg").exists()
@@ -131,7 +133,7 @@ def test_crop_train_fan_out_writes_multiple(env) -> None:
             {"x": 0.0, "y": 0.0, "w": 0.4, "h": 1.0},
             {"x": 0.5, "y": 0.0, "w": 0.4, "h": 1.0},
         ]}},
-        _silence, _silence,
+        NULL_LOG, _silence,
     )
     assert rc == 0
     # fan-out 派生 c0 / c1
@@ -161,7 +163,7 @@ def test_crop_train_fan_out_removes_source_sidecars(env) -> None:
             {"x": 0.0, "y": 0.0, "w": 0.4, "h": 1.0},
             {"x": 0.5, "y": 0.0, "w": 0.4, "h": 1.0},
         ]}},
-        _silence, _silence,
+        NULL_LOG, _silence,
     )
     assert rc == 0
     assert not (sub / "Z.jpg").exists()
@@ -179,7 +181,7 @@ def test_crop_train_skips_when_source_missing(env) -> None:
     rc = worker._run_crop_train(
         env["project"], env["version"],
         {"crops": {"1_data/ghost.png": [{"x": 0, "y": 0, "w": 0.5, "h": 0.5}]}},
-        _silence, _silence,
+        NULL_LOG, _silence,
     )
     assert rc == 0  # job 仍完成；单图 skip
 
@@ -193,7 +195,7 @@ def test_crop_train_rejects_invalid_rel_name(env) -> None:
     rc = worker._run_crop_train(
         env["project"], env["version"],
         {"crops": {"../escape/X.png": [{"x": 0, "y": 0, "w": 0.5, "h": 0.5}]}},
-        _silence, _silence,
+        NULL_LOG, _silence,
     )
     # 路径校验 fail → skip 该项；job 仍 return 0
     assert rc == 0
@@ -219,7 +221,7 @@ def test_crop_train_origin_inherited_from_existing_entry(env) -> None:
             {"x": 0.0, "y": 0.0, "w": 0.5, "h": 1.0},
             {"x": 0.5, "y": 0.0, "w": 0.5, "h": 1.0},
         ]}},
-        _silence, _silence,
+        NULL_LOG, _silence,
     )
     m = pm.train_load(env["pdir"], "v1")
     assert m["images"]["1_data/X_c0_c0.png"]["origin"] == "X.jpg"
@@ -263,7 +265,7 @@ def test_upscale_train_in_place_overwrites_jpg(env, monkeypatch) -> None:
     )
 
     rc = worker._run_upscale_train(
-        env["project"], env["version"], {"mode": "all"}, _silence, _silence,
+        env["project"], env["version"], {"mode": "all"}, NULL_LOG, _silence,
     )
     assert rc == 0
     # src == dst：in-place 覆盖
@@ -304,7 +306,7 @@ def test_upscale_train_in_place_overwrites_png(env, monkeypatch) -> None:
     monkeypatch.setattr(worker.model_downloader, "upscaler_target", lambda label: fake_model)
 
     rc = worker._run_upscale_train(
-        env["project"], env["version"], {"mode": "all"}, _silence, _silence,
+        env["project"], env["version"], {"mode": "all"}, NULL_LOG, _silence,
     )
     assert rc == 0
     assert called["save_kwargs"]["format"] == "PNG"

--- a/tests/test_print_whitelist.py
+++ b/tests/test_print_whitelist.py
@@ -30,8 +30,6 @@ WHITELIST: dict[str, set[str]] = {
     "utils/caption_utils.py": {"<__main__>"},
     # stdout 协议行
     "studio/workers/preprocess_worker.py": {"emit_event"},
-    # CLI 启动 banner（setup_logging 之前）
-    "studio/api/main.py": {"main"},
 }
 
 

--- a/tests/test_studio_cli.py
+++ b/tests/test_studio_cli.py
@@ -432,7 +432,8 @@ def test_check_torch_cuda_info_on_cpu_only_without_gpu(
     )
     cli._check_torch_cuda()
     info = _cli_info(cli_log)
-    assert "CPU-only build" in info
+    # INFO 叙事行走 msg_id 字典（默认 zh）：`CPU-only build` → `CPU-only 构建`
+    assert "CPU-only 构建" in info
     assert "未检测到 NVIDIA GPU" in info
     assert _cli_warn_plus(cli_log) == ""
 
@@ -599,7 +600,7 @@ def test_cmd_run_returns_42_when_installer_changed(
     rc = cli.main(["run", "--no-browser"])
     assert rc == cli._INSTALLER_RELOAD_EXIT_CODE == 42
     assert fake_flag.exists(), "flag 必须保留给 wrapper 走 exec-self 路径"
-    assert "launcher 文件更新" in _cli_info(cli_log)
+    assert "launcher 文件有更新" in _cli_info(cli_log)
 
 
 def test_cmd_run_normal_restart_when_installer_unchanged(

--- a/tests/test_tag_dictionary.py
+++ b/tests/test_tag_dictionary.py
@@ -89,7 +89,11 @@ def test_parse_truncates_at_max_entries(
     with caplog.at_level("WARNING"):
         entries = td.parse_csv(text)
     assert len(entries) == 3
-    assert any("超过" in r.message or "上限" in r.message for r in caplog.records)
+    # studio.log 面统一英文；前缀 `tag_dictionary:` 与 logger 名冗余，已删
+    assert any(
+        "exceeds the" in r.message and "entry limit" in r.message
+        for r in caplog.records
+    )
 
 
 def test_parse_first_comma_only() -> None:

--- a/tests/test_timestep_sampler_resume.py
+++ b/tests/test_timestep_sampler_resume.py
@@ -181,7 +181,7 @@ def test_infonoise_load_state_dict_K_mismatch_falls_back_cold(caplog):
     s_load = _new_info_sched(K=16)  # K 不一致
     with caplog.at_level("WARNING"):
         s_load.load_state_dict(sd)
-    assert any("shape mismatch" in r.message for r in caplog.records)
+    assert any("saved bin layout" in r.message for r in caplog.records)
     # 加载失败但不抛 —— 状态保持初始
     assert s_load._internal_step == 0
     assert s_load._cdf_values is None
@@ -351,6 +351,6 @@ def test_load_corrupted_sampler_state_logs_and_continues(tmp_path, caplog):
     sched2 = _new_info_sched()
     with caplog.at_level("WARNING"):
         load_training_state(state_path, injector2, opt2, timestep_sampler=sched2)
-    assert any("timestep_sampler 状态恢复失败" in r.message for r in caplog.records)
+    assert any("Timestep sampler state failed to restore" in r.message for r in caplog.records)
     # 训练状态本身仍正常返回
     assert sched2._cdf_values is None  # 没装上，保持冷启动

--- a/tests/test_training_models_t5_fallback.py
+++ b/tests/test_training_models_t5_fallback.py
@@ -91,7 +91,7 @@ def test_missing_t5_dir_download_error_is_wrapped(tm, monkeypatch, tmp_path, cap
     assert "t5_tokenizer_path" in msg  # 指引用户检查配置
     assert isinstance(excinfo.value.__cause__, ConnectionError)
     assert t5_calls == ["google/t5-v1_1-xxl"]
-    assert any("本地目录缺失" in r.getMessage() for r in caplog.records)
+    assert any("not found locally" in r.getMessage() for r in caplog.records)
 
 
 def test_missing_t5_dir_fallback_success_logs_warning(tm, monkeypatch, tmp_path, caplog):
@@ -107,7 +107,7 @@ def test_missing_t5_dir_fallback_success_logs_warning(tm, monkeypatch, tmp_path,
     assert t5_tokenizer == "tok"
     assert t5_calls == ["google/t5-v1_1-xxl"]
     warnings = [r.getMessage() for r in caplog.records if r.levelno >= logging.WARNING]
-    assert any("本地目录缺失" in m and "google/t5-v1_1-xxl" in m for m in warnings)
+    assert any("not found locally" in m and "google/t5-v1_1-xxl" in m for m in warnings)
 
 
 def test_local_t5_dir_never_falls_back(tm, monkeypatch, tmp_path, caplog):

--- a/tests/test_vram_trace.py
+++ b/tests/test_vram_trace.py
@@ -6,12 +6,25 @@ from tools.vram_trace import classify_stage, merge_process_rows
 
 
 def test_classify_krea2_task_log_stages():
-    assert classify_stage("INFO loading text encoders (TE 先行) x") == "load_te"
-    assert classify_stage("INFO krea2 预编码 2 条 prompt；TE 已释放") == "te_released"
-    assert classify_stage("INFO loading transformer [krea2] x") == "load_dit"
+    assert classify_stage(
+        "INFO Loading text encoder ahead of the transformer for pre-encoding: x"
+    ) == "load_te"
+    assert classify_stage("INFO 加载文本编码器: x") == "load_te"
+    assert classify_stage("INFO Pre-encoded 2 prompts: text encoder released") == "te_released"
+    assert classify_stage("INFO 已预编码 2 条 prompt: 文本编码器已释放") == "te_released"
+    assert classify_stage("INFO Loading transformer (krea2): x") == "load_dit"
+    assert classify_stage("INFO 加载 Transformer（krea2）: x") == "load_dit"
     assert classify_stage("INFO loading vae x") == "load_vae"
+    assert classify_stage("INFO 加载 VAE") == "load_vae"
     assert classify_stage("INFO VAE 加载完成") == "vae_ready"
-    assert classify_stage("INFO Krea2 fp8 merge：2 份 LoRA") == "lora_merge"
+    assert classify_stage(
+        "INFO LoRA merged into the fp8 base model: 2 LoRA(s) into 240 layers"
+    ) == "lora_merge"
+    assert classify_stage(
+        "INFO LoRA 已合并进 fp8 底模: 2 份 LoRA → 240 个层"
+    ) == "lora_merge"
+    assert classify_stage("INFO Model unloaded: 31.2 GB RAM available") == "unload_all"
+    assert classify_stage("ERROR Generation task failed: task=7") == "failed"
     assert classify_stage("ordinary log line") is None
 
 

--- a/tools/vram_trace.py
+++ b/tools/vram_trace.py
@@ -181,21 +181,32 @@ def target_pids(root_pid: int | None, include_children: bool) -> set[int]:
 
 
 def classify_stage(line: str) -> str | None:
-    """Extract coarse model-lifecycle markers from a Studio task log line."""
+    """Extract coarse model-lifecycle markers from a Studio task log line.
+
+    用户可见的 INFO 叙事行按 UI 语言输出（``studio.infrastructure.log_messages``），
+    所以每个标记要同时列中英两版；排障行（WARNING/ERROR/DEBUG）恒英文，只列一版。
+    """
     lowered = line.lower()
     checks = (
-        (("prompt 预编码失败",), "precache_failed"),
-        (("预编码", "te 已释放"), "te_released"),
-        (("loading text encoders",), "load_te"),
-        (("加载 krea2 qwen",), "load_te"),
+        (("prompt pre-encoding failed",), "precache_failed"),
+        (("text encoder released",), "te_released"),
+        (("文本编码器已释放",), "te_released"),
+        (("loading text encoder",), "load_te"),
+        (("加载文本编码器",), "load_te"),
         (("loading transformer",), "load_dit"),
-        (("loading vae",), "load_vae"),
+        (("加载 transformer",), "load_dit"),
         (("采样完成", "加载 vae"), "load_vae_after_sample"),
+        (("loading vae",), "load_vae"),
+        (("加载 vae",), "load_vae"),
         (("vae 加载完成",), "vae_ready"),
-        (("fp8 merge",), "lora_merge"),
-        (("显存编排", "dit 让位"), "dit_yield_cpu"),
-        (("unloading model",), "unload_all"),
-        (("generate failed",), "failed"),
+        (("merged into the fp8 base model",), "lora_merge"),
+        (("已合并进 fp8 底模",), "lora_merge"),
+        (("decision=yield_dit",), "dit_yield_cpu"),
+        (("moved the transformer to ram",), "dit_yield_cpu"),
+        (("移到内存腾显存",), "dit_yield_cpu"),
+        (("model unloaded",), "unload_all"),
+        (("已卸载模型",), "unload_all"),
+        (("generation task failed",), "failed"),
     )
     for needles, stage in checks:
         if all(needle in lowered for needle in needles):

--- a/utils/caption_utils.py
+++ b/utils/caption_utils.py
@@ -25,6 +25,8 @@ if str(_REPO_ROOT) not in sys.path:
 # normalize_caption_json 的权威实现集中在 studio.services.caption_format —— PR #18
 # review 发现两份实现微妙不同（去重 / appearance 合并策略），改回单一源。
 from studio.services.tagging.caption_format import normalize_caption_json  # noqa: E402, F401
+from studio.infrastructure.log_messages import msg  # noqa: E402
+from utils.log_throttle import RepeatThrottle  # noqa: E402
 
 
 def load_caption_json(json_path: Path) -> dict | None:
@@ -241,6 +243,7 @@ def batch_convert_json(
         转换的文件数量
     """
     count = 0
+    repeat = RepeatThrottle(logger)
     for json_path in data_dir.rglob("*.json"):
         try:
             raw_json = load_caption_json(json_path)
@@ -267,8 +270,15 @@ def batch_convert_json(
             
             count += 1
         except Exception as e:
-            logger.warning(f"Error converting {json_path}: {e}")
-    
+            repeat.hit(
+                "convert_failed",
+                "%d caption files could not be converted (first: %s)",
+                "Caption JSON conversion failed: path=%s (%s); the file was left "
+                "unchanged",
+                json_path, e,
+                first=json_path,
+            )
+    repeat.drain()
     return count
 
 
@@ -292,13 +302,13 @@ if __name__ == "__main__":
             print(json.dumps(result, ensure_ascii=False, indent=2))
         elif args.dir:
             count = batch_convert_json(Path(args.dir), in_place=args.in_place)
-            print(f"Converted {count} files")
+            logger.info(msg("caption.convert_done", n=count))
         else:
-            print("Please specify --dir or --file")
-    
+            parser.error("--dir or --file is required")
+
     elif args.action == "test":
         if args.file:
             caption = load_and_build_caption(Path(args.file), shuffle=True)
             print(caption)
         else:
-            print("Please specify --file")
+            parser.error("--file is required")

--- a/utils/log_throttle.py
+++ b/utils/log_throttle.py
@@ -1,0 +1,130 @@
+"""日志风暴节流小工具（tmp/log-text-audit/verdicts-b-subprocess.md §4 方案 A/B/C-2）。
+
+子进程域里「循环内每张图/每个参数张量打一条」的告警行，正常路径 0 条、
+故障路径直接是数据集规模（1000 张图 = 1000 条 WARNING），会把 run.log
+冲成噪音。三个类分别对应设计稿的三种收法：
+
+- :class:`RepeatThrottle`（方案 A）——同因重复告警：首条全文 WARNING（可带
+  traceback），2..N 条降 DEBUG，任务收尾 ``drain()`` 补一条计数汇总。
+- :class:`ProgressThrottle`（方案 B）——进度行：每 ``max(1, total // 100)``
+  条或每 1.5s 一条，首末强制发。
+- :class:`BackoffThrottle`（方案 C-2）——自治指数退避：第 1、10、100… 次
+  报，其余静默，不需要外部收尾配合。
+
+三个类都只依赖 ``TaskLogLike`` 的 ``debug/warning`` 形状（``logging.Logger``
+天然满足），因此 runtime 入口、utils、workers 可以共用。
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Optional, Protocol
+
+
+class _LogLike(Protocol):
+    def debug(self, msg: str, *args: Any) -> None: ...
+
+    def warning(self, msg: str, *args: Any, exc_info: bool = False) -> None: ...
+
+
+class RepeatThrottle:
+    """方案 A：首条全文 + 中间 DEBUG + 收尾计数汇总。
+
+    ``key`` 是「同一个原因」的分组键（例如 ``"no_caption"``），同 key 的第 2
+    条起只落 DEBUG。``summary`` 是收尾汇总的惰性格式串：带 ``first`` 样例时
+    按 ``(count, first)`` 两个位置参数渲染，否则只 ``(count,)``。
+
+    汇总只在 count >= 2 时发——只出现一次的告警，首条就是全部信息。
+    """
+
+    def __init__(self, log: _LogLike) -> None:
+        self._log = log
+        self._counts: dict[str, int] = {}
+        self._summaries: dict[str, str] = {}
+        self._firsts: dict[str, Optional[Any]] = {}
+
+    def hit(
+        self,
+        key: str,
+        summary: str,
+        msg: str,
+        *args: Any,
+        first: Optional[Any] = None,
+        exc_info: bool = False,
+    ) -> None:
+        n = self._counts.get(key, 0) + 1
+        self._counts[key] = n
+        if n == 1:
+            self._summaries[key] = summary
+            self._firsts[key] = first
+            self._log.warning(msg, *args, exc_info=exc_info)
+        else:
+            self._log.debug(msg, *args)
+
+    def count(self, key: str) -> int:
+        return self._counts.get(key, 0)
+
+    def drain(self) -> None:
+        """任务收尾调用一次（放 ``finally`` 里），发汇总并清空状态。"""
+        for key, n in self._counts.items():
+            if n < 2:
+                continue
+            first = self._firsts.get(key)
+            if first is None:
+                self._log.warning(self._summaries[key], n)
+            else:
+                self._log.warning(self._summaries[key], n, first)
+        self._counts.clear()
+        self._summaries.clear()
+        self._firsts.clear()
+
+
+class ProgressThrottle:
+    """方案 B：进度行按间隔收（D3 豁免级别不豁免量）。
+
+    ``should_emit(done)`` 为 True 时调用方才发那条进度 INFO。首条（done<=1）
+    与末条（done>=total）强制发，中间每 ``max(1, total // 100)`` 条或每
+    ``min_interval`` 秒一条。
+    """
+
+    def __init__(self, total: int, min_interval: float = 1.5) -> None:
+        self._total = max(int(total or 0), 0)
+        self._step = max(1, self._total // 100)
+        self._interval = min_interval
+        self._last = 0.0
+
+    def should_emit(self, done: int) -> bool:
+        now = time.monotonic()
+        if done <= 1 or (self._total and done >= self._total):
+            self._last = now
+            return True
+        if done % self._step == 0 or (now - self._last) >= self._interval:
+            self._last = now
+            return True
+        return False
+
+
+class BackoffThrottle:
+    """方案 C-2：指数退避，无需收尾配合。
+
+    ``tick()`` 返回 ``(count, kind)``，``kind`` ∈ ``{"first", "milestone", ""}``：
+    第 1 次 ``first``（调用方发全文 WARNING），第 10/100/1000… 次
+    ``milestone``（发累计汇总 WARNING），其余空串（调用方只 DEBUG）。
+    """
+
+    def __init__(self, factor: int = 10) -> None:
+        self._factor = max(2, int(factor))
+        self._count = 0
+        self._next = self._factor
+
+    def tick(self) -> tuple[int, str]:
+        self._count += 1
+        if self._count == 1:
+            return self._count, "first"
+        if self._count >= self._next:
+            self._next *= self._factor
+            return self._count, "milestone"
+        return self._count, ""
+
+    @property
+    def count(self) -> int:
+        return self._count

--- a/utils/lycoris_adapter.py
+++ b/utils/lycoris_adapter.py
@@ -26,6 +26,7 @@ import torch.nn as nn
 from safetensors.torch import save_file
 from safetensors import safe_open
 
+from studio.infrastructure.log_messages import msg
 from utils.lycoris_patch import apply_lokr_device_patch
 
 logger = logging.getLogger(__name__)
@@ -194,7 +195,7 @@ class LycorisAdapter:
         )
         if self.algo == "lokr" and has_fp8_base:
             extra["bypass_mode"] = True
-            logger.info("FP8 base detected: forcing LoKr bypass forward")
+            logger.debug("fp8 base detected: LoKr forward switched to bypass mode")
 
         with _suppress_lokr_dropout_spam() as _dropout_filter:
             self.network = LycorisNetwork(
@@ -212,8 +213,9 @@ class LycorisAdapter:
 
         if _dropout_filter.dropped:
             logger.warning(
-                "LoKr/LoHa 不支持 normal dropout（lora_dropout=%s），已静默忽略；"
-                "上游逐层告警 %d 条已收敛。rank_dropout/module_dropout 不受影响。",
+                "LoKr/LoHa ignore normal dropout (lora_dropout=%s): rank_dropout "
+                "and module_dropout still apply, %d upstream per-layer warnings "
+                "suppressed",
                 self.dropout,
                 _dropout_filter.dropped,
             )
@@ -261,12 +263,18 @@ class LycorisAdapter:
 
         n = len(self.network.loras)
         forward_path = "bypass (low-rank)" if extra.get("bypass_mode") else "rebuild (ΔW)"
-        logger.info(f"注入 {self.algo.upper()} 到 {n} 层（lycoris-lora, forward={forward_path}）")
+        logger.info(msg(
+            "lora.injected",
+            algo=self.algo.upper(), n=n, detail=f"forward={forward_path}",
+        ))
         if self.use_lokr:
             full_matrix = [lora for lora in self.network.loras if getattr(lora, "use_w2", False)]
             if full_matrix:
-                logger.info(
-                    "LoKr dim/rank=%s 触发 LyCORIS full dimension：%s/%s 层的第二块不再分解，alpha 将被忽略。",
+                # 用户填的 alpha 在这些层上被静默忽略 → WARNING（R7）
+                logger.warning(
+                    "LoKr rank=%s is larger than the factorized block: %d of %d "
+                    "layers keep a full second block, so the alpha you set has no "
+                    "effect on them",
                     self.rank,
                     len(full_matrix),
                     n,
@@ -315,13 +323,13 @@ class LycorisAdapter:
             lora._anima_original_make_weight = original_make_weight
             lora.make_weight = _make_weight_with_tlora
             lora._anima_tlora_patched = True
-        logger.info(
-            "T-LoRA timestep rank mask enabled on %s/%s LoRA layers (min_rank=%s, alpha_rank_scale=%s)",
-            len(self._tlora_modules),
-            len(self.network.loras),
-            self.tlora_min_rank,
-            self.tlora_alpha_rank_scale,
-        )
+        logger.info(msg(
+            "lora.tlora_mask_enabled",
+            n=len(self._tlora_modules),
+            total=len(self.network.loras),
+            min_rank=self.tlora_min_rank,
+            scale=self.tlora_alpha_rank_scale,
+        ))
 
     def _set_tlora_mask(self, sigma_t: torch.Tensor) -> None:
         if not self._tlora_modules:
@@ -372,12 +380,20 @@ class LycorisAdapter:
                     fn()
                     break
                 except Exception as e:
-                    logger.warning(f"LycorisNetwork.{restore_attr}() 失败: {e}")
+                    logger.warning(
+                        "LycorisNetwork.%s() failed: %s; the model will be "
+                        "reloaded to drop the LoRA hooks",
+                        restore_attr, e,
+                    )
                     ok = False
                     break
         else:
             # 三个接口都不存在 → 当前 lycoris 版本不支持热卸载
-            logger.warning("LycorisNetwork 无 restore/restore_apply/remove_apply 接口；hook 残留")
+            logger.warning(
+                "The installed lycoris-lora has no restore/restore_apply/"
+                "remove_apply API; LoRA hooks stay attached until the model is "
+                "reloaded"
+            )
             ok = False
 
         # 还原 model.train 劫持（无论 restore 是否成功都该还原 monkey patch）
@@ -385,7 +401,10 @@ class LycorisAdapter:
             try:
                 self._injected_model.train = self._orig_train  # type: ignore[method-assign]
             except Exception as e:
-                logger.warning(f"还原 model.train 失败: {e}")
+                logger.warning(
+                    "Restoring model.train failed: %s; the LoRA train/eval switch "
+                    "may stay patched", e,
+                )
                 ok = False
 
         # 释放引用让 GC 清掉 LycorisNetwork（含 closure 内 _network 引用）
@@ -477,11 +496,11 @@ class LycorisAdapter:
             "ss_network_args": json.dumps(ss_args),
         }
         save_file(sd, str(path), metadata=meta)
-        logger.info(f"LoRA 保存到: {path}")
+        logger.info(msg("lora.saved", path=path))
 
     def load(self, path: str | Path) -> None:
         """从 safetensors 加载已有 LoRA 权重（用于继续训练）"""
-        logger.info(f"加载已有 LoRA 权重: {path}")
+        logger.info(msg("lora.loaded", path=path))
         sd: dict[str, torch.Tensor] = {}
         with safe_open(str(path), framework="pt", device="cpu") as f:
             for k in f.keys():
@@ -494,10 +513,17 @@ class LycorisAdapter:
         result = self.load_state_dict(sd, strict=False)
         missing = len(getattr(result, "missing_keys", [])) if hasattr(result, "missing_keys") else 0
         unexpected = len(getattr(result, "unexpected_keys", [])) if hasattr(result, "unexpected_keys") else 0
-        logger.info(
-            f"加载 {len(sd)} 个权重张量，"
-            f"missing={missing}, unexpected={unexpected}"
+        logger.debug(
+            "lora state dict loaded: tensors=%d missing=%d unexpected=%d",
+            len(sd), missing, unexpected,
         )
+        if missing or unexpected:
+            # 续训的 LoRA 没完全加载上 —— 用户会想据此改点什么（R7）
+            logger.warning(
+                "LoRA weights only partly matched: missing=%d unexpected=%d of %d "
+                "tensors; training resumes from a partly initialized LoRA",
+                missing, unexpected, len(sd),
+            )
 
     # ─── ADR 0003 PR-C：AdapterProtocol 可选 hook 的 no-op 实现 ───
     # 给 LyCORIS adapter 满足 runtime_checkable Protocol；论文级变体
@@ -624,9 +650,10 @@ def _apply_reg_dims_(network: nn.Module, lora_reg_dims: dict[str, int]) -> None:
 
         # ── LoKr 全矩阵分支（use_w2=True）：rank 概念不适用，跳过 ──────────
         elif hasattr(lora_mod, "lokr_w2"):
-            logger.warning(
-                "[lora_reg_dims] %s: full-matrix LoKr branch (use_w2=True) — "
-                "rank override not applicable, skipped",
+            # 逐层触发（上百层）→ DEBUG；:647 已有汇总
+            logger.debug(
+                "lora_reg_dims: %s uses a full-matrix LoKr branch (use_w2=True), "
+                "rank override skipped",
                 name,
             )
             skipped += 1
@@ -635,9 +662,14 @@ def _apply_reg_dims_(network: nn.Module, lora_reg_dims: dict[str, int]) -> None:
             skipped += 1
 
     if changed:
-        logger.info("[lora_reg_dims] applied rank overrides to %d modules", changed)
+        logger.info(msg("lora.reg_dims_applied", n=changed))
     if skipped:
-        logger.info("[lora_reg_dims] skipped %d modules (full-matrix or unsupported)", skipped)
+        # 用户配的值在 N 个模块上没生效 = 忽略了用户输入（R7）
+        logger.warning(
+            "lora_reg_dims did not apply to %d of %d modules (full-matrix or "
+            "unsupported); their rank stays at the network default",
+            skipped, changed + skipped,
+        )
 
 
 # 兼容别名（更名于多模型 PR-2b；引用点逐步切换后删除）

--- a/utils/lycoris_patch.py
+++ b/utils/lycoris_patch.py
@@ -54,7 +54,8 @@ def apply_lokr_device_patch() -> PatchStatus:
         from lycoris.modules.lokr import LokrModule, make_kron, rebuild_tucker
     except Exception as exc:  # pragma: no cover - 装了 lycoris-lora 但 import 异常的边界
         logger.warning(
-            "lycoris-lora %s 已安装但 lycoris.modules.lokr 导入失败: %s；跳过 device patch",
+            "lycoris-lora %s is installed but lycoris.modules.lokr could not be "
+            "imported (%s); the rank_dropout device patch was skipped",
             installed,
             exc,
         )
@@ -64,9 +65,11 @@ def apply_lokr_device_patch() -> PatchStatus:
         return "skipped_already_patched"
 
     if installed not in KNOWN_AFFECTED_VERSIONS:
-        logger.warning(
-            "lycoris-lora %s 不在已知受 rank_dropout device bug 影响的版本集合 %s；"
-            "跳过 patch（假定上游已修。若你训练时报 device mismatch，请在 issue 上报版本）",
+        # R4：这是「什么都没做」的正常路径，所有新版用户每次训练吃一条 WARNING
+        # 属误报 —— 降 DEBUG。
+        logger.debug(
+            "lycoris-lora %s is not in the known-affected set %s; rank_dropout "
+            "device patch skipped",
             installed,
             sorted(KNOWN_AFFECTED_VERSIONS),
         )
@@ -103,8 +106,9 @@ def apply_lokr_device_patch() -> PatchStatus:
 
     LokrModule.get_weight = _get_weight_fixed
     setattr(LokrModule, _PATCHED_FLAG, True)
-    logger.info(
-        "lycoris-lora %s: 已 patch LokrModule.get_weight（rank_dropout device 修复）",
+    logger.debug(
+        "lycoris-lora %s: patched LokrModule.get_weight for the rank_dropout "
+        "device bug",
         installed,
     )
     return "applied"

--- a/utils/optimizer_utils.py
+++ b/utils/optimizer_utils.py
@@ -32,6 +32,9 @@ import torch
 from torch import nn
 from torch.optim import Optimizer, AdamW
 
+from studio.infrastructure.log_messages import msg
+from utils.log_throttle import BackoffThrottle
+
 logger = logging.getLogger(__name__)
 
 # 尝试导入 bitsandbytes
@@ -108,13 +111,51 @@ def _filter_kwargs_by_signature(cls_or_fn, kwargs: Dict[str, Any]) -> Dict[str, 
                 f"升级/降级依赖，或在 yaml 关掉对应字段。"
             )
         logger.warning(
-            f"[optimizer] Dropped unsupported kwargs for "
-            f"{getattr(cls_or_fn, '__name__', cls_or_fn)}: {dropped}"
+            "Dropped unsupported options for %s: %s; they have no effect on this run",
+            getattr(cls_or_fn, "__name__", cls_or_fn), dropped,
         )
     return filtered
 
 
 def create_optimizer(
+    optimizer_type: str,
+    params: Iterator[nn.Parameter],
+    learning_rate: float,
+    betas: tuple = (0.9, 0.999),
+    weight_decay: float = 0.01,
+    eps: float = 1e-8,
+    **kwargs
+) -> Optimizer:
+    """创建优化器（工厂出口）。
+
+    各分支的构造逻辑在 :func:`_dispatch_optimizer`；本函数只是加一层出口，
+    把「可训练参数统计」收成唯一一条 INFO —— 原来 Automagic2 / ProdigyPlus /
+    参数分组三处各打一遍同一个数（rewrite-b §1.7）。
+    """
+    optimizer = _dispatch_optimizer(
+        optimizer_type,
+        params,
+        learning_rate,
+        betas=betas,
+        weight_decay=weight_decay,
+        eps=eps,
+        **kwargs,
+    )
+    tensors = 0
+    elements = 0
+    for group in optimizer.param_groups:
+        for p in group["params"]:
+            if p.requires_grad:
+                tensors += 1
+                elements += p.numel()
+    logger.info(msg(
+        "optim.trainable_params",
+        tensors=f"{tensors:,}", elements=f"{elements:,}",
+    ))
+    return optimizer
+
+
+def _dispatch_optimizer(
     optimizer_type: str,
     params: Iterator[nn.Parameter],
     learning_rate: float,
@@ -295,11 +336,6 @@ def create_8bit_adamw(
             "Install with: pip install bitsandbytes"
         )
     
-    logger.info(
-        f"Creating 8-bit AdamW optimizer (lr={lr}, weight_decay={weight_decay}, "
-        f"min_8bit_size={min_8bit_size})"
-    )
-
     # 将参数转换为列表（bitsandbytes 需要可索引的参数）
     param_list = list(params)
     
@@ -314,13 +350,10 @@ def create_8bit_adamw(
         **kwargs
     )
     
-    # 计算内存节省
-    total_params = sum(p.numel() for p in param_list)
-    # 8-bit 优化器状态：约 2 bytes per parameter (vs 8 bytes for 32-bit)
-    # 节省约 75% 的优化器状态内存
-    estimated_savings_gb = (total_params * 6) / (1024 ** 3)  # 节省 6 bytes per param
-    logger.info(f"8-bit AdamW created (estimated memory savings: {estimated_savings_gb:.2f} GB)")
-    
+    logger.info(msg(
+        "optim.created", name="AdamW 8-bit",
+        params=f"lr={lr} weight_decay={weight_decay} min_8bit_size={min_8bit_size}",
+    ))
     return optimizer
 
 
@@ -353,8 +386,6 @@ def create_standard_adamw(
     Returns:
         AdamW: 标准 AdamW 优化器
     """
-    logger.info(f"Creating standard AdamW optimizer (lr={lr}, weight_decay={weight_decay})")
-
     # 将参数转换为列表
     param_list = list(params)
     
@@ -367,8 +398,10 @@ def create_standard_adamw(
         **kwargs
     )
     
-    logger.info("AdamW optimizer created")
-
+    logger.info(msg(
+        "optim.created", name="AdamW",
+        params=f"lr={lr} weight_decay={weight_decay}",
+    ))
     return optimizer
 
 
@@ -494,7 +527,10 @@ class Automagic(Optimizer):
 
         self.lr = min(lr, max_lr)
         if lr > 1e-3:
-            logger.warning("Automagic start lr %s is high; clamping to 1e-6", lr)
+            logger.warning(
+                "Automagic start lr=%.2e is too high and was forced to 1e-6; "
+                "per-parameter lr then adapts within [min_lr, max_lr]", lr,
+            )
             self.lr = 1e-6
         self.min_lr = min_lr
         self.max_lr = max_lr
@@ -718,10 +754,12 @@ def create_automagic(
     # Automagic 上游推荐 init lr=1e-6（每参数自适应起点）；> 1e-5 量级是 AdamW
     # 风格 lr 误用，sign-agreement 调度需要很多 step 才能从过高起点收敛回工作区间。
     # UI 切换 optimizer_type 时会自动改写 lr=1e-6；这里兜底 saved config / CLI 路径。
-    if lr > 1e-5:
+    # 上界收窄到 1e-3：> 1e-3 由 Automagic.__init__ 强制改写并自报，避免双报。
+    if 1e-5 < lr <= 1e-3:
         logger.warning(
-            "Automagic 初始 lr=%.2e 远高于推荐 1e-6；sign-agreement 自适应从过高起点"
-            "收敛慢，建议设为 1e-6（per-param lr 由 [min_lr, max_lr] 自动调）",
+            "Automagic start lr=%.2e is far above the recommended 1e-6; "
+            "sign-agreement adaptation converges slowly from a high start, the "
+            "recommended start is lr=1e-6",
             lr,
         )
     param_list = params if _is_param_groups(params) else list(params)
@@ -737,11 +775,13 @@ def create_automagic(
         weight_decay=weight_decay,
         **kwargs,
     )
-    logger.info(
-        f"Creating Automagic optimizer (lr={lr}, min_lr={min_lr}, max_lr={max_lr}, "
-        f"lr_bump={lr_bump}, beta2={beta2}, weight_decay={weight_decay})"
-    )
-    logger.info("Automagic optimizer created")
+    logger.info(msg(
+        "optim.created", name="Automagic",
+        params=(
+            f"lr={lr} min_lr={min_lr} max_lr={max_lr} lr_bump={lr_bump} "
+            f"beta2={beta2} weight_decay={weight_decay}"
+        ),
+    ))
     return optimizer
 
 
@@ -772,7 +812,10 @@ class Automagic2(Optimizer):
         agreement_threshold: float = 0.5,
     ) -> None:
         if lr > 1e-3:
-            logger.warning("Automagic2 start lr %s is high; forcing to 1e-6.", lr)
+            logger.warning(
+                "Automagic2 start lr=%.2e is too high and was forced to 1e-6; "
+                "per-parameter lr then adapts within [min_lr, max_lr]", lr,
+            )
             lr = 1e-6
         defaults = dict(
             lr=lr, min_lr=min_lr, max_lr=max_lr, lr_bump=lr_bump,
@@ -790,8 +833,8 @@ class Automagic2(Optimizer):
                     )
                     self._hook_handles.append(handle)
 
-        total = sum(p.numel() for g in self.param_groups for p in g["params"])
-        logger.info(f"Automagic2 total training params: {total:,}")
+        # 可训练参数统计统一由 create_optimizer 出口打一条（optim.trainable_params）
+        self._nonfinite = BackoffThrottle()
 
     @staticmethod
     def _rms(t: torch.Tensor) -> torch.Tensor:
@@ -838,10 +881,24 @@ class Automagic2(Optimizer):
         # fused 路径绕过了训练循环的 step 边界 NaN 梯度检查（hook 跑完 p.grad
         # 已是 None），必须在这里自卫 —— 否则一个坏 micro-batch 直接毒化权重。
         if not torch.isfinite(grad).all():
-            logger.warning(
-                "Automagic2: param %s 梯度含 NaN/Inf，跳过本次 fused update",
-                tuple(p.shape),
-            )
+            # 〔R9 十万量级〕指数退避：首条全文，第 10/100/1000… 次报累计，其余 DEBUG
+            count, kind = self._nonfinite.tick()
+            if kind == "first":
+                logger.warning(
+                    "Gradient contains NaN/Inf; skipped the fused update for "
+                    "parameter shape=%s", tuple(p.shape),
+                )
+            elif kind == "milestone":
+                logger.warning(
+                    "Gradient NaN/Inf has skipped %d fused updates so far (latest "
+                    "shape=%s); the affected parameters are not learning",
+                    count, tuple(p.shape),
+                )
+            else:
+                logger.debug(
+                    "Gradient NaN/Inf: skipped fused update, shape=%s",
+                    tuple(p.shape),
+                )
             p.grad = None
             return
 
@@ -963,10 +1020,12 @@ def create_automagic_v2(
     agreement_threshold: float = 0.5,
     **kwargs,
 ) -> Optimizer:
-    if lr > 1e-5:
+    # 上界收窄到 1e-3：> 1e-3 由 Automagic2.__init__ 强制改写并自报，避免双报。
+    if 1e-5 < lr <= 1e-3:
         logger.warning(
-            "Automagic2 初始 lr=%.2e 远高于推荐 1e-6；sign-agreement 自适应从过高起点"
-            "收敛慢，建议设为 1e-6", lr,
+            "Automagic2 start lr=%.2e is far above the recommended 1e-6; "
+            "sign-agreement adaptation converges slowly from a high start, the "
+            "recommended start is lr=1e-6", lr,
         )
     param_list = params if _is_param_groups(params) else list(params)
     optimizer = Automagic2(
@@ -974,11 +1033,14 @@ def create_automagic_v2(
         eps=eps, clip_threshold=clip_threshold, beta2=beta2, weight_decay=weight_decay,
         agreement_threshold=agreement_threshold,
     )
-    logger.info(
-        f"Creating Automagic v2 (lr={lr}, min_lr={min_lr}, max_lr={max_lr}, "
-        f"lr_bump={lr_bump}, beta2={beta2}, wd={weight_decay}, "
-        f"agreement_threshold={agreement_threshold})"
-    )
+    logger.info(msg(
+        "optim.created", name="Automagic v2",
+        params=(
+            f"lr={lr} min_lr={min_lr} max_lr={max_lr} lr_bump={lr_bump} "
+            f"beta2={beta2} weight_decay={weight_decay} "
+            f"agreement_threshold={agreement_threshold}"
+        ),
+    ))
     return optimizer
 
 
@@ -1058,15 +1120,17 @@ def create_lion(
     # lr 落在 AdamW 量级（1e-4 及以上）时提示一下。详细见 docs/user-guide/optimizers.md。
     if lr >= 1e-4:
         logger.warning(
-            "Lion lr=%.2e 接近/高于 AdamW 量级；论文推荐 lr ≈ AdamW lr / 3 "
-            "（如 AdamW 1e-4 → Lion ~3e-5）。继续训练但可能发散，详见 "
-            "docs/user-guide/optimizers.md",
+            "Lion lr=%.2e is at AdamW magnitude; the paper recommends about "
+            "AdamW lr / 3 (AdamW 1e-4 → Lion ~3e-5), training continues but may "
+            "diverge — see docs/user-guide/optimizers.md",
             lr,
         )
     param_list = params if _is_param_groups(params) else list(params)
     optimizer = Lion(param_list, lr=lr, betas=betas, weight_decay=weight_decay, **kwargs)
-    logger.info(f"Creating Lion optimizer (lr={lr}, betas={betas}, weight_decay={weight_decay})")
-    logger.info("Lion optimizer created")
+    logger.info(msg(
+        "optim.created", name="Lion",
+        params=f"lr={lr} betas={betas} weight_decay={weight_decay}",
+    ))
     return optimizer
 
 
@@ -1286,10 +1350,13 @@ def create_came(
         weight_decay=weight_decay,
         **kwargs,
     )
-    logger.info(
-        f"Creating CAME optimizer (lr={lr}, betas={betas}, eps={tuple(eps)}, "
-        f"clip_threshold={clip_threshold}, weight_decay={weight_decay})"
-    )
+    logger.info(msg(
+        "optim.created", name="CAME",
+        params=(
+            f"lr={lr} betas={betas} eps={tuple(eps)} "
+            f"clip_threshold={clip_threshold} weight_decay={weight_decay}"
+        ),
+    ))
     return optimizer
 
 
@@ -1336,15 +1403,10 @@ def create_prodigy(
 
     if abs(lr - 1.0) > 1e-9:
         logger.warning(
-            f"Prodigy requires lr=1.0 (received {lr}); forcing lr=1.0. "
-            f"Tune d_coef/weight_decay instead of lr."
+            "Prodigy requires lr=1.0 (got %s) and it was forced to 1.0; tune "
+            "d_coef/weight_decay instead of lr", lr,
         )
         lr = 1.0
-
-    logger.info(
-        f"Creating Prodigy optimizer (lr={lr}, weight_decay={weight_decay}, "
-        f"d_coef={d_coef}, safeguard_warmup={safeguard_warmup})"
-    )
 
     param_list = list(params)
 
@@ -1360,8 +1422,13 @@ def create_prodigy(
         **kwargs,
     )
 
-    logger.info("Prodigy optimizer created")
-
+    logger.info(msg(
+        "optim.created", name="Prodigy",
+        params=(
+            f"lr={lr} weight_decay={weight_decay} d_coef={d_coef} "
+            f"safeguard_warmup={safeguard_warmup}"
+        ),
+    ))
     return optimizer
 
 
@@ -1428,13 +1495,15 @@ def create_prodigy_plus_schedulefree(
 
     if abs(lr - 1.0) > 1e-9:
         logger.warning(
-            f"[ProdigyPlus] Forcing lr=1.0 (got {lr}); "
-            f"Prodigy adapts step size internally via d."
+            "Prodigy requires lr=1.0 (got %s) and it was forced to 1.0; tune "
+            "d_coef/weight_decay instead of lr", lr,
         )
     lr = 1.0
 
     if isinstance(eps, (int, float)) and eps <= 0:
-        logger.warning(f"[ProdigyPlus] eps={eps} non-positive, falling back to None (Adam-atan2).")
+        logger.warning(
+            "eps=%s is not positive; falling back to Adam-atan2 (eps disabled)", eps,
+        )
         eps = None
 
     # 上层 create_optimizer 默认 betas=(0.9, 0.999)（适合 AdamW），但 PPSF 推荐
@@ -1460,17 +1529,17 @@ def create_prodigy_plus_schedulefree(
 
     param_list = params if _is_param_groups(params) else list(params)
 
-    logger.info(
-        f"Creating ProdigyPlusScheduleFree "
-        f"(d_coef={d_coef}, betas={tuple(betas)}, wd={weight_decay}, "
-        f"eps={eps}, stableadamw={use_stableadamw})"
-    )
-    logger.info(f"[ProdigyPlus] Effective kwargs: {list(safe_kwargs.keys())}")
+    logger.debug("prodigy_plus effective kwargs: %s", list(safe_kwargs.keys()))
 
     optimizer = ProdigyPlusScheduleFree(param_list, **safe_kwargs)
 
-    total = sum(p.numel() for g in optimizer.param_groups for p in g["params"] if p.requires_grad)
-    logger.info(f"[ProdigyPlus] Trainable params: {total:,}")
+    logger.info(msg(
+        "optim.created", name="ProdigyPlusScheduleFree",
+        params=(
+            f"d_coef={d_coef} betas={tuple(betas)} weight_decay={weight_decay} "
+            f"eps={eps} use_stableadamw={use_stableadamw}"
+        ),
+    ))
     return optimizer
 
 
@@ -1518,10 +1587,14 @@ def create_soap(
         precond_in_state=precond_in_state,
         **kwargs,
     )
-    logger.info(
-        f"Creating SOAP optimizer (lr={lr}, betas={tuple(betas)}, wd={weight_decay}, "
-        f"precond_freq={precondition_frequency}, max_precond_dim={max_precond_dim})"
-    )
+    logger.info(msg(
+        "optim.created", name="SOAP",
+        params=(
+            f"lr={lr} betas={tuple(betas)} weight_decay={weight_decay} "
+            f"precondition_frequency={precondition_frequency} "
+            f"max_precond_dim={max_precond_dim}"
+        ),
+    ))
     return optimizer
 
 
@@ -1578,11 +1651,15 @@ def create_soap_sf(
         warmup_steps=warmup_steps,
         **kwargs,
     )
-    logger.info(
-        f"Creating Schedule-Free SOAP optimizer (lr={lr}, betas={tuple(betas)}, "
-        f"wd={weight_decay}, precond_freq={precondition_frequency}, "
-        f"max_precond_dim={max_precond_dim}, weight_lr_power={weight_lr_power}, r={r})"
-    )
+    logger.info(msg(
+        "optim.created", name="SOAP schedule-free",
+        params=(
+            f"lr={lr} betas={tuple(betas)} weight_decay={weight_decay} "
+            f"precondition_frequency={precondition_frequency} "
+            f"max_precond_dim={max_precond_dim} "
+            f"weight_lr_power={weight_lr_power} r={r}"
+        ),
+    ))
     return optimizer
 
 
@@ -1678,10 +1755,11 @@ def create_optimizer_grouped_parameters(
     # 打印统计信息
     num_decay_params = sum(p.numel() for p in decay_params)
     num_no_decay_params = sum(p.numel() for p in no_decay_params)
-    logger.info(
-        f"Parameter groups: with weight decay: {len(decay_params)} params, "
-        f"{num_decay_params:,} elements; without weight decay: "
-        f"{len(no_decay_params)} params, {num_no_decay_params:,} elements"
+    logger.debug(
+        "param groups: decay=%d tensors/%d elements, "
+        "no_decay=%d tensors/%d elements",
+        len(decay_params), num_decay_params,
+        len(no_decay_params), num_no_decay_params,
     )
     
     return optimizer_grouped_parameters

--- a/utils/ortho_adapter.py
+++ b/utils/ortho_adapter.py
@@ -33,6 +33,8 @@ from typing import Any, Optional
 
 import torch
 import torch.nn as nn
+
+from studio.infrastructure.log_messages import msg
 import torch.nn.functional as F
 from safetensors import safe_open
 from safetensors.torch import save_file
@@ -256,11 +258,12 @@ class OrthoLoRAAdapter:
             setattr(parent, child_name, layer)
             self.loras.append(layer)
 
-        logger.info(
-            "注入 %s 到 %s 层（OrthoLoRA, save=baked LoRA）",
-            "T-LORA+ORTHO" if self.use_timestep_mask else "ORTHO",
-            len(self.loras),
-        )
+        logger.info(msg(
+            "lora.injected",
+            algo="T-LORA+ORTHO" if self.use_timestep_mask else "ORTHO",
+            n=len(self.loras),
+            detail="save=baked LoRA",
+        ))
         return {layer.lora_name: layer for layer in self.loras}
 
     def _set_timestep_mask(self, sigma_t: torch.Tensor) -> None:
@@ -353,9 +356,11 @@ class OrthoLoRAAdapter:
 
         if projected_layers:
             logger.warning(
-                "OrthoLoRA: %s 层从 plain LoRA 投影恢复（仅取冻结 SVD 基上的对角分量，"
-                "旋转信息丢失）—— 这是近似续训，非完整恢复。无损断点续训请用训练 state "
-                "(.pt) 而非蒸馏后的 LoRA 文件。", projected_layers,
+                "OrthoLoRA restored %s layers by projecting a plain LoRA onto the "
+                "frozen SVD basis: only the diagonal component survives, the "
+                "rotation is lost — this is an approximate resume, not a full one; "
+                "resume from the training state (.pt) instead of a distilled LoRA "
+                "file for a lossless resume", projected_layers,
             )
 
         if strict and (missing or unexpected):
@@ -384,7 +389,7 @@ class OrthoLoRAAdapter:
             "ss_network_args": json.dumps(ss_args),
         }
         save_file(sd, str(path), metadata=meta)
-        logger.info("OrthoLoRA 保存到: %s (baked as plain LoRA)", path)
+        logger.info(msg("lora.saved_baked", path=path))
 
     def load(self, path: str | Path) -> None:
         sd: dict[str, torch.Tensor] = {}


### PR DESCRIPTION
﻿日志二期（文本与级别复审）主体：风暴节流机制 + i18n 字典基建 + 三域 879 条文案终稿落地。基于 #514（刀 0 TaskLog 收编，已合入 dev）。取代 #515（因 base 分支随 #514 合并删除被 GitHub 连带关闭，无法重开）。

底稿：`tmp/log-text-audit/`（本地，gitignore）——全仓 866 行盘点判决 + 逐条文案终稿 + 规则文档（级别语义一票判定 R1-R10 / 结构 T1-T7 / 文风 S1-S8）。

## Commit 1：风暴节流与契约机制修复

- **NaN 风暴**（最坏 3 万行/任务，会把 error_msg 的 ERROR 块顶出尾部窗口）：loss/grad 各首条全文 → epoch 末汇总一条 → 连续 50 步无有效更新升一条 ERROR（不改控制流）
- warn-once：pyramid_noise / dpmpp torchsde 回退 / W&B 上报失败（finish 汇总）/ caption JSON 按路径去重
- `system_stats`：GPU/psutil 采集连续 3 次失败熔断停采（NVML 坏死时原来是 ~1440 条带 traceback ERROR/小时）；tick 兜底首条 ERROR + 60s 计数
- `event_bus` 丢事件状态化：一次拥塞恒定 2 条（进入 + 恢复带累计数）
- supervisor 四个 1s 轮询站点接 `_ErrorThrottle`（首条全文 → 60s 计数 → 恢复 INFO）
- 自我放大回路摘除：daemon run.log 写失败即关句柄置 None（SSE 继续）；坏 listener 连续 3 次从注册表移除；三处注释锁死「失败记录不走同一通道」
- LyCORIS stderr handler 改用 `HumanConsoleFormatter`：自拼格式行头匹配不上 `LOG_LINE_RE`，在 daemon ring 里被解析成续行、继承别人的级别

## Commit 2：i18n messages 基建

拍板口径：**用户可见面的 INFO 叙事行进双语字典**（`msg_id → {zh, en}`，生成端按 `ANIMA_UI_LANG` 输出）；**WARNING/ERROR/DEBUG 排障行与 studio.log 面统一英文**（可 grep、可贴 issue、与 traceback 同语言；用户「看懂失败」由 errors.* envelope/toast i18n 层保证）。

- `infrastructure/log_messages.py`：`msg()` 按 env → secrets 兜底 → zh 解析语言；缺 key/占位不匹配不抛（日志路径不能因文案崩），fail-loud 可 grep
- 字典按域拆 `_messages_{train,worker,server}.py`，跨域重名 import 时报错
- `secrets.system.ui_language` + 前端两个切语言入口 fire-and-forget 同步 + supervisor/daemon spawn 注入

## Commit 3：三域终稿落地（129 文件，253 msg_id）

- **训练链**（77 msg_id）：block swap 五套措辞收敛为一条基准 INFO 其余降 DEBUG；infonoise「总步数 None × 20%」文本 bug 拆三条；`ctx.emit` 加 level、`log_vram` 改 msg_id、`.upper()` 占位符修复等施工前置
- **子进程域**（72 msg_id）：35 处伪级别前缀剥除按判决升 ERROR/WARNING；7 处 exception+`[error]` 双记删短行；14 处有兜底的 ERROR 降 WARNING（成功任务被标红的全部来源，`exc_info` 保留）；reg_ai 每图 4 条收 1 条 DEBUG + 节流 INFO；新增 `utils/log_throttle.py` 共享节流器
- **server 域**（104 msg_id）：`_failure_summary` 从 grep `✗`/`↳` 改按最后 ERROR 记录取全文（`_RingLog` 平行记录级别，与删前缀同批）；daemon 退出按 `_expected_exit` 拆三条（正常 stop 不再黄行）；404 三处统一 `tried=` 模板全降 DEBUG；6 处自称 non-fatal 的 ERROR 降 WARNING；5 处 `error(str(e))` 改 exception；`as_task_log()` 在 7 个公共入口兼容裸 callable

全仓生效的文风约定：`%s` 惰性格式化、`exc_info=True` 不再拼 `{e}`、key=value 的 key 与主题 tag 恒英文（一条 grep 命中中英两语）、emoji/分隔线/缩进伪层级移除。

## 测试

pytest 关联 ~2570 passed（训练 1113 / 子进程 491 / server 967）+ 机制单测 17 新增；vitest 26 passed；tsc 干净。静态校验：253 个 msg_id 全部有调用点、双语占位符逐点匹配、域内日志调用零中文残留（排障行）。未跑全量（CI 门禁规范，交 CI）。

## 建议真机验证

1. 跑一次训练：run.log 中英按 UI 语言、NaN 场景不再刷屏、error_msg 红框取到真 ERROR 块
2. 下载一次模型：下载卡 ring 正常、失败时前端 toast 取到完整错误行（G7）
3. 切语言后新任务日志语言跟随（`ANIMA_UI_LANG` 注入）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

