### PR TITLE
fix(tagger): base_url 以非 v1 版本段结尾时不再误补 /v1

### DIFF
--- a/studio/services/tagging/llm.py
+++ b/studio/services/tagging/llm.py
@@ -113,10 +113,10 @@ def _openai_compatible_endpoint(base_url: str, *, kind: str) -> str:
         if path.endswith(suffix):
             root = base[: -len(suffix)]
             return f"{root}/{kind}"
-    if path.endswith("/v1"):
+    # 末段已是版本号（/v1、/v4、/v1beta 等）就直接拼；只有无版本段时才补 /v1，
+    # 避免把智谱等 /v4 结尾的 base_url 拼成 /v4/v1/... 导致 404。
+    if re.search(r"/v\d+[a-z0-9]*$", path):
         return f"{base}/{kind}"
-    if path:
-        return f"{base}/v1/{kind}"
     return f"{base}/v1/{kind}"
 
 

--- a/tests/test_llm_tagger.py
+++ b/tests/test_llm_tagger.py
@@ -647,3 +647,42 @@ def test_image_data_url_respects_payload_cap(tmp_path: Path) -> None:
 
     encoded = data_url.split(",", 1)[1].encode("ascii")
     assert len(encoded) <= int(0.25 * 1024 * 1024)
+
+
+@pytest.mark.parametrize(
+    "base_url,kind,expected",
+    [
+        # 标准 OpenAI 风格 /v1 结尾
+        ("http://x/v1", "chat/completions", "http://x/v1/chat/completions"),
+        # 智谱等非 v1 版本段结尾：不能再补 /v1（issue：/v4/v1/... 404）
+        (
+            "https://open.bigmodel.cn/api/paas/v4",
+            "chat/completions",
+            "https://open.bigmodel.cn/api/paas/v4/chat/completions",
+        ),
+        (
+            "https://open.bigmodel.cn/api/paas/v4/",
+            "models",
+            "https://open.bigmodel.cn/api/paas/v4/models",
+        ),
+        # 带字母后缀的版本段（如 Google /v1beta）同样视为版本号
+        ("http://x/v1beta", "chat/completions", "http://x/v1beta/chat/completions"),
+        # 无版本段时才补 /v1
+        (
+            "http://localhost:11434",
+            "chat/completions",
+            "http://localhost:11434/v1/chat/completions",
+        ),
+        ("http://x/api", "chat/completions", "http://x/api/v1/chat/completions"),
+        # 用户粘了完整 endpoint：剥掉末段再拼目标 kind
+        (
+            "http://x/api/paas/v4/chat/completions",
+            "models",
+            "http://x/api/paas/v4/models",
+        ),
+    ],
+)
+def test_openai_compatible_endpoint_versioned_bases(
+    base_url: str, kind: str, expected: str
+) -> None:
+    assert llm_tagger._openai_compatible_endpoint(base_url, kind=kind) == expected


### PR DESCRIPTION
## 背景

用户反馈：LLM 打标填智谱的 base url（`https://open.bigmodel.cn/api/paas/v4`）后请求 404。根因在 `_openai_compatible_endpoint`（studio/services/tagging/llm.py）：判断「已带版本段」只认 `/v1` 结尾，智谱的 `/v4` 匹配不上，落入兜底分支被补成 `.../v4/v1/chat/completions`。

## 改动

- 「以 `/v1` 结尾」的判断放宽为「以任意版本段结尾」（正则 `/v\d+[a-z0-9]*$`，覆盖 `/v1`、`/v4`、Google 风格 `/v1beta` 等），命中即直接拼 `chat/completions` / `models` / `responses`，不再补 `/v1`
- 无版本段的 base_url（如 Ollama 根地址 `http://localhost:11434`）行为不变，仍自动补 `/v1`
- 顺带合并了原来两个返回值完全相同的冗余分支
- joycaption 是 LLM tagger 的 shim、前端仅有 placeholder 文案，均走同一函数，一处修复全覆盖

设计依据：生态里对「自动补 /v1」分两派——OpenAI SDK 系（Open WebUI / LobeChat / Cline）填什么用什么；Cherry Studio 自动补并以 `#` 结尾作逃生门。Continue 曾用与本项目相同的 `endsWith("/v1")` 自动补，因需要按 provider 域名维护例外名单而在 [continuedev/continue#798](https://github.com/continuedev/continue/issues/798) 移除。本修法保留对小白用户的容错，但判断走 URL 语法而非 provider 名单，不会重蹈例外名单覆辙。原有「粘完整 endpoint 会剥掉末段重拼」的逻辑保留，等价于 Cherry Studio 的 `#` 场景。

## 测试

- 新增 `test_openai_compatible_endpoint_versioned_bases` 参数化 7 组用例（智谱 v4、尾斜杠、v1beta、无版本段根地址、带 path 无版本段、粘完整 endpoint）
- `tests/test_llm_tagger.py` 34 passed、`tests/test_joycaption_tagger.py`、`tests/test_tag_endpoints.py` 33 passed
- 横切安全网 `test_route_snapshot.py` + `test_studio_configs.py` 33 passed；`ruff check` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)