### PR TITLE
fix(export): 现场打包的 zip 下载禁用 Range，杜绝多线程下载器分块拼接损坏

### DIFF
--- a/studio/api/responses.py
+++ b/studio/api/responses.py
@@ -2,9 +2,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
+from urllib.parse import quote
 
-from fastapi.responses import FileResponse
+from fastapi import BackgroundTasks
+from fastapi.responses import FileResponse, StreamingResponse
 
 from ..services.dataset import thumb_cache
 
@@ -22,6 +24,47 @@ EMPTY_STATE: dict[str, Any] = {
     "start_time": None,
     "config": {},
 }
+
+
+def packaged_zip_response(
+    path: Path, filename: str, background: BackgroundTasks,
+) -> StreamingResponse:
+    """现场打包的 zip 一次性下载：整流发送，显式不支持 Range。
+
+    这类 zip 每次请求都重新生成，两次生成的字节不保证一致（manifest 里有
+    time.time() 时间戳，float repr 长度还会波动 ±1 字节）。FileResponse 默认
+    宣告 `Accept-Ranges: bytes` 并响应 206——多线程下载器（IDM / Ghost
+    Downloader 等，接管 localhost 一样生效）按 Range 分块并行下载时，各块
+    来自不同的打包实例，拼出来的 zip 必然损坏（真实案例：分段间错位 ±1
+    字节，导入报「文件已损坏」）。所以忽略 Range 头 + `Accept-Ranges: none`，
+    下载器退化为单连接整流下载，字节一致性由单次打包保证。
+
+    Content-Length 显式给出（打包已完成、大小固定），浏览器保留进度条。
+    """
+    size = path.stat().st_size
+
+    def _iter() -> Iterator[bytes]:
+        with path.open("rb") as fh:
+            while chunk := fh.read(1024 * 1024):
+                yield chunk
+
+    # filename 可能含非 ASCII（task/project 名），同 starlette 的编码策略
+    quoted = quote(filename)
+    disposition = (
+        f"attachment; filename*=utf-8''{quoted}"
+        if quoted != filename
+        else f'attachment; filename="{filename}"'
+    )
+    return StreamingResponse(
+        _iter(),
+        media_type="application/zip",
+        headers={
+            "Content-Length": str(size),
+            "Content-Disposition": disposition,
+            "Accept-Ranges": "none",
+        },
+        background=background,
+    )
 
 
 def _thumb_response(src: Path, size: int) -> FileResponse:

--- a/studio/api/routers/projects/exports.py
+++ b/studio/api/routers/projects/exports.py
@@ -20,9 +20,10 @@ from typing import Any
 
 from fastapi import APIRouter, BackgroundTasks, File, UploadFile
 from fastapi.concurrency import run_in_threadpool
-from fastapi.responses import FileResponse
+from fastapi.responses import StreamingResponse
 
 from ...errors import _data_export_path, _export_result, _unique_data_export_path
+from ...responses import packaged_zip_response
 from ....domain.errors import NotFoundError, ValidationError
 from ...schemas.exports import BundleImportBody, BundleOptionsBody
 from ._shared import (
@@ -42,10 +43,11 @@ router = APIRouter()
 @router.get("/api/projects/{pid}/versions/{vid}/train.zip")
 def export_version_train_zip(
     pid: int, vid: int, background: BackgroundTasks,
-) -> FileResponse:
+) -> StreamingResponse:
     """打包 version 的 train/ + manifest.json 为 zip 一次性下载。
 
-    实现：写到临时文件再 FileResponse；响应发完后 BackgroundTasks 清理。
+    实现：写到临时文件再 packaged_zip_response（不支持 Range，见该函数注释）；
+    响应发完后 BackgroundTasks 清理。
     与 outputs.zip 一致用 ZIP_STORED（PNG/jpg 已压缩，再压只是浪费 CPU）。
 
     打包完成 / 失败 publish version_train_zip_ready / _failed —— 前端用 <a>
@@ -92,12 +94,7 @@ def export_version_train_zip(
     })
     background.add_task(lambda: tmp_path.unlink(missing_ok=True))
     archive_name = f"{p['slug']}-{v['label']}.train.zip"
-    return FileResponse(
-        tmp_path,
-        media_type="application/zip",
-        filename=archive_name,
-        background=background,
-    )
+    return packaged_zip_response(tmp_path, archive_name, background)
 
 
 @router.get("/api/projects/{pid}/versions/{vid}/bundle.zip")
@@ -113,7 +110,7 @@ def export_version_bundle(
     train_latent_cache: bool = False,
     reg_latent_cache: bool = False,
     train_masks: bool = False,
-) -> FileResponse:
+) -> StreamingResponse:
     """按选项临时打包 bundle.zip（schema_version 2）并交给浏览器下载。"""
     opts = train_io.BundleOptions(
         train=train,
@@ -151,11 +148,8 @@ def export_version_bundle(
 
     bus.publish({"type": "version_bundle_zip_ready", "project_id": pid, "version_id": vid})
     background.add_task(lambda: tmp_path.unlink(missing_ok=True))
-    return FileResponse(
-        tmp_path,
-        media_type="application/zip",
-        filename=f"{p['slug']}-{v['label']}.bundle.zip",
-        background=background,
+    return packaged_zip_response(
+        tmp_path, f"{p['slug']}-{v['label']}.bundle.zip", background,
     )
 
 

--- a/studio/api/routers/queue/outputs.py
+++ b/studio/api/routers/queue/outputs.py
@@ -20,9 +20,10 @@ from pathlib import Path
 from typing import Any, Optional
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 
 from ...errors import _export_result, _safe_join_or_400, _unique_data_export_path
+from ...responses import packaged_zip_response
 from ...schemas.queue import DeleteOutputsBody, ExportOutputsBody
 from .... import db
 from ....domain.errors import (
@@ -100,9 +101,17 @@ def _select_task_output_files(task_id: int, files: Optional[list[str]] = None) -
 
 
 def _write_outputs_zip(dest: Path, out_dir: Path, selected: list[Path]) -> None:
-    with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
-        for f in selected:
-            zf.write(f, arcname=_task_output_relpath(out_dir, f))
+    # 先写 .part 再原子改名：打包中途进程被杀不给 data_exports/ 留半截 zip
+    # （半截 zip 与正常导出无法区分，导入必报「文件已损坏」）
+    part = dest.with_name(dest.name + ".part")
+    try:
+        with zipfile.ZipFile(part, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
+            for f in selected:
+                zf.write(f, arcname=_task_output_relpath(out_dir, f))
+        os.replace(part, dest)
+    except BaseException:
+        part.unlink(missing_ok=True)
+        raise
 
 
 def _task_archive_basename(task: dict[str, Any]) -> Optional[str]:
@@ -206,7 +215,7 @@ def download_task_outputs_zip(
     task_id: int,
     background: BackgroundTasks,
     files: Optional[str] = None,
-) -> FileResponse:
+) -> StreamingResponse:
     """把 output 目录里的文件打包成 zip 一次性下载。"""
     import tempfile
     wanted = [n for n in files.split(",") if n] if files else None
@@ -240,12 +249,7 @@ def download_task_outputs_zip(
         f"{basename}_outputs_selected.zip" if partial
         else f"{basename}_outputs.zip"
     )
-    return FileResponse(
-        tmp_path,
-        media_type="application/zip",
-        filename=archive_name,
-        background=background,
-    )
+    return packaged_zip_response(tmp_path, archive_name, background)
 
 
 @router.post("/api/queue/{task_id}/export-outputs")

--- a/studio/services/data_io/train_io.py
+++ b/studio/services/data_io/train_io.py
@@ -32,6 +32,7 @@ slug 冲突自动加 -imported-{ts}。
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import time
@@ -43,6 +44,8 @@ from typing import Any, Optional
 from ...services.projects import projects, versions
 from ..dataset.scan import IMAGE_EXTS
 from ...paths import safe_join
+
+logger = logging.getLogger(__name__)
 
 SCHEMA_VERSION = 1
 BUNDLE_SCHEMA_VERSION = 2
@@ -171,12 +174,20 @@ def export_train(
         },
     }
 
-    with zipfile.ZipFile(
-        dest, "w", compression=zipfile.ZIP_STORED, allowZip64=True
-    ) as zf:
-        zf.writestr(MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False, indent=2))
-        for src, arc in payload:
-            zf.write(src, arcname=arc)
+    # 先写 .part 再原子改名：打包中途进程被杀不留半截 zip（半截 zip 与正常
+    # 导出无法区分，导入必报「文件已损坏」）。export_bundle 同款。
+    part = dest.with_name(dest.name + ".part")
+    try:
+        with zipfile.ZipFile(
+            part, "w", compression=zipfile.ZIP_STORED, allowZip64=True
+        ) as zf:
+            zf.writestr(MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False, indent=2))
+            for src, arc in payload:
+                zf.write(src, arcname=arc)
+        os.replace(part, dest)
+    except BaseException:
+        part.unlink(missing_ok=True)
+        raise
 
     return {"manifest": manifest, "size_bytes": dest.stat().st_size}
 
@@ -339,9 +350,11 @@ def import_train(
             assert v is not None and p is not None
 
     except zipfile.BadZipFile as exc:
+        # reason 帮远程排查区分截断（File is not a zip file）和内容损坏（Bad CRC-32）
+        logger.warning("import_train rejected corrupt zip %s: %s", zip_path, exc)
         raise TrainIOError(
             "Import file is corrupt", code="dataset.import_corrupt",
-            http_status=400,
+            details={"reason": str(exc)}, http_status=400,
         ) from exc
 
     stats = {
@@ -599,12 +612,20 @@ def export_bundle(
         },
     }
 
-    with zipfile.ZipFile(dest, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
-        zf.writestr(MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False, indent=2))
-        for content, arc in in_memory:
-            zf.writestr(arc, content)
-        for src, arc in payload:
-            zf.write(src, arcname=arc)
+    # .part + 原子改名，同 export_train（POST export-bundle 直接写 data_exports/，
+    # 非原子写留下的半截 zip 会被用户当正常导出拿去导入/分享）
+    part = dest.with_name(dest.name + ".part")
+    try:
+        with zipfile.ZipFile(part, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
+            zf.writestr(MANIFEST_NAME, json.dumps(manifest, ensure_ascii=False, indent=2))
+            for content, arc in in_memory:
+                zf.writestr(arc, content)
+            for src, arc in payload:
+                zf.write(src, arcname=arc)
+        os.replace(part, dest)
+    except BaseException:
+        part.unlink(missing_ok=True)
+        raise
 
     return {"manifest": manifest, "size_bytes": dest.stat().st_size}
 
@@ -938,9 +959,10 @@ def import_bundle(
             assert v is not None and p is not None
 
     except zipfile.BadZipFile as exc:
+        logger.warning("import_bundle rejected corrupt zip %s: %s", zip_path, exc)
         raise TrainIOError(
             "Import file is corrupt", code="dataset.import_corrupt",
-            http_status=400,
+            details={"reason": str(exc)}, http_status=400,
         ) from exc
 
     return {

--- a/tests/test_project_endpoints.py
+++ b/tests/test_project_endpoints.py
@@ -263,6 +263,39 @@ def test_train_zip_export_alien_version_returns_404(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
+def test_packaged_zip_download_ignores_range(client: TestClient) -> None:
+    """现场打包的 zip 两次请求字节不保证一致（manifest 时间戳），多线程下载器
+    按 Range 分块并行下载会各块触发独立打包、拼出损坏文件——必须整文件 200
+    + Accept-Ranges: none，不能 206。"""
+    import io
+    import zipfile
+
+    p = client.post("/api/projects", json={"title": "Range Guard"}).json()
+    pid = p["id"]
+    vid = p["versions"][0]["id"]
+    train = versions.version_dir(pid, p["slug"], "v1") / "train" / "1_data"
+    train.mkdir(parents=True, exist_ok=True)
+    (train / "a.png").write_bytes(b"png-bytes-long-enough-to-slice")
+    (train / "a.txt").write_text("tag1", encoding="utf-8")
+
+    for url in (
+        f"/api/projects/{pid}/versions/{vid}/train.zip",
+        f"/api/projects/{pid}/versions/{vid}/bundle.zip",
+    ):
+        # identity：下载器分块走的就是无压缩路径（gzip 响应无 Content-Length 本就不可分块）
+        resp = client.get(
+            url,
+            headers={"Range": "bytes=0-9", "Accept-Encoding": "identity"},
+        )
+        assert resp.status_code == 200, f"{url} 必须无视 Range 返回整文件"
+        assert resp.headers.get("accept-ranges") == "none", url
+        assert resp.headers.get("content-length") == str(len(resp.content)), url
+        # 拿到的是完整可解析的 zip，不是前 10 字节
+        with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+            assert zf.testzip() is None
+            assert "manifest.json" in zf.namelist()
+
+
 def test_import_train_rejects_zip_slip(client: TestClient) -> None:
     import io
     import json

--- a/tests/test_studio_queue_endpoints.py
+++ b/tests/test_studio_queue_endpoints.py
@@ -310,6 +310,34 @@ def test_download_outputs_zip(
         assert zf.read("state/task_%d/training_state_epoch2.pt" % tid) == b"CC"
 
 
+def test_download_outputs_zip_ignores_range(
+    client: TestClient, isolated, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """现场打包的 zip 不支持 Range 分块（多线程下载器分块拼接会因两次打包
+    字节不一致得到损坏文件）——带 Range 头也要整文件 200。"""
+    import io
+    import zipfile
+    from studio.services.projects import projects as projects_mod, versions as versions_mod
+    monkeypatch.setattr(projects_mod, "PROJECTS_DIR", isolated / "projects")
+    with db.connection_for() as conn:
+        p = projects_mod.create_project(conn, title="P")
+        v = versions_mod.create_version(conn, project_id=p["id"], label="v1")
+        tid = db.create_task(conn, name="t", config_name="good")
+        db.update_task(conn, tid, status="done", project_id=p["id"], version_id=v["id"])
+    out_dir = versions_mod.version_dir(p["id"], p["slug"], v["label"]) / "output"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "lora_final.safetensors").write_bytes(b"A" * 64)
+
+    resp = client.get(
+        f"/api/queue/{tid}/outputs.zip", headers={"Range": "bytes=0-9"},
+    )
+    assert resp.status_code == 200
+    assert resp.headers.get("accept-ranges") == "none"
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        assert zf.testzip() is None
+        assert zf.namelist() == ["lora_final.safetensors"]
+
+
 def test_list_task_outputs_returns_archive_basename(
     client: TestClient, isolated, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_train_io.py
+++ b/tests/test_train_io.py
@@ -442,6 +442,47 @@ def test_import_bundle_rejects_dot_version_label(isolated, tmp_path: Path) -> No
     assert (vdir / "train" / "1_data" / "a.png").exists()
 
 
+def test_import_bundle_corrupt_reports_reason(isolated, tmp_path: Path) -> None:
+    """BadZipFile 的具体原因要进 details（区分截断 / CRC 损坏，远程排查用）。"""
+    bad = tmp_path / "bad.bundle.zip"
+    bad.write_bytes(b"this is not a zip file at all")
+    with db.connection_for(isolated["db"]) as conn:
+        with pytest.raises(train_io.TrainIOError) as ei:
+            train_io.import_bundle(conn, bad, presets_base=tmp_path / "presets")
+    assert ei.value.code == "dataset.import_corrupt"
+    assert ei.value.details.get("reason")
+
+
+def test_export_atomic_no_partial_zip_on_failure(isolated, tmp_path: Path) -> None:
+    """打包失败 / 中断不得在 dest 留半截 zip（半截 zip 会被当正常导出拿去
+    导入，报「文件已损坏」且无法区分）；成功路径 .part 不残留。"""
+    p, v, train = _make_project_with_train(isolated)
+    (train / "1_data").mkdir(parents=True, exist_ok=True)
+    (train / "1_data" / "a.png").write_bytes(_png())
+
+    dest = tmp_path / "out.zip"
+    with db.connection_for(isolated["db"]) as conn:
+        train_io.export_train(conn, v["id"], dest)
+    assert dest.exists()
+    assert not dest.with_name(dest.name + ".part").exists()
+
+    # 写入中途炸：zf.write 抛错 → dest 不出现、.part 被清理
+    real_zipfile = zipfile.ZipFile
+
+    class ExplodingZip(real_zipfile):
+        def write(self, *a, **kw):  # noqa: ANN002, ANN003
+            raise OSError("disk exploded")
+
+    dest2 = tmp_path / "boom.zip"
+    with db.connection_for(isolated["db"]) as conn:
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(train_io.zipfile, "ZipFile", ExplodingZip)
+            with pytest.raises(OSError):
+                train_io.export_train(conn, v["id"], dest2)
+    assert not dest2.exists()
+    assert not dest2.with_name(dest2.name + ".part").exists()
+
+
 def _build_bundle_with_config(
     tmp_path: Path,
     *,


### PR DESCRIPTION
## 背景 / 动机

用户本地导出 bundle.zip 再本地上传导入，稳定报「导入文件已损坏」。对坏文件逐字节解剖确认：文件是**两个字节级不同的 zip 实例的分块拼接**——分段之间错位 ±1 字节、被分块边界穿过的 4 张 PNG 内容损坏、central directory 与部分数据区来自不同实例、结尾差 1 字节。

zip 双份 CRC（local header / CD）彼此一致但与实际字节不符，证明打包时流过校验器的数据是好的、文件字节是下载环节才变的——打包逻辑本身无 bug。

根因是三个条件叠加：

1. `GET train.zip / bundle.zip / outputs.zip` 每次请求**现场重新打包**，manifest 写 `exported_at=time.time()`，float repr 最短表示长度可变（小数 6/7 位），两次打包的 zip 全部偏移可差 1 字节；
2. starlette `FileResponse` 默认宣告 `Accept-Ranges: bytes` 并完整响应 206；
3. 用户装了多线程下载器（本案 = Ghost Downloader 3，IDM / 迅雷同理）接管浏览器下载（localhost 一样生效），按 Range 分块并行下载——**各分块触发独立打包、来自不同实例**，拼接必坏。

浏览器原生下载不中招（断点续传带 If-Range 校验，ETag 不匹配回退整文件），所以此前一直未暴露。

## 改动概要

一个 PR 三项改动，均围绕同一根因链：Range 禁用是根因修复；原子落盘堵住「损坏 zip」同症状的另一来源（导出中断留半截）；报错细节是本案的排查手段沉淀。

- 新增 `packaged_zip_response`（api/responses.py）：忽略 Range 头整流 200 + `Accept-Ranges: none` + 显式 Content-Length（保留浏览器进度条）。下载器拿不到 206 退化为单连接整流下载，字节一致性由单次打包保证。三个动态打包 GET 端点换用；静态直发端点（缩略图 / 单文件 / 日志等，字节稳定）不动。
- `export_train` / `export_bundle` / `_write_outputs_zip` 改 `.part` + `os.replace` 原子落盘：POST 导出到 data_exports/ 中途进程被杀不再留下与正常导出无法区分的半截 zip。
- 两处 `BadZipFile` → `dataset.import_corrupt` 的 details 带 `reason` 并打 WARNING 日志，远程排查可直接区分截断（File is not a zip file）与内容损坏（Bad CRC-32）；用户面文案不变。

## 外部代码参考声明

`packaged_zip_response` 的 Content-Disposition 编码（非 ASCII 文件名走 `filename*=utf-8''<quoted>`，否则 `filename="..."`）**对照了 starlette `FileResponse` 的实现**（https://github.com/encode/starlette，BSD-3-Clause，`starlette/responses.py` 的 FileResponse.__init__）。属对照校对的 RFC 6266 标准模式（数行），未复制文件；代码注释已注明。

## 测试方式

自动测试（新增 3 个）：

- `test_packaged_zip_download_ignores_range` / `test_download_outputs_zip_ignores_range`：train.zip / bundle.zip / outputs.zip 带 `Range: bytes=0-9` 断言 200 整文件（非 206）+ `accept-ranges: none`；identity 编码下断言 Content-Length 与 body 一致（app 全局 GZipMiddleware 会移除 Content-Length，而下载器分块本就走 identity 路径）
- `test_export_atomic_no_partial_zip_on_failure`：打包 `zf.write` 中途抛错断言 dest 与 `.part` 均不残留；成功路径断言 `.part` 不残留
- `test_import_bundle_corrupt_reports_reason`：喂非 zip 文件断言 `details["reason"]` 非空

提交前自检（CONTRIBUTING §3）：

- 相关测试：`tests/test_train_io.py tests/test_project_endpoints.py tests/test_studio_queue_endpoints.py` — 91 passed
- 横切安全网：`tests/test_route_snapshot.py tests/test_studio_configs.py` — 33 passed
- `ruff check .` — All checks passed
- 前端未改动，vitest / tsc 不适用；全量交 CI

手测：对真实损坏样本（用户提供的 48MB bundle）完成逐字节取证，确认损坏模式与根因假说吻合（分块边界错位 ±1 字节、双份 CRC 一致但与字节不符）；用户侧已确认使用 Ghost Downloader 3 下载。

🤖 Generated with [Claude Code](https://claude.com/claude-code)