### PR TITLE
fix(web): 修复 PreprocessInpaint hook 依赖警告与前端测试竞态

### DIFF
--- a/studio/web/src/components/AnnouncementCenter.test.tsx
+++ b/studio/web/src/components/AnnouncementCenter.test.tsx
@@ -113,8 +113,10 @@ describe('AnnouncementCenter', () => {
     renderCenter()
     await waitFor(() =>
       expect(screen.getByTestId('announcement-center')).toBeInTheDocument())
-    // ### 解析成标题（原文 "### 新增" 不会有 heading role）
-    expect(screen.getByRole('heading', { name: '新增' })).toBeInTheDocument()
+    // modal 会先于默认选中 effect 出现；等待正文标题，避免慢速 CI 读到
+    // selectedId 仍为空的中间态。
+    await waitFor(() =>
+      expect(screen.getByRole('heading', { name: '新增' })).toBeInTheDocument())
     // - 解析成列表项
     expect(screen.getByText('甲项')).toBeInTheDocument()
   })

--- a/studio/web/src/pages/QueueDetail.test.tsx
+++ b/studio/web/src/pages/QueueDetail.test.tsx
@@ -279,10 +279,11 @@ describe('QueueDetailPage 评估 tab', () => {
     )
     renderDetailPage()
 
-    await waitFor(() => expect(screen.getByText('样图')).toBeInTheDocument())
+    // task=null 时按 train 基线暂时也会显示「样图」和「监控」；等待 monitor
+    // 消失才能证明 eval_session 已加载且类型差异化 tab 已收敛。
+    await waitFor(() => expect(screen.queryByText('监控')).not.toBeInTheDocument())
+    expect(screen.getByText('样图')).toBeInTheDocument()
     expect(screen.getByText('指标')).toBeInTheDocument()
-    // 训练专用 tab 不该出现在评估作业上
-    expect(screen.queryByText('监控')).not.toBeInTheDocument()
     // 溯源进了概览的键值表，不是单独一块进度卡。parent 是异步认领的（params 里
     // 只有 session_id），所以等它出现而不是等「关联训练」那一格。
     await waitFor(() => expect(screen.getByText('#88')).toBeInTheDocument())

--- a/studio/web/src/pages/project/steps/PreprocessInpaint.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessInpaint.tsx
@@ -111,8 +111,14 @@ export default function PreprocessInpaintPage() {
     () => images.find((im) => im.name === activeName) ?? null,
     [images, activeName],
   )
-  const activeHistory = activeName ? (historyByImage[activeName] ?? []) : []
-  const activeRedo = activeName ? (redoByImage[activeName] ?? []) : []
+  const activeHistory = useMemo(
+    () => (activeName ? (historyByImage[activeName] ?? []) : []),
+    [activeName, historyByImage],
+  )
+  const activeRedo = useMemo(
+    () => (activeName ? (redoByImage[activeName] ?? []) : []),
+    [activeName, redoByImage],
+  )
   const activePaintStrokes = useMemo(
     () => activeHistory.filter((h) => h.kind === 'paint').map((h) => h.stroke),
     [activeHistory],


### PR DESCRIPTION
## 背景
1. `PreprocessInpaint.tsx` 中的 `activeHistory` 与 `activeRedo` 原为普通局部变量，在 `activeName` 为空时回退为新字面量空数组 `[]`，导致下方的 `useMemo`（`activePaintStrokes` 与 `activeMaskStrokes`）在每次组件 re-render 时依赖项引用变动，触发 `react-hooks/exhaustive-deps` 警告。
2. 前端测试中 `AnnouncementCenter` 与 `QueueDetail` 存在异步状态收敛时序问题，慢速环境下易造成测试抖动。

## 实现
- 使用 `useMemo` 分别包裹 `activeHistory` 和 `activeRedo` 的派生计算，依赖 `[activeName, historyByImage]` 与 `[activeName, redoByImage]`。
- 优化前端测试中的 `waitFor` 等待逻辑以保证异步状态收敛。

## 影响 / 兼容性
- 彻底消除前端启动及构建时的 ESLint warnings（0 error, 0 warning）。
- 未变更 PreprocessInpaint 笔刷历史记录、撤销重做和保存行为。

## 验证
- `cd studio/web && npm run lint` (0 error, 0 warning)
- `cd studio/web && npx tsc --noEmit`
- `cd studio/web && npx vitest run` (75 files / 674 tests passed)
- `./venv/Scripts/python.exe -m pytest tests/test_route_snapshot.py tests/test_studio_configs.py -q` (33 passed)
- `./venv/Scripts/python.exe -m ruff check .`