### PR TITLE
feat(web): establish button and badge design primitives

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,159 @@
+# AnimaLoraStudio Design System
+
+This document is the durable visual contract for Studio Web. Product behavior and
+information architecture remain authoritative in the application and product docs;
+this file defines how those behaviors are presented consistently.
+
+## 1. Direction
+
+AnimaLoraStudio is a focused creative workbench, not a marketing surface. Its visual
+world is warm ivory, restrained orange, precise typography, and compact technical
+controls. Light and dark themes express the same hierarchy. Changes should evolve
+this world rather than replace it.
+
+The interface serves two audiences at once:
+
+- New users need clear hierarchy, familiar controls, and visible next actions.
+- Experienced users need dense parameter editing, fast scanning, and stable layouts.
+
+Consistency means equal semantics receive equal treatment. It does not mean every
+surface has identical density.
+
+## 2. Sources of truth
+
+| Layer | Authority | Responsibility |
+| --- | --- | --- |
+| Foundation | `studio/web/src/styles/tokens.css` | Color, type, spacing, radius, shadow, motion, control states |
+| Utility bridge | `studio/web/tailwind.config.js` | Maps CSS tokens into Tailwind utilities |
+| Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx` | Typed, accessible component APIs |
+| Patterns | `PageHeader`, `StepShell`, `Dialog`, `Toast`, `Field` | Repeated page and interaction structures |
+| Product surfaces | `studio/web/src/pages/` | Business state and composition, not new visual primitives |
+
+A page may compose primitives with layout utilities. It must not recreate an
+existing primitive with arbitrary colors, padding, font sizes, or hover states.
+
+## 3. Foundations
+
+### Color
+
+Use semantic tokens instead of literal colors:
+
+- `canvas` is the page field.
+- `surface` is the normal content plane.
+- `sunken` is for wells, navigation, and code/data regions.
+- `elevated` is for overlays and popovers.
+- `accent` identifies the primary action or active process.
+- `ok`, `warn`, `err`, and `info` communicate state, never decoration alone.
+
+Do not rely on color as the only state cue. Pair it with text, an icon, or an
+indicator. Dark mode must preserve hierarchy rather than simply invert colors.
+
+### Typography
+
+- `text-base`: normal interface and body copy.
+- `text-sm`: compact controls and secondary content.
+- `text-xs`: metadata, timestamps, and badges.
+- `text-2xs`: dense supporting labels only; never primary actions.
+- `text-xl` and above: page or major section hierarchy.
+- `font-mono`: code, paths, identifiers, logs, and measurements—not generic UI chrome.
+- `.tnum`: changing or comparable numeric values.
+
+Use the configured type scale. Arbitrary pixel font sizes require a documented
+layout constraint and should remain exceptional.
+
+### Spacing, radius, and depth
+
+Use the `--s-*`, `--r-*`, and `--sh-*` scales. Within one hierarchy level, use one
+radius: controls use `--r-md`, ordinary cards use `--r-lg`, and pills use
+`--r-pill`. Dense workbench panels may use `--r-md` when their compactness is part
+of the information structure.
+
+Shadows communicate elevation. Borders communicate grouping. Do not add shadows
+merely to decorate every container.
+
+### Density
+
+- **Default** is the baseline for navigation, settings, dialogs, and ordinary forms.
+- **Compact** is allowed for parameter-heavy workbenches, tables, and repeated row
+  controls. It must use an explicit small component size or the global tight density,
+  not local pixel values.
+- **Loose** increases readability without changing component semantics.
+
+## 4. Button contract
+
+Use `Button` for button elements. Links that navigate may use `buttonClassName()`
+when they need button presentation while retaining link semantics.
+
+| Variant | Use | Do not use for |
+| --- | --- | --- |
+| `primary` | The single leading action in a local decision scope | Every positive action on a page |
+| `secondary` | Normal actions and alternate choices | Passive navigation or icon-only chrome |
+| `ghost` | Low-emphasis actions, toolbar controls, dismissals | Destructive actions without another cue |
+| `warning` | Interrupting or canceling reversible/in-progress work | Permanent deletion |
+| `danger` | Irreversible deletion or discarding recoverable state | Routine cancellation |
+
+Sizes:
+
+- `md`: ordinary forms and dialogs.
+- `sm`: headers, cards, and compact action rows.
+- `xs`: dense tables, filters, and micro toolbars; never body copy squeezed smaller.
+
+Rules:
+
+- Button labels name the action.
+- Icon-only buttons require an accessible label.
+- Loading buttons remain labeled, expose `aria-busy`, and cannot be activated.
+- Toggle buttons expose `aria-pressed`.
+- Disabled, hover, active, and keyboard-focus states come from the primitive.
+- Do not combine `bg-*`, `border-*`, and `text-*` to reinvent an existing variant.
+
+## 5. Badge contract
+
+Badges are non-interactive labels. A clickable pill is a button or link, not a badge.
+
+| Tone | Meaning | Common states |
+| --- | --- | --- |
+| `neutral` | Passive, queued, unknown, or canceled metadata | pending, scheduled, canceled |
+| `accent` | Active work or the current process | running, training, evaluating |
+| `success` | Successful completion or confirmed availability | done, completed, available |
+| `warning` | Paused, partial, or attention required | paused, partial |
+| `danger` | Failure or invalid state | failed, error |
+| `info` | Informational classification without success/failure | source or category labels |
+
+An active badge may include the shared pulsing indicator. Use `sm` only for dense
+metadata such as announcement tags; status badges use the default size.
+
+Domain components such as `VersionStatusBadge` own the mapping from backend state to
+badge tone. The generic `Badge` component must not know API enums.
+
+## 6. Forms and help text
+
+Default forms use the standard `.input` surface. Parameter-heavy schema forms may
+use their existing compact canvas treatment as an explicit density variant.
+
+Settings explanations belong in the label-adjacent `InfoButton` tooltip according
+to `docs/design/ui-info-design.md`; do not add permanent explanatory paragraphs
+under individual settings.
+
+## 7. Accessibility and resilience
+
+Every primitive must work with keyboard focus, disabled state, light/dark themes,
+all three density modes, and both Chinese and English labels. Focus is always visible.
+Controls must tolerate longer English copy without fixed-width truncation unless the
+full value is available through an established disclosure pattern.
+
+Respect `prefers-reduced-motion`; status information must remain understandable when
+animation is disabled.
+
+## 8. Migration policy
+
+Migration is incremental:
+
+1. Preserve the CSS classes as compatibility primitives.
+2. Use typed components for new work.
+3. Migrate representative surfaces with tests.
+4. Move remaining pages by component family, not by arbitrary page batches.
+5. Remove old compatibility paths only after repository-wide adoption.
+
+A migration must preserve business behavior, route contracts, schema, SSE events,
+and localization unless those changes are explicitly part of its scope.

--- a/studio/web/src/components/AnnouncementCenter.test.tsx
+++ b/studio/web/src/components/AnnouncementCenter.test.tsx
@@ -84,7 +84,10 @@ describe('AnnouncementCenter', () => {
     renderCenter()
     await waitFor(() =>
       expect(screen.getByTestId('announcement-center')).toBeInTheDocument())
-    fireEvent.click(screen.getByTestId('announcement-filter-notice'))
+    const noticeFilter = screen.getByTestId('announcement-filter-notice')
+    expect(noticeFilter).toHaveClass('btn', 'btn-secondary', 'btn-xs')
+    fireEvent.click(noticeFilter)
+    expect(noticeFilter).toHaveAttribute('aria-pressed', 'true')
     expect(screen.queryByTestId('announcement-item-p-migration')).toBeNull()
     expect(screen.getByTestId('announcement-item-p-notice')).toBeInTheDocument()
   })

--- a/studio/web/src/components/AnnouncementCenter.tsx
+++ b/studio/web/src/components/AnnouncementCenter.tsx
@@ -10,6 +10,8 @@ import { useTranslation } from 'react-i18next'
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { AnnouncementPost } from '../api/client'
+import Badge, { type BadgeTone } from './Badge'
+import Button from './Button'
 import { useAnnouncements } from '../lib/Announcements'
 import { useSettingsDrawer } from '../lib/SettingsDrawer'
 import { SECTION_TO_TAB } from '../pages/tools/settings/constants'
@@ -42,8 +44,8 @@ export function announcementUrlTransform(url: string): string {
 type MdProps<T extends keyof React.JSX.IntrinsicElements> = ComponentPropsWithoutRef<T>
 const MD_COMPONENTS = {
   // # / ## 罕见（正文最高用 ###）；都按版块标题处理
-  h1: (p: MdProps<'h1'>) => <h3 className="mt-5 mb-2 pb-1 text-[15px] font-bold text-fg-primary border-b border-dim" {...p} />,
-  h2: (p: MdProps<'h2'>) => <h3 className="mt-5 mb-2 pb-1 text-[15px] font-bold text-fg-primary border-b border-dim" {...p} />,
+  h1: (p: MdProps<'h1'>) => <h3 className="mt-5 mb-2 pb-1 text-base font-bold text-fg-primary border-b border-dim" {...p} />,
+  h2: (p: MdProps<'h2'>) => <h3 className="mt-5 mb-2 pb-1 text-base font-bold text-fg-primary border-b border-dim" {...p} />,
   // ### = 分组标题（新增/变更/改进/修复…）：加粗 + 下划线，清晰分段
   h3: (p: MdProps<'h3'>) => <h4 className="mt-5 mb-2 pb-1 text-sm font-bold text-fg-primary border-b border-dim first:mt-1" {...p} />,
   h4: (p: MdProps<'h4'>) => <h4 className="mt-4 mb-1.5 text-sm font-semibold text-fg-primary" {...p} />,
@@ -60,11 +62,11 @@ const MD_COMPONENTS = {
   blockquote: (p: MdProps<'blockquote'>) => <blockquote className="my-2 pl-3 border-l-2 border-dim text-fg-tertiary" {...p} />,
 } as const
 
-function tagChipClass(tag: AnnouncementPost['tag']): string {
+function tagChipTone(tag: AnnouncementPost['tag']): BadgeTone {
   switch (tag) {
-    case 'release': return 'text-accent bg-accent-soft'
-    case 'migration': return 'text-warn bg-warn-soft'
-    default: return 'text-info bg-info-soft' // notice
+    case 'release': return 'accent'
+    case 'migration': return 'warning'
+    default: return 'info'
   }
 }
 
@@ -156,45 +158,47 @@ export function AnnouncementCenter() {
             {t('announcements.title')}
           </h1>
           {updateInfo?.has_update && (
-            <button
-              type="button"
+            <Button
+              variant="secondary"
+              size="xs"
               onClick={() => { settingsDrawer.open({ section: 'version' }); closeCenter() }}
               title={t('announcements.updateAvailable', { tag: updateInfo.latest_tag ?? updateInfo.latest_commit.slice(0, 8) })}
-              className="flex items-center gap-1.5 px-2 py-[5px] rounded-md text-xs font-mono text-accent bg-accent-soft border border-accent cursor-pointer hover:bg-accent/10 transition-colors shrink-0"
+              className="font-mono shrink-0"
               data-testid="announcement-update-btn"
             >
-              <span className="w-1.5 h-1.5 rounded-full bg-accent" />
+              <span className="dot bg-accent" aria-hidden="true" />
               <span>{updateInfo.latest_tag ?? t('announcements.updateAvailable', { tag: '' }).trim()}</span>
-            </button>
+            </Button>
           )}
-          <button
-            type="button"
+          <Button
+            variant="ghost"
+            size="xs"
+            iconOnly
             onClick={closeCenter}
             aria-label={t('announcements.close')}
-            className="flex items-center justify-center w-7 h-7 rounded-md text-fg-tertiary hover:text-fg-primary hover:bg-surface bg-transparent border-none cursor-pointer shrink-0"
+            className="shrink-0"
             data-testid="announcement-close"
           >
-            ✕
-          </button>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" aria-hidden="true">
+              <path d="M6 6l12 12M18 6 6 18" />
+            </svg>
+          </Button>
         </div>
 
         {/* tag filter */}
         {tagsPresent.length > 1 && (
           <div className="flex gap-1.5 px-5 py-2 border-b border-dim shrink-0">
             {(['all', ...tagsPresent] as const).map((tg) => (
-              <button
+              <Button
                 key={tg}
-                type="button"
+                variant="secondary"
+                size="xs"
+                aria-pressed={activeTag === tg}
                 onClick={() => setActiveTag(tg)}
-                className={`px-2.5 py-1 text-xs rounded transition-colors cursor-pointer border ${
-                  activeTag === tg
-                    ? 'border-accent bg-accent-soft text-fg-primary'
-                    : 'border-dim bg-surface text-fg-secondary hover:border-accent/50'
-                }`}
                 data-testid={`announcement-filter-${tg}`}
               >
                 {tagLabel(tg)}
-              </button>
+              </Button>
             ))}
           </div>
         )}
@@ -228,9 +232,9 @@ export function AnnouncementCenter() {
                       <span className="text-sm font-medium text-fg-primary truncate">{p.title[lang]}</span>
                     </div>
                     <div className="flex items-center gap-2 mt-1">
-                      <span className={`px-1.5 py-0.5 text-[10px] rounded ${tagChipClass(p.tag)}`}>
+                      <Badge tone={tagChipTone(p.tag)} size="sm">
                         {tagLabel(p.tag)}
-                      </span>
+                      </Badge>
                       <span className="text-xs text-fg-tertiary">{p.date}</span>
                     </div>
                   </button>

--- a/studio/web/src/components/Badge.test.tsx
+++ b/studio/web/src/components/Badge.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Badge from './Badge'
+
+describe('Badge', () => {
+  it('uses a neutral tone by default', () => {
+    render(<Badge>Pending</Badge>)
+    expect(screen.getByText('Pending')).toHaveClass('badge', 'badge-neutral')
+  })
+
+  it('maps semantic tones to existing visual tokens', () => {
+    render(<Badge tone="danger">Failed</Badge>)
+    expect(screen.getByText('Failed')).toHaveClass('badge-err')
+  })
+
+  it('supports dense metadata sizing', () => {
+    render(<Badge size="sm">Release</Badge>)
+    expect(screen.getByText('Release')).toHaveClass('badge-sm')
+  })
+
+  it('adds the shared active-work indicator', () => {
+    const { container } = render(<Badge tone="accent" active>Running</Badge>)
+    expect(container.querySelector('.dot.dot-running')).not.toBeNull()
+    expect(container.querySelector('.dot')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('preserves caller classes and native span attributes', () => {
+    render(<Badge className="shrink-0" title="Current state">Ready</Badge>)
+    expect(screen.getByTitle('Current state')).toHaveClass('shrink-0')
+  })
+})

--- a/studio/web/src/components/Badge.tsx
+++ b/studio/web/src/components/Badge.tsx
@@ -1,0 +1,44 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+export type BadgeTone = 'neutral' | 'accent' | 'info' | 'success' | 'warning' | 'danger'
+export type BadgeSize = 'md' | 'sm'
+
+export interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
+  tone?: BadgeTone
+  size?: BadgeSize
+  /** Active work receives the shared pulsing status indicator. */
+  active?: boolean
+  children: ReactNode
+}
+
+const TONE_CLASS: Record<BadgeTone, string> = {
+  neutral: 'badge-neutral',
+  accent: 'badge-accent',
+  info: 'badge-info',
+  success: 'badge-ok',
+  warning: 'badge-warn',
+  danger: 'badge-err',
+}
+
+export default function Badge({
+  tone = 'neutral',
+  size = 'md',
+  active = false,
+  className = '',
+  children,
+  ...rest
+}: BadgeProps) {
+  const classes = [
+    'badge',
+    TONE_CLASS[tone],
+    size === 'sm' && 'badge-sm',
+    className,
+  ].filter(Boolean).join(' ')
+
+  return (
+    <span {...rest} className={classes}>
+      {active && <span className="dot dot-running" aria-hidden="true" />}
+      {children}
+    </span>
+  )
+}

--- a/studio/web/src/components/Button.test.tsx
+++ b/studio/web/src/components/Button.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Button, { buttonClassName } from './Button'
+
+describe('Button', () => {
+  it('defaults to a non-submitting secondary button', () => {
+    render(<Button>Save</Button>)
+    const button = screen.getByRole('button', { name: 'Save' })
+    expect(button).toHaveAttribute('type', 'button')
+    expect(button).toHaveClass('btn', 'btn-secondary')
+  })
+
+  it('maps variants and sizes to the shared primitive classes', () => {
+    render(<Button variant="warning" size="xs">Cancel</Button>)
+    expect(screen.getByRole('button', { name: 'Cancel' }))
+      .toHaveClass('btn-warn', 'btn-xs')
+  })
+
+  it('disables activation and exposes busy state while loading', () => {
+    render(<Button loading>Saving</Button>)
+    const button = screen.getByRole('button', { name: 'Saving' })
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('aria-busy', 'true')
+    expect(button.querySelector('.btn-spinner')).not.toBeNull()
+  })
+
+  it('supports an accessible icon-only control', () => {
+    render(<Button iconOnly size="sm" aria-label="Close"><span aria-hidden>×</span></Button>)
+    expect(screen.getByRole('button', { name: 'Close' }))
+      .toHaveClass('btn-icon', 'btn-sm')
+  })
+
+  it('builds classes for links without changing link semantics', () => {
+    expect(buttonClassName({ variant: 'ghost', size: 'sm', className: 'no-underline' }))
+      .toBe('btn btn-ghost btn-sm no-underline')
+  })
+})

--- a/studio/web/src/components/Button.tsx
+++ b/studio/web/src/components/Button.tsx
@@ -1,0 +1,89 @@
+import {
+  forwardRef,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from 'react'
+
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'warning' | 'danger'
+export type ButtonSize = 'md' | 'sm' | 'xs'
+
+interface ButtonPropsBase extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'aria-label'> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  loading?: boolean
+  iconOnly?: boolean
+  children: ReactNode
+  'aria-label'?: string
+}
+
+export type ButtonProps = ButtonPropsBase & (
+  | { iconOnly: true; 'aria-label': string }
+  | { iconOnly?: false; 'aria-label'?: string }
+)
+
+const VARIANT_CLASS: Record<ButtonVariant, string> = {
+  primary: 'btn-primary',
+  secondary: 'btn-secondary',
+  ghost: 'btn-ghost',
+  warning: 'btn-warn',
+  danger: 'btn-danger',
+}
+
+const SIZE_CLASS: Record<ButtonSize, string> = {
+  md: '',
+  sm: 'btn-sm',
+  xs: 'btn-xs',
+}
+
+export function buttonClassName({
+  variant = 'secondary',
+  size = 'md',
+  iconOnly = false,
+  loading = false,
+  className = '',
+}: {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  iconOnly?: boolean
+  loading?: boolean
+  className?: string
+} = {}): string {
+  return [
+    'btn',
+    VARIANT_CLASS[variant],
+    SIZE_CLASS[size],
+    iconOnly && 'btn-icon',
+    loading && 'btn-loading',
+    className,
+  ].filter(Boolean).join(' ')
+}
+
+const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button({
+  variant = 'secondary',
+  size = 'md',
+  loading = false,
+  iconOnly = false,
+  className,
+  children,
+  disabled,
+  type,
+  'aria-label': ariaLabel,
+  ...rest
+}, ref) {
+  return (
+    <button
+      {...rest}
+      ref={ref}
+      type={type ?? 'button'}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      aria-label={ariaLabel}
+      className={buttonClassName({ variant, size, iconOnly, loading, className })}
+    >
+      {loading && <span className="btn-spinner" aria-hidden="true" />}
+      {children}
+    </button>
+  )
+})
+
+export default Button

--- a/studio/web/src/components/CheckboxDropdown.test.tsx
+++ b/studio/web/src/components/CheckboxDropdown.test.tsx
@@ -1,0 +1,61 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import { useState } from 'react'
+import { describe, expect, it } from 'vitest'
+import CheckboxDropdown, { type CheckboxDropdownOption } from './CheckboxDropdown'
+
+const OPTIONS: CheckboxDropdownOption[] = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Beta' },
+]
+
+function Harness() {
+  const [selected, setSelected] = useState(new Set(['a']))
+  return (
+    <CheckboxDropdown
+      label="Candidates"
+      options={OPTIONS}
+      selected={selected}
+      onChange={setSelected}
+    />
+  )
+}
+
+describe('CheckboxDropdown', () => {
+  it('uses the compact button primitive and exposes expanded state', () => {
+    render(<Harness />)
+    const trigger = screen.getByRole('button', { name: 'Candidates' })
+    expect(trigger).toHaveClass('btn', 'btn-secondary', 'btn-xs')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('已选 1 / 2')).toBeInTheDocument()
+  })
+
+  it('selects and clears the complete option set', () => {
+    render(<Harness />)
+    fireEvent.click(screen.getByRole('button', { name: 'Candidates' }))
+    fireEvent.click(screen.getByRole('button', { name: '全选' }))
+    expect(screen.getByRole('button', { name: 'Candidates' })).toHaveTextContent('2/2')
+    expect(screen.getByRole('button', { name: '取消选择' })).toBeInTheDocument()
+  })
+
+  it('uses the localized empty state unless a custom hint is supplied', () => {
+    const { rerender } = render(
+      <CheckboxDropdown label="Empty" options={[]} selected={new Set()} onChange={() => {}} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Empty' }))
+    expect(screen.getByText('暂无可选项')).toBeInTheDocument()
+
+    rerender(
+      <CheckboxDropdown
+        label="Empty"
+        options={[]}
+        selected={new Set()}
+        onChange={() => {}}
+        emptyHint="Nothing configured"
+      />,
+    )
+    expect(screen.getByText('Nothing configured')).toBeInTheDocument()
+  })
+})

--- a/studio/web/src/components/CheckboxDropdown.tsx
+++ b/studio/web/src/components/CheckboxDropdown.tsx
@@ -4,6 +4,8 @@
 // 原生 <select multiple> 又没法看清勾了哪些。收进一个 popover：按钮上显示「已选 n/m」，
 // 展开才是完整清单。
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import Button from './Button'
 
 export interface CheckboxDropdownOption {
   value: string
@@ -21,6 +23,7 @@ export default function CheckboxDropdown({
   onChange: (next: Set<string>) => void
   emptyHint?: string
 }) {
+  const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const wrapRef = useRef<HTMLDivElement | null>(null)
 
@@ -46,27 +49,33 @@ export default function CheckboxDropdown({
 
   return (
     <div ref={wrapRef} className="relative">
-      <button
-        type="button"
+      <Button
+        variant="secondary"
+        size="xs"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
         aria-label={label}
-        className="font-mono cursor-pointer flex items-center gap-1.5"
-        style={{
-          fontSize: 11,
-          padding: '4px 8px',
-          borderRadius: 'var(--r-md)',
-          border: '1px solid var(--border-subtle)',
-          background: 'var(--bg-sunken)',
-          color: 'var(--fg-secondary)',
-        }}
+        className="font-mono"
       >
         <span className="font-sans font-semibold">{label}</span>
         <span className="text-fg-tertiary">
           {selected.size}/{options.length}
         </span>
-        <span className="text-fg-tertiary">{open ? '▴' : '▾'}</span>
-      </button>
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          className={`text-fg-tertiary transition-transform ${open ? 'rotate-180' : ''}`}
+          aria-hidden="true"
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </Button>
 
       {open && (
         <div
@@ -76,26 +85,26 @@ export default function CheckboxDropdown({
           style={{ minWidth: 240, maxWidth: 'min(420px, 80vw)' }}
         >
           <div className="flex items-center gap-2 px-2.5 py-1.5 border-b border-subtle">
-            <span className="text-[11px] text-fg-tertiary flex-1">
-              已选 {selected.size} / {options.length}
+            <span className="text-xs text-fg-tertiary flex-1">
+              {t('common.selectedCount', { selected: selected.size, total: options.length })}
             </span>
-            <button
-              type="button"
-              className="text-[11px] text-fg-tertiary hover:text-fg underline bg-transparent border-none cursor-pointer p-0"
+            <Button
+              variant="ghost"
+              size="xs"
               onClick={() => onChange(allPicked ? new Set() : new Set(allValues))}
             >
-              {allPicked ? '清空' : '全选'}
-            </button>
+              {allPicked ? t('common.deselect') : t('common.selectAll')}
+            </Button>
           </div>
           <div className="overflow-y-auto py-1" style={{ maxHeight: 300 }}>
             {options.length === 0 ? (
-              <div className="px-2.5 py-2 text-[11px] text-fg-tertiary">
-                {emptyHint ?? '暂无可选项'}
+              <div className="px-2.5 py-2 text-xs text-fg-tertiary">
+                {emptyHint ?? t('common.noOptions')}
               </div>
             ) : options.map((o) => (
               <label
                 key={o.value}
-                className="flex items-center gap-1.5 px-2.5 py-1 text-[11px] cursor-pointer hover:bg-overlay"
+                className="flex items-center gap-1.5 px-2.5 py-1 text-xs cursor-pointer hover:bg-overlay"
                 title={o.title ?? o.label}
               >
                 <input

--- a/studio/web/src/components/VersionStatusBadge.tsx
+++ b/studio/web/src/components/VersionStatusBadge.tsx
@@ -6,19 +6,16 @@
  */
 import { useTranslation } from 'react-i18next'
 import type { VersionPhase, VersionStatus } from '../api/client'
+import Badge, { type BadgeTone } from './Badge'
 
-const DOT_RUNNING = (
-  <span className="dot dot-running" style={{ flexShrink: 0 }} />
-)
-
-type StatusEntry = { badge: string; key: string; dot?: true }
+type StatusEntry = { tone: BadgeTone; key: string; active?: true }
 
 const STATUS_MAP: Record<VersionStatus, StatusEntry> = {
-  preparing: { badge: 'badge-warn',    key: 'versionStatus.preparing' },
-  training:  { badge: 'badge-accent',  key: 'versionStatus.training', dot: true },
-  completed: { badge: 'badge-ok',      key: 'versionStatus.completed' },
-  failed:    { badge: 'badge-err',     key: 'versionStatus.failed' },
-  canceled:  { badge: 'badge-neutral', key: 'versionStatus.canceled' },
+  preparing: { tone: 'warning', key: 'versionStatus.preparing' },
+  training:  { tone: 'accent',  key: 'versionStatus.training', active: true },
+  completed: { tone: 'success', key: 'versionStatus.completed' },
+  failed:    { tone: 'danger',  key: 'versionStatus.failed' },
+  canceled:  { tone: 'neutral', key: 'versionStatus.canceled' },
 }
 
 /** preparing 时 badge 后缀的 phase 文案（PR #265 评审改：可选步骤
@@ -42,14 +39,13 @@ export default function VersionStatusBadge({
 }) {
   const { t } = useTranslation()
   if (!status) return null
-  const entry = STATUS_MAP[status] ?? { badge: 'badge-neutral', key: status }
+  const entry = STATUS_MAP[status] ?? { tone: 'neutral' as const, key: status }
   const suffixKey =
     status === 'preparing' && phase ? PHASE_SUFFIX_KEY[phase] : undefined
   return (
-    <span className={`badge ${entry.badge}`}>
-      {entry.dot && DOT_RUNNING}
+    <Badge tone={entry.tone} active={entry.active}>
       {STATUS_MAP[status] ? t(entry.key) : status}
       {suffixKey ? ` · ${t(suffixKey)}` : ''}
-    </span>
+    </Badge>
   )
 }

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -48,6 +48,8 @@
     "all": "All",
     "select": "Select",
     "selectAll": "Select all",
+    "selectedCount": "{{selected}} / {{total}} selected",
+    "noOptions": "No options available",
     "deselect": "Deselect",
     "preview": "Preview",
     "search": "Search",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -48,6 +48,8 @@
     "all": "全部",
     "select": "选择",
     "selectAll": "全选",
+    "selectedCount": "已选 {{selected}} / {{total}}",
+    "noOptions": "暂无可选项",
     "deselect": "取消选择",
     "preview": "预览",
     "search": "搜索",

--- a/studio/web/src/pages/QueueDetail.test.tsx
+++ b/studio/web/src/pages/QueueDetail.test.tsx
@@ -183,6 +183,10 @@ describe('QueueDetailPage 暂停按钮 SSE 刷新', () => {
 
     // 初始：running header 已渲染（PID 卡片），但 is_pausable=false → 暂停按钮不在
     await waitFor(() => expect(screen.getByText('取消任务')).toBeInTheDocument())
+    expect(screen.getByRole('button', { name: '取消任务' })).toHaveClass('btn-warn', 'btn-sm')
+    for (const statusBadge of screen.getAllByText('运行中')) {
+      expect(statusBadge).toHaveClass('badge-accent')
+    }
     expect(screen.queryByTestId('detail-pause-btn')).not.toBeInTheDocument()
 
     // 后端首个 epoch backup 落盘 → is_pausable 升级；推一条 SSE 事件

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -10,6 +10,8 @@ import {
   type TaskType,
 } from '../api/client'
 import { PauseProgressModal } from '../components/PauseProgressModal'
+import Badge, { type BadgeTone } from '../components/Badge'
+import Button, { buttonClassName } from '../components/Button'
 import { useDialog } from '../components/Dialog'
 import { useToast } from '../components/Toast'
 import { useEventStream } from '../lib/useEventStream'
@@ -62,14 +64,14 @@ function visibleTabsFor(task: Task | null, hasEval: boolean | null): readonly Ta
   return base.filter((tb) => tb !== 'metrics' && tb !== 'samples')
 }
 
-const STATUS_BADGE: Record<TaskStatus, string> = {
-  pending: 'badge badge-neutral',
-  running: 'badge badge-accent',
-  done: 'badge badge-ok',
-  failed: 'badge badge-err',
-  canceled: 'badge badge-neutral',
-  paused: 'badge badge-warn',
-  scheduled: 'badge badge-neutral',
+const STATUS_TONE: Record<TaskStatus, BadgeTone> = {
+  pending: 'neutral',
+  running: 'accent',
+  done: 'success',
+  failed: 'danger',
+  canceled: 'neutral',
+  paused: 'warning',
+  scheduled: 'neutral',
 }
 
 const TERMINAL: ReadonlyArray<TaskStatus> = ['done', 'failed', 'canceled']
@@ -351,8 +353,12 @@ export default function QueueDetailPage() {
       {/* Header */}
       <header className="px-6 py-4 border-b border-subtle flex flex-col gap-2 shrink-0 bg-canvas">
         <div className="flex items-center gap-2.5 flex-wrap">
-          <Link to="/queue" className="btn btn-ghost btn-sm no-underline"
-          >{t('queueDetail.backToQueue')}</Link>
+          <Link
+            to="/queue"
+            className={buttonClassName({ variant: 'ghost', size: 'sm', className: 'no-underline' })}
+          >
+            {t('queueDetail.backToQueue')}
+          </Link>
           <span className="text-fg-tertiary">/</span>
           <h1 className="m-0 text-xl font-semibold font-mono">
             #{taskId}
@@ -364,32 +370,32 @@ export default function QueueDetailPage() {
             </>
           )}
           {status && (
-            <span className={STATUS_BADGE[status]}>
-              {status === 'running' && <span className="dot dot-running" />}
+            <Badge tone={STATUS_TONE[status]} active={status === 'running'}>
               {STATUS_LABEL[status]}
-            </span>
+            </Badge>
           )}
           {evalProgress?.active && (
-            <span className="badge badge-accent" title={t('eval.evaluatingHint')}>
-              <span className="dot dot-running" />
+            <Badge tone="accent" active title={t('eval.evaluatingHint')}>
               {t('eval.evaluatingProgress', { done: evalProgress.done, total: evalProgress.total })}
-            </span>
+            </Badge>
           )}
           <span className="flex-1" />
           {/* P-H 深链：generate/reg_ai 无训练结果 tab，跳原生页看结果 */}
           {task && kind === 'generate' && (
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => navigate(`/tools/generate?task=${task.id}`)}
-              className="btn btn-secondary btn-sm"
               data-testid="detail-view-generate"
-            >{t('queueDetail.viewInGenerate')}</button>
+            >{t('queueDetail.viewInGenerate')}</Button>
           )}
           {task && kind === 'reg_ai' && task.project_id && task.version_id && (
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => navigate(`/projects/${task.project_id}/v/${task.version_id}/reg`)}
-              className="btn btn-secondary btn-sm"
               data-testid="detail-view-reg"
-            >{t('queueDetail.viewInReg')}</button>
+            >{t('queueDetail.viewInReg')}</Button>
           )}
           {/* R-5：数据作业类 task 跳原生步骤页（download→项目下载页、tag→打标页…） */}
           {/* 诊断包（logging-target-state §3.6）：run.log + 配置快照 + 时间窗 studio.log +
@@ -398,51 +404,71 @@ export default function QueueDetailPage() {
             <a
               href={api.diagnosticsBundleUrl(task.id)}
               download
-              className="btn btn-ghost btn-sm no-underline"
+              className={buttonClassName({ variant: 'ghost', size: 'sm', className: 'no-underline' })}
               title={t('queueDetail.diagBundleHint')}
               data-testid="detail-diag-bundle"
             >{t('queueDetail.diagBundle')}</a>
           )}
           {task && jobJumpPath(task, evalSessionIdOf(task)) && (
-            <button
+            <Button
+              variant="secondary"
+              size="sm"
               onClick={() => navigate(jobJumpPath(task, evalSessionIdOf(task))!)}
-              className="btn btn-secondary btn-sm"
               data-testid="detail-view-job-source"
-            >{t('queue.jobs.jump')} →</button>
+            >{t('queue.jobs.jump')} →</Button>
           )}
           {isLive && status === 'running' && task?.is_pausable && (
-            <button onClick={pauseRunning} disabled={busy || pauseModalOpen} className="btn btn-sm"
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={pauseRunning}
+              disabled={busy || pauseModalOpen}
               data-testid="detail-pause-btn"
               title={t('queue.pauseHint')}
-            >{t('queue.pause')}</button>
+            >{t('queue.pause')}</Button>
           )}
           {isLive && (
-            <button onClick={cancel} disabled={busy} className="btn btn-sm bg-warn-soft border border-warn text-warn"
-            >{t('queueDetail.cancelTask')}</button>
+            <Button variant="warning" size="sm" onClick={cancel} disabled={busy}>
+              {t('queueDetail.cancelTask')}
+            </Button>
           )}
           {/* 0.17 P-B — scheduled：可手动提前 / 取消计划 */}
           {status === 'scheduled' && (
             <>
-              <button onClick={startNow} disabled={busy} className="btn btn-primary btn-sm"
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={startNow}
+                disabled={busy}
                 data-testid="detail-startnow-btn"
                 title={t('queue.startNowHint')}
-              >{t('queue.startNow')}</button>
-              <button onClick={cancel} disabled={busy}
-                className="btn btn-sm bg-warn-soft border border-warn text-warn"
+              >{t('queue.startNow')}</Button>
+              <Button
+                variant="warning"
+                size="sm"
+                onClick={cancel}
+                disabled={busy}
                 title={t('queue.cancelScheduledHint')}
-              >{t('queue.cancelScheduled')}</button>
+              >{t('queue.cancelScheduled')}</Button>
             </>
           )}
           {status === 'paused' && (
             <>
-              <button onClick={resumePaused} disabled={busy} className="btn btn-primary btn-sm"
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={resumePaused}
+                disabled={busy}
                 data-testid="detail-resume-btn"
                 title={t('queue.resumeHint')}
-              >{t('queue.resume')}</button>
-              <button onClick={cancel} disabled={busy}
-                className="btn btn-sm bg-err-soft border border-err text-err"
+              >{t('queue.resume')}</Button>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={cancel}
+                disabled={busy}
                 title={t('queue.cancelPausedHint')}
-              >{t('queue.cancelPaused')}</button>
+              >{t('queue.cancelPaused')}</Button>
             </>
           )}
           {isTerminal && (
@@ -451,21 +477,31 @@ export default function QueueDetailPage() {
                   （done 后端不放行，is_resumable 必为 false）。retry 是从头重跑，
                   两个按钮并列给用户选。 */}
               {task?.is_resumable && (
-                <button onClick={resumePaused} disabled={busy} className="btn btn-primary btn-sm"
+                <Button
+                  variant="primary"
+                  size="sm"
+                  onClick={resumePaused}
+                  disabled={busy}
                   data-testid="detail-resume-btn"
                   title={t('queue.resumeTerminalHint')}
-                >{t('queue.resumeTerminal')}</button>
+                >{t('queue.resumeTerminal')}</Button>
               )}
               {/* train 任务 done 后还挂着训练后评估：这里叫「重试」会被误读成
                   重跑失败的评估（实际是复制配置从头重新训练），所以 train 显式
                   叫「重新训练」；其余类型无此歧义保持「重试」。 */}
-              <button onClick={retry} disabled={busy}
-                className={`btn btn-sm ${task?.is_resumable ? 'btn-secondary' : 'btn-primary'}`}
+              <Button
+                variant={task?.is_resumable ? 'secondary' : 'primary'}
+                size="sm"
+                onClick={retry}
+                disabled={busy}
                 title={kind === 'train' ? t('queueDetail.retryTrainHint') : undefined}
-              >{kind === 'train' ? t('queueDetail.retryTrain') : t('common.retry')}</button>
-              <button onClick={() => setConfirmDelete(true)} disabled={busy}
-                className="btn btn-sm bg-err-soft border border-err text-err"
-              >{t('queueDetail.deleteRecord')}</button>
+              >{kind === 'train' ? t('queueDetail.retryTrain') : t('common.retry')}</Button>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => setConfirmDelete(true)}
+                disabled={busy}
+              >{t('queueDetail.deleteRecord')}</Button>
             </>
           )}
         </div>
@@ -588,7 +624,7 @@ function OverviewTab({ task }: { task: Task }) {
     { label: 'ID',     value: <code className="font-mono">{task.id}</code> },
     { label: t('common.name'), value: task.name },
     { label: 'Config', value: <code className="font-mono">{task.config_name}.yaml</code> },
-    { label: t('common.status'), value: <span className={STATUS_BADGE[task.status]}>{task.status === 'running' && <span className="dot dot-running" />}{statusLabel[task.status]}</span> },
+    { label: t('common.status'), value: <Badge tone={STATUS_TONE[task.status]} active={task.status === 'running'}>{statusLabel[task.status]}</Badge> },
     { label: t('queueDetail.priority'), value: task.priority, mono: true },
     { label: t('queueDetail.enqueuedAt'), value: fmtTime(task.created_at) },
     // 0.17 P-B — 计划任务显示计划开始时间（提升为 pending 后保留作记录）。
@@ -1048,10 +1084,10 @@ export function OutputsTab({ taskId }: { taskId: number }) {
       >
         <div className="flex items-center gap-1.5 min-w-0">
           <code className="font-mono text-fg-primary overflow-hidden text-ellipsis whitespace-nowrap">{f.path || f.name}</code>
-          {f.is_lora && <span className="badge badge-ok">LoRA</span>}
-          {f.kind === 'training_state' && <span className="badge badge-warn">State</span>}
-          {f.kind === 'pause_state' && <span className="badge badge-warn">Pause</span>}
-          {f.kind === 'auto_epoch_state' && <span className="badge badge-warn">Auto</span>}
+          {f.is_lora && <Badge tone="success">LoRA</Badge>}
+          {f.kind === 'training_state' && <Badge tone="warning">State</Badge>}
+          {f.kind === 'pause_state' && <Badge tone="warning">Pause</Badge>}
+          {f.kind === 'auto_epoch_state' && <Badge tone="warning">Auto</Badge>}
         </div>
         <span className="text-right font-mono text-fg-tertiary">{fmtBytes(f.size)}</span>
         <span className="text-right font-mono text-fg-tertiary">{fmtTime(f.mtime)}</span>
@@ -1116,36 +1152,42 @@ export function OutputsTab({ taskId }: { taskId: number }) {
         <div className="flex items-center gap-2 text-xs shrink-0 border-b border-subtle pb-2.5">
           <span className="text-fg-tertiary shrink-0">{t('common.directory')}</span>
           <code className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-fg-primary font-mono">{data.output_dir}</code>
-          <button onClick={copyPath} className="btn btn-ghost btn-sm">{t('queueDetail.copyPath')}</button>
+          <Button variant="ghost" size="sm" onClick={copyPath}>{t('queueDetail.copyPath')}</Button>
           {data.supports_open_folder ? (
-            <button onClick={openFolder} disabled={busy || !data.exists}
-              className="btn btn-ghost btn-sm"
-            >{t('queueDetail.openFolder')}</button>
+            <Button variant="ghost" size="sm" onClick={openFolder} disabled={busy || !data.exists}>
+              {t('queueDetail.openFolder')}
+            </Button>
           ) : (
             <span className="text-xs text-fg-tertiary shrink-0">{t('common.remote')}</span>
           )}
-          <button onClick={() => setRefreshKey((k) => k + 1)} className="btn btn-ghost btn-sm">{t('common.refresh')}</button>
+          <Button variant="ghost" size="sm" onClick={() => setRefreshKey((k) => k + 1)}>
+            {t('common.refresh')}
+          </Button>
           {data.exists && data.files.length > 0 && (
             <>
-              <button
+              <Button
+                variant={selectMode ? 'secondary' : 'ghost'}
+                size="sm"
                 onClick={toggleSelectMode}
-                className={selectMode ? 'btn btn-secondary btn-sm' : 'btn btn-ghost btn-sm'}
+                aria-pressed={selectMode}
               >
                 {selectMode ? t('queueDetail.exitBatchMode') : t('queueDetail.batchMode')}
-              </button>
+              </Button>
               {selectMode && (
-                <button
+                <Button
+                  variant="danger"
+                  size="sm"
                   onClick={handleDelete}
                   disabled={deleting || noneSelected}
-                  className="btn btn-ghost btn-sm text-err"
                 >
                   {t('queueDetail.deleteSelected', { n: selected.size })}
-                </button>
+                </Button>
               )}
-              <button
+              <Button
+                variant="primary"
+                size="sm"
                 onClick={() => setDownloadDialog({ destination: 'download' })}
                 disabled={zipping || exportingOutputs || deleting || (selectMode && noneSelected)}
-                className="btn btn-primary btn-sm"
               >
                 {zipping
                   ? t('queueDetail.compressing')
@@ -1154,7 +1196,7 @@ export function OutputsTab({ taskId }: { taskId: number }) {
                     : selectMode
                       ? (noneSelected ? t('queueDetail.downloadSelectedEmpty') : t('queueDetail.downloadSelected', { n: selected.size, size: fmtBytes(selectedSize) }))
                       : t('queueDetail.downloadAll')}
-              </button>
+              </Button>
             </>
           )}
         </div>
@@ -1256,10 +1298,12 @@ function OutputsDownloadDialog({
           </label>
         </div>
         <footer className="px-[18px] py-3 border-t border-subtle flex items-center gap-2 justify-end">
-          <button onClick={onCancel} disabled={busy} className="btn btn-ghost btn-sm">{t('common.cancel')}</button>
-          <button onClick={onConfirm} disabled={busy} className="btn btn-primary btn-sm">
+          <Button variant="ghost" size="sm" onClick={onCancel} disabled={busy}>
+            {t('common.cancel')}
+          </Button>
+          <Button variant="primary" size="sm" onClick={onConfirm} disabled={busy}>
             {busy ? '...' : t('common.confirm')}
-          </button>
+          </Button>
         </footer>
       </div>
     </div>
@@ -1340,14 +1384,15 @@ export function SnapshotConfigTab({ task }: { task: Task | null }) {
           <h3 className="m-0 text-md font-semibold">{t('snapshot.title')}</h3>
           <p className="m-0 mt-1 text-xs text-fg-tertiary">{t('snapshot.subtitle')}</p>
         </div>
-        <button
-          className="btn btn-primary btn-sm"
+        <Button
+          variant="primary"
+          size="sm"
           onClick={() => setConfirmApply(true)}
           disabled={!canApply || applying}
           title={canApply ? undefined : t('snapshot.noVersionLink')}
         >
           {t('snapshot.applyBtn')}
-        </button>
+        </Button>
       </div>
       <pre className="m-0 p-4 rounded-md border border-subtle bg-sunken text-xs font-mono overflow-auto whitespace-pre flex-1 min-h-0">{data.yaml}</pre>
 
@@ -1382,10 +1427,15 @@ function ConfirmDialog({
         </header>
         <div className="px-[18px] py-3.5 text-sm text-fg-secondary">{message}</div>
         <footer className="px-[18px] py-3 border-t border-subtle flex items-center gap-2 justify-end">
-          <button onClick={onCancel} disabled={busy} className="btn btn-ghost btn-sm">{cancelLabel}</button>
-          <button onClick={onConfirm} disabled={busy}
-            className={danger ? 'btn btn-sm bg-err border border-err text-fg-inverse' : 'btn btn-primary btn-sm'}
-          >{busy ? '...' : confirmLabel}</button>
+          <Button variant="ghost" size="sm" onClick={onCancel} disabled={busy}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant={danger ? 'danger' : 'primary'}
+            size="sm"
+            onClick={onConfirm}
+            disabled={busy}
+          >{busy ? '...' : confirmLabel}</Button>
         </footer>
       </div>
     </div>

--- a/studio/web/src/pages/project/steps/Curation.tsx
+++ b/studio/web/src/pages/project/steps/Curation.tsx
@@ -10,6 +10,7 @@ import {
   type ValidationItem,
   type Version,
 } from '../../../api/client'
+import Button from '../../../components/Button'
 import ImageGrid, { applySelection } from '../../../components/ImageGrid'
 import ImagePreviewModal from '../../../components/ImagePreviewModal'
 import PaneResizer from '../../../components/PaneResizer'
@@ -621,21 +622,21 @@ export default function CurationPage() {
           {/* 数据集切换（对齐队列页数据任务/GPU 任务切换，放最右）：前置切换
               icon（行为）+ 目标数据集名（宾语），读作「切到 X」；当前数据集看
               右栏面板标题。 */}
-          <button
-            type="button"
-            className="btn btn-secondary btn-sm"
+          <Button
+            variant="secondary"
+            size="sm"
             onClick={() => switchBucket(bucket === 'validation' ? 'train' : 'validation')}
             aria-pressed={bucket === 'validation'}
             data-testid="curate-bucket-toggle"
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
               <path d="M17 1l4 4-4 4" />
               <path d="M3 11V9a4 4 0 0 1 4-4h14" />
               <path d="M7 23l-4-4 4-4" />
               <path d="M21 13v2a4 4 0 0 1-4 4H3" />
             </svg>
             <span>{bucket === 'validation' ? t('curate.bucketTrain') : t('curate.bucketValidation')}</span>
-          </button>
+          </Button>
         </>
       }
     >
@@ -653,35 +654,37 @@ export default function CurationPage() {
           subtitle={t('curate.downloadSubtitle', { unused: currentLeft.length, total: downloadTotal, sel: leftSel.size })}
           actions={
             <>
-              <BtnSecondary
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => setLeftSel(new Set(leftSortedNames))}
                 disabled={busy || leftSortedNames.length === 0}
               >
                 {t('curate.selectAll')}
-              </BtnSecondary>
-              <BtnSecondary
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => setLeftSel(new Set())}
                 disabled={busy || leftSel.size === 0}
               >
                 {t('curate.deselect')}
-              </BtnSecondary>
-              {isVal ? (
-                <BtnPrimary
-                  onClick={doCopy}
-                  disabled={busy || leftSel.size === 0}
-                  title={t('curate.copyToValTitle')}
-                >
-                  {t('curate.copyToValBtn', { n: leftSel.size })}
-                </BtnPrimary>
-              ) : (
-                <BtnPrimary
-                  onClick={doCopy}
-                  disabled={busy || leftSel.size === 0 || !rightFolder}
-                  title={rightFolder ? t('curate.copyToTitle', { folder: rightFolder }) : t('curate.noFolderTitle')}
-                >
-                  {t('curate.copyToBtn', { n: leftSel.size, folder: rightFolder || '?' })}
-                </BtnPrimary>
-              )}
+              </Button>
+              <Button
+                variant="primary"
+                size="sm"
+                onClick={doCopy}
+                disabled={busy || leftSel.size === 0 || (!isVal && !rightFolder)}
+                title={isVal
+                  ? t('curate.copyToValTitle')
+                  : rightFolder
+                    ? t('curate.copyToTitle', { folder: rightFolder })
+                    : t('curate.noFolderTitle')}
+              >
+                {isVal
+                  ? t('curate.copyToValBtn', { n: leftSel.size })
+                  : t('curate.copyToBtn', { n: leftSel.size, folder: rightFolder || '?' })}
+              </Button>
             </>
           }
         >
@@ -731,26 +734,35 @@ export default function CurationPage() {
                     className="input input-mono px-2 py-0.5 text-sm"
                     style={{ width: 144 }}
                   />
-                  <BtnSecondary onClick={doCreateFolder} disabled={busy || !newFolder.trim()}>
+                  <Button variant="secondary" size="sm" onClick={doCreateFolder} disabled={busy || !newFolder.trim()}>
                     {t('curate.createFolderBtn')}
-                  </BtnSecondary>
+                  </Button>
                 </>
               )}
-              <BtnSecondary
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => setRightSel(new Set(rightSortedNames))}
                 disabled={busy || rightSortedNames.length === 0}
               >
                 {t('curate.selectAll')}
-              </BtnSecondary>
-              <BtnSecondary
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
                 onClick={() => setRightSel(new Set())}
                 disabled={busy || rightSel.size === 0}
               >
                 {t('curate.deselect')}
-              </BtnSecondary>
-              <BtnDanger onClick={doRemove} disabled={busy || rightSel.size === 0 || (!isVal && !rightFolder)}>
+              </Button>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={doRemove}
+                disabled={busy || rightSel.size === 0 || (!isVal && !rightFolder)}
+              >
                 {t('curate.removeNBtn', { n: rightSel.size })}
-              </BtnDanger>
+              </Button>
             </>
           }
         >
@@ -782,12 +794,12 @@ export default function CurationPage() {
                     className="input input-mono px-2 py-0.5"
                     style={{ width: 176 }}
                   />
-                  <BtnPrimary onClick={doRenameFolder} disabled={busy}>
+                  <Button variant="primary" size="sm" onClick={doRenameFolder} disabled={busy}>
                     {t('curate.renameOk')}
-                  </BtnPrimary>
-                  <button onClick={() => setRenaming(null)} className="btn btn-ghost btn-sm">
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => setRenaming(null)}>
                     {t('common.cancel')}
-                  </button>
+                  </Button>
                 </div>
               )}
             </>
@@ -961,16 +973,4 @@ function PanelCard({
       <div className="flex-1 min-h-0 flex flex-col p-2">{children}</div>
     </section>
   )
-}
-
-function BtnPrimary({ children, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  return <button {...rest} className="btn btn-primary btn-sm">{children}</button>
-}
-
-function BtnSecondary({ children, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  return <button {...rest} className="btn btn-secondary btn-sm">{children}</button>
-}
-
-function BtnDanger({ children, ...rest }: React.ButtonHTMLAttributes<HTMLButtonElement>) {
-  return <button {...rest} className="btn btn-sm bg-err-soft text-err border-err">{children}</button>
 }

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -27,8 +27,11 @@
   --border-strong:  #a8a59a;
 
   /* accents */
-  --accent:        #d8541d;     /* orange — primary action */
+  --accent:        #d8541d;     /* orange — active marks and decorative emphasis */
   --accent-hover:  #b9441a;
+  --accent-strong: #b24616;     /* accessible text on light and soft surfaces */
+  --accent-control: #c64d19;    /* brighter solid control with white-text contrast */
+  --accent-control-hover: #b9441a;
   --accent-soft:   #fbe8de;
   --accent-fg:     #ffffff;
 
@@ -37,13 +40,19 @@
   --row-selected-bg:     var(--accent-soft);
   --row-selected-border: var(--accent);
 
+  /* Base colors drive marks and fills; -strong keeps small text legible on soft fills. */
   --ok:    #2d7a4f;
+  --ok-strong: #23603d;
   --ok-soft: #d6ebde;
   --warn:  #b97a16;
+  --warn-strong: #79500f;
   --warn-soft: #f4e4c3;
+  --warn-on-solid: #15140f;
   --err:   #c2371b;
+  --err-strong: #982713;
   --err-soft: #f6dad1;
   --info:  #2a6597;
+  --info-strong: #24577f;
   --info-soft: #d4e3ef;
 
   /* type */
@@ -116,6 +125,9 @@
 
   --accent:        #ed6b3a;
   --accent-hover:  #f78a5e;
+  --accent-strong: #ed6b3a;
+  --accent-control: #ed6b3a;
+  --accent-control-hover: #f78a5e;
   --accent-soft:   #3a1f12;
   --accent-fg:     #15140f;
 
@@ -123,10 +135,11 @@
   --row-selected-bg:     #2c211a;
   --row-selected-border: #8a563b;
 
-  --ok: #5fc78c;       --ok-soft: #1a3328;
-  --warn: #e0a23a;     --warn-soft: #3a2a10;
-  --err: #e8765c;      --err-soft: #3a1a14;
-  --info: #6db1d9;     --info-soft: #18293a;
+  --ok: #5fc78c;       --ok-strong: #5fc78c;   --ok-soft: #1a3328;
+  --warn: #e0a23a;     --warn-strong: #e0a23a; --warn-soft: #3a2a10;
+  --warn-on-solid: #15140f;
+  --err: #e8765c;      --err-strong: #e8765c;  --err-soft: #3a1a14;
+  --info: #6db1d9;     --info-strong: #6db1d9; --info-soft: #18293a;
 
   --sh-sm: 0 1px 2px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.04);
   --sh-md: 0 4px 8px -2px rgba(0, 0, 0, 0.4), 0 2px 4px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.05);
@@ -201,34 +214,68 @@ select option:checked {
 }
 
 .btn {
-  display: inline-flex; align-items: center; gap: 6px;
-  padding: 8px 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 38px;
+  padding: 7px 14px;
   border-radius: var(--r-md);
   border: 1px solid transparent;
-  font-size: var(--t-base); font-weight: 500;
-  transition: all 120ms ease;
+  background: transparent;
+  color: var(--fg-primary);
+  font-size: var(--t-base);
+  font-weight: 500;
+  line-height: 1.35;
   white-space: nowrap;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    color 120ms ease,
+    box-shadow 120ms ease,
+    transform 120ms ease;
 }
-.btn-primary { background: var(--accent); color: var(--accent-fg); }
-.btn-primary:hover { background: var(--accent-hover); }
+.btn:hover:not(:disabled) { text-decoration: none; }
+.btn:active:not(:disabled) { transform: translateY(1px); }
+.btn:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.btn-primary { background: var(--accent-control); color: var(--accent-fg); }
+.btn-primary:hover:not(:disabled) { background: var(--accent-control-hover); }
 .btn-secondary { background: var(--bg-surface); color: var(--fg-primary); border-color: var(--border-default); }
-.btn-secondary:hover { background: var(--bg-overlay); border-color: var(--border-strong); }
+.btn-secondary:hover:not(:disabled) { background: var(--bg-overlay); border-color: var(--border-strong); }
+.btn[aria-pressed="true"] {
+  background: var(--accent-soft);
+  border-color: var(--accent-strong);
+  color: var(--accent-strong);
+}
 .btn-ghost { background: transparent; color: var(--fg-secondary); }
-.btn-ghost:hover { background: var(--bg-overlay); color: var(--fg-primary); }
+.btn-ghost:hover:not(:disabled) { background: var(--bg-overlay); color: var(--fg-primary); }
 /* 警示/危险按钮走全 app 统一的 soft 语言（soft 底 + 色字 + 色边，同 badge-warn /
-   bg-err-soft 系）；hover 实心化给确认前的强提示。原实心白字版和页面语言脱节。 */
-.btn-danger { background: var(--err-soft); color: var(--err); border-color: var(--err); }
-.btn-danger:hover { background: var(--err); color: white; }
-.btn-warn { background: var(--warn-soft); color: var(--warn); border-color: var(--warn); }
-.btn-warn:hover { background: var(--warn); color: white; }
-.btn-sm { padding: 4px 10px; font-size: var(--t-sm); }
-/* 禁用态：半透明 + not-allowed，hover 不再高亮/提亮（此前无 :disabled 规则，禁用看不出来）。 */
-.btn:disabled { opacity: 0.45; cursor: not-allowed; }
-.btn-primary:disabled:hover { background: var(--accent); }
-.btn-ghost:disabled:hover { background: transparent; color: var(--fg-secondary); }
-.btn-secondary:disabled:hover { background: var(--bg-surface); border-color: var(--border-default); }
-.btn-danger:disabled:hover { background: var(--err-soft); color: var(--err); }
-.btn-warn:disabled:hover { background: var(--warn-soft); color: var(--warn); }
+   bg-err-soft 系）；hover 实心化给确认前的强提示。 */
+.btn-danger { background: var(--err-soft); color: var(--err-strong); border-color: var(--err); }
+.btn-danger:hover:not(:disabled) { background: var(--err); color: var(--fg-inverse); }
+.btn-warn { background: var(--warn-soft); color: var(--warn-strong); border-color: var(--warn); }
+.btn-warn:hover:not(:disabled) { background: var(--warn); color: var(--warn-on-solid); }
+.btn-sm { min-height: 30px; padding: 4px 10px; font-size: var(--t-sm); }
+.btn-xs { min-height: 24px; padding: 2px 8px; gap: 4px; font-size: var(--t-xs); }
+.btn-icon { width: 38px; padding-inline: 0; }
+.btn-icon.btn-sm { width: 30px; }
+.btn-icon.btn-xs { width: 24px; }
+.btn:disabled { opacity: 0.45; cursor: not-allowed; transform: none; }
+.btn-loading { cursor: progress; }
+.btn-spinner {
+  width: 12px;
+  height: 12px;
+  flex: 0 0 auto;
+  border: 2px solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: btn-spin 700ms linear infinite;
+}
+@keyframes btn-spin { to { transform: rotate(360deg); } }
 
 .card {
   background: var(--bg-surface);
@@ -250,19 +297,25 @@ select option:checked {
 }
 
 .badge {
-  display: inline-flex; align-items: center; gap: 4px;
-  font-family: var(--font-mono);
-  font-size: var(--t-xs);
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
   padding: 2px 8px;
   border-radius: var(--r-pill);
+  font-family: var(--font-mono);
+  font-size: var(--t-xs);
+  line-height: 1.4;
   letter-spacing: 0.02em;
+  white-space: nowrap;
 }
-.badge-ok   { background: var(--ok-soft);   color: var(--ok); }
-.badge-warn { background: var(--warn-soft); color: var(--warn); }
-.badge-err  { background: var(--err-soft);  color: var(--err); }
-.badge-info { background: var(--info-soft); color: var(--info); }
+.badge-sm { padding: 1px 6px; font-size: var(--t-2xs); }
+.badge-ok   { background: var(--ok-soft);   color: var(--ok-strong); }
+.badge-warn { background: var(--warn-soft); color: var(--warn-strong); }
+.badge-err  { background: var(--err-soft);  color: var(--err-strong); }
+.badge-info { background: var(--info-soft); color: var(--info-strong); }
 .badge-neutral { background: var(--bg-overlay); color: var(--fg-secondary); }
-.badge-accent { background: var(--accent-soft); color: var(--accent); }
+.badge-accent { background: var(--accent-soft); color: var(--accent-strong); }
+.badge .dot { flex-shrink: 0; }
 
 .dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
 .dot-ok { background: var(--ok); }
@@ -270,6 +323,13 @@ select option:checked {
 .dot-err { background: var(--err); }
 .dot-running { background: var(--accent); animation: pulse 1.6s infinite; }
 @keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.4; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .btn,
+  .card-hover { transition: none; }
+  .btn-spinner,
+  .dot-running { animation: none; }
+}
 
 /* pill radio — 互斥选项组（更新通道 / 显示设置的语言·主题·密度等）。
  * 原 version-section.css 的 .vs-channel-radio 泛化为通用类。


### PR DESCRIPTION
## Summary

- document the existing warm-workbench design language and migration rules in `DESIGN.md`
- add typed `Button` and `Badge` primitives while retaining the legacy CSS classes as the compatibility layer
- formalize button sizes, semantic variants, focus/loading/disabled states, and accessible light/dark theme tokens
- migrate representative call sites in Announcement Center, Checkbox Dropdown, Version Status, Queue Detail, and Curation
- add focused component and behavior tests for the migrated surface

## Design decisions

- this is a progressive migration, not a full-site visual rewrite
- compact training forms remain a supported density variant
- button placement, action copy, and icon policy remain pattern-level concerns and are intentionally out of scope
- the light-theme primary control uses a dedicated brighter control token while retaining WCAG AA contrast for white text

## Validation

- [x] Manual visual check approved by the user
- [x] `npx vitest run` — 78 files / 687 tests passed
- [x] `npm run build` — ESLint, TypeScript, and Vite production build passed
- [x] `venv/Scripts/python.exe -m pytest tests/test_route_snapshot.py -q` — 1 passed
- [x] Impeccable detector — 0 findings on changed UI targets
- [x] Light primary contrast — 4.69:1; hover — 5.38:1

## Notes

The existing Vite warning for a JavaScript chunk larger than 700 kB remains unchanged and is outside this PR's scope.
