### PR TITLE
feat(web): standardize surfaces and empty states

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,7 +25,7 @@ surface has identical density.
 | --- | --- | --- |
 | Foundation | `studio/web/src/styles/tokens.css` | Color, type, spacing, radius, shadow, motion, control states |
 | Utility bridge | `studio/web/tailwind.config.js` | Maps CSS tokens into Tailwind utilities |
-| Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx` | Typed, accessible component APIs |
+| Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx` | Typed, accessible component APIs |
 | Patterns | `PageHeader`, `StepShell`, `Dialog`, `Toast`, `Field` | Repeated page and interaction structures |
 | Product surfaces | `studio/web/src/pages/` | Business state and composition, not new visual primitives |
 
@@ -126,7 +126,26 @@ metadata such as announcement tags; status badges use the default size.
 Domain components such as `VersionStatusBadge` own the mapping from backend state to
 badge tone. The generic `Badge` component must not know API enums.
 
-## 6. Forms and help text
+## 6. Surface and empty-state contract
+
+Use `Card` for ordinary bordered content surfaces. The default card uses the ordinary
+`--r-lg` radius; compact workbench panels opt into the compact radius explicitly.
+Padding belongs to the component API when it describes the whole surface, so density
+modes can adjust it through spacing tokens. Interactive links and buttons retain their
+native semantics and use `cardClassName()` for card presentation.
+
+Use `EmptyState` when a list or page region has no content to present:
+
+- `md` is the primary zero state for an otherwise empty page or tab.
+- `sm` is a compact no-match state inside an existing section.
+- Titles state what is absent; descriptions explain the next useful step.
+- Actions are optional and must use the appropriate Button or link primitive.
+- Loading, errors, and warnings are not empty states and require their own semantics.
+
+Do not reproduce `rounded-* + border-subtle + bg-surface` for an ordinary card or
+hand-build centered zero-state typography on product pages.
+
+## 7. Forms and help text
 
 Default forms use the standard `.input` surface. Parameter-heavy schema forms may
 use their existing compact canvas treatment as an explicit density variant.
@@ -135,7 +154,7 @@ Settings explanations belong in the label-adjacent `InfoButton` tooltip accordin
 to `docs/design/ui-info-design.md`; do not add permanent explanatory paragraphs
 under individual settings.
 
-## 7. Accessibility and resilience
+## 8. Accessibility and resilience
 
 Every primitive must work with keyboard focus, disabled state, light/dark themes,
 all three density modes, and both Chinese and English labels. Focus is always visible.
@@ -145,7 +164,7 @@ full value is available through an established disclosure pattern.
 Respect `prefers-reduced-motion`; status information must remain understandable when
 animation is disabled.
 
-## 8. Migration policy
+## 9. Migration policy
 
 Migration is incremental:
 

--- a/studio/web/src/components/Card.test.tsx
+++ b/studio/web/src/components/Card.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Card, { cardClassName } from './Card'
+
+describe('Card', () => {
+  it('renders the standard surface without implicit padding', () => {
+    render(<Card data-testid="card">Content</Card>)
+    expect(screen.getByTestId('card')).toHaveClass('card')
+    expect(screen.getByTestId('card')).not.toHaveClass('card-pad-md')
+  })
+
+  it('maps tone, radius, padding, and interaction to shared classes', () => {
+    render(
+      <Card
+        data-testid="card"
+        tone="sunken"
+        radius="compact"
+        padding="md"
+        interactive
+      >
+        Content
+      </Card>,
+    )
+    expect(screen.getByTestId('card')).toHaveClass(
+      'card',
+      'card-sunken',
+      'card-compact',
+      'card-pad-md',
+      'card-hover',
+    )
+  })
+
+  it('supports semantic section and article elements', () => {
+    const { rerender } = render(<Card as="section" data-testid="card">Section</Card>)
+    expect(screen.getByTestId('card').tagName).toBe('SECTION')
+
+    rerender(<Card as="article" data-testid="card">Article</Card>)
+    expect(screen.getByTestId('card').tagName).toBe('ARTICLE')
+  })
+
+  it('builds classes for interactive elements that retain their own semantics', () => {
+    expect(cardClassName({
+      interactive: true,
+      radius: 'compact',
+      className: 'cursor-pointer',
+    })).toBe('card card-compact card-hover cursor-pointer')
+  })
+})

--- a/studio/web/src/components/Card.tsx
+++ b/studio/web/src/components/Card.tsx
@@ -1,0 +1,75 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+export type CardTone = 'surface' | 'sunken'
+export type CardRadius = 'default' | 'compact'
+export type CardPadding = 'none' | 'sm' | 'md' | 'lg'
+export type CardElement = 'div' | 'section' | 'article'
+
+export interface CardProps extends HTMLAttributes<HTMLElement> {
+  as?: CardElement
+  tone?: CardTone
+  radius?: CardRadius
+  padding?: CardPadding
+  interactive?: boolean
+  children: ReactNode
+}
+
+const TONE_CLASS: Record<CardTone, string> = {
+  surface: '',
+  sunken: 'card-sunken',
+}
+
+const RADIUS_CLASS: Record<CardRadius, string> = {
+  default: '',
+  compact: 'card-compact',
+}
+
+const PADDING_CLASS: Record<CardPadding, string> = {
+  none: '',
+  sm: 'card-pad-sm',
+  md: 'card-pad-md',
+  lg: 'card-pad-lg',
+}
+
+export function cardClassName({
+  tone = 'surface',
+  radius = 'default',
+  padding = 'none',
+  interactive = false,
+  className = '',
+}: {
+  tone?: CardTone
+  radius?: CardRadius
+  padding?: CardPadding
+  interactive?: boolean
+  className?: string
+} = {}): string {
+  return [
+    'card',
+    TONE_CLASS[tone],
+    RADIUS_CLASS[radius],
+    PADDING_CLASS[padding],
+    interactive && 'card-hover',
+    className,
+  ].filter(Boolean).join(' ')
+}
+
+export default function Card({
+  as: Element = 'div',
+  tone = 'surface',
+  radius = 'default',
+  padding = 'none',
+  interactive = false,
+  className,
+  children,
+  ...rest
+}: CardProps) {
+  return (
+    <Element
+      {...rest}
+      className={cardClassName({ tone, radius, padding, interactive, className })}
+    >
+      {children}
+    </Element>
+  )
+}

--- a/studio/web/src/components/EmptyState.test.tsx
+++ b/studio/web/src/components/EmptyState.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import EmptyState from './EmptyState'
+
+describe('EmptyState', () => {
+  it('renders a title and supporting description with the shared hierarchy', () => {
+    render(<EmptyState title="Nothing here" description="Create an item to get started." />)
+
+    expect(screen.getByText('Nothing here')).toHaveClass('empty-state-title')
+    expect(screen.getByText('Create an item to get started.'))
+      .toHaveClass('empty-state-description')
+  })
+
+  it('supports compact description-only states', () => {
+    render(
+      <EmptyState
+        data-testid="empty"
+        size="sm"
+        description="No matching results"
+      />,
+    )
+
+    expect(screen.getByTestId('empty')).toHaveClass('card', 'empty-state', 'empty-state-sm')
+    expect(screen.queryByText('Nothing here')).not.toBeInTheDocument()
+  })
+
+  it('accepts an action and standard HTML attributes', () => {
+    render(
+      <EmptyState
+        aria-live="polite"
+        title="No projects"
+        description="Create your first project."
+        action={<button type="button">Create project</button>}
+      />,
+    )
+
+    const state = screen.getByText('No projects').closest('.empty-state')
+    expect(state).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByRole('button', { name: 'Create project' }))
+      .toBeInTheDocument()
+  })
+})

--- a/studio/web/src/components/EmptyState.tsx
+++ b/studio/web/src/components/EmptyState.tsx
@@ -1,0 +1,34 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+import Card from './Card'
+
+export type EmptyStateSize = 'md' | 'sm'
+
+export interface EmptyStateProps extends Omit<HTMLAttributes<HTMLElement>, 'children' | 'title'> {
+  title?: ReactNode
+  description: ReactNode
+  action?: ReactNode
+  size?: EmptyStateSize
+}
+
+export default function EmptyState({
+  title,
+  description,
+  action,
+  size = 'md',
+  className = '',
+  ...rest
+}: EmptyStateProps) {
+  const classes = [
+    'empty-state',
+    size === 'sm' && 'empty-state-sm',
+    className,
+  ].filter(Boolean).join(' ')
+
+  return (
+    <Card {...rest} className={classes}>
+      {title && <p className="empty-state-title">{title}</p>}
+      <p className="empty-state-description">{description}</p>
+      {action && <div className="empty-state-action">{action}</div>}
+    </Card>
+  )
+}

--- a/studio/web/src/pages/Queue.test.tsx
+++ b/studio/web/src/pages/Queue.test.tsx
@@ -84,6 +84,21 @@ function renderQueue() {
 }
 
 describe('QueuePage 分区 + 分页', () => {
+  it('空队列使用共享的主空状态层级', async () => {
+    vi.spyOn(api, 'getQueueHold').mockResolvedValue({ held: false } as never)
+    vi.spyOn(api, 'listQueueLive').mockResolvedValue([])
+    vi.spyOn(api, 'listQueueHistory').mockResolvedValue({
+      items: [], total: 0, page: 1, page_size: 20,
+    })
+
+    renderQueue()
+
+    const title = await screen.findByText('队列为空')
+    expect(title.closest('.empty-state')).toHaveClass('card', 'empty-state')
+    expect(screen.getByText('从项目训练页入队任务即可'))
+      .toHaveClass('empty-state-description')
+  })
+
   it('渲染进行中/等待/历史三分区，历史超过一页时出分页器', async () => {
     vi.spyOn(api, 'getQueueHold').mockResolvedValue({ held: false } as never)
     vi.spyOn(api, 'listQueueLive').mockResolvedValue([

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -6,6 +6,8 @@ import {
   type TaskStatus, type TaskType,
 } from '../api/client'
 import { DATA_VIEW_KINDS } from './queue/jobUtils'
+import Card from '../components/Card'
+import EmptyState from '../components/EmptyState'
 import { HoldQueueModal, type HoldDecision } from '../components/HoldQueueModal'
 import { PauseConfirmModal } from '../components/PauseConfirmModal'
 import { PauseProgressModal } from '../components/PauseProgressModal'
@@ -1028,7 +1030,7 @@ export default function QueuePage() {
             refreshToken={jobsRefreshToken}
           />
         ) : !loaded ? (
-          <div className="rounded-lg border border-subtle bg-surface overflow-hidden">
+          <Card className="overflow-hidden">
             {Array.from({ length: 3 }).map((_, i) => (
               <div
                 key={i}
@@ -1047,16 +1049,12 @@ export default function QueuePage() {
                 <div className="h-6 rounded bg-overlay" />
               </div>
             ))}
-          </div>
+          </Card>
         ) : isEmpty ? (
-          <div className="rounded-lg border border-subtle bg-surface py-12 text-center">
-            <div className="text-md font-semibold text-fg-secondary mb-1.5">
-              {t('queue.empty')}
-            </div>
-            <div className="text-sm text-fg-tertiary">
-              {t('queue.emptyHint')}
-            </div>
-          </div>
+          <EmptyState
+            title={t('queue.empty')}
+            description={t('queue.emptyHint')}
+          />
         ) : (
           <div className="flex flex-col gap-4">
             {/* 进行中（running + paused） */}
@@ -1096,9 +1094,7 @@ export default function QueuePage() {
               </h3>
 
               {history.items.length === 0 ? (
-                <div className="rounded-lg border border-subtle bg-surface py-8 text-center text-sm text-fg-tertiary">
-                  {t('queue.noMatch')}
-                </div>
+                <EmptyState size="sm" description={t('queue.noMatch')} />
               ) : (
                 history.items.map(renderRow)
               )}

--- a/studio/web/src/pages/queue/DataJobsPanel.test.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.test.tsx
@@ -88,6 +88,20 @@ describe('DataJobsPanel', () => {
     await waitFor(() => expect(screen.getAllByText(/MyProj/).length).toBeGreaterThan(0))
   })
 
+  it('空数据视图使用共享的主空状态层级', async () => {
+    vi.spyOn(api, 'listQueueLive').mockResolvedValue([])
+    vi.spyOn(api, 'listQueueHistory').mockResolvedValue({
+      items: [], total: 0, page: 1, page_size: 20,
+    })
+
+    renderPanel()
+
+    const title = await screen.findByText('暂无数据任务')
+    expect(title.closest('.empty-state')).toHaveClass('card', 'empty-state')
+    expect(screen.getByText('下载 / 打标 / 正则构建 / 评估等数据任务会显示在这里'))
+      .toHaveClass('empty-state-description')
+  })
+
   it('数据源 = /api/queue resource_class=data（kind/q 透传）', async () => {
     const liveSpy = vi.spyOn(api, 'listQueueLive').mockResolvedValue([])
     const histSpy = vi.spyOn(api, 'listQueueHistory').mockResolvedValue({

--- a/studio/web/src/pages/queue/DataJobsPanel.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.tsx
@@ -12,6 +12,8 @@ import { useNavigate } from 'react-router-dom'
 import {
   api, type QueueHistoryPage, type Task, type TaskType,
 } from '../../api/client'
+import Card from '../../components/Card'
+import EmptyState from '../../components/EmptyState'
 import { useDialog } from '../../components/Dialog'
 import { useToast } from '../../components/Toast'
 import { useEventStream } from '../../lib/useEventStream'
@@ -201,16 +203,14 @@ export default function DataJobsPanel({
       )}
 
       {!loaded ? (
-        <div className="rounded-lg border border-subtle bg-surface py-8 text-center text-sm text-fg-tertiary">
+        <Card className="py-8 text-center text-sm text-fg-tertiary">
           {t('common.loading')}
-        </div>
+        </Card>
       ) : isEmpty ? (
-        <div className="rounded-lg border border-subtle bg-surface py-12 text-center">
-          <div className="text-md font-semibold text-fg-secondary mb-1.5">
-            {t('queue.jobs.empty')}
-          </div>
-          <div className="text-sm text-fg-tertiary">{t('queue.jobs.emptyHint')}</div>
-        </div>
+        <EmptyState
+          title={t('queue.jobs.empty')}
+          description={t('queue.jobs.emptyHint')}
+        />
       ) : (
         <>
           {live.length > 0 && (
@@ -227,9 +227,7 @@ export default function DataJobsPanel({
               {t('queue.sectionHistory')} ({history.total})
             </h3>
             {history.items.length === 0 ? (
-              <div className="rounded-lg border border-subtle bg-surface py-8 text-center text-sm text-fg-tertiary">
-                {t('queue.noMatch')}
-              </div>
+              <EmptyState size="sm" description={t('queue.noMatch')} />
             ) : (
               history.items.map(renderRow)
             )}

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -282,8 +282,45 @@ select option:checked {
   border: 1px solid var(--border-subtle);
   border-radius: var(--r-lg);
 }
-.card-hover { transition: all 120ms ease; }
+.card-compact { border-radius: var(--r-md); }
+.card-sunken { background: var(--bg-sunken); }
+.card-pad-sm { padding: var(--s-3); }
+.card-pad-md { padding: var(--s-4); }
+.card-pad-lg { padding: var(--s-6); }
+.card-hover {
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease,
+    box-shadow 120ms ease,
+    transform 120ms ease;
+}
 .card-hover:hover { box-shadow: var(--sh-md); border-color: var(--border-default); transform: translateY(-1px); }
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: calc(var(--s-8) + var(--s-4)) var(--s-6);
+  text-align: center;
+}
+.empty-state-sm { padding-block: var(--s-8); }
+.empty-state-title {
+  margin: 0;
+  color: var(--fg-secondary);
+  font-size: var(--t-md);
+  font-weight: 600;
+  line-height: 1.35;
+}
+.empty-state-description {
+  max-width: 56ch;
+  margin: 0;
+  color: var(--fg-tertiary);
+  font-size: var(--t-sm);
+  line-height: 1.6;
+}
+.empty-state-title + .empty-state-description { margin-top: var(--s-2); }
+.empty-state-action { margin-top: var(--s-4); }
 
 .kbd {
   font-family: var(--font-mono);


### PR DESCRIPTION
## Summary
- add typed `Card` and `EmptyState` design primitives
- document surface and empty-state usage boundaries in `DESIGN.md`
- migrate Queue and Data Jobs loading, empty, and no-match surfaces
- replace broad card transitions with explicit visual properties

## Validation
- user visual approval: light/dark and representative queue states accepted
- `npx vitest run`: 80 files, 696 tests passed
- focused Card/EmptyState/Queue tests: 4 files, 27 tests passed
- `npm run build`: ESLint, TypeScript, and Vite build passed
- Impeccable detector: 0 findings
- `git diff --check`: passed

## Scope
This is an incremental migration. Dialogs, alerts, schema-form workbenches, special image surfaces, and the remaining product pages are intentionally left for bounded follow-up slices.
