### PR TITLE
feat(web): 标准化字体排版

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -50,16 +50,37 @@ indicator. Dark mode must preserve hierarchy rather than simply invert colors.
 
 ### Typography
 
-- `text-base`: normal interface and body copy.
-- `text-sm`: compact controls and secondary content.
-- `text-xs`: metadata, timestamps, and badges.
-- `text-2xs`: dense supporting labels only; never primary actions.
-- `text-xl` and above: page or major section hierarchy.
-- `font-mono`: code, paths, identifiers, logs, and measurements—not generic UI chrome.
-- `.tnum`: changing or comparable numeric values.
+The Studio uses the local system sans stack for interface copy and the local mono
+stack for machine-readable data. Do not add a network font dependency: the app
+must remain readable while offline and should not shift when a font finishes
+loading. Use no more than `400`, `500`, and `600` for normal UI hierarchy.
 
-Use the configured type scale. Arbitrary pixel font sizes require a documented
-layout constraint and should remain exceptional.
+| Role | Contract | Use |
+| --- | --- | --- |
+| Page title | `.type-page-title`: `text-2xl`, 600, primary | One `h1` for the current page or workflow step |
+| Page description | `.type-page-description`: `text-md`, secondary, relaxed, max `68ch` | A concise explanation directly below the page title |
+| Section title | `.type-section-title`: `text-lg`, 600, primary | A major region inside a page or dialog |
+| Panel title | `.type-panel-title`: `text-sm`, 600, primary | A card, settings group, or compact panel |
+| Section label | `.type-section-label`: `text-xs`, 600, tertiary, tracked uppercase | A direct category heading such as queue status; never an eyebrow above another heading |
+| Field label | `.type-field-label`: `text-sm`, 500, secondary | The human-readable name of a form control |
+| Field help | `.type-field-help`: `text-xs`, tertiary, relaxed | Optional supporting copy below a field |
+| Metadata | `text-xs` + tertiary | Timestamps, counts, and passive context |
+| Technical data | `font-mono`; add `.tnum` for comparable numbers | Code, paths, identifiers, logs, and measurements—not generic UI chrome |
+
+Rules:
+
+- Normal interface and body copy uses `text-base`; compact controls and secondary
+  content use `text-sm`. `text-2xs` is reserved for dense supporting labels and
+  must never carry a primary action or required instruction.
+- Keep normal reading copy between `65ch` and `75ch`; headings and control labels
+  remain content-sized rather than stretching across the viewport.
+- Choose heading elements by document structure, then apply the matching role.
+  Do not skip levels to obtain a visual size.
+- Use sentence case for ordinary headings. Uppercase/tracking is reserved for a
+  category label that stands on its own; it is not a decorative kicker.
+- The configured density changes the scale without changing semantic roles.
+- Arbitrary pixel font sizes require a documented layout constraint and should
+  remain exceptional.
 
 ### Spacing, radius, and depth
 

--- a/studio/web/src/components/Dialog.test.tsx
+++ b/studio/web/src/components/Dialog.test.tsx
@@ -35,6 +35,15 @@ const wrap = (run: (api: ReturnType<typeof useDialog>) => Promise<unknown>) =>
   )
 
 describe('Dialog (useDialog API)', () => {
+  it('uses the shared section-title hierarchy', async () => {
+    const user = userEvent.setup()
+    wrap((api) => api.confirm('删除？', { title: '删除任务' }))
+    await user.click(screen.getByText('trigger'))
+
+    expect(screen.getByRole('heading', { level: 2, name: '删除任务' }))
+      .toHaveClass('type-section-title')
+  })
+
   it('confirm 点确认返回 true', async () => {
     const user = userEvent.setup()
     wrap((api) => api.confirm('删除？'))

--- a/studio/web/src/components/Dialog.tsx
+++ b/studio/web/src/components/Dialog.tsx
@@ -231,11 +231,11 @@ function DialogRoot({ state, onCancel, onOk }: RootProps) {
         onSubmit={handleSubmit}
         className="bg-elevated border border-dim rounded-lg w-[90%] max-w-[440px] p-6 flex flex-col gap-4 shadow-xl"
       >
-        <h2 className="m-0 text-lg font-semibold text-fg-primary">{title}</h2>
+        <h2 className="type-section-title">{title}</h2>
 
         {state.type === 'prompt' ? (
           <label className="flex flex-col gap-1.5">
-            <span className="text-sm text-fg-secondary">{state.label}</span>
+            <span className="type-field-label">{state.label}</span>
             <input
               ref={inputRef}
               className="input input-mono font-mono"

--- a/studio/web/src/components/Field.test.tsx
+++ b/studio/web/src/components/Field.test.tsx
@@ -32,6 +32,20 @@ const codeProp: SchemaProperty = {
 }
 
 describe('Field number input (PP10.3)', () => {
+  it('uses semantic label and supporting-text roles', () => {
+    const { container } = render(
+      <Field
+        name="lr"
+        prop={{ ...floatProp, description: 'Controls the learning rate.' }}
+        value={0.5}
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(container.querySelector('.type-field-label')).toBeInTheDocument()
+    expect(screen.getByText('Controls the learning rate.')).toHaveClass('type-field-help')
+  })
+
   it('does not commit on each keystroke — typing 0.05 stays intact', async () => {
     const onChange = vi.fn()
     const user = userEvent.setup()

--- a/studio/web/src/components/Field.tsx
+++ b/studio/web/src/components/Field.tsx
@@ -88,7 +88,7 @@ export default function Field({
             {label}
             {hintNode}
           </div>
-          {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+          {help && <div className="type-field-help mt-1">{help}</div>}
         </span>
       </label>
     )
@@ -99,7 +99,7 @@ export default function Field({
     const triValue = value === true ? 'true' : value === false ? 'false' : ''
     return (
       <div className="py-1.5">
-        <div className="text-sm font-medium text-fg-secondary mb-1">
+        <div className="type-field-label mb-1">
           {label}{hintNode}
         </div>
         <select
@@ -115,7 +115,7 @@ export default function Field({
           <option value="true">{t('field.yes')}</option>
           <option value="false">{t('field.no')}</option>
         </select>
-        {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+        {help && <div className="type-field-help mt-1">{help}</div>}
       </div>
     )
   }
@@ -124,7 +124,7 @@ export default function Field({
   if (kind === 'select') {
     return (
       <div className="py-1.5">
-        <div className="text-sm font-medium text-fg-secondary mb-1">
+        <div className="type-field-label mb-1">
           {label}{hintNode}
         </div>
         <select
@@ -151,7 +151,7 @@ export default function Field({
             )
           })}
         </select>
-        {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+        {help && <div className="type-field-help mt-1">{help}</div>}
       </div>
     )
   }
@@ -265,7 +265,7 @@ function TextareaField({
   useAutoGrowTextarea(taRef, text)
   return (
     <div className="py-1.5">
-      <div className="text-sm font-medium text-fg-secondary mb-1">
+      <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
       <textarea
@@ -276,7 +276,7 @@ function TextareaField({
         disabled={disabled}
         className="input input-mono resize-none overflow-hidden" style={fieldStyle(disabled)}
       />
-      {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+      {help && <div className="type-field-help mt-1">{help}</div>}
     </div>
   )
 }
@@ -302,7 +302,7 @@ function StringListField({
 
   return (
     <div className="py-1.5">
-      <div className="text-sm font-medium text-fg-secondary mb-1">
+      <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
       <textarea
@@ -317,7 +317,7 @@ function StringListField({
         disabled={disabled}
         className="input input-mono resize-none overflow-hidden" style={fieldStyle(disabled)}
       />
-      {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+      {help && <div className="type-field-help mt-1">{help}</div>}
     </div>
   )
 }
@@ -374,7 +374,7 @@ function JsonCodeField({
 
   return (
     <div className="py-1.5">
-      <div className="text-sm font-medium text-fg-secondary mb-1">
+      <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
       <textarea
@@ -391,7 +391,7 @@ function JsonCodeField({
         style={fieldStyle(disabled)}
       />
       {error && <div className="text-xs text-err mt-1">{error}</div>}
-      {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+      {help && <div className="type-field-help mt-1">{help}</div>}
     </div>
   )
 }
@@ -441,7 +441,7 @@ function IntListField({
 
   return (
     <div className="py-1.5">
-      <div className="text-sm font-medium text-fg-secondary mb-1">
+      <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
       <input
@@ -461,7 +461,7 @@ function IntListField({
         className="input input-mono" style={fieldStyle(disabled)}
         placeholder={placeholder}
       />
-      {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+      {help && <div className="type-field-help mt-1">{help}</div>}
     </div>
   )
 }
@@ -518,7 +518,7 @@ function NumberField({
 
   return (
     <div className="py-1.5">
-      <div className="text-sm font-medium text-fg-secondary mb-1">
+      <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
       <input
@@ -537,7 +537,7 @@ function NumberField({
         disabled={disabled}
         className="input input-mono" style={fieldStyle(disabled)}
       />
-      {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+      {help && <div className="type-field-help mt-1">{help}</div>}
     </div>
   )
 }
@@ -588,7 +588,7 @@ function PathStringField({
 
   return (
     <div className="py-1.5 relative">
-      <div className="text-sm font-medium text-fg-secondary mb-1">
+      <div className="type-field-label mb-1">
         {label}
         {kind === 'path' && (
           <span className="ml-2 text-xs text-fg-tertiary">{t('field.pathHint')}</span>
@@ -660,7 +660,7 @@ function PathStringField({
         )}
         {suffix}
       </div>
-      {help && <div className="text-xs text-fg-tertiary mt-1">{help}</div>}
+      {help && <div className="type-field-help mt-1">{help}</div>}
       {/* resume_state / resume_lora：贴字段的 dropdown，按 version 分组列文件 */}
       {useResumePicker && picking && !disabled && (
         <ResumeFieldPicker

--- a/studio/web/src/components/PageHeader.test.tsx
+++ b/studio/web/src/components/PageHeader.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import PageHeader from './PageHeader'
+
+describe('PageHeader', () => {
+  it('applies the shared page title and description hierarchy', () => {
+    render(<PageHeader title="Projects" subtitle="Manage training workspaces." />)
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Projects' }))
+      .toHaveClass('type-page-title')
+    expect(screen.getByText('Manage training workspaces.'))
+      .toHaveClass('type-page-description')
+  })
+
+  it('lets tabs replace the description without changing the title hierarchy', () => {
+    render(
+      <PageHeader
+        title="Settings"
+        subtitle="Hidden description"
+        tabs={<nav aria-label="Settings sections">Tabs</nav>}
+      />,
+    )
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Settings' }))
+      .toHaveClass('type-page-title')
+    expect(screen.queryByText('Hidden description')).not.toBeInTheDocument()
+    expect(screen.getByRole('navigation', { name: 'Settings sections' })).toBeInTheDocument()
+  })
+
+  it('preserves the action and top-right slots', () => {
+    render(
+      <PageHeader
+        title="Queue"
+        actions={<button type="button">Refresh</button>}
+        topRight={<span>Phase 2</span>}
+        sticky
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument()
+    expect(screen.getByText('Phase 2')).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Queue' }).closest('.sticky')).toBeInTheDocument()
+  })
+})

--- a/studio/web/src/components/PageHeader.tsx
+++ b/studio/web/src/components/PageHeader.tsx
@@ -20,13 +20,13 @@ export default function PageHeader({ title, subtitle, tabs, actions, topRight, s
       )}
       <div className="flex items-end gap-4 flex-wrap">
         <div className="flex-1 min-w-0">
-          <h1 className="m-0 text-2xl font-semibold tracking-tight leading-[1.15]">{title}</h1>
+          <h1 className="type-page-title">{title}</h1>
           {/* tabs 在主标题下方取代 subtitle 位置；两者互斥（tabs 优先）。 */}
           {tabs ? (
             <div className="mt-3">{tabs}</div>
           ) : (
             subtitle && (
-              <p className="mt-1.5 text-fg-secondary text-md max-w-[720px] m-0">{subtitle}</p>
+              <p className="type-page-description mt-1.5">{subtitle}</p>
             )
           )}
         </div>

--- a/studio/web/src/pages/Queue.test.tsx
+++ b/studio/web/src/pages/Queue.test.tsx
@@ -112,9 +112,13 @@ describe('QueuePage 分区 + 分页', () => {
 
     renderQueue()
 
-    await waitFor(() => expect(screen.getByText(/进行中/)).toBeInTheDocument())
-    expect(screen.getByText(/等待入队/)).toBeInTheDocument()
-    expect(screen.getByText(/历史/)).toBeInTheDocument()
+    await waitFor(() => expect(screen.getByRole('heading', { level: 3, name: /进行中/ })).toBeInTheDocument())
+    expect(screen.getByRole('heading', { level: 3, name: /进行中/ }))
+      .toHaveClass('type-section-label')
+    expect(screen.getByRole('heading', { level: 3, name: /等待入队/ }))
+      .toHaveClass('type-section-label')
+    expect(screen.getByRole('heading', { level: 3, name: /历史/ }))
+      .toHaveClass('type-section-label')
     // 历史 total=25 > page_size=20 → 分页器 + 页码指示
     expect(screen.getByText(/第 1 \/ 2 页/)).toBeInTheDocument()
     expect(screen.getByTestId('history-prev')).toBeDisabled()

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -1060,7 +1060,7 @@ export default function QueuePage() {
             {/* 进行中（running + paused） */}
             {activeItems.length > 0 && (
               <section className="flex flex-col gap-2">
-                <h3 className="text-xs font-semibold text-fg-tertiary uppercase tracking-wide">
+                <h3 className="type-section-label">
                   {t('queue.sectionActive')} ({activeItems.length})
                 </h3>
                 {activeItems.map(renderRow)}
@@ -1070,7 +1070,7 @@ export default function QueuePage() {
             {/* 等待入队（pending） */}
             {pendingItems.length > 0 && (
               <section className="flex flex-col gap-2">
-                <h3 className="text-xs font-semibold text-fg-tertiary uppercase tracking-wide">
+                <h3 className="type-section-label">
                   {t('queue.sectionWaiting')} ({pendingItems.length})
                 </h3>
                 {pendingItems.map(renderRow)}
@@ -1080,7 +1080,7 @@ export default function QueuePage() {
             {/* 计划任务（scheduled，0.17 P-B）——到点自动转入等待入队 */}
             {scheduledItems.length > 0 && (
               <section className="flex flex-col gap-2" data-testid="queue-scheduled-section">
-                <h3 className="text-xs font-semibold text-fg-tertiary uppercase tracking-wide">
+                <h3 className="type-section-label">
                   {t('queue.sectionScheduled')} ({scheduledItems.length})
                 </h3>
                 {scheduledItems.map(renderRow)}
@@ -1089,7 +1089,7 @@ export default function QueuePage() {
 
             {/* 历史（terminal，后端分页） */}
             <section className="flex flex-col gap-2">
-              <h3 className="text-xs font-semibold text-fg-tertiary uppercase tracking-wide">
+              <h3 className="type-section-label">
                 {t('queue.sectionHistory')} ({history.total})
               </h3>
 

--- a/studio/web/src/pages/queue/DataJobsPanel.test.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.test.tsx
@@ -83,6 +83,10 @@ describe('DataJobsPanel', () => {
     renderPanel()
 
     await waitFor(() => expect(screen.getByTestId('job-row-10')).toBeInTheDocument())
+    expect(screen.getByRole('heading', { level: 3, name: /进行中/ }))
+      .toHaveClass('type-section-label')
+    expect(screen.getByRole('heading', { level: 3, name: /历史/ }))
+      .toHaveClass('type-section-label')
     expect(within(screen.getByTestId('job-row-10')).getByText('打标')).toBeInTheDocument()
     expect(within(screen.getByTestId('job-row-9')).getByText('素材下载')).toBeInTheDocument()
     await waitFor(() => expect(screen.getAllByText(/MyProj/).length).toBeGreaterThan(0))

--- a/studio/web/src/pages/queue/DataJobsPanel.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.tsx
@@ -215,7 +215,7 @@ export default function DataJobsPanel({
         <>
           {live.length > 0 && (
             <section className="flex flex-col gap-2">
-              <h3 className="text-xs font-semibold text-fg-tertiary uppercase tracking-wide">
+              <h3 className="type-section-label">
                 {t('queue.sectionActive')} ({live.length})
               </h3>
               {live.map(renderRow)}
@@ -223,7 +223,7 @@ export default function DataJobsPanel({
           )}
 
           <section className="flex flex-col gap-2">
-            <h3 className="text-xs font-semibold text-fg-tertiary uppercase tracking-wide">
+            <h3 className="type-section-label">
               {t('queue.sectionHistory')} ({history.total})
             </h3>
             {history.items.length === 0 ? (

--- a/studio/web/src/pages/tools/settings/fields.test.tsx
+++ b/studio/web/src/pages/tools/settings/fields.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { SettingsField, SettingsSection } from './fields'
+
+describe('settings typography hierarchy', () => {
+  it('uses panel and field roles without treating UI labels as code', () => {
+    render(
+      <SettingsSection title="Runtime">
+        <SettingsField label="Cache path">
+          <input aria-label="Cache path value" />
+        </SettingsField>
+      </SettingsSection>,
+    )
+
+    expect(screen.getByRole('heading', { level: 2, name: 'Runtime' }))
+      .toHaveClass('type-panel-title')
+    expect(screen.getByText('Cache path')).toHaveClass('type-field-label')
+    expect(screen.getByText('Cache path')).not.toHaveClass('font-mono')
+  })
+})

--- a/studio/web/src/pages/tools/settings/fields.tsx
+++ b/studio/web/src/pages/tools/settings/fields.tsx
@@ -13,7 +13,7 @@ export function SettingsSection({
   headerExtras?: React.ReactNode  // 可选 slot：渲染在 h2 右侧（紧贴），给 ⓘ tooltip 之类用
   children: React.ReactNode
 }) {
-  const titleEl = <h2 className="text-sm font-semibold text-fg-primary">{title}</h2>
+  const titleEl = <h2 className="type-panel-title">{title}</h2>
   return (
     <section id={id} className="rounded-md border border-subtle bg-surface p-4 flex flex-col gap-3 scroll-mt-24">
       {headerExtras ? (
@@ -89,7 +89,7 @@ export function SectionIndex({
   return (
     <aside className="hidden lg:block">
       <nav className="sticky top-4 flex flex-col gap-0.5">
-        <div className="caption mb-2 px-2">{t('settings.pageIndex')}</div>
+        <div className="type-section-label mb-2 px-2">{t('settings.pageIndex')}</div>
         {sections.map((s) => (
           <button
             key={s.id}
@@ -119,7 +119,7 @@ export function SettingsField({ label, helpTooltip, children }: {
   return (
     <div className="grid grid-cols-[240px_1fr] gap-3 items-start">
       <div className="flex items-center gap-2 min-w-0 pt-1.5">
-        <label className="text-xs text-fg-secondary font-mono leading-none">{label}</label>
+        <label className="type-field-label">{label}</label>
         {helpTooltip && <InfoButton>{helpTooltip}</InfoButton>}
       </div>
       <div className="min-w-0">{children}</div>

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -205,6 +205,73 @@ select option:checked {
 .mono { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .tnum { font-variant-numeric: tabular-nums; }
 .serif { font-family: var(--font-serif); }
+
+/* Semantic typography roles. These classes map meaning onto the density-aware
+ * foundation scale; pages should not reassemble the same font/weight/color tuple. */
+.type-page-title,
+.type-page-description,
+.type-section-title,
+.type-panel-title,
+.type-section-label,
+.type-field-label,
+.type-field-help {
+  font-family: var(--font-sans);
+}
+.type-page-title {
+  margin: 0;
+  color: var(--fg-primary);
+  font-size: var(--t-2xl);
+  font-weight: 600;
+  line-height: 1.2;
+  letter-spacing: -0.015em;
+  overflow-wrap: anywhere;
+}
+.type-page-description {
+  margin: 0;
+  max-width: 68ch;
+  color: var(--fg-secondary);
+  font-size: var(--t-md);
+  font-weight: 400;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+.type-section-title {
+  margin: 0;
+  color: var(--fg-primary);
+  font-size: var(--t-lg);
+  font-weight: 600;
+  line-height: 1.35;
+}
+.type-panel-title {
+  margin: 0;
+  color: var(--fg-primary);
+  font-size: var(--t-sm);
+  font-weight: 600;
+  line-height: 1.4;
+}
+.type-section-label {
+  margin: 0;
+  color: var(--fg-tertiary);
+  font-size: var(--t-xs);
+  font-weight: 600;
+  line-height: 1.4;
+  letter-spacing: 0.025em;
+  text-transform: uppercase;
+}
+.type-field-label {
+  color: var(--fg-secondary);
+  font-size: var(--t-sm);
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: normal;
+  text-transform: none;
+}
+.type-field-help {
+  color: var(--fg-tertiary);
+  font-size: var(--t-xs);
+  font-weight: 400;
+  line-height: 1.5;
+}
 .caption {
   font-family: var(--font-mono);
   font-size: var(--t-xs);


### PR DESCRIPTION
## 变更摘要

- 在 `tokens.css` 中建立支持密度切换的语义化排版角色，并在 `DESIGN.md` 中明确使用边界
- 将共享页面标题、Dialog、Schema 字段、设置面板以及队列分区标题迁移到统一排版角色
- 路径、标识符、日志和数值等技术数据继续使用等宽字体；普通设置标签恢复使用界面无衬线字体
- 补充组件及页面测试，约束排版语义契约

## 验证结果

- `npx vitest run`：82 个测试文件、702 个测试全部通过
- `npm run lint`：通过
- `npx tsc --noEmit`：通过
- `npm run build`：通过
- `node .pi/skills/impeccable/scripts/detect.mjs --json --scope type studio/web/src`：0 findings
- `git diff --check`：通过
- 人工视觉检查：通过

## 影响范围

本次改动不涉及业务行为、API 契约或页面结构，也没有新增外部字体依赖。专业画布中的特殊标注以及技术数据的排版保持不变。

## 审查说明

配置的独立 reviewer 因 xAI API key 被拒绝而未能运行；未在未经许可的情况下改用其他模型。
