### PR TITLE
feat(web): 标准化页面间距

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -84,10 +84,35 @@ Rules:
 
 ### Spacing, radius, and depth
 
-Use the `--s-*`, `--r-*`, and `--sh-*` scales. Within one hierarchy level, use one
-radius: controls use `--r-md`, ordinary cards use `--r-lg`, and pills use
-`--r-pill`. Dense workbench panels may use `--r-md` when their compactness is part
-of the information structure.
+Use the `--s-*`, `--r-*`, and `--sh-*` scales. New shared layouts use the
+semantic Tailwind spacing aliases below instead of choosing a number by eye:
+
+| Alias | Default | Relationship |
+| --- | ---: | --- |
+| `related` | 8px | Icons, labels, and controls that form one action or datum |
+| `field` | 12px | Parts of one field or compact component |
+| `section` | 16px | Sibling groups within one region |
+| `page-start` | 20px | Page-header leading inset |
+| `page` | 24px | Page-shell inset and separation between ordinary regions |
+| `page-loose` | 32px | Major region separation where a stronger pause is required |
+
+The aliases resolve through `--space-*` to the density-aware `--s-*` scale.
+Small `related` gaps stay stable; `field` and larger relationships contract or
+expand with the selected density. Numeric spacing utilities remain a compatibility
+path and migrate by component family. Do not globally remap them in a page PR.
+
+Vertical rhythm follows content hierarchy: elements that form one control stay
+closest, fields form a tighter group than sections, and sections form a tighter
+group than page regions. A heading has more separation from the preceding region
+than from the content it introduces. Shared page chrome uses semantic spacing so
+its header, optional toolbar, and content keep aligned horizontal insets.
+
+Within one hierarchy level, use one radius: controls use `--r-md`, ordinary cards
+use `--r-lg`, and pills use `--r-pill`. Dense workbench panels may use `--r-md`
+when their compactness is part of the information structure. Fixed or arbitrary
+spacing is allowed only where it is geometry rather than rhythm—for example canvas
+coordinates, image crops, table column sizing, or sticky offsets—and must remain
+local to that specialized surface.
 
 Shadows communicate elevation. Borders communicate grouping. Do not add shadows
 merely to decorate every container.

--- a/studio/web/src/components/PageHeader.test.tsx
+++ b/studio/web/src/components/PageHeader.test.tsx
@@ -3,13 +3,20 @@ import { describe, expect, it } from 'vitest'
 import PageHeader from './PageHeader'
 
 describe('PageHeader', () => {
-  it('applies the shared page title and description hierarchy', () => {
-    render(<PageHeader title="Projects" subtitle="Manage training workspaces." />)
+  it('applies the shared page title, description, and shell rhythm', () => {
+    const { container } = render(
+      <PageHeader title="Projects" subtitle="Manage training workspaces." />,
+    )
 
+    expect(container.firstElementChild).toHaveClass(
+      'px-page',
+      'pt-page-start',
+      'pb-section',
+    )
     expect(screen.getByRole('heading', { level: 1, name: 'Projects' }))
       .toHaveClass('type-page-title')
     expect(screen.getByText('Manage training workspaces.'))
-      .toHaveClass('type-page-description')
+      .toHaveClass('type-page-description', 'mt-related')
   })
 
   it('lets tabs replace the description without changing the title hierarchy', () => {
@@ -24,7 +31,10 @@ describe('PageHeader', () => {
     expect(screen.getByRole('heading', { level: 1, name: 'Settings' }))
       .toHaveClass('type-page-title')
     expect(screen.queryByText('Hidden description')).not.toBeInTheDocument()
-    expect(screen.getByRole('navigation', { name: 'Settings sections' })).toBeInTheDocument()
+    expect(screen.getByRole('navigation', { name: 'Settings sections' }))
+      .toBeInTheDocument()
+    expect(screen.getByRole('navigation', { name: 'Settings sections' }).parentElement)
+      .toHaveClass('mt-field')
   })
 
   it('preserves the action and top-right slots', () => {
@@ -38,7 +48,11 @@ describe('PageHeader', () => {
     )
 
     expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Refresh' }).parentElement)
+      .toHaveClass('gap-related')
     expect(screen.getByText('Phase 2')).toBeInTheDocument()
+    expect(screen.getByText('Phase 2').parentElement)
+      .toHaveClass('top-field', 'right-page')
     expect(screen.getByRole('heading', { name: 'Queue' }).closest('.sticky')).toBeInTheDocument()
   })
 })

--- a/studio/web/src/components/PageHeader.tsx
+++ b/studio/web/src/components/PageHeader.tsx
@@ -14,24 +14,24 @@ interface Props {
 
 export default function PageHeader({ title, subtitle, tabs, actions, topRight, sticky }: Props) {
   return (
-    <div className={`px-6 pt-5 pb-4 bg-canvas border-b border-subtle ${sticky ? 'sticky top-0 z-[5]' : 'relative'}`}>
+    <div className={`px-page pt-page-start pb-section bg-canvas border-b border-subtle ${sticky ? 'sticky top-0 z-[5]' : 'relative'}`}>
       {topRight && (
-        <div className="absolute top-3 right-6 z-[1]">{topRight}</div>
+        <div className="absolute top-field right-page z-[1]">{topRight}</div>
       )}
-      <div className="flex items-end gap-4 flex-wrap">
+      <div className="flex items-end gap-section flex-wrap">
         <div className="flex-1 min-w-0">
           <h1 className="type-page-title">{title}</h1>
           {/* tabs 在主标题下方取代 subtitle 位置；两者互斥（tabs 优先）。 */}
           {tabs ? (
-            <div className="mt-3">{tabs}</div>
+            <div className="mt-field">{tabs}</div>
           ) : (
             subtitle && (
-              <p className="type-page-description mt-1.5">{subtitle}</p>
+              <p className="type-page-description mt-related">{subtitle}</p>
             )
           )}
         </div>
         {actions && (
-          <div className="flex gap-2 items-center">{actions}</div>
+          <div className="flex gap-related items-center">{actions}</div>
         )}
       </div>
     </div>

--- a/studio/web/src/components/StepShell.test.tsx
+++ b/studio/web/src/components/StepShell.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import StepShell from './StepShell'
+
+describe('StepShell', () => {
+  it('uses the shared page inset while keeping the toolbar outside the scroll content', () => {
+    render(
+      <StepShell
+        idx={1}
+        title="Queue"
+        belowHeader={<div data-testid="toolbar">Filters</div>}
+      >
+        <div data-testid="content">Content</div>
+      </StepShell>,
+    )
+
+    expect(screen.getByTestId('content').parentElement).toHaveClass('p-page')
+    expect(screen.getByTestId('toolbar').nextElementSibling)
+      .toBe(screen.getByTestId('content').parentElement)
+  })
+})

--- a/studio/web/src/components/StepShell.tsx
+++ b/studio/web/src/components/StepShell.tsx
@@ -10,7 +10,7 @@ interface Props {
   topRight?: ReactNode
   children: ReactNode
   /** header 与内容区之间的全宽条（如过滤 / 排序行），不随内容滚动。与项目页
-   *  FilterBar 一致：自带 `px-6 py-2 border-b`，内容区随之改用 pt-4（贴着分隔线）。 */
+   *  FilterBar 一致：使用 `px-page py-related border-b` 保持壳层水平对齐。 */
   belowHeader?: ReactNode
   /** 本页任务日志源（issue #251 统一抽屉）；falsy 项自动过滤，全空时不渲染。 */
   logSources?: Array<LogSource | null | undefined | false>
@@ -28,8 +28,8 @@ export default function StepShell({ title, subtitle, actions, topRight, children
       />
       {belowHeader}
       {/* flex column container: overflow:hidden stops page scroll; children use flex:1 to fill。
-          内容区四周统一 p-6（含 belowHeader 分隔线下方也对称留白，不再顶部特例 pt-4）。 */}
-      <div className="flex-1 min-h-0 flex flex-col overflow-hidden p-6">
+          内容区四周使用语义 page inset，随全局 density 同步。 */}
+      <div className="flex-1 min-h-0 flex flex-col overflow-hidden p-page">
         {children}
       </div>
       {/* 页面级 footer 抽屉：全宽贴底，展开时 overlay 在内容上方（issue #251） */}

--- a/studio/web/src/components/preprocess/PreprocessToolsBar.tsx
+++ b/studio/web/src/components/preprocess/PreprocessToolsBar.tsx
@@ -39,12 +39,12 @@ const TAB_BASE =
  *  `/projects/:pid/v/:vid/preprocess?tool=...`——query string 让 sidebar 的
  *  `/preprocess` matcher 保持简单，同时切换工具时父路由不卸载。
  *
- *  设计为直接塞进 StepShell 的 `belowHeader`（自带 `border-b px-6` 全宽条）。 */
+ *  设计为直接塞进 StepShell 的 `belowHeader`（自带 `border-b px-page` 全宽条）。 */
 export default function PreprocessToolsBar({ current, projectId, versionId }: Props) {
   const { t } = useTranslation()
   const base = `/projects/${projectId}/v/${versionId}/preprocess`
   return (
-    <nav className="flex items-center gap-0 border-b border-subtle px-6 shrink-0">
+    <nav className="flex items-center gap-0 border-b border-subtle px-page shrink-0">
       {TOOLS.map((tool) => {
         const label = t(`preprocess.tools.${tool.i18nKey}`)
         const isActive = tool.id === current

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -299,13 +299,13 @@ export default function ProjectsPage() {
         />
       )}
 
-      <div className="p-6 pt-4">
+      <div className="px-page pb-page pt-section">
         {error && (
           <div className="mb-4 px-3.5 py-2.5 rounded-md bg-err-soft border border-err text-err text-sm font-mono">{error}</div>
         )}
 
         {loading ? (
-          <div className="grid gap-4" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
+          <div className="grid gap-section" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
             {[1, 2, 3].map(i => (
               <div key={i} className="card p-[18px]" style={{ height: 140 }}>
                 <div className="w-3/5 h-4 rounded bg-overlay mb-2.5" />
@@ -323,7 +323,7 @@ export default function ProjectsPage() {
             {t('common.noResults')}
           </div>
         ) : (
-          <div className="grid gap-4 auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
+          <div className="grid gap-section auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
             {visible.map((p) => (
               <ProjectCard
                 key={p.id}
@@ -404,7 +404,7 @@ function FilterBar({
 }) {
   const { t } = useTranslation()
   return (
-    <div className="px-6 py-2 border-b border-subtle flex items-center gap-3">
+    <div className="px-page py-related border-b border-subtle flex items-center gap-field">
       <input
         className="input"
         style={{ width: '60%' }}

--- a/studio/web/src/pages/Queue.test.tsx
+++ b/studio/web/src/pages/Queue.test.tsx
@@ -115,6 +115,8 @@ describe('QueuePage 分区 + 分页', () => {
     await waitFor(() => expect(screen.getByRole('heading', { level: 3, name: /进行中/ })).toBeInTheDocument())
     expect(screen.getByRole('heading', { level: 3, name: /进行中/ }))
       .toHaveClass('type-section-label')
+    expect(screen.getByRole('heading', { level: 3, name: /进行中/ }).parentElement)
+      .toHaveClass('gap-related')
     expect(screen.getByRole('heading', { level: 3, name: /等待入队/ }))
       .toHaveClass('type-section-label')
     expect(screen.getByRole('heading', { level: 3, name: /历史/ }))
@@ -123,6 +125,8 @@ describe('QueuePage 分区 + 分页', () => {
     expect(screen.getByText(/第 1 \/ 2 页/)).toBeInTheDocument()
     expect(screen.getByTestId('history-prev')).toBeDisabled()
     expect(screen.getByTestId('history-next')).not.toBeDisabled()
+    expect(screen.getByTestId('history-next').parentElement?.parentElement)
+      .toHaveClass('-mx-page', '-mb-page', 'px-page')
     historySpy.mockClear()
 
     // 点下一页 → 以 page=2 重新请求后端
@@ -142,6 +146,8 @@ describe('QueuePage 分区 + 分页', () => {
     renderQueue()
     await waitFor(() => expect(screen.getByTestId('queue-filter-toggle')).toBeInTheDocument())
     fireEvent.click(screen.getByTestId('queue-filter-toggle'))
+    expect(screen.getByTestId('queue-filterbar'))
+      .toHaveClass('px-page', 'py-related', 'gap-field')
     fireEvent.change(screen.getByTestId('queue-search'), { target: { value: 'abc' } })
 
     await waitFor(

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -110,8 +110,8 @@ function PaginationBar({
   const { t } = useTranslation()
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
   return (
-    <div className="shrink-0 -mx-6 -mb-6 px-6 py-1 border-t border-subtle flex items-center justify-between flex-wrap gap-2 bg-canvas text-[11px]">
-      <div className="flex items-center gap-2 text-fg-tertiary">
+    <div className="shrink-0 -mx-page -mb-page px-page py-1 border-t border-subtle flex items-center justify-between flex-wrap gap-related bg-canvas text-[11px]">
+      <div className="flex items-center gap-related text-fg-tertiary">
         <span>{t('queue.pageIndicator', { page, pages: totalPages })}</span>
         <select
           value={pageSize}
@@ -910,7 +910,7 @@ export default function QueuePage() {
       belowHeader={filtersOpen && (queueTab === 'jobs' ? (
         // 0.17 P-G — 数据作业过滤行：kind 单选（与任务视图的过滤行同位）。
         <div
-          className="px-6 py-2 border-b border-subtle flex items-center gap-3"
+          className="px-page py-related border-b border-subtle flex items-center gap-field"
           data-testid="queue-jobs-filterbar"
         >
           <input
@@ -945,7 +945,7 @@ export default function QueuePage() {
         // 下沉后端搜 name/config；类型 select 跨 live+history 按 task_type 过滤；状态
         // select 是历史段终态子过滤。
         <div
-          className="px-6 py-2 border-b border-subtle flex items-center gap-3"
+          className="px-page py-related border-b border-subtle flex items-center gap-field"
           data-testid="queue-filterbar"
         >
           <input
@@ -996,7 +996,7 @@ export default function QueuePage() {
         </div>
       ))}
     >
-      <div className="flex flex-col gap-2.5 flex-1 min-h-0 overflow-y-auto">
+      <div className="flex flex-col gap-field flex-1 min-h-0 overflow-y-auto">
         {/* ADR §4.1 队列挂起 banner — 仅 held=true 时显示，sticky 顶部。
             hold 覆盖全队列（含数据作业派发），两个视图都显示。 */}
         {holdState?.held && (
@@ -1056,10 +1056,10 @@ export default function QueuePage() {
             description={t('queue.emptyHint')}
           />
         ) : (
-          <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-section">
             {/* 进行中（running + paused） */}
             {activeItems.length > 0 && (
-              <section className="flex flex-col gap-2">
+              <section className="flex flex-col gap-related">
                 <h3 className="type-section-label">
                   {t('queue.sectionActive')} ({activeItems.length})
                 </h3>
@@ -1069,7 +1069,7 @@ export default function QueuePage() {
 
             {/* 等待入队（pending） */}
             {pendingItems.length > 0 && (
-              <section className="flex flex-col gap-2">
+              <section className="flex flex-col gap-related">
                 <h3 className="type-section-label">
                   {t('queue.sectionWaiting')} ({pendingItems.length})
                 </h3>
@@ -1079,7 +1079,7 @@ export default function QueuePage() {
 
             {/* 计划任务（scheduled，0.17 P-B）——到点自动转入等待入队 */}
             {scheduledItems.length > 0 && (
-              <section className="flex flex-col gap-2" data-testid="queue-scheduled-section">
+              <section className="flex flex-col gap-related" data-testid="queue-scheduled-section">
                 <h3 className="type-section-label">
                   {t('queue.sectionScheduled')} ({scheduledItems.length})
                 </h3>
@@ -1088,7 +1088,7 @@ export default function QueuePage() {
             )}
 
             {/* 历史（terminal，后端分页） */}
-            <section className="flex flex-col gap-2">
+            <section className="flex flex-col gap-related">
               <h3 className="type-section-label">
                 {t('queue.sectionHistory')} ({history.total})
               </h3>
@@ -1103,7 +1103,7 @@ export default function QueuePage() {
         )}
       </div>
 
-      {/* 0.17 item6：分页下沉成 fixed 底栏（-mx-6/-mb-6 抵消内容区 padding 做全宽贴底）。
+      {/* 分页下沉成 fixed 底栏（-mx-page/-mb-page 抵消语义内容 inset 做全宽贴底）。
           item2：只要历史超过最小每页数就常显（切到 50/100 只剩一页时不消失，能切回
           20）；样式压缩省空间。GPU / 数据两个视图共用同款底栏（P-G 反馈）。 */}
       {queueTab === 'tasks' && loaded && !isEmpty && history.total > HISTORY_PAGE_SIZES[0] && (

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -491,7 +491,7 @@ export default function RegularizationPage() {
       belowHeader={
         /* tab 贴到 header 下方全宽条（对齐任务详情页 nav：下划线式、active 橙字）。
            状态栏移到「生成」tab 右栏，不再横跨顶部。 */
-        <nav className="flex items-center gap-0 border-b border-subtle px-6 shrink-0">
+        <nav className="flex items-center gap-0 border-b border-subtle px-page shrink-0">
           <RegTab
             active={activeTab === 'generate'}
             onClick={() => setActiveTab('generate')}

--- a/studio/web/src/pages/queue/DataJobsPanel.test.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.test.tsx
@@ -83,8 +83,11 @@ describe('DataJobsPanel', () => {
     renderPanel()
 
     await waitFor(() => expect(screen.getByTestId('job-row-10')).toBeInTheDocument())
+    expect(screen.getByTestId('data-jobs-panel')).toHaveClass('gap-section')
     expect(screen.getByRole('heading', { level: 3, name: /进行中/ }))
       .toHaveClass('type-section-label')
+    expect(screen.getByRole('heading', { level: 3, name: /进行中/ }).parentElement)
+      .toHaveClass('gap-related')
     expect(screen.getByRole('heading', { level: 3, name: /历史/ }))
       .toHaveClass('type-section-label')
     expect(within(screen.getByTestId('job-row-10')).getByText('打标')).toBeInTheDocument()

--- a/studio/web/src/pages/queue/DataJobsPanel.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.tsx
@@ -195,7 +195,7 @@ export default function DataJobsPanel({
   }
 
   return (
-    <div className="flex flex-col gap-4" data-testid="data-jobs-panel">
+    <div className="flex flex-col gap-section" data-testid="data-jobs-panel">
       {error && (
         <div className="px-3.5 py-2.5 rounded-md bg-err-soft border border-err text-err text-xs font-mono">
           {error}
@@ -214,7 +214,7 @@ export default function DataJobsPanel({
       ) : (
         <>
           {live.length > 0 && (
-            <section className="flex flex-col gap-2">
+            <section className="flex flex-col gap-related">
               <h3 className="type-section-label">
                 {t('queue.sectionActive')} ({live.length})
               </h3>
@@ -222,7 +222,7 @@ export default function DataJobsPanel({
             </section>
           )}
 
-          <section className="flex flex-col gap-2">
+          <section className="flex flex-col gap-related">
             <h3 className="type-section-label">
               {t('queue.sectionHistory')} ({history.total})
             </h3>

--- a/studio/web/src/pages/tools/Generate.tsx
+++ b/studio/web/src/pages/tools/Generate.tsx
@@ -1059,7 +1059,7 @@ export default function GeneratePage() {
         title={t('generate.title')}
         subtitle={t('generate.subtitle')}
         actions={
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-related">
             {currentTask && (
               <>
                 <span className="caption">#{currentTask.id}</span>
@@ -1098,8 +1098,8 @@ export default function GeneratePage() {
       />
 
       {/* 三列各自独立滚动，整页固定高度 = viewport。relative：进度条 absolute 叠在顶部
-          p-6 既有 gap 上、不占布局，出现/消失不推动内容（防页面抖动）。 */}
-      <div className="relative p-6 flex gap-4 items-stretch flex-wrap xl:flex-nowrap flex-1 min-h-0">
+          语义 page inset 既有间隔上、不占布局，出现/消失不推动内容（防页面抖动）。 */}
+      <div className="relative p-page flex gap-section items-stretch flex-wrap xl:flex-nowrap flex-1 min-h-0">
         {/* 出图进度条：全宽细线（浏览器加载条式）+ 小相位文字，绝对定位叠在 header 与内容间
             的既有 gap 上；覆盖 load/clip/sample/vae 全阶段，切历史图也照常显示当前进度。 */}
         {(busy || progress.currentStep != null || progress.phase != null) && (

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -267,7 +267,7 @@ export default function SettingsPage() {
 
   // Tab nav 抽出来传给 PageHeader 的 tabs prop（取代旧的 subtitle 位置）。
   const tabNav = (
-    <nav className="flex gap-1 -mb-4">
+    <nav className="flex gap-1 -mb-section">
       {TAB_LIST.map((item) => (
         <button
           key={item.id}
@@ -305,9 +305,9 @@ export default function SettingsPage() {
         actions={<SaveIndicator status={saveStatus} />}
       />
 
-      <div ref={scrollContainerRef} className="p-6 pb-12 flex-1 overflow-y-auto">
+      <div ref={scrollContainerRef} className="p-page pb-12 flex-1 overflow-y-auto">
       <div className="grid gap-10 max-w-[1920px]" style={{ gridTemplateColumns: 'minmax(0,1fr) 200px' }}>
-      <div className="flex flex-col gap-8 min-w-0">
+      <div className="flex flex-col gap-page-loose min-w-0">
 
       {error && (
         <div className="p-3 rounded-md bg-err-soft border border-err text-err text-sm font-mono">

--- a/studio/web/src/pages/tools/settings/fields.test.tsx
+++ b/studio/web/src/pages/tools/settings/fields.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 import { SettingsField, SettingsSection } from './fields'
 
-describe('settings typography hierarchy', () => {
-  it('uses panel and field roles without treating UI labels as code', () => {
-    render(
+describe('settings hierarchy', () => {
+  it('uses shared panel, field, and spacing roles without treating UI labels as code', () => {
+    const { container } = render(
       <SettingsSection title="Runtime">
         <SettingsField label="Cache path">
           <input aria-label="Cache path value" />
@@ -12,9 +12,12 @@ describe('settings typography hierarchy', () => {
       </SettingsSection>,
     )
 
+    expect(container.querySelector('section')).toHaveClass('p-section', 'gap-field')
     expect(screen.getByRole('heading', { level: 2, name: 'Runtime' }))
       .toHaveClass('type-panel-title')
     expect(screen.getByText('Cache path')).toHaveClass('type-field-label')
+    expect(screen.getByText('Cache path').parentElement?.parentElement)
+      .toHaveClass('gap-field')
     expect(screen.getByText('Cache path')).not.toHaveClass('font-mono')
   })
 })

--- a/studio/web/src/pages/tools/settings/fields.tsx
+++ b/studio/web/src/pages/tools/settings/fields.tsx
@@ -15,9 +15,9 @@ export function SettingsSection({
 }) {
   const titleEl = <h2 className="type-panel-title">{title}</h2>
   return (
-    <section id={id} className="rounded-md border border-subtle bg-surface p-4 flex flex-col gap-3 scroll-mt-24">
+    <section id={id} className="rounded-md border border-subtle bg-surface p-section flex flex-col gap-field scroll-mt-24">
       {headerExtras ? (
-        <div className="flex items-center gap-2 mb-0.5">
+        <div className="flex items-center gap-related mb-0.5">
           {titleEl}
           {headerExtras}
         </div>
@@ -117,8 +117,8 @@ export function SettingsField({ label, helpTooltip, children }: {
   children: React.ReactNode
 }) {
   return (
-    <div className="grid grid-cols-[240px_1fr] gap-3 items-start">
-      <div className="flex items-center gap-2 min-w-0 pt-1.5">
+    <div className="grid grid-cols-[240px_1fr] gap-field items-start">
+      <div className="flex items-center gap-related min-w-0 pt-1.5">
         <label className="type-field-label">{label}</label>
         {helpTooltip && <InfoButton>{helpTooltip}</InfoButton>}
       </div>

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -85,6 +85,14 @@
   --s-12: 48px;
   --s-16: 64px;
 
+  /* semantic spacing — Tailwind aliases live in tailwind.config.js */
+  --space-related: var(--s-2);
+  --space-field: var(--s-3);
+  --space-section: var(--s-4);
+  --space-page-start: var(--s-5);
+  --space-page: var(--s-6);
+  --space-page-loose: var(--s-8);
+
   /* radius */
   --r-sm: 4px;
   --r-md: 6px;

--- a/studio/web/tailwind.config.js
+++ b/studio/web/tailwind.config.js
@@ -74,6 +74,18 @@ export default {
         '3xl':  ['var(--t-3xl)', { lineHeight: '1.15' }],
       },
 
+      // ── 语义间距 → CSS 变量，支持运行时密度调节 ──────────────────
+      // 数字 utility 暂时保留为兼容路径；共享壳层和新代码按关系选用：
+      // related < field < section < page-start < page < page-loose。
+      spacing: {
+        related: 'var(--space-related)',
+        field: 'var(--space-field)',
+        section: 'var(--space-section)',
+        'page-start': 'var(--space-page-start)',
+        page: 'var(--space-page)',
+        'page-loose': 'var(--space-page-loose)',
+      },
+
       // ── 阴影 → CSS 变量，支持深色模式自动切换 ───────────────────
       // 用法: shadow-sm  shadow-md  shadow-lg  shadow-xl
       boxShadow: {


### PR DESCRIPTION
## 变更摘要

- 新增 `related / field / section / page-start / page / page-loose` 语义间距，并通过现有 `--s-*` token 响应 `tight / default / loose` 密度。
- 在 `DESIGN.md` 中补充间距层级、垂直节奏、页面壳层对齐以及固定几何值的适用边界。
- 迁移共享 `PageHeader` 与 `StepShell`，统一 Header、工具栏和内容区域的水平边距及垂直节奏。
- 迁移 Projects、Queue、Generate、Settings 的代表性页面外壳，以及 Preprocess、Regularization 的 Header 下工具栏。
- 保留数字 spacing utility 作为兼容路径；不修改专业画布、队列表格行高、表单控件内部 padding 或业务逻辑。
- 新增并更新组件与页面测试，约束共享壳层及代表场景的语义间距。

## 验证

- [x] 重点 Vitest：5 个文件、25 个测试通过
- [x] 最终补充 Vitest：3 个文件、6 个测试通过
- [x] 全量 Vitest：83 个文件、703 个测试通过
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] `venv/Scripts/python.exe -m pytest tests/test_route_snapshot.py -q`
- [x] Impeccable layout detector：0 findings
- [x] 已确认 Production CSS 生成全部语义及负向间距类
- [x] 用户完成浅色/深色、密度及代表页面视觉检查

## 影响范围

默认密度下尽量保持既有像素值；主要变化是页面壳层与相邻区域开始随密度一致收紧或放宽。未更改接口、数据流、路由、任务行为、Dialog、专业工作台内部几何布局。

## 审查说明

配置的 scout 因代理队列错误及空响应未产出报告；按项目策略未擅自替换其模型。本次范围由本地 token、Tailwind、共享壳层、代表页面与测试审计收敛。
