### PR TITLE
feat(web): 统一表单控件契约

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,7 +25,7 @@ surface has identical density.
 | --- | --- | --- |
 | Foundation | `studio/web/src/styles/tokens.css` | Color, type, spacing, radius, shadow, motion, control states |
 | Utility bridge | `studio/web/tailwind.config.js` | Maps CSS tokens into Tailwind utilities |
-| Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx` | Typed, accessible component APIs |
+| Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx`, `FormControl.tsx` | Typed, accessible component APIs |
 | Patterns | `PageHeader`, `StepShell`, `Dialog`, `Toast`, `Field` | Repeated page and interaction structures |
 | Product surfaces | `studio/web/src/pages/` | Business state and composition, not new visual primitives |
 
@@ -191,10 +191,36 @@ Use `EmptyState` when a list or page region has no content to present:
 Do not reproduce `rounded-* + border-subtle + bg-surface` for an ordinary card or
 hand-build centered zero-state typography on product pages.
 
-## 7. Forms and help text
+## 7. Form-control contract
 
-Default forms use the standard `.input` surface. Parameter-heavy schema forms may
-use their existing compact canvas treatment as an explicit density variant.
+Use the typed `Input`, `Select`, `Textarea`, and `Checkbox` primitives for ordinary
+native form controls. They preserve browser semantics while sharing focus, disabled,
+invalid, sizing, and theme behavior. The legacy `.input` and `.input-mono` classes
+remain compatibility paths during incremental migration.
+
+Control sizes:
+
+- `md` is the default for dialogs and ordinary forms and aligns with `Button md`.
+- `sm` is for settings rows, filter toolbars, schema forms, and other explicitly
+  compact workbench regions; it must not be recreated with local padding overrides.
+
+Control surfaces communicate placement, not state:
+
+- `surface` is the ordinary form plane and default.
+- `canvas` is the compact Schema `Field` treatment inside a surrounding surface.
+- `sunken` is for settings wells and data-entry regions designed as inset controls.
+
+Use `mono` only for paths, identifiers, JSON, numeric technical values, and other
+machine-readable content. Errors pair visible recovery copy with `invalid`, which
+exposes `aria-invalid` and the shared error border/focus ring. Disabled appearance,
+keyboard focus, placeholder color, and checkbox accent come from the primitive.
+Do not replace a native select or checkbox with a custom interaction only to alter
+its appearance.
+
+The primitive owns presentation only. Debouncing, parsing, commit-on-blur, schema
+validation, picker composition, and business state remain in Field or product
+patterns. File/color/range inputs and composite pickers require their own contracts
+and are not styled as text controls by default.
 
 Settings explanations belong in the label-adjacent `InfoButton` tooltip according
 to `docs/design/ui-info-design.md`; do not add permanent explanatory paragraphs

--- a/studio/web/src/components/CheckboxDropdown.test.tsx
+++ b/studio/web/src/components/CheckboxDropdown.test.tsx
@@ -30,6 +30,8 @@ describe('CheckboxDropdown', () => {
     fireEvent.click(trigger)
     expect(trigger).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('已选 1 / 2')).toBeInTheDocument()
+    expect(screen.getByRole('checkbox', { name: 'Alpha' }))
+      .toHaveClass('form-checkbox', 'form-checkbox-sm')
   })
 
   it('selects and clears the complete option set', () => {

--- a/studio/web/src/components/CheckboxDropdown.tsx
+++ b/studio/web/src/components/CheckboxDropdown.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Button from './Button'
+import { Checkbox } from './FormControl'
 
 export interface CheckboxDropdownOption {
   value: string
@@ -107,8 +108,8 @@ export default function CheckboxDropdown({
                 className="flex items-center gap-1.5 px-2.5 py-1 text-xs cursor-pointer hover:bg-overlay"
                 title={o.title ?? o.label}
               >
-                <input
-                  type="checkbox"
+                <Checkbox
+                  controlSize="sm"
                   checked={selected.has(o.value)}
                   onChange={() => toggle(o.value)}
                 />

--- a/studio/web/src/components/Dialog.test.tsx
+++ b/studio/web/src/components/Dialog.test.tsx
@@ -89,6 +89,7 @@ describe('Dialog (useDialog API)', () => {
     wrap((api) => api.prompt('名称'))
     await user.click(screen.getByText('trigger'))
     const input = screen.getByRole('textbox')
+    expect(input).toHaveClass('form-control', 'form-control-mono')
     // 先 click 聚焦再 type：避免 modal 刚开 / autofocus 未 settle 时 userEvent
     // 丢首字符（CI 慢机偶发 "y-preset"）。
     await user.click(input)
@@ -121,6 +122,7 @@ describe('Dialog (useDialog API)', () => {
     await user.type(screen.getByRole('textbox'), 'ab')
     await user.click(screen.getByText('确定'))
     expect(screen.getByText('至少 3 字符')).toBeInTheDocument()
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true')
     // 错误显示后 dialog 未关闭 — result 仍空
     expect(screen.getByTestId('result')).toHaveTextContent('')
   })

--- a/studio/web/src/components/Dialog.tsx
+++ b/studio/web/src/components/Dialog.tsx
@@ -22,6 +22,7 @@ import {
   useState,
   type ReactNode,
 } from 'react'
+import { Input } from './FormControl'
 
 export type DialogTone = 'default' | 'danger' | 'warn'
 
@@ -236,15 +237,16 @@ function DialogRoot({ state, onCancel, onOk }: RootProps) {
         {state.type === 'prompt' ? (
           <label className="flex flex-col gap-1.5">
             <span className="type-field-label">{state.label}</span>
-            <input
+            <Input
               ref={inputRef}
-              className="input input-mono font-mono"
+              mono
               value={inputValue}
               placeholder={state.options.placeholder}
               onChange={(e) => {
                 setInputValue(e.target.value)
                 if (error) setError(null)
               }}
+              invalid={Boolean(error)}
             />
             {error && (
               <span className="text-xs text-err">{error}</span>

--- a/studio/web/src/components/Field.test.tsx
+++ b/studio/web/src/components/Field.test.tsx
@@ -43,6 +43,8 @@ describe('Field number input (PP10.3)', () => {
     )
 
     expect(container.querySelector('.type-field-label')).toBeInTheDocument()
+    expect(screen.getByRole('textbox'))
+      .toHaveClass('form-control', 'form-control-sm', 'form-control-canvas', 'form-control-mono')
     expect(screen.getByText('Controls the learning rate.')).toHaveClass('type-field-help')
   })
 
@@ -377,5 +379,6 @@ describe('Field code input', () => {
     fireEvent.blur(input)
     expect(onChange).not.toHaveBeenCalled()
     expect(screen.getByText('Invalid JSON')).toBeInTheDocument()
+    expect(input).toHaveAttribute('aria-invalid', 'true')
   })
 })

--- a/studio/web/src/components/Field.tsx
+++ b/studio/web/src/components/Field.tsx
@@ -4,6 +4,7 @@ import type { SchemaProperty } from '../api/client'
 import { useProjectCtx } from '../context/ProjectContext'
 import { controlKind, fieldLabel, schemaEnumLabel } from '../lib/schema'
 import { useAutoGrowTextarea } from '../lib/useAutoGrowTextarea'
+import { Checkbox, Input, Select, Textarea } from './FormControl'
 import ModelPathPicker from './ModelPathPicker'
 import PathPicker from './PathPicker'
 import ResumeFieldPicker from './ResumeFieldPicker'
@@ -37,24 +38,6 @@ interface Props {
   disabledOptionHint?: string
 }
 
-// input 覆盖 .input 默认值（更紧凑；背景用 canvas 而不是 surface）
-const inputStyle: React.CSSProperties = {
-  width: '100%', padding: '5px 10px',
-  background: 'var(--bg-canvas)', border: '1px solid var(--border-default)',
-  borderRadius: 'var(--r-sm)', fontSize: 'var(--t-sm)',
-  color: 'var(--fg-primary)',
-}
-
-// disabled 灰显：行内 inputStyle 指定了 background/color，浏览器默认的
-// disabled 外观被盖掉 —— input/textarea 必须显式叠加（checkbox 的
-// opacity-60 wrapper / select 的原生灰显不受此影响）。
-const disabledInputStyle: React.CSSProperties = {
-  ...inputStyle, opacity: 0.55, cursor: 'not-allowed',
-}
-
-const fieldStyle = (disabled: boolean): React.CSSProperties =>
-  disabled ? disabledInputStyle : inputStyle
-
 const FieldHint = ({ children }: { children: React.ReactNode }) => (
   <span className="ml-2 text-[11px] text-warn align-middle">{children}</span>
 )
@@ -75,15 +58,14 @@ export default function Field({
   // bool ----------------------------------------------------------------
   if (kind === 'bool') {
     return (
-      <label className={`flex items-start gap-3 py-1.5 ${disabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}>
-        <input
-          type="checkbox"
+      <label className={`flex items-start gap-3 py-1.5 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer'}`}>
+        <Checkbox
           checked={Boolean(value)}
           onChange={(e) => onChange(e.target.checked)}
           disabled={disabled}
-          style={{ marginTop: 4, height: 16, width: 16, borderRadius: 'var(--r-sm)' }}
+          className="mt-1"
         />
-        <span className="flex-1">
+        <span className={`flex-1 ${disabled ? 'opacity-60' : ''}`}>
           <div className="text-sm text-fg-primary">
             {label}
             {hintNode}
@@ -102,19 +84,20 @@ export default function Field({
         <div className="type-field-label mb-1">
           {label}{hintNode}
         </div>
-        <select
+        <Select
           value={triValue}
           onChange={(e) => {
             const v = e.target.value
             onChange(v === 'true' ? true : v === 'false' ? false : null)
           }}
           disabled={disabled}
-          className="input" style={inputStyle}
+          controlSize="sm"
+          surface="canvas"
         >
           <option value="">{t('field.useGlobal')}</option>
           <option value="true">{t('field.yes')}</option>
           <option value="false">{t('field.no')}</option>
-        </select>
+        </Select>
         {help && <div className="type-field-help mt-1">{help}</div>}
       </div>
     )
@@ -127,11 +110,12 @@ export default function Field({
         <div className="type-field-label mb-1">
           {label}{hintNode}
         </div>
-        <select
+        <Select
           value={String(value ?? '')}
           onChange={(e) => onChange(e.target.value)}
           disabled={disabled}
-          className="input" style={inputStyle}
+          controlSize="sm"
+          surface="canvas"
         >
           {(enumOptions ?? prop.enum ?? []).map((opt) => {
             // 当前已选中的值即使被禁也保持可选中状态渲染（表单如实反映
@@ -150,7 +134,7 @@ export default function Field({
               </option>
             )
           })}
-        </select>
+        </Select>
         {help && <div className="type-field-help mt-1">{help}</div>}
       </div>
     )
@@ -268,13 +252,16 @@ function TextareaField({
       <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
-      <textarea
+      <Textarea
         ref={taRef}
         rows={5}
         value={text}
         onChange={(e) => onChange(e.target.value)}
         disabled={disabled}
-        className="input input-mono resize-none overflow-hidden" style={fieldStyle(disabled)}
+        controlSize="sm"
+        surface="canvas"
+        mono
+        className="resize-none overflow-hidden"
       />
       {help && <div className="type-field-help mt-1">{help}</div>}
     </div>
@@ -305,7 +292,7 @@ function StringListField({
       <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
-      <textarea
+      <Textarea
         ref={taRef}
         rows={5}
         value={raw}
@@ -315,7 +302,10 @@ function StringListField({
         }}
         onBlur={() => setRaw(parse(raw).join('\n'))}
         disabled={disabled}
-        className="input input-mono resize-none overflow-hidden" style={fieldStyle(disabled)}
+        controlSize="sm"
+        surface="canvas"
+        mono
+        className="resize-none overflow-hidden"
       />
       {help && <div className="type-field-help mt-1">{help}</div>}
     </div>
@@ -377,7 +367,7 @@ function JsonCodeField({
       <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
-      <textarea
+      <Textarea
         ref={inputRef}
         rows={Math.max(3, raw.split('\n').length + 1)}
         value={raw}
@@ -387,8 +377,10 @@ function JsonCodeField({
         }}
         onBlur={commit}
         disabled={disabled}
-        className="input input-mono"
-        style={fieldStyle(disabled)}
+        controlSize="sm"
+        surface="canvas"
+        mono
+        invalid={Boolean(error)}
       />
       {error && <div className="text-xs text-err mt-1">{error}</div>}
       {help && <div className="type-field-help mt-1">{help}</div>}
@@ -444,7 +436,7 @@ function IntListField({
       <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
-      <input
+      <Input
         ref={inputRef}
         type="text"
         inputMode="numeric"
@@ -458,7 +450,9 @@ function IntListField({
           }
         }}
         disabled={disabled}
-        className="input input-mono" style={fieldStyle(disabled)}
+        controlSize="sm"
+        surface="canvas"
+        mono
         placeholder={placeholder}
       />
       {help && <div className="type-field-help mt-1">{help}</div>}
@@ -521,7 +515,7 @@ function NumberField({
       <div className="type-field-label mb-1">
         {label}{hintNode}
       </div>
-      <input
+      <Input
         ref={inputRef}
         type="text"
         inputMode={kind === 'int' ? 'numeric' : 'decimal'}
@@ -535,7 +529,9 @@ function NumberField({
           }
         }}
         disabled={disabled}
-        className="input input-mono" style={fieldStyle(disabled)}
+        controlSize="sm"
+        surface="canvas"
+        mono
       />
       {help && <div className="type-field-help mt-1">{help}</div>}
     </div>
@@ -598,16 +594,15 @@ function PathStringField({
       <div className="flex gap-2">
         {/* 模型路径字段：input 末尾内嵌下箭头开 dropdown，不额外占一个按钮位 */}
         <div className="relative flex-1 min-w-0">
-          <input
+          <Input
             type="text"
             value={text}
             onChange={(e) => onChange(e.target.value)}
             disabled={disabled}
-            className={'input' + (kind === 'path' ? ' input-mono' : '')}
-            style={{
-              ...fieldStyle(disabled),
-              ...(useModelPicker ? { paddingRight: 30 } : null),
-            }}
+            controlSize="sm"
+            surface="canvas"
+            mono={kind === 'path'}
+            style={useModelPicker ? { paddingRight: 30 } : undefined}
           />
           {useModelPicker && (
             <button

--- a/studio/web/src/components/FormControl.test.tsx
+++ b/studio/web/src/components/FormControl.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import {
+  Checkbox,
+  Input,
+  Select,
+  Textarea,
+  controlClassName,
+} from './FormControl'
+
+describe('FormControl primitives', () => {
+  it('applies the default input contract without changing native semantics', () => {
+    render(<Input aria-label="Name" />)
+    expect(screen.getByRole('textbox', { name: 'Name' }))
+      .toHaveClass('form-control', 'form-control-surface')
+  })
+
+  it('maps compact, surface, and technical-value options', () => {
+    render(<Input aria-label="Path" controlSize="sm" surface="canvas" mono />)
+    expect(screen.getByRole('textbox', { name: 'Path' }))
+      .toHaveClass('form-control-sm', 'form-control-canvas', 'form-control-mono')
+  })
+
+  it('preserves native select and textarea elements', () => {
+    render(
+      <>
+        <Select aria-label="Mode" surface="sunken"><option>Auto</option></Select>
+        <Textarea aria-label="Prompt" rows={3} />
+      </>,
+    )
+
+    expect(screen.getByRole('combobox', { name: 'Mode' }))
+      .toHaveClass('form-control-sunken')
+    expect(screen.getByRole('textbox', { name: 'Prompt' }))
+      .toHaveClass('form-control-textarea')
+  })
+
+  it('exposes invalid state to assistive technology', () => {
+    render(<Input aria-label="JSON" invalid />)
+    expect(screen.getByRole('textbox', { name: 'JSON' }))
+      .toHaveAttribute('aria-invalid', 'true')
+  })
+
+  it('keeps checkbox behavior native while applying the shared size', () => {
+    render(<Checkbox aria-label="Enabled" controlSize="sm" disabled />)
+    const checkbox = screen.getByRole('checkbox', { name: 'Enabled' })
+    expect(checkbox).toHaveClass('form-checkbox', 'form-checkbox-sm')
+    expect(checkbox).toBeDisabled()
+  })
+
+  it('builds classes for consumers that cannot use the React primitive yet', () => {
+    expect(controlClassName({ size: 'sm', surface: 'sunken', className: 'max-w-32' }))
+      .toBe('form-control form-control-sm form-control-sunken max-w-32')
+  })
+})

--- a/studio/web/src/components/FormControl.tsx
+++ b/studio/web/src/components/FormControl.tsx
@@ -1,0 +1,152 @@
+import {
+  forwardRef,
+  type InputHTMLAttributes,
+  type SelectHTMLAttributes,
+  type TextareaHTMLAttributes,
+} from 'react'
+
+export type FormControlSize = 'md' | 'sm'
+export type FormControlSurface = 'surface' | 'canvas' | 'sunken'
+
+const SIZE_CLASS: Record<FormControlSize, string> = {
+  md: '',
+  sm: 'form-control-sm',
+}
+
+const SURFACE_CLASS: Record<FormControlSurface, string> = {
+  surface: 'form-control-surface',
+  canvas: 'form-control-canvas',
+  sunken: 'form-control-sunken',
+}
+
+export function controlClassName({
+  size = 'md',
+  surface = 'surface',
+  mono = false,
+  className = '',
+}: {
+  size?: FormControlSize
+  surface?: FormControlSurface
+  mono?: boolean
+  className?: string
+} = {}): string {
+  return [
+    'form-control',
+    SIZE_CLASS[size],
+    SURFACE_CLASS[surface],
+    mono && 'form-control-mono',
+    className,
+  ].filter(Boolean).join(' ')
+}
+
+interface VisualControlProps {
+  controlSize?: FormControlSize
+  surface?: FormControlSurface
+  mono?: boolean
+  invalid?: boolean
+}
+
+export interface InputProps
+  extends InputHTMLAttributes<HTMLInputElement>,
+    VisualControlProps {}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input({
+  controlSize = 'md',
+  surface = 'surface',
+  mono = false,
+  invalid = false,
+  className,
+  'aria-invalid': ariaInvalid,
+  ...rest
+}, ref) {
+  return (
+    <input
+      {...rest}
+      ref={ref}
+      aria-invalid={invalid || ariaInvalid || undefined}
+      className={controlClassName({ size: controlSize, surface, mono, className })}
+    />
+  )
+})
+
+export interface SelectProps
+  extends SelectHTMLAttributes<HTMLSelectElement>,
+    VisualControlProps {}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select({
+  controlSize = 'md',
+  surface = 'surface',
+  mono = false,
+  invalid = false,
+  className,
+  'aria-invalid': ariaInvalid,
+  children,
+  ...rest
+}, ref) {
+  return (
+    <select
+      {...rest}
+      ref={ref}
+      aria-invalid={invalid || ariaInvalid || undefined}
+      className={controlClassName({ size: controlSize, surface, mono, className })}
+    >
+      {children}
+    </select>
+  )
+})
+
+export interface TextareaProps
+  extends TextareaHTMLAttributes<HTMLTextAreaElement>,
+    VisualControlProps {}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea({
+  controlSize = 'md',
+  surface = 'surface',
+  mono = false,
+  invalid = false,
+  className,
+  'aria-invalid': ariaInvalid,
+  ...rest
+}, ref) {
+  return (
+    <textarea
+      {...rest}
+      ref={ref}
+      aria-invalid={invalid || ariaInvalid || undefined}
+      className={controlClassName({
+        size: controlSize,
+        surface,
+        mono,
+        className: ['form-control-textarea', className].filter(Boolean).join(' '),
+      })}
+    />
+  )
+})
+
+export interface CheckboxProps
+  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'type'> {
+  controlSize?: FormControlSize
+  invalid?: boolean
+}
+
+export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox({
+  controlSize = 'md',
+  invalid = false,
+  className,
+  'aria-invalid': ariaInvalid,
+  ...rest
+}, ref) {
+  return (
+    <input
+      {...rest}
+      ref={ref}
+      type="checkbox"
+      aria-invalid={invalid || ariaInvalid || undefined}
+      className={[
+        'form-checkbox',
+        controlSize === 'sm' && 'form-checkbox-sm',
+        className,
+      ].filter(Boolean).join(' ')}
+    />
+  )
+})

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { api, type BundleImportResult, type ProjectSummary, type VersionStatus } from '../api/client'
+import { Input, Select } from '../components/FormControl'
 import PageHeader from '../components/PageHeader'
 import PathPicker from '../components/PathPicker'
 import UploadProgressBar from '../components/UploadProgressBar'
@@ -405,18 +406,18 @@ function FilterBar({
   const { t } = useTranslation()
   return (
     <div className="px-page py-related border-b border-subtle flex items-center gap-field">
-      <input
-        className="input"
-        style={{ width: '60%' }}
+      <Input
+        controlSize="sm"
+        className="w-3/5"
         value={query}
         onChange={(e) => onQuery(e.target.value)}
         placeholder={t('projects.searchPlaceholder')}
         aria-label={t('common.search')}
       />
       <span className="flex-1" />
-      <select
-        className="input"
-        style={{ width: '10%', minWidth: 104 }}
+      <Select
+        controlSize="sm"
+        className="w-[10%] min-w-[104px]"
         value={status}
         onChange={(e) => onStatus(e.target.value as ProjectStatusFilter)}
         aria-label={t('common.status')}
@@ -426,10 +427,10 @@ function FilterBar({
             {s === 'all' ? t('projects.statusAll') : t(`versionStatus.${s}`)}
           </option>
         ))}
-      </select>
-      <select
-        className="input"
-        style={{ width: '10%', minWidth: 104 }}
+      </Select>
+      <Select
+        controlSize="sm"
+        className="w-[10%] min-w-[104px]"
         value={sort}
         onChange={(e) => onSort(e.target.value as ProjectSortKey)}
         aria-label={t('projects.sortLabel')}
@@ -437,7 +438,7 @@ function FilterBar({
         {SORT_OPTIONS.map((s) => (
           <option key={s} value={s}>{t(`projects.sort_${s}`)}</option>
         ))}
-      </select>
+      </Select>
     </div>
   )
 }

--- a/studio/web/src/pages/Queue.test.tsx
+++ b/studio/web/src/pages/Queue.test.tsx
@@ -148,6 +148,8 @@ describe('QueuePage 分区 + 分页', () => {
     fireEvent.click(screen.getByTestId('queue-filter-toggle'))
     expect(screen.getByTestId('queue-filterbar'))
       .toHaveClass('px-page', 'py-related', 'gap-field')
+    expect(screen.getByTestId('queue-search'))
+      .toHaveClass('form-control', 'form-control-sm', 'form-control-surface')
     fireEvent.change(screen.getByTestId('queue-search'), { target: { value: 'abc' } })
 
     await waitFor(
@@ -318,6 +320,8 @@ describe('QueuePage 分区 + 分页', () => {
     expect(screen.queryByText(/等待入队/)).not.toBeInTheDocument()
     fireEvent.click(screen.getByTestId('queue-filter-toggle'))
     expect(screen.getByTestId('jobs-kind-filter')).toBeInTheDocument()
+    expect(screen.getByTestId('jobs-kind-filter'))
+      .toHaveClass('form-control', 'form-control-sm', 'form-control-surface')
     expect(screen.getByTestId('jobs-search')).toBeInTheDocument()
     // 任务视图专属的搜索框不在
     expect(screen.queryByTestId('queue-search')).not.toBeInTheDocument()

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -8,6 +8,7 @@ import {
 import { DATA_VIEW_KINDS } from './queue/jobUtils'
 import Card from '../components/Card'
 import EmptyState from '../components/EmptyState'
+import { Input, Select } from '../components/FormControl'
 import { HoldQueueModal, type HoldDecision } from '../components/HoldQueueModal'
 import { PauseConfirmModal } from '../components/PauseConfirmModal'
 import { PauseProgressModal } from '../components/PauseProgressModal'
@@ -913,9 +914,9 @@ export default function QueuePage() {
           className="px-page py-related border-b border-subtle flex items-center gap-field"
           data-testid="queue-jobs-filterbar"
         >
-          <input
-            className="input"
-            style={{ width: '60%' }}
+          <Input
+            controlSize="sm"
+            className="w-3/5"
             value={jobsSearch}
             onChange={(e) => setJobsSearch(e.target.value)}
             placeholder={t('queue.jobs.searchPlaceholder')}
@@ -923,9 +924,9 @@ export default function QueuePage() {
             data-testid="jobs-search"
           />
           <span className="flex-1" />
-          <select
-            className="input"
-            style={{ width: '15%', minWidth: 150 }}
+          <Select
+            controlSize="sm"
+            className="w-[15%] min-w-[150px]"
             value={jobsKind ?? 'all'}
             onChange={(e) => {
               const v = e.target.value
@@ -938,7 +939,7 @@ export default function QueuePage() {
             {DATA_VIEW_KINDS.map((k) => (
               <option key={k} value={k}>{t(`queue.jobs.kind.${k}`)}</option>
             ))}
-          </select>
+          </Select>
         </div>
       ) : (
         // 0.17 P-C/P-F 过滤行 —— 与项目页 FilterBar 一致：header 下全宽条。搜索 60%
@@ -948,9 +949,9 @@ export default function QueuePage() {
           className="px-page py-related border-b border-subtle flex items-center gap-field"
           data-testid="queue-filterbar"
         >
-          <input
-            className="input"
-            style={{ width: '60%' }}
+          <Input
+            controlSize="sm"
+            className="w-3/5"
             value={search}
             onChange={(e) => setSearch(e.target.value)}
             placeholder={t('queue.searchPlaceholder')}
@@ -958,9 +959,9 @@ export default function QueuePage() {
             data-testid="queue-search"
           />
           <span className="flex-1" />
-          <select
-            className="input"
-            style={{ width: '10%', minWidth: 120 }}
+          <Select
+            controlSize="sm"
+            className="w-[10%] min-w-[120px]"
             value={typeFilter ?? 'all'}
             onChange={(e) => {
               const v = e.target.value
@@ -975,10 +976,10 @@ export default function QueuePage() {
             <option value="reg_ai">{t('queue.typeReg')}</option>
             <option value="generate">{t('queue.typeGenerate')}</option>
             <option value="eval_session">{t('queue.jobs.kind.eval_session')}</option>
-          </select>
-          <select
-            className="input"
-            style={{ width: '10%', minWidth: 120 }}
+          </Select>
+          <Select
+            controlSize="sm"
+            className="w-[10%] min-w-[120px]"
             value={historyStatus ?? 'all'}
             onChange={(e) => {
               const v = e.target.value
@@ -992,7 +993,7 @@ export default function QueuePage() {
             <option value="done">{t('status.done')}</option>
             <option value="failed">{t('status.failed')}</option>
             <option value="canceled">{t('status.canceled')}</option>
-          </select>
+          </Select>
         </div>
       ))}
     >

--- a/studio/web/src/pages/tools/settings/WandBWorkspace.test.tsx
+++ b/studio/web/src/pages/tools/settings/WandBWorkspace.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { WandBConfig, WandBPreset } from '../../../api/client'
+import WandBWorkspace from './WandBWorkspace'
+
+const preset: WandBPreset = {
+  id: 'default',
+  label: 'Default',
+  api_key: '',
+  project: 'AnimaLoraStudio',
+  entity: '',
+  base_url: 'https://api.wandb.ai',
+  mode: 'online',
+  log_samples: false,
+  sample_max_side: 1216,
+  sample_every_n_steps: 0,
+  upload_model: false,
+  upload_model_policy: 'last',
+  upload_state_manual: false,
+  upload_state_manual_policy: 'last',
+  upload_state_auto: false,
+  upload_state_auto_policy: 'last',
+}
+
+const config: WandBConfig = {
+  enabled: false,
+  current_preset: preset.id,
+  presets: [preset],
+}
+
+describe('WandBWorkspace form layout', () => {
+  it('spaces field rows and gives every body control one shared width rail', () => {
+    render(
+      <WandBWorkspace
+        title="Weights & Biases"
+        config={config}
+        serverPresets={[preset]}
+        currentPreset={preset}
+        onToggleEnabled={vi.fn()}
+        onSelectPreset={vi.fn()}
+        onUpdatePreset={vi.fn()}
+        onAddPreset={vi.fn()}
+        onSaveAs={vi.fn()}
+        onDeletePreset={vi.fn()}
+        onExport={vi.fn()}
+        onImportFile={vi.fn()}
+      />,
+    )
+
+    const fields = screen.getByTestId('wandb-fields')
+    expect(fields).toHaveClass('flex', 'flex-col', 'gap-field')
+
+    const controls = fields.querySelectorAll('.form-control')
+    expect(controls).toHaveLength(9)
+    controls.forEach((control) => expect(control).toHaveClass('max-w-md'))
+  })
+})

--- a/studio/web/src/pages/tools/settings/WandBWorkspace.tsx
+++ b/studio/web/src/pages/tools/settings/WandBWorkspace.tsx
@@ -67,6 +67,8 @@ function PBtn({ children, onClick, variant, title }: {
 /** artifact 上传三档合并进一个 dropdown：关闭 / 仅保留最新 / 保留全部。 */
 type UploadChoice = 'off' | 'last' | 'all'
 
+const WANDB_CONTROL_CLASS = 'max-w-md'
+
 /**
  * WandB 预设工作区 —— 骨架与 LLMTaggerWorkspace 完全同款：
  * 卡片(header 标题 + PresetBar 预设条 + 主体)。区别只有两点：
@@ -123,7 +125,7 @@ export default function WandBWorkspace({
           if (v === 'off') apply(false, policy)
           else apply(true, v)
         }}
-        className={`${textInputClass} max-w-40`}
+        className={`${textInputClass} ${WANDB_CONTROL_CLASS}`}
       >
         <option value="off">{t('settings.boolDisabled')}</option>
         <option value="last">{t('settings.policyLast')}</option>
@@ -220,14 +222,19 @@ export default function WandBWorkspace({
       </div>
 
       {/* 主体：单 section（wandb 字段少，不需要 LLM 的双栏 grid） */}
-      <div style={{ padding: '12px 16px 14px' }}>
-        <p className="m-0 mb-3 text-xs text-fg-tertiary">{t('settings.wandbPresetHint')}</p>
+      <div
+        className="flex flex-col gap-field"
+        data-testid="wandb-fields"
+        style={{ padding: '12px 16px 14px' }}
+      >
+        <p className="m-0 text-xs text-fg-tertiary">{t('settings.wandbPresetHint')}</p>
 
         <SettingsField label={t('settings.fieldApiKey')}>
           <SensitiveInput
             value={currentPreset.api_key}
             serverValue={serverPreset?.api_key ?? ''}
             onChange={(v) => onUpdatePreset({ api_key: v })}
+            className={WANDB_CONTROL_CLASS}
           />
         </SettingsField>
         <SettingsField label={t('settings.fieldProject')}>
@@ -236,7 +243,7 @@ export default function WandBWorkspace({
             value={currentPreset.project}
             onChange={(v) => onUpdatePreset({ project: v })}
             placeholder="AnimaLoraStudio"
-            className={textInputClass}
+            className={`${textInputClass} ${WANDB_CONTROL_CLASS}`}
           />
         </SettingsField>
         <SettingsField label={t('settings.fieldEntity')} helpTooltip={<p>{t('settings.wandbEntityHint')}</p>}>
@@ -244,7 +251,7 @@ export default function WandBWorkspace({
             type="text"
             value={currentPreset.entity}
             onChange={(v) => onUpdatePreset({ entity: v })}
-            className={textInputClass}
+            className={`${textInputClass} ${WANDB_CONTROL_CLASS}`}
           />
         </SettingsField>
         <SettingsField label={t('settings.fieldBaseUrl')} helpTooltip={<p>{t('settings.wandbBaseUrlHint')}</p>}>
@@ -253,14 +260,14 @@ export default function WandBWorkspace({
             value={currentPreset.base_url}
             onChange={(v) => onUpdatePreset({ base_url: v })}
             placeholder="https://api.wandb.ai"
-            className={textInputClass}
+            className={`${textInputClass} ${WANDB_CONTROL_CLASS}`}
           />
         </SettingsField>
         <SettingsField label={t('settings.fieldMode')}>
           <select
             value={currentPreset.mode}
             onChange={(e) => onUpdatePreset({ mode: e.target.value as WandBPreset['mode'] })}
-            className={`${textInputClass} max-w-32`}
+            className={`${textInputClass} ${WANDB_CONTROL_CLASS}`}
           >
             <option value="online">online</option>
             <option value="offline">offline</option>
@@ -273,7 +280,11 @@ export default function WandBWorkspace({
             <p><Trans i18nKey="settings.logSamplesHelp" components={{ code: <code /> }} /></p>
           }
         >
-          <Bool value={currentPreset.log_samples} onChange={(v) => onUpdatePreset({ log_samples: v })} />
+          <Bool
+            value={currentPreset.log_samples}
+            onChange={(v) => onUpdatePreset({ log_samples: v })}
+            className={WANDB_CONTROL_CLASS}
+          />
         </SettingsField>
         {currentPreset.log_samples && (
           <>
@@ -287,7 +298,7 @@ export default function WandBWorkspace({
                 step={64}
                 value={currentPreset.sample_max_side}
                 onChange={(v) => onUpdatePreset({ sample_max_side: Math.max(64, parseInt(v) || 1216) })}
-                className={textInputClass}
+                className={`${textInputClass} ${WANDB_CONTROL_CLASS}`}
               />
             </SettingsField>
             <SettingsField
@@ -302,7 +313,7 @@ export default function WandBWorkspace({
                 step={50}
                 value={currentPreset.sample_every_n_steps}
                 onChange={(v) => onUpdatePreset({ sample_every_n_steps: Math.max(0, parseInt(v) || 0) })}
-                className={textInputClass}
+                className={`${textInputClass} ${WANDB_CONTROL_CLASS}`}
               />
             </SettingsField>
           </>
@@ -310,7 +321,7 @@ export default function WandBWorkspace({
 
         {/* artifact 上传与采样图无关，不随 log_samples 隐藏；
             开关 + 保留策略两个下拉合并为三档单下拉：关闭 / 仅保留最新 / 保留全部 */}
-        <h4 className="text-xs font-semibold text-zinc-400 uppercase tracking-wider mt-4 mb-2">
+        <h4 className="type-section-label mt-related">
           {t('settings.uploadArtifacts')}
         </h4>
         {uploadSelect(

--- a/studio/web/src/pages/tools/settings/constants.ts
+++ b/studio/web/src/pages/tools/settings/constants.ts
@@ -1,4 +1,5 @@
 import type { TFunction } from 'i18next'
+import { controlClassName } from '../../../components/FormControl'
 import {
   DEFAULT_WD14_MODELS,
   type LLMPreset,
@@ -254,7 +255,8 @@ export const EMPTY: Secrets = {
   tag_dictionary: { show_translation: null, autocomplete: null },
 }
 
-export const textInputClass = 'w-full px-2 py-1 outline-none rounded-sm bg-sunken border border-subtle text-sm text-fg-primary focus:border-accent'
+/** 兼容设置页尚未逐项迁移的原生控件；视觉契约由 FormControl 统一提供。 */
+export const textInputClass = controlClassName({ size: 'sm', surface: 'sunken' })
 
 export const MODEL_DESCRIPTION_KEYS: Record<string, string> = {
   anima_main: 'settings.modelDescriptions.animaMain',

--- a/studio/web/src/pages/tools/settings/fields.test.tsx
+++ b/studio/web/src/pages/tools/settings/fields.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
-import { SettingsField, SettingsSection } from './fields'
+import { Bool, SettingsField, SettingsSection } from './fields'
 
 describe('settings hierarchy', () => {
   it('uses shared panel, field, and spacing roles without treating UI labels as code', () => {
@@ -19,5 +19,11 @@ describe('settings hierarchy', () => {
     expect(screen.getByText('Cache path').parentElement?.parentElement)
       .toHaveClass('gap-field')
     expect(screen.getByText('Cache path')).not.toHaveClass('font-mono')
+  })
+
+  it('uses the compact sunken form-control contract for boolean settings', () => {
+    render(<Bool value onChange={() => {}} />)
+    expect(screen.getByRole('combobox'))
+      .toHaveClass('form-control', 'form-control-sm', 'form-control-sunken')
   })
 })

--- a/studio/web/src/pages/tools/settings/fields.tsx
+++ b/studio/web/src/pages/tools/settings/fields.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { InfoButton } from '../../../components/InfoButton'
-import { MASK, textInputClass } from './constants'
+import { Input, Select } from '../../../components/FormControl'
+import { MASK } from './constants'
 
 // ── Section / Field ────────────────────────────────────────────────────────
 
@@ -127,23 +128,33 @@ export function SettingsField({ label, helpTooltip, children }: {
   )
 }
 
-export function Bool({ value, onChange, disabled }: { value: boolean; onChange: (v: boolean) => void; disabled?: boolean }) {
+export function Bool({ value, onChange, disabled, className = 'max-w-32' }: {
+  value: boolean
+  onChange: (v: boolean) => void
+  disabled?: boolean
+  className?: string
+}) {
   const { t } = useTranslation()
   return (
-    <select
+    <Select
       value={value ? 'on' : 'off'}
       onChange={(e) => onChange(e.target.value === 'on')}
       disabled={disabled}
-      className={`${textInputClass} max-w-32 disabled:opacity-60`}
+      controlSize="sm"
+      surface="sunken"
+      className={className}
     >
       <option value="on">{t('settings.boolEnabled')}</option>
       <option value="off">{t('settings.boolDisabled')}</option>
-    </select>
+    </Select>
   )
 }
 
-export function SensitiveInput({ value, serverValue, onChange }: {
-  value: string; serverValue: string; onChange: (v: string) => void
+export function SensitiveInput({ value, serverValue, onChange, className }: {
+  value: string
+  serverValue: string
+  onChange: (v: string) => void
+  className?: string
 }) {
   const { t } = useTranslation()
   const [localValue, setLocalValue] = useState(value)
@@ -167,7 +178,7 @@ export function SensitiveInput({ value, serverValue, onChange }: {
   }
 
   return (
-    <input
+    <Input
       type="password"
       value={masked ? '' : localValue}
       placeholder={serverValue === MASK ? t('settings.sensitiveSavedPlaceholder') : ''}
@@ -178,7 +189,9 @@ export function SensitiveInput({ value, serverValue, onChange }: {
       data-lpignore="true"
       data-1p-ignore
       data-form-type="other"
-      className={textInputClass}
+      controlSize="sm"
+      surface="sunken"
+      className={className}
     />
   )
 }

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -438,7 +438,8 @@ select option:checked {
 
 @media (prefers-reduced-motion: reduce) {
   .btn,
-  .card-hover { transition: none; }
+  .card-hover,
+  .form-control { transition: none; }
   .btn-spinner,
   .dot-running { animation: none; }
 }
@@ -496,19 +497,69 @@ select option:checked {
   transform: none;
 }
 
+.form-control,
 .input {
-  background: var(--bg-surface);
+  background: var(--form-control-bg, var(--bg-surface));
   border: 1px solid var(--border-default);
   border-radius: var(--r-md);
   padding: 7px 12px;
   font-size: var(--t-base);
   color: var(--fg-primary);
   outline: none;
-  transition: border-color 100ms ease, box-shadow 100ms ease;
+  transition: border-color 100ms ease, box-shadow 100ms ease, background-color 100ms ease;
   width: 100%;
 }
-.input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.form-control {
+  min-height: 38px;
+  line-height: 1.4;
+}
+.form-control-surface { --form-control-bg: var(--bg-surface); }
+.form-control-canvas { --form-control-bg: var(--bg-canvas); }
+.form-control-sunken { --form-control-bg: var(--bg-sunken); }
+.form-control-sm {
+  min-height: 30px;
+  padding: 4px 10px;
+  border-radius: var(--r-sm);
+  font-size: var(--t-sm);
+}
+.form-control-textarea { min-height: 0; }
+.form-control:focus-visible,
+.input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.form-control:disabled {
+  background: var(--bg-sunken);
+  color: var(--fg-disabled);
+  cursor: not-allowed;
+}
+.form-control[aria-invalid="true"] { border-color: var(--err); }
+.form-control[aria-invalid="true"]:focus-visible {
+  border-color: var(--err);
+  box-shadow: 0 0 0 3px var(--err-soft);
+}
+.form-control::placeholder { color: var(--fg-tertiary); }
+.form-control-mono,
 .input-mono { font-family: var(--font-mono); font-size: var(--t-sm); }
+
+.form-checkbox {
+  width: 16px;
+  height: 16px;
+  margin: 0;
+  flex: 0 0 auto;
+  accent-color: var(--accent-control);
+  cursor: pointer;
+}
+.form-checkbox-sm { width: 14px; height: 14px; }
+.form-checkbox:focus-visible {
+  outline: 3px solid var(--accent-soft);
+  outline-offset: 2px;
+}
+.form-checkbox:disabled { opacity: 0.55; cursor: not-allowed; }
+.form-checkbox[aria-invalid="true"] {
+  outline: 2px solid var(--err);
+  outline-offset: 2px;
+}
 
 .divider { height: 1px; background: var(--border-subtle); }
 


### PR DESCRIPTION
## 变更摘要

- 新增类型化 `Input`、`Select`、`Textarea` 与 `Checkbox` 原语，统一 `md/sm` 尺寸、`surface/canvas/sunken` 表面、mono、focus、disabled、invalid 与原生语义。
- 保留既有 `.input` / `.input-mono` 兼容入口，遗留页面继续按批次迁移，不进行全站机械替换。
- 首批迁移 Schema `Field`、Settings 公共字段、Projects/Queue 过滤栏、Dialog prompt 与 `CheckboxDropdown`。
- 更新 `DESIGN.md`，明确控件语义、尺寸、表面、错误态、无障碍与迁移边界。
- 根据视觉验收反馈修正 Weights & Biases 设置区：增加统一字段间距，并让正文 Input/Select 使用同一宽度轨道；Header 总开关继续保持紧凑尺寸。

## 影响范围

- 仅统一表单控件的视觉与交互契约。
- 不改变字段提交、解析、防抖、校验、路径选择、队列筛选或项目筛选的业务逻辑。
- 文件、颜色、组合 picker、PillRadio 及专业画布控件不在本批迁移范围内。

## 验证结果

- 针对性测试：6 个文件、55 个测试通过
- WandB 布局修正测试：2 个文件、3 个测试通过
- 全量 Vitest：85 个测试文件、711 个测试全部通过
- ESLint：通过
- TypeScript：通过
- Production build：通过
- 路由快照：通过
- Impeccable detector：0 findings
- `git diff --check`：通过
- 浅色/深色、`tight/default/loose`、中文/英文及 WandB 设置区已完成人工视觉检查

## 已知说明

- Production build 仍保留既有的 `>700 kB` chunk 提示，本次未新增构建错误。
- 测试日志中的 React Router future flag、`act(...)` 与既有队列嵌套按钮警告不属于本次改动。
