### PR TITLE
feat(web): 统一状态反馈契约

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,7 +25,7 @@ surface has identical density.
 | --- | --- | --- |
 | Foundation | `studio/web/src/styles/tokens.css` | Color, type, spacing, radius, shadow, motion, control states |
 | Utility bridge | `studio/web/tailwind.config.js` | Maps CSS tokens into Tailwind utilities |
-| Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx`, `FormControl.tsx` | Typed, accessible component APIs |
+| Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx`, `FormControl.tsx`, `Alert.tsx` | Typed, accessible component APIs |
 | Patterns | `PageHeader`, `StepShell`, `Dialog`, `Toast`, `Field` | Repeated page and interaction structures |
 | Product surfaces | `studio/web/src/pages/` | Business state and composition, not new visual primitives |
 
@@ -226,7 +226,35 @@ Settings explanations belong in the label-adjacent `InfoButton` tooltip accordin
 to `docs/design/ui-info-design.md`; do not add permanent explanatory paragraphs
 under individual settings.
 
-## 8. Accessibility and resilience
+## 8. Feedback contract
+
+Use `Alert` for persistent, in-flow information, success confirmation, warnings, and
+errors. `Toast` remains the transient notification pattern and reuses Alert's visual
+tones without changing its timer or invocation API.
+
+| Tone | Meaning | Typical use |
+| --- | --- | --- |
+| `info` | Neutral operational context or guidance | non-blocking system information |
+| `success` | A completed action that remains relevant in the current view | saved or imported confirmation |
+| `warning` | Attention or recovery is required, but the state is not yet a failure | paused or held work |
+| `danger` | An operation failed or content is invalid | failed loads and rejected operations |
+
+Use `md` for ordinary page feedback and `sm` inside compact workbench regions. A
+semantic icon accompanies each tone so meaning does not depend on color alone. Titles
+are optional and should name the condition; body copy explains the consequence or
+recovery. Actions belong in the dedicated action slot and use `Button`.
+
+ARIA live behavior is explicit because not every visible notice is newly announced:
+use `role="alert"` only for urgent dynamic failures, `role="status"` for non-urgent
+dynamic confirmation, and no live role for persistent page context. Do not announce the
+same event through both an in-flow Alert and a Toast; choose the surface nearest to the
+recovery action. Field validation stays adjacent to its control; empty states, domain
+status cards, and modal workflow steps are not Alerts. Error copy and recovery details
+must wrap rather than truncate.
+
+Do not recreate feedback with local `bg-*-soft + border-* + text-*` combinations.
+
+## 9. Accessibility and resilience
 
 Every primitive must work with keyboard focus, disabled state, light/dark themes,
 all three density modes, and both Chinese and English labels. Focus is always visible.
@@ -236,7 +264,7 @@ full value is available through an established disclosure pattern.
 Respect `prefers-reduced-motion`; status information must remain understandable when
 animation is disabled.
 
-## 9. Migration policy
+## 10. Migration policy
 
 Migration is incremental:
 

--- a/studio/web/src/components/Alert.test.tsx
+++ b/studio/web/src/components/Alert.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import Alert, { alertClassName } from './Alert'
+
+describe('Alert', () => {
+  it('uses the informational medium treatment by default', () => {
+    render(<Alert>Background sync is active.</Alert>)
+
+    const alert = screen.getByText('Background sync is active.').closest('.alert')
+    expect(alert).toHaveClass('alert', 'alert-info')
+    expect(alert).not.toHaveClass('alert-sm')
+    expect(alert?.querySelector('.alert-icon')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('supports a title, action, compact danger tone, and explicit live semantics', () => {
+    render(
+      <Alert
+        tone="danger"
+        size="sm"
+        role="alert"
+        title="Could not load"
+        action={<button type="button">Retry</button>}
+      >
+        Check the connection and try again.
+      </Alert>,
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveClass('alert-danger', 'alert-sm')
+    expect(screen.getByText('Could not load')).toHaveClass('alert-title')
+    expect(screen.getByRole('button', { name: 'Retry' }).parentElement)
+      .toHaveClass('alert-action')
+  })
+
+  it('allows the semantic icon to be omitted and merges custom classes', () => {
+    render(<Alert icon={false} className="font-mono">Technical details</Alert>)
+
+    const alert = screen.getByText('Technical details').closest('.alert')
+    expect(alert).toHaveClass('font-mono')
+    expect(alert?.querySelector('.alert-icon')).toBeNull()
+  })
+
+  it('builds stable classes for compatibility wrappers', () => {
+    expect(alertClassName({ tone: 'success', size: 'sm', className: 'shadow-lg' }))
+      .toBe('alert alert-success alert-sm shadow-lg')
+  })
+})

--- a/studio/web/src/components/Alert.tsx
+++ b/studio/web/src/components/Alert.tsx
@@ -1,0 +1,109 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+export type AlertTone = 'info' | 'success' | 'warning' | 'danger'
+export type AlertSize = 'md' | 'sm'
+
+export interface AlertProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'title'> {
+  tone?: AlertTone
+  size?: AlertSize
+  title?: ReactNode
+  action?: ReactNode
+  icon?: ReactNode | false
+  children: ReactNode
+}
+
+const TONE_CLASS: Record<AlertTone, string> = {
+  info: 'alert-info',
+  success: 'alert-success',
+  warning: 'alert-warning',
+  danger: 'alert-danger',
+}
+
+const SIZE_CLASS: Record<AlertSize, string> = {
+  md: '',
+  sm: 'alert-sm',
+}
+
+export function alertClassName({
+  tone = 'info',
+  size = 'md',
+  className = '',
+}: {
+  tone?: AlertTone
+  size?: AlertSize
+  className?: string
+} = {}): string {
+  return [
+    'alert',
+    TONE_CLASS[tone],
+    SIZE_CLASS[size],
+    className,
+  ].filter(Boolean).join(' ')
+}
+
+function AlertIcon({ tone }: { tone: AlertTone }) {
+  if (tone === 'success') {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="9" />
+        <path d="m8.5 12 2.2 2.2 4.8-5" />
+      </svg>
+    )
+  }
+
+  if (tone === 'warning') {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M10.3 4.2 2.7 17.4A1.8 1.8 0 0 0 4.3 20h15.4a1.8 1.8 0 0 0 1.6-2.6L13.7 4.2a2 2 0 0 0-3.4 0Z" />
+        <path d="M12 9v4" />
+        <path d="M12 17h.01" />
+      </svg>
+    )
+  }
+
+  if (tone === 'danger') {
+    return (
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="12" cy="12" r="9" />
+        <path d="M12 8v5" />
+        <path d="M12 17h.01" />
+      </svg>
+    )
+  }
+
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 11v5" />
+      <path d="M12 8h.01" />
+    </svg>
+  )
+}
+
+export default function Alert({
+  tone = 'info',
+  size = 'md',
+  title,
+  action,
+  icon,
+  className,
+  children,
+  ...rest
+}: AlertProps) {
+  const resolvedIcon = icon === false ? null : (icon ?? <AlertIcon tone={tone} />)
+
+  return (
+    <div {...rest} className={alertClassName({ tone, size, className })}>
+      {resolvedIcon && (
+        <span className="alert-icon" aria-hidden="true">
+          {resolvedIcon}
+        </span>
+      )}
+      <div className="alert-content">
+        {title && <div className="alert-title">{title}</div>}
+        <div className="alert-message">{children}</div>
+      </div>
+      {action && <div className="alert-action">{action}</div>}
+    </div>
+  )
+}

--- a/studio/web/src/components/Toast.test.tsx
+++ b/studio/web/src/components/Toast.test.tsx
@@ -1,0 +1,55 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ToastProvider, useToast } from './Toast'
+
+type Kind = 'info' | 'success' | 'error'
+
+function ToastTrigger({ kind }: { kind: Kind }) {
+  const { toast } = useToast()
+  return (
+    <button type="button" onClick={() => toast(`${kind} message`, kind)}>
+      Show {kind}
+    </button>
+  )
+}
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
+
+describe('ToastProvider', () => {
+  it.each([
+    ['info', 'alert-info', 'status'],
+    ['success', 'alert-success', 'status'],
+    ['error', 'alert-danger', 'alert'],
+  ] as const)('maps %s feedback onto the shared Alert contract', (kind, toneClass, role) => {
+    vi.useFakeTimers()
+    render(
+      <ToastProvider>
+        <ToastTrigger kind={kind} />
+      </ToastProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: `Show ${kind}` }))
+
+    const toast = screen.getByRole(role)
+    expect(toast).toHaveClass('alert', toneClass, 'shadow-lg')
+    expect(toast).toHaveAttribute('aria-atomic', 'true')
+  })
+
+  it('keeps the existing timeout policy for transient feedback', () => {
+    vi.useFakeTimers()
+    render(
+      <ToastProvider>
+        <ToastTrigger kind="info" />
+      </ToastProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show info' }))
+    expect(screen.getByText('info message')).toBeInTheDocument()
+
+    act(() => { vi.advanceTimersByTime(3000) })
+    expect(screen.queryByText('info message')).not.toBeInTheDocument()
+  })
+})

--- a/studio/web/src/components/Toast.tsx
+++ b/studio/web/src/components/Toast.tsx
@@ -5,8 +5,15 @@ import {
   useState,
   type ReactNode,
 } from 'react'
+import Alert, { type AlertTone } from './Alert'
 
 type Kind = 'info' | 'success' | 'error'
+
+const ALERT_TONE: Record<Kind, AlertTone> = {
+  info: 'info',
+  success: 'success',
+  error: 'danger',
+}
 
 interface ToastItem {
   id: number
@@ -36,19 +43,15 @@ export function ToastProvider({ children }: { children: ReactNode }) {
       {children}
       <div className="fixed bottom-4 right-4 z-50 space-y-2 max-w-sm">
         {items.map((t) => (
-          <div
+          <Alert
             key={t.id}
-            className={
-              'px-4 py-2 rounded-lg shadow-lg text-sm border ' +
-              (t.kind === 'error'
-                ? 'bg-err-soft border-err text-err'
-                : t.kind === 'success'
-                ? 'bg-ok-soft border-ok text-ok'
-                : 'bg-elevated border-subtle text-fg-primary')
-            }
+            tone={ALERT_TONE[t.kind]}
+            role={t.kind === 'error' ? 'alert' : 'status'}
+            aria-atomic="true"
+            className="shadow-lg"
           >
             {t.message}
-          </div>
+          </Alert>
         ))}
       </div>
     </Ctx.Provider>

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { api, type BundleImportResult, type ProjectSummary, type VersionStatus } from '../api/client'
+import Alert from '../components/Alert'
 import { Input, Select } from '../components/FormControl'
 import PageHeader from '../components/PageHeader'
 import PathPicker from '../components/PathPicker'
@@ -302,7 +303,9 @@ export default function ProjectsPage() {
 
       <div className="px-page pb-page pt-section">
         {error && (
-          <div className="mb-4 px-3.5 py-2.5 rounded-md bg-err-soft border border-err text-err text-sm font-mono">{error}</div>
+          <Alert tone="danger" role="alert" className="mb-section font-mono">
+            {error}
+          </Alert>
         )}
 
         {loading ? (

--- a/studio/web/src/pages/Queue.test.tsx
+++ b/studio/web/src/pages/Queue.test.tsx
@@ -6,7 +6,7 @@
  *   2) 缺字段（老 mock / 极老行）兜底 'train'；
  *   3) 不再受 config_name 影响 —— 修掉旧 inferKind 把名字含 "reg"/"tag" 的
  *      训练任务误判成别的类型的 latent bug。 */
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DialogProvider } from '../components/Dialog'
@@ -97,6 +97,23 @@ describe('QueuePage 分区 + 分页', () => {
     expect(title.closest('.empty-state')).toHaveClass('card', 'empty-state')
     expect(screen.getByText('从项目训练页入队任务即可'))
       .toHaveClass('empty-state-description')
+  })
+
+  it('队列挂起使用共享 warning Alert，并保留恢复操作', async () => {
+    vi.spyOn(api, 'getQueueHold').mockResolvedValue({
+      held: true, pending_waiting: 2,
+    })
+    vi.spyOn(api, 'listQueueLive').mockResolvedValue([])
+    vi.spyOn(api, 'listQueueHistory').mockResolvedValue({
+      items: [], total: 0, page: 1, page_size: 20,
+    })
+
+    renderQueue()
+
+    const banner = await screen.findByTestId('queue-hold-banner')
+    expect(banner).toHaveClass('alert', 'alert-warning', 'alert-sm', 'sticky')
+    expect(within(banner).getByRole('button', { name: '恢复调度' }))
+      .toHaveClass('btn', 'btn-ghost', 'btn-xs')
   })
 
   it('渲染进行中/等待/历史三分区，历史超过一页时出分页器', async () => {

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -6,6 +6,8 @@ import {
   type TaskStatus, type TaskType,
 } from '../api/client'
 import { DATA_VIEW_KINDS } from './queue/jobUtils'
+import Alert from '../components/Alert'
+import Button from '../components/Button'
 import Card from '../components/Card'
 import EmptyState from '../components/EmptyState'
 import { Input, Select } from '../components/FormControl'
@@ -1001,23 +1003,28 @@ export default function QueuePage() {
         {/* ADR §4.1 队列挂起 banner — 仅 held=true 时显示，sticky 顶部。
             hold 覆盖全队列（含数据作业派发），两个视图都显示。 */}
         {holdState?.held && (
-          <div
-            className="sticky top-0 z-10 px-3.5 py-2.5 rounded-md bg-warn-soft border border-warn text-warn text-xs flex items-center justify-between"
+          <Alert
+            tone="warning"
+            size="sm"
+            className="sticky top-0 z-10"
             data-testid="queue-hold-banner"
+            action={(
+              <Button
+                variant="ghost"
+                size="xs"
+                onClick={() => void releaseQueue()}
+              >
+                {t('queue.releaseQueue')}
+              </Button>
+            )}
           >
-            <span>{t('queue.heldBanner')}</span>
-            <button
-              onClick={() => void releaseQueue()}
-              className="btn btn-ghost btn-xs text-warn"
-            >
-              {t('queue.releaseQueue')}
-            </button>
-          </div>
+            {t('queue.heldBanner')}
+          </Alert>
         )}
         {error && (
-          <div className="px-3.5 py-2.5 rounded-md bg-err-soft border border-err text-err text-xs font-mono">
+          <Alert tone="danger" size="sm" role="alert" className="font-mono">
             {error}
-          </div>
+          </Alert>
         )}
 
         {queueTab === 'jobs' ? (

--- a/studio/web/src/pages/queue/DataJobsPanel.test.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.test.tsx
@@ -109,6 +109,19 @@ describe('DataJobsPanel', () => {
       .toHaveClass('empty-state-description')
   })
 
+  it('加载失败使用共享 danger Alert 与即时播报语义', async () => {
+    vi.spyOn(api, 'listQueueLive').mockRejectedValue(new Error('offline'))
+    vi.spyOn(api, 'listQueueHistory').mockResolvedValue({
+      items: [], total: 0, page: 1, page_size: 20,
+    })
+
+    renderPanel()
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveClass('alert', 'alert-danger', 'alert-sm', 'font-mono')
+    expect(alert).toHaveTextContent('offline')
+  })
+
   it('数据源 = /api/queue resource_class=data（kind/q 透传）', async () => {
     const liveSpy = vi.spyOn(api, 'listQueueLive').mockResolvedValue([])
     const histSpy = vi.spyOn(api, 'listQueueHistory').mockResolvedValue({

--- a/studio/web/src/pages/queue/DataJobsPanel.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.tsx
@@ -12,6 +12,7 @@ import { useNavigate } from 'react-router-dom'
 import {
   api, type QueueHistoryPage, type Task, type TaskType,
 } from '../../api/client'
+import Alert from '../../components/Alert'
 import Card from '../../components/Card'
 import EmptyState from '../../components/EmptyState'
 import { useDialog } from '../../components/Dialog'
@@ -197,9 +198,9 @@ export default function DataJobsPanel({
   return (
     <div className="flex flex-col gap-section" data-testid="data-jobs-panel">
       {error && (
-        <div className="px-3.5 py-2.5 rounded-md bg-err-soft border border-err text-err text-xs font-mono">
+        <Alert tone="danger" size="sm" role="alert" className="font-mono">
           {error}
-        </div>
+        </Alert>
       )}
 
       {!loaded ? (

--- a/studio/web/src/pages/tools/generate/GalleryPickerDrawer.tsx
+++ b/studio/web/src/pages/tools/generate/GalleryPickerDrawer.tsx
@@ -259,9 +259,7 @@ function GalleryPickerDrawer({
       await onApplyPrompt(response.prompt, autoGenerate)
       toast(t('generate.galleryTagSuccess'), 'success')
     } catch (reason) {
-      const message = String(reason)
-      setError(message)
-      toast(message, 'error')
+      setError(String(reason))
     } finally {
       setTagging(false)
     }

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -397,6 +397,67 @@ select option:checked {
 .empty-state-title + .empty-state-description { margin-top: var(--s-2); }
 .empty-state-action { margin-top: var(--s-4); }
 
+.alert {
+  --alert-bg: var(--info-soft);
+  --alert-border: var(--info);
+  --alert-fg: var(--info-strong);
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-related);
+  padding: var(--s-3) var(--s-4);
+  border: 1px solid var(--alert-border);
+  border-radius: var(--r-md);
+  background: var(--alert-bg);
+  color: var(--alert-fg);
+  font-size: var(--t-sm);
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+.alert-sm {
+  padding: var(--s-2) var(--s-3);
+  font-size: var(--t-xs);
+}
+.alert-info {
+  --alert-bg: var(--info-soft);
+  --alert-border: var(--info);
+  --alert-fg: var(--info-strong);
+}
+.alert-success {
+  --alert-bg: var(--ok-soft);
+  --alert-border: var(--ok);
+  --alert-fg: var(--ok-strong);
+}
+.alert-warning {
+  --alert-bg: var(--warn-soft);
+  --alert-border: var(--warn);
+  --alert-fg: var(--warn-strong);
+}
+.alert-danger {
+  --alert-bg: var(--err-soft);
+  --alert-border: var(--err);
+  --alert-fg: var(--err-strong);
+}
+.alert-icon {
+  width: 18px;
+  height: 18px;
+  margin-top: 0.1em;
+  flex: 0 0 auto;
+}
+.alert-sm .alert-icon { width: 16px; height: 16px; }
+.alert-icon > svg { display: block; width: 100%; height: 100%; }
+.alert-content { min-width: 0; flex: 1 1 auto; }
+.alert-title { font-weight: 600; line-height: 1.4; }
+.alert-title + .alert-message { margin-top: var(--s-1); }
+.alert-message { min-width: 0; white-space: pre-wrap; }
+.alert-action {
+  display: flex;
+  align-items: center;
+  align-self: center;
+  flex: 0 0 auto;
+  margin-inline-start: var(--space-related);
+}
+.alert-action .btn-ghost { color: inherit; }
+
 .kbd {
   font-family: var(--font-mono);
   font-size: var(--t-xs);


### PR DESCRIPTION
## 变更摘要

- 新增类型化 `Alert` 原语，统一 `info`、`success`、`warning`、`danger` 四种反馈语义。
- 支持 `sm` / `md` 尺寸、默认语义图标、可选标题、操作区以及显式 live-region 配置。
- 将 `Toast` 的视觉层迁移到统一反馈契约，保留原有调用 API、堆叠与自动关闭行为。
- 首批迁移 Projects、Queue、DataJobsPanel 的加载失败提示，以及 Queue hold warning 与恢复操作。
- 补充 `DESIGN.md` 中的反馈层级、ARIA 使用和去重规则。

## 无障碍与反馈去重

- info / success Toast 使用 `role="status"`，错误 Toast 使用 `role="alert"`。
- in-flow Alert 默认不声明 live-region，由调用场景根据错误是否动态产生显式配置。
- 修复 Gallery 打标失败同时显示 inline error 和错误 Toast、导致同一错误重复播报的问题；保留离恢复操作最近的 inline error。
- 四种语义色在深浅主题下最低文本对比度为 5.36:1。

## 影响范围

- 不修改路由、接口、schema、SSE 或队列业务状态。
- 不迁移表单 inline validation、EmptyState、Dialog/Modal 内业务状态或全站剩余旧 callout。
- Toast 定时、调用方式与调用方 API 保持兼容。

## 验证

- 聚焦反馈测试：30 个测试通过
- Gallery 重复播报回归：9 个测试通过
- 全量 Vitest：87 个测试文件、721 个测试通过
- ESLint：通过
- TypeScript：通过
- Production build：通过
- 路由快照：通过
- Impeccable detector：0 findings
- `git diff --check`：通过

## 人工视觉验收

已覆盖 Toast、Queue hold warning、页面错误反馈，以及浅色/深色主题、三档密度、中英文和较窄桌面宽度；人工检查通过。
