### PR TITLE
feat(web): 统一操作区与保存模式

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,7 +26,7 @@ surface has identical density.
 | Foundation | `studio/web/src/styles/tokens.css` | Color, type, spacing, radius, shadow, motion, control states |
 | Utility bridge | `studio/web/tailwind.config.js` | Maps CSS tokens into Tailwind utilities |
 | Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx`, `FormControl.tsx`, `Alert.tsx` | Typed, accessible component APIs |
-| Patterns | `PageHeader`, `StepShell`, `Dialog`, `Toast`, `Field` | Repeated page and interaction structures |
+| Patterns | `PageHeader`, `StepShell`, `ActionGroup`, `SaveIndicator`, `SaveBar`, `Dialog`, `Toast`, `Field` | Repeated page and interaction structures |
 | Product surfaces | `studio/web/src/pages/` | Business state and composition, not new visual primitives |
 
 A page may compose primitives with layout utilities. It must not recreate an
@@ -254,7 +254,40 @@ must wrap rather than truncate.
 
 Do not recreate feedback with local `bg-*-soft + border-* + text-*` combinations.
 
-## 9. Accessibility and resilience
+## 9. Action-area and save-pattern contract
+
+`ActionGroup` is the typed Pattern-layer entry point for related save, submit, and
+recovery controls. Its slots render in a stable order: optional status first,
+secondary or destructive actions next, and the single primary action last. The primary
+action therefore stays at the far right in left-to-right layouts. A visual divider may
+separate destructive or context-changing actions, but it does not create another
+primary action.
+
+Save and submit buttons are text-first. Do not prefix ordinary labels with floppy-disk,
+checkmark, or other decorative emoji; reserve icons for established compact utilities,
+and provide an accessible label for icon-only controls. Use `Button` loading and disabled
+states rather than replacing the label with an unrelated spinner. An explicit save may
+lose primary emphasis when nothing is dirty, but it remains in the primary slot so the
+layout does not jump.
+
+Placement follows editing scope:
+
+- Use the page or step header for short, viewport-contained edits and quick actions.
+- Use a footer action area for long or scroll-heavy forms that require deliberate review
+  before submit. Make it sticky only when the final action would otherwise be difficult
+  to reach, and reserve content space so it never obscures fields.
+- Keep actions that affect only one panel inside that panel; do not promote them to a
+  page-level bar.
+- Autosave surfaces show `SaveIndicator` status instead of a redundant Save button.
+  If an error Toast already announces the same failure, disable the indicator's error
+  announcement so assistive technology receives it only once.
+
+Status copy precedes controls and uses a stable polite live region. At narrow widths,
+action groups may wrap, but the primary action remains last and right-aligned. Snapshot
+restore, reset, and destructive actions remain secondary to saving unless that recovery
+operation is the sole purpose of the current scope.
+
+## 10. Accessibility and resilience
 
 Every primitive must work with keyboard focus, disabled state, light/dark themes,
 all three density modes, and both Chinese and English labels. Focus is always visible.
@@ -264,7 +297,7 @@ full value is available through an established disclosure pattern.
 Respect `prefers-reduced-motion`; status information must remain understandable when
 animation is disabled.
 
-## 10. Migration policy
+## 11. Migration policy
 
 Migration is incremental:
 

--- a/studio/web/src/components/ActionGroup.test.tsx
+++ b/studio/web/src/components/ActionGroup.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import ActionGroup from './ActionGroup'
+
+function slotOrder(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('[data-action-slot]'))
+    .map((element) => element.getAttribute('data-action-slot') ?? '')
+}
+
+describe('ActionGroup', () => {
+  it('keeps status, secondary actions, and the primary action in semantic order', () => {
+    const { container } = render(
+      <ActionGroup
+        aria-label="Caption actions"
+        status={<span>2 unsaved</span>}
+        secondary={<button type="button">Restore</button>}
+        primary={<button type="button">Save</button>}
+      />,
+    )
+
+    expect(screen.getByRole('group', { name: 'Caption actions' })).toHaveClass(
+      'flex-wrap',
+      'justify-end',
+      'gap-related',
+    )
+    expect(slotOrder(container)).toEqual(['status', 'secondary', 'primary'])
+    expect(screen.getByRole('button', { name: 'Save' }).closest('[data-action-slot]'))
+      .toHaveAttribute('data-action-slot', 'primary')
+  })
+
+  it('omits empty slots without changing the primary position', () => {
+    const { container } = render(
+      <ActionGroup primary={<button type="button">Submit</button>} />,
+    )
+
+    expect(slotOrder(container)).toEqual(['primary'])
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument()
+    expect(container.firstElementChild).not.toHaveAttribute('role')
+  })
+})

--- a/studio/web/src/components/ActionGroup.tsx
+++ b/studio/web/src/components/ActionGroup.tsx
@@ -1,0 +1,57 @@
+import type { HTMLAttributes, ReactNode } from 'react'
+
+export interface ActionGroupProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children'> {
+  /** Save state or other non-interactive context. Rendered before every action. */
+  status?: ReactNode
+  /** Lower-emphasis, recovery, or destructive actions. */
+  secondary?: ReactNode
+  /** The single primary action for this scope. Always rendered last. */
+  primary?: ReactNode
+}
+
+/**
+ * Pattern-layer scaffold for a related set of save or submit actions.
+ *
+ * Slot order is intentional: status → secondary → primary. Callers keep all
+ * business state and handlers; this component only owns ordering, wrapping,
+ * and spacing.
+ */
+export default function ActionGroup({
+  status,
+  secondary,
+  primary,
+  className = '',
+  role,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+  ...rest
+}: ActionGroupProps) {
+  return (
+    <div
+      {...rest}
+      role={role ?? (ariaLabel || ariaLabelledBy ? 'group' : undefined)}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      className={[
+        'flex min-w-0 flex-wrap items-center justify-end gap-related',
+        className,
+      ].filter(Boolean).join(' ')}
+    >
+      {status && (
+        <div data-action-slot="status" className="min-w-0 shrink-0">
+          {status}
+        </div>
+      )}
+      {secondary && (
+        <div data-action-slot="secondary" className="flex flex-wrap items-center justify-end gap-related">
+          {secondary}
+        </div>
+      )}
+      {primary && (
+        <div data-action-slot="primary" className="flex items-center justify-end">
+          {primary}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/studio/web/src/components/SaveBar.test.tsx
+++ b/studio/web/src/components/SaveBar.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (key === 'saveBar.save') return `Save (${String(options?.n ?? '')})`
+      if (key === 'saveBar.saved') return 'Saved'
+      if (key === 'saveBar.restorePoints') return 'Restore points'
+      if (key === 'saveBar.tooltip') return 'Save captions'
+      return key
+    },
+  }),
+}))
+
+vi.mock('../api/client', () => ({
+  api: {
+    listCaptionSnapshots: vi.fn().mockResolvedValue([]),
+    restoreCaptionSnapshot: vi.fn(),
+    deleteCaptionSnapshot: vi.fn(),
+  },
+}))
+
+vi.mock('./Dialog', () => ({
+  useDialog: () => ({ confirm: vi.fn().mockResolvedValue(true) }),
+}))
+
+vi.mock('./Toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}))
+
+import SaveBar from './SaveBar'
+
+describe('SaveBar', () => {
+  it('keeps the text-first save action last and restore secondary', () => {
+    const { container } = render(
+      <SaveBar
+        pid={1}
+        vid={2}
+        dirtyCount={3}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onAfterRestore={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+
+    const group = container.querySelector('[data-action-slot="secondary"]')?.parentElement
+    expect(group).not.toBeNull()
+    expect(within(group as HTMLElement).getAllByRole('button').map((button) => button.textContent))
+      .toEqual(['Restore points', 'Save (3)'])
+    expect(screen.getByRole('button', { name: 'Save (3)' })).toHaveClass('btn-primary')
+    expect(screen.getByRole('button', { name: 'Restore points' })).toHaveClass('btn-ghost')
+    expect(group?.textContent).not.toMatch(/[💾🕒]/u)
+  })
+
+  it('keeps the clean save position stable without primary emphasis', () => {
+    render(
+      <SaveBar
+        pid={1}
+        vid={2}
+        dirtyCount={0}
+        onSave={vi.fn().mockResolvedValue(undefined)}
+        onAfterRestore={vi.fn().mockResolvedValue(undefined)}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Saved' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Saved' })).toHaveClass('btn-secondary')
+    expect(screen.getByRole('button', { name: 'Saved' }).closest('[data-action-slot]'))
+      .toHaveAttribute('data-action-slot', 'primary')
+  })
+})

--- a/studio/web/src/components/SaveBar.tsx
+++ b/studio/web/src/components/SaveBar.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { api, type CaptionSnapshot } from '../api/client'
+import ActionGroup from './ActionGroup'
+import Button from './Button'
 import { useDialog } from './Dialog'
 import { useToast } from './Toast'
 
@@ -79,31 +81,40 @@ export default function SaveBar({
 
   return (
     <div className="relative" ref={ref}>
-      <div className="flex items-center gap-1">
-        <button
-          onClick={save}
-          disabled={saving || dirtyCount === 0}
-          className={dirtyCount > 0 ? 'btn btn-primary btn-sm' : 'btn btn-secondary btn-sm'}
-          title={t('saveBar.tooltip')}
-        >
-          {saving
-            ? t('common.saving')
-            : dirtyCount > 0
-              ? t('saveBar.save', { n: dirtyCount })
-              : t('saveBar.saved')}
-        </button>
-        <button
-          onClick={() => setOpen(!open)}
-          className="btn btn-ghost btn-sm"
-        >
-          {t('saveBar.restorePoints')}
-        </button>
-      </div>
+      <ActionGroup
+        secondary={(
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setOpen(!open)}
+            aria-expanded={open}
+            aria-haspopup="dialog"
+          >
+            {t('saveBar.restorePoints')}
+          </Button>
+        )}
+        primary={(
+          <Button
+            variant={dirtyCount > 0 ? 'primary' : 'secondary'}
+            size="sm"
+            onClick={save}
+            disabled={dirtyCount === 0}
+            loading={saving}
+            title={t('saveBar.tooltip')}
+          >
+            {saving
+              ? t('common.saving')
+              : dirtyCount > 0
+                ? t('saveBar.save', { n: dirtyCount })
+                : t('saveBar.saved')}
+          </Button>
+        )}
+      />
 
       {open && (
         <div
           role="dialog"
-          aria-label="snapshot-list"
+          aria-label={t('saveBar.restorePoints')}
           className="absolute right-0 top-[calc(100%+4px)] w-80 max-h-80 overflow-y-auto rounded-md border border-subtle bg-elevated shadow-xl z-30"
         >
           {items.length === 0 ? (
@@ -125,21 +136,25 @@ export default function SaveBar({
                       {t('saveBar.restoreEntry', { n: s.file_count, size: fmtSize(s.size) })}
                     </div>
                   </div>
-                  <button
+                  <Button
+                    variant="primary"
+                    size="sm"
                     onClick={() => restore(s.id)}
                     disabled={busyId === s.id}
-                    className="btn btn-primary btn-sm"
                   >
                     {t('common.restore')}
-                  </button>
-                  <button
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="xs"
+                    iconOnly
                     onClick={() => del(s.id)}
                     disabled={busyId === s.id}
-                    className="btn btn-ghost btn-sm text-fg-tertiary hover:text-err"
+                    className="text-fg-tertiary hover:text-err"
                     aria-label={t('common.delete')}
                   >
-                    ✕
-                  </button>
+                    ×
+                  </Button>
                 </li>
               ))}
             </ul>

--- a/studio/web/src/components/SaveIndicator.test.tsx
+++ b/studio/web/src/components/SaveIndicator.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import SaveIndicator from './SaveIndicator'
+
+describe('SaveIndicator', () => {
+  it('keeps a stable polite live region while autosave state changes', () => {
+    const { rerender } = render(<SaveIndicator status={{ state: 'idle' }} />)
+    const status = screen.getByRole('status')
+
+    expect(status).toHaveAttribute('aria-live', 'polite')
+    expect(status).toHaveAttribute('aria-atomic', 'true')
+    expect(status).toHaveAttribute('data-state', 'idle')
+    expect(status).toBeEmptyDOMElement()
+
+    rerender(<SaveIndicator status={{ state: 'saving' }} />)
+    expect(status).toHaveAttribute('data-state', 'saving')
+    expect(status).not.toBeEmptyDOMElement()
+
+    rerender(<SaveIndicator status={{ state: 'saved', at: Date.now() }} />)
+    expect(status).toHaveAttribute('data-state', 'saved')
+    expect(status.querySelector('svg')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('exposes the full failure and can suppress a duplicate live announcement', () => {
+    const { rerender } = render(
+      <SaveIndicator status={{ state: 'error', error: 'Disk is read-only' }} />,
+    )
+
+    expect(screen.getByRole('status')).toHaveAttribute('title', 'Disk is read-only')
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'polite')
+    expect(screen.getByRole('status')).toHaveClass('text-err')
+
+    rerender(
+      <SaveIndicator
+        status={{ state: 'error', error: 'Disk is read-only' }}
+        announceError={false}
+      />,
+    )
+    expect(screen.getByRole('status')).toHaveAttribute('aria-live', 'off')
+  })
+})

--- a/studio/web/src/components/SaveIndicator.tsx
+++ b/studio/web/src/components/SaveIndicator.tsx
@@ -1,31 +1,63 @@
+import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { SaveStatus } from '../lib/SettingsData'
 
 /**
- * 自动保存状态指示(instant-apply / debounce 自动保存页面共用):
- * saving → 「保存中…」;saved → 「✓ 已保存 hh:mm:ss」带 flash 动画;
- * error → 红色错误;idle 不渲染。原 Settings 页私有组件,刀 2 UX 收尾抽出,
- * Settings 顶栏 / Train 页 header / Presets 页 header 三处共用。
+ * Stable autosave live region shared by Settings, Train, and Presets.
+ *
+ * The element stays mounted while idle so assistive technology can announce
+ * later state changes. Autosave failures remain non-urgent here; callers may
+ * provide a separate nearby recovery surface when one exists.
  */
-export default function SaveIndicator({ status }: { status: SaveStatus }) {
+export interface SaveIndicatorProps {
+  status: SaveStatus
+  /** Set false when the same failure is already announced by an error Toast. */
+  announceError?: boolean
+}
+
+export default function SaveIndicator({
+  status,
+  announceError = true,
+}: SaveIndicatorProps) {
   const { t } = useTranslation()
+
+  let content: ReactNode = null
+  let toneClass = 'text-fg-tertiary'
+  let title: string | undefined
+
   if (status.state === 'saving') {
-    return <span className="text-xs text-fg-tertiary">{t('settings.saveStatus.saving')}</span>
-  }
-  if (status.state === 'saved') {
-    const time = new Date(status.at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
-    // key={status.at}：每次保存重挂载 → 重播 flash 动画，连续保存也能一眼看出"又存了"。
-    return (
-      <span key={status.at} className="settings-saved-flash text-xs inline-flex items-center gap-1">
-        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+    content = t('settings.saveStatus.saving')
+  } else if (status.state === 'saved') {
+    const time = new Date(status.at).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+    content = (
+      <span key={status.at} className="settings-saved-flash inline-flex items-center gap-1">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+          strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M20 6L9 17l-5-5" />
         </svg>
         {t('settings.saveStatus.saved', { time })}
       </span>
     )
+  } else if (status.state === 'error') {
+    toneClass = 'text-err'
+    title = status.error
+    content = t('settings.saveStatus.error')
   }
-  if (status.state === 'error') {
-    return <span className="text-xs text-err">{t('settings.saveStatus.error')}</span>
-  }
-  return null
+
+  return (
+    <span
+      role="status"
+      aria-live={status.state === 'error' && !announceError ? 'off' : 'polite'}
+      aria-atomic="true"
+      data-state={status.state}
+      className={`inline-flex min-w-0 max-w-72 items-center gap-1.5 whitespace-nowrap text-xs ${toneClass}`}
+      title={title}
+    >
+      {content}
+    </span>
+  )
 }

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -226,9 +226,9 @@
   },
   "saveBar": {
     "tooltip": "Write local edits to disk; auto-creates a restore point before saving",
-    "save": "💾 Save ({{n}})",
-    "saved": "💾 Saved",
-    "restorePoints": "🕒 Restore points",
+    "save": "Save ({{n}})",
+    "saved": "Saved",
+    "restorePoints": "Restore points",
     "noRestorePoints": "No restore points yet. Auto-created on save.",
     "restoreEntry": "{{n}} files · {{size}}",
     "confirmRestore": "Restore will overwrite all captions (including unsaved changes). Continue?",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -226,9 +226,9 @@
   },
   "saveBar": {
     "tooltip": "把本地编辑写入磁盘；写之前自动生成还原点",
-    "save": "💾 保存（{{n}}）",
-    "saved": "💾 已保存",
-    "restorePoints": "🕒 还原点",
+    "save": "保存（{{n}}）",
+    "saved": "已保存",
+    "restorePoints": "还原点",
     "noRestorePoints": "还没有还原点。每次「保存」会自动生成一个。",
     "restoreEntry": "{{n}} 文件 · {{size}}",
     "confirmRestore": "还原会覆盖当前所有 caption（含未保存的本地改动）。确定？",

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -14,6 +14,8 @@ import {
 } from '../../../api/client'
 import { parseFolderMeta } from '../../../lib/folderMeta'
 import { useLocalStorageState } from '../../../lib/useLocalStorageState'
+import ActionGroup from '../../../components/ActionGroup'
+import Button from '../../../components/Button'
 import ConfigSkeleton from '../../../components/ConfigSkeleton'
 import ConfigYamlPanel from '../../../components/ConfigYamlPanel'
 import { useDialog } from '../../../components/Dialog'
@@ -621,7 +623,7 @@ export default function TrainPage() {
               「项目专属配置」，不再显示「绑定哪个预设」+「已自定义」标签 —— 这套
               判定逻辑骗人（全局模型 4 字段 fork 时被注入绝对路径，跟全局预设
               相对路径 diff 永远存在）。预设变成纯"模板起点"概念。 */}
-          <section className="flex items-center gap-2.5 shrink-0 relative">
+          <section className="flex items-center gap-2.5 shrink-0 relative flex-wrap">
             <button
               ref={pickerAnchorRef}
               onClick={() => { setPickerOpen((v) => !v); setPickerSearch('') }}
@@ -651,16 +653,20 @@ export default function TrainPage() {
               </span>
               <span className="text-fg-tertiary text-md">▾</span>
             </button>
-            <button
-              onClick={() => void onSaveAsPreset()}
-              disabled={busy || !configResp?.has_config}
-              className="btn btn-ghost btn-sm"
-              title={t('train.saveAsPresetTitle')}
-            >
-              {t('train.saveAsPreset')}
-            </button>
-            {/* 自动保存指示（Settings / Presets 页同款）：600ms debounce 落盘后显示时间 */}
-            <SaveIndicator status={saveStatus} />
+            <ActionGroup
+              status={<SaveIndicator status={saveStatus} announceError={false} />}
+              secondary={(
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => void onSaveAsPreset()}
+                  disabled={busy || !configResp?.has_config}
+                  title={t('train.saveAsPresetTitle')}
+                >
+                  {t('train.saveAsPreset')}
+                </Button>
+              )}
+            />
 
             {/* popover */}
             {pickerOpen && (

--- a/studio/web/src/pages/tools/Presets.tsx
+++ b/studio/web/src/pages/tools/Presets.tsx
@@ -7,6 +7,8 @@ import {
   type PresetSummary,
   type SchemaResponse,
 } from '../../api/client'
+import ActionGroup from '../../components/ActionGroup'
+import Button from '../../components/Button'
 import ConfigSkeleton from '../../components/ConfigSkeleton'
 import { useDialog } from '../../components/Dialog'
 import PathPicker from '../../components/PathPicker'
@@ -558,11 +560,11 @@ export default function PresetsPage() {
   return (
     <div className="fade-in flex flex-col h-full">
 
-      {/* ── 单行 header：picker + 状态 + 全部操作 ──
+      {/* ── 宽屏单行、窄屏可换行的 header：picker + 状态 + 全部操作 ──
         Topbar 已经显示「预设」面包屑，这里不再重复 h1。把上一版的页面标题
         和底部操作栏并成一行，picker 当做"当前编辑上下文"的标识，状态 +
         所有动作（导入 / 复制 / 导出 / 删除 / 保存）右侧排齐。 */}
-      <div className="py-3 px-6 border-b border-subtle bg-canvas shrink-0 flex items-center gap-3.5 relative">
+      <div className="py-3 px-6 border-b border-subtle bg-canvas shrink-0 flex flex-wrap items-center gap-3.5 relative">
         <button
           ref={pickerAnchorRef}
           onClick={() => { setPickerOpen((v) => !v); setPickerSearch('') }}
@@ -586,69 +588,64 @@ export default function PresetsPage() {
           <span className="text-fg-tertiary text-md">▾</span>
         </button>
 
-        {/* 状态指示：新建模式显示「新建中」圆点;已有 preset 走自动保存,
-            与 Settings / Train 页同款 SaveIndicator */}
-        <div className="flex items-center gap-2 min-w-0">
-          {isNew ? (
-            <>
-              <span className="inline-block w-2 h-2 rounded-full shrink-0 bg-accent" />
-              <span className="text-sm text-fg-secondary whitespace-nowrap">
-                {t('presets.creating')}
-              </span>
-            </>
-          ) : (
-            <SaveIndicator status={saveStatus} />
+        <ActionGroup
+          className="ml-auto"
+          status={(
+            <div className="flex items-center gap-2 min-w-0">
+              {isNew ? (
+                <>
+                  <span aria-hidden="true" className="inline-block w-2 h-2 rounded-full shrink-0 bg-accent" />
+                  <span className="text-sm text-fg-secondary whitespace-nowrap">
+                    {t('presets.creating')}
+                  </span>
+                </>
+              ) : (
+                <SaveIndicator status={saveStatus} announceError={false} />
+              )}
+            </div>
           )}
-        </div>
+          secondary={(
+            <>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".json,.yaml,.yml"
+                className="hidden"
+                onChange={(e) => {
+                  const f = e.target.files?.[0]
+                  if (f) void handleImportFile(f)
+                  if (fileInputRef.current) fileInputRef.current.value = ''
+                }}
+              />
+              <Button variant="ghost" size="sm" onClick={onImportClick} disabled={busy}>
+                {t('presets.importUpload')}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => setShowImportPathPicker(true)} disabled={busy}>
+                {t('presets.importPath')}
+              </Button>
 
-        <span style={{ flex: 1 }} />
-
-        {/* 全局动作 */}
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept=".json,.yaml,.yml"
-          style={{ display: 'none' }}
-          onChange={(e) => {
-            const f = e.target.files?.[0]
-            if (f) void handleImportFile(f)
-            if (fileInputRef.current) fileInputRef.current.value = ''
-          }}
+              {!isNew && (
+                <>
+                  <span aria-hidden="true" className="h-[22px] w-px bg-subtle" />
+                  <Button variant="ghost" size="sm" onClick={handleDuplicate} disabled={busy || !config}>
+                    {t('presets.duplicate')}
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={() => setExportDialogOpen(true)} disabled={busy || !config}>
+                    {t('presets.exportYaml')}
+                  </Button>
+                  <Button variant="ghost" size="sm" onClick={handleDelete} disabled={busy} className="text-err">
+                    {t('common.delete')}
+                  </Button>
+                </>
+              )}
+            </>
+          )}
+          primary={isNew ? (
+            <Button variant="primary" size="sm" onClick={handleSave} disabled={saveDisabled}>
+              {t('common.save')}
+            </Button>
+          ) : undefined}
         />
-        <button onClick={onImportClick} disabled={busy} className="btn btn-ghost btn-sm">
-          {t('presets.importUpload')}
-        </button>
-        <button onClick={() => setShowImportPathPicker(true)} disabled={busy} className="btn btn-ghost btn-sm">
-          {t('presets.importPath')}
-        </button>
-
-        {/* 编辑模式下的预设级动作 */}
-        {!isNew && (
-          <>
-            <span style={{ width: 1, height: 22, background: 'var(--border-subtle)' }} />
-            <button onClick={handleDuplicate} disabled={busy || !config} className="btn btn-ghost btn-sm">
-              {t('presets.duplicate')}
-            </button>
-            <button onClick={() => setExportDialogOpen(true)} disabled={busy || !config} className="btn btn-ghost btn-sm">
-              {t('presets.exportYaml')}
-            </button>
-            <button onClick={handleDelete} disabled={busy} className="btn btn-ghost btn-sm" style={{ color: 'var(--err)' }}>
-              {t('common.delete')}
-            </button>
-          </>
-        )}
-
-        {/* 主操作：仅新建模式需要（已有 preset 自动保存） */}
-        {isNew && (
-          <button
-            onClick={handleSave}
-            disabled={saveDisabled}
-            className="btn btn-primary btn-sm inline-flex items-center justify-center"
-            style={{ minWidth: 0, paddingLeft: 12, paddingRight: 12 }}
-          >
-            {t('common.save')}
-          </button>
-        )}
 
         {/* popover */}
         {pickerOpen && (

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -302,7 +302,7 @@ export default function SettingsPage() {
             </svg>
           </button>
         ) : undefined}
-        actions={<SaveIndicator status={saveStatus} />}
+        actions={<SaveIndicator status={saveStatus} announceError={false} />}
       />
 
       <div ref={scrollContainerRef} className="p-page pb-12 flex-1 overflow-y-auto">


### PR DESCRIPTION
## 变更摘要

- 新增类型化 `ActionGroup` Pattern，统一操作区的状态、次要操作和主操作顺序。
- 重构 `SaveBar` 与 `SaveIndicator`，统一手动保存、自动保存、保存中、已保存和失败状态。
- 迁移标签编辑、Presets、Train 与 Settings 的代表性操作区。
- 将标签编辑页的保存按钮统一放置在最右侧，并移除保存/还原点文案中的装饰性 emoji。
- 在窄屏下允许操作区自然换行，同时保持主操作始终位于语义顺序末尾。
- 避免保存失败状态与错误 Toast 对同一事件进行重复无障碍播报。
- 更新 `DESIGN.md`，补充 Header、Footer、Panel 操作区的使用边界与迁移规则。

## 影响范围

- 仅调整操作区和保存状态的视觉、布局及无障碍语义。
- 不修改保存、自动保存、训练、Preset 导入导出或还原点等业务逻辑。
- 不进行全站机械迁移；其余操作区将按后续 Pattern 批次逐步治理。

## 验证

- 聚焦测试：5 个文件、14 个测试通过
- 全量 Vitest：90 个测试文件、727 个测试通过
- ESLint：通过
- TypeScript：通过
- Production build：通过
- 路由快照：通过
- Impeccable detector：0 findings
- `git diff --check`：通过

## 人工视觉检查

已覆盖：

- 标签编辑页还原点与保存按钮层级、位置和状态
- Presets 新建/编辑模式的状态、次要操作和主操作顺序
- Train 自动保存状态与训练操作层级
- Settings 自动保存状态
- 浅色/深色主题
- `tight/default/loose` 密度
- 中文/英文
- 常规及较窄桌面宽度
- 键盘 focus、保存中、已保存与保存失败状态

人工视觉检查通过。
