### PR TITLE
feat(web): 统一覆盖式抽屉生命周期

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -26,7 +26,7 @@ surface has identical density.
 | Foundation | `studio/web/src/styles/tokens.css` | Color, type, spacing, radius, shadow, motion, control states |
 | Utility bridge | `studio/web/tailwind.config.js` | Maps CSS tokens into Tailwind utilities |
 | Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx`, `FormControl.tsx`, `Alert.tsx` | Typed, accessible component APIs |
-| Patterns | `PageHeader`, `StepShell`, `ActionGroup`, `SaveIndicator`, `SaveBar`, `Dialog`, `Modal`, `Tabs`, `SegmentedControl`, `Toast`, `Field` | Repeated page and interaction structures |
+| Patterns | `PageHeader`, `StepShell`, `ActionGroup`, `SaveIndicator`, `SaveBar`, `Dialog`, `Modal`, `Drawer`, `Tabs`, `SegmentedControl`, `Toast`, `Field` | Repeated page and interaction structures |
 | Product surfaces | `studio/web/src/pages/` | Business state and composition, not new visual primitives |
 
 A page may compose primitives with layout utilities. It must not recreate an
@@ -322,7 +322,43 @@ Toast must not duplicate an error already announced inside the modal. Toast feed
 above the modal layer when an operation keeps the dialog open. Do not recreate modal
 backdrops, panel geometry, focus listeners, or title linkage in feature code.
 
-## 11. Tabs and segmented-selection contract
+## 11. Overlay-drawer contract
+
+Use `Drawer` for an interruptive task that slides above the current workspace while
+preserving visible context. It is an overlay side sheet, not a generic name for every
+panel attached to an edge: bottom task logs remain page-owned footer panels, and Generate
+pickers/editors remain attached workspaces with their own keep-alive geometry.
+
+Drawer motion has one owner and one lifecycle: `closed → opening → open → closing`.
+The shell remains mounted so cold and warm opens take the same path. Feature content must
+not add a second entrance animation or independently decide when the panel becomes visible.
+Static local content mounts in the same commit as the shell and moves with the panel; once
+mounted, keep it alive across later opens. Do not insert a transient loading label or skeleton
+for a page whose code and structure are already local—it creates flicker without communicating
+real progress. Use a local skeleton only for genuinely asynchronous remote content with a
+perceptible wait, and never replace the whole Drawer shell. Reduced-motion skips the authored
+transition consistently.
+
+Geometry and interaction belong to the Pattern:
+
+- The panel is portalled above the AppShell and below Modal/Toast layers. Its width is always
+  bounded by the viewport; long content scrolls inside the panel and never widens the page.
+- The backdrop and panel animate as one authored moment. Closing is shorter than opening;
+  loading, section changes, and lazy-module timing must not alter the shell motion.
+- Opening focuses the panel or an explicit initial target. Tab remains inside, Escape and a
+  direct backdrop press request a reversible close, and closing restores focus to the opener.
+- While open, the application root is inert. Do not mutate `body` overflow for Studio drawers:
+  the AppShell owns its own scroll container, and body scrollbar changes cause layout shift.
+- A Modal opened from a Drawer is the active top layer. Escape closes the Modal first; the
+  Drawer remains until its own close request succeeds.
+- Deep links or `open({ section })` requests wait for `open` readiness, then scroll only the
+  Drawer content owner. Never call early `scrollIntoView` in parallel with panel motion.
+
+Settings is the first representative adoption. Its data and instant-save behavior remain
+outside the Drawer Pattern; only shell timing, focus, dismissal, width, and internal scroll
+readiness are shared.
+
+## 12. Tabs and segmented-selection contract
 
 Use `Tabs` for navigation among peer content panels and `SegmentedControl` for changing
 one mutually exclusive value or working mode. They share visual rhythm and keyboard
@@ -353,7 +389,7 @@ as the accessible name and title. Underlined tabs keep their intrinsic width and
 rather than truncating. Both appearances must preserve visible focus, disabled state,
 theme contrast, density response, and Chinese/English label stability.
 
-## 12. Accessibility and resilience
+## 13. Accessibility and resilience
 
 Every primitive must work with keyboard focus, disabled state, light/dark themes,
 all three density modes, and both Chinese and English labels. Focus is always visible.
@@ -363,7 +399,7 @@ full value is available through an established disclosure pattern.
 Respect `prefers-reduced-motion`; status information must remain understandable when
 animation is disabled.
 
-## 13. Migration policy
+## 14. Migration policy
 
 Migration is incremental:
 

--- a/studio/web/src/components/Drawer.test.tsx
+++ b/studio/web/src/components/Drawer.test.tsx
@@ -1,0 +1,227 @@
+import { useState } from 'react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import Drawer from './Drawer'
+import Modal from './Modal'
+
+function endAnimation(element: Element, animationName: string) {
+  const event = new Event('animationend', { bubbles: true })
+  Object.defineProperty(event, 'animationName', { value: animationName })
+  fireEvent(element, event)
+}
+
+function DrawerHarness({ onEntered = () => {} }: { onEntered?: () => void }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>Open settings</button>
+      <Drawer
+        open={open}
+        title="Settings"
+        onClose={() => setOpen(false)}
+        onEntered={onEntered}
+        testId="drawer-root"
+      >
+        <button type="button">First action</button>
+        <button type="button">Last action</button>
+      </Drawer>
+    </>
+  )
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  document.getElementById('root')?.remove()
+})
+
+describe('Drawer', () => {
+  it('keeps one shell mounted and completes deterministic enter and exit phases', async () => {
+    const onEntered = vi.fn()
+    const { rerender } = render(
+      <Drawer open={false} title="Settings" onClose={() => {}} onEntered={onEntered} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+
+    const root = screen.getByTestId('drawer-root')
+    const dialog = screen.getByRole('dialog', { hidden: true })
+    expect(root).toHaveAttribute('data-state', 'closed')
+    expect(root).toHaveAttribute('aria-hidden', 'true')
+
+    rerender(
+      <Drawer open title="Settings" onClose={() => {}} onEntered={onEntered} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'opening'))
+    expect(screen.getByRole('dialog', { name: 'Settings' })).toBe(dialog)
+
+    endAnimation(dialog, 'drawer-panel-in')
+    expect(root).toHaveAttribute('data-state', 'open')
+    expect(onEntered).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <Drawer open={false} title="Settings" onClose={() => {}} onEntered={onEntered} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'closing'))
+    endAnimation(dialog, 'drawer-panel-out')
+    expect(root).toHaveAttribute('data-state', 'closed')
+    expect(dialog).toBeInTheDocument()
+  })
+
+  it('ignores stale animation events when direction reverses quickly', async () => {
+    const { rerender } = render(
+      <Drawer open={false} title="Settings" onClose={() => {}} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+    const root = screen.getByTestId('drawer-root')
+    const dialog = screen.getByRole('dialog', { hidden: true })
+
+    rerender(<Drawer open title="Settings" onClose={() => {}} testId="drawer-root"><p>Content</p></Drawer>)
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'opening'))
+    rerender(<Drawer open={false} title="Settings" onClose={() => {}} testId="drawer-root"><p>Content</p></Drawer>)
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'closing'))
+    rerender(<Drawer open title="Settings" onClose={() => {}} testId="drawer-root"><p>Content</p></Drawer>)
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'opening'))
+
+    endAnimation(dialog, 'drawer-panel-out')
+    expect(root).toHaveAttribute('data-state', 'opening')
+    endAnimation(dialog, 'drawer-panel-in')
+    expect(root).toHaveAttribute('data-state', 'open')
+  })
+
+  it('settles motion when animationend is lost', () => {
+    vi.useFakeTimers()
+    const onEntered = vi.fn()
+    const { rerender } = render(
+      <Drawer open={false} title="Settings" onClose={() => {}} onEntered={onEntered} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+    const root = screen.getByTestId('drawer-root')
+
+    rerender(
+      <Drawer open title="Settings" onClose={() => {}} onEntered={onEntered} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+    expect(root).toHaveAttribute('data-state', 'opening')
+    act(() => vi.advanceTimersByTime(320))
+    expect(root).toHaveAttribute('data-state', 'open')
+    expect(onEntered).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <Drawer open={false} title="Settings" onClose={() => {}} onEntered={onEntered} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+    expect(root).toHaveAttribute('data-state', 'closing')
+    act(() => vi.advanceTimersByTime(240))
+    expect(root).toHaveAttribute('data-state', 'closed')
+  })
+
+  it('skips motion consistently when reduced motion is requested', async () => {
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }))
+    const onEntered = vi.fn()
+    const { rerender } = render(
+      <Drawer open={false} title="Settings" onClose={() => {}} onEntered={onEntered} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+    const root = screen.getByTestId('drawer-root')
+
+    rerender(
+      <Drawer open title="Settings" onClose={() => {}} onEntered={onEntered} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'open'))
+    expect(onEntered).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <Drawer open={false} title="Settings" onClose={() => {}} onEntered={onEntered} testId="drawer-root">
+        <p>Content</p>
+      </Drawer>,
+    )
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'closed'))
+  })
+
+  it('traps focus, closes from Escape or backdrop, and restores the opener', async () => {
+    const user = userEvent.setup()
+    render(<DrawerHarness />)
+
+    const opener = screen.getByRole('button', { name: 'Open settings' })
+    await user.click(opener)
+    const dialog = screen.getByRole('dialog', { name: 'Settings' })
+    await waitFor(() => expect(dialog).toHaveFocus())
+
+    await user.tab()
+    expect(screen.getByRole('button', { name: 'First action' })).toHaveFocus()
+    await user.tab({ shift: true })
+    expect(screen.getByRole('button', { name: 'Last action' })).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.getByTestId('drawer-root')).toHaveAttribute('data-state', 'closing'))
+    expect(opener).not.toHaveFocus()
+
+    endAnimation(dialog, 'drawer-panel-out')
+    expect(opener).toHaveFocus()
+    await user.click(opener)
+    await waitFor(() => expect(screen.getByTestId('drawer-root')).toHaveAttribute('data-state', 'opening'))
+    fireEvent.mouseDown(screen.getByTestId('drawer-root').querySelector('.ui-drawer-backdrop')!)
+    await waitFor(() => expect(screen.getByTestId('drawer-root')).toHaveAttribute('data-state', 'closing'))
+  })
+
+  it('keeps a parent drawer open when Escape belongs to a nested modal', () => {
+    const onDrawerClose = vi.fn()
+    const onModalClose = vi.fn()
+    render(
+      <>
+        <Drawer open title="Settings" onClose={onDrawerClose}>
+          <button type="button">Drawer action</button>
+        </Drawer>
+        <Modal title="Discard changes?" onClose={onModalClose}>
+          <p>Confirmation</p>
+        </Modal>
+      </>,
+    )
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(onModalClose).toHaveBeenCalledTimes(1)
+    expect(onDrawerClose).not.toHaveBeenCalled()
+  })
+
+  it('makes the app root inert without changing body overflow', async () => {
+    const appRoot = document.createElement('div')
+    appRoot.id = 'root'
+    document.body.appendChild(appRoot)
+    document.body.style.overflow = 'auto'
+
+    const { rerender, unmount } = render(
+      <Drawer open={false} title="Settings" onClose={() => {}} testId="drawer-root"><p>Content</p></Drawer>,
+      { container: appRoot },
+    )
+    rerender(<Drawer open title="Settings" onClose={() => {}} testId="drawer-root"><p>Content</p></Drawer>)
+
+    await waitFor(() => expect(appRoot.inert).toBe(true))
+    expect(document.body.style.overflow).toBe('auto')
+
+    rerender(<Drawer open={false} title="Settings" onClose={() => {}} testId="drawer-root"><p>Content</p></Drawer>)
+    await waitFor(() => expect(screen.getByTestId('drawer-root')).toHaveAttribute('data-state', 'closing'))
+    expect(appRoot.inert).toBe(true)
+    endAnimation(screen.getByRole('dialog', { name: 'Settings' }), 'drawer-panel-out')
+    await waitFor(() => expect(appRoot.inert).toBe(false))
+    expect(document.body.style.overflow).toBe('auto')
+    unmount()
+    document.body.style.overflow = ''
+  })
+})

--- a/studio/web/src/components/Drawer.tsx
+++ b/studio/web/src/components/Drawer.tsx
@@ -1,0 +1,263 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type AnimationEvent,
+  type ReactNode,
+  type RefObject,
+} from 'react'
+import { createPortal } from 'react-dom'
+
+export type DrawerSize = 'md' | 'lg' | 'page'
+export type DrawerPhase = 'closed' | 'opening' | 'open' | 'closing'
+
+export interface DrawerProps {
+  open: boolean
+  title: ReactNode
+  onClose: () => void
+  children?: ReactNode
+  size?: DrawerSize
+  showTitle?: boolean
+  closeOnBackdrop?: boolean
+  closeOnEscape?: boolean
+  initialFocusRef?: RefObject<HTMLElement | null>
+  onEntered?: () => void
+  panelClassName?: string
+  testId?: string
+}
+
+const MOTION_FALLBACK_MS: Record<'opening' | 'closing', number> = {
+  opening: 320,
+  closing: 240,
+}
+
+const SIZE_CLASS: Record<DrawerSize, string> = {
+  md: 'ui-drawer-size-md',
+  lg: 'ui-drawer-size-lg',
+  page: 'ui-drawer-size-page',
+}
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+function prefersReducedMotion(): boolean {
+  return typeof window !== 'undefined' &&
+    Boolean(window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches)
+}
+
+function getFocusable(panel: HTMLElement): HTMLElement[] {
+  return Array.from(panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR))
+    .filter((element) => (
+      element.tabIndex >= 0 &&
+      !element.hidden &&
+      !element.closest('[hidden], [aria-hidden="true"]')
+    ))
+}
+
+function isTopmostDialog(panel: HTMLElement): boolean {
+  const dialogs = Array.from(
+    document.querySelectorAll<HTMLElement>('[role="dialog"], [role="alertdialog"]'),
+  ).filter((element) => (
+    !element.hidden &&
+    !element.closest('[hidden], [aria-hidden="true"]')
+  ))
+  return dialogs[dialogs.length - 1] === panel
+}
+
+export default function Drawer({
+  open,
+  title,
+  onClose,
+  children,
+  size = 'md',
+  showTitle = true,
+  closeOnBackdrop = true,
+  closeOnEscape = true,
+  initialFocusRef,
+  onEntered,
+  panelClassName = '',
+  testId,
+}: DrawerProps) {
+  const titleId = useId()
+  const panelRef = useRef<HTMLElement | null>(null)
+  const previousFocusRef = useRef<HTMLElement | null>(null)
+  const enteredRef = useRef(false)
+  const openRef = useRef(open)
+  openRef.current = open
+  const [phase, setPhase] = useState<DrawerPhase>(() => {
+    if (!open) return 'closed'
+    return prefersReducedMotion() ? 'open' : 'opening'
+  })
+  const layerActive = phase !== 'closed'
+
+  useEffect(() => {
+    setPhase((current) => {
+      if (open) {
+        if (current === 'open' || current === 'opening') return current
+        return prefersReducedMotion() ? 'open' : 'opening'
+      }
+      if (current === 'closed' || current === 'closing') return current
+      return prefersReducedMotion() ? 'closed' : 'closing'
+    })
+  }, [open])
+
+  const settlePhase = useCallback((expected: 'opening' | 'closing') => {
+    setPhase((current) => {
+      if (current !== expected) return current
+      if (current === 'opening') return openRef.current ? 'open' : 'closing'
+      return openRef.current ? 'opening' : 'closed'
+    })
+  }, [])
+
+  useEffect(() => {
+    if (phase !== 'opening' && phase !== 'closing') return
+    const timer = window.setTimeout(() => settlePhase(phase), MOTION_FALLBACK_MS[phase])
+    return () => window.clearTimeout(timer)
+  }, [phase, settlePhase])
+
+  useEffect(() => {
+    if (!open) {
+      enteredRef.current = false
+      return
+    }
+    if (phase === 'open' && !enteredRef.current) {
+      enteredRef.current = true
+      onEntered?.()
+    }
+  }, [onEntered, open, phase])
+
+  useEffect(() => {
+    if (!open) return
+
+    if (!previousFocusRef.current) {
+      previousFocusRef.current = document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null
+    }
+
+    const frame = requestAnimationFrame(() => {
+      const panel = panelRef.current
+      if (!panel || panel.contains(document.activeElement)) return
+      const target = initialFocusRef?.current ?? panel
+      target.focus()
+    })
+
+    return () => cancelAnimationFrame(frame)
+  }, [initialFocusRef, open])
+
+  useEffect(() => {
+    if (!layerActive) {
+      previousFocusRef.current?.focus()
+      previousFocusRef.current = null
+      return
+    }
+
+    const appRoot = document.getElementById('root')
+    const appWasInert = appRoot?.inert ?? false
+    if (appRoot) appRoot.inert = true
+    return () => {
+      if (appRoot) appRoot.inert = appWasInert
+    }
+  }, [layerActive])
+
+  useEffect(() => () => {
+    previousFocusRef.current?.focus()
+    previousFocusRef.current = null
+  }, [])
+
+  useEffect(() => {
+    if (!open) return
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      const panel = panelRef.current
+      if (!panel || !isTopmostDialog(panel)) return
+
+      if (event.key === 'Escape' && closeOnEscape) {
+        event.preventDefault()
+        event.stopPropagation()
+        onClose()
+        return
+      }
+
+      if (event.key !== 'Tab') return
+      const focusable = getFocusable(panel)
+      if (focusable.length === 0) {
+        event.preventDefault()
+        panel.focus()
+        return
+      }
+
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      const activeElement = document.activeElement
+      if (event.shiftKey && (activeElement === first || !panel.contains(activeElement))) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && (activeElement === last || !panel.contains(activeElement))) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [closeOnEscape, onClose, open])
+
+  const finishMotion = (event: AnimationEvent<HTMLElement>) => {
+    if (event.target !== event.currentTarget) return
+    if (phase === 'opening' && event.animationName === 'drawer-panel-in') {
+      settlePhase('opening')
+    } else if (phase === 'closing' && event.animationName === 'drawer-panel-out') {
+      settlePhase('closing')
+    }
+  }
+
+  return createPortal(
+    <div
+      className="ui-drawer-root"
+      data-testid={testId}
+      data-state={phase}
+      aria-hidden={phase === 'closed' || undefined}
+    >
+      <div
+        className="ui-drawer-backdrop"
+        onMouseDown={(event) => {
+          if (closeOnBackdrop && event.target === event.currentTarget) onClose()
+        }}
+      />
+      <aside
+        ref={(node) => { panelRef.current = node }}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-hidden={phase === 'closed' || undefined}
+        tabIndex={-1}
+        className={[
+          'ui-drawer-panel',
+          SIZE_CLASS[size],
+          panelClassName,
+        ].filter(Boolean).join(' ')}
+        onAnimationEnd={finishMotion}
+      >
+        <h2
+          id={titleId}
+          className={showTitle ? 'type-section-title shrink-0 px-page pt-page' : 'sr-only'}
+        >
+          {title}
+        </h2>
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+          {children}
+        </div>
+      </aside>
+    </div>,
+    document.body,
+  )
+}

--- a/studio/web/src/components/SettingsDrawer.test.tsx
+++ b/studio/web/src/components/SettingsDrawer.test.tsx
@@ -1,0 +1,75 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+import { DialogProvider } from './Dialog'
+import SettingsDrawer from './SettingsDrawer'
+import { SettingsDrawerProvider, useSettingsDrawer } from '../lib/SettingsDrawer'
+
+vi.mock('../pages/tools/Settings', () => ({
+  default: () => <div data-testid="settings-content">Settings content</div>,
+}))
+
+function endAnimation(element: Element, animationName: string) {
+  const event = new Event('animationend', { bubbles: true })
+  Object.defineProperty(event, 'animationName', { value: animationName })
+  fireEvent(element, event)
+}
+
+function Harness() {
+  const drawer = useSettingsDrawer()
+  return (
+    <>
+      <button type="button" onClick={() => drawer.open()}>Open settings</button>
+      <output data-testid="drawer-ready">{String(drawer.isReady)}</output>
+      <SettingsDrawer />
+    </>
+  )
+}
+
+function renderHarness() {
+  return render(
+    <DialogProvider>
+      <SettingsDrawerProvider>
+        <Harness />
+      </SettingsDrawerProvider>
+    </DialogProvider>,
+  )
+}
+
+describe('SettingsDrawer', () => {
+  it('mounts static content with the shell and keeps one instance across opens', async () => {
+    const user = userEvent.setup()
+    renderHarness()
+
+    expect(screen.getByTestId('settings-drawer')).toHaveAttribute('data-state', 'closed')
+    expect(screen.queryByTestId('settings-content')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Open settings' }))
+    const root = screen.getByTestId('settings-drawer')
+    const dialog = screen.getByRole('dialog', { name: /设置|Settings/ })
+    const content = await screen.findByTestId('settings-content')
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'opening'))
+    expect(content).toBeVisible()
+    expect(screen.queryByText(/加载中|Loading/)).not.toBeInTheDocument()
+    expect(screen.getByTestId('drawer-ready')).toHaveTextContent('false')
+
+    endAnimation(dialog, 'drawer-panel-in')
+    expect(root).toHaveAttribute('data-state', 'open')
+    expect(content).toBeVisible()
+    expect(screen.getByTestId('drawer-ready')).toHaveTextContent('true')
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'closing'))
+    expect(content).toBeVisible()
+    expect(screen.queryByText(/加载中|Loading/)).not.toBeInTheDocument()
+    expect(screen.getByTestId('drawer-ready')).toHaveTextContent('false')
+    endAnimation(dialog, 'drawer-panel-out')
+    expect(root).toHaveAttribute('data-state', 'closed')
+
+    await user.click(screen.getByRole('button', { name: 'Open settings' }))
+    await waitFor(() => expect(root).toHaveAttribute('data-state', 'opening'))
+    expect(screen.getByTestId('settings-content')).toBe(content)
+    expect(content).toBeVisible()
+    expect(screen.queryByText(/加载中|Loading/)).not.toBeInTheDocument()
+  })
+})

--- a/studio/web/src/components/SettingsDrawer.tsx
+++ b/studio/web/src/components/SettingsDrawer.tsx
@@ -1,123 +1,49 @@
-// SettingsDrawer.tsx —— 右侧滑出的设置抽屉外壳。
+// SettingsDrawer.tsx —— Settings 覆盖式抽屉。
 //
-// 渲染策略（解决"打开瞬间 mount 1000+ 行 Settings 卡帧"问题）：
-//
-// 1. 代码分割（React.lazy）：Settings 不进首屏 bundle，首次 open 才下载
-// 2. Skeleton-first：抽屉外壳立即滑入显示骨架，下一帧（rAF）才真正 mount Settings；
-//    动画跑在 GPU 上（transform + opacity），mount 卡顿被动画掩盖
-// 3. 关闭对称：isOpen=false 时立刻卸掉 Settings，再播 slide-out；
-//    避免 React 卸 8 个 tab 组件树跟动画抢主线程
-//
-// Settings 数据（secrets / catalog / SSE）住在 SettingsDataProvider 里常驻，
-// 所以这里 mount/unmount Settings 不付重新拉数据的成本，只付 React render 的成本。
-import { lazy, Suspense, useEffect, useState } from 'react'
+// Settings 是本地静态配置页，不制造 transient loading shell。首次打开时内容与 Drawer
+// 在同一次 commit 中挂载并作为一个整体入场；之后保持挂载，避免再次打开时重建组件树。
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import Drawer from './Drawer'
+import SettingsPage from '../pages/tools/Settings'
 import { useSettingsDrawer } from '../lib/SettingsDrawer'
 
-const SettingsPageLazy = lazy(() => import('../pages/tools/Settings'))
-
-// 宽度：70vw，小屏给 1024px 兜底（避免笔记本 viewport 太小时表单挤）。
-//   1366 viewport（小笔记本）：70vw=956 → 撑到 1024
-//   1707 viewport（缩放后 2k 150%）：70vw=1195
-//   1920 viewport（1k FHD）：70vw=1344
-//   2320 viewport（缩放后 2k 110-125%）：70vw=1624
-//   2560 viewport（原生 2k）：70vw=1792
-//   3840 viewport（4k）：70vw=2688
-const DRAWER_WIDTH_CLASS = 'w-[max(1024px,70vw)]'
-const ANIM_MS = 220
-
 export default function SettingsDrawer() {
-  const { isOpen, close } = useSettingsDrawer()
-  const [contentReady, setContentReady] = useState(false)
-  const [shouldRender, setShouldRender] = useState(isOpen)
-  const [active, setActive] = useState(isOpen)
+  const { isOpen, close, setReady } = useSettingsDrawer()
+  const { t } = useTranslation()
+  const [contentMounted, setContentMounted] = useState(false)
 
   useEffect(() => {
     if (isOpen) {
-      setShouldRender(true)
-    } else {
-      setActive(false)
-      const timer = setTimeout(() => {
-        setShouldRender(false)
-      }, ANIM_MS)
-      return () => clearTimeout(timer)
-    }
-  }, [isOpen])
-
-  useEffect(() => {
-    if (shouldRender && isOpen) {
-      const id = requestAnimationFrame(() => {
-        setActive(true)
-      })
-      return () => cancelAnimationFrame(id)
-    }
-  }, [shouldRender, isOpen])
-
-  // open: 让外壳先滑进来（GPU 动画），下一帧再 mount Settings
-  // close: 立刻卸 Settings，外壳的 slide-out 在空骨架上跑
-  useEffect(() => {
-    if (!isOpen) {
-      setContentReady(false)
+      setContentMounted(true)
       return
     }
-    const id = requestAnimationFrame(() => setContentReady(true))
-    return () => cancelAnimationFrame(id)
-  }, [isOpen])
+    setReady(false)
+  }, [isOpen, setReady])
 
-  if (!shouldRender) return null
+  const handleEntered = useCallback(() => {
+    setReady(true)
+  }, [setReady])
+
+  // isOpen 直接参与条件，确保首次打开时内容和 opening 壳层在同一次 commit 中出现；
+  // state 仅负责在第一次打开后保活内容。
+  const shouldMountContent = isOpen || contentMounted
 
   return (
-    <div
-      aria-hidden={!isOpen}
-      className={`fixed inset-0 z-40 ${active ? '' : 'pointer-events-none'}`}
+    <Drawer
+      open={isOpen}
+      title={t('nav.settings')}
+      showTitle={false}
+      size="page"
+      onClose={() => { void close() }}
+      onEntered={handleEntered}
+      testId="settings-drawer"
     >
-      {/* backdrop：absolute 铺满 viewport，让 panel slide-in 中途不会从右边露出底页。
-       *  之前用 flex + flex-1 时 backdrop 只占 panel 左边那条，panel 滑动期间右侧
-       *  panel 槽位无人覆盖 → 看见底层页面 / 出现黑白闪屏。 */}
-      <div
-        onClick={() => void close()}
-        className={`absolute inset-0 transition-colors ease-out ${
-          active ? 'bg-black/35' : 'bg-black/0'
-        }`}
-        style={{ transitionDuration: `${ANIM_MS}ms` }}
-        aria-label="close settings"
-      />
-      <aside
-        role="dialog"
-        aria-modal="true"
-        className={`absolute top-0 right-0 bottom-0 flex flex-col bg-canvas border-l border-subtle shadow-2xl transition-transform ease-out ${DRAWER_WIDTH_CLASS} ${
-          active ? 'translate-x-0' : 'translate-x-full'
-        }`}
-        style={{ transitionDuration: `${ANIM_MS}ms` }}
-      >
-        {contentReady && isOpen ? (
-          <Suspense fallback={<DrawerSkeleton />}>
-            <SettingsPageLazy />
-          </Suspense>
-        ) : (
-          <DrawerSkeleton />
-        )}
-      </aside>
-    </div>
-  )
-}
-
-function DrawerSkeleton() {
-  const { t } = useTranslation()
-  return (
-    <div className="flex flex-col h-full">
-      {/* 跟 PageHeader 同结构的占位条 —— 高度对齐，slide-in 切到真内容时不跳 */}
-      <div className="px-6 pt-5 pb-4 bg-canvas border-b border-subtle">
-        <div className="h-7 w-24 rounded bg-overlay" />
-        <div className="mt-4 flex gap-2">
-          {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="h-7 w-16 rounded bg-overlay/60" />
-          ))}
+      {shouldMountContent && (
+        <div className="flex h-full min-h-0 flex-col">
+          <SettingsPage />
         </div>
-      </div>
-      <div className="flex-1 grid place-items-center text-fg-tertiary text-sm">
-        {t('settings.drawerLoading')}
-      </div>
-    </div>
+      )}
+    </Drawer>
   )
 }

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -871,7 +871,6 @@
   "settings": {
     "drawerTitle": "Settings",
     "drawerClose": "Close settings",
-    "drawerLoading": "Loading…",
     "closeDirtyTitle": "Unsaved changes",
     "closeDirtyConfirm": "Closing the drawer will discard unsaved changes. Close anyway?",
     "closeDirtyOk": "Discard & close",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -871,7 +871,6 @@
   "settings": {
     "drawerTitle": "设置",
     "drawerClose": "关闭设置",
-    "drawerLoading": "加载中…",
     "closeDirtyTitle": "未保存的改动",
     "closeDirtyConfirm": "关闭抽屉会丢弃未保存的改动，确认关闭？",
     "closeDirtyOk": "丢弃并关闭",

--- a/studio/web/src/lib/SettingsData.tsx
+++ b/studio/web/src/lib/SettingsData.tsx
@@ -1,13 +1,13 @@
 // SettingsData.tsx —— Settings 全局数据层。
 //
 // 把 secrets / catalog / downloadBusy / SSE 订阅从 SettingsPage 提到根级 Provider，
-// 让 SettingsPage 本身可以 unmount + remount 不付重新拉数据的代价：
+// 让 SettingsPage 的展示生命周期与数据请求解耦：
 // - secrets：一次 fetch，常驻 context；save 后由 SettingsPage 调 setSecrets 更新
 // - catalog：reloadCatalog + model_download_changed SSE 订阅常驻，跟下载组件共享
 // - downloadBusy：跟 startDownload 配对的 in-flight Set
 //
-// 这层只持有数据，不渲染 UI。SettingsDrawer 关闭时 SettingsPage 卸载，
-// 第二次打开瞬间渲染——数据已经在 context 里。
+// 这层只持有数据，不渲染 UI。SettingsPage 首次打开后可在 Drawer 内保活，
+// 无论 UI 是否挂载，权威数据和订阅都继续由这里持有。
 import {
   createContext,
   useCallback,

--- a/studio/web/src/lib/SettingsDrawer.tsx
+++ b/studio/web/src/lib/SettingsDrawer.tsx
@@ -11,7 +11,6 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useRef,
   useState,
   type ReactNode,
@@ -26,11 +25,15 @@ interface OpenOptions {
 
 interface SettingsDrawerApi {
   isOpen: boolean
-  /** 上一次 open 调用带的 section；SettingsPage 内 effect 监听它做 scrollIntoView。
+  /** Drawer 完成 opening 动画且内部滚动容器可安全定位。 */
+  isReady: boolean
+  /** 上一次 open 调用带的 section；SettingsPage 仅在 isReady 后消费。
    *  每次 open 哪怕同一 section 也会换引用，便于触发 effect。 */
   sectionRequest: { section: string; nonce: number } | null
   open: (opts?: OpenOptions) => void
   close: () => void
+  /** Drawer 壳层内部使用；业务调用方不应手动修改。 */
+  setReady: (ready: boolean) => void
   /** SettingsPage mount 时注册「当前 draft 是否 dirty」的查询函数；unmount 时传 null。 */
   registerDirtyGuard: (fn: (() => boolean) | null) => void
 }
@@ -41,6 +44,7 @@ export function SettingsDrawerProvider({ children }: { children: ReactNode }) {
   const { t } = useTranslation()
   const { confirm } = useDialog()
   const [isOpen, setIsOpen] = useState(false)
+  const [isReady, setReady] = useState(false)
   const [sectionRequest, setSectionRequest] = useState<SettingsDrawerApi['sectionRequest']>(null)
   const dirtyGuardRef = useRef<(() => boolean) | null>(null)
   const nonceRef = useRef(0)
@@ -67,6 +71,7 @@ export function SettingsDrawerProvider({ children }: { children: ReactNode }) {
       })
       if (!ok) return
     }
+    setReady(false)
     setIsOpen(false)
   }, [confirm, t])
 
@@ -74,21 +79,16 @@ export function SettingsDrawerProvider({ children }: { children: ReactNode }) {
     dirtyGuardRef.current = fn
   }, [])
 
-  // ESC 关：放在 Provider 里而非 Drawer 组件，避免 lazy 加载期间快捷键失效。
-  useEffect(() => {
-    if (!isOpen) return
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        void close()
-      }
-    }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
-  }, [isOpen, close])
-
   return (
-    <Ctx.Provider value={{ isOpen, sectionRequest, open, close, registerDirtyGuard }}>
+    <Ctx.Provider value={{
+      isOpen,
+      isReady,
+      sectionRequest,
+      open,
+      close,
+      setReady,
+      registerDirtyGuard,
+    }}>
       {children}
     </Ctx.Provider>
   )

--- a/studio/web/src/pages/tools/Settings.test.tsx
+++ b/studio/web/src/pages/tools/Settings.test.tsx
@@ -6,7 +6,7 @@ import { DialogProvider } from '../../components/Dialog'
 import { ToastProvider } from '../../components/Toast'
 import { AnnouncementsProvider } from '../../lib/Announcements'
 import { SettingsDataProvider } from '../../lib/SettingsData'
-import { SettingsDrawerProvider } from '../../lib/SettingsDrawer'
+import { SettingsDrawerProvider, useSettingsDrawer } from '../../lib/SettingsDrawer'
 import SettingsPage from './Settings'
 
 const initialServerState = {
@@ -441,7 +441,17 @@ afterEach(() => {
   vi.unstubAllGlobals()
 })
 
-function renderPage() {
+function DrawerTestControls() {
+  const drawer = useSettingsDrawer()
+  return (
+    <>
+      <button type="button" onClick={() => drawer.open({ section: 'models' })}>Open model settings</button>
+      <button type="button" onClick={() => drawer.setReady(true)}>Finish drawer motion</button>
+    </>
+  )
+}
+
+function renderPage({ withDrawerControls = false } = {}) {
   return render(
     <MemoryRouter>
       <ToastProvider>
@@ -449,6 +459,7 @@ function renderPage() {
           <AnnouncementsProvider>
             <SettingsDataProvider>
               <SettingsDrawerProvider>
+                {withDrawerControls && <DrawerTestControls />}
                 <SettingsPage />
               </SettingsDrawerProvider>
             </SettingsDataProvider>
@@ -460,6 +471,25 @@ function renderPage() {
 }
 
 describe('SettingsPage (PP0)', () => {
+  it('waits for drawer readiness before positioning a deep-linked section', async () => {
+    const user = userEvent.setup()
+    renderPage({ withDrawerControls: true })
+    const scrollContainer = screen.getByTestId('settings-scroll-container')
+    const scrollTo = vi.fn()
+    scrollContainer.scrollTo = scrollTo
+
+    await user.click(screen.getByRole('button', { name: 'Open model settings' }))
+    expect(scrollTo).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Finish drawer motion' }))
+    await waitFor(() => expect(scrollTo).toHaveBeenCalledWith({ top: expect.any(Number), behavior: 'auto' }))
+    expect(screen.getByRole('button', { name: '训练' })).toHaveClass('border-accent')
+
+    await user.click(screen.getByRole('button', { name: '测试' }))
+    expect(screen.getByRole('button', { name: '测试' })).toHaveClass('border-accent')
+    expect(screen.getByRole('button', { name: '训练' })).not.toHaveClass('border-accent')
+  })
+
   it('测试页底部管理非项目 LoRA 来源：默认目录无移除按钮，额外目录即时保存', async () => {
     const user = userEvent.setup()
     renderPage()

--- a/studio/web/src/pages/tools/Settings.tsx
+++ b/studio/web/src/pages/tools/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 import {
   api,
@@ -55,7 +55,7 @@ import WandBWorkspace from './settings/WandBWorkspace'
 export default function SettingsPage() {
   const { t } = useTranslation()
   // 共享数据层（SettingsDataProvider）：secrets / catalog / SSE / downloadBusy 都在根级常驻，
-  // 本组件 mount/unmount（抽屉开关）不再触发重拉。`server` 别名保留是为了让下方
+  // UI 首次打开后可在 Drawer 内保活；权威数据不依赖其展示状态。`server` 别名保留是为了让下方
   // 大段表单代码改动最小。
   const {
     secrets: server,
@@ -83,6 +83,7 @@ export default function SettingsPage() {
   const drawer = useSettingsDrawer()
   // 右侧 section index 用：sticky nav 的 IntersectionObserver root + 滚动平移容器
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const consumedSectionNonceRef = useRef<number | null>(null)
 
   // 数据层 fetch secrets 失败时把错误透出到本组件 error 状态。
   useEffect(() => { if (secretsError) setError(secretsError) }, [secretsError])
@@ -102,20 +103,33 @@ export default function SettingsPage() {
     return () => drawer.registerDirtyGuard(null)
   }, [drawer])
 
-  // 抽屉以 open({ section }) 打开时跳到对应 section（取代旧的 ?section= URL 参数）。
-  // sectionRequest 带 nonce，相同 section 重复 open 也会触发 effect 重跑。
+  // 抽屉深链接：等 Drawer 完成开场后，再在它自己的滚动容器内定位。
+  // useLayoutEffect 让首次挂载和热打开都在内容显现前落到目标，避免页面先闪在顶部。
   const drawerSectionReq = drawer.sectionRequest
-  useEffect(() => {
-    if (!drawerSectionReq) return
+  useLayoutEffect(() => {
+    if (!drawerSectionReq || !drawer.isReady) return
+    if (consumedSectionNonceRef.current === drawerSectionReq.nonce) return
+
     const section = drawerSectionReq.section
     const targetTab = SECTION_TO_TAB[section]
-    if (targetTab) setTab(targetTab)
-    const t1 = setTimeout(() => {
-      const el = document.getElementById(section)
-      el?.scrollIntoView({ behavior: 'smooth', block: 'start' })
-    }, 50)
-    return () => clearTimeout(t1)
-  }, [drawerSectionReq])
+    if (targetTab && targetTab !== tab) {
+      setTab(targetTab)
+      return
+    }
+
+    consumedSectionNonceRef.current = drawerSectionReq.nonce
+    const container = scrollContainerRef.current
+    const target = container?.querySelector<HTMLElement>(`[id="${section}"]`)
+    if (!container || !target) return
+
+    const top = target.getBoundingClientRect().top -
+      container.getBoundingClientRect().top + container.scrollTop
+    if (typeof container.scrollTo === 'function') {
+      container.scrollTo({ top, behavior: 'auto' })
+    } else {
+      container.scrollTop = top
+    }
+  }, [drawer.isReady, drawerSectionReq, tab])
 
   const update = <S extends Section, K extends keyof Secrets[S]>(
     section: S,
@@ -305,7 +319,7 @@ export default function SettingsPage() {
         actions={<SaveIndicator status={saveStatus} announceError={false} />}
       />
 
-      <div ref={scrollContainerRef} className="p-page pb-12 flex-1 overflow-y-auto">
+      <div ref={scrollContainerRef} data-testid="settings-scroll-container" className="p-page pb-12 flex-1 overflow-y-auto">
       <div className="grid gap-10 max-w-[1920px]" style={{ gridTemplateColumns: 'minmax(0,1fr) 200px' }}>
       <div className="flex flex-col gap-page-loose min-w-0">
 

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -764,3 +764,91 @@ select option:checked {
 /* page transitions */
 .fade-in { animation: fade-in 200ms ease; }
 @keyframes fade-in { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+
+/* overlay drawer — one state machine owns shell motion; feature content never authors
+ * its own entrance. The root remains mounted so cold and warm opens share the same path. */
+.ui-drawer-root {
+  position: fixed;
+  inset: 0;
+  z-index: 40;
+  visibility: hidden;
+  pointer-events: none;
+  isolation: isolate;
+}
+.ui-drawer-root[data-state="opening"],
+.ui-drawer-root[data-state="open"],
+.ui-drawer-root[data-state="closing"] {
+  visibility: visible;
+}
+.ui-drawer-root[data-state="opening"],
+.ui-drawer-root[data-state="open"] {
+  pointer-events: auto;
+}
+.ui-drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgb(0 0 0 / 0.35);
+  opacity: 0;
+  touch-action: none;
+}
+.ui-drawer-panel {
+  position: absolute;
+  inset-block: 0;
+  right: 0;
+  display: flex;
+  height: 100dvh;
+  min-width: 0;
+  max-width: 100vw;
+  flex-direction: column;
+  overflow: hidden;
+  overscroll-behavior: contain;
+  border-left: 1px solid var(--border-subtle);
+  background: var(--bg-canvas);
+  box-shadow: var(--sh-xl);
+  outline: none;
+  transform: translate3d(100%, 0, 0);
+  contain: layout paint;
+}
+.ui-drawer-size-md { width: min(100vw, 28rem); }
+.ui-drawer-size-lg { width: min(100vw, 40rem); }
+.ui-drawer-size-page { width: min(100vw, max(64rem, 70vw)); }
+.ui-drawer-root[data-state="opening"] .ui-drawer-backdrop,
+.ui-drawer-root[data-state="open"] .ui-drawer-backdrop { opacity: 1; }
+.ui-drawer-root[data-state="closing"] .ui-drawer-backdrop { opacity: 0; }
+.ui-drawer-root[data-state="opening"] .ui-drawer-panel,
+.ui-drawer-root[data-state="open"] .ui-drawer-panel { transform: translate3d(0, 0, 0); }
+.ui-drawer-root[data-state="closing"] .ui-drawer-panel { transform: translate3d(100%, 0, 0); }
+.ui-drawer-root[data-state="opening"] .ui-drawer-backdrop {
+  animation: drawer-backdrop-in 220ms ease-out both;
+}
+.ui-drawer-root[data-state="opening"] .ui-drawer-panel {
+  animation: drawer-panel-in 220ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  will-change: transform;
+}
+.ui-drawer-root[data-state="closing"] .ui-drawer-backdrop {
+  animation: drawer-backdrop-out 160ms ease-in both;
+}
+.ui-drawer-root[data-state="closing"] .ui-drawer-panel {
+  animation: drawer-panel-out 160ms cubic-bezier(0.4, 0, 1, 1) both;
+  will-change: transform;
+}
+@keyframes drawer-panel-in {
+  from { transform: translate3d(100%, 0, 0); }
+  to { transform: translate3d(0, 0, 0); }
+}
+@keyframes drawer-panel-out {
+  from { transform: translate3d(0, 0, 0); }
+  to { transform: translate3d(100%, 0, 0); }
+}
+@keyframes drawer-backdrop-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+@keyframes drawer-backdrop-out {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .ui-drawer-backdrop,
+  .ui-drawer-panel { animation: none !important; }
+}


### PR DESCRIPTION
## 概要

- 新增覆盖式 `Drawer` Pattern，统一 `closed → opening → open → closing` 生命周期、焦点约束与恢复、Escape/遮罩关闭、背景 `inert`、reduced-motion 及 viewport 宽度边界
- 将 Settings 迁移到共享 Drawer 壳层；不同入口统一经过同一套开关状态机，关闭后保活内容与表单状态
- Settings 作为本地静态页面与抽屉在同一次渲染中整体入场，不再显示短暂 Loading/Skeleton，避免首次闪烁及再次打开时内容挤压
- Deep-link 仅在入场完成后滚动 Drawer 自有容器，并按 nonce 消费一次，不干扰用户后续切换标签
- 明确 Overlay Drawer、底部任务日志与 Generate 附着工作区的边界，避免用一个万能抽屉破坏既有几何和保活语义
- 在 `DESIGN.md` 中记录 Overlay Drawer 契约与静态内容加载原则

## 交互与可访问性

- Portal 层级位于 AppShell 之上、Modal/Toast 之下
- 打开后焦点保持在抽屉内，关闭后恢复至触发控件
- Drawer 活跃期间应用根节点使用 `inert`，不修改 `body` overflow，避免滚动条引起页面抖动
- 嵌套 Modal 成为最上层交互，Escape 优先关闭 Modal
- 快速开关时过滤旧方向动画事件，并用超时兜底收口丢失的 `animationend`
- reduced-motion 下直接进入稳定终态

## 代表性迁移

- Settings 覆盖式抽屉
- Sidebar、Command Palette 与业务 deep-link 等现有入口继续复用统一 Settings Drawer store

本 PR 不改 Queue/Train 的底部日志面板，也不改 Generate 的 LoRA、画廊与 XY 附着工作区。

## 验证

- 聚焦 Vitest：3 个文件、22 个测试通过
- 全量 Vitest：95 个文件、751 个测试通过
- ESLint：通过
- TypeScript：通过
- Production build：通过
- Python 路由快照：通过
- Impeccable detector：0 findings
- 独立代码审查：无 P0/P1，复核通过
- 人工视觉检查：首次/再次打开、无 Loading/Skeleton、页面稳定性与抽屉动画通过

## 视觉检查范围

- 浅色 / 深色主题
- `tight / default / loose` 密度
- 中文 / 英文
- 首次打开与再次打开
- 快速打开/关闭/重开
- Settings deep-link
- 未保存修改确认 Modal
- 常规与较窄桌面窗口
