### PR TITLE
feat(web): 统一异步进度与加载状态

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,7 +25,7 @@ surface has identical density.
 | --- | --- | --- |
 | Foundation | `studio/web/src/styles/tokens.css` | Color, type, spacing, radius, shadow, motion, control states |
 | Utility bridge | `studio/web/tailwind.config.js` | Maps CSS tokens into Tailwind utilities |
-| Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx`, `FormControl.tsx`, `Alert.tsx` | Typed, accessible component APIs |
+| Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx`, `FormControl.tsx`, `Alert.tsx`, `ProgressBar.tsx` | Typed, accessible component APIs |
 | Patterns | `PageHeader`, `StepShell`, `ActionGroup`, `SaveIndicator`, `SaveBar`, `ListToolbar`, `Dialog`, `Modal`, `Drawer`, `Tabs`, `SegmentedControl`, `Toast`, `Field` | Repeated page and interaction structures |
 | Product surfaces | `studio/web/src/pages/` | Business state and composition, not new visual primitives |
 
@@ -413,7 +413,49 @@ persistence, active-filter dots, sorting, API parameters, paging resets, result 
 refresh, clear behavior, and list mutations remain page-owned. Do not add unused result
 or clear slots until a repeated product behavior has been established.
 
-## 14. Accessibility and resilience
+## 14. Async-state and progress contract
+
+Async UI describes real work; it must not fabricate a waiting phase for local static
+content. Use `Button` loading for one pending action, `ConfigSkeleton` for a genuine
+initial remote schema/config fetch, and `ProgressBar` for an operation with duration.
+A spinner or progress bar is not a substitute for the page's ordinary empty state.
+
+`ProgressBar` is the typed visual and accessibility primitive. Every instance has a
+localized accessible label. Pass `value` and `max` only when the application has a
+meaningful quantity; the primitive clamps it and exposes `aria-valuemin`,
+`aria-valuemax`, and `aria-valuenow`. Omit `value` when work is real but its amount is
+unknown—the indeterminate state must not display a fabricated `0%` or a pretend ETA.
+`aria-valuetext` may add phase, batch, file, or step context. The primitive owns track,
+fill, sizes, motion, and reduced-motion fallback; it never owns SSE, polling, upload
+state, cancellation, retry, or business estimates.
+
+Use `xs` for an edge-aligned workbench pipeline, `sm` for ordinary inline/background
+work, and `md` for a blocking transfer dialog. Percentage text and byte/step metadata
+use tabular mono numerals beside the bar rather than inside a narrow fill. Progress
+color means active or complete work; errors move to `Alert`/Toast instead of leaving a
+red bar that still claims to be progressing. Capacity, utilization, scores, and crop
+ratios are data visualizations and do not use this async contract.
+
+Announcements are event-based, not frame-based:
+
+- Do not put rapidly changing percentages, bytes, or steps in a polite live region.
+  The progressbar value remains available to assistive technology without announcing
+  every tick.
+- Announce a phase boundary such as processing, completion, or failure once through a
+  stable atomic status/alert. Avoid duplicating the same event in inline feedback and
+  a Toast.
+- A blocking operation uses `Modal`; disable Escape/backdrop only while interruption
+  would be unsafe. A background operation must not steal focus merely because progress
+  updates.
+
+A skeleton reserves the expected geometry of remote content and carries `aria-busy`.
+Use it only while the initial remote structure is unavailable and the wait is
+perceptible. Do not insert skeletons for local Settings/static pages, short state
+transitions, refreshes where content can remain visible, or as an entrance animation.
+Skeleton and indeterminate motion become a stable static indicator under
+`prefers-reduced-motion`; meaning cannot depend on pulsing or travel.
+
+## 15. Accessibility and resilience
 
 Every primitive must work with keyboard focus, disabled state, light/dark themes,
 all three density modes, and both Chinese and English labels. Focus is always visible.
@@ -423,7 +465,7 @@ full value is available through an established disclosure pattern.
 Respect `prefers-reduced-motion`; status information must remain understandable when
 animation is disabled.
 
-## 15. Migration policy
+## 16. Migration policy
 
 Migration is incremental:
 

--- a/studio/web/src/components/ConfigSkeleton.test.tsx
+++ b/studio/web/src/components/ConfigSkeleton.test.tsx
@@ -32,7 +32,17 @@ describe('ConfigSkeleton', () => {
     render(<ConfigSkeleton label="加载训练配置中" />)
     const status = screen.getByRole('status')
     expect(status.getAttribute('aria-label')).toBe('加载训练配置中')
+    expect(status).toHaveAttribute('aria-busy', 'true')
     expect(screen.getByText('加载训练配置中...')).toBeInTheDocument()
+  })
+
+  it('uses the shared motion-safe skeleton class', () => {
+    const { container, rerender } = render(<ConfigSkeleton groups={[1]} />)
+    expect(container.querySelector('.ui-skeleton')).toBeInTheDocument()
+    expect(container.querySelector('.animate-pulse')).not.toBeInTheDocument()
+
+    rerender(<ConfigSkeleton variant="flat" groups={[1]} />)
+    expect(screen.getByRole('status')).toHaveClass('ui-skeleton')
   })
 
   it('defaults to 4 groups when groups prop is omitted', () => {

--- a/studio/web/src/components/ConfigSkeleton.tsx
+++ b/studio/web/src/components/ConfigSkeleton.tsx
@@ -32,9 +32,9 @@ export default function ConfigSkeleton({
   const Wrapper = isCard ? 'section' : 'div'
   const wrapperClass = isCard
     ? 'flex-1 min-h-0 overflow-y-auto pr-1 space-y-3'
-    : 'flex flex-col gap-3 animate-pulse'
+    : 'flex flex-col gap-3 ui-skeleton'
   const groupClass = isCard
-    ? 'animate-pulse rounded-md border border-subtle bg-surface p-3.5'
+    ? 'ui-skeleton rounded-md border border-subtle bg-surface p-3.5'
     : 'flex flex-col gap-2'
   const titleBarClass = isCard
     ? 'h-3.5 w-32 rounded-sm bg-sunken mb-2.5'
@@ -53,7 +53,7 @@ export default function ConfigSkeleton({
     : 'h-[26px] rounded-sm border border-subtle bg-canvas'
 
   return (
-    <Wrapper className={wrapperClass} role="status" aria-label={label}>
+    <Wrapper className={wrapperClass} role="status" aria-label={label} aria-busy="true">
       {groups.map((rows, gi) => (
         <div key={gi} className={groupClass}>
           <div className={titleBarClass} />

--- a/studio/web/src/components/ModelsRootMigrateModal.test.tsx
+++ b/studio/web/src/components/ModelsRootMigrateModal.test.tsx
@@ -53,9 +53,14 @@ describe('ModelsRootMigrateModal', () => {
   it('confirm 态点开始迁移 → 调 startModelsRootMigrate(target, undefined) 并进入 running', async () => {
     render(<ModelsRootMigrateModal target="D:\newroot" onClose={() => {}} onDone={() => {}} />)
     await screen.findByText('开始迁移')
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-labelledby')
     await userEvent.click(screen.getByText('开始迁移'))
     expect(mockApi.startModelsRootMigrate).toHaveBeenCalledWith('D:\\newroot', undefined)
     await screen.findByText('正在复制…')
+    const progress = screen.getByRole('progressbar', { name: '正在复制…' })
+    expect(progress).not.toHaveAttribute('aria-valuenow')
+    expect(progress).toHaveAttribute('data-state', 'indeterminate')
+    expect(document.activeElement).toBe(screen.getByTestId('models-root-migration-phase'))
   })
 
   it('409 target_conflict → conflict 态展示统计，跳过已有文件 → 带 skip 重发进 running', async () => {
@@ -67,6 +72,7 @@ describe('ModelsRootMigrateModal', () => {
     await userEvent.click(screen.getByText('开始迁移'))
 
     await screen.findByText('目标目录已包含 models 数据')
+    expect(screen.getByRole('alertdialog')).toHaveAttribute('aria-labelledby')
     // 统计插值：目标路径 + 已有文件数/大小 + 同名数
     expect(screen.getByText(/已有 12 个文件（2\.0 MB），其中 3 个/)).toBeInTheDocument()
 

--- a/studio/web/src/components/ModelsRootMigrateModal.tsx
+++ b/studio/web/src/components/ModelsRootMigrateModal.tsx
@@ -9,9 +9,14 @@
  * 目标已有 models 数据时后端回 409 target_conflict → conflict 相位（issue #351）：
  * 「跳过已有文件」（合并补齐，同名保留目标现有版本）/「覆盖已有文件」/ 取消。
  */
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import ActionGroup from './ActionGroup'
+import Alert from './Alert'
+import Button from './Button'
+import Modal from './Modal'
+import ProgressBar from './ProgressBar'
 import { api, type ApiError, type ModelsRootInfo } from '../api/client'
 import { formatBytes } from '../lib/useUploadProgress'
 import { useEventStream } from '../lib/useEventStream'
@@ -52,6 +57,11 @@ export default function ModelsRootMigrateModal({ target, onClose, onDone }: {
   const [progress, setProgress] = useState<Progress>(EMPTY_PROGRESS)
   const [conflict, setConflict] = useState<ConflictInfo | null>(null)
   const [error, setError] = useState('')
+  const phaseContentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (phase === 'running') phaseContentRef.current?.focus()
+  }, [phase])
 
   useEffect(() => {
     let cancelled = false
@@ -125,154 +135,169 @@ export default function ModelsRootMigrateModal({ target, onClose, onDone }: {
   const closable = phase !== 'running'
   const pct = progress.totalBytes > 0
     ? Math.min(100, Math.round((progress.doneBytes / progress.totalBytes) * 100))
-    : 0
+    : null
+  const progressDetail = progress.totalBytes > 0
+    ? `${progress.doneFiles}/${progress.totalFiles} · ${formatBytes(progress.doneBytes)}/${formatBytes(progress.totalBytes)} · ${pct}%`
+    : null
+
+  const footer = (() => {
+    if (phase === 'loading') {
+      return (
+        <ActionGroup
+          secondary={<Button variant="ghost" onClick={onClose}>{t('common.close')}</Button>}
+        />
+      )
+    }
+    if (phase === 'confirm') {
+      return (
+        <ActionGroup
+          secondary={<Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button>}
+          primary={(
+            <Button variant="primary" onClick={() => void handleStart()}>
+              {t('settings.storage.startMigrate')}
+            </Button>
+          )}
+        />
+      )
+    }
+    if (phase === 'conflict') {
+      return (
+        <ActionGroup
+          secondary={(
+            <>
+              <Button variant="ghost" onClick={() => setPhase('confirm')}>
+                {t('common.cancel')}
+              </Button>
+              <Button variant="danger" onClick={() => void handleStart('overwrite')}>
+                {t('settings.storage.conflictOverwrite')}
+              </Button>
+            </>
+          )}
+          primary={(
+            <Button variant="primary" onClick={() => void handleStart('skip')}>
+              {t('settings.storage.conflictSkip')}
+            </Button>
+          )}
+        />
+      )
+    }
+    if (phase === 'done' || phase === 'error') {
+      return (
+        <ActionGroup
+          primary={<Button variant="primary" onClick={onClose}>{t('common.close')}</Button>}
+        />
+      )
+    }
+    return undefined
+  })()
 
   return (
-    <div
-      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
-      onClick={closable ? onClose : undefined}
+    <Modal
+      title={t('settings.storage.modelsMigrateTitle')}
+      onClose={onClose}
+      closeOnBackdrop={closable}
+      closeOnEscape={closable}
+      footer={footer}
+      size="md"
+      role={phase === 'conflict' ? 'alertdialog' : 'dialog'}
     >
       <div
-        className="bg-elevated border border-dim rounded-lg shadow-xl w-[560px] max-h-[80vh] flex flex-col overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
+        ref={phaseContentRef}
+        data-testid="models-root-migration-phase"
+        tabIndex={-1}
+        className="flex flex-col gap-field focus:outline-none"
+        aria-busy={phase === 'loading' || phase === 'running'}
       >
-        <header className="px-4 py-3 border-b border-subtle flex items-center gap-2 shrink-0">
-          <h3 className="m-0 text-sm font-semibold flex-1 text-fg-primary">
-            {t('settings.storage.modelsMigrateTitle')}
-          </h3>
-          {closable && (
-            <button className="btn btn-ghost text-xs" onClick={onClose} aria-label={t('common.close')}>×</button>
-          )}
-        </header>
+        {phase === 'loading' && (
+          <div className="flex flex-col gap-related" role="status" aria-live="polite">
+            <div className="text-sm text-fg-secondary">{t('settings.storage.scanning')}</div>
+            <ProgressBar label={t('settings.storage.scanning')} value={null} />
+          </div>
+        )}
 
-        <div className="p-4 flex flex-col gap-3 overflow-y-auto">
-          {phase === 'loading' && (
-            <div className="text-sm text-fg-tertiary py-6 text-center">
-              {t('settings.storage.scanning')}
+        {phase === 'confirm' && info?.scan && (
+          <>
+            <div className="flex flex-col gap-1 text-xs text-fg-secondary">
+              <div>
+                <span className="text-fg-tertiary">{t('settings.storage.from')}</span>{' '}
+                <code className="font-mono">{info.current}</code>
+              </div>
+              <div>
+                <span className="text-fg-tertiary">{t('settings.storage.to')}</span>{' '}
+                <code className="font-mono">{destination}</code>
+              </div>
             </div>
-          )}
-
-          {phase === 'confirm' && info?.scan && (
-            <>
-              <div className="text-xs text-fg-secondary flex flex-col gap-1">
-                <div>
-                  <span className="text-fg-tertiary">{t('settings.storage.from')}</span>{' '}
-                  <code className="font-mono">{info.current}</code>
-                </div>
-                <div>
-                  <span className="text-fg-tertiary">{t('settings.storage.to')}</span>{' '}
-                  <code className="font-mono">{destination}</code>
-                </div>
-              </div>
-              <div className="text-sm font-semibold">
-                {t('settings.storage.totalLine', {
-                  files: info.scan.total_files,
-                  size: formatBytes(info.scan.total_bytes),
-                })}
-              </div>
-              <div
-                className="bg-sunken border border-subtle rounded-md text-xs font-mono overflow-y-auto"
-                style={{ maxHeight: 200 }}
-              >
-                {info.scan.entries.map((e) => (
-                  <div key={e.name} className="flex justify-between gap-2 px-2.5 py-1 border-b border-subtle last:border-b-0">
-                    <span className="truncate">{e.is_dir ? `${e.name}/` : e.name}</span>
-                    <span className="text-fg-tertiary shrink-0">
-                      {t('settings.storage.entryMeta', { files: e.files, size: formatBytes(e.bytes) })}
-                    </span>
-                  </div>
-                ))}
-              </div>
-              <div className="text-xs text-fg-tertiary">
-                {t('settings.storage.modelsKeepOriginalNote')}
-              </div>
-            </>
-          )}
-
-          {phase === 'conflict' && conflict && (
-            <>
-              <div className="text-sm font-semibold">
-                {t('settings.storage.conflictTitle')}
-              </div>
-              <div className="text-xs text-fg-secondary">
-                {t('settings.storage.conflictSummary', {
-                  path: destination,
-                  files: conflict.existingFiles,
-                  size: formatBytes(conflict.existingBytes),
-                  same: conflict.sameNameFiles,
-                })}
-              </div>
-              <div className="text-xs text-fg-tertiary">
-                {t('settings.storage.conflictHint')}
-              </div>
-            </>
-          )}
-
-          {phase === 'running' && (
-            <>
-              <div className="text-sm">{t('settings.storage.migrating')}</div>
-              <div className="h-2 rounded-full bg-sunken border border-subtle overflow-hidden">
-                <div
-                  className="h-full rounded-full"
-                  style={{
-                    width: `${pct}%`,
-                    background: 'var(--accent)',
-                    transition: 'width 200ms linear',
-                  }}
-                />
-              </div>
-              <div className="text-xs text-fg-tertiary font-mono flex justify-between gap-2">
-                <span className="truncate">{progress.currentFile}</span>
-                <span className="shrink-0">
-                  {progress.doneFiles}/{progress.totalFiles} · {formatBytes(progress.doneBytes)}/{formatBytes(progress.totalBytes)} · {pct}%
-                </span>
-              </div>
-            </>
-          )}
-
-          {phase === 'done' && (
-            <>
-              <div className="text-sm text-ok">{t('settings.storage.doneTitle')}</div>
-              <div className="text-xs text-fg-secondary">
-                {t('settings.storage.modelsDoneNote')}
-              </div>
-            </>
-          )}
-
-          {phase === 'error' && (
-            <div className="text-sm text-err break-all">
-              {t('settings.storage.failed', { error })}
+            <div className="text-sm font-semibold">
+              {t('settings.storage.totalLine', {
+                files: info.scan.total_files,
+                size: formatBytes(info.scan.total_bytes),
+              })}
             </div>
-          )}
-        </div>
+            <div
+              className="overflow-y-auto rounded-md border border-subtle bg-sunken font-mono text-xs"
+              style={{ maxHeight: 200 }}
+            >
+              {info.scan.entries.map((entry) => (
+                <div key={entry.name} className="flex justify-between gap-related border-b border-subtle px-2.5 py-1 last:border-b-0">
+                  <span className="truncate">{entry.is_dir ? `${entry.name}/` : entry.name}</span>
+                  <span className="shrink-0 text-fg-tertiary">
+                    {t('settings.storage.entryMeta', { files: entry.files, size: formatBytes(entry.bytes) })}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div className="text-xs text-fg-tertiary">
+              {t('settings.storage.modelsKeepOriginalNote')}
+            </div>
+          </>
+        )}
 
-        <footer className="px-4 py-3 border-t border-subtle flex justify-end gap-2 shrink-0">
-          {phase === 'confirm' && (
-            <>
-              <button className="btn btn-ghost" onClick={onClose}>{t('common.cancel')}</button>
-              <button className="btn btn-primary" onClick={() => void handleStart()}>
-                {t('settings.storage.startMigrate')}
-              </button>
-            </>
-          )}
-          {phase === 'conflict' && (
-            <>
-              <button className="btn btn-ghost" onClick={() => setPhase('confirm')}>
-                {t('common.cancel')}
-              </button>
-              <button className="btn btn-danger" onClick={() => void handleStart('overwrite')}>
-                {t('settings.storage.conflictOverwrite')}
-              </button>
-              <button className="btn btn-primary" onClick={() => void handleStart('skip')}>
-                {t('settings.storage.conflictSkip')}
-              </button>
-            </>
-          )}
-          {(phase === 'done' || phase === 'error') && (
-            <button className="btn btn-primary" onClick={onClose}>{t('common.close')}</button>
-          )}
-        </footer>
+        {phase === 'conflict' && conflict && (
+          <Alert tone="warning" size="sm" title={t('settings.storage.conflictTitle')}>
+            <span className="block">
+              {t('settings.storage.conflictSummary', {
+                path: destination,
+                files: conflict.existingFiles,
+                size: formatBytes(conflict.existingBytes),
+                same: conflict.sameNameFiles,
+              })}
+            </span>
+            <span className="mt-related block text-fg-tertiary">
+              {t('settings.storage.conflictHint')}
+            </span>
+          </Alert>
+        )}
+
+        {phase === 'running' && (
+          <>
+            <div className="text-sm text-fg-secondary" role="status" aria-live="polite">
+              {t('settings.storage.migrating')}
+            </div>
+            <ProgressBar
+              label={t('settings.storage.migrating')}
+              value={pct}
+              valueText={progressDetail ?? undefined}
+              size="md"
+            />
+            <div className="flex justify-between gap-related font-mono text-xs text-fg-tertiary">
+              <span className="truncate">{progress.currentFile}</span>
+              {progressDetail && <span className="shrink-0">{progressDetail}</span>}
+            </div>
+          </>
+        )}
+
+        {phase === 'done' && (
+          <Alert tone="success" size="sm" role="status" aria-live="polite" title={t('settings.storage.doneTitle')}>
+            {t('settings.storage.modelsDoneNote')}
+          </Alert>
+        )}
+
+        {phase === 'error' && (
+          <Alert tone="danger" size="sm" role="alert">
+            <span className="break-all">{t('settings.storage.failed', { error })}</span>
+          </Alert>
+        )}
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/studio/web/src/components/ProgressBar.test.tsx
+++ b/studio/web/src/components/ProgressBar.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import ProgressBar from './ProgressBar'
+
+describe('ProgressBar', () => {
+  it('exposes a labelled determinate progressbar and clamps its value', () => {
+    const { rerender } = render(
+      <ProgressBar label="Upload progress" value={35} valueText="35%, 7 MB of 20 MB" />,
+    )
+
+    const progress = screen.getByRole('progressbar', { name: 'Upload progress' })
+    expect(progress).toHaveAttribute('aria-valuemin', '0')
+    expect(progress).toHaveAttribute('aria-valuemax', '100')
+    expect(progress).toHaveAttribute('aria-valuenow', '35')
+    expect(progress).toHaveAttribute('aria-valuetext', '35%, 7 MB of 20 MB')
+    expect(progress).toHaveAttribute('data-state', 'determinate')
+    expect(progress.querySelector('.ui-progress-fill')).toHaveStyle({ transform: 'scaleX(0.35)' })
+
+    rerender(<ProgressBar label="Upload progress" value={140} />)
+    expect(progress).toHaveAttribute('aria-valuenow', '100')
+    expect(progress.querySelector('.ui-progress-fill')).toHaveStyle({ transform: 'scaleX(1)' })
+  })
+
+  it('omits aria-valuenow when progress is indeterminate', () => {
+    render(<ProgressBar label="Preparing generation" value={null} size="xs" />)
+
+    const progress = screen.getByRole('progressbar', { name: 'Preparing generation' })
+    expect(progress).not.toHaveAttribute('aria-valuenow')
+    expect(progress).toHaveAttribute('data-state', 'indeterminate')
+    expect(progress).toHaveClass('ui-progress', 'ui-progress-xs', 'ui-progress-accent')
+    expect(progress.querySelector('.ui-progress-fill')).not.toHaveAttribute('style')
+  })
+
+  it('supports a custom max, success tone, size, and class name', () => {
+    render(
+      <ProgressBar
+        label="Copy files"
+        value={3}
+        max={4}
+        size="md"
+        tone="success"
+        className="mt-related"
+      />,
+    )
+
+    const progress = screen.getByRole('progressbar', { name: 'Copy files' })
+    expect(progress).toHaveAttribute('aria-valuemax', '4')
+    expect(progress).toHaveAttribute('aria-valuenow', '3')
+    expect(progress).toHaveClass('ui-progress-md', 'ui-progress-success', 'mt-related')
+    expect(progress.querySelector('.ui-progress-fill')).toHaveStyle({ transform: 'scaleX(0.75)' })
+  })
+})

--- a/studio/web/src/components/ProgressBar.tsx
+++ b/studio/web/src/components/ProgressBar.tsx
@@ -1,0 +1,69 @@
+import type { HTMLAttributes } from 'react'
+
+export type ProgressBarSize = 'xs' | 'sm' | 'md'
+export type ProgressBarTone = 'accent' | 'success'
+
+export interface ProgressBarProps extends Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'role'> {
+  /** Accessible name for the operation whose progress is shown. */
+  label: string
+  /** Omit or pass null when the amount of work is unknown. */
+  value?: number | null
+  max?: number
+  valueText?: string
+  size?: ProgressBarSize
+  tone?: ProgressBarTone
+}
+
+const SIZE_CLASS: Record<ProgressBarSize, string> = {
+  xs: 'ui-progress-xs',
+  sm: 'ui-progress-sm',
+  md: 'ui-progress-md',
+}
+
+const TONE_CLASS: Record<ProgressBarTone, string> = {
+  accent: 'ui-progress-accent',
+  success: 'ui-progress-success',
+}
+
+export default function ProgressBar({
+  label,
+  value,
+  max = 100,
+  valueText,
+  size = 'sm',
+  tone = 'accent',
+  className = '',
+  ...rest
+}: ProgressBarProps) {
+  const safeMax = Number.isFinite(max) && max > 0 ? max : 100
+  const determinate = value != null && Number.isFinite(value)
+  const safeValue = determinate
+    ? Math.min(safeMax, Math.max(0, value))
+    : undefined
+  const percentage = safeValue == null ? undefined : (safeValue / safeMax) * 100
+
+  return (
+    <div
+      {...rest}
+      role="progressbar"
+      aria-label={label}
+      aria-valuemin={0}
+      aria-valuemax={safeMax}
+      aria-valuenow={safeValue}
+      aria-valuetext={valueText}
+      data-state={determinate ? 'determinate' : 'indeterminate'}
+      className={[
+        'ui-progress',
+        SIZE_CLASS[size],
+        TONE_CLASS[tone],
+        className,
+      ].filter(Boolean).join(' ')}
+    >
+      <div
+        className="ui-progress-fill"
+        style={percentage == null ? undefined : { transform: `scaleX(${percentage / 100})` }}
+        aria-hidden="true"
+      />
+    </div>
+  )
+}

--- a/studio/web/src/components/StudioDataMigrateModal.test.tsx
+++ b/studio/web/src/components/StudioDataMigrateModal.test.tsx
@@ -1,11 +1,19 @@
 /** StudioDataMigrateModal：confirm 信息展示 / 启动调用 / running 不可关。
  *  SSE 在 jsdom 下不连（useEventStream 内部 EventSource guard），相位推进
  *  只测到 running —— done/error 由 SSE 事件驱动，后端测试覆盖事件发布。 */
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 import StudioDataMigrateModal from './StudioDataMigrateModal'
+
+let onEventCb: ((evt: Record<string, unknown>) => void) | null = null
+
+vi.mock('../lib/useEventStream', () => ({
+  useEventStream: (cb: (evt: Record<string, unknown>) => void) => {
+    onEventCb = cb
+  },
+}))
 
 const mockApi = {
   getStudioDataInfo: vi.fn(),
@@ -33,6 +41,7 @@ const INFO = {
 describe('StudioDataMigrateModal', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    onEventCb = null
     mockApi.getStudioDataInfo.mockResolvedValue(INFO)
     mockApi.startStudioDataMigrate.mockResolvedValue({ ok: true })
   })
@@ -44,6 +53,7 @@ describe('StudioDataMigrateModal', () => {
     await waitFor(() => {
       expect(screen.getByText(/共 42 个文件/)).toBeInTheDocument()
     })
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-labelledby')
     expect(screen.getByText(/5\.0 MB/)).toBeInTheDocument()
     // 目标显示实际落地目录 target\studio_data（用户选的是父目录）
     expect(screen.getByText('D:\\data\\studio_data')).toBeInTheDocument()
@@ -60,8 +70,23 @@ describe('StudioDataMigrateModal', () => {
     await userEvent.click(screen.getByText('开始迁移'))
     expect(mockApi.startStudioDataMigrate).toHaveBeenCalledWith('D:\\data')
     await screen.findByText('正在复制…')
-    // running 态：header 的关闭 × 不渲染
-    expect(screen.queryByLabelText('关闭')).not.toBeInTheDocument()
+    const progress = screen.getByRole('progressbar', { name: '正在复制…' })
+    expect(progress).not.toHaveAttribute('aria-valuenow')
+    expect(document.activeElement).toBe(screen.getByTestId('studio-data-migration-phase'))
+    act(() => {
+      onEventCb?.({
+        type: 'studio_data_migrate_progress',
+        done_files: 21,
+        total_files: 42,
+        done_bytes: 2.5 * 1024 * 1024,
+        total_bytes: 5 * 1024 * 1024,
+        current_file: 'projects/example.json',
+      })
+    })
+    expect(progress).toHaveAttribute('aria-valuenow', '50')
+    expect(progress).toHaveAttribute('aria-valuetext', expect.stringContaining('50%'))
+    // running 态：没有关闭操作，Escape / backdrop 也由 Modal 禁用
+    expect(screen.queryByRole('button', { name: '关闭' })).not.toBeInTheDocument()
     expect(onClose).not.toHaveBeenCalled()
   })
 
@@ -83,6 +108,6 @@ describe('StudioDataMigrateModal', () => {
     await screen.findByText('开始迁移')
     await userEvent.click(screen.getByText('开始迁移'))
     await screen.findByText(/目标目录非空/)
-    expect(screen.getByLabelText('关闭')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '关闭' })).toBeInTheDocument()
   })
 })

--- a/studio/web/src/components/StudioDataMigrateModal.tsx
+++ b/studio/web/src/components/StudioDataMigrateModal.tsx
@@ -7,9 +7,14 @@
  * 不引入"后台迁移中再重开看进度"的游离状态）。完成后新位置**重启 server
  * 生效**（指针文件 import 时求值），done 态给「立即重启」。
  */
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import ActionGroup from './ActionGroup'
+import Alert from './Alert'
+import Button from './Button'
+import Modal from './Modal'
+import ProgressBar from './ProgressBar'
 import { api, type StudioDataInfo } from '../api/client'
 import { formatBytes } from '../lib/useUploadProgress'
 import { useEventStream } from '../lib/useEventStream'
@@ -43,6 +48,11 @@ export default function StudioDataMigrateModal({ target, onClose, onRestart }: {
   const [info, setInfo] = useState<StudioDataInfo | null>(null)
   const [progress, setProgress] = useState<Progress>(EMPTY_PROGRESS)
   const [error, setError] = useState('')
+  const phaseContentRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (phase === 'running') phaseContentRef.current?.focus()
+  }, [phase])
 
   useEffect(() => {
     let cancelled = false
@@ -105,130 +115,143 @@ export default function StudioDataMigrateModal({ target, onClose, onRestart }: {
   const closable = phase !== 'running'
   const pct = progress.totalBytes > 0
     ? Math.min(100, Math.round((progress.doneBytes / progress.totalBytes) * 100))
-    : 0
+    : null
+  const progressDetail = progress.totalBytes > 0
+    ? `${progress.doneFiles}/${progress.totalFiles} · ${formatBytes(progress.doneBytes)}/${formatBytes(progress.totalBytes)} · ${pct}%`
+    : null
+
+  const footer = (() => {
+    if (phase === 'loading') {
+      return (
+        <ActionGroup
+          secondary={<Button variant="ghost" onClick={onClose}>{t('common.close')}</Button>}
+        />
+      )
+    }
+    if (phase === 'confirm') {
+      return (
+        <ActionGroup
+          secondary={<Button variant="ghost" onClick={onClose}>{t('common.cancel')}</Button>}
+          primary={(
+            <Button variant="primary" onClick={() => void handleStart()}>
+              {t('settings.storage.startMigrate')}
+            </Button>
+          )}
+        />
+      )
+    }
+    if (phase === 'done') {
+      return (
+        <ActionGroup
+          secondary={<Button variant="ghost" onClick={onClose}>{t('common.close')}</Button>}
+          primary={(
+            <Button variant="primary" onClick={onRestart}>
+              {t('settings.storage.restartNow')}
+            </Button>
+          )}
+        />
+      )
+    }
+    if (phase === 'error') {
+      return (
+        <ActionGroup
+          primary={<Button variant="primary" onClick={onClose}>{t('common.close')}</Button>}
+        />
+      )
+    }
+    return undefined
+  })()
 
   return (
-    <div
-      className="fixed inset-0 z-50 bg-black/50 flex items-center justify-center"
-      onClick={closable ? onClose : undefined}
+    <Modal
+      title={t('settings.storage.migrateTitle')}
+      onClose={onClose}
+      closeOnBackdrop={closable}
+      closeOnEscape={closable}
+      footer={footer}
+      size="md"
     >
       <div
-        className="bg-elevated border border-dim rounded-lg shadow-xl w-[560px] max-h-[80vh] flex flex-col overflow-hidden"
-        onClick={(e) => e.stopPropagation()}
+        ref={phaseContentRef}
+        data-testid="studio-data-migration-phase"
+        tabIndex={-1}
+        className="flex flex-col gap-field focus:outline-none"
+        aria-busy={phase === 'loading' || phase === 'running'}
       >
-        <header className="px-4 py-3 border-b border-subtle flex items-center gap-2 shrink-0">
-          <h3 className="m-0 text-sm font-semibold flex-1 text-fg-primary">
-            {t('settings.storage.migrateTitle')}
-          </h3>
-          {closable && (
-            <button className="btn btn-ghost text-xs" onClick={onClose} aria-label={t('common.close')}>×</button>
-          )}
-        </header>
+        {phase === 'loading' && (
+          <div className="flex flex-col gap-related" role="status" aria-live="polite">
+            <div className="text-sm text-fg-secondary">{t('settings.storage.scanning')}</div>
+            <ProgressBar label={t('settings.storage.scanning')} value={null} />
+          </div>
+        )}
 
-        <div className="p-4 flex flex-col gap-3 overflow-y-auto">
-          {phase === 'loading' && (
-            <div className="text-sm text-fg-tertiary py-6 text-center">
-              {t('settings.storage.scanning')}
+        {phase === 'confirm' && info?.scan && (
+          <>
+            <div className="flex flex-col gap-1 text-xs text-fg-secondary">
+              <div>
+                <span className="text-fg-tertiary">{t('settings.storage.from')}</span>{' '}
+                <code className="font-mono">{info.current}</code>
+              </div>
+              <div>
+                <span className="text-fg-tertiary">{t('settings.storage.to')}</span>{' '}
+                <code className="font-mono">{destination}</code>
+              </div>
             </div>
-          )}
-
-          {phase === 'confirm' && info?.scan && (
-            <>
-              <div className="text-xs text-fg-secondary flex flex-col gap-1">
-                <div>
-                  <span className="text-fg-tertiary">{t('settings.storage.from')}</span>{' '}
-                  <code className="font-mono">{info.current}</code>
-                </div>
-                <div>
-                  <span className="text-fg-tertiary">{t('settings.storage.to')}</span>{' '}
-                  <code className="font-mono">{destination}</code>
-                </div>
-              </div>
-              <div className="text-sm font-semibold">
-                {t('settings.storage.totalLine', {
-                  files: info.scan.total_files,
-                  size: formatBytes(info.scan.total_bytes),
-                })}
-              </div>
-              <div
-                className="bg-sunken border border-subtle rounded-md text-xs font-mono overflow-y-auto"
-                style={{ maxHeight: 200 }}
-              >
-                {info.scan.entries.map((e) => (
-                  <div key={e.name} className="flex justify-between gap-2 px-2.5 py-1 border-b border-subtle last:border-b-0">
-                    <span className="truncate">{e.is_dir ? `${e.name}/` : e.name}</span>
-                    <span className="text-fg-tertiary shrink-0">
-                      {t('settings.storage.entryMeta', { files: e.files, size: formatBytes(e.bytes) })}
-                    </span>
-                  </div>
-                ))}
-              </div>
-              <div className="text-xs text-fg-tertiary">
-                {t('settings.storage.keepOriginalNote')}
-              </div>
-            </>
-          )}
-
-          {phase === 'running' && (
-            <>
-              <div className="text-sm">{t('settings.storage.migrating')}</div>
-              <div className="h-2 rounded-full bg-sunken border border-subtle overflow-hidden">
-                <div
-                  className="h-full rounded-full"
-                  style={{
-                    width: `${pct}%`,
-                    background: 'var(--accent)',
-                    transition: 'width 200ms linear',
-                  }}
-                />
-              </div>
-              <div className="text-xs text-fg-tertiary font-mono flex justify-between gap-2">
-                <span className="truncate">{progress.currentFile}</span>
-                <span className="shrink-0">
-                  {progress.doneFiles}/{progress.totalFiles} · {formatBytes(progress.doneBytes)}/{formatBytes(progress.totalBytes)} · {pct}%
-                </span>
-              </div>
-            </>
-          )}
-
-          {phase === 'done' && (
-            <>
-              <div className="text-sm text-ok">{t('settings.storage.doneTitle')}</div>
-              <div className="text-xs text-fg-secondary">
-                {t('settings.storage.doneRestartNote')}
-              </div>
-            </>
-          )}
-
-          {phase === 'error' && (
-            <div className="text-sm text-err break-all">
-              {t('settings.storage.failed', { error })}
+            <div className="text-sm font-semibold">
+              {t('settings.storage.totalLine', {
+                files: info.scan.total_files,
+                size: formatBytes(info.scan.total_bytes),
+              })}
             </div>
-          )}
-        </div>
+            <div
+              className="overflow-y-auto rounded-md border border-subtle bg-sunken font-mono text-xs"
+              style={{ maxHeight: 200 }}
+            >
+              {info.scan.entries.map((entry) => (
+                <div key={entry.name} className="flex justify-between gap-related border-b border-subtle px-2.5 py-1 last:border-b-0">
+                  <span className="truncate">{entry.is_dir ? `${entry.name}/` : entry.name}</span>
+                  <span className="shrink-0 text-fg-tertiary">
+                    {t('settings.storage.entryMeta', { files: entry.files, size: formatBytes(entry.bytes) })}
+                  </span>
+                </div>
+              ))}
+            </div>
+            <div className="text-xs text-fg-tertiary">
+              {t('settings.storage.keepOriginalNote')}
+            </div>
+          </>
+        )}
 
-        <footer className="px-4 py-3 border-t border-subtle flex justify-end gap-2 shrink-0">
-          {phase === 'confirm' && (
-            <>
-              <button className="btn btn-ghost" onClick={onClose}>{t('common.cancel')}</button>
-              <button className="btn btn-primary" onClick={() => void handleStart()}>
-                {t('settings.storage.startMigrate')}
-              </button>
-            </>
-          )}
-          {phase === 'done' && (
-            <>
-              <button className="btn btn-ghost" onClick={onClose}>{t('common.close')}</button>
-              <button className="btn btn-primary" onClick={onRestart}>
-                {t('settings.storage.restartNow')}
-              </button>
-            </>
-          )}
-          {phase === 'error' && (
-            <button className="btn btn-ghost" onClick={onClose}>{t('common.close')}</button>
-          )}
-        </footer>
+        {phase === 'running' && (
+          <>
+            <div className="text-sm text-fg-secondary" role="status" aria-live="polite">
+              {t('settings.storage.migrating')}
+            </div>
+            <ProgressBar
+              label={t('settings.storage.migrating')}
+              value={pct}
+              valueText={progressDetail ?? undefined}
+              size="md"
+            />
+            <div className="flex justify-between gap-related font-mono text-xs text-fg-tertiary">
+              <span className="truncate">{progress.currentFile}</span>
+              {progressDetail && <span className="shrink-0">{progressDetail}</span>}
+            </div>
+          </>
+        )}
+
+        {phase === 'done' && (
+          <Alert tone="success" size="sm" role="status" aria-live="polite" title={t('settings.storage.doneTitle')}>
+            {t('settings.storage.doneRestartNote')}
+          </Alert>
+        )}
+
+        {phase === 'error' && (
+          <Alert tone="danger" size="sm" role="alert">
+            <span className="break-all">{t('settings.storage.failed', { error })}</span>
+          </Alert>
+        )}
       </div>
-    </div>
+    </Modal>
   )
 }

--- a/studio/web/src/components/UploadProgressBar.test.tsx
+++ b/studio/web/src/components/UploadProgressBar.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { UploadProgressState } from '../lib/useUploadProgress'
+import UploadProgressBar from './UploadProgressBar'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => ({
+      'upload.progressLabel': 'Upload progress',
+      'upload.processing': 'Server processing…',
+      'upload.complete': 'Upload complete',
+      'upload.failed': 'Failed',
+      'upload.etaPrefix': 'ETA',
+    })[key] ?? key,
+  }),
+}))
+
+const makeState = (overrides: Partial<UploadProgressState>): UploadProgressState => ({
+  phase: 'uploading',
+  loaded: 0,
+  total: 100,
+  speedBps: 0,
+  etaSec: null,
+  error: null,
+  ...overrides,
+})
+
+describe('UploadProgressBar', () => {
+  it('renders upload bytes as determinate progress without a live region per tick', () => {
+    render(
+      <UploadProgressBar
+        state={makeState({ loaded: 50, total: 100, speedBps: 25, etaSec: 2 })}
+      />,
+    )
+
+    const progress = screen.getByRole('progressbar', { name: 'Upload progress' })
+    expect(progress).toHaveAttribute('aria-valuenow', '50')
+    expect(progress).toHaveAttribute('aria-valuetext', expect.stringContaining('50%'))
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+    expect(screen.getByText(/ETA 2s/)).toBeInTheDocument()
+  })
+
+  it('keeps an unknown-length upload indeterminate without fabricating 0%', () => {
+    render(
+      <UploadProgressBar state={makeState({ loaded: 512, total: 0 })} />,
+    )
+
+    const progress = screen.getByRole('progressbar', { name: 'Upload progress' })
+    expect(progress).not.toHaveAttribute('aria-valuenow')
+    expect(progress).toHaveAttribute('data-state', 'indeterminate')
+    expect(screen.getByText('512 B')).toBeInTheDocument()
+    expect(screen.queryByText('0%')).not.toBeInTheDocument()
+  })
+
+  it('switches server processing to indeterminate progress and announces the phase once', () => {
+    render(
+      <UploadProgressBar state={makeState({ phase: 'processing', loaded: 100, total: 100 })} />,
+    )
+
+    const progress = screen.getByRole('progressbar', { name: 'Server processing…' })
+    expect(progress).not.toHaveAttribute('aria-valuenow')
+    expect(progress).toHaveAttribute('data-state', 'indeterminate')
+    expect(screen.getByRole('status')).toHaveTextContent('Server processing…')
+  })
+
+  it('uses an alert instead of presenting a failed operation as active progress', () => {
+    render(
+      <UploadProgressBar state={makeState({ phase: 'error', error: 'network down' })} />,
+    )
+
+    expect(screen.queryByRole('progressbar')).not.toBeInTheDocument()
+    expect(screen.getByRole('alert')).toHaveTextContent('Failed: network down')
+  })
+
+  it('marks the completed state with success progress and a phase announcement', () => {
+    render(
+      <UploadProgressBar state={makeState({ phase: 'done', loaded: 100, total: 100 })} />,
+    )
+
+    expect(screen.getByRole('progressbar', { name: 'Upload complete' }))
+      .toHaveAttribute('aria-valuenow', '100')
+    expect(screen.getByRole('progressbar')).toHaveClass('ui-progress-success')
+    expect(screen.getByRole('status')).toHaveTextContent('Upload complete')
+  })
+})

--- a/studio/web/src/components/UploadProgressBar.tsx
+++ b/studio/web/src/components/UploadProgressBar.tsx
@@ -1,21 +1,14 @@
 /**
- * UploadProgressBar — 浏览器上传共用进度条 UI。
- *
- * 三个阶段视觉区分：
- *   - uploading  → 实进度 + speed + ETA
- *   - processing → 100% 满条 + "处理中…"（server 同步解包 / 落盘的等待）
- *   - error      → 红色边 + 错误信息
- *
- * 业务侧只负责喂 state（来自 useUploadProgress），其余完全 stateless。
+ * UploadProgressBar — browser upload status composed from the shared ProgressBar.
+ * Numeric XHR ticks stay in progressbar value semantics; only phase transitions
+ * (processing, complete, failure) enter a live region.
  */
 import { useTranslation } from 'react-i18next'
 
-import {
-  formatBytes,
-  formatEta,
-  formatSpeed,
-  type UploadProgressState,
-} from '../lib/useUploadProgress'
+import type { UploadProgressState } from '../lib/useUploadProgress'
+import { formatBytes, formatEta, formatSpeed } from '../lib/useUploadProgress'
+import Alert from './Alert'
+import ProgressBar from './ProgressBar'
 
 interface Props {
   state: UploadProgressState
@@ -26,67 +19,69 @@ export default function UploadProgressBar({ state, className }: Props) {
   const { t } = useTranslation()
   if (state.phase === 'idle') return null
 
-  const pct =
-    state.total > 0
-      ? Math.min(100, Math.max(0, (state.loaded / state.total) * 100))
-      : state.phase === 'processing' || state.phase === 'done'
-        ? 100
-        : 0
+  const determinate = state.total > 0
+  const pct = determinate
+    ? Math.min(100, Math.round((state.loaded / state.total) * 100))
+    : null
 
-  const isErr = state.phase === 'error'
-  const isUploading = state.phase === 'uploading'
-  const isProcessing = state.phase === 'processing'
+  if (state.phase === 'error') {
+    return (
+      <Alert
+        tone="danger"
+        size="sm"
+        icon={false}
+        role="alert"
+        className={className}
+      >
+        {t('upload.failed')}: {state.error ?? ''}
+      </Alert>
+    )
+  }
+
+  const processing = state.phase === 'processing'
+  const done = state.phase === 'done'
+  const label = processing
+    ? t('upload.processing')
+    : done
+      ? t('upload.complete')
+      : t('upload.progressLabel')
+  const detail = determinate
+    ? `${formatBytes(state.loaded)} / ${formatBytes(state.total)}`
+    : formatBytes(state.loaded)
 
   return (
-    <div
-      className={`flex flex-col gap-1 ${className ?? ''}`}
-      role="status"
-      aria-live="polite"
-    >
-      <div
-        className={`relative w-full h-1.5 rounded-sm overflow-hidden ${
-          isErr ? 'bg-err-soft' : 'bg-overlay'
-        }`}
-      >
-        <div
-          className={`absolute inset-y-0 left-0 transition-[width] duration-150 ease-out ${
-            isErr ? 'bg-err' : isProcessing ? 'bg-accent animate-pulse' : 'bg-accent'
-          }`}
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-      <div className="flex items-center gap-2 text-[11px] text-fg-tertiary font-mono">
-        {isErr ? (
-          <span className="text-err truncate">
-            {t('upload.failed')}: {state.error}
-          </span>
-        ) : isProcessing ? (
+    <div className={['flex flex-col gap-related', className].filter(Boolean).join(' ')}>
+      <ProgressBar
+        label={label}
+        value={processing ? null : (done ? 100 : pct)}
+        valueText={processing ? t('upload.processing') : (pct == null ? undefined : `${pct}% · ${detail}`)}
+        tone={done ? 'success' : 'accent'}
+        size="sm"
+      />
+
+      {processing ? (
+        <div className="flex items-center gap-related text-xs text-fg-secondary" role="status" aria-live="polite">
+          <span className="dot dot-running" aria-hidden="true" />
           <span>{t('upload.processing')}</span>
-        ) : isUploading ? (
-          <>
-            <span>{pct.toFixed(0)}%</span>
-            <span>·</span>
-            <span>
-              {formatBytes(state.loaded)}
-              {state.total > 0 && ` / ${formatBytes(state.total)}`}
+        </div>
+      ) : done ? (
+        <div className="text-xs text-ok" role="status" aria-live="polite">
+          {t('upload.complete')}
+        </div>
+      ) : (
+        <div className="flex items-center justify-between gap-related font-mono text-xs text-fg-tertiary">
+          <span className="truncate">
+            {detail}
+            {state.speedBps > 0 && <> · {formatSpeed(state.speedBps)}</>}
+          </span>
+          {(state.etaSec != null || pct != null) && (
+            <span className="shrink-0">
+              {state.etaSec != null && <>{t('upload.etaPrefix')} {formatEta(state.etaSec)}{pct != null && ' · '}</>}
+              {pct != null && `${pct}%`}
             </span>
-            {state.speedBps > 0 && (
-              <>
-                <span>·</span>
-                <span>{formatSpeed(state.speedBps)}</span>
-              </>
-            )}
-            {state.etaSec != null && (
-              <>
-                <span>·</span>
-                <span>
-                  {t('upload.etaPrefix')} {formatEta(state.etaSec)}
-                </span>
-              </>
-            )}
-          </>
-        ) : null}
-      </div>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1743,6 +1743,8 @@
     "phaseLoad": "Loading model",
     "phaseClip": "Encoding text",
     "phaseSample": "Sampling {{step}}/{{total}}",
+    "phaseSampling": "Sampling",
+    "pipelineProgress": "Generation pipeline progress",
     "phaseVae": "VAE decode",
     "progressPreparingShort": "Preparing…",
     "progressSampling": "Sampling: step {{step}} / {{total}}",
@@ -2717,7 +2719,9 @@
     "agoDays": "{{n}} days ago"
   },
   "upload": {
+    "progressLabel": "Upload progress",
     "processing": "Server processing…",
+    "complete": "Upload complete",
     "failed": "Failed",
     "etaPrefix": "ETA"
   },

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1743,6 +1743,8 @@
     "phaseLoad": "加载模型",
     "phaseClip": "文本编码",
     "phaseSample": "采样 {{step}}/{{total}}",
+    "phaseSampling": "正在采样",
+    "pipelineProgress": "生成流程进度",
     "phaseVae": "VAE 解码",
     "progressPreparingShort": "准备中…",
     "progressSampling": "采样: step {{step}} / {{total}}",
@@ -2717,7 +2719,9 @@
     "agoDays": "{{n}} 天前"
   },
   "upload": {
+    "progressLabel": "上传进度",
     "processing": "服务器处理中…",
+    "complete": "上传完成",
     "failed": "失败",
     "etaPrefix": "剩余"
   },

--- a/studio/web/src/pages/tools/generate/GenerateProgress.test.tsx
+++ b/studio/web/src/pages/tools/generate/GenerateProgress.test.tsx
@@ -1,0 +1,106 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import GenerateProgressBar, { type GenerateProgress } from './GenerateProgress'
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, values?: Record<string, number>) => {
+      if (key === 'generate.pipelineProgress') return 'Pipeline progress'
+      if (key === 'generate.progressPreparing') return 'Preparing…'
+      if (key === 'generate.phaseLoad') return 'Loading model…'
+      if (key === 'generate.phaseClip') return 'Encoding prompt…'
+      if (key === 'generate.phaseVae') return 'Decoding image…'
+      if (key === 'generate.phaseSample') return `Sampling ${values?.step}/${values?.total}`
+      if (key === 'generate.phaseSampling') return 'Sampling'
+      if (key === 'generate.totalProgress') return `Total ${values?.pct}%`
+      return key
+    },
+  }),
+}))
+
+const EMPTY_PROGRESS: GenerateProgress = {
+  phase: null,
+  batchIdx: null,
+  batchTotal: null,
+  currentStep: null,
+  totalSteps: null,
+}
+
+describe('GenerateProgressBar', () => {
+  it('does not render while the pipeline is idle', () => {
+    const { container } = render(
+      <GenerateProgressBar busy={false} progress={EMPTY_PROGRESS} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('uses indeterminate progress while busy but before the first phase event', () => {
+    render(<GenerateProgressBar busy progress={EMPTY_PROGRESS} />)
+
+    const progress = screen.getByRole('progressbar', { name: 'Pipeline progress' })
+    expect(progress).not.toHaveAttribute('aria-valuenow')
+    expect(progress).toHaveAttribute('aria-valuetext', 'Preparing…')
+    expect(screen.queryByText(/Total \d+%/)).not.toBeInTheDocument()
+  })
+
+  it('uses the stable sampling announcement for legacy step events without a phase', () => {
+    render(
+      <GenerateProgressBar
+        busy
+        progress={{
+          phase: null,
+          batchIdx: null,
+          batchTotal: null,
+          currentStep: 2,
+          totalSteps: 10,
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('progressbar')).toHaveAttribute('aria-valuenow')
+    expect(screen.getByRole('status')).toHaveTextContent('Sampling')
+    expect(screen.getByRole('status')).not.toHaveTextContent('2/10')
+  })
+
+  it('maps sampling steps into determinate pipeline progress', () => {
+    render(
+      <GenerateProgressBar
+        busy
+        progress={{
+          phase: 'sample',
+          batchIdx: 0,
+          batchTotal: 1,
+          currentStep: 10,
+          totalSteps: 20,
+        }}
+      />,
+    )
+
+    const progress = screen.getByRole('progressbar', { name: 'Pipeline progress' })
+    expect(progress).toHaveAttribute('aria-valuenow', '56')
+    expect(progress).toHaveAttribute('aria-valuetext', 'Sampling 10/20 · Total 56%')
+    expect(screen.getByRole('status')).toHaveTextContent('Sampling')
+    expect(screen.getByText('Total 56%')).toBeInTheDocument()
+  })
+
+  it('folds the current phase into multi-image batch progress', () => {
+    render(
+      <GenerateProgressBar
+        busy
+        progress={{
+          phase: 'sample',
+          batchIdx: 1,
+          batchTotal: 4,
+          currentStep: 10,
+          totalSteps: 20,
+        }}
+      />,
+    )
+
+    expect(screen.getByRole('progressbar'))
+      .toHaveAttribute('aria-valuenow', '39')
+    expect(screen.getByRole('progressbar'))
+      .toHaveAttribute('aria-valuetext', '2/4 · Sampling 10/20 · Total 39%')
+  })
+})

--- a/studio/web/src/pages/tools/generate/GenerateProgress.tsx
+++ b/studio/web/src/pages/tools/generate/GenerateProgress.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from 'react-i18next'
 
+import ProgressBar from '../../../components/ProgressBar'
+
 /** 出图进度：细条 + 相位标签，覆盖**全流程**（不再只有采样 step）。
  *
  * 来源：daemon 推 SSE
@@ -52,11 +54,13 @@ export default function GenerateProgressBar({
   else if (progress.phase) frac = PHASE_BASE[progress.phase]
   else frac = stepFrac > 0 ? PHASE_BASE.sample + stepFrac * 0.72 : 0
 
-  // 多图（batch / XY）：把当前图的 frac 摊进整体
+  // 多图（batch / XY）：把当前图的 frac 摊进整体。尚未收到阶段/step 时
+  // 工作量未知，应保持 indeterminate，不能把「准备中」伪装成 0%。
   const bt = progress.batchTotal
   const bi = progress.batchIdx
+  const determinate = progress.phase != null || stepFrac > 0
   const overall = bt && bt > 1 && bi != null ? Math.min(1, (bi + frac) / bt) : frac
-  const pct = Math.round(overall * 100)
+  const pct = determinate ? Math.round(overall * 100) : null
 
   // 相位文字
   let phaseLabel: string
@@ -67,25 +71,37 @@ export default function GenerateProgressBar({
     phaseLabel = t('generate.phaseSample', { step: progress.currentStep ?? 0, total: progress.totalSteps ?? 0 })
   else phaseLabel = t('generate.progressPreparing')
 
-  const batchTag = bt && bt > 1 && bi != null ? `${bi + 1}/${bt} · ` : ''
+  const phaseAnnouncement = progress.phase === 'sample' || (progress.phase == null && stepFrac > 0)
+    ? t('generate.phaseSampling')
+    : phaseLabel
+  const batchTag = bt && bt > 1 && bi != null ? `${bi + 1}/${bt}` : ''
+  const valueText = [
+    batchTag,
+    phaseLabel,
+    pct == null ? null : t('generate.totalProgress', { pct }),
+  ].filter(Boolean).join(' · ')
 
   return (
     <div className="shrink-0">
-      {/* 浏览器加载条式：贴页面 header 下沿的全宽细线（2px） */}
-      <div style={{ height: 2, background: 'var(--bg-sunken)', overflow: 'hidden' }}>
-        <div
-          style={{
-            width: `${pct}%`,
-            height: '100%',
-            background: 'var(--accent)',
-            transition: 'width 150ms linear',
-          }}
-        />
-      </div>
-      {/* 小相位文字（与页面内容 p-6 对齐） */}
-      <div className="flex items-center justify-between px-6 font-mono text-2xs" style={{ paddingTop: 2, paddingBottom: 2 }}>
-        <span className="text-fg-secondary truncate">{batchTag}{phaseLabel}</span>
-        <span className="text-fg-tertiary shrink-0 ml-2">{pct}%</span>
+      <span className="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {phaseAnnouncement}
+      </span>
+      <ProgressBar
+        label={t('generate.pipelineProgress')}
+        value={pct}
+        valueText={valueText}
+        size="xs"
+      />
+      <div className="flex items-center justify-between gap-related px-page py-1 font-mono text-2xs">
+        <span className="truncate text-fg-secondary">
+          {batchTag && <>{batchTag} · </>}
+          {phaseLabel}
+        </span>
+        {pct != null && (
+          <span className="shrink-0 text-fg-tertiary">
+            {t('generate.totalProgress', { pct })}
+          </span>
+        )}
       </div>
     </div>
   )

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -490,6 +490,40 @@ select option:checked {
 .badge-accent { background: var(--accent-soft); color: var(--accent-strong); }
 .badge .dot { flex-shrink: 0; }
 
+/* Async progress is a semantic indicator, not a data meter. Determinate bars own
+ * their fill width; indeterminate bars use a bounded traveling segment. */
+.ui-progress {
+  position: relative;
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--r-pill);
+  background: var(--bg-sunken);
+}
+.ui-progress-xs { height: 3px; border: 0; }
+.ui-progress-sm { height: 6px; }
+.ui-progress-md { height: 8px; }
+.ui-progress-fill {
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent);
+  transform-origin: left center;
+  transition: transform 200ms linear;
+}
+.ui-progress-success .ui-progress-fill { background: var(--ok); }
+.ui-progress[data-state="indeterminate"] .ui-progress-fill {
+  width: 36%;
+  transform-origin: center;
+  animation: ui-progress-indeterminate 1.4s ease-in-out infinite;
+}
+@keyframes ui-progress-indeterminate {
+  from { transform: translateX(-110%); }
+  to { transform: translateX(310%); }
+}
+
+.ui-skeleton { animation: pulse 1.6s ease-in-out infinite; }
+
 .dot { width: 6px; height: 6px; border-radius: 50%; display: inline-block; }
 .dot-ok { background: var(--ok); }
 .dot-warn { background: var(--warn); }
@@ -501,9 +535,15 @@ select option:checked {
   .btn,
   .card-hover,
   .form-control,
+  .ui-progress-fill,
   .ui-selection-item { transition: none; }
   .btn-spinner,
-  .dot-running { animation: none; }
+  .dot-running,
+  .ui-skeleton { animation: none; }
+  .ui-progress[data-state="indeterminate"] .ui-progress-fill {
+    animation: none;
+    transform: translateX(90%);
+  }
 }
 
 /* tabs + segmented selection — content navigation and mutually exclusive values share


### PR DESCRIPTION
## 概要

统一前端异步加载与进度反馈模式，新增类型化 `ProgressBar` 原语，并将配置骨架、上传、Generate 流程及存储迁移作为首批代表性场景迁移到同一设计契约。

## 主要改动

- 新增 `ProgressBar`：
  - 支持 determinate / indeterminate；
  - 提供 `xs` / `sm` / `md` 尺寸；
  - 统一 `progressbar`、value/max/valueText 等无障碍语义；
  - 使用 transform 驱动确定进度，提供 reduced-motion 静态降级。
- 收敛 `ConfigSkeleton`：仅用于真实远程 schema/config 首次等待，保留稳定几何与 `aria-busy`；静态 Settings/Drawer 不创建虚构 Loading。
- 重构上传反馈：
  - 已知总量显示确定百分比、字节、速度与 ETA；
  - 未知总量保持不确定进度，不伪造 `0%`；
  - 服务器处理、完成与失败使用独立阶段语义；
  - 高频 XHR tick 不进入 live region。
- 重构 Generate 进度：
  - 未收到 phase/step 时保持不确定状态；
  - 收到阶段后显示流程估算与批次信息；
  - 读屏只播报稳定阶段，不逐 step 播报。
- 迁移 Studio Data / Models Root 对话框：
  - 统一使用 `Modal + ActionGroup + ProgressBar + Alert`；
  - 保留原 API、SSE、冲突、重启和完成行为；
  - 阻塞运行期间禁用 Escape/遮罩关闭；
  - 运行态移除操作按钮后，焦点继续留在 Modal 内。
- 更新 `DESIGN.md`，新增 Async-state and progress 契约。

## 边界

本次不迁移 Queue 行、Monitor、PauseProgress 等后续 adoption 场景；SystemStats、容量占比、评分与裁剪比例属于数据可视化，不套用异步进度契约。

## 验证

- 聚焦 Vitest：6 个文件、28 个测试通过
- 全量 Vitest：99 个文件、769 个测试通过
- ESLint：通过
- TypeScript：通过
- Production build：通过
- Python 路由快照：通过
- Impeccable detector：0 findings
- `git diff --check`：通过
- 独立代码审查 findings：全部修复
- 浅色/深色、密度、中文/英文、键盘与 reduced-motion 人工视觉检查：通过

构建仅保留既有的 `>700 kB` 主 chunk 提示。
