### PR TITLE
feat(web): 统一应用壳层与滚动架构

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -27,6 +27,7 @@ surface has identical density.
 | Utility bridge | `studio/web/tailwind.config.js` | Maps CSS tokens into Tailwind utilities |
 | Primitives | `studio/web/src/components/Button.tsx`, `Badge.tsx`, `Card.tsx`, `EmptyState.tsx`, `FormControl.tsx`, `Alert.tsx`, `ProgressBar.tsx` | Typed, accessible component APIs |
 | Patterns | `PageHeader`, `StepShell`, `ActionGroup`, `SaveIndicator`, `SaveBar`, `ListToolbar`, `Dialog`, `Modal`, `Drawer`, `Tabs`, `SegmentedControl`, `Toast`, `Field` | Repeated page and interaction structures |
+| Layout | `studio/web/src/components/AppShell.tsx`, `studio/web/src/styles/app-shell.css` | Viewport tracks, landmarks, and scroll ownership |
 | Product surfaces | `studio/web/src/pages/` | Business state and composition, not new visual primitives |
 
 A page may compose primitives with layout utilities. It must not recreate an
@@ -455,7 +456,46 @@ transitions, refreshes where content can remain visible, or as an entrance anima
 Skeleton and indeterminate motion become a stable static indicator under
 `prefers-reduced-motion`; meaning cannot depend on pulsing or travel.
 
-## 15. Accessibility and resilience
+## 15. App-shell and viewport contract
+
+`AppShell` is the single desktop workspace frame. It owns the viewport, Sidebar
+track, Topbar track, default main landmark, and the page-level scroll container.
+Routes render inside its `main`; they must not recreate a second viewport-height
+application shell. The Studio supports a wide desktop class above 1280px and a
+compact desktop class at or below the shared 1280px breakpoint. This phase does
+not define a mobile information architecture.
+
+Geometry and scroll responsibility are fixed:
+
+- The shell uses `100dvh` with a `100vh` fallback, `minmax(0, 1fr)` for the
+  workspace track, and explicit `min-width: 0` / `min-height: 0` boundaries.
+  `html`, `body`, and `#root` fill the viewport and do not become competing
+  document scroll owners.
+- The main landmark is the default page scroll owner and reserves a stable
+  scrollbar gutter. A full-height workbench may add local panel scrolling only
+  when its outer route still fits the main track; nested scroll regions must be
+  deliberate and keyboard reachable.
+- Sidebar width and Topbar height come from layout tokens. Sidebar branding and
+  footer actions remain fixed while the named primary navigation region scrolls
+  internally, so long project workflows never push collapse/settings actions
+  outside the viewport.
+- Topbar breadcrumb, active-task status, global notices, and search preserve that
+  priority order. At compact desktop widths, auxiliary system resource meters
+  yield before navigation or actions; breadcrumb labels truncate visually while
+  their full title and accessible name remain available.
+- A visible-on-focus skip link targets the main landmark. Sidebar, breadcrumb,
+  main, and overlay components retain native landmark/dialog semantics; route
+  changes do not steal focus automatically.
+- Modal, Drawer, Toast, command surfaces, and image preview remain portalled
+  overlay layers and never consume AppShell grid space. Drawers may inert the app
+  root; overlays must not alter shell width or introduce a second body scrollbar.
+
+App-shell responsiveness belongs to `styles/responsive.css` and uses the shared
+1280px breakpoint. Route-specific workbench restructuring is a later Layout
+adoption concern, not permission to hide primary actions or add arbitrary
+component-local breakpoints.
+
+## 16. Accessibility and resilience
 
 Every primitive must work with keyboard focus, disabled state, light/dark themes,
 all three density modes, and both Chinese and English labels. Focus is always visible.
@@ -465,7 +505,7 @@ full value is available through an established disclosure pattern.
 Respect `prefers-reduced-motion`; status information must remain understandable when
 animation is disabled.
 
-## 16. Migration policy
+## 17. Migration policy
 
 Migration is incremental:
 

--- a/docs/architecture/studio-pipeline.md
+++ b/docs/architecture/studio-pipeline.md
@@ -377,11 +377,22 @@ python -m studio test    # pytest + vitest
 
 ---
 
-## 11. 前端样式约定
+## 11. 前端布局与响应式约定
 
-**现阶段不做全局响应式**，布局以桌面端宽屏为主。单个页面 / 组件如有窄屏拥挤，可加简单单点适配，但必须遵守下述约定，方便未来做全局响应式时统一升级：
+Studio 仍以桌面工作台为目标，但全局 AppShell 已开始统一治理。当前支持两类
+桌面视口：宽桌面（`> 1280px`）与紧凑桌面（`<= 1280px`）。本阶段不承诺移动端
+信息架构；业务工作台的结构性适配按 Layout phase 分批实施。
 
-- 所有媒体查询集中在 `studio/web/src/styles/responsive.css`，不要散落到组件里
-- 断点统一 `max-width: 1280px`（< laptop 中屏阈值），不要自创新断点
-- 单点适配只动 padding / 尺寸 / 显隐 label，**不改布局结构**（结构性改造留给未来的全局响应式）
-- 给目标元素加专属 className（如 `.banner-shell` / `.phase-timeline-label`），CSS 用 className 命中，不写到全局选择器
+- AppShell 是唯一 viewport 外壳，负责 Sidebar、Topbar、主内容轨道与默认页面滚动；
+  路由页面不得再创建第二个 `100vh` 应用外壳。
+- `main` 是默认页面级 scroll owner；专业工作台只在自身外层完整落入 main 轨道时
+  建立明确的局部滚动区。所有 flex/grid 中间轨道必须保留 `min-width: 0` 与
+  `min-height: 0`。
+- 公共响应式媒体查询集中在 `studio/web/src/styles/responsive.css`，目标元素使用
+  专属 className。共享紧凑桌面断点为 `max-width: 1280px`，不要为普通页面自创新断点。
+- 紧凑桌面优先保留导航、当前任务与操作入口；辅助资源指标和低优先级说明先让位。
+  不允许通过遮挡、负 margin 或隐藏主操作解决拥挤。
+- Drawer/Modal/Toast 等全局 overlay 不参与 AppShell 网格尺寸计算，不得通过 body
+  scrollbar 的出现/消失改变页面宽度。
+- Generate 附着工作区、图片瀑布流等已有专用几何可保留局部阈值，但必须集中在
+  `responsive.css` 并在组件注释中说明，不能成为普通页面的默认模式。

--- a/studio/web/src/App.tsx
+++ b/studio/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   createBrowserRouter,
   Navigate,
@@ -7,6 +8,7 @@ import {
   useLocation,
   useNavigate,
 } from 'react-router-dom'
+import AppShell from './components/AppShell'
 import SettingsDrawer from './components/SettingsDrawer'
 import Sidebar from './components/Sidebar'
 import Topbar from './components/Topbar'
@@ -68,23 +70,18 @@ function QueueDetailRedirect({ tab }: { tab: 'log' | 'monitor' }) {
   )
 }
 
-/** Sidebar + Topbar 外壳；所有路由 element 渲染进 <Outlet />。
- *  SettingsDrawer 用 fixed inset-0 铺满整个 viewport（含左侧 Sidebar）—— 这样点
- *  backdrop 的任意位置（包括 Sidebar 区域）都会收起抽屉。
- *  列父级 position:relative 保留作 <main> 内 absolute 元素（如任务日志抽屉贴底
- *  footer）的定位锚点。 */
+/** Shared desktop workspace frame; all route elements render into its main scroll owner. */
 function RootLayout() {
+  const { t } = useTranslation()
   return (
-    <div style={{ display: 'flex', height: '100vh', overflow: 'hidden' }}>
-      <Sidebar />
-      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', minWidth: 0, position: 'relative' }}>
-        <Topbar />
-        <main style={{ flex: 1, overflow: 'auto', background: 'var(--bg-canvas)' }}>
-          <Outlet />
-        </main>
-        <SettingsDrawer />
-      </div>
-    </div>
+    <AppShell
+      navigation={<Sidebar />}
+      topbar={<Topbar />}
+      skipLabel={t('appShell.skipToContent')}
+      overlay={<SettingsDrawer />}
+    >
+      <Outlet />
+    </AppShell>
   )
 }
 

--- a/studio/web/src/components/AppShell.test.tsx
+++ b/studio/web/src/components/AppShell.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import AppShell, { APP_MAIN_ID } from './AppShell'
+
+describe('AppShell', () => {
+  it('provides the workspace landmarks and a keyboard skip target', () => {
+    const { container } = render(
+      <AppShell
+        navigation={<aside aria-label="Primary navigation">Navigation</aside>}
+        topbar={<header>Topbar</header>}
+        skipLabel="Skip to content"
+        overlay={<div data-testid="overlay-slot">Overlay</div>}
+      >
+        <h1>Workspace</h1>
+      </AppShell>,
+    )
+
+    const shell = container.firstElementChild as HTMLElement
+    const workspace = shell.lastElementChild as HTMLElement
+    const main = screen.getByRole('main')
+    const overlay = screen.getByTestId('overlay-slot')
+
+    expect(shell).toHaveClass('ui-app-shell')
+    expect(screen.getByRole('complementary', { name: 'Primary navigation' })).toBeInTheDocument()
+    expect(screen.getByRole('banner')).toBeInTheDocument()
+    expect(main).toHaveAttribute('id', APP_MAIN_ID)
+    expect(main).toHaveAttribute('tabindex', '-1')
+    expect(main).toHaveClass('ui-app-shell-main')
+    expect(screen.getByRole('link', { name: 'Skip to content' })).toHaveAttribute('href', `#${APP_MAIN_ID}`)
+    expect(workspace).toContainElement(screen.getByRole('main'))
+    expect(workspace).not.toContainElement(overlay)
+    expect(overlay.previousElementSibling).toBe(shell)
+  })
+
+  it('supports an explicit main target without changing slot order', () => {
+    const { container } = render(
+      <AppShell
+        navigation={<aside>Navigation</aside>}
+        topbar={<header>Topbar</header>}
+        skipLabel="Skip"
+        mainId="workspace-content"
+      >
+        Content
+      </AppShell>,
+    )
+
+    const shell = container.firstElementChild as HTMLElement
+    const workspace = shell.lastElementChild as HTMLElement
+    expect(screen.getByRole('link', { name: 'Skip' })).toHaveAttribute('href', '#workspace-content')
+    expect(workspace.children[0]).toBe(screen.getByRole('banner'))
+    expect(workspace.children[1]).toBe(screen.getByRole('main'))
+  })
+})

--- a/studio/web/src/components/AppShell.tsx
+++ b/studio/web/src/components/AppShell.tsx
@@ -1,0 +1,46 @@
+import type { ReactNode } from 'react'
+
+export const APP_MAIN_ID = 'app-main'
+
+interface AppShellProps {
+  navigation: ReactNode
+  topbar: ReactNode
+  children: ReactNode
+  skipLabel: string
+  overlay?: ReactNode
+  mainId?: string
+}
+
+/**
+ * Desktop workspace frame.
+ *
+ * Owns the viewport, fixed navigation/topbar tracks, and the default document
+ * scroll container. Pages may create local scroll owners inside `main`, but
+ * should not add another viewport-height shell around this component.
+ */
+export default function AppShell({
+  navigation,
+  topbar,
+  children,
+  skipLabel,
+  overlay,
+  mainId = APP_MAIN_ID,
+}: AppShellProps) {
+  return (
+    <>
+      <div className="ui-app-shell">
+        <a className="ui-app-shell-skip" href={`#${mainId}`}>
+          {skipLabel}
+        </a>
+        {navigation}
+        <div className="ui-app-shell-workspace">
+          {topbar}
+          <main id={mainId} className="ui-app-shell-main" tabIndex={-1}>
+            {children}
+          </main>
+        </div>
+      </div>
+      {overlay}
+    </>
+  )
+}

--- a/studio/web/src/components/CommandPalette.tsx
+++ b/studio/web/src/components/CommandPalette.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { api, type CaptionEntry, type PresetSummary, type ProjectSummary } from '../api/client'
@@ -273,7 +274,7 @@ export default function CommandPalette({ open, onClose, anchorEl }: Props) {
 
   if (!open) return null
 
-  return (
+  return createPortal(
     <>
       <div className="fixed inset-0 z-40" onClick={onClose} />
 
@@ -355,6 +356,7 @@ export default function CommandPalette({ open, onClose, anchorEl }: Props) {
           )}
         </div>
       </div>
-    </>
+    </>,
+    document.body,
   )
 }

--- a/studio/web/src/components/Sidebar.test.tsx
+++ b/studio/web/src/components/Sidebar.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { SettingsDrawerProvider } from '../lib/SettingsDrawer'
 import {
   ProjectContext,
@@ -85,6 +85,10 @@ function makeCtx(versions: Version[]): ProjectCtxValue {
 }
 
 describe('Sidebar (PP0)', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
   it('shows main items + tools with all 5 destinations', () => {
     renderAt('/')
     // 主导航
@@ -108,6 +112,34 @@ describe('Sidebar (PP0)', () => {
     // 设置不再是路由 link，而是打开右侧抽屉的 button；没有 href
     expect(screen.getByRole('button', { name: /设置/ })).toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /设置/ })).toBeNull()
+  })
+
+  it('provides a scrollable primary navigation and exposes collapse state', () => {
+    renderAt('/')
+
+    const navigation = screen.getByRole('navigation', { name: '主导航' })
+    const sidebar = navigation.closest('aside')
+    expect(navigation).toHaveAttribute('id', 'primary-navigation')
+    expect(navigation).toHaveClass('ui-app-shell-sidebar-nav')
+    expect(sidebar).toHaveAttribute('data-collapsed', 'false')
+
+    const toggle = screen.getByRole('button', { name: '折叠' })
+    expect(toggle).toHaveAttribute('aria-controls', 'primary-navigation')
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    fireEvent.click(toggle)
+
+    expect(sidebar).toHaveAttribute('data-collapsed', 'true')
+    expect(window.sessionStorage.getItem('studio.sidebar.expanded')).toBe('0')
+    expect(screen.getByRole('button', { name: '展开' })).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('restores the collapsed state from the current session', () => {
+    window.sessionStorage.setItem('studio.sidebar.expanded', '0')
+    renderAt('/')
+
+    const navigation = screen.getByRole('navigation', { name: '主导航' })
+    expect(navigation.closest('aside')).toHaveAttribute('data-collapsed', 'true')
+    expect(screen.getByRole('button', { name: '展开' })).toHaveAttribute('aria-expanded', 'false')
   })
 
   it('marks the active route', () => {
@@ -165,6 +197,10 @@ describe('Sidebar (PP0)', () => {
 })
 
 describe('Sidebar version row (live / in project)', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
   it('single version: new + export present, switch + delete hidden', () => {
     renderLive('/projects/3', makeCtx([MOCK_VERSION]))
     expect(screen.getByTitle('新版本')).toBeInTheDocument()

--- a/studio/web/src/components/Sidebar.tsx
+++ b/studio/web/src/components/Sidebar.tsx
@@ -605,17 +605,20 @@ export default function Sidebar() {
 
   return (
     <aside
-      className="shrink-0 bg-sunken border-r border-subtle flex flex-col overflow-hidden h-full transition-[width] duration-[160ms] ease-in-out"
-      style={{ width: collapsed ? 'var(--sidebar-collapsed-w)' : 'var(--sidebar-w)' }}
+      className="ui-app-shell-sidebar shrink-0 bg-sunken border-r border-subtle flex flex-col overflow-hidden h-full"
+      data-collapsed={collapsed}
     >
       <div
-        className={`flex items-center border-b border-subtle shrink-0 px-3.5 ${collapsed ? 'justify-center' : ''}`}
-        style={{ height: 'var(--topbar-h)' }}
+        className={`ui-app-shell-sidebar-brand flex items-center border-b border-subtle shrink-0 px-3.5 ${collapsed ? 'justify-center' : ''}`}
       >
         <Logo collapsed={collapsed} />
       </div>
 
-      <nav className={`flex-1 flex flex-col gap-0.5 overflow-hidden ${collapsed ? 'px-2 py-2.5' : 'px-2 py-3.5'}`}>
+      <nav
+        id="primary-navigation"
+        aria-label={t('sidebar.navigation')}
+        className={`ui-app-shell-sidebar-nav flex-1 flex flex-col gap-0.5 ${collapsed ? 'px-2 py-2.5' : 'px-2 py-3.5'}`}
+      >
         <NavItem to="/" label={t('nav.projects')} icon={I.folder} active={location.pathname === '/'} collapsed={collapsed} prominent />
 
         {/* 当前项目下的全部内容（概览 + ①② + VersionPanel + ③-⑦）夹在 项目 / 队列 之间。
@@ -643,7 +646,11 @@ export default function Sidebar() {
         />
         <ThemeToggle collapsed={collapsed} />
         <button
+          type="button"
           onClick={toggle}
+          aria-controls="primary-navigation"
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? t('sidebar.expand') : t('sidebar.collapse')}
           title={collapsed ? t('sidebar.expand') : t('sidebar.collapse')}
           className={`text-fg-tertiary bg-transparent border-none rounded cursor-pointer hover:bg-overlay transition-colors ${collapsed ? 'flex justify-center p-2 mt-1' : 'flex items-center gap-1.5 p-2 mt-1 text-xs'}`}
         >

--- a/studio/web/src/components/SystemStats.test.tsx
+++ b/studio/web/src/components/SystemStats.test.tsx
@@ -41,6 +41,7 @@ describe('SystemStats', () => {
     vi.spyOn(api, 'systemStats').mockResolvedValue(makeStats())
     render(<SystemStats />)
     await waitFor(() => expect(screen.getByText('CPU')).toBeInTheDocument())
+    expect(screen.getByText('CPU').closest('.ui-app-shell-topbar-stats')).toBeInTheDocument()
     expect(screen.getByText('13%')).toBeInTheDocument()
     expect(screen.getByText('MEM')).toBeInTheDocument()
     expect(screen.getByText('8.0/32G')).toBeInTheDocument()

--- a/studio/web/src/components/SystemStats.tsx
+++ b/studio/web/src/components/SystemStats.tsx
@@ -90,7 +90,7 @@ export default function SystemStats() {
   const gpuLabel = gpu0 ? `${gpu0.name}${gpuTempText}${gpuExtra}` : ''
 
   return (
-    <div className="hidden md:flex items-center gap-2 shrink-0">
+    <div className="ui-app-shell-topbar-stats">
       <Pill
         label="CPU"
         value={`${stats.cpu_pct.toFixed(0)}%`}

--- a/studio/web/src/components/Topbar.tsx
+++ b/studio/web/src/components/Topbar.tsx
@@ -205,11 +205,8 @@ export default function Topbar() {
 
   return (
     <>
-      <header
-        className="flex items-center gap-3 border-b border-subtle bg-canvas shrink-0 px-5"
-        style={{ height: 'var(--topbar-h)' }}
-      >
-        <div className="flex items-center gap-2 flex-1 min-w-0">
+      <header className="ui-app-shell-topbar flex shrink-0 items-center border-b border-subtle bg-canvas">
+        <nav className="ui-app-shell-breadcrumbs" aria-label={t('topbar.breadcrumbs')}>
           {crumbs.map((b, i) => {
             const isLast = i === crumbs.length - 1
             const cls =
@@ -218,22 +215,23 @@ export default function Topbar() {
                 ? 'text-fg-primary font-semibold'
                 : 'text-fg-secondary hover:text-fg-primary transition-colors')
             return (
-              <span key={i} className="flex items-center gap-2">
+              <span key={i} className="ui-app-shell-breadcrumb-item">
                 {i > 0 && <span className="text-fg-tertiary select-none">/</span>}
                 {!isLast && b.to ? (
-                  <Link to={b.to} className={cls}>{b.label}</Link>
+                  <Link to={b.to} className={`ui-app-shell-breadcrumb-label ${cls}`} title={b.label}>{b.label}</Link>
                 ) : (
-                  <span className={cls}>{b.label}</span>
+                  <span className={`ui-app-shell-breadcrumb-label ${cls}`} aria-current="page" title={b.label}>{b.label}</span>
                 )}
               </span>
             )
           })}
-        </div>
+        </nav>
 
         {runningTask && (
           <button
+            type="button"
             onClick={() => navigate(`/queue/${runningTask.id}`)}
-            className="flex items-center gap-2 px-3 py-[5px] rounded-md border border-warn bg-warn-soft cursor-pointer hover:bg-warn/10 transition-colors shrink-0 max-w-xs"
+            className="ui-app-shell-running-task flex shrink-0 items-center gap-2 rounded-md border border-warn bg-warn-soft px-3 py-[5px] cursor-pointer hover:bg-warn/10 transition-colors"
             title={t('topbar.taskId', { id: runningTask.id })}
           >
             <span className="w-1.5 h-1.5 rounded-full bg-warn animate-pulse shrink-0" />

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -89,7 +89,11 @@
     "generating": "Generating",
     "offline": "offline"
   },
+  "appShell": {
+    "skipToContent": "Skip to main content"
+  },
   "topbar": {
+    "breadcrumbs": "Breadcrumbs",
     "search": "Search (⌘K)",
     "searchAriaLabel": "Search",
     "newVersion": "New version {{tag}} available",
@@ -137,6 +141,7 @@
     "projectItem": "Project #{{id}}"
   },
   "sidebar": {
+    "navigation": "Primary navigation",
     "title": "Anima",
     "subtitle": "lora studio",
     "newVersion": "New version",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -89,7 +89,11 @@
     "generating": "生成中",
     "offline": "offline"
   },
+  "appShell": {
+    "skipToContent": "跳到主要内容"
+  },
   "topbar": {
+    "breadcrumbs": "面包屑导航",
     "search": "搜索 (⌘K)",
     "searchAriaLabel": "搜索",
     "newVersion": "新版本 {{tag}} 可用",
@@ -137,6 +141,7 @@
     "projectItem": "项目 #{{id}}"
   },
   "sidebar": {
+    "navigation": "主导航",
     "title": "Anima",
     "subtitle": "lora studio",
     "newVersion": "新版本",

--- a/studio/web/src/index.css
+++ b/studio/web/src/index.css
@@ -1,4 +1,5 @@
 @import './styles/tokens.css';
+@import './styles/app-shell.css';
 @import './styles/info-button.css';
 @import './styles/version-section.css';
 @import './styles/preprocess-crop.css';

--- a/studio/web/src/styles/app-shell.css
+++ b/studio/web/src/styles/app-shell.css
@@ -1,0 +1,139 @@
+/* Application-shell geometry. This file owns viewport tracks and scroll
+ * responsibility; page-level layout remains with each route. */
+
+html,
+body,
+#root {
+  overflow: hidden;
+}
+
+.ui-app-shell {
+  position: relative;
+  isolation: isolate;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--bg-canvas);
+}
+
+.ui-app-shell-workspace {
+  position: relative;
+  display: grid;
+  grid-template-rows: var(--topbar-h) minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.ui-app-shell-main {
+  min-width: 0;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  background: var(--bg-canvas);
+}
+
+.ui-app-shell-main:focus {
+  outline: none;
+}
+
+.ui-app-shell-main:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+
+.ui-app-shell-skip {
+  position: fixed;
+  top: var(--s-2);
+  left: var(--s-2);
+  z-index: 1000;
+  padding: var(--s-2) var(--s-3);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-md);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+  box-shadow: var(--sh-md);
+  font-size: var(--t-sm);
+  font-weight: 600;
+  transform: translateY(calc(-100% - var(--s-4)));
+  transition: transform 140ms ease-out;
+}
+
+.ui-app-shell-skip:focus-visible {
+  transform: translateY(0);
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.ui-app-shell-sidebar {
+  width: var(--sidebar-w);
+  min-width: 0;
+  min-height: 0;
+}
+
+.ui-app-shell-sidebar[data-collapsed='true'] {
+  width: var(--sidebar-collapsed-w);
+}
+
+.ui-app-shell-sidebar-brand,
+.ui-app-shell-topbar {
+  height: var(--topbar-h);
+}
+
+.ui-app-shell-sidebar-nav {
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+
+.ui-app-shell-topbar {
+  min-width: 0;
+  gap: var(--s-3);
+  padding-inline: var(--s-5);
+}
+
+.ui-app-shell-breadcrumbs {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: var(--s-2);
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.ui-app-shell-breadcrumb-item {
+  display: flex;
+  min-width: 0;
+  flex: 0 1 auto;
+  align-items: center;
+  gap: var(--s-2);
+}
+
+.ui-app-shell-breadcrumb-label {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ui-app-shell-running-task {
+  min-width: 0;
+  max-width: min(20rem, 32vw);
+}
+
+.ui-app-shell-topbar-stats {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--s-2);
+}

--- a/studio/web/src/styles/responsive.css
+++ b/studio/web/src/styles/responsive.css
@@ -1,12 +1,20 @@
-/* 单点窄屏优化 —— 项目当前不做系统级响应式（见
- * docs/architecture/studio-pipeline.md §11），需要时再单独加 className + 媒体查询。
- * 断点取 viewport 1280px（< laptop "中屏" 阈值），不用 container query。
+/* Shared responsive policy. AppShell defines the supported desktop frame;
+ * route-specific exceptions keep a dedicated class and stay in this file.
  */
 
 .banner-shell { padding: 16px 18px; }
 .banner-shell-icon { width: 32px; height: 32px; font-size: 16px; }
 
 @media (max-width: 1280px) {
+  /* AppShell keeps primary navigation and actions visible while auxiliary
+     resource meters yield at the compact-desktop breakpoint. */
+  .ui-app-shell-topbar {
+    gap: var(--space-related);
+    padding-inline: var(--space-section);
+  }
+  .ui-app-shell-topbar-stats { display: none; }
+  .ui-app-shell-running-task { max-width: min(14rem, 30vw); }
+
   .banner-shell { padding: 10px 14px; }
   .banner-shell-icon { width: 26px; height: 26px; font-size: 13px; }
   .phase-timeline-label { display: none; }
@@ -30,7 +38,7 @@
   }
 }
 
-@media (max-width: 1279px) {
+@media (max-width: 1280px) {
   /* 双类选择器确保覆盖组件上的 Tailwind `absolute` / `z-20` 工具类。 */
   .generate-attached-drawer.generate-attached-drawer {
     position: fixed;
@@ -57,6 +65,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .ui-app-shell-skip,
   .xy-axis-sortable-row,
   .lora-sortable-card { transition: none !important; }
 }

--- a/studio/web/src/styles/tokens.css
+++ b/studio/web/src/styles/tokens.css
@@ -173,9 +173,12 @@
 
 * { box-sizing: border-box; }
 
-html, body, #app {
+html, body, #root {
   margin: 0; padding: 0;
+  width: 100%;
   height: 100%;
+  min-width: 0;
+  min-height: 0;
   background: var(--bg-canvas);
   color: var(--fg-primary);
   font-family: var(--font-sans);


### PR DESCRIPTION
## 概述

本 PR 完成前端优化路线图 Phase 3A：App Shell / Workspace Frame，统一 Studio Web 的视口轨道、滚动归属、导航地标与全局 Overlay 边界。

## 主要变更

- 新增 `AppShell` Layout 入口，统一 Sidebar / Topbar / main 的桌面工作区轨道；
- 使用 `100dvh`（含 `100vh` fallback）、`minmax(0, 1fr)` 与稳定 scrollbar gutter，明确 main 为默认页面级滚动容器；
- Sidebar 改为品牌与底部操作固定、中部具名主导航独立滚动，并保留会话内折叠状态；
- Topbar 收敛面包屑、运行任务与全局操作的伸缩优先级，长文案安全截断；
- 1280px 及以下进入紧凑桌面模式，优先隐藏辅助系统资源数据，并与 Generate 共用断点；
- 新增可见焦点的“跳到主要内容”链接及中英文文案；
- Overlay slot 移至 AppShell 网格外，Command Palette 改为 portal，确保 Drawer / Modal / 命令面板不占用布局轨道；
- 更新 `DESIGN.md` 与 Studio 架构文档中的 AppShell、viewport、scroll owner 和响应式契约。

## 行为边界

- 不修改路由与业务状态；
- 不重构 Generate 专业工作台的局部分栏；
- 不改变 Drawer、Modal、Task Log 的业务生命周期；
- 本阶段只定义宽桌面与 1280px 紧凑桌面，不引入移动端信息架构。

## 验证

- 聚焦 Vitest：3 个文件、23 个测试通过；
- 全量 Vitest：100 个文件、773 个测试通过；
- ESLint：通过；
- TypeScript：通过；
- Production build：通过；
- `tests/test_route_snapshot.py`：通过；
- Impeccable layout detector：0 findings；
- `git diff --check`：通过；
- 独立布局 / a11y 审查：无 P0/P1/P2 finding；
- 人工视觉检查：通过（宽屏、紧凑桌面、Sidebar、Topbar、局部滚动、Overlay、主题/密度/中英文/键盘）。

构建仅保留既有的 `>700 kB` 主 chunk 提示。
