### PR TITLE
feat(web): 统一桌面响应式布局规则

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -495,7 +495,41 @@ App-shell responsiveness belongs to `styles/responsive.css` and uses the shared
 adoption concern, not permission to hide primary actions or add arbitrary
 component-local breakpoints.
 
-## 16. Accessibility and resilience
+## 16. Responsive-layout contract
+
+The responsive layer distinguishes **wide desktop** (`> 1280px`) from
+**compact desktop** (`<= 1280px`). It adapts content hierarchy inside the
+AppShell; it does not invent a mobile navigation model. Shared responsive rules
+live in `styles/responsive.css`, while business state and DOM order remain owned
+by the page.
+
+Ordinary pages follow these rules:
+
+- Page headers keep title, helper navigation, and primary actions visible. At
+  compact desktop, the action slot may take a full row and `topRight` helpers
+  rejoin normal flow instead of overlapping title or actions.
+- Auto-fill card grids use a container-safe minimum such as
+  `minmax(min(100%, <preferred-width>), 1fr)`, so the grid never forces the main
+  track wider than the available content area.
+- Dense list rows preserve identity, type/state, live progress, and actions.
+  Auxiliary timestamps or duplicated metadata yield first at compact desktop;
+  hidden visual metadata must remain available in the row's accessible name,
+  title, or detail route.
+- Summary cards may reduce column count. Action rows wrap without changing DOM
+  order. A genuinely tabular fixed-width region establishes its own labelled,
+  keyboard-focusable horizontal scroll boundary instead of overflowing the page.
+- Truncation is limited to secondary labels and long paths, with the full value
+  available through `title` or an equivalent disclosure. Density and translated
+  copy must not remove controls or alter action priority.
+
+Professional split workspaces (Generate canvas, media curation, evaluation
+matrices, image editors, and similar surfaces) preserve their task-specific
+geometry and explicit local scroll owners. They must not inherit ordinary-page
+stacking mechanically. Any later restructuring requires a representative pilot
+and content-driven evidence; `md`/`lg`/`xl` utility classes are not an independent
+breakpoint policy.
+
+## 17. Accessibility and resilience
 
 Every primitive must work with keyboard focus, disabled state, light/dark themes,
 all three density modes, and both Chinese and English labels. Focus is always visible.
@@ -505,7 +539,7 @@ full value is available through an established disclosure pattern.
 Respect `prefers-reduced-motion`; status information must remain understandable when
 animation is disabled.
 
-## 17. Migration policy
+## 18. Migration policy
 
 Migration is incremental:
 

--- a/studio/web/src/components/PageHeader.test.tsx
+++ b/studio/web/src/components/PageHeader.test.tsx
@@ -9,6 +9,7 @@ describe('PageHeader', () => {
     )
 
     expect(container.firstElementChild).toHaveClass(
+      'ui-page-header',
       'px-page',
       'pt-page-start',
       'pb-section',
@@ -49,10 +50,12 @@ describe('PageHeader', () => {
 
     expect(screen.getByRole('button', { name: 'Refresh' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Refresh' }).parentElement)
-      .toHaveClass('gap-related')
+      .toHaveClass('ui-page-header-actions')
+    expect(screen.getByRole('button', { name: 'Refresh' }).parentElement?.parentElement)
+      .toHaveClass('ui-page-header-layout')
     expect(screen.getByText('Phase 2')).toBeInTheDocument()
     expect(screen.getByText('Phase 2').parentElement)
-      .toHaveClass('top-field', 'right-page')
+      .toHaveClass('ui-page-header-top-right')
     expect(screen.getByRole('heading', { name: 'Queue' }).closest('.sticky')).toBeInTheDocument()
   })
 })

--- a/studio/web/src/components/PageHeader.tsx
+++ b/studio/web/src/components/PageHeader.tsx
@@ -14,12 +14,12 @@ interface Props {
 
 export default function PageHeader({ title, subtitle, tabs, actions, topRight, sticky }: Props) {
   return (
-    <div className={`px-page pt-page-start pb-section bg-canvas border-b border-subtle ${sticky ? 'sticky top-0 z-[5]' : 'relative'}`}>
+    <div className={`ui-page-header px-page pt-page-start pb-section bg-canvas border-b border-subtle ${sticky ? 'sticky top-0 z-[5]' : ''}`}>
       {topRight && (
-        <div className="absolute top-field right-page z-[1]">{topRight}</div>
+        <div className="ui-page-header-top-right">{topRight}</div>
       )}
-      <div className="flex items-end gap-section flex-wrap">
-        <div className="flex-1 min-w-0">
+      <div className="ui-page-header-layout">
+        <div className="ui-page-header-copy">
           <h1 className="type-page-title">{title}</h1>
           {/* tabs 在主标题下方取代 subtitle 位置；两者互斥（tabs 优先）。 */}
           {tabs ? (
@@ -31,7 +31,7 @@ export default function PageHeader({ title, subtitle, tabs, actions, topRight, s
           )}
         </div>
         {actions && (
-          <div className="flex gap-related items-center">{actions}</div>
+          <div className="ui-page-header-actions">{actions}</div>
         )}
       </div>
     </div>

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -813,6 +813,8 @@
     "tabEval": "Metrics",
     "tabSamples": "Samples",
     "tabOutputs": "Outputs",
+    "outputFiles": "Output files",
+    "trainingStates": "Training states",
     "tabSnapshot": "Snapshot config",
     "viewInGenerate": "View render →",
     "viewInReg": "View reg set →",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -813,6 +813,8 @@
     "tabEval": "指标",
     "tabSamples": "样图",
     "tabOutputs": "输出",
+    "outputFiles": "输出文件",
+    "trainingStates": "训练状态",
     "tabSnapshot": "关联配置",
     "viewInGenerate": "查看出图结果 →",
     "viewInReg": "查看正则集 →",

--- a/studio/web/src/pages/Projects.tsx
+++ b/studio/web/src/pages/Projects.tsx
@@ -311,7 +311,7 @@ export default function ProjectsPage() {
         )}
 
         {loading ? (
-          <div className="grid gap-section" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
+          <div className="ui-project-grid grid gap-section">
             {[1, 2, 3].map(i => (
               <div key={i} className="card p-[18px]" style={{ height: 140 }}>
                 <div className="w-3/5 h-4 rounded bg-overlay mb-2.5" />
@@ -329,7 +329,7 @@ export default function ProjectsPage() {
             {t('common.noResults')}
           </div>
         ) : (
-          <div className="grid gap-section auto-rows-fr" style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(340px, 1fr))' }}>
+          <div className="ui-project-grid grid gap-section auto-rows-fr">
             {visible.map((p) => (
               <ProjectCard
                 key={p.id}

--- a/studio/web/src/pages/Queue.test.tsx
+++ b/studio/web/src/pages/Queue.test.tsx
@@ -138,6 +138,10 @@ describe('QueuePage 分区 + 分页', () => {
       .toHaveClass('type-section-label')
     expect(screen.getByRole('heading', { level: 3, name: /历史/ }))
       .toHaveClass('type-section-label')
+    expect(screen.getByTestId('queue-task-grid-10'))
+      .toHaveClass('ui-queue-task-grid')
+    expect(screen.getByTestId('queue-task-grid-10').querySelector('.ui-queue-task-timing'))
+      .toBeInTheDocument()
     // 历史 total=25 > page_size=20 → 分页器 + 页码指示
     expect(screen.getByText(/第 1 \/ 2 页/)).toBeInTheDocument()
     expect(screen.getByTestId('history-prev')).toBeDisabled()

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -222,8 +222,8 @@ function QueueTaskRow({
       className={`card card-hover block overflow-hidden text-left p-0 cursor-pointer ${isRunning ? 'border border-accent bg-accent-soft' : 'border border-subtle bg-surface'}`}
     >
       <div
-        className="px-[22px] py-4 grid gap-3 items-center"
-        style={{ gridTemplateColumns: '48px minmax(0,1fr) 88px 96px 150px 128px 176px' }}
+        className="ui-queue-task-grid px-[22px] py-4 grid gap-3 items-center"
+        data-testid={`queue-task-grid-${task.id}`}
       >
         <span className={`font-mono text-sm ${isRunning ? 'text-accent font-semibold' : 'text-fg-tertiary font-normal'}`}>
           #{task.id}
@@ -315,7 +315,7 @@ function QueueTaskRow({
           )}
         </div>
 
-        <span className="font-mono text-sm text-fg-tertiary text-right">
+        <span className="ui-queue-task-timing font-mono text-sm text-fg-tertiary text-right">
           {isRunning ? (
             <>
               {eta && <span className="text-accent">{eta}</span>}
@@ -1048,8 +1048,7 @@ export default function QueuePage() {
             {Array.from({ length: 3 }).map((_, i) => (
               <div
                 key={i}
-                className={`py-[18px] px-[22px] grid gap-3 items-center opacity-40 ${i < 2 ? 'border-b border-subtle' : 'border-b-0'}`}
-                style={{ gridTemplateColumns: '48px minmax(0,1fr) 88px 96px 150px 128px 176px' }}
+                className={`ui-queue-task-grid py-[18px] px-[22px] grid gap-3 items-center opacity-40 ${i < 2 ? 'border-b border-subtle' : 'border-b-0'}`}
               >
                 <div className="h-3.5 rounded bg-overlay" />
                 <div className="flex flex-col gap-1">
@@ -1059,7 +1058,7 @@ export default function QueuePage() {
                 <div className="h-2.5 rounded bg-overlay" />
                 <div className="h-5 rounded bg-overlay" />
                 <div className="h-2.5 rounded bg-overlay" />
-                <div className="h-2.5 rounded bg-overlay" />
+                <div className="ui-queue-task-timing h-2.5 rounded bg-overlay" />
                 <div className="h-6 rounded bg-overlay" />
               </div>
             ))}

--- a/studio/web/src/pages/QueueDetail.test.tsx
+++ b/studio/web/src/pages/QueueDetail.test.tsx
@@ -7,9 +7,10 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DialogProvider } from '../components/Dialog'
 import { ToastProvider } from '../components/Toast'
 import type { Task } from '../api/client'
-import QueueDetailPage, { SnapshotConfigTab } from './QueueDetail'
+import QueueDetailPage, { OutputsTab, SnapshotConfigTab } from './QueueDetail'
 
 const SNAPSHOT_URL_PREFIX = '/api/queue/'
 const SNAPSHOT_URL_SUFFIX = '/snapshot/config'
@@ -111,6 +112,45 @@ describe('SnapshotConfigTab', () => {
   })
 })
 
+describe('OutputsTab 响应式输出表', () => {
+  it('为两个横向滚动区提供独立名称，并披露被截断的完整目录', async () => {
+    const outputDir = 'C:/very/long/output/path'
+    const body = {
+      task_id: 119,
+      output_dir: outputDir,
+      exists: true,
+      supports_open_folder: false,
+      archive_basename: 'project-version',
+      files: [
+        { name: 'model.safetensors', path: 'model.safetensors', size: 100, mtime: 2, kind: 'lora', is_lora: true },
+        { name: 'state.pt', path: 'state.pt', size: 200, mtime: 1, kind: 'training_state', is_lora: false },
+      ],
+    }
+    fetchMock.mockResolvedValue({
+      ok: true, status: 200,
+      json: async () => body, text: async () => JSON.stringify(body),
+      headers: new Headers({ 'content-type': 'application/json' }),
+    } as Response)
+
+    render(
+      <MemoryRouter>
+        <ToastProvider>
+          <DialogProvider>
+            <OutputsTab taskId={119} />
+          </DialogProvider>
+        </ToastProvider>
+      </MemoryRouter>,
+    )
+
+    expect(await screen.findByRole('region', { name: '输出文件' }))
+      .toHaveClass('ui-queue-output-table')
+    expect(screen.getByRole('region', { name: '训练状态' }))
+      .toHaveClass('ui-queue-output-table')
+    expect(screen.getByText(outputDir, { selector: 'code' }))
+      .toHaveAttribute('title', outputDir)
+  })
+})
+
 // ── 暂停按钮的 SSE 刷新（QueueDetailPage header）─────────────────────────────
 //
 // regression：恢复 / 启动后 is_pausable 由 train_loop_started + auto_epoch_backup_written
@@ -184,6 +224,14 @@ describe('QueueDetailPage 暂停按钮 SSE 刷新', () => {
 
     // 初始：running header 已渲染（PID 卡片），但 is_pausable=false → 暂停按钮不在
     await waitFor(() => expect(screen.getByText('取消任务')).toBeInTheDocument())
+    const stats = screen.getByTestId('queue-detail-stats')
+    expect(stats).toHaveClass('ui-queue-detail-stats')
+    expect(stats.querySelector('[title="train"]'))
+      .toHaveClass('overflow-hidden', 'text-ellipsis')
+    expect(screen.getByText('train', { selector: '.ui-queue-detail-title' }))
+      .toHaveAttribute('title', 'train')
+    expect(screen.getByText('train.yaml', { selector: '.ui-queue-detail-title' }))
+      .toHaveAttribute('title', 'train.yaml')
     expect(screen.getByRole('button', { name: '取消任务' })).toHaveClass('btn-warn', 'btn-sm')
     for (const statusBadge of screen.getAllByText('运行中')) {
       expect(statusBadge).toHaveClass('badge-accent')

--- a/studio/web/src/pages/QueueDetail.tsx
+++ b/studio/web/src/pages/QueueDetail.tsx
@@ -110,12 +110,13 @@ function StatCard({ label, value, sub, mono, large, tone }: {
 }) {
   const toneClass = tone ? `text-${tone}` : 'text-fg-primary'
   return (
-    <div className="flex flex-col gap-1 px-[18px] py-3.5 bg-surface rounded-md border border-subtle">
+    <div className="flex min-w-0 flex-col gap-1 px-[18px] py-3.5 bg-surface rounded-md border border-subtle">
       <span className="text-xs text-fg-tertiary font-mono tracking-widest uppercase">
         {label}
       </span>
       <span
-        className={`${large ? 'text-3xl' : 'text-xl'} font-semibold ${mono ? 'font-mono' : 'font-sans'} tabular-nums ${toneClass}`}
+        className={`${large ? 'text-3xl' : 'text-xl'} overflow-hidden text-ellipsis whitespace-nowrap font-semibold ${mono ? 'font-mono' : 'font-sans'} tabular-nums ${toneClass}`}
+        title={value}
         style={{ letterSpacing: '-0.02em', lineHeight: 1.1 }}
       >
         {value}
@@ -366,8 +367,8 @@ export default function QueueDetailPage() {
           </h1>
           {task && (
             <>
-              <span className="text-fg-secondary text-md">{task.name}</span>
-              <code className="text-xs text-fg-tertiary font-mono">{task.config_name}.yaml</code>
+              <span className="ui-queue-detail-title text-fg-secondary text-md" title={task.name}>{task.name}</span>
+              <code className="ui-queue-detail-title text-xs text-fg-tertiary font-mono" title={`${task.config_name}.yaml`}>{task.config_name}.yaml</code>
             </>
           )}
           {status && (
@@ -515,7 +516,7 @@ export default function QueueDetailPage() {
 
         {/* Stat cards for running tasks */}
         {task && task.status === 'running' && (
-          <div className="grid grid-cols-4 gap-2.5 mt-1">
+          <div className="ui-queue-detail-stats grid gap-2.5 mt-1" data-testid="queue-detail-stats">
             <StatCard label={t('queueDetail.duration')} value={fmtDuration(task.started_at, null)} mono large tone="accent" />
             <StatCard label={t('queueDetail.startTime')} value={fmtTime(task.started_at)} mono />
             <StatCard label="Config" value={task.config_name} mono />
@@ -1082,8 +1083,7 @@ export function OutputsTab({ taskId }: { taskId: number }) {
       <div
         key={f.path}
         onClick={selectMode ? () => toggleOne(f.path) : undefined}
-        className={`grid gap-2 px-4 py-2 items-center border-b border-subtle text-xs transition-colors ${selectMode ? `cursor-pointer ${isSel ? 'bg-accent-soft' : 'hover:bg-overlay'}` : 'hover:bg-overlay'}`}
-        style={{ gridTemplateColumns: '1fr 100px 160px 80px' }}
+        className={`ui-queue-output-grid grid gap-2 px-4 py-2 items-center border-b border-subtle text-xs transition-colors ${selectMode ? `cursor-pointer ${isSel ? 'bg-accent-soft' : 'hover:bg-overlay'}` : 'hover:bg-overlay'}`}
       >
         <div className="flex items-center gap-1.5 min-w-0">
           <code className="font-mono text-fg-primary overflow-hidden text-ellipsis whitespace-nowrap">{f.path || f.name}</code>
@@ -1114,11 +1114,15 @@ export function OutputsTab({ taskId }: { taskId: number }) {
     )
   })
 
-  const renderFileTable = (files: typeof sortedFiles) => (
-    <div className="card overflow-hidden p-0">
+  const renderFileTable = (files: typeof sortedFiles, label: string) => (
+    <div
+      className="ui-queue-output-table card p-0"
+      role="region"
+      aria-label={label}
+      tabIndex={0}
+    >
       <div
-        className="grid gap-2 px-4 py-2 text-xs text-fg-tertiary border-b border-subtle font-mono"
-        style={{ gridTemplateColumns: '1fr 100px 160px 80px' }}
+        className="ui-queue-output-grid grid gap-2 px-4 py-2 text-xs text-fg-tertiary border-b border-subtle font-mono"
       >
         <button
           onClick={() => onHeaderClick('name')}
@@ -1152,9 +1156,14 @@ export function OutputsTab({ taskId }: { taskId: number }) {
   return (
     <div className="flex flex-col flex-1 min-h-0 p-4 gap-2.5">
       {data?.output_dir ? (
-        <div className="flex items-center gap-2 text-xs shrink-0 border-b border-subtle pb-2.5">
+        <div className="ui-queue-output-actions flex items-center gap-2 text-xs shrink-0 border-b border-subtle pb-2.5" data-testid="queue-output-actions">
           <span className="text-fg-tertiary shrink-0">{t('common.directory')}</span>
-          <code className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-fg-primary font-mono">{data.output_dir}</code>
+          <code
+            className="ui-queue-output-path min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-fg-primary font-mono"
+            title={data.output_dir}
+          >
+            {data.output_dir}
+          </code>
           <Button variant="ghost" size="sm" onClick={copyPath}>{t('queueDetail.copyPath')}</Button>
           {data.supports_open_folder ? (
             <Button variant="ghost" size="sm" onClick={openFolder} disabled={busy || !data.exists}>
@@ -1222,14 +1231,14 @@ export function OutputsTab({ taskId }: { taskId: number }) {
           <div className="flex flex-col gap-3">
             {regularFiles.length > 0 && (
               <section className="flex flex-col gap-1.5">
-                <div className="px-1 text-xs font-semibold text-fg-secondary">输出文件</div>
-                {renderFileTable(regularFiles)}
+                <div className="px-1 text-xs font-semibold text-fg-secondary">{t('queueDetail.outputFiles')}</div>
+                {renderFileTable(regularFiles, t('queueDetail.outputFiles'))}
               </section>
             )}
             {stateFiles.length > 0 && (
               <section className="flex flex-col gap-1.5">
-                <div className="px-1 text-xs font-semibold text-warn">训练状态</div>
-                {renderFileTable(stateFiles)}
+                <div className="px-1 text-xs font-semibold text-warn">{t('queueDetail.trainingStates')}</div>
+                {renderFileTable(stateFiles, t('queueDetail.trainingStates'))}
               </section>
             )}
           </div>

--- a/studio/web/src/pages/queue/DataJobsPanel.test.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.test.tsx
@@ -84,6 +84,10 @@ describe('DataJobsPanel', () => {
 
     await waitFor(() => expect(screen.getByTestId('job-row-10')).toBeInTheDocument())
     expect(screen.getByTestId('data-jobs-panel')).toHaveClass('gap-section')
+    expect(screen.getByTestId('job-row-10').firstElementChild)
+      .toHaveClass('ui-queue-job-grid')
+    expect(screen.getByTestId('job-row-10').querySelector('.ui-queue-job-timing'))
+      .toBeInTheDocument()
     expect(screen.getByRole('heading', { level: 3, name: /进行中/ }))
       .toHaveClass('type-section-label')
     expect(screen.getByRole('heading', { level: 3, name: /进行中/ }).parentElement)

--- a/studio/web/src/pages/queue/DataJobsPanel.tsx
+++ b/studio/web/src/pages/queue/DataJobsPanel.tsx
@@ -131,10 +131,7 @@ export default function DataJobsPanel({
         className={`card card-hover block overflow-hidden text-left p-0 cursor-pointer ${task.status === 'running' ? 'border border-accent bg-accent-soft' : 'border border-subtle bg-surface'}`}
         data-testid={`job-row-${task.id}`}
       >
-        <div
-          className="px-[22px] py-4 grid gap-3 items-center"
-          style={{ gridTemplateColumns: '48px minmax(0,1fr) 96px 150px 120px' }}
-        >
+        <div className="ui-queue-job-grid px-[22px] py-4 grid gap-3 items-center">
           <span className={`font-mono text-sm ${task.status === 'running' ? 'text-accent font-semibold' : 'text-fg-tertiary'}`}>
             #{task.id}
           </span>
@@ -150,7 +147,7 @@ export default function DataJobsPanel({
             {task.status === 'running' && <span className="dot dot-running" />}
             {STATUS_LABEL[task.status] ?? task.status}
           </span>
-          <span className="font-mono text-xs text-fg-tertiary text-right">
+          <span className="ui-queue-job-timing font-mono text-xs text-fg-tertiary text-right">
             {task.status === 'running' ? (
               fmtJobDuration(task.started_at, null)
             ) : task.finished_at ? (

--- a/studio/web/src/styles/responsive.css
+++ b/studio/web/src/styles/responsive.css
@@ -5,6 +5,70 @@
 .banner-shell { padding: 16px 18px; }
 .banner-shell-icon { width: 32px; height: 32px; font-size: 16px; }
 
+/* Ordinary route chrome may reflow at compact desktop, but its title, helper
+ * navigation, and primary actions all remain visible and keep DOM order. */
+.ui-page-header { position: relative; }
+.ui-page-header-layout {
+  display: flex;
+  min-width: 0;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: var(--space-section);
+}
+.ui-page-header-copy { min-width: 0; flex: 1 1 24rem; }
+.ui-page-header-actions {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: var(--space-related);
+}
+.ui-page-header-top-right {
+  position: absolute;
+  z-index: 1;
+  inset-block-start: var(--space-field);
+  inset-inline-end: var(--space-page);
+}
+
+/* Container-safe cards never force the AppShell main track wider than its
+ * available inline size. */
+.ui-project-grid {
+  grid-template-columns: repeat(auto-fill, minmax(min(100%, 340px), 1fr));
+}
+
+/* Dense queue rows preserve identity, kind, state, progress, and actions. The
+ * auxiliary timestamp yields first at compact desktop. */
+.ui-queue-task-grid {
+  grid-template-columns: 48px minmax(0, 1fr) 88px 96px 150px 128px 176px;
+}
+.ui-queue-job-grid {
+  grid-template-columns: 48px minmax(0, 1fr) 96px 150px 120px;
+}
+.ui-queue-detail-stats { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+.ui-queue-detail-title {
+  min-width: 0;
+  max-width: min(24rem, 32vw);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ui-queue-output-actions { flex-wrap: wrap; }
+.ui-queue-output-path { flex: 1 1 20rem; }
+.ui-queue-output-table {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+.ui-queue-output-table:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 2px var(--accent-soft);
+}
+.ui-queue-output-grid {
+  min-width: 34rem;
+  grid-template-columns: minmax(0, 1fr) 100px 160px 80px;
+}
+
 @media (max-width: 1280px) {
   /* AppShell keeps primary navigation and actions visible while auxiliary
      resource meters yield at the compact-desktop breakpoint. */
@@ -14,6 +78,26 @@
   }
   .ui-app-shell-topbar-stats { display: none; }
   .ui-app-shell-running-task { max-width: min(14rem, 30vw); }
+
+  .ui-page-header-layout { align-items: flex-start; }
+  .ui-page-header-actions { flex: 1 1 100%; }
+  .ui-page-header-top-right {
+    position: static;
+    display: flex;
+    justify-content: flex-end;
+    margin-block-end: var(--space-related);
+  }
+
+  .ui-queue-task-grid {
+    grid-template-columns: 48px minmax(9rem, 1fr) 80px 88px minmax(7rem, 0.75fr) minmax(9rem, auto);
+  }
+  .ui-queue-job-grid {
+    grid-template-columns: 48px minmax(9rem, 1fr) 88px minmax(7rem, auto);
+  }
+  .ui-queue-task-timing,
+  .ui-queue-job-timing { display: none; }
+  .ui-queue-detail-stats { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .ui-queue-detail-title { max-width: min(18rem, 40vw); }
 
   .banner-shell { padding: 10px 14px; }
   .banner-shell-icon { width: 26px; height: 26px; font-size: 13px; }


### PR DESCRIPTION
## 概要

完成前端优化路线图 Phase 3B（Responsive Rules），在不引入移动端信息架构的前提下，统一普通页面在宽桌面与紧凑桌面间的响应式降级规则。

## 主要改动

- 将 Studio 支持的桌面 viewport classes 固化为：
  - wide desktop：`>1280px`
  - compact desktop：`<=1280px`
- `PageHeader` 在紧凑桌面下让辅助导航回归文档流，并将操作区换到独立行，避免标题覆盖。
- Projects 卡片网格改为容器安全的最小宽度，不再由固定 `340px` 卡片撑破主内容区。
- Queue / Data Jobs 密集行在紧凑桌面隐藏辅助时间列，保留身份、类型、状态、进度与主要操作；加载骨架同步使用相同列契约。
- QueueDetail：
  - 状态摘要降为两列；
  - 长任务名、配置名和状态值安全截断并保留完整披露；
  - 输出操作区允许换行；
  - 固定宽度文件表格建立具名、可聚焦的局部横向滚动边界；
  - “输出文件”与“训练状态”使用独立中英文可访问名称。
- 在 `DESIGN.md` 固化响应式责任边界：普通页面可换行/隐藏辅助信息，专业工作台保留局部几何，不机械堆叠。

## 明确不包含

- 不引入手机端导航或移动端信息架构。
- 不重排 Generate、Gallery、Eval、媒体编辑等专业工作台。
- 不改 API、schema、SSE、路由或业务状态。
- 不混入既存 LyCORIS backend CI 兼容问题的修复。

## 审查修复

独立审查无 P0/P1；已修复两项 P2：

1. 两个输出文件表格不再使用相同 region 名称；
2. 紧凑布局中被截断的输出目录通过 `title` 披露完整路径。

## 验证

- 聚焦 Vitest：4 个文件，35 个测试通过
- 全量 Vitest：100 个文件，774 个测试通过
- ESLint：通过
- TypeScript：通过
- Production build：通过（498 modules）
- `tests/test_route_snapshot.py`：通过
- Impeccable detector：0 findings
- `git diff --check`：通过
- 人工视觉检查：通过（1280/1281px、Queue、Projects、QueueDetail、主题/密度/中英文）

## 已知基线问题

PR #539/#540 的 backend CI 已存在 `tests/test_lycoris_patch.py` 失败：CI 安装的 `lycoris-lora 3.4.0` 不再导出 `make_kron`。该问题与本 PR 的前端响应式改动无关，本 PR 不混入后端依赖兼容修复。
