### PR TITLE
feat(web): 统一页面与工作区壳层

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -495,7 +495,41 @@ App-shell responsiveness belongs to `styles/responsive.css` and uses the shared
 adoption concern, not permission to hide primary actions or add arbitrary
 component-local breakpoints.
 
-## 16. Responsive-layout contract
+## 16. Page and workflow shell contract
+
+Routes use one of three explicit compositions; do not introduce a universal shell
+that hides scroll ownership.
+
+A **document page** follows `PageHeader` → optional full-bleed toolbar/subnav →
+page-inset body. `AppShell` main remains its only vertical scroll owner. Document
+routes must not add `h-full`, `overflow-hidden`, or a second page-level
+`overflow-y-auto`. The header may be sticky because it shares the main scroller.
+Projects is the representative ordinary list-page contract.
+
+A **bounded list page** is reserved for high-frequency lists whose persistent
+controls must remain visible while many items scroll. Its route fills the AppShell
+main track and composes `PageHeader` → optional full-bleed toolbar → named,
+keyboard-focusable list scrollport → persistent footer. Header, toolbar, and footer
+are siblings outside the scrollport; the route marks AppShell scrolling as contained
+so the outer stable scrollbar gutter is released, and content inset belongs to an
+inner wrapper so the active browser scrollbar reaches the route edge. Queue is the
+representative contract. Do not use `StepShell` for this composition or add nested
+scrolling inside list rows.
+
+A **workspace step** uses `StepShell`. It fills the route track, keeps page scrolling
+locked, and delegates scrolling to explicit inner panels. Its order is `PageHeader`
+→ optional `belowHeader` → workspace content → optional `TaskLogDrawer` footer.
+The workspace header is not sticky because the shell itself does not scroll.
+`belowHeader` is full bleed and owns its own padding. Content defaults to the shared
+page inset; specialized canvas geometry may choose `inset="none"` only when the
+caller also owns its boundaries and keyboard-reachable scroll regions.
+
+`StepShell` is not a workflow-state machine: it does not receive step indexes,
+change routes, save data, or own business status. `SaveBar` remains a header action,
+not an invented sticky footer. Settings Drawer, Generate, Gallery, evaluation
+matrices, and image editors retain their documented specialized scroll geometry.
+
+## 17. Responsive-layout contract
 
 The responsive layer distinguishes **wide desktop** (`> 1280px`) from
 **compact desktop** (`<= 1280px`). It adapts content hierarchy inside the
@@ -529,7 +563,7 @@ stacking mechanically. Any later restructuring requires a representative pilot
 and content-driven evidence; `md`/`lg`/`xl` utility classes are not an independent
 breakpoint policy.
 
-## 17. Accessibility and resilience
+## 18. Accessibility and resilience
 
 Every primitive must work with keyboard focus, disabled state, light/dark themes,
 all three density modes, and both Chinese and English labels. Focus is always visible.
@@ -539,7 +573,7 @@ full value is available through an established disclosure pattern.
 Respect `prefers-reduced-motion`; status information must remain understandable when
 animation is disabled.
 
-## 18. Migration policy
+## 19. Migration policy
 
 Migration is incremental:
 

--- a/studio/web/src/components/ImageGrid.test.tsx
+++ b/studio/web/src/components/ImageGrid.test.tsx
@@ -90,6 +90,23 @@ describe('ImageGrid (PP3)', () => {
     expect(cells[1]).toHaveAttribute('aria-selected', 'true')
   })
 
+  it('keeps the height chain on the grid while applying inset inside the Virtuoso scrollport', () => {
+    const { container } = render(
+      <ImageGrid
+        items={items}
+        selected={new Set()}
+        onSelect={() => {}}
+        className="flex-1 min-h-0"
+        contentClassName="p-2"
+      />
+    )
+
+    const grid = screen.getByRole('grid')
+    expect(grid).toHaveClass('h-full', 'min-h-0', 'flex-1')
+    expect(grid).not.toHaveClass('p-2', '-mr-2')
+    expect(container.querySelector('.grid')).toHaveClass('p-2')
+  })
+
   it('clicking a cell calls onSelect with name', async () => {
     const onSelect = vi.fn()
     const user = userEvent.setup()

--- a/studio/web/src/components/ImageGrid.tsx
+++ b/studio/web/src/components/ImageGrid.tsx
@@ -14,6 +14,10 @@ export interface ImageGridItem {
 interface Props {
   items: ImageGridItem[]
   selected: Set<string>
+  /** Classes for the stable height-constrained grid wrapper. */
+  className?: string
+  /** Classes for grid content inside Virtuoso's scrollport (for example panel inset). */
+  contentClassName?: string
   /** 单击 = checkbox 切换；shift+click = 区间选；详见 applySelection。 */
   onSelect: (name: string, e: React.MouseEvent) => void
   /** 鼠标悬停时回调：用于驱动外部「大图预览面板」。 */
@@ -96,10 +100,18 @@ export default function ImageGrid({
   ariaLabel,
   columnsClass = DEFAULT_COLUMNS,
   activeName,
+  className = '',
+  contentClassName = '',
 }: Props) {
   const { t } = useTranslation()
   if (items.length === 0) {
-    return <p className="text-fg-tertiary text-sm py-2">{emptyHint ?? t('imageGrid.noImages')}</p>
+    return (
+      <div className={`h-full min-h-0 ${className}`.trim()}>
+        <p className={`text-fg-tertiary text-sm py-2 ${contentClassName}`.trim()}>
+          {emptyHint ?? t('imageGrid.noImages')}
+        </p>
+      </div>
+    )
   }
   const decoupled = activeName !== undefined
 
@@ -108,12 +120,16 @@ export default function ImageGrid({
   // style；外层 wrapper 是稳定的。getAllByRole('gridcell') 会穿透中间 div 找到
   // Cell 上的 role="gridcell"，AT / 测试都不受影响。
   return (
-    <div role="grid" aria-label={ariaLabel} className="h-full">
+    <div
+      role="grid"
+      aria-label={ariaLabel}
+      className={`h-full min-h-0 ${className}`.trim()}
+    >
       <VirtuosoGrid
         style={{ height: '100%' }}
         totalCount={items.length}
         overscan={OVERSCAN_PX}
-        listClassName={`grid ${columnsClass} gap-1`}
+        listClassName={`grid ${columnsClass} gap-1 ${contentClassName}`.trim()}
         itemContent={(index) => {
           const it = items[index]
           const isSel = selected.has(it.name)

--- a/studio/web/src/components/StepShell.test.tsx
+++ b/studio/web/src/components/StepShell.test.tsx
@@ -3,10 +3,9 @@ import { describe, expect, it } from 'vitest'
 import StepShell from './StepShell'
 
 describe('StepShell', () => {
-  it('uses the shared page inset while keeping the toolbar outside the scroll content', () => {
+  it('uses the shared page inset while keeping the toolbar outside workspace content', () => {
     render(
       <StepShell
-        idx={1}
         title="Queue"
         belowHeader={<div data-testid="toolbar">Filters</div>}
       >
@@ -14,8 +13,50 @@ describe('StepShell', () => {
       </StepShell>,
     )
 
-    expect(screen.getByTestId('content').parentElement).toHaveClass('p-page')
-    expect(screen.getByTestId('toolbar').nextElementSibling)
-      .toBe(screen.getByTestId('content').parentElement)
+    const shell = screen.getByTestId('content').closest('[data-step-shell]')
+    const content = screen.getByTestId('content').parentElement
+
+    expect(shell).toHaveClass('h-full', 'min-h-0', 'relative')
+    expect(content).toHaveClass('p-page', 'overflow-hidden')
+    expect(content).toHaveAttribute('data-inset', 'page')
+    expect(screen.getByTestId('toolbar').nextElementSibling).toBe(content)
+    expect(screen.getByRole('heading', { level: 1 }).closest('.ui-page-header'))
+      .not.toHaveClass('sticky')
+  })
+
+  it('allows specialized workspaces to own edge geometry explicitly', () => {
+    render(
+      <StepShell title="Canvas" inset="none">
+        <div data-testid="canvas">Canvas</div>
+      </StepShell>,
+    )
+
+    const content = screen.getByTestId('canvas').parentElement
+    expect(content).toHaveAttribute('data-inset', 'none')
+    expect(content).not.toHaveClass('p-page')
+    expect(content).toHaveClass('overflow-hidden')
+  })
+
+  it('mounts the task log footer after the bounded workspace content', () => {
+    render(
+      <StepShell
+        title="Train"
+        logSources={[{
+          key: 'train',
+          label: 'Train',
+          status: 'done',
+          lines: ['Complete'],
+        }]}
+      >
+        <div data-testid="workspace">Workspace</div>
+      </StepShell>,
+    )
+
+    const content = screen.getByTestId('workspace').parentElement
+    const spacer = content?.nextElementSibling
+    const drawer = spacer?.nextElementSibling
+
+    expect(spacer).toHaveAttribute('aria-hidden', 'true')
+    expect(drawer).toContainElement(screen.getByRole('button', { name: /Train/ }))
   })
 })

--- a/studio/web/src/components/StepShell.tsx
+++ b/studio/web/src/components/StepShell.tsx
@@ -3,7 +3,6 @@ import PageHeader from './PageHeader'
 import TaskLogDrawer, { type LogSource } from './TaskLogDrawer'
 
 interface Props {
-  idx: number | string
   title: string
   subtitle?: string
   actions?: ReactNode
@@ -11,24 +10,38 @@ interface Props {
   children: ReactNode
   /** header 与内容区之间的全宽 Pattern（如 ListToolbar），不随内容滚动。 */
   belowHeader?: ReactNode
+  /** 内容区 inset；专业画布可显式选择 none，并自行声明边界与滚动。 */
+  inset?: 'page' | 'none'
   /** 本页任务日志源（issue #251 统一抽屉）；falsy 项自动过滤，全空时不渲染。 */
   logSources?: Array<LogSource | null | undefined | false>
 }
 
-export default function StepShell({ title, subtitle, actions, topRight, children, belowHeader, logSources }: Props) {
+export default function StepShell({
+  title,
+  subtitle,
+  actions,
+  topRight,
+  children,
+  belowHeader,
+  inset = 'page',
+  logSources,
+}: Props) {
   return (
-    <div className="fade-in flex flex-col h-full relative">
+    <div className="fade-in flex flex-col h-full min-h-0 relative" data-step-shell>
       <PageHeader
         title={title}
         subtitle={subtitle}
         actions={actions}
         topRight={topRight}
-        sticky
       />
       {belowHeader}
-      {/* flex column container: overflow:hidden stops page scroll; children use flex:1 to fill。
-          内容区四周使用语义 page inset，随全局 density 同步。 */}
-      <div className="flex-1 min-h-0 flex flex-col overflow-hidden p-page">
+      {/* Workspace shell 不参与页面滚动；子工作区声明自己的局部滚动。
+          默认沿用 page inset，专业画布可显式选择 none 并自行负责边界。 */}
+      <div
+        className={`flex-1 min-h-0 flex flex-col overflow-hidden ${inset === 'page' ? 'p-page' : ''}`}
+        data-step-shell-content
+        data-inset={inset}
+      >
         {children}
       </div>
       {/* 页面级 footer 抽屉：全宽贴底，展开时 overlay 在内容上方（issue #251） */}

--- a/studio/web/src/pages/Queue.test.tsx
+++ b/studio/web/src/pages/Queue.test.tsx
@@ -111,12 +111,13 @@ describe('QueuePage 分区 + 分页', () => {
     renderQueue()
 
     const banner = await screen.findByTestId('queue-hold-banner')
-    expect(banner).toHaveClass('alert', 'alert-warning', 'alert-sm', 'sticky')
+    expect(banner).toHaveClass('alert', 'alert-warning', 'alert-sm')
+    expect(banner).not.toHaveClass('sticky')
     expect(within(banner).getByRole('button', { name: '恢复调度' }))
       .toHaveClass('btn', 'btn-ghost', 'btn-xs')
   })
 
-  it('渲染进行中/等待/历史三分区，历史超过一页时出分页器', async () => {
+  it('渲染进行中/等待/历史三分区，历史超过一页时固定分页器', async () => {
     vi.spyOn(api, 'getQueueHold').mockResolvedValue({ held: false } as never)
     vi.spyOn(api, 'listQueueLive').mockResolvedValue([
       makeTask({ id: 10, name: 'run', status: 'running', started_at: 1000 }),
@@ -128,6 +129,25 @@ describe('QueuePage 分区 + 分页', () => {
     })
 
     renderQueue()
+
+    expect(screen.getByTestId('queue-page'))
+      .toHaveClass('h-full', 'min-h-0', 'flex', 'flex-col', 'overflow-hidden')
+    expect(screen.getByTestId('queue-page'))
+      .toHaveAttribute('data-app-shell-scroll', 'contained')
+    expect(screen.getByTestId('queue-page')).not.toHaveClass('min-h-full')
+    expect(screen.getByTestId('queue-scroll-region'))
+      .toHaveClass('ui-queue-scroll-region', 'flex-1', 'min-h-0')
+    expect(screen.getByTestId('queue-scroll-region'))
+      .toHaveAttribute('role', 'region')
+    expect(screen.getByTestId('queue-scroll-region'))
+      .toHaveAccessibleName(/任务队列/)
+    expect(screen.getByTestId('queue-scroll-region')).toHaveAttribute('tabindex', '0')
+    expect(screen.getByTestId('queue-page-content'))
+      .toHaveClass('px-page', 'py-section')
+    expect(screen.getByTestId('queue-page-content'))
+      .not.toHaveClass('overflow-y-auto', 'overflow-hidden')
+    expect(screen.getByRole('heading', { level: 1 }).closest('.ui-page-header'))
+      .not.toHaveClass('sticky')
 
     await waitFor(() => expect(screen.getByRole('heading', { level: 3, name: /进行中/ })).toBeInTheDocument())
     expect(screen.getByRole('heading', { level: 3, name: /进行中/ }))
@@ -146,8 +166,11 @@ describe('QueuePage 分区 + 分页', () => {
     expect(screen.getByText(/第 1 \/ 2 页/)).toBeInTheDocument()
     expect(screen.getByTestId('history-prev')).toBeDisabled()
     expect(screen.getByTestId('history-next')).not.toBeDisabled()
-    expect(screen.getByTestId('history-next').parentElement?.parentElement)
-      .toHaveClass('-mx-page', '-mb-page', 'px-page')
+    const pagination = screen.getByTestId('queue-pagination')
+    expect(pagination).toHaveClass('shrink-0', 'px-page', 'border-t')
+    expect(pagination).not.toHaveClass('mt-section', '-mx-page', '-mb-page')
+    expect(screen.getByTestId('queue-scroll-region').nextElementSibling)
+      .toBe(pagination)
     historySpy.mockClear()
 
     // 点下一页 → 以 page=2 重新请求后端

--- a/studio/web/src/pages/Queue.tsx
+++ b/studio/web/src/pages/Queue.tsx
@@ -12,10 +12,10 @@ import Card from '../components/Card'
 import EmptyState from '../components/EmptyState'
 import { Input, Select } from '../components/FormControl'
 import ListToolbar from '../components/ListToolbar'
+import PageHeader from '../components/PageHeader'
 import { HoldQueueModal, type HoldDecision } from '../components/HoldQueueModal'
 import { PauseConfirmModal } from '../components/PauseConfirmModal'
 import { PauseProgressModal } from '../components/PauseProgressModal'
-import StepShell from '../components/StepShell'
 import { useDialog } from '../components/Dialog'
 import { useToast } from '../components/Toast'
 import { useEventStream } from '../lib/useEventStream'
@@ -102,7 +102,7 @@ function estimateEta(task: Task): string | null {
   return `已运行 ${fmtDurationShort(elapsed)}`
 }
 
-/** 历史分页固定底栏（GPU / 数据两个视图共用同款，P-G 反馈统一）。
+/** 历史分页持久底栏（GPU / 数据两个视图共用同款，P-G 反馈统一）。
  *  只要 total 超过最小每页数就常显；testid 复用（同一时刻只渲染一个视图）。 */
 function PaginationBar({
   page, total, pageSize, onPage, onPageSize,
@@ -116,7 +116,10 @@ function PaginationBar({
   const { t } = useTranslation()
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
   return (
-    <div className="shrink-0 -mx-page -mb-page px-page py-1 border-t border-subtle flex items-center justify-between flex-wrap gap-related bg-canvas text-[11px]">
+    <div
+      className="shrink-0 px-page py-1 border-t border-subtle flex items-center justify-between flex-wrap gap-related bg-canvas text-[11px]"
+      data-testid="queue-pagination"
+    >
       <div className="flex items-center gap-related text-fg-tertiary">
         <span>{t('queue.pageIndicator', { page, pages: totalPages })}</span>
         <select
@@ -484,7 +487,7 @@ export default function QueuePage() {
   const [jobsSearch, setJobsSearch] = useLocalStorageState('studio:queue:jobsSearch', '')
   const [jobsSearchDebounced, setJobsSearchDebounced] = useState(jobsSearch)
   const [jobsRefreshToken, setJobsRefreshToken] = useState(0)
-  // 数据任务历史分页（与 GPU 视图同款固定底栏；total 由 Panel 拉取后回报）。
+  // 数据任务历史分页（与 GPU 视图共用持久底栏；total 由 Panel 拉取后回报）。
   const [jobsHistoryPage, setJobsHistoryPage] = useState(1)
   const [jobsPageSize, setJobsPageSize] =
     useLocalStorageState('studio:queue:jobsPageSize', HISTORY_PAGE_SIZES[0])
@@ -801,8 +804,12 @@ export default function QueuePage() {
     search.trim() !== '' || historyStatus !== null || typeFilter !== DEFAULT_TYPE_FILTER
 
   return (
-    <StepShell
-      idx={-1}
+    <div
+      className="ui-queue-page fade-in h-full min-h-0 flex flex-col overflow-hidden"
+      data-app-shell-scroll="contained"
+      data-testid="queue-page"
+    >
+      <PageHeader
       /* 0.17 P-G — title/描述随视图切换：明确这是两条独立队列，不是同一列表的
          类型 filter。 */
       title={queueTab === 'jobs' ? t('queue.titleJobs') : t('queue.title')}
@@ -915,7 +922,9 @@ export default function QueuePage() {
           </button>
         </>
       }
-      belowHeader={queueTab === 'jobs' ? (
+      />
+
+      {queueTab === 'jobs' ? (
         <ListToolbar
           id={QUEUE_JOBS_LIST_TOOLBAR_ID}
           hidden={!filtersOpen}
@@ -1004,15 +1013,21 @@ export default function QueuePage() {
           )}
         />
       )}
-    >
-      <div className="flex flex-col gap-field flex-1 min-h-0 overflow-y-auto">
-        {/* ADR §4.1 队列挂起 banner — 仅 held=true 时显示，sticky 顶部。
+
+      <div
+        className="ui-queue-scroll-region flex-1 min-h-0"
+        role="region"
+        aria-label={queueTab === 'jobs' ? t('queue.titleJobs') : t('queue.title')}
+        tabIndex={0}
+        data-testid="queue-scroll-region"
+      >
+      <div className="px-page py-section flex flex-col gap-field" data-testid="queue-page-content">
+        {/* ADR §4.1 队列挂起 banner — 仅 held=true 时显示在文档内容顶部。
             hold 覆盖全队列（含数据作业派发），两个视图都显示。 */}
         {holdState?.held && (
           <Alert
             tone="warning"
             size="sm"
-            className="sticky top-0 z-10"
             data-testid="queue-hold-banner"
             action={(
               <Button
@@ -1115,10 +1130,11 @@ export default function QueuePage() {
           </div>
         )}
       </div>
+      </div>
 
-      {/* 分页下沉成 fixed 底栏（-mx-page/-mb-page 抵消语义内容 inset 做全宽贴底）。
+      {/* 持久分页栏位于列表 scrollport 之后，始终固定在 route viewport 底部。
           item2：只要历史超过最小每页数就常显（切到 50/100 只剩一页时不消失，能切回
-          20）；样式压缩省空间。GPU / 数据两个视图共用同款底栏（P-G 反馈）。 */}
+          20）；GPU / 数据两个视图共用同款底栏（P-G 反馈）。 */}
       {queueTab === 'tasks' && loaded && !isEmpty && history.total > HISTORY_PAGE_SIZES[0] && (
         <PaginationBar
           page={history.page}
@@ -1163,6 +1179,6 @@ export default function QueuePage() {
           onConfirm={onHoldConfirm}
         />
       )}
-    </StepShell>
+    </div>
   )
 }

--- a/studio/web/src/pages/project/steps/Curation.tsx
+++ b/studio/web/src/pages/project/steps/Curation.tsx
@@ -92,8 +92,6 @@ type Focus =
 
 const FOLDER_PATTERN = /^([0-9]+_)?[A-Za-z][A-Za-z0-9_-]*$/
 
-const SCROLL_BOX = 'flex-1 min-h-0 overflow-y-auto pr-1'
-
 export default function CurationPage() {
   const { t } = useTranslation()
   const { project, activeVersion, reload } = useOutletContext<Ctx>()
@@ -601,7 +599,6 @@ export default function CurationPage() {
 
   return (
     <StepShell
-      idx={2}
       title={t('steps.curate.title')}
       subtitle={t('steps.curate.subtitle')}
       actions={
@@ -640,7 +637,7 @@ export default function CurationPage() {
         </>
       }
     >
-    <div className="flex flex-col h-full gap-3">
+    <div className="flex flex-col h-full gap-3 min-h-0">
 
       <div
         ref={rowRef}
@@ -688,20 +685,20 @@ export default function CurationPage() {
             </>
           }
         >
-          <div className={SCROLL_BOX}>
-            <ImageGrid
-              items={leftItems}
-              selected={leftSel}
-              activeName={preview?.side === 'left' ? preview.name : undefined}
-              onSelect={handleLeftClick}
-              onHover={onLeftHover}
-              onPreview={openLeftPreview}
-              onActivate={openLeftPreview}
-              clickMode="activate"
-              ariaLabel="download-grid"
-              emptyHint={t('curate.downloadEmptyHint')}
-            />
-          </div>
+          <ImageGrid
+            className="flex-1 min-h-0"
+            contentClassName="p-2"
+            items={leftItems}
+            selected={leftSel}
+            activeName={preview?.side === 'left' ? preview.name : undefined}
+            onSelect={handleLeftClick}
+            onHover={onLeftHover}
+            onPreview={openLeftPreview}
+            onActivate={openLeftPreview}
+            clickMode="activate"
+            ariaLabel="download-grid"
+            emptyHint={t('curate.downloadEmptyHint')}
+          />
         </PanelCard>
 
         <PaneResizer
@@ -767,21 +764,23 @@ export default function CurationPage() {
           }
         >
           {isVal ? (
-            <p className="text-xs text-fg-tertiary">{t('curate.valHint')}</p>
+            <p className="px-2 pt-2 text-xs text-fg-tertiary">{t('curate.valHint')}</p>
           ) : (
             <>
-              <FolderSummary
-                folders={folderNames}
-                counts={Object.fromEntries(folderNames.map((f) => [f, view?.right[f]?.length ?? 0]))}
-                activeFolder={rightFolder}
-                busy={busy}
-                onSwitch={switchRightFolder}
-                onRename={(name) => setRenaming({ target: name, value: name })}
-                onDelete={doDeleteFolder}
-              />
+              <div className="px-2 pt-2">
+                <FolderSummary
+                  folders={folderNames}
+                  counts={Object.fromEntries(folderNames.map((f) => [f, view?.right[f]?.length ?? 0]))}
+                  activeFolder={rightFolder}
+                  busy={busy}
+                  onSwitch={switchRightFolder}
+                  onRename={(name) => setRenaming({ target: name, value: name })}
+                  onDelete={doDeleteFolder}
+                />
+              </div>
 
               {renaming && (
-                <div className="flex items-center gap-2 my-3 text-sm">
+                <div className="flex items-center gap-2 mx-2 my-3 text-sm">
                   <span className="text-fg-secondary">{t('curate.renameLabel', { name: renaming.target })}</span>
                   <input
                     autoFocus
@@ -805,28 +804,28 @@ export default function CurationPage() {
             </>
           )}
 
-          <div className={`${SCROLL_BOX} mt-3`}>
-            <ImageGrid
-              items={rightItems}
-              selected={rightSel}
-              activeName={preview?.side === 'right' ? preview.name : undefined}
-              onSelect={handleRightClick}
-              onHover={onRightHover}
-              onPreview={openRightPreview}
-              onActivate={openRightPreview}
-              clickMode="activate"
-              ariaLabel={isVal ? 'validation-grid' : 'train-grid'}
-              emptyHint={
-                rightLoading
-                  ? t('curate.loading')
-                  : isVal
-                    ? t('curate.valEmpty')
-                    : rightFolder
-                      ? t('curate.trainEmptyFolder', { folder: rightFolder })
-                      : t('curate.trainNoFolder')
-              }
-            />
-          </div>
+          <ImageGrid
+            className="flex-1 min-h-0 mt-3"
+            contentClassName="px-2 pb-2"
+            items={rightItems}
+            selected={rightSel}
+            activeName={preview?.side === 'right' ? preview.name : undefined}
+            onSelect={handleRightClick}
+            onHover={onRightHover}
+            onPreview={openRightPreview}
+            onActivate={openRightPreview}
+            clickMode="activate"
+            ariaLabel={isVal ? 'validation-grid' : 'train-grid'}
+            emptyHint={
+              rightLoading
+                ? t('curate.loading')
+                : isVal
+                  ? t('curate.valEmpty')
+                  : rightFolder
+                    ? t('curate.trainEmptyFolder', { folder: rightFolder })
+                    : t('curate.trainNoFolder')
+            }
+          />
         </PanelCard>
       </div>
 
@@ -970,7 +969,7 @@ function PanelCard({
         <span className="flex-1" />
         {actions}
       </header>
-      <div className="flex-1 min-h-0 flex flex-col p-2">{children}</div>
+      <div className="flex-1 min-h-0 flex flex-col">{children}</div>
     </section>
   )
 }

--- a/studio/web/src/pages/project/steps/Download.tsx
+++ b/studio/web/src/pages/project/steps/Download.tsx
@@ -197,7 +197,6 @@ export default function DownloadPage() {
 
   return (
     <StepShell
-      idx={1}
       title={t('steps.download.title')}
       subtitle={t('steps.download.subtitle')}
       logSources={[

--- a/studio/web/src/pages/project/steps/Preprocess.tsx
+++ b/studio/web/src/pages/project/steps/Preprocess.tsx
@@ -378,7 +378,6 @@ export default function PreprocessPage() {
 
   return (
     <StepShell
-      idx={2}
       title={t('steps.preprocess.title')}
       subtitle={t('steps.preprocess.subtitle')}
       actions={

--- a/studio/web/src/pages/project/steps/PreprocessCrop.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessCrop.tsx
@@ -351,7 +351,6 @@ export default function PreprocessCropPage() {
 
   return (
     <StepShell
-      idx={2}
       title={t('steps.preprocess.title')}
       subtitle={t('preprocessCrop.subtitle')}
       actions={

--- a/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessDuplicates.tsx
@@ -152,7 +152,6 @@ export default function PreprocessDuplicatesPage() {
 
   return (
     <StepShell
-      idx={2}
       title={t('steps.preprocess.title')}
       subtitle={t('duplicates.subtitle')}
       actions={

--- a/studio/web/src/pages/project/steps/PreprocessInpaint.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessInpaint.tsx
@@ -365,7 +365,6 @@ export default function PreprocessInpaintPage() {
 
   return (
     <StepShell
-      idx={2}
       title={t('steps.preprocess.title')}
       subtitle={t('preprocessInpaint.subtitle')}
       actions={

--- a/studio/web/src/pages/project/steps/PreprocessOverview.tsx
+++ b/studio/web/src/pages/project/steps/PreprocessOverview.tsx
@@ -231,7 +231,6 @@ export default function PreprocessOverviewPage() {
 
   return (
     <StepShell
-      idx={2}
       title={t('steps.preprocess.title')}
       subtitle={t('preprocessOverview.subtitle')}
       belowHeader={<PreprocessToolsBar current="overview" projectId={project.id} versionId={vid} />}

--- a/studio/web/src/pages/project/steps/Regularization.tsx
+++ b/studio/web/src/pages/project/steps/Regularization.tsx
@@ -419,7 +419,6 @@ export default function RegularizationPage() {
 
   return (
     <StepShell
-      idx={5}
       title={t('steps.reg.title')}
       subtitle={t('steps.reg.subtitle')}
       logSources={[

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -349,7 +349,6 @@ export default function TagEditPage() {
 
   return (
     <StepShell
-      idx={4}
       title={t('tagEdit.title')}
       subtitle={t('tagEdit.subtitle')}
       actions={

--- a/studio/web/src/pages/project/steps/Tagging.tsx
+++ b/studio/web/src/pages/project/steps/Tagging.tsx
@@ -371,7 +371,6 @@ export default function TaggingPage() {
 
   return (
     <StepShell
-      idx={3}
       title={t('steps.tag.title')}
       subtitle={t('steps.tag.subtitle')}
       logSources={[
@@ -406,7 +405,7 @@ export default function TaggingPage() {
         </button>
       }
     >
-    <div className="flex flex-col h-full gap-3">
+    <div className="flex flex-col h-full gap-3 min-h-0">
 
       <div className="grid gap-3 flex-1 min-h-0" style={{ gridTemplateColumns: '1.5fr 1fr' }}>
 

--- a/studio/web/src/pages/project/steps/Train.tsx
+++ b/studio/web/src/pages/project/steps/Train.tsx
@@ -519,7 +519,6 @@ export default function TrainPage() {
 
   return (
     <StepShell
-      idx={6}
       title={t('steps.train.title')}
       subtitle={t('steps.train.subtitle')}
       actions={
@@ -611,7 +610,7 @@ export default function TrainPage() {
         </>
       }
     >
-      <div className="flex flex-col h-full gap-3">
+      <div className="flex flex-col h-full gap-3 min-h-0">
 
         {/* 两栏布局：左（预设 + config 编辑） / 右（估算面板） */}
         <div className="flex gap-3 flex-1 min-h-0">

--- a/studio/web/src/styles/app-shell.css
+++ b/studio/web/src/styles/app-shell.css
@@ -39,6 +39,11 @@ body,
   background: var(--bg-canvas);
 }
 
+.ui-app-shell-main:has(> [data-app-shell-scroll='contained']) {
+  overflow: hidden;
+  scrollbar-gutter: auto;
+}
+
 .ui-app-shell-main:focus {
   outline: none;
 }

--- a/studio/web/src/styles/responsive.css
+++ b/studio/web/src/styles/responsive.css
@@ -37,6 +37,19 @@
   grid-template-columns: repeat(auto-fill, minmax(min(100%, 340px), 1fr));
 }
 
+/* Queue is a viewport-contained list page: its chrome and persistent pager stay
+ * fixed while this named region owns the only route-local vertical scrolling. */
+.ui-queue-scroll-region {
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+}
+.ui-queue-scroll-region:focus-visible {
+  outline: none;
+  box-shadow: inset 0 0 0 2px var(--accent-soft);
+}
+
 /* Dense queue rows preserve identity, kind, state, progress, and actions. The
  * auxiliary timestamp yields first at compact desktop. */
 .ui-queue-task-grid {


### PR DESCRIPTION
## 摘要

完成 Phase 3C（Page / Workflow Shell Adoption），明确普通文档页、持久控制列表页与 viewport-contained 工作区的滚动及布局职责。

## 主要改动

- Queue 不再复用 `StepShell`，采用持久控制列表页契约：
  - Header、筛选工具栏与分页栏固定在 route viewport；
  - 中间具名列表区域承担唯一 route-local 滚动；
  - AppShell 对 contained route 释放外层 scrollbar gutter；
  - 大量任务时分页操作始终可达。
- `StepShell` 明确只服务 viewport-contained 项目工作区：
  - 删除未使用的 `idx` 接口与 11 个调用点参数；
  - 新增 `inset="page" | "none"`；
  - 固化 `Header → belowHeader → workspace → TaskLogDrawer` 顺序；
  - 内容槽统一 `min-h-0 + overflow-hidden`。
- 修复 Train、Tagging、Curation flex shrink chain，避免内部滚动区被裁切。
- 修复 Curation 图片列表：
  - 保持 Virtuoso 确定高度链，避免列表计算为 0 高度；
  - 内容 inset 放入 Virtuoso list，scrollbar 贴面板右边；
  - 不使用负 margin 或 padding 数值抵消。
- 更新 `DESIGN.md` 页面与工作区壳层契约，并补充结构回归测试。

## 范围边界

- 不改 API、schema、SSE 或业务状态。
- 不改 Generate、Gallery、Eval 等专业 split workspace 的既有几何。
- SaveBar 继续位于 Header actions，不新增底部保存条。

## 验证

- 聚焦测试：4 个文件、32 个测试通过（最终视觉修复切片）
- 全量 Vitest：100 个文件、777 个测试通过
- ESLint：通过
- TypeScript：通过
- Production build：通过（498 modules）
- 路由快照：通过
- Impeccable layout detector：0 findings
- `git diff --check`：通过
- 独立复审：初始滚动裁切 P1 已修复并复核通过
- 人工视觉检查：通过（含 Curation 图片列表/滚动条与 Queue 固定分页）

## 已知非本 PR 项

- `LogView.test.tsx` 既有 React `act(...)` 警告。
- Queue 行级交互存在既有嵌套 `<button>` 警告，本 PR 未引入。
- Vite 保留既有 `>700 kB` 主 chunk 提示。
- Backend CI 的 LyCORIS `make_kron` 兼容失败已在此前 PR 基线存在，与本前端改动无关。
