### PR TITLE
feat(web): 统一分栏工作区几何与拖动契约

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -563,7 +563,40 @@ stacking mechanically. Any later restructuring requires a representative pilot
 and content-driven evidence; `md`/`lg`/`xl` utility classes are not an independent
 breakpoint policy.
 
-## 18. Accessibility and resilience
+## 18. Split-workspace and pane-geometry contract
+
+A split workspace preserves simultaneous context for a task; it is not an ordinary
+responsive grid and there is no universal split-shell component. `PaneResizer` is
+the shared interaction primitive only for authored, user-resizable horizontal
+separators. The parent remains authoritative for pane DOM order, percentage state,
+persistence, compact behavior, and local scroll owners.
+
+Pane geometry follows these rules:
+
+- Persisted percentages are untrusted input. The same bounded effective value must
+  drive pane geometry, separator ARIA, pointer drag, and keyboard changes. Invalid
+  two-fixed-pane state is repaired against one shared width budget so a flexible
+  middle pane retains its declared minimum.
+- A separator names its controlled pane with `aria-controls`, exposes min/current/max
+  percentage values, supports Left/Right plus Home/End, and restores body cursor and
+  text-selection styles after pointer up, cancellation, capture loss, or unmount.
+- Every bounded flex pane and every link in its height chain uses `min-width: 0` /
+  `min-height: 0`. Exactly one descendant owns overflow for each axis. Virtualized
+  media grids remain direct bounded children of their pane; visual inset belongs to
+  the virtual list content, never to a wrapper that breaks measured height or moves
+  the browser scrollbar inward.
+- Curation is the representative responsive two-pane workspace: at compact desktop
+  it stacks panes and removes the inactive separator; at wide desktop the fixed pane
+  uses the bounded persisted percentage. Tag Edit is the representative authored
+  three-pane workspace: the two fixed panes share one budget and reserve the middle
+  preview minimum even when stored values are stale or corrupt. If the three authored
+  panes no longer fit, its named workspace establishes one keyboard-focusable
+  horizontal boundary rather than shrinking tools below useful widths or clipping them.
+- Train preview, Tagging status, Generate canvas and attached drawers, preprocessing
+  editors, and evaluation matrices retain their specialist topology. Do not add
+  resize handles or migrate them to `PaneResizer` without task-specific evidence.
+
+## 19. Accessibility and resilience
 
 Every primitive must work with keyboard focus, disabled state, light/dark themes,
 all three density modes, and both Chinese and English labels. Focus is always visible.
@@ -573,7 +606,7 @@ full value is available through an established disclosure pattern.
 Respect `prefers-reduced-motion`; status information must remain understandable when
 animation is disabled.
 
-## 19. Migration policy
+## 20. Migration policy
 
 Migration is incremental:
 

--- a/studio/web/src/components/PaneResizer.test.tsx
+++ b/studio/web/src/components/PaneResizer.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 import { createRef } from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import PaneResizer from './PaneResizer'
+import PaneResizer, { clampPaneValue, normalizePanePair } from './PaneResizer'
 
 // jsdom 无 layout & 无 pointer capture：容器宽度和 capture API 都得自己补，
 // 否则 onPointerDown 直接 early-return（width <= 0）。
@@ -24,7 +24,7 @@ if (!w.PointerEvent) {
 function setup(props: Partial<React.ComponentProps<typeof PaneResizer>> = {}) {
   const onChange = vi.fn()
   const ref = createRef<HTMLDivElement>()
-  render(
+  const view = render(
     <div ref={ref}>
       <PaneResizer
         containerRef={ref}
@@ -38,7 +38,7 @@ function setup(props: Partial<React.ComponentProps<typeof PaneResizer>> = {}) {
   vi.spyOn(ref.current!, 'getBoundingClientRect').mockReturnValue({
     width: CONTAINER_WIDTH,
   } as DOMRect)
-  return { onChange, handle: screen.getByRole('separator') }
+  return { onChange, handle: screen.getByRole('separator'), unmount: view.unmount }
 }
 
 /** 从 startX 拖到 endX（按下 → 移动 → 抬起） */
@@ -49,9 +49,36 @@ function drag(handle: HTMLElement, startX: number, endX: number) {
 }
 
 beforeEach(() => {
+  document.body.style.cursor = ''
+  document.body.style.userSelect = ''
   Object.assign(HTMLElement.prototype, {
     setPointerCapture: vi.fn(),
+    hasPointerCapture: vi.fn(() => true),
     releasePointerCapture: vi.fn(),
+  })
+})
+
+describe('pane value bounds', () => {
+  it('clamps invalid persisted values to the declared range', () => {
+    expect(clampPaneValue(90, 25, 70)).toBe(70)
+    expect(clampPaneValue(Number.NaN, 25, 70)).toBe(25)
+  })
+
+  it('repairs a three-pane budget proportionally while preserving valid values', () => {
+    expect(normalizePanePair(40, 32, {
+      startMin: 15,
+      endMin: 20,
+      flexibleMin: 15,
+    })).toEqual({ start: 40, end: 32 })
+
+    const repaired = normalizePanePair(90, 90, {
+      startMin: 15,
+      endMin: 20,
+      flexibleMin: 15,
+    })
+    expect(repaired.start + repaired.end).toBeCloseTo(85)
+    expect(repaired.start).toBeGreaterThanOrEqual(15)
+    expect(repaired.end).toBeGreaterThanOrEqual(20)
   })
 })
 
@@ -76,12 +103,16 @@ describe('PaneResizer', () => {
     expect(onChange).toHaveBeenLastCalledWith(20)
   })
 
-  it('方向键调整，同样受 min / max 约束', () => {
-    const { onChange, handle } = setup({ value: 41, max: 42 })
+  it('方向键与 Home / End 调整，同样受 min / max 约束', () => {
+    const { onChange, handle } = setup({ value: 41, min: 15, max: 42 })
     fireEvent.keyDown(handle, { key: 'ArrowRight' })
     expect(onChange).toHaveBeenLastCalledWith(42)
     fireEvent.keyDown(handle, { key: 'ArrowLeft' })
     expect(onChange).toHaveBeenLastCalledWith(39)
+    fireEvent.keyDown(handle, { key: 'Home' })
+    expect(onChange).toHaveBeenLastCalledWith(15)
+    fireEvent.keyDown(handle, { key: 'End' })
+    expect(onChange).toHaveBeenLastCalledWith(42)
   })
 
   it('抬起后继续移动不再改值', () => {
@@ -92,11 +123,28 @@ describe('PaneResizer', () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 
-  it('暴露 separator 语义供辅助技术读数', () => {
-    const { handle } = setup({ min: 15, max: 55 })
+  it('pointer cancel 或卸载时恢复全局 cursor 与文字选择', () => {
+    const { handle, unmount } = setup()
+    fireEvent.pointerDown(handle, { button: 0, clientX: 500, pointerId: 1 })
+    expect(document.body.style.cursor).toBe('col-resize')
+    expect(document.body.style.userSelect).toBe('none')
+    fireEvent.pointerCancel(handle, { pointerId: 1 })
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+
+    fireEvent.pointerDown(handle, { button: 0, clientX: 500, pointerId: 2 })
+    unmount()
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
+  })
+
+  it('暴露 separator 语义、受控 pane 关联与修复后的当前值', () => {
+    const { handle } = setup({ value: 80, min: 15, max: 55, ariaControls: 'start-pane' })
     expect(handle).toHaveAttribute('aria-orientation', 'vertical')
-    expect(handle).toHaveAttribute('aria-valuenow', '40')
+    expect(handle).toHaveAttribute('aria-controls', 'start-pane')
+    expect(handle).toHaveAttribute('aria-valuenow', '55')
     expect(handle).toHaveAttribute('aria-valuemin', '15')
     expect(handle).toHaveAttribute('aria-valuemax', '55')
+    expect(handle).toHaveAttribute('aria-valuetext', '55%')
   })
 })

--- a/studio/web/src/components/PaneResizer.tsx
+++ b/studio/web/src/components/PaneResizer.tsx
@@ -1,13 +1,13 @@
 /**
  * PaneResizer —— 横向 flex 布局里两栏之间的竖向拖动分隔条（受控组件）。
  *
- * value = 左栏占 containerRef 宽度的百分比，拖动 / 方向键改 value，
- * 持久化交给父层（本组件不碰 localStorage）。
+ * value = anchor 所指固定栏占 containerRef 宽度的百分比，拖动 / 方向键改 value，
+ * 持久化与最终 pane geometry 交给父层（本组件不碰 localStorage）。
  *
  * 用 pointer capture 而不是 window 监听：拖过 canvas / img 等子元素时事件
  * 仍回到 handle 上，不会中途丢失。
  */
-import type { RefObject } from 'react'
+import { useEffect, useRef, type RefObject } from 'react'
 
 interface Props {
   /** 百分比基准容器（两栏 + 本 handle 的共同父节点） */
@@ -24,10 +24,54 @@ interface Props {
    */
   anchor?: 'start' | 'end'
   ariaLabel?: string
+  /** ID of the pane whose size this separator controls. */
+  ariaControls?: string
   className?: string
 }
 
-const clamp = (v: number, lo: number, hi: number) => Math.min(hi, Math.max(lo, v))
+export const clampPaneValue = (value: number, min: number, max: number): number => {
+  const lo = Math.min(min, max)
+  const hi = Math.max(min, max)
+  if (!Number.isFinite(value)) return lo
+  return Math.min(hi, Math.max(lo, value))
+}
+
+export interface PanePairBounds {
+  startMin: number
+  endMin: number
+  flexibleMin: number
+}
+
+/**
+ * Repairs two persisted fixed-pane percentages while reserving a flexible middle pane.
+ * Valid values pass through unchanged. If the pair exceeds the shared budget, only
+ * the space above each pane's minimum is reduced, proportionally.
+ */
+export function normalizePanePair(
+  start: number,
+  end: number,
+  { startMin, endMin, flexibleMin }: PanePairBounds,
+): { start: number; end: number } {
+  const fixedBudget = 100 - flexibleMin
+  if (startMin + endMin > fixedBudget) {
+    throw new RangeError('Pane minimums exceed the available width budget')
+  }
+
+  const boundedStart = clampPaneValue(start, startMin, fixedBudget - endMin)
+  const boundedEnd = clampPaneValue(end, endMin, fixedBudget - startMin)
+  if (boundedStart + boundedEnd <= fixedBudget) {
+    return { start: boundedStart, end: boundedEnd }
+  }
+
+  const extraBudget = fixedBudget - startMin - endMin
+  const startExtra = boundedStart - startMin
+  const endExtra = boundedEnd - endMin
+  const scale = extraBudget / (startExtra + endExtra)
+  return {
+    start: startMin + startExtra * scale,
+    end: endMin + endExtra * scale,
+  }
+}
 
 /** 方向键单步（%） */
 const KEY_STEP = 2
@@ -40,9 +84,16 @@ export default function PaneResizer({
   max = 60,
   anchor = 'start',
   ariaLabel,
+  ariaControls,
   className = '',
 }: Props) {
   const dir = anchor === 'end' ? -1 : 1
+  const boundedMin = Math.min(min, max)
+  const boundedMax = Math.max(min, max)
+  const boundedValue = clampPaneValue(value, boundedMin, boundedMax)
+  const activeDragCleanupRef = useRef<(() => void) | null>(null)
+
+  useEffect(() => () => activeDragCleanupRef.current?.(), [])
 
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     const container = containerRef.current
@@ -52,36 +103,58 @@ export default function PaneResizer({
     e.preventDefault()
 
     const startX = e.clientX
-    const startPct = value
+    const startPct = boundedValue
     const el = e.currentTarget
+    activeDragCleanupRef.current?.()
     el.setPointerCapture(e.pointerId)
 
-    // 拖动期间全局锁光标 + 禁选中，否则划过文字会拖出选区
+    // 拖动期间全局锁光标 + 禁选中，否则划过文字会拖出选区。
+    // cleanup 同时覆盖 pointercancel、capture 丢失和组件卸载，避免 body 永久锁住。
     const prevCursor = document.body.style.cursor
     const prevSelect = document.body.style.userSelect
     document.body.style.cursor = 'col-resize'
     document.body.style.userSelect = 'none'
 
+    let cleaned = false
     const move = (ev: PointerEvent) => {
-      onChange(clamp(startPct + (dir * (ev.clientX - startX) * 100) / width, min, max))
+      onChange(clampPaneValue(
+        startPct + (dir * (ev.clientX - startX) * 100) / width,
+        boundedMin,
+        boundedMax,
+      ))
     }
-    const up = () => {
-      el.releasePointerCapture?.(e.pointerId)
+    const cleanup = () => {
+      if (cleaned) return
+      cleaned = true
       el.removeEventListener('pointermove', move)
-      el.removeEventListener('pointerup', up)
-      el.removeEventListener('pointercancel', up)
+      el.removeEventListener('pointerup', cleanup)
+      el.removeEventListener('pointercancel', cleanup)
+      el.removeEventListener('lostpointercapture', cleanup)
+      if (el.hasPointerCapture?.(e.pointerId)) el.releasePointerCapture?.(e.pointerId)
       document.body.style.cursor = prevCursor
       document.body.style.userSelect = prevSelect
+      if (activeDragCleanupRef.current === cleanup) activeDragCleanupRef.current = null
     }
+    activeDragCleanupRef.current = cleanup
     el.addEventListener('pointermove', move)
-    el.addEventListener('pointerup', up)
-    el.addEventListener('pointercancel', up)
+    el.addEventListener('pointerup', cleanup)
+    el.addEventListener('pointercancel', cleanup)
+    el.addEventListener('lostpointercapture', cleanup)
   }
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Home' || e.key === 'End') {
+      e.preventDefault()
+      onChange(e.key === 'Home' ? boundedMin : boundedMax)
+      return
+    }
     if (e.key !== 'ArrowLeft' && e.key !== 'ArrowRight') return
     e.preventDefault()
-    onChange(clamp(value + dir * (e.key === 'ArrowLeft' ? -KEY_STEP : KEY_STEP), min, max))
+    onChange(clampPaneValue(
+      boundedValue + dir * (e.key === 'ArrowLeft' ? -KEY_STEP : KEY_STEP),
+      boundedMin,
+      boundedMax,
+    ))
   }
 
   return (
@@ -89,9 +162,11 @@ export default function PaneResizer({
       role="separator"
       aria-orientation="vertical"
       aria-label={ariaLabel}
-      aria-valuenow={Math.round(value)}
-      aria-valuemin={min}
-      aria-valuemax={max}
+      aria-controls={ariaControls}
+      aria-valuenow={Math.round(boundedValue)}
+      aria-valuemin={boundedMin}
+      aria-valuemax={boundedMax}
+      aria-valuetext={`${Math.round(boundedValue)}%`}
       tabIndex={0}
       onPointerDown={onPointerDown}
       onKeyDown={onKeyDown}

--- a/studio/web/src/i18n/locales/en.json
+++ b/studio/web/src/i18n/locales/en.json
@@ -1963,6 +1963,7 @@
   "tagEdit": {
     "title": "Tag edit",
     "subtitle": "Batch edit tags · stage locally · write on save",
+    "workspaceLabel": "Resizable image and tag editing workspace",
     "taggedBadge": "{{tagged}}/{{total}} tagged",
     "downloadZip": "Download dataset",
     "zipping": "Packing…",

--- a/studio/web/src/i18n/locales/zh.json
+++ b/studio/web/src/i18n/locales/zh.json
@@ -1963,6 +1963,7 @@
   "tagEdit": {
     "title": "标签编辑",
     "subtitle": "批量编辑标签 · 暂存本地 · 保存后写盘",
+    "workspaceLabel": "可调整宽度的图片与标签编辑工作区",
     "taggedBadge": "{{tagged}}/{{total}} 已打标",
     "downloadZip": "下载训练集",
     "zipping": "打包中…",

--- a/studio/web/src/pages/project/steps/Curation.tsx
+++ b/studio/web/src/pages/project/steps/Curation.tsx
@@ -13,7 +13,7 @@ import {
 import Button from '../../../components/Button'
 import ImageGrid, { applySelection } from '../../../components/ImageGrid'
 import ImagePreviewModal from '../../../components/ImagePreviewModal'
-import PaneResizer from '../../../components/PaneResizer'
+import PaneResizer, { clampPaneValue } from '../../../components/PaneResizer'
 import StepShell from '../../../components/StepShell'
 import { useDialog } from '../../../components/Dialog'
 import { useToast } from '../../../components/Toast'
@@ -36,6 +36,9 @@ const DEFAULT_SORT: SortMode = 'id-asc'
 // 右栏目标桶：训练集（默认，现行为）/ 验证集（held-out，扁平无文件夹）
 type Bucket = 'train' | 'validation'
 const BUCKET_STORAGE_KEY = 'curation:bucket'
+const CURATION_PANE_MIN = 25
+const CURATION_PANE_MAX = 70
+const CURATION_DOWNLOAD_PANE_ID = 'curation-download-pane'
 
 function compareItems(a: CurationItem, b: CurationItem, mode: SortMode): number {
   switch (mode) {
@@ -126,6 +129,12 @@ export default function CurationPage() {
   // 默认 50 = 改造前的 xl:grid-cols-2 等分。窄屏（<1280px）堆叠时该值不生效。
   const rowRef = useRef<HTMLDivElement>(null)
   const [leftPct, setLeftPct] = useLocalStorageState('studio:curate:left_pct', 50)
+  const boundedLeftPct = clampPaneValue(leftPct, CURATION_PANE_MIN, CURATION_PANE_MAX)
+
+  // Repair stale/corrupt persisted ratios before they can collapse the flexible pane.
+  useEffect(() => {
+    if (leftPct !== boundedLeftPct) setLeftPct(boundedLeftPct)
+  }, [boundedLeftPct, leftPct, setLeftPct])
 
   const [leftSel, setLeftSel] = useState<Set<string>>(new Set())
   const [leftAnchor, setLeftAnchor] = useState<string | null>(null)
@@ -642,9 +651,10 @@ export default function CurationPage() {
       <div
         ref={rowRef}
         className="split-row gap-3 items-stretch flex-1 min-h-0"
-        style={{ '--split-pct': `${leftPct}%` } as React.CSSProperties}
+        style={{ '--split-pct': `${boundedLeftPct}%` } as React.CSSProperties}
       >
         <PanelCard
+          id={CURATION_DOWNLOAD_PANE_ID}
           className="split-pane-fixed"
           accent="emerald"
           title={t('curate.downloadPanelTitle')}
@@ -703,11 +713,12 @@ export default function CurationPage() {
 
         <PaneResizer
           containerRef={rowRef}
-          value={leftPct}
+          value={boundedLeftPct}
           onChange={setLeftPct}
-          min={25}
-          max={70}
+          min={CURATION_PANE_MIN}
+          max={CURATION_PANE_MAX}
           ariaLabel={t('curate.resizePanels')}
+          ariaControls={CURATION_DOWNLOAD_PANE_ID}
           className="split-resizer"
         />
 
@@ -951,8 +962,9 @@ const ACCENT_BAR_CLS: Record<'emerald' | 'cyan', string> = {
 }
 
 function PanelCard({
-  accent, title, subtitle, actions, children, className = '',
+  id, accent, title, subtitle, actions, children, className = '',
 }: {
+  id?: string
   accent: 'emerald' | 'cyan'
   title: string
   subtitle: string
@@ -961,7 +973,7 @@ function PanelCard({
   className?: string
 }) {
   return (
-    <section className={`flex flex-col min-h-0 rounded-md border border-subtle bg-surface overflow-hidden ${className}`}>
+    <section id={id} className={`flex flex-col min-h-0 rounded-md border border-subtle bg-surface overflow-hidden ${className}`}>
       <div className={`h-0.5 ${ACCENT_BAR_CLS[accent]}`} />
       <header className="flex flex-wrap items-center gap-1.5 px-2.5 py-1.5 border-b border-subtle text-sm">
         <h3 className="font-semibold">{title}</h3>

--- a/studio/web/src/pages/project/steps/Download.tsx
+++ b/studio/web/src/pages/project/steps/Download.tsx
@@ -412,18 +412,18 @@ function DownloadedGrid({
           {deleting ? t('download.deleting') : t('download.deleteBtn', { n: selected.size })}
         </button>
       </header>
-      <div className="flex-1 min-h-0 overflow-y-auto p-2">
-        <ImageGrid
-          items={items}
-          selected={selected}
-          onSelect={onSelect}
-          onActivate={onPreview}
-          onPreview={onPreview}
-          clickMode="activate"
-          ariaLabel="downloaded-grid"
-          emptyHint={t('download.emptyHint')}
-        />
-      </div>
+      <ImageGrid
+        className="flex-1 min-h-0"
+        contentClassName="p-2"
+        items={items}
+        selected={selected}
+        onSelect={onSelect}
+        onActivate={onPreview}
+        onPreview={onPreview}
+        clickMode="activate"
+        ariaLabel="downloaded-grid"
+        emptyHint={t('download.emptyHint')}
+      />
     </section>
   )
 }

--- a/studio/web/src/pages/project/steps/Preprocess.tsx
+++ b/studio/web/src/pages/project/steps/Preprocess.tsx
@@ -816,18 +816,18 @@ function ImagesPanel({
           className="btn btn-ghost btn-sm"
         >{t('common.deselect')}</button>
       </header>
-      <div className="flex-1 min-h-0 overflow-y-auto p-2">
-        <ImageGrid
-          items={items}
-          selected={selected}
-          onSelect={onSelect}
-          onActivate={onPreview}
-          onPreview={onPreview}
-          clickMode="activate"
-          ariaLabel="preprocess-grid"
-          emptyHint={t('preprocess.emptyForBin')}
-        />
-      </div>
+      <ImageGrid
+        className="flex-1 min-h-0"
+        contentClassName="p-2"
+        items={items}
+        selected={selected}
+        onSelect={onSelect}
+        onActivate={onPreview}
+        onPreview={onPreview}
+        clickMode="activate"
+        ariaLabel="preprocess-grid"
+        emptyHint={t('preprocess.emptyForBin')}
+      />
     </section>
   )
 }

--- a/studio/web/src/pages/project/steps/TagEdit.tsx
+++ b/studio/web/src/pages/project/steps/TagEdit.tsx
@@ -10,7 +10,7 @@ import {
 import BulkActionBar from '../../../components/BulkActionBar'
 import { useDialog } from '../../../components/Dialog'
 import ImageGrid, { applySelection } from '../../../components/ImageGrid'
-import PaneResizer from '../../../components/PaneResizer'
+import PaneResizer, { normalizePanePair } from '../../../components/PaneResizer'
 import SaveBar from '../../../components/SaveBar'
 import StepShell from '../../../components/StepShell'
 import TagEditor from '../../../components/TagEditor'
@@ -29,6 +29,12 @@ interface Ctx {
 }
 
 const keyOf = (folder: string, name: string) => `${folder}/${name}`
+
+const TAG_EDIT_GRID_MIN = 15
+const TAG_EDIT_SIDE_MIN = 20
+const TAG_EDIT_PREVIEW_MIN = 15
+const TAG_EDIT_GRID_PANE_ID = 'tag-edit-grid-pane'
+const TAG_EDIT_SIDE_PANE_ID = 'tag-edit-side-pane'
 
 interface CaptionMeta {
   folder: string
@@ -66,11 +72,23 @@ export default function TagEditPage() {
   const rowRef = useRef<HTMLDivElement>(null)
   const [gridPct, setGridPct] = useLocalStorageState('studio:tagEdit:grid_pct', 40)
   const [sidePct, setSidePct] = useLocalStorageState('studio:tagEdit:side_pct', 32)
+  const normalizedPanes = normalizePanePair(gridPct, sidePct, {
+    startMin: TAG_EDIT_GRID_MIN,
+    endMin: TAG_EDIT_SIDE_MIN,
+    flexibleMin: TAG_EDIT_PREVIEW_MIN,
+  })
+  const boundedGridPct = normalizedPanes.start
+  const boundedSidePct = normalizedPanes.end
 
-  // 两栏共享同一条宽度预算，各自的上限得看对方吃掉多少，否则中间预览栏会被挤没。
-  const MIN_PREVIEW_PCT = 15
-  const gridMax = Math.max(15, 100 - sidePct - MIN_PREVIEW_PCT)
-  const sideMax = Math.max(20, 100 - gridPct - MIN_PREVIEW_PCT)
+  // The two persisted fixed panes share one width budget. Repair invalid old values
+  // together so the flexible preview pane always retains its declared minimum.
+  useEffect(() => {
+    if (gridPct !== boundedGridPct) setGridPct(boundedGridPct)
+    if (sidePct !== boundedSidePct) setSidePct(boundedSidePct)
+  }, [boundedGridPct, boundedSidePct, gridPct, setGridPct, setSidePct, sidePct])
+
+  const gridMax = 100 - boundedSidePct - TAG_EDIT_PREVIEW_MIN
+  const sideMax = 100 - boundedGridPct - TAG_EDIT_PREVIEW_MIN
 
   const reloadCache = useCallback(async () => {
     if (versionId == null) return
@@ -374,11 +392,18 @@ export default function TagEditPage() {
         </>
       }
     >
-      <div ref={rowRef} className="flex flex-1 min-h-0 gap-2.5">
+      <div
+        ref={rowRef}
+        role="region"
+        aria-label={t('tagEdit.workspaceLabel')}
+        tabIndex={0}
+        className="flex flex-1 min-h-0 gap-2.5 overflow-x-auto overflow-y-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent"
+      >
 
         <section
-          className="rounded-md border border-subtle bg-surface flex flex-col min-w-0 overflow-hidden"
-          style={{ flex: isEditing ? `0 0 ${gridPct}%` : 1 }}
+          id={TAG_EDIT_GRID_PANE_ID}
+          className="rounded-md border border-subtle bg-surface flex flex-col min-w-[240px] overflow-hidden"
+          style={{ flex: isEditing ? `0 0 ${boundedGridPct}%` : 1 }}
         >
           {folderNames.length > 1 && (
             <div className="px-2 pt-2 pb-1.5 flex items-center gap-1 flex-wrap shrink-0 border-b border-subtle">
@@ -404,37 +429,38 @@ export default function TagEditPage() {
               })}
             </div>
           )}
-          <div className="flex-1 overflow-y-auto p-2">
-            <ImageGrid
-              items={captionItems}
-              selected={sel}
-              activeName={activeKey || undefined}
-              onSelect={handleClick}
-              onActivate={setActiveKey}
-              clickMode="activate"
-              ariaLabel="tag-edit-grid"
-              emptyHint={
-                folderFilter
-                  ? t('tagEdit.noImagesInFolder', { folder: folderFilter })
-                  : t('tagEdit.noImagesHint')
-              }
-            />
-          </div>
+          <ImageGrid
+            className="flex-1 min-h-0"
+            contentClassName="p-2"
+            items={captionItems}
+            selected={sel}
+            activeName={activeKey || undefined}
+            onSelect={handleClick}
+            onActivate={setActiveKey}
+            clickMode="activate"
+            ariaLabel="tag-edit-grid"
+            emptyHint={
+              folderFilter
+                ? t('tagEdit.noImagesInFolder', { folder: folderFilter })
+                : t('tagEdit.noImagesHint')
+            }
+          />
         </section>
 
         {isEditing && (
           <PaneResizer
             containerRef={rowRef}
-            value={gridPct}
+            value={boundedGridPct}
             onChange={setGridPct}
-            min={15}
+            min={TAG_EDIT_GRID_MIN}
             max={gridMax}
             ariaLabel={t('tagEdit.resizeGrid')}
+            ariaControls={TAG_EDIT_GRID_PANE_ID}
           />
         )}
 
         {isEditing && (
-          <section className="flex-1 rounded-md border border-subtle bg-surface flex flex-col min-w-0 overflow-hidden">
+          <section className="flex-1 min-w-[240px] rounded-md border border-subtle bg-surface flex flex-col overflow-hidden">
             <div className="px-3 py-2 border-b border-subtle shrink-0 flex items-center gap-2">
               <span className="text-xs text-fg-tertiary">{t('tagEdit.singleEdit')}</span>
               <code className="flex-1 min-w-0 text-xs font-mono text-fg-secondary truncate">
@@ -456,15 +482,20 @@ export default function TagEditPage() {
 
         <PaneResizer
           containerRef={rowRef}
-          value={sidePct}
+          value={boundedSidePct}
           onChange={setSidePct}
-          min={20}
+          min={TAG_EDIT_SIDE_MIN}
           max={sideMax}
           anchor="end"
           ariaLabel={t('tagEdit.resizeSide')}
+          ariaControls={TAG_EDIT_SIDE_PANE_ID}
         />
 
-        <div className="flex flex-col gap-2.5 min-w-0 min-h-0" style={{ flex: `0 0 ${sidePct}%` }}>
+        <div
+          id={TAG_EDIT_SIDE_PANE_ID}
+          className="flex flex-col gap-2.5 min-w-[260px] min-h-0"
+          style={{ flex: `0 0 ${boundedSidePct}%` }}
+        >
           {isEditing ? (
             // editing 时：bulk + 标签分布 都和"调单图标签"无关，整个侧栏让位给
             // TagEditor。退出 editing 后自动回来，sel / folderFilter 等 state


### PR DESCRIPTION
## 概述

本 PR 完成前端优化 Phase 3D（Split Workspace / Pane Geometry），统一现有可拖拽工作区的比例边界、三栏宽度预算、键盘与无障碍语义、拖动生命周期清理，以及虚拟图片列表的滚动与内容 inset 契约。

## 主要改动

### PaneResizer

- 统一修复非有限值、越界值和反向 min/max；
- 支持 `ArrowLeft` / `ArrowRight`、`Home` / `End`；
- 支持 `anchor="start" | "end"`，右侧 pane 的键盘方向与手柄视觉移动一致；
- 补齐 `aria-controls`、`aria-valuenow/min/max/text`；
- 在 `pointerup`、`pointercancel`、capture 丢失和组件卸载时完整恢复 body cursor / user-select 并释放监听。

### Curation

- 持久化双栏比例统一经过合法边界修复；
- pane、separator 与存储使用同一 bounded ratio；
- 保持 `ImageGrid → VirtuosoGrid` 的直接有界高度链；
- 保持 compact desktop 的既有安全堆叠策略。

### Tag Edit

- 左、右固定 pane 使用共享宽度预算，始终为中间预览保留最小空间；
- 两个 separator 分别关联正确 pane；
- 三栏最小宽度无法容纳时使用具名、可聚焦的局部横向滚动边界，不裁切工具；
- 修复历史异常持久化比例导致 pane 消失的问题。

### 虚拟图片列表滚动契约

- Tag Edit、Preprocess、Download 删除 `ImageGrid` 外层冗余 `.overflow-y-auto + padding`；
- `ImageGrid` 直接占据 `flex-1 min-h-0` 有界槽位；
- 内容 inset 通过 `contentClassName` 放入 Virtuoso list，避免父级稳定 scrollbar gutter 与 padding 叠加形成右侧假留白。

## 边界与后续

- Train、Tagging、Generate、Gallery、Eval 等专业拓扑不强制迁移为可拖 pane；
- `PreprocessOverview` 仍存在同类 ImageGrid 右侧 gutter 现象，按人工验收决定留到 Phase 4 全站 adoption 统一处理，本 PR 不继续扩项；
- `.pi/` 与 `PRODUCT.md` 未进入提交。

## 验证

- 聚焦测试：2 个文件、21 个测试通过；
- 全量 Vitest：100 个测试文件、780 个测试通过；
- ESLint：通过；
- TypeScript：通过；
- Production build：通过（498 个模块）；
- `tests/test_route_snapshot.py`：通过；
- Impeccable layout detector：0 findings；
- `git diff --check`：通过；
- 独立复审：Merge verdict OK。

仅保留既有 `LogView.test.tsx` React `act(...)` 警告与 `>700 kB` 主 chunk 提示。

## 人工视觉验收

已检查 Curation 与 Tag Edit 的 pane 拖动、滚动条位置、虚拟图片列表显示、紧凑桌面降级、键盘 separator，以及 Tag Edit / Preprocess 图片栏的内容 inset。