### PR TITLE
fix(generate): 兼容正负提示词 conditioning 长度不一致

### DIFF
--- a/runtime/training/families/anima/sampling.py
+++ b/runtime/training/families/anima/sampling.py
@@ -404,16 +404,37 @@ def sample_image(
                         cross_cond,  # noqa: F821
                         padding_mask=pad_mask.expand(x_model.shape[0], -1, -1, -1).contiguous(),  # noqa: F821
                     )
-                x_batch = torch.cat([x_model, x_model], dim=0)
-                cross_batch = torch.cat([cross_uncond, cross_cond], dim=0)  # noqa: F821
-                pad_batch = pad_mask.expand(x_batch.shape[0], -1, -1, -1).contiguous()  # noqa: F821
-                sigma_batch = sigma_1d.expand(x_batch.shape[0])
-                v_uncond, v_cond = model(
-                    x_batch,
-                    sigma_batch,
-                    cross_batch,
-                    padding_mask=pad_batch,
-                ).chunk(2)
+                if cross_uncond.shape[1:] == cross_cond.shape[1:]:  # noqa: F821
+                    x_batch = torch.cat([x_model, x_model], dim=0)
+                    cross_batch = torch.cat([cross_uncond, cross_cond], dim=0)  # noqa: F821
+                    pad_batch = pad_mask.expand(x_batch.shape[0], -1, -1, -1).contiguous()  # noqa: F821
+                    sigma_batch = sigma_1d.expand(x_batch.shape[0])
+                    v_uncond, v_cond = model(
+                        x_batch,
+                        sigma_batch,
+                        cross_batch,
+                        padding_mask=pad_batch,
+                    ).chunk(2)
+                else:
+                    # ComfyUI only batches CONDCrossAttn values when their
+                    # sequence shapes are concat-compatible.  A long positive
+                    # prompt and a short negative prompt therefore run as two
+                    # forwards instead of truncating either conditioning.
+                    model_args = (
+                        x_model,
+                        sigma_1d.expand(x_model.shape[0]),
+                    )
+                    model_kwargs = {
+                        "padding_mask": pad_mask.expand(  # noqa: F821
+                            x_model.shape[0], -1, -1, -1,
+                        ).contiguous(),
+                    }
+                    v_uncond = model(
+                        *model_args, cross_uncond, **model_kwargs,  # noqa: F821
+                    )
+                    v_cond = model(
+                        *model_args, cross_cond, **model_kwargs,  # noqa: F821
+                    )
                 return v_uncond + cfg_scale * (v_cond - v_uncond)
 
         v = _run_model_forward()

--- a/tests/test_comfy_anima_text_encoding.py
+++ b/tests/test_comfy_anima_text_encoding.py
@@ -467,6 +467,40 @@ def test_sample_image_comfy_parity_batches_cfg_like_comfyui(monkeypatch) -> None
     assert cross_max == [2.0, 1.0]
 
 
+def test_sample_image_cfg_handles_positive_and_negative_lengths_above_floor(monkeypatch) -> None:
+    model = RecordingBatchedDenoiseModel()
+
+    def one_step_sampler(denoise_fn, x, sigmas, **_kwargs):
+        denoise_fn(x, sigmas[0])
+        return x
+
+    monkeypatch.setattr(inference_samplers, "build_inference_sampler", lambda _name: one_step_sampler)
+
+    image = sample_image(
+        model,
+        FakeVAE(),
+        FakeQwenModel(),
+        RecordingQwenTokenizer(),
+        FakeTokenizer(),
+        "a" * 526,
+        height=16,
+        width=16,
+        steps=1,
+        cfg_scale=4.0,
+        negative_prompt="",
+        sampler_name="er_sde",
+        scheduler="simple",
+        device="cpu",
+        dtype=torch.float32,
+        seed=123,
+    )
+
+    assert image.size == (2, 2)
+    assert len(model.forward_calls) == 2
+    assert [call["cross"].shape[1] for call in model.forward_calls] == [512, 527]
+    assert [call["cross"].amax().item() for call in model.forward_calls] == [2.0, 1.0]
+
+
 def test_sample_image_retries_with_sdpa_when_xformers_outputs_nan(monkeypatch) -> None:
     from modeling.anima import cosmos_predict2_modeling as cosmos
 


### PR DESCRIPTION
## 背景 / 紧急性

稳定版 v0.26.1 的 Anima 测试生图在长正向提示词搭配空或较短负向提示词时会直接失败。正向 conditioning 超过 512 token、负向 conditioning 保持 512 token 后，CFG 路径无条件拼接并触发 tensor 尺寸错误。

这是稳定版用户可直接触发的出图阻断；dev 当前包含未发布功能，不能等待或绑定下一次常规 dev release，因此走 hotfix 到 master。

## 修复

- conditioning 序列长度相同时继续使用单次 CFG 合批 forward。
- 长度不同时分别执行 unconditional 与 conditional forward，再按原 CFG 公式合成。
- 不截断长提示词，不修改 schema、SSE、训练路径或用户数据。
- 增加 512/527 token 组合的回归测试。

## 上游对照与许可

行为对照 ComfyUI 的 CONDCrossAttn 不可拼接分流：
https://github.com/Comfy-Org/ComfyUI/blob/master/comfy/conds.py

ComfyUI 使用 GPL-3.0；本改动仅对照行为与接口语义，未复制上游代码。

## 验证

- 69 项相关采样、Generate 与 daemon 测试通过。
- 33 项后端横切安全网通过。
- python -m ruff check . 通过。
- 无 UI 改动，不需要截图。